### PR TITLE
plugins: Fix auto-load of plugins

### DIFF
--- a/include/internal/plugin_manager.h
+++ b/include/internal/plugin_manager.h
@@ -74,6 +74,10 @@ public:
     nixlPluginManager(const nixlPluginManager&) = delete;
     nixlPluginManager& operator=(const nixlPluginManager&) = delete;
 
+    std::shared_ptr<nixlPluginHandle> loadPluginFromPath(const std::string& plugin_path);
+
+    void loadPluginsFromList(const std::string& filename);
+
     // Load a specific plugin
     std::shared_ptr<nixlPluginHandle> loadPlugin(const std::string& plugin_name);
 

--- a/meson.build
+++ b/meson.build
@@ -69,14 +69,12 @@ endif
 
 # Define a specific plugin directory
 plugin_install_dir = join_paths(get_option('libdir'), 'plugins')
-plugin_build_dir = meson.current_build_dir() / 'plugins'
-
-# Create plugin directory
-run_command('rm', '-f', plugin_build_dir, check: false)
-run_command('mkdir', '-p', plugin_build_dir, check: true)
+plugin_build_dir = meson.current_build_dir()
 
 # Add to global args so plugin managers can find it
-add_project_arguments('-DNIXL_DEFAULT_PLUGIN_DIR="' + plugin_build_dir + '"', language: 'cpp')
+if get_option('buildtype') == 'debug'
+    add_project_arguments('-DNIXL_USE_PLUGIN_FILE="' + plugin_build_dir + '/pluginlist"',  language: 'cpp')
+endif
 
 inc_dir = include_directories('include', 'include/internal', 'include/backend',
                               'src', 'src/utils/serdes', 'src/utils/data_structures',

--- a/src/nixl_nw_backends/meson.build
+++ b/src/nixl_nw_backends/meson.build
@@ -39,11 +39,13 @@ else
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir)
-    custom_target('copy_ucx_plugin',
-                 input: ucx_backend_lib,
-                 output: 'copied_ucx_plugin',
-                 command: ['cp', '@INPUT@', plugin_build_dir / 'libplugin_UCX.so'],
-                 build_by_default: true)
+
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+                    'echo "UCX=' + ucx_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+                    check: true
+                )
+    endif
 endif
 
 ucx_backend_interface = declare_dependency(link_with: ucx_backend_lib)

--- a/src/nixl_storage_backends/gds/meson.build
+++ b/src/nixl_storage_backends/gds/meson.build
@@ -44,11 +44,12 @@ else
                     cpp_args : ['-fPIC'],
                     name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                     install_dir: plugin_install_dir)
-  custom_target('copy_gds_plugin',
-               input: gds_backend_lib,
-               output: 'copied_gds_plugin',
-               command: ['cp', '@INPUT@', plugin_build_dir / 'libplugin_GDS.so'],
-               build_by_default: true)
+  if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+                    'echo "GDS=' + gds_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+                    check: true
+                )
+    endif
 endif
 
 gds_backend_interface = declare_dependency(link_with: gds_backend_lib)


### PR DESCRIPTION
Previously, since the plugins were being copied into the plugins folder, the dependencies were lost. Now, just use the plugins from their specific build folders by creating a file with name=pluginpath, then parse the file in plugin manager. Note, this is only enabled for debug builds so we can test the in-tree plugins. We can generally enable it if there are other requirements.

Also, some refactor of plugin manager code for loading plugins from path.

Tested with agentExample and testPlugin.