### PR TITLE
BackendEngine: Added bookkeeping of custom_params of each backend to …

### DIFF
--- a/include/nixl_types.h
+++ b/include/nixl_types.h
@@ -41,7 +41,8 @@ typedef enum {
     NIXL_ERR_NOT_FOUND = -3,
     NIXL_ERR_NYI = -4,
     NIXL_ERR_MISMATCH = -5,
-    NIXL_ERR_BAD = -6
+    NIXL_ERR_BAD = -6,
+    NIXL_ERR_NOT_ALLOWED = -7
 } nixl_status_t;
 
 class nixlSerDes;

--- a/src/nixl_agent.cpp
+++ b/src/nixl_agent.cpp
@@ -92,7 +92,7 @@ nixlBackendH* nixlAgent::createBackend(const nixl_backend_t &type,
     nixl_status_t ret;
     std::string str;
 
-    // Registring same type of backend is not supported, unlikey and prob error
+    // Registering same type of backend is not supported, unlikely and prob error
     if (data->backendEngines.count(type)!=0)
         return nullptr;
 
@@ -116,7 +116,7 @@ nixlBackendH* nixlAgent::createBackend(const nixl_backend_t &type,
     }
 
     if (backend!=nullptr) {
-        if (backend->initErr) {
+        if (backend->getInitErr()) {
             delete backend;
             return nullptr;
         }
@@ -447,7 +447,7 @@ nixl_status_t nixlAgent::makeXferReq (const nixlXferSideH* local_side,
     // }
 
     // Populate has been already done, no benefit in having sorted descriptors
-    // which will be overwritten by [] assignement operator.
+    // which will be overwritten by [] assignment operator.
     nixlXferReqH *handle = new nixlXferReqH;
     handle->initiatorDescs = new nixl_meta_dlist_t (
                                      local_side->descs->getType(),


### PR DESCRIPTION
…the base class.

* The backend plugin should not modify the passed parameters by the user, so the base class bookkeeps them and gives setter and getter methods to the plugin to access it.
* Now plugin can ask for value of a key, or add key/values for default parameters.
* Also added an API on the base class to return all the key/values, to be used in the agent API.
* Some rearragements in the base backend class to use protected when appropriate. Also the agent name is set only during construction and cannot be modified later.