### PR TITLE
Fixed a typo in flake8 invocation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8
-        args: [--max-line-length=88, --select=C,E,F,W,B,B950, --extend-ignore=E203,E501,]
+        args: ["--max-line-length=88", "--select=C,E,F,W,B,B950", "--extend-ignore=E203,E501"]
         types_or: [python, cython]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
It was missing a comma at the end of the arg list.