### PR TITLE
headers: purge xfer_state

### DIFF
--- a/include/backend/backend_engine.h
+++ b/include/backend/backend_engine.h
@@ -102,15 +102,15 @@ class nixlBackendEngine {
         virtual nixl_status_t unloadMD (nixlBackendMD* input) = 0;
 
         // Posting a request, which returns populates the async handle.
-        virtual nixl_xfer_state_t postXfer (const nixl_meta_dlist_t &local,
-                                            const nixl_meta_dlist_t &remote,
-                                            const nixl_xfer_op_t &operation,
-                                            const std::string &remote_agent,
-                                            const std::string &notif_msg,
-                                            nixlBackendReqH* &handle) = 0;
+        virtual nixl_status_t postXfer (const nixl_meta_dlist_t &local,
+                                        const nixl_meta_dlist_t &remote,
+                                        const nixl_xfer_op_t &operation,
+                                        const std::string &remote_agent,
+                                        const std::string &notif_msg,
+                                        nixlBackendReqH* &handle) = 0;
 
         // Use a handle to progress backend engine and see if a transfer is completed or not
-        virtual nixl_xfer_state_t checkXfer(nixlBackendReqH* handle) = 0;
+        virtual nixl_status_t checkXfer(nixlBackendReqH* handle) = 0;
 
         //Backend aborts the transfer if necessary, and destructs the relevant objects
         virtual void releaseReqH(nixlBackendReqH* handle) = 0;

--- a/include/internal/transfer_request.h
+++ b/include/internal/transfer_request.h
@@ -31,7 +31,7 @@ class nixlXferReqH {
         std::string        notifMsg;
 
         nixl_xfer_op_t     backendOp;
-        nixl_xfer_state_t  state;
+        nixl_status_t      status;
 
     public:
         inline nixlXferReqH() {

--- a/include/nixl.h
+++ b/include/nixl.h
@@ -65,10 +65,10 @@ class nixlAgent {
                                      const nixlBackendH* backend = nullptr) const;
 
         // Submit a transfer request, which populates the req async handler.
-        nixl_xfer_state_t postXferReq (nixlXferReqH* req);
+        nixl_status_t postXferReq (nixlXferReqH* req);
 
         // Check the status of transfer requests
-        nixl_xfer_state_t getXferStatus (nixlXferReqH* req);
+        nixl_status_t getXferStatus (nixlXferReqH* req);
 
         // Invalidate transfer request if we no longer need it.
         // Will also abort a running transfer.

--- a/include/nixl_types.h
+++ b/include/nixl_types.h
@@ -28,21 +28,20 @@ typedef std::string nixl_backend_t;
 //FILE_SEG must be last
 typedef enum {DRAM_SEG, VRAM_SEG, BLK_SEG, FILE_SEG} nixl_mem_t;
 
-typedef enum {NIXL_XFER_INIT, NIXL_XFER_PROC,
-              NIXL_XFER_DONE, NIXL_XFER_ERR} nixl_xfer_state_t;
-
 typedef enum {NIXL_READ,  NIXL_RD_NOTIF,
               NIXL_WRITE, NIXL_WR_NOTIF} nixl_xfer_op_t;
 
 typedef enum {
+    NIXL_IN_PROG = 1,
     NIXL_SUCCESS = 0,
-    NIXL_ERR_INVALID_PARAM = -1,
-    NIXL_ERR_BACKEND = -2,
-    NIXL_ERR_NOT_FOUND = -3,
-    NIXL_ERR_NYI = -4,
+    NIXL_ERR_NOT_POSTED = -1,
+    NIXL_ERR_INVALID_PARAM = -2,
+    NIXL_ERR_BACKEND = -3,
+    NIXL_ERR_NOT_FOUND = -4,
     NIXL_ERR_MISMATCH = -5,
-    NIXL_ERR_BAD = -6,
-    NIXL_ERR_NOT_ALLOWED = -7
+    NIXL_ERR_NOT_ALLOWED = -6,
+    NIXL_ERR_REPOST_ACTIVE = -7,
+    NIXL_ERR_UNKNOWN = -8
 } nixl_status_t;
 
 class nixlSerDes;

--- a/src/nixl_descriptors.cpp
+++ b/src/nixl_descriptors.cpp
@@ -158,7 +158,7 @@ nixlDescList<T>::nixlDescList(nixlSerDes* deserializer) {
     if (str.size()==0)
         return;
 
-    // nixlMetaDesc should be internall and not be serialized
+    // nixlMetaDesc should be internal and not be serialized
     if ((str == "nixlMDList") || (std::is_same<nixlMetaDesc, T>::value))
         return;
 
@@ -370,7 +370,7 @@ nixl_status_t nixlDescList<T>::populate (const nixlDescList<nixlBasicDesc> &quer
             return NIXL_SUCCESS;
         } else {
             resp.clear();
-            return NIXL_ERR_BAD;
+            return NIXL_ERR_UNKNOWN;
         }
     } else {
         if (q_sorted) {
@@ -391,7 +391,7 @@ nixl_status_t nixlDescList<T>::populate (const nixlDescList<nixlBasicDesc> &quer
                     // if ((descAddrCompare(*q, descs[s_index], unifiedAddr)) ||
                     if (s_index==size) {
                         resp.clear();
-                        return NIXL_ERR_BAD;
+                        return NIXL_ERR_UNKNOWN;
                     }
                 }
             }
@@ -427,7 +427,7 @@ nixl_status_t nixlDescList<T>::populate (const nixlDescList<nixlBasicDesc> &quer
                     resp.descs[i] = new_elm;
                 } else {
                     resp.clear();
-                    return NIXL_ERR_BAD;
+                    return NIXL_ERR_UNKNOWN;
                 }
             }
             resp.sorted = query.isSorted(); // Update as resize resets it
@@ -457,18 +457,18 @@ int nixlDescList<T>::getIndex(const nixlBasicDesc &query) const {
     if (!sorted) {
         auto itr = std::find(descs.begin(), descs.end(), query);
         if (itr == descs.end())
-            return -1; // not found
+            return NIXL_ERR_NOT_FOUND; // not found
         return itr - descs.begin();
     } else {
         auto itr = std::lower_bound(descs.begin(), descs.end(),
                                     query, desc_comparator_f);
         if (itr == descs.end())
-            return -1; // not found
+            return NIXL_ERR_NOT_FOUND; // not found
         // As desired, becomes nixlBasicDesc on both sides
         if (*itr == query)
             return itr - descs.begin();
     }
-    return -1;
+    return NIXL_ERR_NOT_FOUND;
 }
 
 template <class T>
@@ -477,7 +477,7 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
     nixl_status_t ret;
     size_t n_desc = descs.size();
 
-    // nixlMetaDesc should be internall and not be serialized
+    // nixlMetaDesc should be internal and not be serialized
     if(std::is_same<nixlMetaDesc, T>::value)
         return NIXL_ERR_INVALID_PARAM;
 

--- a/src/nixl_memory_section.cpp
+++ b/src/nixl_memory_section.cpp
@@ -155,7 +155,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_meta_dlist_t &mem_elms,
         // registering back what was deregistered is not meaningful.
         // Can be secured by going through all the list then deregister
         if (index<0)
-            return NIXL_ERR_BAD;
+            return NIXL_ERR_UNKNOWN;
 
         backend->deregisterMem
             ((*(const nixl_meta_dlist_t*)target)[index].metadataP);
@@ -242,7 +242,7 @@ nixl_status_t nixlRemoteSection::addDescList (
                                  const nixl_reg_dlist_t& mem_elms,
                                  nixlBackendEngine* backend) {
     if (!backend->supportsRemote())
-        return NIXL_ERR_BAD;
+        return NIXL_ERR_UNKNOWN;
 
     // Less checks than LocalSection, as it's private and called by loadRemoteData
     // In RemoteSection, if we support updates, value for a key gets overwritten
@@ -293,7 +293,7 @@ nixl_status_t nixlRemoteSection::loadRemoteData (nixlSerDes* deserializer) {
             return NIXL_ERR_INVALID_PARAM;
         nixl_reg_dlist_t s_desc(deserializer);
         if (s_desc.descCount()==0) // can be used for entry removal in future
-            return NIXL_ERR_NYI;
+            return NIXL_ERR_NOT_FOUND;
         ret = addDescList(s_desc, backendToEngineMap[nixl_backend]);
         if (ret) return ret;
     }
@@ -305,7 +305,7 @@ nixl_status_t nixlRemoteSection::loadLocalData (
                                  nixlBackendEngine* backend) {
 
     if (mem_elms.descCount()==0) // Shouldn't happen
-        return NIXL_ERR_BAD;
+        return NIXL_ERR_UNKNOWN;
 
     nixl_mem_t     nixl_mem     = mem_elms.getType();
     nixl_backend_t nixl_backend = backend->getType();

--- a/src/nixl_nw_backends/ucx_backend.h
+++ b/src/nixl_nw_backends/ucx_backend.h
@@ -178,24 +178,24 @@ class nixlUcxEngine : public nixlBackendEngine {
 
         static ucs_status_t
         connectionTermAmCb(void *arg, const void *header,
-                            size_t header_length, void *data,
-                            size_t length,
-                            const ucp_am_recv_param_t *param);
+                           size_t header_length, void *data,
+                           size_t length,
+                           const ucp_am_recv_param_t *param);
 
         // Notifications
         static ucs_status_t notifAmCb(void *arg, const void *header,
                                       size_t header_length, void *data,
                                       size_t length,
                                       const ucp_am_recv_param_t *param);
-        nixl_xfer_state_t notifSendPriv(const std::string &remote_agent,
-                                        const std::string &msg, nixlUcxReq &req);
+        nixl_status_t notifSendPriv(const std::string &remote_agent,
+                                    const std::string &msg, nixlUcxReq &req);
         void notifProgress();
         void notifCombineHelper(notif_list_t &src, notif_list_t &tgt);
         void notifProgressCombineHelper(notif_list_t &src, notif_list_t &tgt);
 
 
         // Data transfer (priv)
-        nixl_status_t retHelper(nixl_xfer_state_t ret, nixlUcxBckndReq *head, nixlUcxReq &req);
+        nixl_status_t retHelper(nixl_status_t ret, nixlUcxBckndReq *head, nixlUcxReq &req);
 
     public:
         nixlUcxEngine(const nixlBackendInitParams* init_params);
@@ -230,13 +230,13 @@ class nixlUcxEngine : public nixlBackendEngine {
         nixl_status_t unloadMD (nixlBackendMD* input);
 
         // Data transfer
-        nixl_xfer_state_t postXfer (const nixl_meta_dlist_t &local,
-                                    const nixl_meta_dlist_t &remote,
-                                    const nixl_xfer_op_t &op,
-                                    const std::string &remote_agent,
-                                    const std::string &notif_msg,
-                                    nixlBackendReqH* &handle);
-        nixl_xfer_state_t checkXfer (nixlBackendReqH* handle);
+        nixl_status_t postXfer (const nixl_meta_dlist_t &local,
+                                const nixl_meta_dlist_t &remote,
+                                const nixl_xfer_op_t &op,
+                                const std::string &remote_agent,
+                                const std::string &notif_msg,
+                                nixlBackendReqH* &handle);
+        nixl_status_t checkXfer (nixlBackendReqH* handle);
         void releaseReqH(nixlBackendReqH* handle);
 
         int progress();

--- a/src/nixl_storage_backends/gds/gds_backend.h
+++ b/src/nixl_storage_backends/gds/gds_backend.h
@@ -46,7 +46,7 @@ private:
     CUfileIOEvents_t    *io_batch_events;
     CUfileIOParams_t    *io_batch_params;
     CUfileError_t       init_err;
-    nixl_xfer_state_t   current_status;
+    nixl_status_t       current_status;
     unsigned int        entries_completed;
     unsigned int        batch_size;
 
@@ -58,7 +58,7 @@ public:
                                    size_t size, size_t file_offset,
                                    size_t ptr_offset, CUfileOpcode_t type);
     nixl_status_t       submitBatch(int flags);
-    nixl_xfer_state_t   checkStatus();
+    nixl_status_t       checkStatus();
     nixl_status_t       cancelBatch();
     void                destroyBatch();
 };
@@ -124,14 +124,14 @@ public:
                               nixlBackendMD* &out);
     void deregisterMem (nixlBackendMD *meta);
 
-    nixl_xfer_state_t postXfer (const nixl_meta_dlist_t &local,
-                                const nixl_meta_dlist_t &remote,
-                                const nixl_xfer_op_t &op,
-                                const std::string &remote_agent,
-                                const std::string &notif_msg,
-                                nixlBackendReqH* &handle);
+    nixl_status_t postXfer (const nixl_meta_dlist_t &local,
+                            const nixl_meta_dlist_t &remote,
+                            const nixl_xfer_op_t &op,
+                            const std::string &remote_agent,
+                            const std::string &notif_msg,
+                            nixlBackendReqH* &handle);
 
-    nixl_xfer_state_t checkXfer (nixlBackendReqH* handle);
+    nixl_status_t checkXfer (nixlBackendReqH* handle);
     void releaseReqH(nixlBackendReqH* handle);
 };
 #endif

--- a/src/pybind/_api.py
+++ b/src/pybind/_api.py
@@ -238,21 +238,21 @@ class nixl_agent:
 
     def transfer(self, handle):
         status = self.agent.postXferReq(handle)
-        if status == nixlBind.NIXL_XFER_ERR:
-            return "ERR"
-        elif status != nixlBind.NIXL_XFER_DONE:
+        if status == nixlBind.NIXL_SUCCESS:
+            return "DONE"
+        elif status == nixlBind.NIXL_IN_PROG:
             return "PROC"
         else:
-            return "DONE"
+            return "ERR"
 
     def check_xfer_state(self, handle):
         status = self.agent.getXferStatus(handle)
-        if status == nixlBind.NIXL_XFER_ERR:
-            return "ERR"
-        elif status != nixlBind.NIXL_XFER_DONE:
+        if status == nixlBind.NIXL_SUCCESS:
+            return "DONE"
+        elif status == nixlBind.NIXL_IN_PROG:
             return "PROC"
         else:
-            return "DONE"
+            return "ERR"
 
     # Only removes the specific notification from self.notifs
     def check_remote_xfer_done(self, remote_agent_name, lookup_msg):

--- a/src/pybind/nixl_bindings.cpp
+++ b/src/pybind/nixl_bindings.cpp
@@ -39,13 +39,6 @@ PYBIND11_MODULE(_bindings, m) {
         .value("FILE_SEG", FILE_SEG)
         .export_values();
 
-    py::enum_<nixl_xfer_state_t>(m, "nixl_xfer_state_t")
-        .value("NIXL_XFER_INIT", NIXL_XFER_INIT)
-        .value("NIXL_XFER_PROC", NIXL_XFER_PROC)
-        .value("NIXL_XFER_DONE", NIXL_XFER_DONE)
-        .value("NIXL_XFER_ERR", NIXL_XFER_ERR)
-        .export_values();
-
     py::enum_<nixl_xfer_op_t>(m, "nixl_xfer_op_t")
         .value("NIXL_READ", NIXL_READ)
         .value("NIXL_RD_NOTIF", NIXL_RD_NOTIF)
@@ -54,12 +47,16 @@ PYBIND11_MODULE(_bindings, m) {
         .export_values();
 
     py::enum_<nixl_status_t>(m, "nixl_status_t")
+        .value("NIXL_IN_PROG", NIXL_IN_PROG)
         .value("NIXL_SUCCESS", NIXL_SUCCESS)
+        .value("NIXL_ERR_NOT_POSTED", NIXL_ERR_NOT_POSTED)
         .value("NIXL_ERR_INVALID_PARAM", NIXL_ERR_INVALID_PARAM)
         .value("NIXL_ERR_BACKEND", NIXL_ERR_BACKEND)
         .value("NIXL_ERR_NOT_FOUND", NIXL_ERR_NOT_FOUND)
-        .value("NIXL_ERR_NYI", NIXL_ERR_NYI)
-        .value("NIXL_ERR_BAD", NIXL_ERR_BAD)
+        .value("NIXL_ERR_MISMATCH", NIXL_ERR_MISMATCH)
+        .value("NIXL_ERR_NOT_ALLOWED", NIXL_ERR_NOT_ALLOWED)
+        .value("NIXL_ERR_REPOST_ACTIVE", NIXL_ERR_REPOST_ACTIVE)
+        .value("NIXL_ERR_UNKNOWN", NIXL_ERR_UNKNOWN)
         .export_values();
 
     py::class_<nixl_xfer_dlist_t>(m, "nixlXferDList")
@@ -236,10 +233,10 @@ PYBIND11_MODULE(_bindings, m) {
         .def("invalidateXferSide", [](nixlAgent &agent, uintptr_t handle) -> void {
                     agent.invalidateXferSide((nixlXferSideH*) handle);
                 })
-        .def("postXferReq", [](nixlAgent &agent, uintptr_t reqh) -> nixl_xfer_state_t {
+        .def("postXferReq", [](nixlAgent &agent, uintptr_t reqh) -> nixl_status_t {
                     return agent.postXferReq((nixlXferReqH*) reqh);
                 })
-        .def("getXferStatus", [](nixlAgent &agent, uintptr_t reqh) -> nixl_xfer_state_t {
+        .def("getXferStatus", [](nixlAgent &agent, uintptr_t reqh) -> nixl_status_t {
                     return agent.getXferStatus((nixlXferReqH*) reqh);
                 })
         .def("getNotifs", [](nixlAgent &agent, nixl_notifs_t notif_map) -> nixl_notifs_t {

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -67,8 +67,8 @@ public:
 
     typedef void req_cb_t(void *request);
     nixlUcxContext(std::vector<std::string> devices,
-                    size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
-                    nixl_ucx_mt_t mt_type);
+                   size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
+                   nixl_ucx_mt_t mt_type);
     ~nixlUcxContext();
 
     static bool mtLevelIsSupproted(nixl_ucx_mt_t mt_type);
@@ -103,29 +103,28 @@ public:
 
     /* Active message handling */
     int regAmCallback(unsigned msg_id, ucp_am_recv_callback_t cb, void* arg);
-    nixl_xfer_state_t sendAm(nixlUcxEp &ep, unsigned msg_id,
-                             void* hdr, size_t hdr_len,
-                             void* buffer, size_t len,
-                             uint32_t flags, nixlUcxReq &req);
+    nixl_status_t sendAm(nixlUcxEp &ep, unsigned msg_id,
+                         void* hdr, size_t hdr_len,
+                         void* buffer, size_t len,
+                         uint32_t flags, nixlUcxReq &req);
     int getRndvData(void* data_desc, void* buffer, size_t len,
                     const ucp_request_param_t *param, nixlUcxReq &req);
 
     /* Data access */
     int progress();
-    nixl_xfer_state_t flushEp(nixlUcxEp &ep, nixlUcxReq &req);
-    nixl_xfer_state_t read(nixlUcxEp &ep,
-                           uint64_t raddr, nixlUcxRkey &rk,
-                           void *laddr, nixlUcxMem &mem,
-                           size_t size, nixlUcxReq &req);
-    nixl_xfer_state_t write(nixlUcxEp &ep,
-                            void *laddr, nixlUcxMem &mem,
-                            uint64_t raddr, nixlUcxRkey &rk,
-                            size_t size, nixlUcxReq &req);
-    nixl_xfer_state_t test(nixlUcxReq req);
+    nixl_status_t flushEp(nixlUcxEp &ep, nixlUcxReq &req);
+    nixl_status_t read(nixlUcxEp &ep,
+                       uint64_t raddr, nixlUcxRkey &rk,
+                       void *laddr, nixlUcxMem &mem,
+                       size_t size, nixlUcxReq &req);
+    nixl_status_t write(nixlUcxEp &ep,
+                        void *laddr, nixlUcxMem &mem,
+                        uint64_t raddr, nixlUcxRkey &rk,
+                        size_t size, nixlUcxReq &req);
+    nixl_status_t test(nixlUcxReq req);
 
     void reqRelease(nixlUcxReq req);
     void reqCancel(nixlUcxReq req);
 };
 
 #endif
-

--- a/src/utils/ucx/ucx_worker_test.cpp
+++ b/src/utils/ucx/ucx_worker_test.cpp
@@ -56,10 +56,10 @@ static void nixlUcxRequestInit(void *request)
     req->initialized = 1;
 }
 
-void completeRequest(nixlUcxWorker w[2], std::string op, bool is_flush, nixl_xfer_state_t ret,  nixlUcxReq &req)
+void completeRequest(nixlUcxWorker w[2], std::string op, bool is_flush, nixl_status_t ret,  nixlUcxReq &req)
 {
-    assert( ret == NIXL_XFER_DONE || ret == NIXL_XFER_PROC);
-    if (ret == NIXL_XFER_DONE) {
+    assert( ret == NIXL_SUCCESS || ret == NIXL_IN_PROG);
+    if (ret == NIXL_SUCCESS) {
         if (!is_flush) {
             cout << "WARNING: " << op << " request completed immediately - no testing non-inline path" << endl;
         }
@@ -69,12 +69,12 @@ void completeRequest(nixlUcxWorker w[2], std::string op, bool is_flush, nixl_xfe
         }
         assert( ((requestData *)req)->initialized == 1);
 
-        ret = NIXL_XFER_PROC;
+        ret = NIXL_IN_PROG;
         do {
             ret = w[0].test(req);
             w[1].progress();
-        } while( ret == NIXL_XFER_PROC);
-        assert(ret == NIXL_XFER_DONE);
+        } while( ret == NIXL_IN_PROG);
+        assert(ret == NIXL_SUCCESS);
         w[0].reqRelease(req);
     }
 }
@@ -100,7 +100,7 @@ int main()
     nixlUcxReq req;
     uint8_t *buffer[2];
     uint8_t *chk_buffer;
-    nixl_xfer_state_t ret;
+    nixl_status_t ret;
     size_t buf_size = 128 * 1024 * 1024; /* Use large buffer to ensure non-inline transfer */
     size_t i;
 

--- a/test/agent_example.cpp
+++ b/test/agent_example.cpp
@@ -238,11 +238,11 @@ nixl_status_t sideXferTest(nixlAgent* A1, nixlAgent* A2, nixlXferReqH* src_handl
     status = A1->makeXferReq(src_side, indices1, dst_side, indices1, "", NIXL_WRITE, req1);
     assert(status == NIXL_SUCCESS);
 
-    nixl_xfer_state_t xfer_status = A1->postXferReq(req1);
+    nixl_status_t xfer_status = A1->postXferReq(req1);
 
-    while(xfer_status != NIXL_XFER_DONE) {
-        if(xfer_status != NIXL_XFER_DONE) xfer_status = A1->getXferStatus(req1);
-        assert(xfer_status != NIXL_XFER_ERR);
+    while(xfer_status != NIXL_SUCCESS) {
+        if(xfer_status != NIXL_SUCCESS) xfer_status = A1->getXferStatus(req1);
+        assert(xfer_status >= 0);
     }
 
     for(int i = 0; i<(n_bufs/2); i++)
@@ -256,9 +256,9 @@ nixl_status_t sideXferTest(nixlAgent* A1, nixlAgent* A2, nixlXferReqH* src_handl
 
     xfer_status = A1->postXferReq(req2);
 
-    while(xfer_status != NIXL_XFER_DONE) {
-        if(xfer_status != NIXL_XFER_DONE) xfer_status = A1->getXferStatus(req2);
-        assert(xfer_status != NIXL_XFER_ERR);
+    while(xfer_status != NIXL_SUCCESS) {
+        if(xfer_status != NIXL_SUCCESS) xfer_status = A1->getXferStatus(req2);
+        assert(xfer_status >= 0);
     }
 
     for(int i = (n_bufs/2); i<n_bufs; i++)
@@ -272,9 +272,9 @@ nixl_status_t sideXferTest(nixlAgent* A1, nixlAgent* A2, nixlXferReqH* src_handl
 
     xfer_status = A1->postXferReq(req3);
 
-    while(xfer_status != NIXL_XFER_DONE) {
-        if(xfer_status != NIXL_XFER_DONE) xfer_status = A1->getXferStatus(req3);
-        assert(xfer_status != NIXL_XFER_ERR);
+    while(xfer_status != NIXL_SUCCESS) {
+        if(xfer_status != NIXL_SUCCESS) xfer_status = A1->getXferStatus(req3);
+        assert(xfer_status >= 0);
     }
 
     for(int i = (n_bufs/2); i<n_bufs; i++)
@@ -421,17 +421,17 @@ int main()
     ret1 = A1.createXferReq(req_src_descs, req_dst_descs, agent2, "notification", NIXL_WR_NOTIF, req_handle);
     assert(ret1 == NIXL_SUCCESS);
 
-    nixl_xfer_state_t status = A1.postXferReq(req_handle);
+    nixl_status_t status = A1.postXferReq(req_handle);
 
     std::cout << "Transfer was posted\n";
 
     nixl_notifs_t notif_map;
     int n_notifs = 0;
 
-    while(status != NIXL_XFER_DONE || n_notifs == 0) {
-        if(status != NIXL_XFER_DONE) status = A1.getXferStatus(req_handle);
+    while(status != NIXL_SUCCESS || n_notifs == 0) {
+        if(status != NIXL_SUCCESS) status = A1.getXferStatus(req_handle);
         if(n_notifs == 0) n_notifs = A2.getNotifs(notif_map);
-        assert(status != NIXL_XFER_ERR);
+        assert(status >= 0);
         assert(n_notifs >= 0);
     }
 
@@ -454,10 +454,10 @@ int main()
     status = A1.postXferReq(req_handle2);
     std::cout << "Local transfer was posted\n";
 
-    while(status != NIXL_XFER_DONE || n_notifs == 0) {
-        if(status != NIXL_XFER_DONE) status = A1.getXferStatus(req_handle2);
+    while(status != NIXL_SUCCESS || n_notifs == 0) {
+        if(status != NIXL_SUCCESS) status = A1.getXferStatus(req_handle2);
         if(n_notifs == 0) n_notifs = A1.getNotifs(notif_map);
-        assert(status != NIXL_XFER_ERR);
+        assert(status >= 0);
         assert(n_notifs >= 0);
     }
 

--- a/test/desc_example.cpp
+++ b/test/desc_example.cpp
@@ -193,15 +193,15 @@ int main()
     dlist4.print();
     dlist5.print();
 
-    assert(dlist1.remDesc(2)==-1);
+    assert(dlist1.remDesc(2)== NIXL_ERR_INVALID_PARAM);
     std::cout << dlist1.getIndex(meta3) << "\n";
     dlist1.remDesc(0);
     std::cout << dlist1.getIndex(meta3) << "\n";
-    assert(dlist2.remDesc(dlist2.getIndex(meta1))==-1);
+    assert(dlist2.remDesc(dlist2.getIndex(meta1))== NIXL_ERR_INVALID_PARAM);
     dlist2.remDesc(dlist2.getIndex(meta3));
-    assert(dlist2.getIndex(meta3)==-1);
-    assert(dlist3.getIndex(meta1)==-1);
-    assert (dlist3.remDesc(dlist3.getIndex(meta4))==-1);
+    assert(dlist2.getIndex(meta3)== NIXL_ERR_NOT_FOUND);
+    assert(dlist3.getIndex(meta1)== NIXL_ERR_NOT_FOUND);
+    assert (dlist3.remDesc(dlist3.getIndex(meta4))== NIXL_ERR_INVALID_PARAM);
 
     dlist1.print();
     dlist2.print();

--- a/test/nixl_gds_test.cpp
+++ b/test/nixl_gds_test.cpp
@@ -130,9 +130,9 @@ int main(int argc, char *argv[])
         std::cout << " GDS File IO has been posted\n";
         std::cout << " Waiting for completion\n";
 
-        while (status != NIXL_XFER_DONE) {
+        while (status != NIXL_SUCCESS) {
             status = agent.getXferStatus(treq);
-            assert(status != NIXL_XFER_ERR);
+            assert(status >= 0);
         }
         std::cout <<" Completed writing data using GDS backend\n";
         agent.invalidateXferReq(treq);
@@ -143,4 +143,3 @@ int main(int argc, char *argv[])
 
         return 0;
 }
-

--- a/test/nixl_test.cpp
+++ b/test/nixl_test.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
 
     } else {
 
-        std::cout << " Receive metadaat from Target \n";
+        std::cout << " Receive metadata from Target \n";
         std::cout << " \t -- To be handled by runtime - currently received via a TCP Stream\n";
         std::string rrstr = recvFromTarget(initiator_port);
 
@@ -222,9 +222,9 @@ int main(int argc, char *argv[]) {
         std::cout << " Initiator posted Data Path transfer\n";
         std::cout << " Waiting for completion\n";
 
-        while (status != NIXL_XFER_DONE) {
+        while (status != NIXL_SUCCESS) {
             status = agent.getXferStatus(treq);
-            assert(status != NIXL_XFER_ERR);
+            assert(status >= 0);
         }
         std::cout << " Completed Sending Data using UCX backend\n";
         agent.invalidateXferReq(treq);

--- a/test/python/nixl_bindings_test.py
+++ b/test/python/nixl_bindings_test.py
@@ -122,22 +122,21 @@ def test_agent():
 
     print(handle)
 
-    ret = agent1.postXferReq(handle)
-    assert ret != nixl.NIXL_XFER_ERR
+    status = agent1.postXferReq(handle)
+    assert status == nixl.NIXL_SUCCESS or status == nixl.NIXL_IN_PROG
 
     print("Transfer posted")
 
-    status = 0
     notifMap = {}
 
-    while status != nixl.NIXL_XFER_DONE or len(notifMap) == 0:
-        if status != nixl.NIXL_XFER_DONE:
+    while status != nixl.NIXL_SUCCESS or len(notifMap) == 0:
+        if status != nixl.NIXL_SUCCESS:
             status = agent1.getXferStatus(handle)
 
         if len(notifMap) == 0:
             notifMap = agent2.getNotifs(notifMap)
 
-        assert status != nixl.NIXL_XFER_ERR
+        assert status == nixl.NIXL_SUCCESS or status == nixl.NIXL_IN_PROG
 
     nixl_utils.verify_transfer(addr1 + offset, addr2 + offset, req_size)
     assert len(notifMap[name1]) == 1


### PR DESCRIPTION
This PR removes the nixl_xfer_state_t enum in favor of new nixl_status_t: new errors for unposted handles and a new NIXL_IN_PROG status.