### PR TITLE
nixl/plug_mgr: Show static plugins as loaded

### DIFF
--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -98,7 +98,7 @@ public:
     void addPluginDirectory(const std::string& directory);
 
     // Static Plugin Helpers
-    static void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);
+    void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);
     static std::vector<nixlStaticPluginInfo>& getStaticPlugins();
 };
 


### PR DESCRIPTION
Static plugins are already loaded so add them to the loaded_plugins list during registration.