### PR TITLE
nixl/plug_mr: Fix unload of static plugins

### DIFF
--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -260,6 +260,12 @@ std::shared_ptr<nixlPluginHandle> nixlPluginManager::loadPlugin(const std::strin
 }
 
 void nixlPluginManager::unloadPlugin(const nixl_backend_t& plugin_name) {
+    // Do no unload static plugins
+    for (const auto& splugin : getStaticPlugins()) {
+        if (splugin.name == plugin_name) {
+            return;
+        }
+    }
     loaded_plugins_.erase(plugin_name);
 }
 

--- a/test/nixl/test_plugin.cpp
+++ b/test/nixl/test_plugin.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <iostream>
+#include <set>
 #include <string>
 #include "nixl.h"
 #include "plugin_manager.h"
@@ -62,6 +63,7 @@ int verify_plugin(std::string name, nixlPluginManager& plugin_manager)
 
 int main(int argc, char** argv) {
     char *plugindir = NULL;
+    std::set<nixl_backend_t> staticPlugs;
 
     if (argc > 1 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help")) {
         print_usage(argv[0]);
@@ -84,6 +86,7 @@ int main(int argc, char** argv) {
     std::cout << "Available static plugins:" << std::endl;
     for (const auto& plugin : nixlPluginManager::getStaticPlugins()) {
         std::cout << " - " << plugin.name << std::endl;
+        staticPlugs.insert(plugin.name);
     }
 
     verify_plugin("UCX", plugin_manager);
@@ -97,6 +100,19 @@ int main(int argc, char** argv) {
 
     plugin_manager.unloadPlugin("UCX");
     plugin_manager.unloadPlugin("GDS");
+
+    // List all loaded plugins and make sure static plugins are present
+    std::cout << "Loaded plugins after unload:" << std::endl;
+    for (const auto& name : plugin_manager.getLoadedPluginNames()) {
+        std::cout << " - " << name << std::endl;
+    }
+
+    // Plugins loaded should only be the static plugins
+    if (plugin_manager.getLoadedPluginNames().size() !=
+        staticPlugs.size()) {
+        std::cout << "Static Plugins not kept loaded" << std::endl;
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Static plugins are always loaded so any unload of them should be prevented. I modified the test to make sure that if there is a static plugin it persists through load nad unload of plugins.