### PR TITLE
Mem section: Minor restructuring to move the backend decision making fully to the agent

### DIFF
--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -34,10 +34,10 @@ class nixlAgentData {
 
         nixlLocalSection                                       memorySection;
 
+        std::unordered_map<std::string, std::set<nixl_backend_t>,
+                           std::hash<std::string>, strEqual>   remoteBackends;
         std::unordered_map<std::string, nixlRemoteSection*,
                            std::hash<std::string>, strEqual>   remoteSections;
-        std::unordered_map<std::string, bknd_type_set_t,
-                           std::hash<std::string>, strEqual>   remoteBackends;
 
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);
         ~nixlAgentData();

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -27,16 +27,16 @@ class nixlAgentData {
 
         // some handle that can be used to instantiate and object from the lib
         std::map<std::string, void*>                           backendLibs;
+        backend_map_t                                          backendEngines;
 
         std::unordered_map<nixl_backend_t, nixlBackendH*>      backendHandles;
-        std::unordered_map<nixl_backend_t, nixlBackendEngine*> backendEngines;
         std::unordered_map<nixl_backend_t, std::string>        connMD; // Local info
 
         nixlLocalSection                                       memorySection;
 
         std::unordered_map<std::string, nixlRemoteSection*,
                            std::hash<std::string>, strEqual>   remoteSections;
-        std::unordered_map<std::string, backend_set_t,
+        std::unordered_map<std::string, bknd_type_set_t,
                            std::hash<std::string>, strEqual>   remoteBackends;
 
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -209,7 +209,6 @@ nixlAgent::createBackend(const nixl_backend_t &type,
         }
 
         data->backendEngines[type] = backend;
-        data->memorySection.addBackendHandler(backend);
         data->backendHandles[type] = bknd_hndl;
 
         // TODO: Check if backend supports ProgThread when threading is in agent
@@ -241,8 +240,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
 
     if (backend->supportsLocal()) {
         if (data->remoteSections.count(data->name)==0)
-            data->remoteSections[data->name] = new nixlRemoteSection(
-                                data->name, data->backendEngines);
+            data->remoteSections[data->name] = new nixlRemoteSection(data->name);
 
         ret = data->remoteSections[data->name]->loadLocalData(remote_self,
                                                               backend);
@@ -274,7 +272,7 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
     // TODO: can use getIndex for exact match before populate
     // Or in case of supporting overlapping registers with splitting,
     // add logic to find each (after todo in addDescList for local sec).
-    ret = data->memorySection.populate(trimmed, backend->getType(), resp);
+    ret = data->memorySection.populate(trimmed, backend, resp);
     if (ret != NIXL_SUCCESS)
         return ret;
     return (data->memorySection.remDescList(resp, backend));
@@ -344,12 +342,12 @@ nixlAgent::prepXferDlist (const std::string &remote_agent,
         handle->isLocal = true;
         handle->remoteAgent = "";
         ret = data->memorySection.populate(
-                   descs, backend->getType(), *(handle->descs[backend]));
+                   descs, backend, *(handle->descs[backend]));
     } else {
         handle->isLocal = false;
         handle->remoteAgent = remote_agent;
         ret = data->remoteSections[remote_agent]->populate(
-                   descs, backend->getType(), *(handle->descs[backend]));
+                   descs, backend, *(handle->descs[backend]));
     }
 
     if (ret<0) {
@@ -557,7 +555,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
         }
     } else {
         ret = data->memorySection.populate(local_descs,
-                                           backend->getType(),
+                                           backend->engine,
                                            *handle->initiatorDescs);
        if (ret!=NIXL_SUCCESS) {
             delete handle;
@@ -578,7 +576,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     // Based on the decided local backend, we check the remote counterpart
     ret = data->remoteSections[remote_agent]->populate(remote_descs,
-               handle->engine->getType(), *handle->targetDescs);
+               handle->engine, *handle->targetDescs);
     if (ret!=NIXL_SUCCESS) {
         delete handle;
         return ret;
@@ -882,9 +880,10 @@ nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
 
     if (data->remoteSections.count(remote_agent) == 0)
         data->remoteSections[remote_agent] = new nixlRemoteSection(
-                            remote_agent, data->backendEngines);
+                                                  remote_agent);
 
-    ret = data->remoteSections[remote_agent]->loadRemoteData(&sd);
+    ret = data->remoteSections[remote_agent]->loadRemoteData(&sd,
+                                                  data->backendEngines);
 
     // TODO: can be more graceful, if just the new MD blob was improper
     if (ret) {

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -29,7 +29,6 @@
 
 typedef std::pair<nixl_mem_t, nixlBackendEngine*>              section_key_t;
 typedef std::set<nixlBackendEngine*>                           backend_set_t;
-typedef std::set<nixl_backend_t>                               bknd_type_set_t;
 typedef std::unordered_map<nixl_backend_t, nixlBackendEngine*> backend_map_t;
 
 
@@ -41,9 +40,12 @@ class nixlMemSection {
     public:
         nixlMemSection () {};
 
+        backend_set_t* queryBackends (const nixl_mem_t &mem);
+
         nixl_status_t populate (const nixl_xfer_dlist_t &query,
                                 nixlBackendEngine* backend,
                                 nixl_meta_dlist_t &resp) const;
+
 
         virtual ~nixlMemSection () = 0; // Making the class abstract
 };
@@ -62,13 +64,6 @@ class nixlLocalSection : public nixlMemSection {
         // Each nixlBasicDesc should be same as original registration region
         nixl_status_t remDescList (const nixl_meta_dlist_t &mem_elms,
                                    nixlBackendEngine* backend);
-
-        // Find a nixlBasicDesc in the section, if available fills the resp based
-        // on that, and returns the backend pointer that can use the resp
-        nixlBackendEngine* findQuery (const nixl_xfer_dlist_t &query,
-                                      const nixl_mem_t &remote_nixl_mem,
-                                      const bknd_type_set_t &remote_backends,
-                                      nixl_meta_dlist_t &resp) const;
 
         nixl_status_t serialize(nixlSerDes* serializer) const;
 

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -27,8 +27,9 @@
 #include "nixl.h"
 #include "backend/backend_engine.h"
 
-typedef std::pair<nixl_mem_t, nixl_backend_t>                  section_key_t;
-typedef std::set<nixl_backend_t>                               backend_set_t;
+typedef std::pair<nixl_mem_t, nixlBackendEngine*>              section_key_t;
+typedef std::set<nixlBackendEngine*>                           backend_set_t;
+typedef std::set<nixl_backend_t>                               bknd_type_set_t;
 typedef std::unordered_map<nixl_backend_t, nixlBackendEngine*> backend_map_t;
 
 
@@ -36,14 +37,12 @@ class nixlMemSection {
     protected:
         std::array<backend_set_t, FILE_SEG+1>         memToBackendMap;
         std::map<section_key_t,   nixl_meta_dlist_t*> sectionMap;
-        // Replica of what Agent has, but tiny in size and helps with modularity
-        backend_map_t backendToEngineMap;
 
     public:
         nixlMemSection () {};
 
         nixl_status_t populate (const nixl_xfer_dlist_t &query,
-                                const nixl_backend_t &nixl_backend,
+                                nixlBackendEngine* backend,
                                 nixl_meta_dlist_t &resp) const;
 
         virtual ~nixlMemSection () = 0; // Making the class abstract
@@ -56,8 +55,6 @@ class nixlLocalSection : public nixlMemSection {
                                const nixlBackendEngine* backend,
                                const nixl_meta_dlist_t &d_list) const;
     public:
-        nixl_status_t addBackendHandler (nixlBackendEngine* backend);
-
         nixl_status_t addDescList (const nixl_reg_dlist_t &mem_elms,
                                    nixlBackendEngine* backend,
                                    nixl_meta_dlist_t &remote_self);
@@ -70,7 +67,7 @@ class nixlLocalSection : public nixlMemSection {
         // on that, and returns the backend pointer that can use the resp
         nixlBackendEngine* findQuery (const nixl_xfer_dlist_t &query,
                                       const nixl_mem_t &remote_nixl_mem,
-                                      const backend_set_t &remote_backends,
+                                      const bknd_type_set_t &remote_backends,
                                       nixl_meta_dlist_t &resp) const;
 
         nixl_status_t serialize(nixlSerDes* serializer) const;
@@ -87,10 +84,10 @@ class nixlRemoteSection : public nixlMemSection {
                            const nixl_reg_dlist_t &mem_elms,
                            nixlBackendEngine *backend);
     public:
-        nixlRemoteSection (const std::string &agent_name,
-                           backend_map_t &engine_map);
+        nixlRemoteSection (const std::string &agent_name);
 
-        nixl_status_t loadRemoteData (nixlSerDes* deserializer);
+        nixl_status_t loadRemoteData (nixlSerDes* deserializer,
+                                      backend_map_t &backendToEngineMap);
 
         // When adding self as a remote agent for local operations
         nixl_status_t loadLocalData (const nixl_meta_dlist_t& mem_elms,

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -27,12 +27,12 @@
 nixlMemSection::~nixlMemSection () {}
 
 nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
-                                        const nixl_backend_t &nixl_backend,
+                                        nixlBackendEngine* backend,
                                         nixl_meta_dlist_t &resp) const {
 
     if (query.getType() != resp.getType())
         return NIXL_ERR_INVALID_PARAM;
-    section_key_t sec_key = std::make_pair(query.getType(), nixl_backend);
+    section_key_t sec_key = std::make_pair(query.getType(), backend);
     auto it = sectionMap.find(sec_key);
     if (it==sectionMap.end())
         return NIXL_ERR_NOT_FOUND;
@@ -68,14 +68,6 @@ nixl_reg_dlist_t nixlLocalSection::getStringDesc (
     return output_desclist;
 }
 
-nixl_status_t nixlLocalSection::addBackendHandler (nixlBackendEngine* backend) {
-    if (!backend)
-        return NIXL_ERR_INVALID_PARAM;
-    // Agent has already checked for not being the same type of backend
-    backendToEngineMap[backend->getType()] = backend;
-    return NIXL_SUCCESS;
-}
-
 // Calls into backend engine to register the memories in the desc list
 nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
                                              nixlBackendEngine* backend,
@@ -85,8 +77,7 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
         return NIXL_ERR_INVALID_PARAM;
     // Find the MetaDesc list, or add it to the map
     nixl_mem_t     nixl_mem     = mem_elms.getType();
-    nixl_backend_t nixl_backend = backend->getType();
-    section_key_t  sec_key      = std::make_pair(nixl_mem, nixl_backend);
+    section_key_t  sec_key      = std::make_pair(nixl_mem, backend);
 
     if ((nixl_mem == FILE_SEG) && mem_elms.isUnifiedAddr())
         return NIXL_ERR_INVALID_PARAM;
@@ -95,7 +86,7 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
     if (it==sectionMap.end()) { // New desc list
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-        memToBackendMap[nixl_mem].insert(nixl_backend);
+        memToBackendMap[nixl_mem].insert(backend);
     }
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
@@ -149,8 +140,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_meta_dlist_t &mem_elms,
     if (!backend)
         return NIXL_ERR_INVALID_PARAM;
     nixl_mem_t     nixl_mem     = mem_elms.getType();
-    nixl_backend_t nixl_backend = backend->getType();
-    section_key_t sec_key = std::make_pair(nixl_mem, nixl_backend);
+    section_key_t sec_key = std::make_pair(nixl_mem, backend);
     auto it = sectionMap.find(sec_key);
     if (it==sectionMap.end())
         return NIXL_ERR_NOT_FOUND;
@@ -172,7 +162,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_meta_dlist_t &mem_elms,
     if (target->descCount()==0){
         delete target;
         sectionMap.erase(sec_key);
-        memToBackendMap[nixl_mem].erase(nixl_backend);
+        memToBackendMap[nixl_mem].erase(backend);
     }
 
     return NIXL_SUCCESS;
@@ -181,7 +171,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_meta_dlist_t &mem_elms,
 nixlBackendEngine* nixlLocalSection::findQuery(
                        const nixl_xfer_dlist_t &query,
                        const nixl_mem_t &remote_nixl_mem,
-                       const backend_set_t &remote_backends,
+                       const bknd_type_set_t &remote_backends,
                        nixl_meta_dlist_t &resp) const {
 
     nixlBackendEngine* backend = nullptr;
@@ -203,7 +193,7 @@ nixlBackendEngine* nixlLocalSection::findQuery(
     for (auto & elm : *backend_set) {
         // If populate fails, it clears the resp before return
         if (populate(query, elm, resp) == NIXL_SUCCESS)
-            return backendToEngineMap.at(elm);
+            return elm;
     }
     return backend;
 }
@@ -211,20 +201,18 @@ nixlBackendEngine* nixlLocalSection::findQuery(
 nixl_status_t nixlLocalSection::serialize(nixlSerDes* serializer) const {
     nixl_status_t ret;
     size_t seg_count = sectionMap.size();
-    nixl_backend_t nixl_backend;
     nixlBackendEngine* eng;
 
     ret = serializer->addBuf("nixlSecElms", &seg_count, sizeof(seg_count));
     if (ret) return ret;
 
     for (auto &seg : sectionMap) {
-        nixl_backend = seg.first.second;
-        eng = backendToEngineMap.at(nixl_backend);
+        eng = seg.first.second;
         if (!eng->supportsRemote())
             continue;
 
         nixl_reg_dlist_t s_desc = getStringDesc(eng, *seg.second);
-        ret = serializer->addStr("bknd", nixl_backend);
+        ret = serializer->addStr("bknd", eng->getType());
         if (ret) return ret;
         ret = s_desc.serialize(serializer);
         if (ret) return ret;
@@ -235,16 +223,13 @@ nixl_status_t nixlLocalSection::serialize(nixlSerDes* serializer) const {
 
 nixlLocalSection::~nixlLocalSection() {
     for (auto &seg : sectionMap)
-        remDescList(*seg.second, backendToEngineMap[seg.first.second]);
+        remDescList(*seg.second, seg.first.second);
 }
 
 /*** Class nixlRemoteSection implementation ***/
 
-nixlRemoteSection::nixlRemoteSection (
-                   const std::string &agent_name,
-                   backend_map_t &engine_map) {
+nixlRemoteSection::nixlRemoteSection (const std::string &agent_name) {
     this->agentName    = agent_name;
-    backendToEngineMap = engine_map;
 }
 
 nixl_status_t nixlRemoteSection::addDescList (
@@ -257,12 +242,11 @@ nixl_status_t nixlRemoteSection::addDescList (
     // In RemoteSection, if we support updates, value for a key gets overwritten
     // Without it, its corrupt data, we keep the last option without raising an error
     nixl_mem_t     nixl_mem     = mem_elms.getType();
-    nixl_backend_t nixl_backend = backend->getType();
-    section_key_t sec_key = std::make_pair(nixl_mem, nixl_backend);
+    section_key_t sec_key = std::make_pair(nixl_mem, backend);
     if (sectionMap.count(sec_key) == 0)
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-    memToBackendMap[nixl_mem].insert(nixl_backend); // Fine to overwrite, it's a set
+    memToBackendMap[nixl_mem].insert(backend); // Fine to overwrite, it's a set
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
 
@@ -286,7 +270,8 @@ nixl_status_t nixlRemoteSection::addDescList (
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlRemoteSection::loadRemoteData (nixlSerDes* deserializer) {
+nixl_status_t nixlRemoteSection::loadRemoteData (nixlSerDes* deserializer,
+                                                 backend_map_t &backendToEngineMap) {
     nixl_status_t ret;
     size_t seg_count;
     nixl_backend_t nixl_backend;
@@ -317,33 +302,29 @@ nixl_status_t nixlRemoteSection::loadLocalData (
         return NIXL_ERR_UNKNOWN;
 
     nixl_mem_t     nixl_mem     = mem_elms.getType();
-    nixl_backend_t nixl_backend = backend->getType();
-    section_key_t sec_key = std::make_pair(nixl_mem, nixl_backend);
+    section_key_t sec_key = std::make_pair(nixl_mem, backend);
 
     if (sectionMap.count(sec_key) == 0)
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-    memToBackendMap[nixl_mem].insert(nixl_backend); // Fine to overwrite, it's a set
+    memToBackendMap[nixl_mem].insert(backend); // Fine to overwrite, it's a set
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
     for (auto & elm: mem_elms)
         target->addDesc(elm);
 
-    if(backendToEngineMap.count(nixl_backend)==0)
-        backendToEngineMap[nixl_backend]=backend;
-
     return NIXL_SUCCESS;
 }
 
 nixlRemoteSection::~nixlRemoteSection() {
-    nixl_backend_t nixl_backend;
     nixl_meta_dlist_t *m_desc;
+    nixlBackendEngine* eng;
 
     for (auto &seg : sectionMap) {
-        nixl_backend = seg.first.second;
+        eng = seg.first.second;
         m_desc = seg.second;
         for (auto & elm : *m_desc)
-            backendToEngineMap[nixl_backend]->unloadMD(elm.metadataP);
+            eng->unloadMD(elm.metadataP);
         delete m_desc;
     }
     // nixlMemSection destructor will clean up the rest


### PR DESCRIPTION
* Using backend pointer in the section key, look ups are easier and in future multiple backends of the same type can be handled eaiser.
* With the previous changes and some method arguments changes in the memory section classes, now only the deserializer for remote section memory requires a map from backend type to backend engine, which is passed by reference in agent which holds such a map.