### PR TITLE
Mkhazraee/auto register

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -32,7 +32,7 @@ class nixlBackendOptionalArgs {
     public:
         // During postXfer, user might ask for a notification if supported
         nixl_blob_t notifMsg;
-        bool        hasNotif;
+        bool        hasNotif = false;
 };
 
 typedef nixlBackendOptionalArgs nixl_opt_b_args_t;

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -31,7 +31,7 @@ class nixlAgentData {
         std::map<std::string, void*> backendLibs;
 
         // Bookkeeping from backend type and memory type to backend engine
-        backend_set_t                          notifEngines;
+        backend_list_t                         notifEngines;
         backend_map_t                          backendEngines;
         std::array<backend_list_t, FILE_SEG+1> memToBackend;
 

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -31,6 +31,7 @@ class nixlAgentData {
         std::map<std::string, void*> backendLibs;
 
         // Bookkeeping from backend type and memory type to backend engine
+        backend_set_t                          notifEngines;
         backend_map_t                          backendEngines;
         std::array<backend_list_t, FILE_SEG+1> memToBackend;
 

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -25,13 +25,18 @@ class nixlAgentData {
         std::string     name;
         nixlAgentConfig config;
 
-        // some handle that can be used to instantiate and object from the lib
+        // some handle that can be used to instantiate an object from the lib
         std::map<std::string, void*>                           backendLibs;
+
+        // Bookkeeping from backend type and memory type to backend engine
         backend_map_t                                          backendEngines;
+        std::array<backend_set_t, FILE_SEG+1>                  memToBackend;
 
+        // Bookkeping for local connection metadata and user handles per backend
         std::unordered_map<nixl_backend_t, nixlBackendH*>      backendHandles;
-        std::unordered_map<nixl_backend_t, std::string>        connMD; // Local info
+        std::unordered_map<nixl_backend_t, std::string>        connMD;
 
+        // Local section, and Remote sections and their available common backends
         nixlLocalSection                                       memorySection;
 
         std::unordered_map<std::string, std::set<nixl_backend_t>,

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -20,29 +20,31 @@
 #include "common/str_tools.h"
 #include "mem_section.h"
 
+typedef std::vector<nixlBackendEngine*> backend_list_t;
+
 class nixlAgentData {
     private:
         std::string     name;
         nixlAgentConfig config;
 
         // some handle that can be used to instantiate an object from the lib
-        std::map<std::string, void*>                           backendLibs;
+        std::map<std::string, void*> backendLibs;
 
         // Bookkeeping from backend type and memory type to backend engine
-        backend_map_t                                          backendEngines;
-        std::array<backend_set_t, FILE_SEG+1>                  memToBackend;
+        backend_map_t                          backendEngines;
+        std::array<backend_list_t, FILE_SEG+1> memToBackend;
 
         // Bookkeping for local connection metadata and user handles per backend
-        std::unordered_map<nixl_backend_t, nixlBackendH*>      backendHandles;
-        std::unordered_map<nixl_backend_t, std::string>        connMD;
+        std::unordered_map<nixl_backend_t, nixlBackendH*> backendHandles;
+        std::unordered_map<nixl_backend_t, std::string>   connMD;
 
         // Local section, and Remote sections and their available common backends
-        nixlLocalSection                                       memorySection;
+        nixlLocalSection                                         memorySection;
 
         std::unordered_map<std::string, std::set<nixl_backend_t>,
-                           std::hash<std::string>, strEqual>   remoteBackends;
+                           std::hash<std::string>, strEqual>     remoteBackends;
         std::unordered_map<std::string, nixlRemoteSection*,
-                           std::hash<std::string>, strEqual>   remoteSections;
+                           std::hash<std::string>, strEqual>     remoteSections;
 
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);
         ~nixlAgentData();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -150,10 +150,11 @@ nixlAgent::createBackend(const nixl_backend_t &type,
                          const nixl_b_params_t &params,
                          nixlBackendH* &bknd_hndl) {
 
+    nixlBackendEngine*    backend = nullptr;
     nixlBackendInitParams init_params;
-    nixlBackendEngine* backend = nullptr;
-    nixl_status_t ret;
-    std::string str;
+    nixl_mem_list_t       mems;
+    nixl_status_t         ret;
+    std::string           str;
 
     // Registering same type of backend is not supported, unlikely and prob error
     if (data->backendEngines.count(type)!=0)
@@ -173,7 +174,6 @@ nixlAgent::createBackend(const nixl_backend_t &type,
         // Plugin found, use it to create the backend
         backend = plugin_handle->createEngine(&init_params);
     } else {
-        // Fallback to built-in backends
         std::cout << "Unsupported backend: " << type << std::endl;
         return NIXL_ERR_NOT_FOUND;
     }
@@ -210,6 +210,9 @@ nixlAgent::createBackend(const nixl_backend_t &type,
 
         data->backendEngines[type] = backend;
         data->backendHandles[type] = bknd_hndl;
+        mems = backend->getSupportedMems();
+        for (auto & elm : mems)
+            data->memToBackend[elm].insert(backend);
 
         // TODO: Check if backend supports ProgThread when threading is in agent
     }

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -21,26 +21,21 @@
 // and verified DescLists, and other state and metadata needed for a NIXL transfer
 class nixlXferReqH {
     private:
-        nixlBackendEngine* engine;
-        nixlBackendReqH*   backendHandle;
+        nixlBackendEngine* engine         = nullptr;
+        nixlBackendReqH*   backendHandle  = nullptr;
 
-        nixl_meta_dlist_t* initiatorDescs;
-        nixl_meta_dlist_t* targetDescs;
+        nixl_meta_dlist_t* initiatorDescs = nullptr;
+        nixl_meta_dlist_t* targetDescs    = nullptr;
 
         std::string        remoteAgent;
         nixl_blob_t        notifMsg;
-        bool               hasNotif;
+        bool               hasNotif       = false;
 
         nixl_xfer_op_t     backendOp;
         nixl_status_t      status;
 
     public:
-        inline nixlXferReqH() {
-            initiatorDescs = nullptr;
-            targetDescs    = nullptr;
-            engine         = nullptr;
-            backendHandle  = nullptr;
-        }
+        inline nixlXferReqH() { }
 
         inline ~nixlXferReqH() {
             // delete checks for nullptr itself

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -34,7 +34,7 @@ typedef std::unordered_map<nixl_backend_t, nixlBackendEngine*> backend_map_t;
 
 class nixlMemSection {
     protected:
-        std::array<backend_set_t, FILE_SEG+1>         memToBackendMap;
+        std::array<backend_set_t, FILE_SEG+1>         memToBackend;
         std::map<section_key_t,   nixl_meta_dlist_t*> sectionMap;
 
     public:

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -30,7 +30,7 @@ backend_set_t* nixlMemSection::queryBackends (const nixl_mem_t &mem) {
     if (mem<DRAM_SEG || mem>FILE_SEG)
         return nullptr;
     else
-        return &memToBackendMap[mem];
+        return &memToBackend[mem];
 }
 
 nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
@@ -93,7 +93,7 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
     if (it==sectionMap.end()) { // New desc list
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-        memToBackendMap[nixl_mem].insert(backend);
+        memToBackend[nixl_mem].insert(backend);
     }
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
@@ -169,7 +169,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_meta_dlist_t &mem_elms,
     if (target->descCount()==0){
         delete target;
         sectionMap.erase(sec_key);
-        memToBackendMap[nixl_mem].erase(backend);
+        memToBackend[nixl_mem].erase(backend);
     }
 
     return NIXL_SUCCESS;
@@ -223,7 +223,7 @@ nixl_status_t nixlRemoteSection::addDescList (
     if (sectionMap.count(sec_key) == 0)
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-    memToBackendMap[nixl_mem].insert(backend); // Fine to overwrite, it's a set
+    memToBackend[nixl_mem].insert(backend); // Fine to overwrite, it's a set
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
 
@@ -284,7 +284,7 @@ nixl_status_t nixlRemoteSection::loadLocalData (
     if (sectionMap.count(sec_key) == 0)
         sectionMap[sec_key] = new nixl_meta_dlist_t(
                                   nixl_mem, mem_elms.isUnifiedAddr(), true);
-    memToBackendMap[nixl_mem].insert(backend); // Fine to overwrite, it's a set
+    memToBackend[nixl_mem].insert(backend); // Fine to overwrite, it's a set
     nixl_meta_dlist_t *target = sectionMap[sec_key];
 
     for (auto & elm: mem_elms)

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -218,7 +218,7 @@ nixl_status_t nixlRemoteSection::addDescList (
     // Less checks than LocalSection, as it's private and called by loadRemoteData
     // In RemoteSection, if we support updates, value for a key gets overwritten
     // Without it, its corrupt data, we keep the last option without raising an error
-    nixl_mem_t     nixl_mem     = mem_elms.getType();
+    nixl_mem_t nixl_mem   = mem_elms.getType();
     section_key_t sec_key = std::make_pair(nixl_mem, backend);
     if (sectionMap.count(sec_key) == 0)
         sectionMap[sec_key] = new nixl_meta_dlist_t(

--- a/test/python/nixl_exception_test.py
+++ b/test/python/nixl_exception_test.py
@@ -21,21 +21,9 @@ from nixl._api import nixl_agent
 if __name__ == "__main__":
     nixl_agent1 = nixl_agent("bad agent", None)
 
-    buf_size = 256
-    addr1 = nixl_utils.malloc_passthru(buf_size * 2)
-    addr2 = addr1 + buf_size
-
-    agent1_addrs = [(addr1, buf_size, 0), (addr2, buf_size, 0)]
-    agent1_strings = [(addr1, buf_size, 0, "a"), (addr2, buf_size, 0, "b")]
-
-    agent1_reg_descs = nixl_agent1.get_reg_descs(agent1_strings, "DRAM", True)
-
-    agent1_xfer_descs = nixl_agent1.get_xfer_descs(agent1_addrs, "DRAM", True)
-
     try:
-        # null backend not supported
-        nixl_agent1.backends["UVX"] = 0
-        nixl_agent1.register_memory(agent1_reg_descs, backend="UVX")
+        # oops, I can't spell
+        nixl_agent1.create_backend("UVX")
     except Exception as e:
         print("Caught you!")
         print(e)

--- a/test/python/nixl_exception_test.py
+++ b/test/python/nixl_exception_test.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import nixl._utils as nixl_utils
 from nixl._api import nixl_agent
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds support for automatic selection of backend, or specifying a list by the user:
- In registerMem/deregisterMem/prepXferDlist, user can provide no backends, and based on the memory type we would register with the relevant backends. They can also provide a list of backends instead of a single backend, and we will register with those.
- In createXferReq they can provide a set to limit which backends are explored in the decision making. The decision making logic is also more comprehensive now.
- In makeXferReq, it goes over the available backends in each prepXferDlist per side, and find a common one to deliver.
- In getNotifs they can provide a set to limit which backends they want to get the notifications from.
- In genNotif they can provide a list of backends, and we would use the first one that can deliver the notification.
- Since the exception handling test was checking the ERR_NOT_SUPPORTED, and we added features for those cases, had to change the code to look for another exception.
- A minor initialization bug was also fixed.