### PR TITLE
ucx_utils: Fix performance issue with ucp_get_nbx path

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -199,7 +199,8 @@ int nixlUcxWorker::connect(void* addr, size_t size, nixlUcxEp &ep)
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
                            UCP_EP_PARAM_FIELD_ERR_HANDLER |
                            UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
-    ep_params.err_mode = UCP_ERR_HANDLING_MODE_PEER;
+    ep_params.err_mode = UCP_ERR_HANDLING_MODE_NONE; // TODO: Need to be UCP_ERR_HANDLING_MODE_PEER
+                                                     // to properly handle disconnect
     ep_params.err_handler.cb = err_cb;
     ep_params.address = (ucp_address_t*) addr;
 

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -199,8 +199,9 @@ int nixlUcxWorker::connect(void* addr, size_t size, nixlUcxEp &ep)
     ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS |
                            UCP_EP_PARAM_FIELD_ERR_HANDLER |
                            UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE;
-    ep_params.err_mode = UCP_ERR_HANDLING_MODE_NONE; // TODO: Need to be UCP_ERR_HANDLING_MODE_PEER
-                                                     // to properly handle disconnect
+    // TODO: Need to be UCP_ERR_HANDLING_MODE_PEER to properly handle disconnect
+    ep_params.err_mode = UCP_ERR_HANDLING_MODE_NONE;
+
     ep_params.err_handler.cb = err_cb;
     ep_params.address = (ucp_address_t*) addr;
 


### PR DESCRIPTION
* Issue: UCP falls back to send-recv instead of RDMA READ
* Fix: Temporarily disable UCP_ERR_HANDLING_MODE_PEER during ep create