### PR TITLE
Multi-Object (MO) UCX backend implementation (rebased over code restructuring PR)

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -19,6 +19,11 @@ if 'UCX' in static_plugins
     nixl_lib_deps += [ ucx_backend_interface, cuda_dep ]
 endif
 
+if 'UCX_MO' in static_plugins
+    nixl_lib_deps += [ ucx_mo_backend_interface, cuda_dep ]
+endif
+
+
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and cuda_dep.found()
     nixl_lib_deps += [ gds_backend_interface, cuda_dep ]

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ucx_backend_inc_dirs = include_directories('./ucx')
+
 subdir('ucx')
+subdir('ucx_mo')
 
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and cuda_dep.found()

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -18,6 +18,19 @@
 #include "serdes/serdes.h"
 #include <cassert>
 
+#ifdef HAVE_CUDA
+
+#include <cuda_runtime.h>
+#include <cufile.h>
+
+#endif
+
+
+
+/****************************************
+ * CUDA related code
+ *****************************************/
+
 class nixlUcxCudaCtx {
 public:
 #ifdef HAVE_CUDA
@@ -33,10 +46,6 @@ public:
 };
 
 #ifdef HAVE_CUDA
-
-/****************************************
- * CUDA related code
-*****************************************/
 
 static int cudaQueryAddr(void *address, bool &is_dev,
                          CUdevice &dev, CUcontext &ctx)

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -32,13 +32,6 @@
 #include "ucx/ucx_utils.h"
 #include "common/list_elem.h"
 
-#ifdef HAVE_CUDA
-
-#include <cuda_runtime.h>
-#include <cufile.h>
-
-#endif
-
 typedef enum {CONN_CHECK, NOTIF_STR, DISCONNECT} ucx_cb_op_t;
 
 struct nixl_ucx_am_hdr {

--- a/src/plugins/ucx_mo/meson.build
+++ b/src/plugins/ucx_mo/meson.build
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ucx_mo_utils_dep = declare_dependency(link_with: [ucx_utils_lib, ucx_backend_lib],
+                                      include_directories: [utils_inc_dirs, ucx_backend_inc_dirs] )
+
+compile_flags = []
+if cuda_dep.found()
+    compile_flags = [ '-DHAVE_CUDA' ]
+endif
+
+if 'UCX_MO' in static_plugins
+    ucx_mo_backend_lib = static_library('UCX_MO',
+               'ucx_mo_backend.cpp', 'ucx_mo_backend.h', 'ucx_mo_plugin.cpp',
+               dependencies: [nixl_infra, ucx_utils_dep, serdes_interface, cuda_dep, ucx_dep],
+               link_with: [ucx_backend_lib],
+               include_directories: [nixl_inc_dirs, utils_inc_dirs, ucx_backend_inc_dirs],
+               install: false,
+               cpp_args : compile_flags,
+               name_prefix: 'libplugin_') # Custom prefix for plugin libraries
+else
+    ucx_mo_backend_lib = shared_library('UCX_MO',
+               'ucx_mo_backend.cpp', 'ucx_mo_backend.h', 'ucx_mo_plugin.cpp',
+               dependencies: [nixl_infra, ucx_utils_dep, serdes_interface, cuda_dep, ucx_dep],
+               link_with: [ucx_backend_lib],
+               include_directories: [nixl_inc_dirs, utils_inc_dirs, ucx_backend_inc_dirs],
+               install: true,
+               cpp_args : compile_flags + ['-fPIC'],
+               name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
+               install_dir: plugin_install_dir)
+
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+                    'echo "UCX_MO=' + ucx_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+                    check: true
+                )
+    endif
+endif
+
+ucx_mo_backend_interface = declare_dependency(link_with: ucx_mo_backend_lib)

--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -1,0 +1,661 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+#include <cassert>
+
+
+// Local includes
+#include <nixl.h>
+#include <common/nixl_time.h>
+#include <serdes/serdes.h>
+#include <ucx_mo_backend.h>
+
+using namespace std;
+
+/****************************************
+ * CUDA related code
+*****************************************/
+
+#ifdef HAVE_CUDA
+
+#include <cuda_runtime.h>
+
+static uint32_t _getNumVramDevices()
+{
+    cudaError_t result;
+    int n_vram_dev;
+    result = cudaGetDeviceCount(&n_vram_dev);
+    if (result != cudaSuccess) {
+        return 0;
+    } else {
+        return n_vram_dev;
+    }
+}
+
+
+#else
+
+static uint32_t _getNumVramDevices(){
+    return 0;
+}
+
+#endif
+
+/****************************************
+ * UCX Engine management
+*****************************************/
+
+
+int
+nixlUcxMoEngine::setEngCnt(uint32_t num_host)
+{
+    _gpuCnt = _getNumVramDevices();
+    _engineCnt = (_gpuCnt > num_host) ? _gpuCnt : num_host;
+    return 0;
+}
+
+uint32_t
+nixlUcxMoEngine::getEngCnt()
+{
+    return _engineCnt;
+}
+
+int32_t
+nixlUcxMoEngine::getEngIdx(nixl_mem_t type, uint32_t devId)
+{
+    switch (type) {
+    case VRAM_SEG:
+        assert(devId < _gpuCnt);
+        if (!(devId < _gpuCnt)) {
+            return -1;
+        }
+    case DRAM_SEG:
+        break;
+    default:
+        return -1;
+    }
+    assert(devId < _engineCnt);
+    return (devId < _engineCnt) ? devId : -1;
+}
+
+string
+nixlUcxMoEngine::getEngName(const string &baseName, uint32_t eidx)
+{
+    return baseName + ":" + to_string(eidx);
+}
+
+string
+nixlUcxMoEngine::getEngBase(const string &engName)
+{
+    // find the last occurrence (agent name may have colon in its name)
+    if (string::npos == engName.find_last_of(":")) {
+        assert(engName.find_last_of(":") != string::npos);
+        return engName;
+    }
+    return engName.substr(0, engName.find_last_of(":"));
+}
+
+/****************************************
+ * Constructor/Destructor
+*****************************************/
+
+nixlUcxMoEngine::nixlUcxMoEngine(const nixlBackendInitParams* init_params):
+                                 nixlBackendEngine(init_params)
+{
+    nixl_b_params_t* custom_params = init_params->customParams;
+    uint32_t num_ucx_engines = 1;
+    if (custom_params->count("num_ucx_engines")) {
+        const char *cptr = (*custom_params)["num_ucx_engines"].c_str();
+        char *eptr;
+        uint32_t tmp = strtoul(cptr, &eptr, 0);
+        if ( (size_t)(eptr - cptr) == (*custom_params)["num_ucx_engines"].length()) {
+            num_ucx_engines = tmp;
+        } else {
+            this->initErr = true;
+            // TODO: Log error
+            return;
+        }
+    }
+
+    setEngCnt(num_ucx_engines);
+    // Initialize required number of engines
+    for (uint32_t i = 0; i < getEngCnt(); i++) {
+        nixlBackendEngine *e;
+        e = (nixlBackendEngine *)new nixlUcxEngine(init_params);
+        engines.push_back(e);
+        if (engines[0]->getInitErr()) {
+            this->initErr = true;
+            // TODO: Log error
+            return;
+        }
+    }
+}
+
+nixl_mem_list_t
+nixlUcxMoEngine::getSupportedMems () const {
+    nixl_mem_list_t mems;
+    mems.push_back(DRAM_SEG);
+    // TODO: test and open this feature in a follow-up
+    //mems.push_back(VRAM_SEG);
+    return mems;
+}
+
+nixlUcxMoEngine::~nixlUcxMoEngine()
+{
+    for( auto &e : engines ) {
+        delete e;
+    }
+}
+
+/****************************************
+ * Connection management
+*****************************************/
+
+nixl_status_t
+nixlUcxMoEngine::getConnInfo(std::string &str) const
+{
+    nixlSerDes sd;
+    nixl_status_t status;
+
+    // Serialize the number of engines
+    size_t sz = engines.size();
+    sd.addBuf("Count", &sz, sizeof(sz));
+
+    for( auto &e : engines ) {
+        string s;
+        status = e->getConnInfo(s);
+        if (NIXL_SUCCESS != status) {
+            return status;
+        }
+        sd.addStr("Value", s);
+    }
+
+    str = sd.exportStr();
+    return NIXL_SUCCESS;
+}
+
+
+nixl_status_t
+nixlUcxMoEngine::loadRemoteConnInfo (const string  &remote_agent,
+                                     const string &remote_conn_info)
+{
+    nixlSerDes sd;
+    nixlUcxMoConnection conn;
+    nixl_status_t status;
+    size_t sz;
+    remote_comm_it_t it = remoteConnMap.find(remote_agent);
+
+    if(it != remoteConnMap.end()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    conn.remoteAgent = remote_agent;
+
+    status = sd.importStr(remote_conn_info);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    ssize_t ret = sd.getBufLen("Count");
+    if (ret != sizeof(sz)) {
+        return NIXL_ERR_MISMATCH;
+    }
+    status = sd.getBuf("Count", &sz, ret);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    conn.num_engines = sz;
+
+    for(size_t idx = 0; idx < sz; idx++) {
+        string cinfo;
+        cinfo = sd.getStr("Value");
+        for (auto &e : engines) {
+            status = e->loadRemoteConnInfo(getEngName(remote_agent, idx), cinfo);
+            if (status != NIXL_SUCCESS) {
+                return status;
+            }
+        }
+    }
+
+    remoteConnMap[remote_agent] = conn;
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::connect(const string &remote_agent)
+{
+    remote_comm_it_t it = remoteConnMap.find(remote_agent);
+    nixl_status_t status;
+
+    if(it == remoteConnMap.end()) {
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    nixlUcxMoConnection &conn = it->second;
+
+    for (auto &e : engines) {
+        for (uint32_t idx = 0; idx < conn.num_engines; idx++) {
+            status = e->connect(getEngName(remote_agent, idx));
+            if (status != NIXL_SUCCESS) {
+                return status;
+            }
+        }
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::disconnect(const string &remote_agent)
+{
+    nixl_status_t status;
+    remote_comm_it_t it = remoteConnMap.find(remote_agent);
+
+    if(it == remoteConnMap.end()) {
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    nixlUcxMoConnection &conn = it->second;
+
+    for (auto &e : engines) {
+        for (uint32_t idx = 0; idx < conn.num_engines; idx++) {
+            status = e->disconnect(getEngName(remote_agent, idx));
+            if (status != NIXL_SUCCESS) {
+                return status;
+            }
+        }
+    }
+
+    remoteConnMap.erase(remote_agent);
+
+    return NIXL_SUCCESS;
+}
+
+/****************************************
+ * Memory management
+*****************************************/
+
+
+nixl_status_t
+nixlUcxMoEngine::registerMem (const nixlBlobDesc &mem,
+                              const nixl_mem_t &nixl_mem,
+                              nixlBackendMD* &out)
+{
+    nixlUcxMoPrivateMetadata *priv = new nixlUcxMoPrivateMetadata;
+    int32_t eidx = getEngIdx(nixl_mem, mem.devId);
+    nixlSerDes sd;
+    string str;
+    nixl_status_t status;
+
+    if (eidx < 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    priv->eidx = eidx;
+    engines[eidx]->registerMem(mem, nixl_mem, priv->md);
+
+    sd.addBuf("EngIdx", &eidx, sizeof(eidx));
+    status = engines[eidx]->getPublicData(priv->md, str);
+    if (NIXL_SUCCESS != status) {
+        return status;
+    }
+    sd.addStr("RkeyStr", str);
+    priv->rkeyStr = sd.exportStr();
+    out = (nixlBackendMD*) priv;
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::getPublicData (const nixlBackendMD* meta,
+                                std::string &str) const
+{
+    const nixlUcxMoPrivateMetadata *priv = (nixlUcxMoPrivateMetadata*) meta;
+    str = priv->get();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::deregisterMem (nixlBackendMD* meta)
+{
+    nixlUcxMoPrivateMetadata *priv = (nixlUcxMoPrivateMetadata*) meta;
+
+    engines[priv->eidx]->deregisterMem(priv->md);
+    delete priv;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::loadLocalMD(nixlBackendMD* input,
+                             nixlBackendMD* &output)
+{
+    // TODO
+    return NIXL_ERR_NOT_FOUND;
+}
+
+nixl_status_t
+nixlUcxMoEngine::loadRemoteMD (const nixlBlobDesc &input,
+                               const nixl_mem_t &nixl_mem,
+                               const string &remote_agent,
+                               nixlBackendMD* &output)
+{
+    nixlUcxMoConnection conn;
+    nixlSerDes sd;
+    string rkeyStr;
+    nixl_status_t status;
+    nixlBlobDesc input_int;
+
+    nixlUcxMoPublicMetadata *md = new nixlUcxMoPublicMetadata;
+
+    auto search = remoteConnMap.find(remote_agent);
+
+    if(search == remoteConnMap.end()) {
+        //TODO: err: remote connection not found
+        return NIXL_ERR_NOT_FOUND;
+    }
+    conn = (nixlUcxMoConnection) search->second;
+
+    status = sd.importStr(input.metaInfo);
+
+    ssize_t ret = sd.getBufLen("EngIdx");
+    if (ret != sizeof(md->eidx)) {
+        return NIXL_ERR_MISMATCH;
+    }
+    status = sd.getBuf("EngIdx", &md->eidx, ret);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    rkeyStr = sd.getStr("RkeyStr");
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    for (auto &e : engines) {
+        nixlBackendMD *int_md;
+        input_int.metaInfo = rkeyStr;
+        status = e->loadRemoteMD(input_int, nixl_mem,
+                                 getEngName(remote_agent, md->eidx),
+                                 int_md);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        md->int_mds.push_back(int_md);
+    }
+
+    output = (nixlBackendMD*)md;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxMoEngine::unloadMD (nixlBackendMD* input)
+{
+    nixl_status_t status;
+
+    nixlUcxMoPublicMetadata *md = (nixlUcxMoPublicMetadata *)input;
+    for (size_t i = 0; i < md->int_mds.size(); i++) {
+        status = engines[i]->unloadMD(md->int_mds[i]);
+        if (NIXL_SUCCESS != status) {
+            return status;
+        }
+    }
+    return NIXL_SUCCESS;
+}
+
+/****************************************
+ * Data movement
+*****************************************/
+
+void
+nixlUcxMoEngine::cancelRequests(nixlUcxMoRequestH *req)
+{
+    // Iterate over all elements cancelling each one
+    for ( auto &p : req->reqs ) {
+        p.first->releaseReqH(p.second);
+        p.first = NULL;
+        p.second = NULL;
+    }
+}
+
+
+nixl_status_t
+nixlUcxMoEngine::retHelper(nixl_status_t ret, nixlBackendEngine *eng,
+                           nixlUcxMoRequestH *req, nixlBackendReqH *&int_req)
+{
+    /* if transfer wasn't immediately completed */
+    switch(ret) {
+    case NIXL_IN_PROG:
+        req->reqs.push_back(nixlUcxMoRequestH::req_pair_t{eng, int_req});
+    case NIXL_SUCCESS:
+        // Nothing to do
+        return NIXL_SUCCESS;
+    default:
+        // Error. Release all previously initiated ops and exit:
+        cancelRequests(req);
+        delete(req);
+        return ret;
+    }
+}
+
+nixl_status_t
+nixlUcxMoEngine::prepXfer (const nixl_xfer_op_t &operation,
+                           const nixl_meta_dlist_t &local,
+                           const nixl_meta_dlist_t &remote,
+                           const std::string &remote_agent,
+                           nixlBackendReqH* &handle,
+                           const nixl_opt_b_args_t *opt_args)
+{
+    return NIXL_SUCCESS;
+}
+
+
+// Data transfer
+nixl_status_t
+nixlUcxMoEngine::postXfer (const nixl_xfer_op_t &op,
+                           const nixl_meta_dlist_t &local,
+                           const nixl_meta_dlist_t &remote,
+                           const std::string &remote_agent,
+                           nixlBackendReqH* &out_handle,
+                           const nixl_opt_b_args_t *opt_args)
+{
+    size_t l_eng_cnt = engines.size();
+    size_t r_eng_cnt;
+    int des_cnt = local.descCount();
+    nixlUcxMoRequestH *req = new nixlUcxMoRequestH;
+    remote_comm_it_t it = remoteConnMap.find(remote_agent);
+
+    // Input check
+    if (des_cnt != remote.descCount()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if(it == remoteConnMap.end()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    nixlUcxMoConnection &conn = it->second;
+
+    /* Allocate temp distribution matrix */
+    r_eng_cnt = conn.num_engines;
+    typedef pair<nixl_meta_dlist_t *,nixl_meta_dlist_t *> _dlist_pair_t;
+    typedef vector<vector<_dlist_pair_t>> _dlist_matrix_t;
+    _dlist_matrix_t dlmatrix(l_eng_cnt, vector<_dlist_pair_t>(r_eng_cnt, _dlist_pair_t{NULL, NULL}));
+
+
+    // Convert the operation type
+    switch(op) {
+    case NIXL_READ:
+    case NIXL_WRITE:
+        break;
+    default:
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    /* Go over all input */
+    for(int i = 0; i < des_cnt; i++) {
+        size_t lsize = local[i].len;
+        size_t rsize = remote[i].len;
+        nixlUcxMoPrivateMetadata *lmd;
+        lmd = (nixlUcxMoPrivateMetadata *)local[i].metadataP;
+        nixlUcxMoPublicMetadata *rmd;
+        rmd = (nixlUcxMoPublicMetadata *)remote[i].metadataP;
+        size_t lidx = lmd->eidx;
+        size_t ridx = rmd->eidx;
+
+        assert( (lidx < l_eng_cnt) && (ridx < r_eng_cnt));
+        if (lsize != rsize) {
+            // TODO: err output
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        /* Allocate internal dlists if needed */
+        if (NULL == dlmatrix[lidx][ridx].first) {
+            dlmatrix[lidx][ridx].first = new nixl_meta_dlist_t (
+                                                local.getType(),
+                                                local.isUnifiedAddr(),
+                                                local.isSorted());
+
+            dlmatrix[lidx][ridx].second = new nixl_meta_dlist_t (
+                                                remote.getType(),
+                                                remote.isUnifiedAddr(),
+                                                remote.isSorted());
+        }
+
+        nixlMetaDesc ldesc = local[i];
+        ldesc.metadataP = lmd->md;
+        dlmatrix[lidx][ridx].first->addDesc(ldesc);
+
+        nixlMetaDesc rdesc = remote[i];
+        rdesc.metadataP = rmd->int_mds[lidx];
+        dlmatrix[lidx][ridx].second->addDesc(rdesc);
+    }
+
+    for(size_t lidx = 0; lidx < l_eng_cnt; lidx++) {
+        for(size_t ridx = 0; ridx < r_eng_cnt; ridx++) {
+            string no_notif_msg;
+            nixlBackendReqH *int_req;
+            nixl_status_t ret;
+
+            if (NULL == dlmatrix[lidx][ridx].first) {
+                // Skip unused matrix elements
+                continue;
+            }
+            ret = engines[lidx]->postXfer(op,
+                                          *dlmatrix[lidx][ridx].first,
+                                          *dlmatrix[lidx][ridx].second,
+                                          getEngName(remote_agent, ridx),
+                                          int_req);
+            ret = retHelper(ret, engines[lidx], req, int_req);
+            if (NIXL_SUCCESS != ret) {
+                return ret;
+            }
+        }
+    }
+
+    if (opt_args->hasNotif) {
+        // The transfers are performed via parallel UCX workers (read QPs)
+        // This doesn't allows piggybacking the notification command in postXfer
+        // as we need to chose one of the workers to send it,
+        // but we can only be sent after all workers are flushed.
+        // Instead, we will initiate Notification from the CheckXfer
+        req->notifNeed = true;
+        req->notifMsg = opt_args->notifMsg;
+        req->remoteAgent = remote_agent;
+    }
+
+    if (req->reqs.size()) {
+        out_handle = req;
+        return NIXL_IN_PROG;
+    } else {
+        delete req;
+        return  NIXL_SUCCESS;
+    }
+}
+
+nixl_status_t
+nixlUcxMoEngine::checkXfer (nixlBackendReqH *handle)
+{
+    nixlUcxMoRequestH *req = (nixlUcxMoRequestH *)handle;
+    nixlUcxMoRequestH::req_list_t &l = req->reqs;
+    nixlUcxMoRequestH::req_list_it_t it;
+    nixl_status_t out_ret = NIXL_SUCCESS;
+
+    for (it = l.begin(); it != l.end(); ) {
+        nixl_status_t ret;
+
+        ret = it->first->checkXfer(it->second);
+        switch (ret) {
+        case NIXL_SUCCESS:
+            /* Mark as completed */
+            it->first->releaseReqH(it->second);
+            it = l.erase(it);
+            break;
+        case NIXL_IN_PROG:
+            out_ret = NIXL_IN_PROG;
+            it++;
+            break;
+        default:
+            /* Any other ret value is unexpected */
+            return ret;
+        }
+    }
+
+    if ((NIXL_SUCCESS == out_ret) && req->notifNeed) {
+        nixl_status_t ret;
+
+        // Now as all UCX backends (workers) have been flushed,
+        // it is safe to send Notification
+        ret = engines[0]->genNotif(getEngName(req->remoteAgent, 0), req->notifMsg);
+        if (NIXL_SUCCESS != ret) {
+            /* Mark as completed */
+            return ret;
+        }
+    }
+
+    return out_ret;
+}
+
+nixl_status_t
+nixlUcxMoEngine::releaseReqH(nixlBackendReqH* handle)
+{
+    cancelRequests((nixlUcxMoRequestH *)handle);
+    return NIXL_SUCCESS;
+}
+
+int
+nixlUcxMoEngine::progress()
+{
+    int ret = 0;
+    // Iterate over all elements cancelling each one
+    for ( auto &e : engines ) {
+        ret += e->progress();
+    }
+    return ret;
+}
+
+nixl_status_t
+nixlUcxMoEngine::getNotifs(notif_list_t &notif_list)
+{
+    return engines[0]->getNotifs(notif_list);
+}
+
+nixl_status_t
+nixlUcxMoEngine::genNotif(const string &remote_agent, const string &msg)
+{
+    return engines[0]->genNotif(getEngName(remote_agent, 0), msg);
+}

--- a/src/plugins/ucx_mo/ucx_mo_backend.h
+++ b/src/plugins/ucx_mo/ucx_mo_backend.h
@@ -1,0 +1,203 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UCX_MO_BACKEND_H
+#define __UCX_MO_BACKEND_H
+
+#include <vector>
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <mutex>
+#include <cassert>
+
+#include "nixl.h"
+#include "ucx_backend.h"
+
+// Local includes
+#include <common/nixl_time.h>
+#include <common/list_elem.h>
+#include <ucx/ucx_utils.h>
+
+class nixlUcxMoConnection : public nixlBackendConnMD {
+    private:
+        std::string remoteAgent;
+        uint32_t num_engines;
+
+    public:
+        // Extra information required for UCX connections
+
+    friend class nixlUcxMoEngine;
+};
+
+// A private metadata has to implement get, and has all the metadata
+class nixlUcxMoPrivateMetadata : public nixlBackendMD
+{
+private:
+    uint32_t eidx;
+    nixlBackendMD *md;
+    std::string rkeyStr;
+public:
+    nixlUcxMoPrivateMetadata() : nixlBackendMD(true) {
+    }
+
+    ~nixlUcxMoPrivateMetadata(){
+    }
+
+    std::string get() const {
+        return rkeyStr;
+    }
+
+    friend class nixlUcxMoEngine;
+};
+
+// A public metadata has to implement put, and only has the remote metadata
+class nixlUcxMoPublicMetadata : public nixlBackendMD
+{
+    uint32_t eidx;
+    nixlUcxMoConnection conn;
+    std::vector<nixlBackendMD*> int_mds;
+
+public:
+    nixlUcxMoPublicMetadata() : nixlBackendMD(false) {}
+
+    ~nixlUcxMoPublicMetadata(){
+    }
+
+    friend class nixlUcxMoEngine;
+};
+
+
+class nixlUcxMoRequestH : public nixlBackendReqH {
+private:
+    typedef std::pair<nixlBackendEngine *,nixlBackendReqH *> req_pair_t;
+    typedef std::vector<req_pair_t> req_list_t;
+    typedef req_list_t::iterator req_list_it_t;
+
+    req_list_t reqs;
+
+    std::string remoteAgent;
+    bool notifNeed;
+    std::string notifMsg;
+public:
+    nixlUcxMoRequestH()
+    {
+        notifNeed = false;
+    }
+
+    friend class nixlUcxMoEngine;
+
+};
+
+class nixlUcxMoEngine : public nixlBackendEngine {
+private:
+    uint32_t _engineCnt;
+    uint32_t _gpuCnt;
+    int setEngCnt(uint32_t host_engines);
+    uint32_t getEngCnt();
+    int32_t getEngIdx(nixl_mem_t type, uint32_t devId);
+    std::string getEngName(const std::string &baseName, uint32_t eidx);
+    std::string getEngBase(const std::string &engName);
+    bool pthrOn;
+
+    // UCX backends data
+    std::vector<nixlBackendEngine*> engines;
+    // Map of agent name to saved nixlUcxConnection info
+    typedef std::map<std::string, nixlUcxMoConnection> remote_conn_map_t;
+    typedef remote_conn_map_t::iterator remote_comm_it_t;
+    remote_conn_map_t remoteConnMap;
+
+    class nixlUcxMoBckndReq : public nixlBackendReqH {
+        private:
+            int engIdx;
+            nixlBackendReqH *req;
+        public:
+
+            nixlUcxMoBckndReq() : nixlBackendReqH() {
+            }
+
+            ~nixlUcxMoBckndReq() {
+            }
+    };
+
+
+    // Data transfer
+    nixl_status_t retHelper(nixl_status_t ret, nixlBackendEngine *eng,
+                            nixlUcxMoRequestH *req, nixlBackendReqH *&int_req);
+    void cancelRequests(nixlUcxMoRequestH *req);
+public:
+    nixlUcxMoEngine(const nixlBackendInitParams* init_params);
+    ~nixlUcxMoEngine();
+
+    bool supportsRemote () const { return true; }
+    bool supportsLocal () const { return false; }
+    bool supportsNotif () const { return true; }
+    bool supportsProgTh () const { return pthrOn; }
+
+    nixl_mem_list_t getSupportedMems () const;
+
+    /* Object management */
+    nixl_status_t getPublicData (const nixlBackendMD* meta,
+                                 std::string &str) const;
+    nixl_status_t getConnInfo(std::string &str) const;
+    nixl_status_t loadRemoteConnInfo (const std::string &remote_agent,
+                                        const std::string &remote_conn_info);
+
+    nixl_status_t connect(const std::string &remote_agent);
+    nixl_status_t disconnect(const std::string &remote_agent);
+
+    nixl_status_t registerMem (const nixlBlobDesc &mem,
+                               const nixl_mem_t &nixl_mem,
+                               nixlBackendMD* &out);
+    nixl_status_t deregisterMem (nixlBackendMD* meta);
+
+    nixl_status_t loadLocalMD (nixlBackendMD* input,
+                               nixlBackendMD* &output);
+
+    nixl_status_t loadRemoteMD (const nixlBlobDesc &input,
+                                const nixl_mem_t &nixl_mem,
+                                const std::string &remote_agent,
+                                nixlBackendMD* &output);
+    nixl_status_t unloadMD (nixlBackendMD* input);
+
+    // Data transfer
+    nixl_status_t prepXfer (const nixl_xfer_op_t &operation,
+                            const nixl_meta_dlist_t &local,
+                            const nixl_meta_dlist_t &remote,
+                            const std::string &remote_agent,
+                            nixlBackendReqH* &handle,
+                            const nixl_opt_b_args_t* opt_args=nullptr);
+
+    nixl_status_t postXfer (const nixl_xfer_op_t &operation,
+                            const nixl_meta_dlist_t &local,
+                            const nixl_meta_dlist_t &remote,
+                            const std::string &remote_agent,
+                            nixlBackendReqH* &handle,
+                            const nixl_opt_b_args_t* opt_args=nullptr);
+    nixl_status_t checkXfer (nixlBackendReqH* handle);
+    nixl_status_t releaseReqH(nixlBackendReqH* handle);
+
+    int progress();
+
+    nixl_status_t getNotifs(notif_list_t &notif_list);
+    nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg);
+
+    //public function for UCX worker to mark connections as connected
+    nixl_status_t checkConn(const std::string &remote_agent);
+    nixl_status_t endConn(const std::string &remote_agent);
+};
+
+#endif

--- a/src/plugins/ucx_mo/ucx_mo_plugin.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_plugin.cpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ #include "backend/backend_plugin.h"
+ #include "ucx_mo_backend.h"
+ // Plugin version information
+ static const char* PLUGIN_NAME = "UCX_MO";
+ static const char* PLUGIN_VERSION = "1.0.0";
+ // Function to create a new UCX backend engine instance
+ static nixlBackendEngine* create_engine(const nixlBackendInitParams* init_params)
+ {
+     return new nixlUcxMoEngine(init_params);
+ }
+ static void destroy_engine(nixlBackendEngine *engine)
+ {
+     delete (nixlUcxMoEngine*)engine;
+ }
+ // Function to get the plugin name
+ static const char* get_plugin_name() {
+     return PLUGIN_NAME;
+ }
+ // Function to get the plugin version
+ static const char* get_plugin_version() {
+     return PLUGIN_VERSION;
+ }
+ // Function to get backend options
+ static nixl_b_params_t get_backend_options() {
+     nixl_b_params_t params;
+     params["ucx_devices"] = "";
+     params["num_ucx_engines"] = "8";
+     return params;
+ }
+ // Static plugin structure
+ static nixlBackendPlugin plugin = {
+     NIXL_PLUGIN_API_VERSION,
+     create_engine,
+     destroy_engine,
+     get_plugin_name,
+     get_plugin_version,
+     get_backend_options
+ };
+ #ifdef STATIC_PLUGIN_UCX_MO
+ nixlBackendPlugin* createStaticUcxMoPlugin() {
+     return &plugin; // Return the static plugin instance
+ }
+ #else
+ // Plugin initialization function
+ extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin* nixl_plugin_init() {
+     return &plugin;
+ }
+ // Plugin cleanup function
+ extern "C" NIXL_PLUGIN_EXPORT void nixl_plugin_fini() {
+     // Cleanup any resources if needed
+ }
+ #endif

--- a/test/unit/plugins/meson.build
+++ b/test/unit/plugins/meson.build
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 subdir('ucx')
+subdir('ucx_mo')
 
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend

--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -289,7 +289,7 @@ void performTransfer(nixlBackendEngine *ucx1, nixlBackendEngine *ucx2,
                      nixl_meta_dlist_t &req_src_descs,
                      nixl_meta_dlist_t &req_dst_descs,
                      void* addr1, void* addr2, size_t len,
-                     nixl_xfer_op_t op, bool progress_ucx2, bool use_notif)
+                     nixl_xfer_op_t op, bool progress, bool use_notif)
 {
     int ret2;
     nixl_status_t ret3;
@@ -322,7 +322,7 @@ void performTransfer(nixlBackendEngine *ucx1, nixlBackendEngine *ucx2,
 
         while(ret3 == NIXL_IN_PROG) {
             ret3 = ucx1->checkXfer(handle);
-            if(progress_ucx2){
+            if(progress){
                 ucx2->progress();
             }
             assert( ret3 == NIXL_SUCCESS || ret3 == NIXL_IN_PROG);
@@ -341,6 +341,9 @@ void performTransfer(nixlBackendEngine *ucx1, nixlBackendEngine *ucx2,
         while(ret2 == 0){
             ret3 = ucx2->getNotifs(target_notifs);
             ret2 = target_notifs.size();
+            if(progress){
+                ucx1->progress();
+            }
             assert(ret3 == NIXL_SUCCESS);
         }
 

--- a/test/unit/plugins/ucx_mo/meson.build
+++ b/test/unit/plugins/ucx_mo/meson.build
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ucx_backend_dep = declare_dependency(link_with: ucx_backend_lib, include_directories: [nixl_inc_dirs, '../../../../src/plugins/ucx'])
+ucx_mo_backend_dep = declare_dependency(link_with: ucx_mo_backend_lib, include_directories: [nixl_inc_dirs, '../../../../src/plugins/ucx_mo'])
+
+if cuda_dep.found()
+    cuda_dependencies = [cuda_dep]
+    cpp_args = '-DUSE_VRAM'
+else
+    cuda_dependencies = []
+    cpp_args = '-UUSE_VRAM'
+endif
+
+ucx_backend_test = executable('ucx_mo_backend_test',
+        'ucx_mo_backend_test.cpp',
+        dependencies: [nixl_dep, nixl_infra, ucx_backend_dep, ucx_mo_backend_dep, ucx_dep] + cuda_dependencies,
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: true)

--- a/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
+++ b/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
@@ -1,0 +1,569 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <cassert>
+
+#include "ucx_mo_backend.h"
+
+using namespace std;
+
+#ifdef USE_VRAM
+
+#include <cuda_runtime.h>
+
+int gpu_id = 0;
+
+static void checkCudaError(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+	std::cerr << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+#endif
+
+
+static string op2string(nixl_xfer_op_t op, bool hasNotif)
+{
+    if(op == NIXL_READ && !hasNotif)
+        return string("READ");
+    if(op == NIXL_WRITE && !hasNotif)
+        return string("WRITE");
+    if(op == NIXL_READ && hasNotif)
+        return string("READ/NOTIF");
+    if(op == NIXL_WRITE && hasNotif)
+        return string("WRITE/NOTIF");
+
+    return string("ERR-OP");
+}
+
+std::string memType2Str(nixl_mem_t mem_type)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        return std::string("DRAM");
+    case VRAM_SEG:
+        return std::string("VRAM");
+    case BLK_SEG:
+        return std::string("BLOCK");
+    case FILE_SEG:
+        return std::string("FILE");
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+}
+
+nixlBackendEngine *createEngine(std::string name, uint32_t ndev, bool p_thread)
+{
+    nixlBackendEngine     *ucx_mo;
+    nixlBackendInitParams init;
+    nixl_b_params_t       custom_params;
+
+    custom_params["num_ucx_engines"] = std::to_string(ndev);
+    init.enableProgTh = p_thread;
+    init.pthrDelay    = 100;
+    init.localAgent   = name;
+    init.customParams = &custom_params;
+    init.type         = "UCX_MO";
+
+    ucx_mo = (nixlBackendEngine*) new nixlUcxMoEngine (&init);
+    assert(!ucx_mo->getInitErr());
+    if (ucx_mo->getInitErr()) {
+        std::cout << "Failed to initialize worker1" << std::endl;
+        exit(1);
+    }
+
+    return ucx_mo;
+}
+
+void releaseEngine(nixlBackendEngine *ucx)
+{
+    //protected now, should not call
+    delete ucx;
+}
+
+#ifdef USE_VRAM
+
+static int cudaQueryAddr(void *address, bool &is_dev,
+                         CUdevice &dev, CUcontext &ctx)
+{
+    CUmemorytype mem_type = CU_MEMORYTYPE_HOST;
+    uint32_t is_managed = 0;
+#define NUM_ATTRS 4
+    CUpointer_attribute attr_type[NUM_ATTRS];
+    void *attr_data[NUM_ATTRS];
+    CUresult result;
+
+    attr_type[0] = CU_POINTER_ATTRIBUTE_MEMORY_TYPE;
+    attr_data[0] = &mem_type;
+    attr_type[1] = CU_POINTER_ATTRIBUTE_IS_MANAGED;
+    attr_data[1] = &is_managed;
+    attr_type[2] = CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
+    attr_data[2] = &dev;
+    attr_type[3] = CU_POINTER_ATTRIBUTE_CONTEXT;
+    attr_data[3] = &ctx;
+
+    result = cuPointerGetAttributes(4, attr_type, attr_data, (CUdeviceptr)address);
+
+    is_dev = (mem_type == CU_MEMORYTYPE_DEVICE);
+
+    return (CUDA_SUCCESS != result);
+}
+
+#endif
+
+
+void allocateBuffer(nixl_mem_t mem_type, int dev_id, size_t len, void* &addr)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        //addr = calloc(1, len);
+        posix_memalign(&addr, 4096, len);
+        break;
+#ifdef USE_VRAM
+    case VRAM_SEG:{
+        bool is_dev;
+        CUdevice dev;
+        CUcontext ctx;
+
+        checkCudaError(cudaSetDevice(dev_id), "Failed to set device");
+        checkCudaError(cudaMalloc(&addr, len), "Failed to allocate CUDA buffer 0");
+        cudaQueryAddr(addr, is_dev, dev, ctx);
+        std::cout << "CUDA addr: " << std::hex << addr << " dev=" << std::dec << dev
+            << " ctx=" << std::hex << ctx << std::dec << std::endl;
+        break;
+    }
+#endif
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+    assert(addr);
+}
+
+void releaseBuffer(nixl_mem_t mem_type, int dev_id, void* &addr)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        free(addr);
+        break;
+#ifdef USE_VRAM
+    case VRAM_SEG:
+        checkCudaError(cudaSetDevice(dev_id), "Failed to set device");
+        checkCudaError(cudaFree(addr), "Failed to allocate CUDA buffer 0");
+        break;
+#endif
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+}
+
+void doMemset(nixl_mem_t mem_type, int dev_id, void *addr, char byte, size_t len)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        memset(addr, byte, len);
+        break;
+#ifdef USE_VRAM
+    case VRAM_SEG:
+        checkCudaError(cudaSetDevice(dev_id), "Failed to set device");
+        checkCudaError(cudaMemset(addr, byte, len), "Failed to memset");
+        break;
+#endif
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+}
+
+void *getValidationPtr(nixl_mem_t mem_type, void *addr, size_t len)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        return addr;
+        break;
+#ifdef USE_VRAM
+    case VRAM_SEG: {
+        void *ptr = calloc(len, 1);
+        checkCudaError(cudaMemcpy(ptr, addr, len, cudaMemcpyDeviceToHost), "Failed to memcpy");
+        return ptr;
+    }
+#endif
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+}
+
+void *releaseValidationPtr(nixl_mem_t mem_type, void *addr)
+{
+    switch(mem_type) {
+    case DRAM_SEG:
+        break;
+#ifdef USE_VRAM
+    case VRAM_SEG:
+        free(addr);
+        break;
+#endif
+    default:
+        std::cout << "Unsupported memory type!" << std::endl;
+        assert(0);
+    }
+    return NULL;
+}
+
+void createLocalDescs(nixlBackendEngine *ucx, nixl_meta_dlist_t &descs,
+                      int dev_cnt,
+                      int desc_cnt, size_t desc_size)
+{
+
+    for(int i = 0; i < desc_cnt; i++) {
+        nixlBasicDesc desc;
+        nixlMetaDesc desc_m;
+        nixlBlobDesc desc_s;
+        void *addr;
+
+        desc.len = desc_size;
+        desc.devId = i % dev_cnt;
+
+        allocateBuffer(descs.getType(), desc.devId, desc.len, addr);
+        desc.addr = (uintptr_t)addr;
+        *((nixlBasicDesc*)&desc_s) = desc;
+        *((nixlBasicDesc*)&desc_m) = desc;
+        int ret = ucx->registerMem(desc_s, descs.getType(), desc_m.metadataP);
+        assert(ret == NIXL_SUCCESS);
+        descs.addDesc(desc_m);
+    }
+}
+
+
+void destroyLocalDescs(nixlBackendEngine *ucx, nixl_meta_dlist_t &descs)
+{
+    for(int i = 0; i < descs.descCount(); i++) {
+        auto dev_id = descs[i].devId;
+        void *addr = (void*)descs[i].addr;
+        ucx->deregisterMem(descs[i].metadataP);
+        releaseBuffer(descs.getType(), dev_id, addr);
+    }
+
+    while(descs.descCount()) {
+        descs.remDesc(0);
+    }
+}
+
+void createRemoteDescs(nixlBackendEngine *src_ucx,
+                       std::string agent,
+                       nixl_meta_dlist_t &src_descs,
+                       nixlBackendEngine *dst_ucx,
+                       nixl_meta_dlist_t &dst_descs)
+{
+    for(int i = 0; i < src_descs.descCount(); i++) {
+        nixlBlobDesc desc_s;
+        nixlMetaDesc desc_m;
+        nixl_status_t status;
+
+        *((nixlBasicDesc*)&desc_s) = (nixlBasicDesc)src_descs[i];
+        *((nixlBasicDesc*)&desc_m) = (nixlBasicDesc)src_descs[i];
+        status = src_ucx->getPublicData(src_descs[i].metadataP, desc_s.metaInfo);
+        assert(NIXL_SUCCESS == status);
+        status = dst_ucx->loadRemoteMD (desc_s, src_descs.getType(),
+                                        agent, desc_m.metadataP);
+        assert(status == NIXL_SUCCESS);
+        dst_descs.addDesc(desc_m);
+    }
+}
+
+void destroyRemoteDescs(nixlBackendEngine *dst_ucx,
+                        nixl_meta_dlist_t &dst_descs)
+{
+    nixl_status_t status;
+    for(int i = 0; i < dst_descs.descCount(); i++) {
+        status = dst_ucx->unloadMD (dst_descs[i].metadataP);
+        assert(status == NIXL_SUCCESS);
+    }
+
+    while(dst_descs.descCount()) {
+        dst_descs.remDesc(0);
+    }
+}
+
+void performTransfer(nixlBackendEngine *ucx1, nixlBackendEngine *ucx2,
+                     nixl_meta_dlist_t &req_src_descs,
+                     nixl_meta_dlist_t &req_dst_descs,
+                     nixl_xfer_op_t op, bool progress, bool use_notif)
+{
+    nixl_status_t status;
+    nixlBackendReqH* handle;
+    void *chkptr1, *chkptr2;
+
+    std::string remote_agent ("Agent2");
+
+    if(ucx1 == ucx2) remote_agent = "Agent1";
+
+    std::string test_str("test");
+    std::cout << "\t" << op2string(op, use_notif) << "\n";
+    nixl_opt_b_args_t opt_args;
+    opt_args.notifMsg = test_str;
+    opt_args.hasNotif = use_notif;
+
+    // Posting a request, to be updated to return an async handler,
+    // or an ID that later can be used to check the status as a new method
+    // Also maybe we would remove the WRITE and let the backend class decide the op
+    status = ucx1->postXfer(op, req_src_descs, req_dst_descs, remote_agent, handle, &opt_args);
+    assert(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
+
+
+    if (status == NIXL_SUCCESS) {
+        cout << "\t\tWARNING: Tansfer request completed immediately - no testing non-inline path" << endl;
+    } else {
+        cout << "\t\tNOTE: Testing non-inline Transfer path!" << endl;
+
+        while(status == NIXL_IN_PROG) {
+            status = ucx1->checkXfer(handle);
+            if(progress){
+                ucx2->progress();
+            }
+            assert( (NIXL_SUCCESS == status) || (NIXL_IN_PROG == status) );
+        }
+        ucx1->releaseReqH(handle);
+    }
+
+    if(use_notif) {
+        /* Test notification path */
+        notif_list_t target_notifs;
+
+        cout << "\t\tChecking notification flow: " << flush;
+
+        while(!target_notifs.size()){
+            status = ucx2->getNotifs(target_notifs);
+            assert(NIXL_SUCCESS == status);
+            if(progress){
+                ucx1->progress();
+            }
+        }
+
+        assert(target_notifs.size() == 1);
+        assert(target_notifs.front().first == "Agent1");
+        assert(target_notifs.front().second == test_str);
+
+        cout << "OK" << endl;
+    }
+
+    cout << "\t\tData verification: " << flush;
+
+    assert(req_src_descs.descCount() == req_dst_descs.descCount());
+    for(int i = 0; i < req_src_descs.descCount(); i++) {
+        auto sdesc = req_src_descs[i];
+        auto ddesc = req_dst_descs[i];
+        assert(sdesc.len == ddesc.len);
+        size_t len = ddesc.len;
+        chkptr1 = getValidationPtr(req_src_descs.getType(), (void*)sdesc.addr, len);
+        chkptr2 = getValidationPtr(req_dst_descs.getType(), (void*)ddesc.addr, len);
+
+        // Perform correctness check.
+        for(size_t i = 0; i < len; i++){
+            assert( ((uint8_t*) chkptr1)[i] == ((uint8_t*) chkptr2)[i]);
+        }
+
+        releaseValidationPtr(req_src_descs.getType(), chkptr1);
+        releaseValidationPtr(req_dst_descs.getType(), chkptr2);
+    }
+    cout << "OK" << endl;
+}
+
+void test_inter_agent_transfer(bool p_thread,
+                nixlBackendEngine *ucx1, nixl_mem_t src_mem_type, int src_dev_cnt,
+                nixlBackendEngine *ucx2, nixl_mem_t dst_mem_type, int dst_dev_cnt)
+{
+    int iter = 10;
+    nixl_status_t status;
+
+    std::cout << std::endl << std::endl;
+    std::cout << "****************************************************" << std::endl;
+    std::cout << "    Inter-agent memory transfer test P-Thr=" <<
+                        (p_thread ? "ON" : "OFF") << std::endl;
+    std::cout << "         (" << memType2Str(src_mem_type) << " -> "
+                << memType2Str(dst_mem_type) << ")" << std::endl;
+    std::cout << "****************************************************" << std::endl;
+    std::cout << std::endl << std::endl;
+
+    // Example: assuming two agents running on the same machine,
+    // with separate memory regions in DRAM
+    std::string agent1("Agent1");
+    std::string agent2("Agent2");
+
+    // We get the required connection info from UCX to be put on the central
+    // location and ask for it for a remote node
+    std::string conn_info1;
+    status = ucx1->getConnInfo(conn_info1);
+    assert(NIXL_SUCCESS == status);
+
+    std::string conn_info2;
+    status = ucx2->getConnInfo(conn_info2);
+    assert(NIXL_SUCCESS == status);
+
+    // We assumed we put them to central location and now receiving it on the other process
+    status = ucx1->loadRemoteConnInfo (agent2, conn_info2);
+    assert(NIXL_SUCCESS == status);
+
+    // TODO: Causes race condition - investigate conn management implementation
+    // ret = ucx2->loadRemoteConnInfo (agent1, conn_info1);
+
+    std::cout << "Synchronous handshake complete\n";
+
+    // Number of transfer descriptors
+    int desc_cnt = 16;
+    // Size of a single descriptor
+    size_t desc_size = 32 * 1024 * 1024;
+    nixl_meta_dlist_t ucx1_src_descs (src_mem_type);
+    nixl_meta_dlist_t ucx2_src_descs (dst_mem_type);
+    nixl_meta_dlist_t ucx1_dst_descs (dst_mem_type);
+
+    createLocalDescs(ucx1, ucx1_src_descs, src_dev_cnt,
+                     desc_cnt, desc_size);
+    createLocalDescs(ucx2, ucx2_src_descs, dst_dev_cnt,
+                     desc_cnt, desc_size);
+    createRemoteDescs(ucx2, agent2, ucx2_src_descs,
+                      ucx1, ucx1_dst_descs);
+
+
+    nixl_xfer_op_t ops[] = {  NIXL_READ, NIXL_WRITE };
+    bool use_notifs[] = { true, false };
+
+    for (size_t i = 0; i < sizeof(ops)/sizeof(ops[i]); i++) {
+
+        for(bool use_notif : use_notifs) {
+            cout << endl << op2string(ops[i], use_notif) << " test (" << iter << ") iterations" <<endl;
+            for(int k = 0; k < iter; k++ ) {
+                /* Init data */
+                for(int i = 0; i < ucx1_src_descs.descCount(); i++) {
+                    auto desc = ucx1_src_descs[i];
+                    doMemset(src_mem_type, desc.devId, (void*)desc.addr, 0xda, desc.len);
+                }
+                for(int i = 0; i < ucx2_src_descs.descCount(); i++) {
+                    auto desc = ucx2_src_descs[i];
+                    doMemset(dst_mem_type, desc.devId, (void*)desc.addr, 0xff, desc.len);
+                }
+
+                /* Test */
+                performTransfer(ucx1, ucx2, ucx1_src_descs, ucx1_dst_descs,
+                                ops[i], !p_thread, use_notif);
+            }
+        }
+    }
+
+    cout << endl << "Test genNotif operation" << endl;
+
+    for(int k = 0; k < iter; k++) {
+        std::string test_str("test");
+        std::string tgt_agent("Agent2");
+        notif_list_t target_notifs;
+
+        cout << "\t gnNotif to Agent2" <<endl;
+
+        ucx1->genNotif(tgt_agent, test_str);
+
+        cout << "\t\tChecking notification flow: " << flush;
+
+        while(target_notifs.size() == 0){
+            status = ucx2->getNotifs(target_notifs);
+            assert(NIXL_SUCCESS == status);
+            if (!p_thread) {
+                /* progress UCX1 as well */
+                ucx1->progress();
+            }
+        }
+
+        assert(target_notifs.size() == 1);
+        assert(target_notifs.front().first == "Agent1");
+        assert(target_notifs.front().second == test_str);
+
+        cout << "OK" << endl;
+    }
+
+    // As well as all the remote notes, asking to remove them one by one
+    // need to provide list of descs
+    destroyRemoteDescs(ucx1, ucx1_dst_descs);
+
+    destroyLocalDescs(ucx1, ucx1_src_descs);
+    destroyLocalDescs(ucx2, ucx2_src_descs);
+
+    // Test one-sided disconnect (initiator only)
+    ucx1->disconnect(agent2);
+
+    // TODO: Causes race condition - investigate conn management implementation
+    //ucx2->disconnect(agent1);
+}
+
+int main()
+{
+    bool thread_on[] = {false , true};
+#define THREAD_ON_SIZE (sizeof(thread_on) / sizeof(thread_on[0]))
+    nixlBackendEngine *ucx[THREAD_ON_SIZE][2] = { 0 };
+
+#define NUM_WORKERS 8
+
+int ndevices = NUM_WORKERS;
+#ifdef USE_VRAM
+    int n_vram_dev;
+    cudaGetDeviceCount(&n_vram_dev);
+    std::cout << "Detected " << n_vram_dev << " CUDA devices" << std::endl;
+#endif
+
+
+    // Allocate UCX engines
+    for(size_t i = 0; i < THREAD_ON_SIZE; i++) {
+        for(int j = 0; j < 2; j++) {
+            std::stringstream s;
+            s << "Agent" << (j + 1);
+            ucx[i][j] = createEngine(s.str(), ndevices, thread_on[i]);
+        }
+    }
+
+    for(size_t i = 0; i < THREAD_ON_SIZE; i++) {
+        test_inter_agent_transfer(thread_on[i],
+                                ucx[i][0], DRAM_SEG, ndevices,
+                                ucx[i][1], DRAM_SEG, ndevices);
+#ifdef USE_VRAM
+        if (n_vram_dev) {
+            test_inter_agent_transfer(thread_on[i],
+                                    ucx[i][0], VRAM_SEG, n_vram_dev,
+                                    ucx[i][1], VRAM_SEG, n_vram_dev);
+            test_inter_agent_transfer(thread_on[i],
+                                    ucx[i][0], VRAM_SEG, n_vram_dev,
+                                    ucx[i][1], VRAM_SEG, n_vram_dev);
+            test_inter_agent_transfer(thread_on[i],
+                                    ucx[i][0], VRAM_SEG, n_vram_dev,
+                                    ucx[i][1], DRAM_SEG, n_vram_dev);
+            test_inter_agent_transfer(thread_on[i],
+                                    ucx[i][0], DRAM_SEG, n_vram_dev,
+                                    ucx[i][1], VRAM_SEG, n_vram_dev);
+        }
+#endif
+    }
+
+    // Allocate UCX engines
+    for(int i = 0; i < 2; i++) {
+        for(int j = 0; j < 2; j++) {
+            releaseEngine(ucx[i][j]);
+        }
+    }
+}


### PR DESCRIPTION
Replaces PR #30 (see unit test outputs there)

Adds new UCX-based backend that allows associating NIXL
logical "devices" with different UCX workers.
The primary motivation is that UCX v1.18 doesn't
support more than one GPGPU per UCX context.

NOTE: this is expected to be fixed in UCX v1.19
so this backend might be viewed as a workaround
unless other uses will be found.

Limitations:
* Doesn't support loopback transfers
* Doesn't support VRAM

Both limitations will be removed in a follow-up PRs

