### PR TITLE
pybind: add support for empty string messages

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -380,7 +380,7 @@ class nixl_agent:
         message = None
         if remote_agent_name in self.notifs:
             for msg in self.notifs[remote_agent_name]:
-                if lookup_msg in msg:
+                if lookup_msg == msg:
                     message = msg
                     break
         if message:

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -260,9 +260,15 @@ class nixl_agent:
         local_indices,
         remote_xfer_side,
         remote_indices,
-        notif_msg="",
+        notif_msg=None,
         skip_desc_merge=False,
     ):
+        if notif_msg:
+            has_notif = True
+        else:
+            notif_msg = ""
+            has_notif = False
+
         op = self.nixl_ops[operation]
         if op:
             handle = self.agent.makeXferReq(
@@ -272,6 +278,7 @@ class nixl_agent:
                 remote_xfer_side,
                 remote_indices,
                 notif_msg,
+                has_notif,
                 skip_desc_merge,
             )
             if handle == 0:
@@ -287,9 +294,15 @@ class nixl_agent:
         local_descs,
         remote_descs,
         remote_agent,
-        notif_msg="",
+        notif_msg=None,
         xfer_backend=None,
     ):
+        if notif_msg:
+            has_notif = True
+        else:
+            notif_msg = ""
+            has_notif = False
+
         op = self.nixl_ops[operation]
         if op:
             if xfer_backend:
@@ -299,11 +312,12 @@ class nixl_agent:
                     remote_descs,
                     remote_agent,
                     notif_msg,
+                    has_notif,
                     xfer_backend,
                 )
             else:
                 handle = self.agent.createXferReq(
-                    op, local_descs, remote_descs, remote_agent, notif_msg
+                    op, local_descs, remote_descs, remote_agent, notif_msg, has_notif
                 )
 
             if handle == 0:
@@ -312,8 +326,14 @@ class nixl_agent:
         else:
             return None
 
-    def transfer(self, handle, notif_msg=""):
-        status = self.agent.postXferReq(handle, notif_msg)
+    def transfer(self, handle, notif_msg=None):
+        if notif_msg:
+            has_notif = True
+        else:
+            notif_msg = ""
+            has_notif = False
+
+        status = self.agent.postXferReq(handle, notif_msg, has_notif)
         if status == nixlBind.NIXL_SUCCESS:
             return "DONE"
         elif status == nixlBind.NIXL_IN_PROG:

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -341,22 +341,22 @@ PYBIND11_MODULE(_bindings, m) {
                                  const nixl_xfer_dlist_t &remote_descs,
                                  const std::string &remote_agent,
                                  const std::string &notif_msg,
+                                 bool  has_notif,
                                  uintptr_t backend) -> uintptr_t {
                     nixlXferReqH* handle = nullptr;
                     nixl_opt_args_t extra_params;
                     if (backend!=0)
                         extra_params.backends.push_back((nixlBackendH*) backend);
-                    if (notif_msg.size()>0) {
-                        extra_params.notifMsg = notif_msg;
-                        extra_params.hasNotif = true;
-                    }
+                    extra_params.hasNotif = has_notif;
+                    extra_params.notifMsg = notif_msg;
+
                     nixl_status_t ret = agent.createXferReq(operation, local_descs, remote_descs, remote_agent, handle, &extra_params);
 
                     throw_nixl_exception(ret);
                     return (uintptr_t) handle;
                 }, py::arg("operation"), py::arg("local_descs"),
                    py::arg("remote_descs"), py::arg("remote_agent"),
-                   py::arg("notif_msg") = std::string(""),
+                   py::arg("notif_msg") = std::string(""), py::arg("has_notif") = false,
                    py::arg("backend") = ((uintptr_t) nullptr))
         .def("queryXferBackend", [](nixlAgent &agent, uintptr_t reqh) -> uintptr_t {
                     nixlBackendH* handle = nullptr;
@@ -381,14 +381,14 @@ PYBIND11_MODULE(_bindings, m) {
                                uintptr_t remote_side,
                                const std::vector<int> &remote_indices,
                                const std::string &notif_msg,
+                               bool has_notif,
                                bool skip_desc_merge) -> uintptr_t {
                     nixlXferReqH* handle = nullptr;
                     nixl_opt_args_t extra_params;
-                    if (notif_msg.size()>0) {
-                        extra_params.notifMsg = notif_msg;
-                        extra_params.hasNotif = true;
-                    }
+                    extra_params.hasNotif = has_notif;
+                    extra_params.notifMsg = notif_msg;
                     extra_params.skipDescMerge = skip_desc_merge;
+
                     throw_nixl_exception(agent.makeXferReq(operation,
                                                            (nixlDlistH*) local_side, local_indices,
                                                            (nixlDlistH*) remote_side, remote_indices,
@@ -398,20 +398,19 @@ PYBIND11_MODULE(_bindings, m) {
                 }, py::arg("operation"), py::arg("local_side"),
                    py::arg("local_indices"), py::arg("remote_side"),
                    py::arg("remote_indices"), py::arg("notif_msg") = std::string(""),
-                   py::arg("skip_desc_merg") = false)
-        .def("postXferReq", [](nixlAgent &agent, uintptr_t reqh, std::string notif_msg) -> nixl_status_t {
+                   py::arg("has_notif") = false, py::arg("skip_desc_merg") = false)
+        .def("postXferReq", [](nixlAgent &agent, uintptr_t reqh, std::string notif_msg, bool has_notif) -> nixl_status_t {
                     nixl_opt_args_t extra_params;
                     nixl_status_t ret;
-                    if (notif_msg.size()>0) {
-                        extra_params.notifMsg = notif_msg;
-                        extra_params.hasNotif = true;
-                        ret = agent.postXferReq((nixlXferReqH*) reqh, &extra_params);
-                    } else {
-                        ret = agent.postXferReq((nixlXferReqH*) reqh);
-                    }
+
+                    extra_params.notifMsg = notif_msg;
+                    extra_params.hasNotif = has_notif;
+
+                    ret = agent.postXferReq((nixlXferReqH*) reqh, &extra_params);
                     throw_nixl_exception(ret);
                     return ret;
-                }, py::arg("reqh"), py::arg("notif_msg") = std::string(""))
+                }, py::arg("reqh"), py::arg("notif_msg") = std::string(""),
+                   py::arg("has_notif") = false)
         .def("getXferStatus", [](nixlAgent &agent, uintptr_t reqh) -> nixl_status_t {
                     nixl_status_t ret = agent.getXferStatus((nixlXferReqH*) reqh);
                     throw_nixl_exception(ret);

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -347,6 +347,9 @@ PYBIND11_MODULE(_bindings, m) {
                     nixl_opt_args_t extra_params;
                     if (backend!=0)
                         extra_params.backends.push_back((nixlBackendH*) backend);
+
+                    if(notif_msg.size() > 0) has_notif = true;
+
                     extra_params.hasNotif = has_notif;
                     extra_params.notifMsg = notif_msg;
 
@@ -385,6 +388,9 @@ PYBIND11_MODULE(_bindings, m) {
                                bool skip_desc_merge) -> uintptr_t {
                     nixlXferReqH* handle = nullptr;
                     nixl_opt_args_t extra_params;
+
+                    if(notif_msg.size() > 0) has_notif = true;
+
                     extra_params.hasNotif = has_notif;
                     extra_params.notifMsg = notif_msg;
                     extra_params.skipDescMerge = skip_desc_merge;
@@ -403,10 +409,14 @@ PYBIND11_MODULE(_bindings, m) {
                     nixl_opt_args_t extra_params;
                     nixl_status_t ret;
 
-                    extra_params.notifMsg = notif_msg;
-                    extra_params.hasNotif = has_notif;
+                    if(notif_msg.size() > 0 || has_notif) {
+                        extra_params.notifMsg = notif_msg;
+                        extra_params.hasNotif = has_notif;
 
-                    ret = agent.postXferReq((nixlXferReqH*) reqh, &extra_params);
+                        ret = agent.postXferReq((nixlXferReqH*) reqh, &extra_params);
+                    } else
+                        ret = agent.postXferReq((nixlXferReqH*) reqh);
+
                     throw_nixl_exception(ret);
                     return ret;
                 }, py::arg("reqh"), py::arg("notif_msg") = std::string(""),

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -115,8 +115,9 @@ if __name__ == "__main__":
     assert local_prep_handle != 0
     assert remote_prep_handle != 0
 
+    # test empty message
     xfer_handle_2 = nixl_agent2.make_prepped_xfer(
-        "WRITE", local_prep_handle, [0, 1], remote_prep_handle, [1, 0], "UUID2"
+        "WRITE", local_prep_handle, [0, 1], remote_prep_handle, [1, 0], ""
     )
     if not local_prep_handle or not remote_prep_handle:
         print("Preparing transfer side handles failed.")
@@ -143,7 +144,7 @@ if __name__ == "__main__":
                 print("Initiator done")
 
         if not target_done:
-            if nixl_agent1.check_remote_xfer_done("initiator", "UUID2"):
+            if nixl_agent1.check_remote_xfer_done("initiator", "") is not None:
                 target_done = True
                 print("Target done")
 


### PR DESCRIPTION
Add the option to our python API and directly in our bindings for users to explicitly specify if they want to attach a notification to a transfer. This gives us the option to send empty strings as notifications. 

Note1: Once we have pytest we will create unit tests for this feature. 
Note2: This will be mentioned in the Python API Doxygen, once it exists