### PR TITLE
ucx/ucx_mo tests: fix for CUDA buffer case

### DIFF
--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -149,8 +149,7 @@ nixl_mem_list_t
 nixlUcxMoEngine::getSupportedMems () const {
     nixl_mem_list_t mems;
     mems.push_back(DRAM_SEG);
-    // TODO: test and open this feature in a follow-up
-    //mems.push_back(VRAM_SEG);
+    mems.push_back(VRAM_SEG);
     return mems;
 }
 

--- a/test/unit/plugins/ucx/meson.build
+++ b/test/unit/plugins/ucx/meson.build
@@ -17,20 +17,22 @@ ucx_backend_dep = declare_dependency(link_with: ucx_backend_lib, include_directo
 
 if cuda_dep.found()
     cuda_dependencies = [cuda_dep]
-    cpp_args = '-DUSE_VRAM'
+    cpp_args = '-DHAVE_CUDA'
 else
     cuda_dependencies = []
-    cpp_args = '-UUSE_VRAM'
+    cpp_args = '-UHAVE_CUDA'
 endif
 
 ucx_backend_test = executable('ucx_backend_test',
         'ucx_backend_test.cpp',
         dependencies: [nixl_dep, nixl_infra, ucx_backend_dep, ucx_dep] + cuda_dependencies,
         include_directories: [nixl_inc_dirs, utils_inc_dirs, '../../../../src/plugins/ucx'],
+        cpp_args : cpp_args,
         install: true)
 
 ucx_backend_multi = executable('ucx_backend_multi',
            'ucx_backend_multi.cpp',
            dependencies: [nixl_dep, nixl_infra, ucx_backend_dep, ucx_dep] + cuda_dependencies,
            include_directories: [nixl_inc_dirs, utils_inc_dirs, '../../../../src/plugins/ucx'],
+           cpp_args : cpp_args,
            install: true)

--- a/test/unit/plugins/ucx_mo/meson.build
+++ b/test/unit/plugins/ucx_mo/meson.build
@@ -18,14 +18,15 @@ ucx_mo_backend_dep = declare_dependency(link_with: ucx_mo_backend_lib, include_d
 
 if cuda_dep.found()
     cuda_dependencies = [cuda_dep]
-    cpp_args = '-DUSE_VRAM'
+    cpp_args = '-DHAVE_CUDA'
 else
     cuda_dependencies = []
-    cpp_args = '-UUSE_VRAM'
+    cpp_args = '-UHAVE_CUDA'
 endif
 
 ucx_backend_test = executable('ucx_mo_backend_test',
         'ucx_mo_backend_test.cpp',
         dependencies: [nixl_dep, nixl_infra, ucx_backend_dep, ucx_mo_backend_dep, ucx_dep] + cuda_dependencies,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        cpp_args : cpp_args,
         install: true)


### PR DESCRIPTION
* Fix meson build scripts to build with CUDA support when detected
* Fix the cuda include files
* Enable "VRAM_SEG" in UCX_MO backend
* Replace "USE_VRAM" with "HAVE_CUDA" in UCX and UCX_MO tests