### PR TITLE
nixl/plug_mgr: Discover plugins in directory

### DIFF
--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -82,6 +82,9 @@ public:
     // Load a specific plugin
     std::shared_ptr<nixlPluginHandle> loadPlugin(const nixl_backend_t& plugin_name);
 
+    // Search a directory for plugins
+    void discoverPluginsFromDir(const std::string& dirpath);
+
     // Unload a plugin
     void unloadPlugin(const nixl_backend_t& plugin_name);
 


### PR DESCRIPTION
When a plugin directory is added, search the directory for plugins and add them to the list. Also, make sure plugin handle is stored after loading plugin.