### PR TITLE
Add performance test engine with custom-traffic perf test 

### DIFF
--- a/tools/perf/common.py
+++ b/tools/perf/common.py
@@ -1,0 +1,28 @@
+import torch
+from nixl._api import nixl_agent
+from dist_utils import dist_utils 
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class NixlBuffer:
+    """Can be sharded"""
+    def __init__(self, size: int, mem_type: str, nixl_agent: nixl_agent, shards=2, fill_value=0):
+        if mem_type in ("cuda", "vram"):
+            device = "cuda"
+        elif mem_type in ("cpu", "dram"):
+            device = "cpu"
+        else:
+            raise ValueError(f"Unsupported memory type: {mem_type}")
+
+        log.debug(f"[Rank {dist_utils.get_rank()}] Initializing NixlBuffer with size {size}, device {device}, shards {shards}, fill_value {fill_value}")
+        self.bufs = [
+            torch.full((size // shards,), fill_value=fill_value, dtype=torch.uint8, device=device) for _ in range(shards)
+        ]
+        self.reg_descs = nixl_agent.get_reg_descs(self.bufs, mem_type=mem_type)
+        self.xfer_descs = nixl_agent.get_xfer_descs(self.bufs, mem_type=mem_type)
+
+        log.debug(f"[Rank {dist_utils.get_rank()}] Registering memory for bufs {self.bufs}")
+        assert nixl_agent.register_memory(self.reg_descs) is not None, "Failed to register memory"
+

--- a/tools/perf/custom_traffic_perftest.py
+++ b/tools/perf/custom_traffic_perftest.py
@@ -1,0 +1,171 @@
+from dist_utils import dist_utils
+from pathlib import Path
+from utils import load_matrix
+from os import PathLike
+from common import NixlBuffer
+from typing import *
+import logging
+from dataclasses import dataclass
+import uuid
+import time
+import numpy as np
+import torch
+
+
+from nixl._api import nixl_agent
+
+log = logging.getLogger(__name__)
+
+@dataclass
+class TrafficPattern:
+    matrix_file: PathLike
+    shards: int
+    mem_type: Literal["cuda", "vram", "cpu", "dram"]
+    xfer_op: Literal["WRITE", "READ"]  # Transfer operation type
+
+    id: str = str(uuid.uuid4())
+
+class CTPerftest:
+    def __init__(self, traffic_patterns: list[TrafficPattern]):
+        self.my_rank = dist_utils.get_rank()
+        self.world_size = dist_utils.get_world_size()
+        self.traffic_patterns = traffic_patterns
+
+        log.debug(f"[Rank {self.my_rank}] Initializing Nixl agent")
+        self.nixl_agent = nixl_agent(f"{self.my_rank}")
+        assert "UCX" in self.nixl_agent.get_plugin_list(), "UCX plugin is not loaded"
+
+        self.send_bufs: list[Optional[NixlBuffer]] = [] # [i]=None if no send to rank i
+        self.recv_bufs: list[Optional[NixlBuffer]] = [] # [i]=None if no recv from rank i  
+        self.dst_bufs_descs = [] # [i]=None if no recv from rank i else descriptor of the dst buffer
+
+    def _share_md(self):
+        """Needs to be run after init_buffers"""
+        log.debug(f"[Rank {self.my_rank}] Sharing agent metadata with other ranks")
+        md = self.nixl_agent.get_agent_metadata()
+        mds = dist_utils.allgather_obj(md)
+        for other_rank, metadata in enumerate(mds):
+            if other_rank == self.my_rank:
+                continue
+            self.nixl_agent.add_remote_agent(metadata)
+            log.debug(f"[Rank {self.my_rank}] Added remote agent {other_rank}'s metadata")
+        
+    def share_recv_buf_descs(self, my_recv_bufs: list[NixlBuffer]):
+        """Send descriptors of the buffers to the world as an alltoall (rank 0 get bufs[0], rank 1 get bufs[1], etc)"""
+
+        my_recv_bufs_descs = [buf.xfer_descs if buf is not None else None for buf in my_recv_bufs]
+        my_recv_bufs_serdes = [self.nixl_agent.get_serialized_descs(des) for des in my_recv_bufs_descs]
+
+        dst_bufs_serdes = dist_utils.alltoall_obj(my_recv_bufs_serdes)
+        dst_bufs_descs = [self.nixl_agent.deserialize_descs(serdes) for serdes in dst_bufs_serdes]
+        return dst_bufs_descs
+
+    def init_buffers(self, tp: TrafficPattern) -> tuple[list[Optional[NixlBuffer]], list[Optional[NixlBuffer]]]:
+    
+        send_bufs = []
+        recv_bufs = []
+        for other_rank in range(self.world_size):
+            matrix = load_matrix(tp.matrix_file)
+            send_size = matrix[self.my_rank][other_rank]
+            recv_size = matrix[other_rank][self.my_rank]
+            send_buf = recv_buf = None
+            if send_size > 0:
+                send_buf = NixlBuffer(send_size, mem_type=tp.mem_type, nixl_agent=self.nixl_agent, fill_value=self.my_rank)
+            if recv_size > 0:
+                recv_buf = NixlBuffer(recv_size, mem_type=tp.mem_type, nixl_agent=self.nixl_agent)
+            send_bufs.append(send_buf)
+            recv_bufs.append(recv_buf)
+        
+        self._share_md()
+        return send_bufs, recv_bufs
+
+    def prepare_tp(self, tp: TrafficPattern) -> list:
+
+        send_bufs, recv_bufs = self.init_buffers(tp)
+        dst_bufs_descs = self.share_recv_buf_descs(recv_bufs)
+
+        handles = []
+        for other, buf in enumerate(send_bufs):
+            if buf is None:
+                continue
+
+            handle = self.nixl_agent.initialize_xfer(
+                "WRITE",
+                buf.xfer_descs,
+                dst_bufs_descs[other],
+                f"{other}",
+                f"{tp.id}_{self.my_rank}_{other}"
+            )
+            handles.append(handle)
+        
+        return handles, send_bufs, recv_bufs
+    
+    def run_tp(self, handles: list):
+        for handle in handles:
+            status = self.nixl_agent.transfer(handle)
+            assert status != "ERR", "Transfer failed"
+
+        return
+
+    def wait(self, handles: list):
+        # Wait for transfers to complete
+        while True:
+            pending = []
+            for handle in handles:
+                state = self.nixl_agent.check_xfer_state(handle)
+                assert state != "ERR", "Transfer got to Error state."
+                if state == "DONE":
+                    self.nixl_agent.release_xfer_handle(handle)
+                else:
+                    pending.append(handle)
+
+            if not pending:
+                break
+            handles = pending
+    
+    def _destroy(self):
+        for other_rank in range(self.world_size):
+            if other_rank == self.my_rank:
+                continue
+            self.nixl_agent.remove_remote_agent(f"{other_rank}")
+        
+
+    def run(self, verify_buffers: bool = False):
+        tp_handles: list[list] = []
+        tp_bufs = []
+        for tp in self.traffic_patterns:
+            handles, send_bufs, recv_bufs = self.prepare_tp(tp)
+            tp_bufs.append((send_bufs, recv_bufs))
+            tp_handles.append(handles)
+
+        start = time.time()
+        for handles in tp_handles:
+            self.run_tp(handles)
+        
+        self.wait([h for handles in tp_handles for h in handles])
+        end = time.time()
+
+        log.info(f"Total time taken to run all traffic patterns: {end - start} seconds")
+
+        if verify_buffers:
+            for i, tp in enumerate(self.traffic_patterns):
+                send_bufs, recv_bufs = tp_bufs[i]
+                matrix = load_matrix(tp.matrix_file)
+                for r, recv_buf in enumerate(recv_bufs):
+                    if recv_buf is None:
+                        if matrix[r][self.my_rank] > 0:
+                            log.error(f"Rank {self.my_rank} expected {matrix[r][self.my_rank]} bytes from rank {r}, but got 0")
+                            raise RuntimeError("Buffer verification failed")
+                        continue
+                    # recv_buf has to be filled with the rank of the sender
+                    # and its size has to be the same as matrix[r][my_rank]
+                    full_recv_buf = torch.cat([b for b in recv_buf.bufs])
+                    expected = torch.full_like(full_recv_buf, r)
+                    assert torch.all(full_recv_buf == expected), f"Vector not equal to {r}, got {full_recv_buf}"
+                    assert full_recv_buf.size(0) == matrix[r][self.my_rank], f"Size of vector {r} is not the same as matrix[r][{self.my_rank}], got {full_recv_buf.size(0)}"
+                    log.info(f"Vector {r} verified successfully")
+
+
+        self._destroy()
+
+        return end - start

--- a/tools/perf/dist_utils.py
+++ b/tools/perf/dist_utils.py
@@ -1,0 +1,163 @@
+import time
+import sys
+import os 
+from typing import *
+import logging
+from abc import ABC, abstractmethod
+
+from nixl._api import nixl_agent
+
+try:
+    import torch
+    import torch.distributed as dist
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+log = logging.getLogger(__name__)
+
+
+class _DistUtils(ABC):
+    """Allow for different distributed backends"""
+
+    @final
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def init_dist():
+        pass
+
+    @abstractmethod
+    def destroy_dist():
+        pass
+
+    @abstractmethod
+    def allgather_obj(self, obj: Any) -> List[Any]:
+        pass
+
+    @abstractmethod
+    def alltoall_obj(self, send_objs: List[Any]) -> List[Any]:
+        pass
+
+    @abstractmethod
+    def get_rank(self) -> int:
+        pass
+
+    @abstractmethod
+    def get_world_size(self) -> int:
+        pass
+
+    def share_world_metadata(self, nixl_agent: 'nixl_agent') -> None:
+        my_rank = self.get_rank()
+
+        log.debug(f"[Rank {my_rank}] Sharing agent metadata with other ranks")
+        md = nixl_agent.get_agent_metadata()
+        world_mds = self.allgather_obj(md)
+        for other_rank, metadata in enumerate(world_mds):
+            if other_rank == my_rank:
+                continue
+            nixl_agent.add_remote_agent(metadata)
+            log.debug(f"[Rank {my_rank}] Added remote agent {other_rank}'s metadata")
+
+
+class _TorchDistUtils(_DistUtils):
+
+    def get_rank(self) -> int:
+        return dist.get_rank()
+
+    def get_world_size(self) -> int:
+        return dist.get_world_size()
+
+    def init_dist(self) -> Tuple[int, int]:
+        """Init torch distributed module
+        
+        Returns:
+            Tuple[int, int]: Tuple of (rank, world_size)
+            
+        Raises:
+            ValueError: If rank and world size cannot be determined
+            RuntimeError: If CUDA is not available
+        """
+        if dist.is_initialized():
+            return dist.get_rank(), dist.get_world_size()
+
+        log.debug("Initializing torch distributed module")
+        if os.environ.get("SLURM_PROCID"):
+            rank = int(os.environ["SLURM_PROCID"])
+            world_size = int(os.environ["SLURM_NTASKS"])
+        elif os.environ.get("RANK"):
+            rank = int(os.environ.get("RANK"))
+            world_size = int(os.environ.get("WORLD_SIZE"))
+        else:
+            raise ValueError("Could not parse rank and world size")
+
+        dist.init_process_group(
+            backend='nccl',
+            rank=rank,
+            world_size=world_size,
+        )
+
+        rank = dist.get_rank()
+
+        if torch.cuda.device_count() == 0: 
+            print("No CUDA device have been detected, maybe you forgot to add --gpus-per-node option in srun?")
+            return 
+
+        device = rank % torch.cuda.device_count()
+        torch.cuda.set_device(device)
+        torch.set_default_device(device)
+        log.debug(f"[Rank {rank}] Using CUDA device {device}")
+
+        return rank, world_size
+
+    def destroy_dist(self):
+        """Cleanup distributed process group"""
+        if dist.is_initialized():
+            dist.destroy_process_group()
+    
+    def allgather_obj(self, obj: Any) -> List[Any]:
+        """Allgather arbitrary object on world
+        
+        Args:
+            obj: Object to gather from all ranks
+            
+        Returns:
+            List[Any]: List of gathered objects, one from each rank
+        """
+        to = [None for _ in range(self.get_world_size())]
+        dist.all_gather_object(to, obj)
+        return to
+
+    def alltoall_obj(self, send_objs: List[Any]) -> List[Any]:
+        """All-to-all communication of arbitrary objects on world
+        
+        Args:
+            send_objs: List of objects to send, length must equal world_size
+            
+        Returns:
+            List[Any]: List of received objects
+            
+        Raises:
+            AssertionError: If length of send_objs doesn't match world_size
+        """
+        my_rank = self.get_rank()
+        world_size = self.get_world_size()
+
+        assert len(send_objs) == world_size, f"Invalid number of objects {len(send_objs)}, expected {world_size}"
+
+        recv_objs = [None for _ in range(len(send_objs))]
+
+        for other_rank in range(world_size):
+            output = [None]
+            dist.scatter_object_list(
+                scatter_object_output_list=output, 
+                scatter_object_input_list=send_objs, 
+                src=other_rank
+            )
+            recv_objs[other_rank] = output[0]
+
+        return recv_objs
+
+dist_utils = _TorchDistUtils()
+dist_utils.init_dist()

--- a/tools/perf/utils.py
+++ b/tools/perf/utils.py
@@ -1,0 +1,46 @@
+import logging
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+def format_size(nbytes: int, precision=2) -> str:
+    units = ['B', 'K', 'M', 'G']
+    units_ix = 0
+    while nbytes/1024 >= 1 and units_ix < len(units)-1:
+        nbytes /= 1024
+        units_ix += 1
+    
+    nbytes = round(nbytes, precision)
+    return f"{nbytes:g}{units[units_ix]}"
+    
+def parse_size(nbytes: str) -> int:
+    """Convert formatted string with unit to bytes"""
+    options = {'g': 1024*1024*1024,
+                'm': 1024*1024,
+                'k': 1024}
+    unit = 1
+    key = nbytes[-1].lower()
+    if key in options:
+        unit = options[key]
+        value = int(nbytes[:-1])
+    else:
+        value = int(nbytes)
+    count = unit * value 
+    return count
+
+def load_matrix(matrix_file: str) -> list[list[int]]:
+    log.debug(f"Loading matrix from {matrix_file}")
+    # Cell i,j of the matrix is the size of the message to send from process i to process j
+    matrix = []
+    with open(matrix_file, 'r') as f:
+        for line in f:
+            row = line.strip().split()
+            row = [parse_size(x) for x in row]
+            matrix.append(row)
+    mat = np.array(matrix)
+
+    log.debug("Matrix loaded:")
+    for row in mat:
+        log.debug(row)
+
+    return mat


### PR DESCRIPTION
# Custom Traffic Performance Test Implementation

## Overview
This PR introduces a new performance testing capability that measure the performance of customizable traffic patterns, where each rank sends a custom message size to every other rank (can be 0). 

Such a pattern is defined using a transfer matrix, i.e a matrix where cell [i.j] defines the size of the message sent by rank i to rank j. 

## Implementation Details
- `custom_traffic_perftest.py` is the main implementation file
- Integrated with existing performance testing infrastructure
- Utilizes common utilities from `utils.py` and `dist_utils.py` for distributed testing support
- Command-line interface extensions in `cli.py` for test configuration

## Use Cases
This test is particularly useful for:
- Analyzing network performance with specific traffic patterns
- Testing irregular communication patterns
- Benchmarking targeted rank-to-rank communication
- Validating network performance under custom load scenarios

## Testing
The implementation has been tested with various matrix configurations and rank counts to ensure reliable performance measurements.

## Next Steps
- [ ] Add documentation with example usage
- [ ] Consider adding pre-defined traffic patterns
- [ ] Add visualization support for test results