### PR TITLE
agent: properly release backend handles for reposts

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -736,6 +736,11 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
         }
     }
 
+    // We CAN repost a previous request that is completed
+    if (req_hndl->status == NIXL_SUCCESS && req_hndl->backendHandle)
+        req_hndl->status = req_hndl->engine->releaseReqH(
+                                     req_hndl->backendHandle);
+
     // // The remote was invalidated
     // if (data->remoteBackends.count(req_hndl->remoteAgent)==0)
     //     delete req_hndl;

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -83,26 +83,28 @@ if __name__ == "__main__":
         print("Creating transfer failed.")
         exit()
 
-    state = nixl_agent2.transfer(xfer_handle_1)
-    assert state != "ERR"
+    # test multiple postings
+    for _ in range(2):
+        state = nixl_agent2.transfer(xfer_handle_1)
+        assert state != "ERR"
 
-    target_done = False
-    init_done = False
+        target_done = False
+        init_done = False
 
-    while (not init_done) or (not target_done):
-        if not init_done:
-            state = nixl_agent2.check_xfer_state(xfer_handle_1)
-            if state == "ERR":
-                print("Transfer got to Error state.")
-                exit()
-            elif state == "DONE":
-                init_done = True
-                print("Initiator done")
+        while (not init_done) or (not target_done):
+            if not init_done:
+                state = nixl_agent2.check_xfer_state(xfer_handle_1)
+                if state == "ERR":
+                    print("Transfer got to Error state.")
+                    exit()
+                elif state == "DONE":
+                    init_done = True
+                    print("Initiator done")
 
-        if not target_done:
-            if nixl_agent1.check_remote_xfer_done("initiator", "UUID1"):
-                target_done = True
-                print("Target done")
+            if not target_done:
+                if nixl_agent1.check_remote_xfer_done("initiator", "UUID1"):
+                    target_done = True
+                    print("Target done")
 
     # prep transfer mode
     local_prep_handle = nixl_agent2.prep_xfer_dlist(


### PR DESCRIPTION
Add a fix in the agent code to properly release previously allocated backend request handles when reposting a handle.

Updates our python API test to check for this case. 