### PR TITLE
Fix incorrect method call in desc_perf_test.py

### DIFF
--- a/test/python/desc_perf_test.py
+++ b/test/python/desc_perf_test.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
 
     start_time = time.perf_counter()
 
-    descs = agent.get_descs(("DRAM", addr_list), True)
+    descs = agent.get_xfer_descs(addr_list, "DRAM", is_sorted=True)
 
     end_time = time.perf_counter()
 


### PR DESCRIPTION
# Issue

In the test script test/python/desc_perf_test.py, the nixl_agent object was calling a non-existent `get_descs` method, resulting in the following error:

```bash
$ docker build -t nixl-container -f contrib/Dockerfile .
$ docker run -it --rm nixl-container ./nixl/test/python/desc_perf_test.py
Initialized NIXL agent: test
Traceback (most recent call last):
 File “/workspace/nixl/test/python/desc_perf_test.py”, line 32, in <module>
  descs = agent.get_descs((“DRAM”, addr_list), True)
      ^^^^^^^^^^^^^^^
AttributeError: ‘nixl_agent’ object has no attribute ‘get_descs’. Did you mean: ‘get_reg_descs’?
```

# Changes

It replaced `get_descs` with `get_xfer_descs` in the test script.

# Testing

```bash
$ docker build -t nixl-container -f contrib/Dockerfile .
$ docker run -it --rm nixl-container ./nixl/test/python/desc_perf_test.py
Initialized NIXL agent: test
Time per desc add in us: 0.07380280368322427
```

The error has been resolved, and the test script now runs correctly.