### PR TITLE
wheel: initial effort to allow dynamic linking of plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 [build-system]
-requires = ["meson-python", "pybind11", "patchelf", "libucx-cu12"]
+requires = ["meson-python", "pybind11", "patchelf"]
 build-backend = "mesonpy"
 
 [project]
@@ -32,4 +32,4 @@ authors = [
 ]
 
 [tool.meson-python.args]
-setup = ['-Ddisable_gds_backend=true', '-Dinstall_headers=false', '-Dstatic_plugins=UCX']
+setup = ['-Ddisable_gds_backend=true', '-Dinstall_headers=false']

--- a/src/api/python/__init__.py
+++ b/src/api/python/__init__.py
@@ -13,7 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import nixl._utils as nixl_utils
-from nixl._api import nixl_agent
+import os
 
-__all__ = [nixl_utils, nixl_agent]
+import nixl
+
+__all__ = [nixl]
+
+if "NIXL_PLUGIN_DIR" not in os.environ:
+    # name for local installation
+    plugin_dir = nixl.__file__[:-16] + ".nixl.mesonpy.libs/plugins/"
+
+    # name for pypi installation
+    if not os.path.isdir(plugin_dir):
+        plugin_dir = nixl.__file__[:-16] + ".nixl_pybind.mesonpy.libs/plugins/"
+
+    if os.path.isdir(plugin_dir):
+        os.environ["NIXL_PLUGIN_DIR"] = plugin_dir

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -272,12 +272,13 @@ void nixlPluginManager::discoverPluginsFromDir(const std::string& dirpath) {
     while ((entry = readdir(dp))) {
         std::string filename = entry->d_name;
 
+        if(filename.size() < 11) continue;
         // Check if this is a plugin file
-        if (filename.substr(0, 11) == "libplugin_" &&
+        if (filename.substr(0, 10) == "libplugin_" &&
             filename.substr(filename.size() - 3) == ".so") {
 
             // Extract plugin name
-            std::string plugin_name = filename.substr(11, filename.size() - 14);
+            std::string plugin_name = filename.substr(10, filename.size() - 13);
 
             // Try to load the plugin
             auto plugin = loadPlugin(plugin_name);

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import torch
 
 import nixl._utils as nixl_utils
@@ -23,6 +25,10 @@ from nixl._api import nixl_agent
 if __name__ == "__main__":
     buf_size = 256
     # Allocate memory and register with NIXL
+
+    print("Using NIXL Plugins from:")
+    print(os.environ["NIXL_PLUGIN_DIR"])
+
     nixl_agent1 = nixl_agent("target")
 
     plugin_list = nixl_agent1.get_plugin_list()


### PR DESCRIPTION
Update our wheel configuration and plugin manager to allow for plugins to be dynamically linked instead of needing static linking. This is done by updating our init python script. 