### PR TITLE
Agent/API: renamed remote_agent to agent_name for prepXferDlist to be more clear.

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -139,23 +139,24 @@ class nixlAgent {
          * @brief  Prepare a list of descriptors for a transfer request, so later elements
          *         from this list can be used to create a transfer request by index. It should
          *         be done on the initiator agent, and for both sides of an transfer.
-         *         Considering loopback, there are 3 modes for remote_agent value:
+         *         Considering loopback, there are 3 modes for agent_name:
          *           - For local descriptors, it is set to NIXL_INIT_AGENT,
          *             indicating that this is a local preparation to be used as local_side handle.
          *           - For remote descriptors: it is set to the remote name, indicating
          *             that this is remote side preparation to be used for remote_side handle.
-         *           - For loopback descriptors, it is set to local agent name for local transfers.
+         *           - For loopback descriptors, it is set to local agent's name, indicating that
+         *             this is for a loopback (local) transfer to be uued for remote_side handle
          *         If a list of backends hints is provided (via extra_params), the preparation
          *         is limited to the specified backends.
          *
-         * @param  remote_agent     Remote agent name as a string for preparing xfer handle
+         * @param  agent_name       Agent name as a string for preparing xfer handle
          * @param  descs            The descriptor list to be prepared for transfer requests
          * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
          * @param  extra_params     Optional additional parameters used in preparing dlist handle
          * @return nixl_status_t    Error code if call was not successful
          */
         nixl_status_t
-        prepXferDlist (const std::string &remote_agent,
+        prepXferDlist (const std::string &agent_name,
                        const nixl_xfer_dlist_t &descs,
                        nixlDlistH* &dlist_hndl,
                        const nixl_opt_args_t* extra_params = nullptr) const;

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -188,11 +188,12 @@ class nixl_agent:
     def make_connection(self, remote_agent: str):
         self.agent.makeConnection(remote_agent)
 
-    # remote_agent should be "NIXL_INIT_AGENT" for local descriptors on the initiator side
+    # agent_name should be "NIXL_INIT_AGENT" for local descriptors on the initiator side. For a
+    # remote agent, it would be that agent's name, or for loopback, local agent's name as target.
     # xfer_list can be any of the types supported by get_xfer_descs
     def prep_xfer_dlist(
         self,
-        remote_agent: str,
+        agent_name: str,
         xfer_list,
         mem_type: Optional[str] = None,
         is_sorted: bool = False,
@@ -200,14 +201,14 @@ class nixl_agent:
     ) -> nixl_prepped_dlist_handle:
         descs = self.get_xfer_descs(xfer_list, mem_type, is_sorted)
 
-        if remote_agent == "NIXL_INIT_AGENT" or remote_agent == "":
-            remote_agent = nixlBind.NIXL_INIT_AGENT
+        if agent_name == "NIXL_INIT_AGENT" or agent_name == "":
+            agent_name = nixlBind.NIXL_INIT_AGENT
 
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
 
-        handle = self.agent.prepXferDlist(remote_agent, descs, handle_list)
+        handle = self.agent.prepXferDlist(agent_name, descs, handle_list)
 
         return handle
 

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -367,7 +367,7 @@ PYBIND11_MODULE(_bindings, m) {
                     return (uintptr_t) handle;
             })
         .def("prepXferDlist", [](nixlAgent &agent,
-                                 std::string &remote_agent,
+                                 std::string &agent_name,
                                  const nixl_xfer_dlist_t &descs,
                                  std::vector<uintptr_t> backends) -> uintptr_t {
                     nixlDlistH* handle = nullptr;
@@ -376,10 +376,10 @@ PYBIND11_MODULE(_bindings, m) {
                     for(uintptr_t backend: backends)
                         extra_params.backends.push_back((nixlBackendH*) backend);
 
-                    throw_nixl_exception(agent.prepXferDlist(remote_agent, descs, handle, &extra_params));
+                    throw_nixl_exception(agent.prepXferDlist(agent_name, descs, handle, &extra_params));
 
                     return (uintptr_t) handle;
-                }, py::arg("remote_agent"), py::arg("descs"), py::arg("backend") = std::vector<uintptr_t>({}))
+                }, py::arg("agent_name"), py::arg("descs"), py::arg("backend") = std::vector<uintptr_t>({}))
         .def("makeXferReq", [](nixlAgent &agent,
                                const nixl_xfer_op_t &operation,
                                uintptr_t local_side,


### PR DESCRIPTION


* For both cpp and python. Clarified the comments accordingly too.
* A minor code clarity improvement in prepXferDlist cpp implementation