### PR TITLE
meson: Switch to C++17

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -16,7 +16,7 @@
 project('nixl', 'CPP', version: '0.1.0',
     default_options: ['buildtype=debug',
                 'werror=true',
-                'cpp_std=c++11',
+                'cpp_std=c++17',
                 'prefix=/opt/nvidia/nvda_nixl'],
     meson_version: '>= 0.64.0'
 )


### PR DESCRIPTION
Lets switch to C++17 standard to build. We could use newer features and gtest will rely only on C++17 for later releases.

Tested-by: Subhadeep Bhattacharya <subhadeepb@nvidia.com>
Signed-off-by: Adit Ranadive <aranadive@nvidia.com>