### PR TITLE
contrib: Update dockerfiles and add scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,32 @@ The pybind11 bindings for the public facing NIXL API are available in src/bindin
 
 The preferred way is to build it through meson-python, which will just let it be installed with pip. This can be done from the root nixl directory:
 
-` $pip install .`
+` $ pip install .`
 
 ### Building Docker container
 To build the docker container, first clone the current repository. Also make sure you are able to pull docker images to your machine before attempting to build the container.
 
 Run the following from the root folder of the cloned NIXL repository:
-
 ```
-$ docker build -t nixl-container -f contrib/Dockerfile .
+$ ./contrib/build-container.sh
+```
+
+By default, the container is built with Ubuntu 24.04. To build a container for Ubuntu 22.04 use the --os option as follows:
+```
+$ ./contrib/build-container.sh --os 22.04
+```
+
+To see all the options supported by the container use:
+```
+$ ./contrib/build-container.sh -h
+```
+
+The container also includes a prebuilt python wheel in /workspace/dist if required for installing/distributing. Also, the wheel can be built with a separate script (see below).
+
+### Building the python wheel
+The contrib folder also includes a script to build the python wheel with the UCX dependencies. Note, that UCX and other NIXL dependencies are required to be installed.
+```
+$ ./contrib/build-wheel.sh
 ```
 
 ## Examples

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,8 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/pytorch:25.02-py3
+ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
+ARG BASE_IMAGE_TAG="25.02-py3"
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
+
 ARG MOFED_VERSION=24.10-1.1.4.0
+ARG UBUNTUOS=24.04
 
 ENV TZ=America
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -22,56 +27,63 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ARG NSYS_URL=https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2025_1/
 ARG NSYS_PKG=NsightSystems-linux-cli-public-2025.1.1.131-3554042.deb
 
-RUN apt-get update -y && apt-get -y install curl \
-                                            git \
-                                            libnuma-dev \
-                                            numactl \
-                                            wget \
-                                            autotools-dev \
-                                            automake \
-                                            libtool \
-                                            libz-dev \
-                                            libiberty-dev \
-                                            flex \
-                                            build-essential \
-                                            cmake \
-                                            libibverbs-dev \
-                                            libgoogle-glog-dev \
-                                            libgtest-dev \
-                                            libjsoncpp-dev \
-                                            libpython3-dev \
-                                            libboost-all-dev \
-                                            libssl-dev \
-                                            libgrpc-dev \
-                                            libgrpc++-dev \
-                                            libprotobuf-dev \
-                                            protobuf-compiler-grpc \
-                                            pybind11-dev \
-                                            python3-full \
-                                            python3-pip \
-                                            python3-numpy \
-                                            etcd-server \
-                                            net-tools \
-                                            pciutils \
-                                            libpci-dev \
-                                            vim \
-                                            tmux \
-                                            screen \
-                                            ibverbs-utils \
-                                            libibmad-dev
+ARG NIXL_COMMIT
+ARG NIXL_REPO
 
-RUN apt-get install -y linux-tools-common linux-tools-generic ethtool iproute2
-RUN apt-get install -y dkms linux-headers-generic
-RUN apt-get install -y meson ninja-build uuid-dev gdb
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install curl \
+    git \
+    libnuma-dev \
+    numactl \
+    wget \
+    autotools-dev \
+    automake \
+    libtool \
+    libz-dev \
+    libiberty-dev \
+    flex \
+    build-essential \
+    cmake \
+    libibverbs-dev \
+    libgoogle-glog-dev \
+    libgtest-dev \
+    libjsoncpp-dev \
+    libpython3-dev \
+    libboost-all-dev \
+    libssl-dev \
+    libgrpc-dev \
+    libgrpc++-dev \
+    libprotobuf-dev \
+    protobuf-compiler-grpc \
+    pybind11-dev \
+    python3-full \
+    python3-pip \
+    python3-numpy \
+    etcd-server \
+    net-tools \
+    pciutils \
+    libpci-dev \
+    vim \
+    tmux \
+    screen \
+    ibverbs-utils \
+    libibmad-dev \
+    googletest
 
-RUN apt-get update && apt install -y wget libglib2.0-0
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y linux-tools-common linux-tools-generic ethtool iproute2
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y dkms linux-headers-generic
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y meson ninja-build uuid-dev gdb
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y wget libglib2.0-0
 RUN wget ${NSYS_URL}${NSYS_PKG} && dpkg -i $NSYS_PKG && rm $NSYS_PKG
 
 RUN cd /usr/local/src && \
-    curl -fSsL "https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu24.04-x86_64.tgz" -o mofed.tgz && \
+    curl -fSsL "https://content.mellanox.com/ofed/MLNX_OFED-${MOFED_VERSION}/MLNX_OFED_LINUX-${MOFED_VERSION}-ubuntu${UBUNTUOS}-x86_64.tgz" -o mofed.tgz && \
     tar -xf /usr/local/src/mofed.tgz && \
     cd MLNX_OFED_LINUX-* && \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ./DEBS/libibverbs* ./DEBS/ibverbs-providers* ./DEBS/librdmacm* ./DEBS/libibumad* && \
     rm -rf /var/lib/apt/lists/* /usr/local/src/*
 
@@ -87,7 +99,6 @@ RUN PREFIX=/usr/local DESTLIB=/usr/local/lib make -C /workspace/gdrcopy lib_inst
 RUN cp gdrcopy/src/libgdrapi.so.2.* /usr/lib/x86_64-linux-gnu/
 RUN ldconfig
 
-ARG OPENMPI_VERSION=5.0.6
 ARG UCX_VERSION=v1.18.0
 
 RUN cd /usr/local/src && \
@@ -115,36 +126,31 @@ ENV PATH=/usr/bin:$PATH
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 SHELL ["/bin/bash", "-c"]
 
-RUN cd /usr/local/src && \
-    curl -fSsL "https://www.open-mpi.org/software/ompi/v${OPENMPI_VERSION:0:3}/downloads/openmpi-${OPENMPI_VERSION}.tar.gz" | tar xz && \
-    cd openmpi-${OPENMPI_VERSION} && \
-    ./configure                          \
-        --prefix=/usr/local/ompi         \
-        --with-cuda=/usr/local/cuda      \
-        --enable-mpi1-compatibility --with-slurm --without-ofi --with-libevent=internal --with-pmix=internal --with-prrte=internal --enable-hwloc=internal && \
-    make -j &&                           \
-    make -j install-strip &&             \
-    ldconfig
+ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
+ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:$PYTHONPATH
 
-WORKDIR /workspace
-
-ENV LD_LIBRARY_PATH=/usr/local/ompi/lib:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
-ENV CPATH=/usr/local/ompi/include:$CPATH
-ENV PATH=/usr/local/ompi/bin:$PATH
-ENV PKG_CONFIG_PATH=/usr/local/ompi/lib/pkgconfig:$PKG_CONFIG_PATH
-
-# Disabling CUDA IPC not to use NVLINK, as it slows down local
-# UCX transfers and can cause contention with local collectives.
-ENV UCX_TLS=^cuda_ipc
+# Required for Ubuntu 22.04
+RUN pip3 install --upgrade meson torch
 
 # Make sure to build the container from the cloned git repository
-RUN mkdir nixl
-COPY . /workspace/nixl
-RUN cd nixl && git clean -d -f && rm -rf .git build
-RUN cd nixl && mkdir build && meson setup build/ --prefix=/usr/local/nixl && cd build/ && ninja && ninja install
+WORKDIR /opt/nixl
+COPY --from=nixl . .
+RUN echo "NIXL commit: ${NIXL_COMMIT}" > /opt/nixl/commit.txt
+RUN cd /opt/nixl && \
+    mkdir build && \
+    meson setup build/ --prefix=/usr/local/nixl && \
+    cd build/ && \
+    ninja && \
+    ninja install
 
 RUN echo "/usr/local/nixl/lib/x86_64-linux-gnu" > /etc/ld.so.conf.d/nixl.conf
 RUN echo "/usr/local/nixl/lib/x86_64-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
 RUN ldconfig
 
-RUN cd nixl && pip3 install --break-system-packages .
+# Create the wheel
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN pip3 install patchelf auditwheel
+RUN cd /opt/nixl && uv build --wheel --out-dir /workspace/dist
+RUN auditwheel repair /workspace/dist/nixl-*cp31*.whl --plat manylinux_2_39_x86_64

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE_DIR=$(dirname "$(readlink -f "$0")")
+BUILD_CONTEXT=$(dirname "$(readlink -f "$SOURCE_DIR")")
+DOCKER_FILE="${SOURCE_DIR}/Dockerfile"
+
+commit_id=$(git rev-parse --short HEAD)
+FULLCOMMIT=$(git rev-parse HEAD)
+
+# Get latest TAG and add COMMIT_ID for dev
+latest_tag=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1 main) | sed 's/^v//') || true
+if [[ -z ${latest_tag} ]]; then
+    latest_tag="0.0.1"
+    echo "No git release tag found, setting to unknown version: ${latest_tag}"
+fi
+
+BASE_IMAGE=nvcr.io/nvidia/pytorch
+BASE_IMAGE_TAG=25.02-py3
+VERSION=v$latest_tag.dev.$commit_id
+UBUNTUOS="24.04"
+USE_LOCAL_DIR=0
+NIXL_DIR=/tmp/nixl
+
+NIXL_COMMIT=ec6345c5279142a3805ab1a0e876f954d079dbf7
+NIXL_REPO=ai-dynamo/nixl.git
+
+get_options() {
+    while :; do
+        case $1 in
+        -h | -\? | --help)
+            show_help
+            exit
+            ;;
+        --base-image)
+	    if [ "$2" ]; then
+		BASE_IMAGE="$2"
+		shift
+	    else
+		missing_requirement $1
+	    fi
+	    ;;
+        --base-imge-tag)
+            if [ "$2" ]; then
+                BASE_IMAGE_TAG=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+	--os)
+            if [ "$2" ]; then
+                UBUNTUOS=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+        --no-cache)
+            NO_CACHE=" --no-cache"
+            ;;
+        --tag)
+            if [ "$2" ]; then
+                TAG="--tag $2"
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+	--use-local)
+	    USE_LOCAL_DIR=1
+	    ;;
+        --)
+            shift
+            break
+            ;;
+         -?*)
+            error 'ERROR: Unknown option: ' $1
+            ;;
+         ?*)
+            error 'ERROR: Unknown option: ' $1
+            ;;
+        *)
+            break
+            ;;
+        esac
+        shift
+    done
+
+    if [[ $UBUNTUOS == "22.04" ]]; then
+	BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base
+	BASE_IMAGE_TAG=24.10-cuda12.6-devel-ubuntu22.04
+    fi
+
+    if [ -z "$TAG" ]; then
+        TAG="--tag nixl:${VERSION}"
+    fi
+
+    if [ $USE_LOCAL_DIR -eq 1 ]; then
+	NIXL_DIR=$BUILD_CONTEXT
+	NIXL_COMMIT=$FULLCOMMIT
+    fi
+}
+
+show_build_options() {
+    echo ""
+    echo "Building NIXL Image: '${TAG}' for Ubuntu${UBUNTUOS}"
+    echo "Using local nixl source: ${NIXL_DIR}"
+    echo "    Build Context: ${BUILD_CONTEXT}"
+}
+
+show_help() {
+    echo "usage: build.sh"
+    echo "  [--base base image]"
+    echo "  [--base-imge-tag base image tag]"
+    echo "  [--no-cache disable docker build cache]"
+    echo "  [--os [24.04|22.04] to select Ubuntu version]"
+    echo "  [--tag tag for image]"
+    echo "  [--use-local copy current source dir to container]"
+    exit 0
+}
+
+missing_requirement() {
+    error "ERROR: $1 requires an argument."
+}
+
+error() {
+    printf '%s %s\n' "$1" "$2" >&2
+    exit 1
+}
+
+get_options "$@"
+
+show_build_options
+
+if [ $USE_LOCAL_DIR -eq 0 ]; then
+    if [ -d "$NIXL_DIR" ]; then
+	echo "Warning: $NIXL_DIR exists, skipping clone"
+    else
+	git clone https://github.com/${NIXL_REPO} ${NIXL_DIR}
+    fi
+
+    if ! git checkout ${NIXL_COMMIT}; then
+	echo "ERROR: Failed to checkout commit ${NIXL_COMMIT}."
+	echo "Please delete $NIXL_DIR and retry."
+	exit 1
+    fi
+else
+    if [ -d "$NIXL_DIR/build" ]; then
+	echo "Please delete the build directory before creating container"
+	exit 1
+    fi
+fi
+
+BUILD_CONTEXT_ARGS+=" --build-context nixl=$NIXL_DIR"
+BUILD_ARGS+=" --build-arg NIXL_COMMIT=${NIXL_COMMIT} --build-arg NIXL_REPO=${NIXL_REPO}"
+BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
+BUILD_ARGS+=" --build-arg UBUNTUOS=$UBUNTUOS"
+
+docker build -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT_ARGS $BUILD_CONTEXT

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+source $HOME/.local/bin/env
+
+# install auditwheel
+pip3 install auditwheel
+
+# build the wheel
+uv build --wheel
+
+# Fix up wheel
+auditwheel repair dist/nixl-*-cp31*.whl --plat manylinux_2_39_x86_64


### PR DESCRIPTION
Dockerfile:
 - Remove the MPI install for nixl library
 - Update the nixl repo to use github version or local copy based on new build script arg
 - Added support to have a uv wheel built within the container

Scripts:
 - Added scripts for build container, uv wheel
 - Build script for container can use Ubuntu 22.04 images if required