### PR TITLE
python API: return bytes for python notifications

### DIFF
--- a/examples/python/blocking_send_recv_example.py
+++ b/examples/python/blocking_send_recv_example.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         # For now the notification is just UUID, could be any python bytes.
         # Also can have more than UUID, and check_remote_xfer_done returns
         # the full python bytes, here it would be just UUID.
-        while not agent.check_remote_xfer_done(peer_name, "UUID".encode()):
+        while not agent.check_remote_xfer_done(peer_name, b'UUID'):
             continue
     else:
         # If send_notif is used, get_new_notifs should listen for it,

--- a/examples/python/blocking_send_recv_example.py
+++ b/examples/python/blocking_send_recv_example.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         # For now the notification is just UUID, could be any python bytes.
         # Also can have more than UUID, and check_remote_xfer_done returns
         # the full python bytes, here it would be just UUID.
-        while not agent.check_remote_xfer_done(peer_name, b'UUID'):
+        while not agent.check_remote_xfer_done(peer_name, b"UUID"):
             continue
     else:
         # If send_notif is used, get_new_notifs should listen for it,

--- a/examples/python/blocking_send_recv_example.py
+++ b/examples/python/blocking_send_recv_example.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         # For now the notification is just UUID, could be any python bytes.
         # Also can have more than UUID, and check_remote_xfer_done returns
         # the full python bytes, here it would be just UUID.
-        while not agent.check_remote_xfer_done(peer_name, "UUID"):
+        while not agent.check_remote_xfer_done(peer_name, "UUID".encode()):
             continue
     else:
         # If send_notif is used, get_new_notifs should listen for it,

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -53,7 +53,7 @@ class nixl_agent:
         self.agent = nixlBind.nixlAgent(agent_name, agent_config)
 
         self.name = agent_name
-        self.notifs: dict[str, list[str]] = {}
+        self.notifs: dict[str, list[bytes]] = {}
         self.backends: dict[str, nixl_backend_handle] = {}
         self.backend_mems: dict[str, list[str]] = {}
         self.backend_options: dict[str, dict[str, str]] = {}
@@ -300,22 +300,23 @@ class nixl_agent:
         self.agent.releasedDlistH(handle)
 
     # Returns new notifs, without touching self.notifs
-    def get_new_notifs(self) -> dict[str, list[str]]:
+    def get_new_notifs(self) -> dict[str, list[bytes]]:
         return self.agent.getNotifs({})
 
     # Adds new notifs to self.notifs and returns it
-    def update_notifs(self) -> dict[str, list[str]]:
+    def update_notifs(self) -> dict[str, list[bytes]]:
         self.notifs = self.agent.getNotifs(self.notifs)
         return self.notifs
 
     # Only removes the specific notification from self.notifs
-    def check_remote_xfer_done(self, remote_agent_name: str, lookup_msg: str) -> bool:
+    def check_remote_xfer_done(self, remote_agent_name: str, lookup_msg: bytes) -> bool:
         self.notifs = self.agent.getNotifs(self.notifs)  # Adds new notifs
         found = False
-        message = ""
+        message = None
+
         if remote_agent_name in self.notifs:
             for msg in self.notifs[remote_agent_name]:
-                if lookup_msg in msg:
+                if lookup_msg == msg:
                     message = lookup_msg
                     found = True
                     break

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -316,7 +316,7 @@ class nixl_agent:
 
         if remote_agent_name in self.notifs:
             for msg in self.notifs[remote_agent_name]:
-                if lookup_msg == msg:
+                if lookup_msg in msg:
                     message = lookup_msg
                     found = True
                     break

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                     print("Initiator done")
 
             if not target_done:
-                if nixl_agent1.check_remote_xfer_done("initiator", "UUID1".encode()):
+                if nixl_agent1.check_remote_xfer_done("initiator", b'UUID1'):
                     target_done = True
                     print("Target done")
 
@@ -173,7 +173,7 @@ if __name__ == "__main__":
                 print("Initiator done")
 
         if not target_done:
-            if nixl_agent1.check_remote_xfer_done("initiator", "UUID2".encode()):
+            if nixl_agent1.check_remote_xfer_done("initiator", b'UUID2'):
                 target_done = True
                 print("Target done")
 

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                     print("Initiator done")
 
             if not target_done:
-                if nixl_agent1.check_remote_xfer_done("initiator", b'UUID1'):
+                if nixl_agent1.check_remote_xfer_done("initiator", b"UUID1"):
                     target_done = True
                     print("Target done")
 
@@ -173,7 +173,7 @@ if __name__ == "__main__":
                 print("Initiator done")
 
         if not target_done:
-            if nixl_agent1.check_remote_xfer_done("initiator", b'UUID2'):
+            if nixl_agent1.check_remote_xfer_done("initiator", b"UUID2"):
                 target_done = True
                 print("Target done")
 

--- a/test/python/nixl_api_test.py
+++ b/test/python/nixl_api_test.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     # Exchange metadata
     meta = nixl_agent1.get_agent_metadata()
     remote_name = nixl_agent2.add_remote_agent(meta)
-    print("Loaded name from metadata:", remote_name)
+    print("Loaded name from metadata:", remote_name, flush=True)
 
     serdes = nixl_agent1.get_serialized_descs(agent1_reg_descs)
     src_descs_recvd = nixl_agent2.deserialize_descs(serdes)
@@ -108,7 +108,7 @@ if __name__ == "__main__":
                     print("Initiator done")
 
             if not target_done:
-                if nixl_agent1.check_remote_xfer_done("initiator", "UUID1"):
+                if nixl_agent1.check_remote_xfer_done("initiator", "UUID1".encode()):
                     target_done = True
                     print("Target done")
 
@@ -122,6 +122,26 @@ if __name__ == "__main__":
 
     assert local_prep_handle != 0
     assert remote_prep_handle != 0
+
+    # test send_notif
+
+    test_notif = str.encode("DESCS: ") + serdes
+    nixl_agent2.send_notif(remote_name, test_notif)
+
+    print("sent notif ")
+    print(test_notif)
+
+    notif_recv = False
+
+    while not notif_recv:
+        notif_map = nixl_agent1.get_new_notifs()
+        if "initiator" in notif_map:
+            print("received message from initiator")
+            for msg in notif_map["initiator"]:
+                if msg == test_notif:
+                    notif_recv = True
+
+    print("notif test complete, doing transfer 2\n")
 
     xfer_handle_2 = nixl_agent2.make_prepped_xfer(
         "WRITE", local_prep_handle, [0, 1], remote_prep_handle, [1, 0], "UUID2"
@@ -140,6 +160,8 @@ if __name__ == "__main__":
     target_done = False
     init_done = False
 
+    print("Transfer 2 started")
+
     while (not init_done) or (not target_done):
         if not init_done:
             state = nixl_agent2.check_xfer_state(xfer_handle_2)
@@ -151,7 +173,7 @@ if __name__ == "__main__":
                 print("Initiator done")
 
         if not target_done:
-            if nixl_agent1.check_remote_xfer_done("initiator", "UUID2"):
+            if nixl_agent1.check_remote_xfer_done("initiator", "UUID2".encode()):
                 target_done = True
                 print("Target done")
 

--- a/test/python/nixl_bindings_test.py
+++ b/test/python/nixl_bindings_test.py
@@ -138,7 +138,7 @@ def test_agent():
     nixl_utils.verify_transfer(addr1 + offset, addr2 + offset, req_size)
     assert len(notifMap[name1]) == 1
     print(notifMap[name1][0])
-    assert notifMap[name1][0] == noti_str
+    assert notifMap[name1][0] == noti_str.encode()
 
     print("Transfer verified")
 


### PR DESCRIPTION
Update our python API to always return bytes for notifications, as well as updating tests to account for this.