### PR TITLE
GDS: prepXfer usage, better test example

### DIFF
--- a/examples/python/nixl_gds_example.py
+++ b/examples/python/nixl_gds_example.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import nixl._utils as nixl_utils
+from nixl._api import nixl_agent
+
+if __name__ == "__main__":
+    buf_size = 16 * 4096
+    # Allocate memory and register with NIXL
+
+    if len(sys.argv) < 2:
+        print("Please specify file path in argv")
+        exit(0)
+
+    print("Using NIXL Plugins from:")
+    print(os.environ["NIXL_PLUGIN_DIR"])
+
+    nixl_agent1 = nixl_agent("GDSTester")
+
+    plugin_list = nixl_agent1.get_plugin_list()
+    assert "GDS" in plugin_list
+
+    print("Plugin parameters")
+    print(nixl_agent1.get_plugin_mem_types("GDS"))
+    print(nixl_agent1.get_plugin_params("GDS"))
+
+    nixl_agent1.create_backend("GDS")
+
+    print("\nLoaded backend parameters")
+    print(nixl_agent1.get_backend_mem_types("GDS"))
+    print(nixl_agent1.get_backend_params("GDS"))
+    print()
+
+    # get DRAM buf and initialize it to 0xba for verification
+    addr1 = nixl_utils.malloc_passthru(buf_size)
+    addr2 = nixl_utils.malloc_passthru(buf_size)
+    nixl_utils.ba_buf(addr1, buf_size)
+
+    agent1_strings = [(addr1, buf_size, 0, "a"), (addr2, buf_size, 0, "b")]
+
+    agent1_reg_descs = nixl_agent1.get_reg_descs(agent1_strings, "DRAM")
+    agent1_xfer1_descs = nixl_agent1.get_xfer_descs([(addr1, buf_size, 0)], "DRAM")
+    agent1_xfer2_descs = nixl_agent1.get_xfer_descs([(addr2, buf_size, 0)], "DRAM")
+
+    assert nixl_agent1.register_memory(agent1_reg_descs) is not None
+
+    # user must pass full file path for test
+    agent1_fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT)
+    assert agent1_fd >= 0
+
+    agent1_file_list = [(0, buf_size, agent1_fd, "b")]
+
+    agent1_file_descs = nixl_agent1.register_memory(agent1_file_list, "FILE")
+    assert agent1_file_descs is not None
+
+    agent1_xfer_files = agent1_file_descs.trim()
+
+    # initialize transfer mode
+    xfer_handle_1 = nixl_agent1.initialize_xfer(
+        "WRITE", agent1_xfer1_descs, agent1_xfer_files, "GDSTester"
+    )
+    if not xfer_handle_1:
+        print("Creating transfer failed.")
+        exit()
+
+    state = nixl_agent1.transfer(xfer_handle_1)
+    assert state != "ERR"
+
+    done = False
+
+    while not done:
+        state = nixl_agent1.check_xfer_state(xfer_handle_1)
+        if state == "ERR":
+            print("Transfer got to Error state.")
+            exit()
+        elif state == "DONE":
+            done = True
+            print("Initiator done")
+
+    # read file data back into second buffer
+    xfer_handle_2 = nixl_agent1.initialize_xfer(
+        "READ", agent1_xfer2_descs, agent1_xfer_files, "GDSTester"
+    )
+    if not xfer_handle_2:
+        print("Creating transfer failed.")
+        exit()
+
+    state = nixl_agent1.transfer(xfer_handle_2)
+    assert state != "ERR"
+
+    done = False
+
+    while not done:
+        state = nixl_agent1.check_xfer_state(xfer_handle_2)
+        if state == "ERR":
+            print("Transfer got to Error state.")
+            exit()
+        elif state == "DONE":
+            done = True
+            print("Initiator done")
+
+    # transfer verification
+    nixl_utils.verify_transfer(addr1, addr2, buf_size)
+
+    nixl_agent1.release_xfer_handle(xfer_handle_1)
+    nixl_agent1.release_xfer_handle(xfer_handle_2)
+    nixl_agent1.deregister_memory(agent1_reg_descs)
+    nixl_agent1.deregister_memory(agent1_file_descs)
+
+    nixl_utils.free_passthru(addr1)
+    nixl_utils.free_passthru(addr2)
+
+    os.close(agent1_fd)
+
+    print("Test Complete.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ authors = [
 ]
 
 [tool.meson-python.args]
-setup = ['-Ddisable_gds_backend=true', '-Dinstall_headers=false']
+setup = ['-Dinstall_headers=false']

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -98,6 +98,9 @@ class nixl_agent:
         self.nixl_mems = {
             "DRAM": nixlBind.DRAM_SEG,
             "VRAM": nixlBind.VRAM_SEG,
+            "FILE": nixlBind.FILE_SEG,
+            "BLOCK": nixlBind.BLK_SEG,
+            "OBJ": nixlBind.OBJ_SEG,
             "cpu": nixlBind.DRAM_SEG,
             "cuda": nixlBind.VRAM_SEG,
         }

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -287,6 +287,18 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
+    // Check for VRAM size limitation
+    if ((local.getType() == VRAM_SEG || remote.getType() == VRAM_SEG)) {
+        for (size_t i = 0; i < buf_cnt; i++) {
+            size_t size = (local.getType() == VRAM_SEG) ? local[i].len : remote[i].len;
+            if (size > (16 * 1024 * 1024)) {  // 16MB
+                std::cerr << "Error: VRAM transfers larger than 16MB are not supported in this plugin\n";
+                delete gds_handle;
+                return NIXL_ERR_INVALID_PARAM;
+            }
+        }
+    }
+
     if ((remote.getType() != FILE_SEG) && (local.getType() != FILE_SEG)) {
         std::cerr << "Only support I/O between memory (DRAM/VRAM) and file type\n";
         delete gds_handle;

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -329,11 +329,11 @@ nixl_status_t nixlGdsEngine::postXfer (const nixl_xfer_op_t &operation,
         size_t current_req = 0;
         for (auto* batch : gds_handle->batch_io_list) {
             batch->reset();  // Just reset counters
-            
+
             // Repopulate this batch
             size_t batch_size = std::min(gds_handle->request_list.size() - current_req,
                                        (size_t)batch->getMaxReqs());
-            
+
             for (size_t i = 0; i < batch_size; i++) {
                 const auto& req = gds_handle->request_list[current_req + i];
                 ret = batch->addToBatch(req.fh, req.addr, req.size,

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -515,11 +515,14 @@ nixl_status_t nixlGdsEngine::releaseReqH(nixlBackendReqH* handle)
 nixlGdsEngine::~nixlGdsEngine() {
     // Clean up the batch pool
     for (auto* batch : batch_pool) {
-        batch->destroyBatch();
-        delete batch;
+        delete batch;  // This will automatically call the nixlGdsIOBatch destructor
     }
     batch_pool.clear();
 
+    if (gds_utils) {
+        delete gds_utils;
+        gds_utils = nullptr;
+    }
+
     cuFileDriverClose();
-    delete gds_utils;
 }

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -169,7 +169,7 @@ nixlGdsEngine::nixlGdsEngine(const nixlBackendInitParams* init_params)
                 batch_limit = std::stoi((*custom_params)["batch_limit"]);
                 // Ensure reasonable limits
                 if (batch_limit < 1) batch_limit = 1;
-                if (batch_limit > 1024) batch_limit = 1024;
+                if (batch_limit > 128) batch_limit = 128;
             } catch (...) {
                 // Keep default if conversion fails
             }
@@ -180,8 +180,8 @@ nixlGdsEngine::nixlGdsEngine(const nixlBackendInitParams* init_params)
             try {
                 max_request_size = std::stoul((*custom_params)["max_request_size"]);
                 // Ensure reasonable limits (minimum 1MB, maximum 1GB)
-                size_t min_size = 1024 * 1024;        // 1MB
-                size_t max_size = 1024 * 1024 * 1024; // 1GB
+                size_t min_size = 1;        // 1
+                size_t max_size = 16 * 1024 * 1024; // 16 MB
                 if (max_request_size < min_size) max_request_size = min_size;
                 if (max_request_size > max_size) max_request_size = max_size;
             } catch (...) {
@@ -194,9 +194,10 @@ nixlGdsEngine::nixlGdsEngine(const nixlBackendInitParams* init_params)
     if (gds_utils->openGdsDriver() == NIXL_ERR_BACKEND)
         this->initErr = true;
 
-    // Pre-populate the batch pool with full pool size
-    for (unsigned int i = 0; i < batch_pool_size; i++) {
-        batch_pool.push_back(new nixlGdsIOBatch(batch_limit));
+    if (!this->initErr) {
+        for (unsigned int i = 0; i < batch_pool_size; i++) {
+         batch_pool.push_back(new nixlGdsIOBatch(batch_limit));
+        }
     }
 }
 

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -28,125 +28,126 @@
 #include "backend/backend_engine.h"
 
 class nixlGdsMetadata : public nixlBackendMD {
-    public:
-        gdsFileHandle  handle;
-        gdsMemBuf      buf;
-        nixl_mem_t     type;
+public:
+    gdsFileHandle handle;
+    gdsMemBuf buf;
+    nixl_mem_t type;
 
-        nixlGdsMetadata() : nixlBackendMD(true) { }
-        ~nixlGdsMetadata() { }
+    nixlGdsMetadata() : nixlBackendMD(true) { }
+    ~nixlGdsMetadata() { }
 };
 
+class nixlGdsIOBatch {
+private:
+    unsigned int max_reqs;
+    CUfileBatchHandle_t batch_handle;
+    CUfileIOEvents_t *io_batch_events;
+    CUfileIOParams_t *io_batch_params;
+    CUfileError_t init_err;
+    nixl_status_t current_status;
+    unsigned int entries_completed;
+    unsigned int batch_size;
 
-class nixlGdsIOBatch  {
-    private:
-        unsigned int        max_reqs;
+public:
+    nixlGdsIOBatch(unsigned int size);
+    ~nixlGdsIOBatch();
 
-        CUfileBatchHandle_t batch_handle;
-        CUfileIOEvents_t    *io_batch_events;
-        CUfileIOParams_t    *io_batch_params;
-        CUfileError_t       init_err;
-        nixl_status_t       current_status;
-        unsigned int        entries_completed;
-        unsigned int        batch_size;
-
-    public:
-        nixlGdsIOBatch(unsigned int size);
-        ~nixlGdsIOBatch();
-
-        nixl_status_t       addToBatch(CUfileHandle_t fh,  void *buffer,
-                                       size_t size, size_t file_offset,
-                                       size_t ptr_offset, CUfileOpcode_t type);
-        nixl_status_t       submitBatch(int flags);
-        nixl_status_t       checkStatus();
-        nixl_status_t       cancelBatch();
-        void                destroyBatch();
+    nixl_status_t addToBatch(CUfileHandle_t fh, void *buffer,
+                            size_t size, size_t file_offset,
+                            size_t ptr_offset, CUfileOpcode_t type);
+    nixl_status_t submitBatch(int flags);
+    nixl_status_t checkStatus();
+    nixl_status_t cancelBatch();
+    void destroyBatch();
+    void reset();
+    unsigned int getMaxReqs() const { return max_reqs; }
 };
 
 class nixlGdsBackendReqH : public nixlBackendReqH {
-    public:
-       std::list<nixlGdsIOBatch *> batch_io_list;
+public:
+    std::list<nixlGdsIOBatch *> batch_io_list;
 
-       nixlGdsBackendReqH() {}
-       ~nixlGdsBackendReqH() {
-       for (auto obj : batch_io_list)
-           delete obj;
-       }
+    nixlGdsBackendReqH() {}
+    ~nixlGdsBackendReqH() {
+        for (auto obj : batch_io_list)
+            delete obj;
+    }
 };
 
-
 class nixlGdsEngine : public nixlBackendEngine {
-    private:
-        gdsUtil                      *gds_utils;
-        std::unordered_map<int, gdsFileHandle> gds_file_map;
+private:
+    gdsUtil *gds_utils;
+    std::unordered_map<int, gdsFileHandle> gds_file_map;
+    std::list<nixlGdsIOBatch*> batch_pool;
+    unsigned int pool_size;  // Configurable pool size
 
-    public:
-        nixlGdsEngine(const nixlBackendInitParams* init_params);
-        ~nixlGdsEngine();
+    nixlGdsIOBatch* getBatchFromPool(unsigned int size);
+    void returnBatchToPool(nixlGdsIOBatch* batch);
 
-        // File operations - target is the distributed FS
-        // So no requirements to connect to target.
-        // Just treat it locally.
-        bool supportsNotif () const {
-            return false;
-        }
-        bool supportsRemote  () const {
-            return false;
-        }
-        bool supportsLocal   () const {
-            return true;
-        }
-        bool supportsProgTh  () const {
-            return false;
-        }
+public:
+    nixlGdsEngine(const nixlBackendInitParams* init_params);
+    ~nixlGdsEngine();
 
-        nixl_mem_list_t getSupportedMems () const {
-            nixl_mem_list_t mems;
-            mems.push_back(VRAM_SEG);
-            mems.push_back(FILE_SEG);
-            return mems;
-        }
+    // File operations - target is the distributed FS
+    // So no requirements to connect to target.
+    // Just treat it locally.
+    bool supportsNotif() const {
+        return false;
+    }
+    bool supportsRemote() const {
+        return false;
+    }
+    bool supportsLocal() const {
+        return true;
+    }
+    bool supportsProgTh() const {
+        return false;
+    }
 
-        nixl_status_t connect(const std::string &remote_agent)
-        {
-            return NIXL_SUCCESS;
-        }
+    nixl_mem_list_t getSupportedMems() const {
+        nixl_mem_list_t mems;
+        mems.push_back(VRAM_SEG);
+        mems.push_back(FILE_SEG);
+        return mems;
+    }
 
-        nixl_status_t disconnect(const std::string &remote_agent)
-        {
-            return NIXL_SUCCESS;
-        }
+    nixl_status_t connect(const std::string &remote_agent) {
+        return NIXL_SUCCESS;
+    }
 
-        nixl_status_t loadLocalMD (nixlBackendMD* input,
-                                   nixlBackendMD* &output) {
-            output = input;
+    nixl_status_t disconnect(const std::string &remote_agent) {
+        return NIXL_SUCCESS;
+    }
 
-            return NIXL_SUCCESS;
-        }
+    nixl_status_t loadLocalMD(nixlBackendMD* input,
+                             nixlBackendMD* &output) {
+        output = input;
+        return NIXL_SUCCESS;
+    }
 
-        nixl_status_t unloadMD (nixlBackendMD* input) {
-            return NIXL_SUCCESS;
-        }
-        nixl_status_t registerMem(const nixlBlobDesc &mem,
-                                  const nixl_mem_t &nixl_mem,
-                                  nixlBackendMD* &out);
-        nixl_status_t deregisterMem (nixlBackendMD *meta);
+    nixl_status_t unloadMD(nixlBackendMD* input) {
+        return NIXL_SUCCESS;
+    }
+    nixl_status_t registerMem(const nixlBlobDesc &mem,
+                             const nixl_mem_t &nixl_mem,
+                             nixlBackendMD* &out);
+    nixl_status_t deregisterMem(nixlBackendMD *meta);
 
-        nixl_status_t prepXfer (const nixl_xfer_op_t &operation,
-                                const nixl_meta_dlist_t &local,
-                                const nixl_meta_dlist_t &remote,
-                                const std::string &remote_agent,
-                                nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+    nixl_status_t prepXfer(const nixl_xfer_op_t &operation,
+                          const nixl_meta_dlist_t &local,
+                          const nixl_meta_dlist_t &remote,
+                          const std::string &remote_agent,
+                          nixlBackendReqH* &handle,
+                          const nixl_opt_b_args_t* opt_args=nullptr);
 
-        nixl_status_t postXfer (const nixl_xfer_op_t &operation,
-                                const nixl_meta_dlist_t &local,
-                                const nixl_meta_dlist_t &remote,
-                                const std::string &remote_agent,
-                                nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+    nixl_status_t postXfer(const nixl_xfer_op_t &operation,
+                          const nixl_meta_dlist_t &local,
+                          const nixl_meta_dlist_t &remote,
+                          const std::string &remote_agent,
+                          nixlBackendReqH* &handle,
+                          const nixl_opt_b_args_t* opt_args=nullptr);
 
-        nixl_status_t checkXfer (nixlBackendReqH* handle);
-        nixl_status_t releaseReqH(nixlBackendReqH* handle);
+    nixl_status_t checkXfer(nixlBackendReqH* handle);
+    nixl_status_t releaseReqH(nixlBackendReqH* handle);
 };
 #endif

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -24,8 +24,18 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <list>
+#include <vector>
 #include "gds_utils.h"
 #include "backend/backend_engine.h"
+
+// Struct for transfer request
+struct TransferRequest {
+    void* addr;
+    size_t size;
+    size_t file_offset;
+    CUfileHandle_t fh;
+    CUfileOpcode_t op;
+};
 
 class nixlGdsMetadata : public nixlBackendMD {
 public:
@@ -66,6 +76,7 @@ public:
 class nixlGdsBackendReqH : public nixlBackendReqH {
 public:
     std::list<nixlGdsIOBatch *> batch_io_list;
+    std::vector<TransferRequest> request_list;  // Added to store prepared requests
 
     nixlGdsBackendReqH() {}
     ~nixlGdsBackendReqH() {
@@ -79,7 +90,9 @@ private:
     gdsUtil *gds_utils;
     std::unordered_map<int, gdsFileHandle> gds_file_map;
     std::list<nixlGdsIOBatch*> batch_pool;
-    unsigned int pool_size;  // Configurable pool size
+    unsigned int batch_pool_size;  // Renamed from pool_size
+    unsigned int batch_limit;      // Added for configurable batch limit
+    unsigned int max_request_size; // Added for configurable request size
 
     nixlGdsIOBatch* getBatchFromPool(unsigned int size);
     void returnBatchToPool(nixlGdsIOBatch* batch);

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -29,146 +29,146 @@
 #include "backend/backend_engine.h"
 
 class nixlGdsMetadata : public nixlBackendMD {
-public:
-    gdsFileHandle handle;
-    gdsMemBuf buf;
-    nixl_mem_t type;
+    public:
+        gdsFileHandle handle;
+        gdsMemBuf buf;
+        nixl_mem_t type;
 
-    nixlGdsMetadata() : nixlBackendMD(true) { }
-    ~nixlGdsMetadata() { }
+        nixlGdsMetadata() : nixlBackendMD(true) { }
+        ~nixlGdsMetadata() { }
 };
 
 class nixlGdsIOBatch {
-private:
-    unsigned int max_reqs{0};
-    CUfileBatchHandle_t batch_handle{nullptr};
-    CUfileIOEvents_t *io_batch_events{nullptr};
-    CUfileIOParams_t *io_batch_params{nullptr};
-    CUfileError_t init_err{};
-    nixl_status_t current_status{NIXL_ERR_NOT_POSTED};
-    unsigned int entries_completed{0};
-    unsigned int batch_size{0};
+    private:
+        unsigned int max_reqs{0};
+        CUfileBatchHandle_t batch_handle{nullptr};
+        CUfileIOEvents_t *io_batch_events{nullptr};
+        CUfileIOParams_t *io_batch_params{nullptr};
+        CUfileError_t init_err{};
+        nixl_status_t current_status{NIXL_ERR_NOT_POSTED};
+        unsigned int entries_completed{0};
+        unsigned int batch_size{0};
 
-public:
-    nixlGdsIOBatch(unsigned int size);
-    ~nixlGdsIOBatch();
+    public:
+        nixlGdsIOBatch(unsigned int size);
+        ~nixlGdsIOBatch();
 
-    nixl_status_t addToBatch(CUfileHandle_t fh, void *buffer,
-                            size_t size, size_t file_offset,
-                            size_t ptr_offset, CUfileOpcode_t type);
-    nixl_status_t submitBatch(int flags);
-    nixl_status_t checkStatus();
-    nixl_status_t cancelBatch();
-    void destroyBatch();
-    void reset();
-    unsigned int getMaxReqs() const { return max_reqs; }
+        nixl_status_t addToBatch(CUfileHandle_t fh, void *buffer,
+                                size_t size, size_t file_offset,
+                                size_t ptr_offset, CUfileOpcode_t type);
+        nixl_status_t submitBatch(int flags);
+        nixl_status_t checkStatus();
+        nixl_status_t cancelBatch();
+        void destroyBatch();
+        void reset();
+        unsigned int getMaxReqs() const { return max_reqs; }
 };
 
 class GdsTransferRequestH {
-public:
-    void* addr;
-    size_t size;
-    size_t file_offset;
-    CUfileHandle_t fh;
-    CUfileOpcode_t op;
+    public:
+        void* addr;
+        size_t size;
+        size_t file_offset;
+        CUfileHandle_t fh;
+        CUfileOpcode_t op;
 
-    GdsTransferRequestH() {}
-    ~GdsTransferRequestH() {}
+        GdsTransferRequestH() {}
+        ~GdsTransferRequestH() {}
 };
 
 class nixlGdsBackendReqH : public nixlBackendReqH {
-public:
-    std::list<nixlGdsIOBatch *> batch_io_list;
-    std::vector<GdsTransferRequestH> request_list;  // Store GdsTransferRequestH objects
+    public:
+        std::list<nixlGdsIOBatch *> batch_io_list;
+        std::vector<GdsTransferRequestH> request_list;  // Store GdsTransferRequestH objects
 
-    nixlGdsBackendReqH() {}
-    ~nixlGdsBackendReqH() {
-        for (auto obj : batch_io_list)
-            delete obj;
-    }
+        nixlGdsBackendReqH() {}
+        ~nixlGdsBackendReqH() {
+            for (auto obj : batch_io_list)
+                delete obj;
+        }
 };
 
 class nixlGdsEngine : public nixlBackendEngine {
-private:
-    gdsUtil *gds_utils;
-    std::unordered_map<int, gdsFileHandle> gds_file_map;
-    std::list<nixlGdsIOBatch*> batch_pool;
-    unsigned int batch_pool_size;  // Renamed from pool_size
-    unsigned int batch_limit;      // Added for configurable batch limit
-    unsigned int max_request_size; // Added for configurable request size
+    private:
+        gdsUtil *gds_utils;
+        std::unordered_map<int, gdsFileHandle> gds_file_map;
+        std::list<nixlGdsIOBatch*> batch_pool;
+        unsigned int batch_pool_size;  // Renamed from pool_size
+        unsigned int batch_limit;      // Added for configurable batch limit
+        unsigned int max_request_size; // Added for configurable request size
 
-    nixlGdsIOBatch* getBatchFromPool(unsigned int size);
-    void returnBatchToPool(nixlGdsIOBatch* batch);
-    nixl_status_t createBatches(const nixl_xfer_op_t &operation,
-                               const nixl_meta_dlist_t &local,
-                               const nixl_meta_dlist_t &remote,
-                               nixlGdsBackendReqH* gds_handle);
+        nixlGdsIOBatch* getBatchFromPool(unsigned int size);
+        void returnBatchToPool(nixlGdsIOBatch* batch);
+        nixl_status_t createBatches(const nixl_xfer_op_t &operation,
+                                   const nixl_meta_dlist_t &local,
+                                   const nixl_meta_dlist_t &remote,
+                                   nixlGdsBackendReqH* gds_handle);
 
-public:
-    nixlGdsEngine(const nixlBackendInitParams* init_params);
-    ~nixlGdsEngine();
+    public:
+        nixlGdsEngine(const nixlBackendInitParams* init_params);
+        ~nixlGdsEngine();
 
-    // File operations - target is the distributed FS
-    // So no requirements to connect to target.
-    // Just treat it locally.
-    bool supportsNotif() const {
-        return false;
-    }
-    bool supportsRemote() const {
-        return false;
-    }
-    bool supportsLocal() const {
-        return true;
-    }
-    bool supportsProgTh() const {
-        return false;
-    }
+        // File operations - target is the distributed FS
+        // So no requirements to connect to target.
+        // Just treat it locally.
+        bool supportsNotif() const {
+            return false;
+        }
+        bool supportsRemote() const {
+            return false;
+        }
+        bool supportsLocal() const {
+            return true;
+        }
+        bool supportsProgTh() const {
+            return false;
+        }
 
-    nixl_mem_list_t getSupportedMems() const {
-        nixl_mem_list_t mems;
-        mems.push_back(DRAM_SEG);
-        mems.push_back(VRAM_SEG);
-        mems.push_back(FILE_SEG);
-        return mems;
-    }
+        nixl_mem_list_t getSupportedMems() const {
+            nixl_mem_list_t mems;
+            mems.push_back(DRAM_SEG);
+            mems.push_back(VRAM_SEG);
+            mems.push_back(FILE_SEG);
+            return mems;
+        }
 
-    nixl_status_t connect(const std::string &remote_agent) {
-        return NIXL_SUCCESS;
-    }
+        nixl_status_t connect(const std::string &remote_agent) {
+            return NIXL_SUCCESS;
+        }
 
-    nixl_status_t disconnect(const std::string &remote_agent) {
-        return NIXL_SUCCESS;
-    }
+        nixl_status_t disconnect(const std::string &remote_agent) {
+            return NIXL_SUCCESS;
+        }
 
-    nixl_status_t loadLocalMD(nixlBackendMD* input,
-                             nixlBackendMD* &output) {
-        output = input;
-        return NIXL_SUCCESS;
-    }
+        nixl_status_t loadLocalMD(nixlBackendMD* input,
+                                 nixlBackendMD* &output) {
+            output = input;
+            return NIXL_SUCCESS;
+        }
 
-    nixl_status_t unloadMD(nixlBackendMD* input) {
-        return NIXL_SUCCESS;
-    }
-    nixl_status_t registerMem(const nixlBlobDesc &mem,
-                             const nixl_mem_t &nixl_mem,
-                             nixlBackendMD* &out);
-    nixl_status_t deregisterMem(nixlBackendMD *meta);
+        nixl_status_t unloadMD(nixlBackendMD* input) {
+            return NIXL_SUCCESS;
+        }
+        nixl_status_t registerMem(const nixlBlobDesc &mem,
+                                 const nixl_mem_t &nixl_mem,
+                                 nixlBackendMD* &out);
+        nixl_status_t deregisterMem(nixlBackendMD *meta);
 
-    nixl_status_t prepXfer(const nixl_xfer_op_t &operation,
-                          const nixl_meta_dlist_t &local,
-                          const nixl_meta_dlist_t &remote,
-                          const std::string &remote_agent,
-                          nixlBackendReqH* &handle,
-                          const nixl_opt_b_args_t* opt_args=nullptr);
+        nixl_status_t prepXfer(const nixl_xfer_op_t &operation,
+                              const nixl_meta_dlist_t &local,
+                              const nixl_meta_dlist_t &remote,
+                              const std::string &remote_agent,
+                              nixlBackendReqH* &handle,
+                              const nixl_opt_b_args_t* opt_args=nullptr);
 
-    nixl_status_t postXfer(const nixl_xfer_op_t &operation,
-                          const nixl_meta_dlist_t &local,
-                          const nixl_meta_dlist_t &remote,
-                          const std::string &remote_agent,
-                          nixlBackendReqH* &handle,
-                          const nixl_opt_b_args_t* opt_args=nullptr);
+        nixl_status_t postXfer(const nixl_xfer_op_t &operation,
+                              const nixl_meta_dlist_t &local,
+                              const nixl_meta_dlist_t &remote,
+                              const std::string &remote_agent,
+                              nixlBackendReqH* &handle,
+                              const nixl_opt_b_args_t* opt_args=nullptr);
 
-    nixl_status_t checkXfer(nixlBackendReqH* handle);
-    nixl_status_t releaseReqH(nixlBackendReqH* handle);
+        nixl_status_t checkXfer(nixlBackendReqH* handle);
+        nixl_status_t releaseReqH(nixlBackendReqH* handle);
 };
 #endif

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -106,6 +106,7 @@ public:
 
     nixl_mem_list_t getSupportedMems() const {
         nixl_mem_list_t mems;
+        mems.push_back(DRAM_SEG);
         mems.push_back(VRAM_SEG);
         mems.push_back(FILE_SEG);
         return mems;

--- a/src/plugins/cuda_gds/gds_plugin.cpp
+++ b/src/plugins/cuda_gds/gds_plugin.cpp
@@ -27,7 +27,7 @@ static nixlBackendEngine* create_gds_engine(const nixlBackendInitParams* init_pa
     return new nixlGdsEngine(init_params);
 }
 
-static void destroy_gds_engine(nixlBackendEngine *engine) {
+static void destroy_gds_engine(nixlBackendEngine* engine) {
     delete engine;
 }
 

--- a/src/plugins/cuda_gds/gds_plugin.cpp
+++ b/src/plugins/cuda_gds/gds_plugin.cpp
@@ -50,6 +50,7 @@ static nixl_b_params_t get_backend_options() {
 // Function to get supported backend mem types
 static nixl_mem_list_t get_backend_mems() {
     nixl_mem_list_t mems;
+    mems.push_back(DRAM_SEG);
     mems.push_back(VRAM_SEG);
     mems.push_back(FILE_SEG);
     return mems;

--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -17,9 +17,10 @@
 #include <iostream>
 #include "gds_utils.h"
 
-nixl_status_t gdsUtil::registerFileHandle(int fd, size_t size,
-                                        std::string metaInfo,
-                                        gdsFileHandle& gds_handle)
+nixl_status_t gdsUtil::registerFileHandle(int fd,
+                                         size_t size,
+                                         std::string metaInfo,
+                                         gdsFileHandle& gds_handle)
 {
     CUfileError_t status;
     CUfileDescr_t descr;
@@ -42,7 +43,9 @@ nixl_status_t gdsUtil::registerFileHandle(int fd, size_t size,
     return NIXL_SUCCESS;
 }
 
-nixl_status_t gdsUtil::registerBufHandle(void *ptr, size_t size, int flags)
+nixl_status_t gdsUtil::registerBufHandle(void *ptr,
+                                        size_t size,
+                                        int flags)
 {
     CUfileError_t status;
 

--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -18,11 +18,11 @@
 #include "gds_utils.h"
 
 nixl_status_t gdsUtil::registerFileHandle(int fd, size_t size,
-        std::string metaInfo,
-        gdsFileHandle& gds_handle)
+                                        std::string metaInfo,
+                                        gdsFileHandle& gds_handle)
 {
-    CUfileError_t  status;
-    CUfileDescr_t  descr;
+    CUfileError_t status;
+    CUfileDescr_t descr;
     CUfileHandle_t handle;
 
     descr.handle.fd = fd;
@@ -30,8 +30,7 @@ nixl_status_t gdsUtil::registerFileHandle(int fd, size_t size,
 
     status = cuFileHandleRegister(&handle, &descr);
     if (status.err != CU_FILE_SUCCESS) {
-        std::cerr << "file register error:"
-                  << std::endl;
+        std::cerr << "file register error:" << std::endl;
         return NIXL_ERR_BACKEND;
     }
 
@@ -45,7 +44,7 @@ nixl_status_t gdsUtil::registerFileHandle(int fd, size_t size,
 
 nixl_status_t gdsUtil::registerBufHandle(void *ptr, size_t size, int flags)
 {
-    CUfileError_t  status;
+    CUfileError_t status;
 
     status = cuFileBufRegister(ptr, size, flags);
     if (status.err != CU_FILE_SUCCESS) {
@@ -57,12 +56,11 @@ nixl_status_t gdsUtil::registerBufHandle(void *ptr, size_t size, int flags)
 
 nixl_status_t gdsUtil::openGdsDriver()
 {
-    CUfileError_t   err;
-
+    CUfileError_t err;
 
     err = cuFileDriverOpen();
     if (err.err != CU_FILE_SUCCESS) {
-        std::cerr <<" Error initializing GPU Direct Storage driver\n";
+        std::cerr << "Error initializing GPU Direct Storage driver\n";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;
@@ -80,11 +78,11 @@ void gdsUtil::deregisterFileHandle(gdsFileHandle& handle)
 
 nixl_status_t gdsUtil::deregisterBufHandle(void *ptr)
 {
-    CUfileError_t  status;
+    CUfileError_t status;
 
     status = cuFileBufDeregister(ptr);
     if (status.err != CU_FILE_SUCCESS) {
-        std::cerr <<"Error De-Registering Buffer\n";
+        std::cerr << "Error De-Registering Buffer\n";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;

--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -18,9 +18,9 @@
 #include "gds_utils.h"
 
 nixl_status_t gdsUtil::registerFileHandle(int fd,
-                                         size_t size,
-                                         std::string metaInfo,
-                                         gdsFileHandle& gds_handle)
+                                          size_t size,
+                                          std::string metaInfo,
+                                          gdsFileHandle& gds_handle)
 {
     CUfileError_t status;
     CUfileDescr_t descr;
@@ -44,8 +44,8 @@ nixl_status_t gdsUtil::registerFileHandle(int fd,
 }
 
 nixl_status_t gdsUtil::registerBufHandle(void *ptr,
-                                        size_t size,
-                                        int flags)
+                                         size_t size,
+                                         int flags)
 {
     CUfileError_t status;
 

--- a/src/plugins/cuda_gds/gds_utils.h
+++ b/src/plugins/cuda_gds/gds_utils.h
@@ -20,21 +20,20 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <nixl.h>
-
 #include <cufile.h>
 
 class gdsFileHandle {
 public:
-    int            fd;
+    int fd;
     // -1 means inf size file?
-    size_t         size;
-    std::string    metadata;
+    size_t size;
+    std::string metadata;
     CUfileHandle_t cu_fhandle;
 };
 
 class gdsMemBuf {
 public:
-    void   *base;
+    void *base;
     size_t size;
 };
 
@@ -43,8 +42,8 @@ public:
     gdsUtil() {}
     ~gdsUtil() {}
     nixl_status_t registerFileHandle(int fd, size_t size,
-                                     std::string metaInfo,
-                                     gdsFileHandle& handle);
+                                   std::string metaInfo,
+                                   gdsFileHandle& handle);
     nixl_status_t registerBufHandle(void *ptr, size_t size, int flags);
     void deregisterFileHandle(gdsFileHandle& handle);
     nixl_status_t deregisterBufHandle(void *ptr);

--- a/src/plugins/cuda_gds/gds_utils.h
+++ b/src/plugins/cuda_gds/gds_utils.h
@@ -23,32 +23,32 @@
 #include <cufile.h>
 
 class gdsFileHandle {
-public:
-    int fd;
-    // -1 means inf size file?
-    size_t size;
-    std::string metadata;
-    CUfileHandle_t cu_fhandle;
+    public:
+        int fd;
+        // -1 means inf size file?
+        size_t size;
+        std::string metadata;
+        CUfileHandle_t cu_fhandle;
 };
 
 class gdsMemBuf {
-public:
-    void *base;
-    size_t size;
+    public:
+        void *base;
+        size_t size;
 };
 
 class gdsUtil {
-public:
-    gdsUtil() {}
-    ~gdsUtil() {}
-    nixl_status_t registerFileHandle(int fd, size_t size,
-                                   std::string metaInfo,
-                                   gdsFileHandle& handle);
-    nixl_status_t registerBufHandle(void *ptr, size_t size, int flags);
-    void deregisterFileHandle(gdsFileHandle& handle);
-    nixl_status_t deregisterBufHandle(void *ptr);
-    nixl_status_t openGdsDriver();
-    void closeGdsDriver();
+    public:
+        gdsUtil() {}
+        ~gdsUtil() {}
+        nixl_status_t registerFileHandle(int fd, size_t size,
+                                       std::string metaInfo,
+                                       gdsFileHandle& handle);
+        nixl_status_t registerBufHandle(void *ptr, size_t size, int flags);
+        void deregisterFileHandle(gdsFileHandle& handle);
+        nixl_status_t deregisterBufHandle(void *ptr);
+        nixl_status_t openGdsDriver();
+        void closeGdsDriver();
 };
 
 #endif

--- a/src/plugins/cuda_gds/meson.build
+++ b/src/plugins/cuda_gds/meson.build
@@ -15,39 +15,39 @@
 
 gds_path = get_option('gds_path')
 if gds_path != ''
-  gds_lib_path = gds_path + '/lib'
-  gds_inc_path = gds_path + '/include'
-  cufile_dep = declare_dependency(
-    link_args : ['-L' + gds_lib_path, '-lcufile'],
-    include_directories : include_directories(gds_inc_path))
+    gds_lib_path = gds_path + '/lib'
+    gds_inc_path = gds_path + '/include'
+    cufile_dep = declare_dependency(
+        link_args: ['-L' + gds_lib_path, '-lcufile'],
+        include_directories: include_directories(gds_inc_path))
 endif
 
 if 'GDS' in static_plugins
-  gds_backend_lib = static_library('GDS',
-                    'gds_utils.cpp', 'gds_utils.h',
-                    'gds_backend.cpp', 'gds_backend.h',
-                    'gds_plugin.cpp',
-                    dependencies: [ nixl_infra, cuda_dep, cufile_dep],
-                    include_directories: [nixl_inc_dirs,utils_inc_dirs],
-                    install: false,
-                    cpp_args : compile_flags,
-                    name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
+    gds_backend_lib = static_library('GDS',
+        'gds_utils.cpp', 'gds_utils.h',
+        'gds_backend.cpp', 'gds_backend.h',
+        'gds_plugin.cpp',
+        dependencies: [nixl_infra, cuda_dep, cufile_dep],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: false,
+        cpp_args: compile_flags,
+        name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
-  gds_backend_lib = shared_library('GDS',
-                    'gds_utils.cpp', 'gds_utils.h',
-                    'gds_backend.cpp', 'gds_backend.h',
-                    'gds_plugin.cpp',
-                    dependencies: [nixl_infra, cuda_dep, cufile_dep],
-                    include_directories: [nixl_inc_dirs,utils_inc_dirs],
-                    install: true,
-                    cpp_args : ['-fPIC'],
-                    name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-                    install_dir: plugin_install_dir)
-  if get_option('buildtype') == 'debug'
+    gds_backend_lib = shared_library('GDS',
+        'gds_utils.cpp', 'gds_utils.h',
+        'gds_backend.cpp', 'gds_backend.h',
+        'gds_plugin.cpp',
+        dependencies: [nixl_infra, cuda_dep, cufile_dep],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: true,
+        cpp_args: ['-fPIC'],
+        name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
+        install_dir: plugin_install_dir)
+    if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
-                    'echo "GDS=' + gds_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
-                    check: true
-                )
+            'echo "GDS=' + gds_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+            check: true
+        )
     endif
 endif
 

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -29,122 +29,548 @@
 #include <sstream>
 #include <cerrno>
 #include <cstring>
+#include <getopt.h>
+#include <stdlib.h>
+#include <chrono>
 
-#define NUM_TRANSFERS 250
-#define SIZE 10485760
+// Default values
+#define DEFAULT_NUM_TRANSFERS 250
+#define DEFAULT_TRANSFER_SIZE (10 * 1024 * 1024)  // 10MB
+#define TEST_PHRASE "NIXL Storage Test Pattern 2025"
+#define TEST_PHRASE_LEN (sizeof(TEST_PHRASE) - 1)  // -1 to exclude null terminator
 
+// Progress bar configuration
+#define PROGRESS_WIDTH 50
+
+// Helper function to parse size strings like "1K", "2M", "3G"
+size_t parse_size(const char* size_str) {
+    char* end;
+    size_t size = strtoull(size_str, &end, 10);
+    if (end == size_str) {
+        return 0;  // Invalid number
+    }
+
+    if (*end) {
+        switch (toupper(*end)) {
+            case 'K': size *= 1024; break;
+            case 'M': size *= 1024 * 1024; break;
+            case 'G': size *= 1024 * 1024 * 1024; break;
+            default: return 0;  // Invalid suffix
+        }
+    }
+    return size;
+}
+
+void print_usage(const char* program_name) {
+    std::cerr << "Usage: " << program_name << " [options] <directory_path>\n"
+              << "Options:\n"
+              << "  -d, --dram              Use DRAM for memory operations\n"
+              << "  -v, --vram              Use VRAM for memory operations (default)\n"
+              << "  -n, --num-transfers N   Number of transfers to perform (default: " << DEFAULT_NUM_TRANSFERS << ")\n"
+              << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE << " bytes)\n"
+              << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
+              << "  -r, --no-read           Skip read test\n"
+              << "  -w, --no-write          Skip write test\n"
+              << "  -h, --help              Show this help message\n"
+              << "\nExample:\n"
+              << "  " << program_name << " -d -n 100 -s 2M /path/to/dir  # 100 transfers of 2MB each using DRAM\n";
+}
+
+void printProgress(float progress) {
+    int barWidth = PROGRESS_WIDTH;
+
+    std::cout << "[";
+    int pos = barWidth * progress;
+    for (int i = 0; i < barWidth; ++i) {
+        if (i < pos) std::cout << "=";
+        else if (i == pos) std::cout << ">";
+        else std::cout << " ";
+    }
+    std::cout << "] " << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
+
+    // Add completion indicator
+    if (progress >= 1.0) {
+        std::cout << "DONE!" << std::endl;
+    } else {
+        std::cout << "\r";
+        std::cout.flush();
+    }
+}
 
 std::string generate_timestamped_filename(const std::string& base_name) {
     std::time_t t = std::time(nullptr);
     char timestamp[100];
     std::strftime(timestamp, sizeof(timestamp),
                   "%Y%m%d%H%M%S", std::localtime(&t));
-    std::string return_val = base_name + std::string(timestamp);
+    return base_name + std::string(timestamp);
+}
 
-    return return_val;
+void validateBuffer(void* expected, void* actual, size_t size, const char* operation) {
+    if (memcmp(expected, actual, size) != 0) {
+        std::cerr << "Data validation failed for " << operation << std::endl;
+        exit(-1);
+    }
+}
+
+// Helper function to fill buffer with repeating pattern
+void fill_test_pattern(void* buffer, size_t size) {
+    char* buf = (char*)buffer;
+    size_t phrase_len = TEST_PHRASE_LEN;
+    size_t offset = 0;
+
+    while (offset < size) {
+        size_t remaining = size - offset;
+        size_t copy_len = (remaining < phrase_len) ? remaining : phrase_len;
+        memcpy(buf + offset, TEST_PHRASE, copy_len);
+        offset += copy_len;
+    }
+}
+
+// Helper function to fill GPU buffer with repeating pattern
+cudaError_t fill_gpu_test_pattern(void* gpu_buffer, size_t size) {
+    char* host_buffer = (char*)malloc(size);
+    if (!host_buffer) {
+        return cudaErrorMemoryAllocation;
+    }
+
+    fill_test_pattern(host_buffer, size);
+    cudaError_t err = cudaMemcpy(gpu_buffer, host_buffer, size, cudaMemcpyHostToDevice);
+    free(host_buffer);
+    return err;
+}
+
+void clear_buffer(void* buffer, size_t size) {
+    memset(buffer, 0, size);
+}
+
+cudaError_t clear_gpu_buffer(void* gpu_buffer, size_t size) {
+    return cudaMemset(gpu_buffer, 0, size);
+}
+
+// Helper function to validate GPU buffer
+bool validate_gpu_buffer(void* gpu_buffer, size_t size) {
+    char* host_buffer = (char*)malloc(size);
+    char* expected_buffer = (char*)malloc(size);
+    if (!host_buffer || !expected_buffer) {
+        free(host_buffer);
+        free(expected_buffer);
+        return false;
+    }
+
+    // Copy GPU data to host
+    cudaError_t err = cudaMemcpy(host_buffer, gpu_buffer, size, cudaMemcpyDeviceToHost);
+    if (err != cudaSuccess) {
+        free(host_buffer);
+        free(expected_buffer);
+        return false;
+    }
+
+    // Create expected pattern
+    fill_test_pattern(expected_buffer, size);
+
+    // Compare
+    bool match = (memcmp(host_buffer, expected_buffer, size) == 0);
+
+    free(host_buffer);
+    free(expected_buffer);
+    return match;
+}
+
+// Helper function to format duration
+std::string format_duration(std::chrono::microseconds us) {
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(us).count();
+    if (ms < 1000) {
+        return std::to_string(ms) + " ms";
+    }
+    double seconds = ms / 1000.0;
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(3) << seconds << " sec";
+    return ss.str();
 }
 
 int main(int argc, char *argv[])
 {
-        nixl_status_t           ret = NIXL_SUCCESS;
-        void                    *addr[NUM_TRANSFERS];
-        std::string             role;
-        int                     status = 0;
-        int                     i;
-        int                     fd[NUM_TRANSFERS];
+    nixl_status_t           ret = NIXL_SUCCESS;
+    void                    **vram_addr = NULL;
+    void                    **dram_addr = NULL;
+    std::string             role;
+    int                     status = 0;
+    int                     i;
+    int                     *fd = NULL;
+    bool                    use_dram = false;
+    bool                    use_vram = false;
+    int                     opt;
+    std::string             dir_path;
+    size_t                  transfer_size = DEFAULT_TRANSFER_SIZE;
+    int                     num_transfers = DEFAULT_NUM_TRANSFERS;
+    bool                    skip_read = false;
+    bool                    skip_write = false;
+    std::chrono::microseconds total_time(0);
+    double total_data_gb = 0;
 
-        nixlAgentConfig         cfg(true);
-        nixl_b_params_t         params;
-        nixlBlobDesc            buf[NUM_TRANSFERS];
-        nixlBlobDesc            ftrans[NUM_TRANSFERS];
-        nixlBackendH            *gds, *ucx;
+    // Parse command line options
+    static struct option long_options[] = {
+        {"dram", no_argument, 0, 'd'},
+        {"vram", no_argument, 0, 'v'},
+        {"num-transfers", required_argument, 0, 'n'},
+        {"size", required_argument, 0, 's'},
+        {"no-read", no_argument, 0, 'r'},
+        {"no-write", no_argument, 0, 'w'},
+        {"help", no_argument, 0, 'h'},
+        {0, 0, 0, 0}
+    };
 
-        nixl_reg_dlist_t        vram_for_gds(VRAM_SEG);
-        nixl_reg_dlist_t        file_for_gds(FILE_SEG);
-        nixlXferReqH            *treq;
-        std::string             name;
-
-        std::cout << "Starting Agent for " << "GDS Test Agent" << "\n";
-        nixlAgent agent("GDSTester", cfg);
-
-        // To also test the decision making of createXferReq
-        agent.createBackend("UCX", params, ucx);
-        agent.createBackend("GDS", params, gds);
-
-        if (gds == nullptr) {
-            std::cerr <<"Error creating a new backend\n";
-            exit(-1);
-        }
-
-        /** Argument Parsing */
-        if (argc < 2) {
-            std::cout <<"Enter the required arguments\n" << std::endl;
-            std::cout <<"Directory path " << std::endl;
-            exit(-1);
-        }
-
-        for (i = 0; i < NUM_TRANSFERS; i++) {
-            cudaMalloc((void **)&addr[i], SIZE);
-            cudaMemset(addr[i], 'A', SIZE);
-            name = generate_timestamped_filename("testfile");
-            std::string path = std::string(argv[1]);
-            name = path +"/"+ name +"_"+ std::to_string(i);
-
-            std::cout << "Opening File " << name << std::endl;
-            fd[i] = open(name.c_str(), O_RDWR|O_CREAT, 0744);
-            if (fd[i] < 0) {
-                std::cerr<<"Error: "<<strerror(errno)<<std::endl;
-                std::cerr<<"Open call failed to open file\n";
-                    std::cerr<<"Cannot run tests\n";
+    while ((opt = getopt_long(argc, argv, "dvn:s:rwh", long_options, NULL)) != -1) {
+        switch (opt) {
+            case 'd':
+                use_dram = true;
+                break;
+            case 'v':
+                use_vram = true;
+                break;
+            case 'n':
+                num_transfers = atoi(optarg);
+                if (num_transfers <= 0) {
+                    std::cerr << "Error: Number of transfers must be positive\n";
                     return 1;
+                }
+                break;
+            case 's':
+                transfer_size = parse_size(optarg);
+                if (transfer_size == 0) {
+                    std::cerr << "Error: Invalid transfer size format\n";
+                    return 1;
+                }
+                break;
+            case 'r':
+                skip_read = true;
+                break;
+            case 'w':
+                skip_write = true;
+                break;
+            case 'h':
+                print_usage(argv[0]);
+                return 0;
+            default:
+                print_usage(argv[0]);
+                return 1;
+        }
+    }
+
+    if (skip_read && skip_write) {
+        std::cerr << "Error: Cannot skip both read and write tests\n";
+        return 1;
+    }
+
+    // Check if directory path is provided
+    if (optind >= argc) {
+        std::cerr << "Error: Directory path is required\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+    dir_path = argv[optind];
+
+    // If neither is specified, default to VRAM
+    if (!use_dram && !use_vram) {
+        use_vram = true;
+    }
+
+    // Allocate arrays based on num_transfers
+    if (use_vram) {
+        vram_addr = new void*[num_transfers];
+    }
+    if (use_dram) {
+        dram_addr = new void*[num_transfers];
+    }
+    fd = new int[num_transfers];
+
+    // Initialize NIXL components
+    nixlAgentConfig         cfg(true);
+    nixl_b_params_t         params;
+    nixlBlobDesc            *vram_buf = use_vram ? new nixlBlobDesc[num_transfers] : NULL;
+    nixlBlobDesc            *dram_buf = use_dram ? new nixlBlobDesc[num_transfers] : NULL;
+    nixlBlobDesc            *ftrans = new nixlBlobDesc[num_transfers];
+    nixlBackendH            *gds;
+
+    nixl_reg_dlist_t        vram_for_gds(VRAM_SEG);
+    nixl_reg_dlist_t        dram_for_gds(DRAM_SEG);
+    nixl_reg_dlist_t        file_for_gds(FILE_SEG);
+    nixlXferReqH            *treq;
+    std::string             name;
+
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "                 NIXL STORAGE TEST STARTING (GDS PLUGIN)                     " << std::endl;
+    std::cout << "============================================================" << std::endl;
+    std::cout << "Configuration:" << std::endl;
+    std::cout << "- Mode: " << (use_dram ? "DRAM" : "VRAM") << std::endl;
+    std::cout << "- Number of transfers: " << num_transfers << std::endl;
+    std::cout << "- Transfer size: " << transfer_size << " bytes" << std::endl;
+    std::cout << "- Directory: " << dir_path << std::endl;
+    std::cout << "- Operation: ";
+    if (!skip_read && !skip_write) {
+        std::cout << "Read and Write";
+    } else if (skip_read) {
+        std::cout << "Write Only";
+    } else {  // skip_write
+        std::cout << "Read Only";
+    }
+    std::cout << std::endl;
+    std::cout << "============================================================\n" << std::endl;
+
+    nixlAgent agent("GDSTester", cfg);
+
+    // Create backends
+    agent.createBackend("GDS", params, gds);
+
+    if (gds == NULL) {
+        std::cerr << "Error creating GDS backend\n";
+        goto cleanup;
+    }
+
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "PHASE 1: Allocating and initializing buffers" << std::endl;
+    std::cout << "============================================================" << std::endl;
+    for (i = 0; i < num_transfers; i++) {
+        if (use_vram) {
+            // Allocate and initialize VRAM buffer
+            if (cudaMalloc(&vram_addr[i], transfer_size) != cudaSuccess) {
+                std::cerr << "CUDA malloc failed\n";
+                goto cleanup;
             }
-            std::cout << "Opened File " << name << std::endl;
-
-            std::cout << "Allocating for src buffer : "
-                      << addr[i] << ","
-                      << "Setting to As "
-                      << std::endl;
-            /* If O_CREATE is specified, mode flags need to be specified */
-            /* Use 0744 as mode */
-            buf[i].addr   = (uintptr_t)(addr[i]);
-            buf[i].len    = SIZE;
-            buf[i].devId  = 0;
-            vram_for_gds.addDesc(buf[i]);
-
-            ftrans[i].addr  = 0; // this is offset
-            ftrans[i].len   = SIZE;
-            ftrans[i].devId = fd[i];
-            file_for_gds.addDesc(ftrans[i]);
+            if (fill_gpu_test_pattern(vram_addr[i], transfer_size) != cudaSuccess) {
+                std::cerr << "CUDA buffer initialization failed\n";
+                goto cleanup;
+            }
         }
 
-        agent.registerMem(file_for_gds);
-        agent.registerMem(vram_for_gds);
+        if (use_dram) {
+            // Allocate and initialize DRAM buffer
+            if (posix_memalign(&dram_addr[i], 4096, transfer_size) != 0) {
+                std::cerr << "DRAM allocation failed\n";
+                goto cleanup;
+            }
+            fill_test_pattern(dram_addr[i], transfer_size);
+        }
 
-        nixl_xfer_dlist_t vram_for_gds_list = vram_for_gds.trim();
-        nixl_xfer_dlist_t file_for_gds_list = file_for_gds.trim();
+        // Create test file
+        name = generate_timestamped_filename("testfile");
+        name = dir_path + "/" + name + "_" + std::to_string(i);
 
-        ret = agent.createXferReq(NIXL_WRITE, vram_for_gds_list, file_for_gds_list,
-                                  "GDSTester", treq);
+        fd[i] = open(name.c_str(), O_RDWR|O_CREAT, 0744);
+        if (fd[i] < 0) {
+            std::cerr << "Failed to open file: " << name << " - " << strerror(errno) << std::endl;
+            goto cleanup;
+        }
+
+        // Set up descriptors
+        if (use_vram) {
+            vram_buf[i].addr   = (uintptr_t)(vram_addr[i]);
+            vram_buf[i].len    = transfer_size;
+            vram_buf[i].devId  = 0;
+            vram_for_gds.addDesc(vram_buf[i]);
+        }
+
+        if (use_dram) {
+            dram_buf[i].addr   = (uintptr_t)(dram_addr[i]);
+            dram_buf[i].len    = transfer_size;
+            dram_buf[i].devId  = 0;
+            dram_for_gds.addDesc(dram_buf[i]);
+        }
+
+        ftrans[i].addr  = 0;
+        ftrans[i].len   = transfer_size;
+        ftrans[i].devId = fd[i];
+        file_for_gds.addDesc(ftrans[i]);
+
+        printProgress(float(i + 1) / num_transfers);
+    }
+
+    std::cout << "\n=== Registering memory ===" << std::endl;
+    agent.registerMem(file_for_gds);
+    if (use_vram) agent.registerMem(vram_for_gds);
+    if (use_dram) agent.registerMem(dram_for_gds);
+
+    // Prepare transfer lists
+    nixl_xfer_dlist_t file_for_gds_list = file_for_gds.trim();
+    nixl_xfer_dlist_t src_list = use_dram ? dram_for_gds.trim() : vram_for_gds.trim();
+
+    // Perform write test if not skipped
+    if (!skip_write) {
+        std::cout << "\n============================================================" << std::endl;
+        std::cout << "PHASE 2: Memory to File Transfer (Write Test)" << std::endl;
+        std::cout << "============================================================" << std::endl;
+
+        auto write_start = std::chrono::high_resolution_clock::now();
+
+        ret = agent.createXferReq(NIXL_WRITE, src_list, file_for_gds_list,
+                                 "GDSTester", treq);
         if (ret != NIXL_SUCCESS) {
-            std::cerr << "Error creating transfer request\n" << ret;
-            exit(-1);
+            std::cerr << "Failed to create write transfer request\n";
+            goto cleanup;
         }
 
-        std::cout << " Post the request with GDS backend\n ";
         status = agent.postXferReq(treq);
-        std::cout << " GDS File IO has been posted\n";
-        std::cout << " Waiting for completion\n";
-
         while (status != NIXL_SUCCESS) {
             status = agent.getXferStatus(treq);
             assert(status >= 0);
         }
-        std::cout <<" Completed writing data using GDS backend\n";
         agent.releaseXferReq(treq);
 
-        std::cout <<"Cleanup.. \n";
-        agent.deregisterMem(vram_for_gds);
-        agent.deregisterMem(file_for_gds);
+        auto write_end = std::chrono::high_resolution_clock::now();
+        auto write_duration = std::chrono::duration_cast<std::chrono::microseconds>(write_end - write_start);
+        total_time += write_duration;
 
-        return 0;
+        double data_gb = (transfer_size * num_transfers) / (1024.0 * 1024.0 * 1024.0);
+        total_data_gb += data_gb;
+        double seconds = write_duration.count() / 1000000.0;
+        double gbps = data_gb / seconds;
+
+        std::cout << "Write completed:" << std::endl;
+        std::cout << "- Time: " << format_duration(write_duration) << std::endl;
+        std::cout << "- Data: " << std::fixed << std::setprecision(2) << data_gb << " GB" << std::endl;
+        std::cout << "- Speed: " << gbps << " GB/s" << std::endl;
+    }
+
+    // Clear buffers before read if doing both operations
+    if (!skip_read && !skip_write) {
+        std::cout << "\n============================================================" << std::endl;
+        std::cout << "PHASE 3: Clearing buffers for read test" << std::endl;
+        std::cout << "============================================================" << std::endl;
+        for (i = 0; i < num_transfers; i++) {
+            if (use_vram && vram_addr[i]) {
+                if (clear_gpu_buffer(vram_addr[i], transfer_size) != cudaSuccess) {
+                    std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
+                    goto cleanup;
+                }
+            }
+            if (use_dram && dram_addr[i]) {
+                clear_buffer(dram_addr[i], transfer_size);
+            }
+            printProgress(float(i + 1) / num_transfers);
+        }
+    }
+
+    // Perform read test if not skipped
+    if (!skip_read) {
+        std::cout << "\n============================================================" << std::endl;
+        std::cout << "PHASE 4: File to Memory Transfer (Read Test)" << std::endl;
+        std::cout << "============================================================" << std::endl;
+
+        auto read_start = std::chrono::high_resolution_clock::now();
+
+        ret = agent.createXferReq(NIXL_READ, src_list, file_for_gds_list,
+                                 "GDSTester", treq);
+        if (ret != NIXL_SUCCESS) {
+            std::cerr << "Failed to create read transfer request\n";
+            goto cleanup;
+        }
+
+        status = agent.postXferReq(treq);
+        while (status != NIXL_SUCCESS) {
+            status = agent.getXferStatus(treq);
+            assert(status >= 0);
+        }
+        agent.releaseXferReq(treq);
+
+        auto read_end = std::chrono::high_resolution_clock::now();
+        auto read_duration = std::chrono::duration_cast<std::chrono::microseconds>(read_end - read_start);
+        total_time += read_duration;
+
+        double data_gb = (transfer_size * num_transfers) / (1024.0 * 1024.0 * 1024.0);
+        total_data_gb += data_gb;
+        double seconds = read_duration.count() / 1000000.0;
+        double gbps = data_gb / seconds;
+
+        std::cout << "Read completed:" << std::endl;
+        std::cout << "- Time: " << format_duration(read_duration) << std::endl;
+        std::cout << "- Data: " << std::fixed << std::setprecision(2) << data_gb << " GB" << std::endl;
+        std::cout << "- Speed: " << gbps << " GB/s" << std::endl;
+
+        std::cout << "\n============================================================" << std::endl;
+        std::cout << "PHASE 5: Validating read data" << std::endl;
+        std::cout << "============================================================" << std::endl;
+        for (i = 0; i < num_transfers; i++) {
+            if (use_vram) {
+                if (!validate_gpu_buffer(vram_addr[i], transfer_size)) {
+                    std::cerr << "VRAM buffer " << i << " validation failed\n";
+                    goto cleanup;
+                }
+            }
+            if (use_dram) {
+                char* expected_buffer = (char*)malloc(transfer_size);
+                if (!expected_buffer) {
+                    std::cerr << "Failed to allocate validation buffer\n";
+                    goto cleanup;
+                }
+                fill_test_pattern(expected_buffer, transfer_size);
+                if (memcmp(dram_addr[i], expected_buffer, transfer_size) != 0) {
+                    std::cerr << "DRAM buffer " << i << " validation failed\n";
+                    free(expected_buffer);
+                    goto cleanup;
+                }
+                free(expected_buffer);
+            }
+            printProgress(float(i + 1) / num_transfers);
+        }
+    }
+
+cleanup:
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "PHASE 6: Cleanup" << std::endl;
+    std::cout << "============================================================" << std::endl;
+
+    // Delete test files
+    std::cout << "Deleting test files..." << std::endl;
+    for (i = 0; i < num_transfers; i++) {
+        if (fd[i] > 0) {
+            // Get the filename from the file descriptor
+            char proc_path[64];
+            char filename[PATH_MAX];
+            snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd[i]);
+            ssize_t len = readlink(proc_path, filename, sizeof(filename) - 1);
+            if (len != -1) {
+                filename[len] = '\0';
+                close(fd[i]);
+                if (unlink(filename) != 0) {
+                    std::cerr << "Warning: Failed to delete file " << filename << ": " << strerror(errno) << std::endl;
+                }
+            }
+        }
+    }
+    printProgress(1.0);
+
+    // Cleanup resources
+    agent.deregisterMem(file_for_gds);
+    if (use_vram) {
+        agent.deregisterMem(vram_for_gds);
+        for (i = 0; i < num_transfers; i++) {
+            if (vram_addr[i]) cudaFree(vram_addr[i]);
+        }
+        delete[] vram_addr;
+        delete[] vram_buf;
+    }
+    if (use_dram) {
+        agent.deregisterMem(dram_for_gds);
+        for (i = 0; i < num_transfers; i++) {
+            if (dram_addr[i]) free(dram_addr[i]);
+        }
+        delete[] dram_addr;
+        delete[] dram_buf;
+    }
+    if (fd) {
+        delete[] fd;
+    }
+    delete[] ftrans;
+
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "                    TEST SUMMARY                             " << std::endl;
+    std::cout << "============================================================" << std::endl;
+    std::cout << "Total time: " << format_duration(total_time) << std::endl;
+    std::cout << "Total data: " << std::fixed << std::setprecision(2) << total_data_gb << " GB" << std::endl;
+    if (total_time.count() > 0) {
+        double avg_speed = total_data_gb / (total_time.count() / 1000000.0);
+        std::cout << "Average speed: " << avg_speed << " GB/s" << std::endl;
+    }
+    std::cout << "============================================================" << std::endl;
+    return 0;
 }

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -447,7 +447,6 @@ int main(int argc, char *argv[])
         std::cout << "PHASE 2: Memory to File Transfer (Write Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
 
-        auto write_start = std::chrono::high_resolution_clock::now();
 
         ret = agent.createXferReq(NIXL_WRITE, src_list, file_for_gds_list,
                                  "GDSTester", treq);
@@ -456,6 +455,7 @@ int main(int argc, char *argv[])
             goto cleanup;
         }
 
+        auto write_start = std::chrono::high_resolution_clock::now();
         status = agent.postXferReq(treq);
         while (status != NIXL_SUCCESS) {
             status = agent.getXferStatus(treq);
@@ -503,7 +503,6 @@ int main(int argc, char *argv[])
         std::cout << "PHASE 4: File to Memory Transfer (Read Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
 
-        auto read_start = std::chrono::high_resolution_clock::now();
 
         ret = agent.createXferReq(NIXL_READ, src_list, file_for_gds_list,
                                  "GDSTester", treq);
@@ -512,13 +511,13 @@ int main(int argc, char *argv[])
             goto cleanup;
         }
 
+        auto read_start = std::chrono::high_resolution_clock::now();
         status = agent.postXferReq(treq);
         while (status != NIXL_SUCCESS) {
             status = agent.getXferStatus(treq);
             assert(status >= 0);
         }
         agent.releaseXferReq(treq);
-
         auto read_end = std::chrono::high_resolution_clock::now();
         auto read_duration = std::chrono::duration_cast<std::chrono::microseconds>(read_end - read_start);
         total_time += read_duration;

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -306,6 +306,13 @@ int main(int argc, char *argv[])
         use_vram = true;
     }
 
+    // Check if both DRAM and VRAM are specified
+    if (use_dram && use_vram) {
+        std::cerr << "Error: Cannot specify both DRAM (-d) and VRAM (-v) options\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
     // Allocate arrays based on num_transfers
     if (use_vram) {
         vram_addr = new void*[num_transfers];

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -552,6 +552,7 @@ int main(int argc, char *argv[])
             }
             printProgress(float(i + 1) / num_transfers);
         }
+        std::cout << "\nVerification completed successfully!" << std::endl;
     }
 
 cleanup:


### PR DESCRIPTION
This patch improves the plugin implementation with the following
1. Create a batch pool for GDS batches
2. Provide a way to split and create requests to work-around 16M shadow buffer limit in GDS
3. Use PrepXfer to pre-create the batches and keep it ready for submission
4. postXfer just does submission
5. All parameters are configurable through backend params
6. Improved C++ test to exercise and test all these options.
7. New Python test to ensure compatibility with Python API