### PR TITLE
contrib: use ubuntu22 as default build and add python versions option

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE="nvcr.io/nvidia/pytorch"
-ARG BASE_IMAGE_TAG="25.02-py3"
+ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
+ARG BASE_IMAGE_TAG="24.10-cuda12.6-devel-ubuntu22.04"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 
 ARG MOFED_VERSION=24.10-1.1.4.0
-ARG UBUNTUOS=24.04
+ARG UBUNTUOS=22.04
+ARG DEFAULT_PYTHON_VERSION="3.12"
 
 ENV TZ=America
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
@@ -27,55 +28,43 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ARG NSYS_URL=https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2025_1/
 ARG NSYS_PKG=NsightSystems-linux-cli-public-2025.1.1.131-3554042.deb
 
-ARG NIXL_COMMIT
-ARG NIXL_REPO
-
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get -y install curl \
-    git \
-    libnuma-dev \
-    numactl \
-    wget \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     autotools-dev \
     automake \
     libtool \
     libz-dev \
     libiberty-dev \
     flex \
-    build-essential \
     cmake \
-    libibverbs-dev \
     libgoogle-glog-dev \
     libgtest-dev \
     libjsoncpp-dev \
-    libpython3-dev \
     libboost-all-dev \
-    libssl-dev \
     libgrpc-dev \
     libgrpc++-dev \
     libprotobuf-dev \
     protobuf-compiler-grpc \
-    pybind11-dev \
-    python3-full \
-    python3-pip \
-    python3-numpy \
     etcd-server \
     net-tools \
     pciutils \
     libpci-dev \
-    vim \
     tmux \
     screen \
-    ibverbs-utils \
     libibmad-dev \
-    googletest
+    googletest \
+    linux-tools-common \
+    linux-tools-generic \
+    ethtool \
+    iproute2 \
+    dkms \
+    linux-headers-generic \
+    ninja-build \
+    uuid-dev \
+    gdb \
+    python3-pip \
+    pybind11-dev
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y linux-tools-common linux-tools-generic ethtool iproute2
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y dkms linux-headers-generic
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y meson ninja-build uuid-dev gdb
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y wget libglib2.0-0
 RUN wget ${NSYS_URL}${NSYS_PKG} && dpkg -i $NSYS_PKG && rm $NSYS_PKG
 
 RUN cd /usr/local/src && \
@@ -93,9 +82,8 @@ ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/lib64 \
 ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib \
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-WORKDIR /workspace
 RUN git clone https://github.com/NVIDIA/gdrcopy.git
-RUN PREFIX=/usr/local DESTLIB=/usr/local/lib make -C /workspace/gdrcopy lib_install
+RUN PREFIX=/usr/local DESTLIB=/usr/local/lib make -C gdrcopy lib_install
 RUN cp gdrcopy/src/libgdrapi.so.2.* /usr/lib/x86_64-linux-gnu/
 RUN ldconfig
 
@@ -130,17 +118,21 @@ ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH
 ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages/:$PYTHONPATH
 
-# Required for Ubuntu 22.04
-RUN pip3 install --upgrade meson torch
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Make sure to build the container from the cloned git repository
-WORKDIR /opt/nixl
-COPY --from=nixl . .
-RUN echo "NIXL commit: ${NIXL_COMMIT}" > /opt/nixl/commit.txt
-RUN cd /opt/nixl && \
+WORKDIR /workspace/nixl
+ENV VIRTUAL_ENV=/workspace/nixl/.venv
+
+RUN uv venv $VIRTUAL_ENV --python 3.12 && \
+    # pybind11 pip install needed for ubuntu 22.04
+    uv pip install --upgrade meson pybind11 patchelf
+
+COPY . /workspace/nixl 
+
+RUN cd /workspace/nixl && \
     mkdir build && \
-    meson setup build/ --prefix=/usr/local/nixl && \
-    cd build/ && \
+    uv run meson setup build/ --prefix=/usr/local/nixl && \
+    cd build && \
     ninja && \
     ninja install
 
@@ -150,7 +142,11 @@ ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
 RUN ldconfig
 
 # Create the wheel
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-RUN pip3 install patchelf auditwheel
-RUN cd /opt/nixl && uv build --wheel --out-dir /workspace/dist
-RUN auditwheel repair /workspace/dist/nixl-*cp31*.whl --plat manylinux_2_39_x86_64
+ARG WHL_PYTHON_VERSIONS="3.12"
+ARG WHL_PLATFORM="manylinux_2_34_x86_64"
+RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
+    for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
+        uv build --wheel --out-dir /tmp/dist --python $PYTHON_VERSION; \
+    done
+RUN uv pip install auditwheel && \
+    uv run auditwheel repair /tmp/dist/nixl-*cp31*.whl --plat $WHL_PLATFORM --wheel-dir /workspace/nixl/dist

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -18,9 +18,7 @@
 SOURCE_DIR=$(dirname "$(readlink -f "$0")")
 BUILD_CONTEXT=$(dirname "$(readlink -f "$SOURCE_DIR")")
 DOCKER_FILE="${SOURCE_DIR}/Dockerfile"
-
 commit_id=$(git rev-parse --short HEAD)
-FULLCOMMIT=$(git rev-parse HEAD)
 
 # Get latest TAG and add COMMIT_ID for dev
 latest_tag=$(git describe --tags --abbrev=0 $(git rev-list --tags --max-count=1 main) | sed 's/^v//') || true
@@ -28,16 +26,13 @@ if [[ -z ${latest_tag} ]]; then
     latest_tag="0.0.1"
     echo "No git release tag found, setting to unknown version: ${latest_tag}"
 fi
-
-BASE_IMAGE=nvcr.io/nvidia/pytorch
-BASE_IMAGE_TAG=25.02-py3
 VERSION=v$latest_tag.dev.$commit_id
-UBUNTUOS="24.04"
-USE_LOCAL_DIR=0
-NIXL_DIR=/tmp/nixl
 
-NIXL_COMMIT=ec6345c5279142a3805ab1a0e876f954d079dbf7
-NIXL_REPO=ai-dynamo/nixl.git
+BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base
+BASE_IMAGE_TAG=24.10-cuda12.6-devel-ubuntu22.04
+WHL_PLATFORM=manylinux_2_34_x86_64
+WHL_PYTHON_VERSIONS="3.12"
+UBUNTUOS="22.04"
 
 get_options() {
     while :; do
@@ -47,14 +42,14 @@ get_options() {
             exit
             ;;
         --base-image)
-	    if [ "$2" ]; then
-		BASE_IMAGE="$2"
-		shift
-	    else
-		missing_requirement $1
-	    fi
-	    ;;
-        --base-imge-tag)
+            if [ "$2" ]; then
+                BASE_IMAGE="$2"
+                shift
+            else
+                missing_requirement $1
+            fi
+        ;;
+        --base-image-tag)
             if [ "$2" ]; then
                 BASE_IMAGE_TAG=$2
                 shift
@@ -62,7 +57,7 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
-	--os)
+        --os)
             if [ "$2" ]; then
                 UBUNTUOS=$2
                 shift
@@ -81,9 +76,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
-	--use-local)
-	    USE_LOCAL_DIR=1
-	    ;;
+        --python-versions)
+            if [ "$2" ]; then
+                WHL_PYTHON_VERSIONS=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --)
             shift
             break
@@ -101,36 +101,31 @@ get_options() {
         shift
     done
 
-    if [[ $UBUNTUOS == "22.04" ]]; then
-	BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base
-	BASE_IMAGE_TAG=24.10-cuda12.6-devel-ubuntu22.04
+    if [[ $UBUNTUOS == "24.04" ]]; then
+        BASE_IMAGE_TAG=25.01-cuda12.8-devel-ubuntu24.04
+        WHL_PLATFORM=manylinux_2_39_x86_64
     fi
 
     if [ -z "$TAG" ]; then
         TAG="--tag nixl:${VERSION}"
-    fi
-
-    if [ $USE_LOCAL_DIR -eq 1 ]; then
-	NIXL_DIR=$BUILD_CONTEXT
-	NIXL_COMMIT=$FULLCOMMIT
     fi
 }
 
 show_build_options() {
     echo ""
     echo "Building NIXL Image: '${TAG}' for Ubuntu${UBUNTUOS}"
-    echo "Using local nixl source: ${NIXL_DIR}"
-    echo "    Build Context: ${BUILD_CONTEXT}"
+    echo "Build Context: ${BUILD_CONTEXT}"
+    echo "Build Args: ${BUILD_ARGS}"
 }
 
 show_help() {
-    echo "usage: build.sh"
+    echo "usage: build-container.sh"
     echo "  [--base base image]"
-    echo "  [--base-imge-tag base image tag]"
+    echo "  [--base-image-tag base image tag]"
     echo "  [--no-cache disable docker build cache]"
     echo "  [--os [24.04|22.04] to select Ubuntu version]"
     echo "  [--tag tag for image]"
-    echo "  [--use-local copy current source dir to container]"
+    echo "  [--python-versions python versions to build for, comma separated]"
     exit 0
 }
 
@@ -145,30 +140,16 @@ error() {
 
 get_options "$@"
 
-show_build_options
-
-if [ $USE_LOCAL_DIR -eq 0 ]; then
-    if [ -d "$NIXL_DIR" ]; then
-	echo "Warning: $NIXL_DIR exists, skipping clone"
-    else
-	git clone https://github.com/${NIXL_REPO} ${NIXL_DIR}
-    fi
-
-    if ! git checkout ${NIXL_COMMIT}; then
-	echo "ERROR: Failed to checkout commit ${NIXL_COMMIT}."
-	echo "Please delete $NIXL_DIR and retry."
-	exit 1
-    fi
-else
-    if [ -d "$NIXL_DIR/build" ]; then
-	echo "Please delete the build directory before creating container"
-	exit 1
-    fi
+if [ -d "$NIXL_DIR/build" ]; then
+    echo "Please delete the build directory before creating container"
+    exit 1
 fi
 
-BUILD_CONTEXT_ARGS+=" --build-context nixl=$NIXL_DIR"
-BUILD_ARGS+=" --build-arg NIXL_COMMIT=${NIXL_COMMIT} --build-arg NIXL_REPO=${NIXL_REPO}"
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
 BUILD_ARGS+=" --build-arg UBUNTUOS=$UBUNTUOS"
+BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
+BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 
-docker build -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT_ARGS $BUILD_CONTEXT
+show_build_options
+
+docker build -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_ARGS $BUILD_CONTEXT


### PR DESCRIPTION
* Use ubuntu22 as default base image for docker builds
* remove apt installs for packages already present in base image 
* Add option to pass in python-versions
* use python 3.12 virtual env for pip installs
* always use local for nixl repo code
  * to run a specific commit/tag, run git checkout prior to build script
 
### Testing

`./contrib/build-container.sh --python-versions 3.10,3.11,3.12`

