### PR TITLE
CPP test: Modified delimiter handling for OOB transfer

### DIFF
--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -124,7 +124,8 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
         }
 
         *lp = mem_elms[i]; // Copy the basic desc part
-        if ((nixl_mem == FILE_SEG) && (lp->len==0))
+        if (((nixl_mem == BLK_SEG) || (nixl_mem == OBJ_SEG) ||
+             (nixl_mem == FILE_SEG)) && (lp->len==0))
             lp->len = SIZE_MAX; // File has no range limit
 
         target->addDesc(local_meta);

--- a/test/nixl/nixl_test.cpp
+++ b/test/nixl/nixl_test.cpp
@@ -26,31 +26,12 @@
 #define NUM_TRANSFERS 1
 #define SIZE 1024
 
-static const char *delimiter = ";descriptor=";
-static const size_t delimiter_stride = (strlen(delimiter) - 1);
 /**
  * This test does p2p from using PUT.
  * intitator -> target so the metadata and
  * desc list needs to move from
  * target to initiator
  */
-
-std::vector<std::string> split(const std::string& str, const char *delimiter) {
-    std::vector<std::string> tokens;
-    std::string token;
-    size_t start = 0, end = 0;
-
-    while ((end = str.find(delimiter, start)) != std::string::npos) {
-        end += delimiter_stride;
-        token = str.substr(start, end - start);
-        tokens.push_back(token);
-        start = end + 1;
-    }
-    // Add the last token
-    token = str.substr(start);
-    tokens.push_back(token);
-    return tokens;
-}
 
 bool allBytesAre(void* buffer, size_t size, uint8_t value) {
     uint8_t* byte_buffer = static_cast<uint8_t*>(buffer); // Cast void* to uint8_t*
@@ -81,10 +62,9 @@ int main(int argc, char *argv[]) {
     void                    *addr[NUM_TRANSFERS];
     std::string             role;
     const char              *initiator_ip;
-    std::string             str_desc;
-    std::string             remote_desc;
-    std::string             tgt_metadata;
-    std::string             tgt_md_init;
+    nixl_blob_t             remote_desc;
+    nixl_blob_t             tgt_metadata;
+    nixl_blob_t             tgt_md_init;
     int                     status = 0;
     bool                    rc = false;
 
@@ -162,16 +142,13 @@ int main(int argc, char *argv[]) {
         std::cout << " Desc List from Target to Initiator\n";
         dram_for_ucx.print();
 
-        /** Serialize for MD transfer */
-        assert(dram_for_ucx.trim().serialize(serdes) == NIXL_SUCCESS);
-
         /** Sending both metadata strings together */
-        str_desc                    = serdes->exportStr();
-        std::string sstr            = tgt_metadata + delimiter + str_desc;
+        assert(serdes->addStr("AgentMD", tgt_metadata) == NIXL_SUCCESS);
+        assert(dram_for_ucx.trim().serialize(serdes) == NIXL_SUCCESS);
 
         std::cout << " Serialize Metadata to string and Send to Initiator\n";
         std::cout << " \t -- To be handled by runtime - currently sent via a TCP Stream\n";
-        sendToInitiator(initiator_ip, initiator_port, sstr);
+        sendToInitiator(initiator_ip, initiator_port, serdes->exportStr());
         std::cout << " End Control Path metadata exchanges \n";
 
         std::cout << " Start Data Path Exchanges \n";
@@ -198,18 +175,16 @@ int main(int argc, char *argv[]) {
         std::cout << " \t -- To be handled by runtime - currently received via a TCP Stream\n";
         std::string rrstr = recvFromTarget(initiator_port);
 
-        std::vector<std::string> tokens = split(rrstr, delimiter);
-        tgt_md_init = tokens[0];
-        remote_desc = tokens[1];
-
+        remote_serdes->importStr(rrstr);
+        tgt_md_init = remote_serdes->getStr("AgentMD");
+        assert (tgt_md_init != "");
         std::string target_name;
+        agent.loadRemoteMD(tgt_md_init, target_name);
 
         std::cout << " Verify Deserialized Target's Desc List at Initiator\n";
-        remote_serdes->importStr(remote_desc);
         nixl_xfer_dlist_t dram_target_ucx(remote_serdes);
         nixl_xfer_dlist_t dram_initiator_ucx = dram_for_ucx.trim();
         dram_target_ucx.print();
-        agent.loadRemoteMD(tgt_md_init, target_name);
 
         std::cout << " Got metadata from " << target_name << " \n";
         std::cout << " End Control Path metadata exchanges \n";

--- a/test/nixl/nixl_test.cpp
+++ b/test/nixl/nixl_test.cpp
@@ -26,7 +26,8 @@
 #define NUM_TRANSFERS 1
 #define SIZE 1024
 
-
+static const char *delimiter = ";descriptor=";
+static const size_t delimiter_stride = (strlen(delimiter) - 1);
 /**
  * This test does p2p from using PUT.
  * intitator -> target so the metadata and
@@ -34,12 +35,13 @@
  * target to initiator
  */
 
-std::vector<std::string> split(const std::string& str, char delimiter) {
+std::vector<std::string> split(const std::string& str, const char *delimiter) {
     std::vector<std::string> tokens;
     std::string token;
     size_t start = 0, end = 0;
 
     while ((end = str.find(delimiter, start)) != std::string::npos) {
+        end += delimiter_stride;
         token = str.substr(start, end - start);
         tokens.push_back(token);
         start = end + 1;
@@ -165,7 +167,7 @@ int main(int argc, char *argv[]) {
 
         /** Sending both metadata strings together */
         str_desc                    = serdes->exportStr();
-        std::string sstr            = tgt_metadata + ";" + str_desc;
+        std::string sstr            = tgt_metadata + delimiter + str_desc;
 
         std::cout << " Serialize Metadata to string and Send to Initiator\n";
         std::cout << " \t -- To be handled by runtime - currently sent via a TCP Stream\n";
@@ -196,7 +198,7 @@ int main(int argc, char *argv[]) {
         std::cout << " \t -- To be handled by runtime - currently received via a TCP Stream\n";
         std::string rrstr = recvFromTarget(initiator_port);
 
-        std::vector<std::string> tokens = split(rrstr, ';');
+        std::vector<std::string> tokens = split(rrstr, delimiter);
         tgt_md_init = tokens[0];
         remote_desc = tokens[1];
 

--- a/util/test_cpp.sh
+++ b/util/test_cpp.sh
@@ -44,6 +44,11 @@ cd ${INSTALL_DIR}
 ./bin/ucx_backend_multi
 ./bin/serdes_test
 
+# Run NIXL client-server test
+./bin/nixl_test initiator 127.0.0.1 1234&
+sleep 1
+./bin/nixl_test target 127.0.0.1 1234
+
 echo "${TEXT_YELLOW}==== Disabled tests==="
 echo "./bin/md_streamer disabled"
 echo "./bin/nixl_test disabled"

--- a/util/test_python.sh
+++ b/util/test_python.sh
@@ -34,6 +34,7 @@ export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/x86_64-linux-gnu/plugins
 
 pip3 install --break-system-packages .
 pip3 install --break-system-packages pytest
+pip3 install --break-system-packages zmq torch
 
 echo "==== Running python tests ===="
 python3 examples/python/nixl_api_example.py

--- a/util/test_python.sh
+++ b/util/test_python.sh
@@ -34,7 +34,7 @@ export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/x86_64-linux-gnu/plugins
 
 pip3 install --break-system-packages .
 pip3 install --break-system-packages pytest
-pip3 install --break-system-packages zmq torch
+pip3 install --break-system-packages zmq
 
 echo "==== Running python tests ===="
 python3 examples/python/nixl_api_example.py

--- a/util/test_python.sh
+++ b/util/test_python.sh
@@ -38,3 +38,9 @@ pip3 install --break-system-packages pytest
 echo "==== Running python tests ===="
 python3 examples/python/nixl_api_example.py
 pytest test/python
+
+echo "==== Running python example ===="
+cd examples/python
+python3 blocking_send_recv_example.py --name="B" --mode="target" --zmq_ip=127.0.0.1 --zmq_port=1234&
+sleep 1
+python3 blocking_send_recv_example.py --name="A" --mode="initiator" --zmq_ip=127.0.0.1 --zmq_port=1234


### PR DESCRIPTION
The use of the delimiter ';' to separate metadata and desc info during OOB transfer sometimes fails because this delimiter is present in the serialized metadata/desc string.
* Use custom delimiter string ";descriptor=" instead of ';'
* Add support for CPP and Python test in CI