### PR TITLE
README: remove autogen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ NIXL was tested with UCX version 1.18.0.
 $ wget https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz
 $ tar xzf ucx-1.18.0.tar.gz
 $ cd ucx-1.18.0
-$ ./autogen.sh
 $ ./configure     					   \
     --enable-shared             	   \
     --disable-static            	   \

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ NIXL was tested with UCX version 1.18.0.
 $ wget https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz
 $ tar xzf ucx-1.18.0.tar.gz
 $ cd ucx-1.18.0
-$ ./configure     					   \
-    --enable-shared             	   \
-    --disable-static            	   \
-    --disable-doxygen-doc       	   \
-    --enable-optimizations      	   \
-    --enable-cma                	   \
-    --enable-devel-headers      	   \
-    --with-cuda=<cuda install>  	   \
-    --with-verbs               	 	   \
-    --with-dm                   	   \
+$ ./configure                          \
+    --enable-shared                    \
+    --disable-static                   \
+    --disable-doxygen-doc              \
+    --enable-optimizations             \
+    --enable-cma                       \
+    --enable-devel-headers             \
+    --with-cuda=<cuda install>         \
+    --with-verbs                       \
+    --with-dm                          \
     --with-gdrcopy=<gdrcopy install>   \
     --enable-mt
 $ make -j


### PR DESCRIPTION
I don't know why but this tarball does not have an autogen.sh (the one in the README):
https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz

but this one does (the one in CI where the config was copied from):
https://github.com/openucx/ucx/tarball/v1.18.0