### PR TITLE
backend/ucx_mo: Leverage prepXfer for preparing the transfer

### DIFF
--- a/src/plugins/ucx_mo/ucx_mo_backend.h
+++ b/src/plugins/ucx_mo/ucx_mo_backend.h
@@ -88,15 +88,34 @@ private:
     typedef std::vector<req_pair_t> req_list_t;
     typedef req_list_t::iterator req_list_it_t;
 
+    typedef std::pair<nixl_meta_dlist_t *,nixl_meta_dlist_t *> dl_pair_t;
+    typedef std::vector<std::vector<dl_pair_t>> dl_matrix_t;
+
+    dl_matrix_t dlMatrix;
     req_list_t reqs;
 
     std::string remoteAgent;
     bool notifNeed;
     std::string notifMsg;
 public:
-    nixlUcxMoRequestH()
+    nixlUcxMoRequestH(size_t l_eng_cnt, size_t r_eng_cnt) :
+        dlMatrix(l_eng_cnt, std::vector<dl_pair_t>(r_eng_cnt, dl_pair_t{ NULL, NULL }))
     {
         notifNeed = false;
+    }
+
+    ~nixlUcxMoRequestH()
+    {
+        for (auto &row : dlMatrix) {
+            for (auto &p : row) {
+                if (p.first) {
+                    delete p.first;
+                }
+                if (p.second) {
+                    delete p.second;
+                }
+            }
+        }
     }
 
     friend class nixlUcxMoEngine;

--- a/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
+++ b/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
@@ -354,6 +354,8 @@ void performTransfer(nixlBackendEngine *ucx1, nixlBackendEngine *ucx2,
     // Posting a request, to be updated to return an async handler,
     // or an ID that later can be used to check the status as a new method
     // Also maybe we would remove the WRITE and let the backend class decide the op
+    status = ucx1->prepXfer(op, req_src_descs, req_dst_descs, remote_agent, handle, &opt_args);
+    assert(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
     status = ucx1->postXfer(op, req_src_descs, req_dst_descs, remote_agent, handle, &opt_args);
     assert(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
 


### PR DESCRIPTION
Move descriptor list comm matrix preparation to prepXfer. This would allow applications that leverage single prepare followed by multiple post operations optimization
to avoid extra memory allocations and computations.