### PR TITLE
python API: optional backends for send_notif

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -325,9 +325,14 @@ class nixl_agent:
         return found
 
     # Extra notification APIs
-    def send_notif(self, remote_agent_name: str, notif_msg: str):
-        # To be updated when automatic backend selection is supported
-        self.agent.genNotif(remote_agent_name, notif_msg, self.backends["UCX"])
+    def send_notif(
+        self, remote_agent_name: str, notif_msg: str, backends: list[str] = []
+    ):
+        handle_list = []
+        for backend_string in backends:
+            handle_list.append(self.backends[backend_string])
+
+        self.agent.genNotif(remote_agent_name, notif_msg, handle_list)
 
     def get_agent_metadata(self) -> bytes:
         return self.agent.getLocalMD()

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -454,15 +454,19 @@ PYBIND11_MODULE(_bindings, m) {
                 })
         .def("genNotif", [](nixlAgent &agent, const std::string &remote_agent,
                                               const std::string &msg,
-                                              uintptr_t backend) {
+                                              std::vector<uintptr_t> backends) {
                     nixl_opt_args_t extra_params;
                     nixl_status_t ret;
-                    extra_params.backends.push_back((nixlBackendH*) backend);
+
+                    for(uintptr_t backend: backends)
+                        extra_params.backends.push_back((nixlBackendH*) backend);
+
+
                     ret = agent.genNotif(remote_agent, msg, &extra_params);
 
                     throw_nixl_exception(ret);
                     return ret;
-                })
+                }, py::arg("remote_agent"), py::arg("msg"), py::arg("backends") = std::vector<uintptr_t>({}))
         .def("getLocalMD", [](nixlAgent &agent) -> py::bytes {
                     //python can only interpret text strings
                     std::string ret_str("");


### PR DESCRIPTION
Add the option to select specific backends for send_notif, or allow automatic backend selection.