### PR TITLE
Mkhazraee/best effort reg

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -34,9 +34,11 @@ class nixlUcxCudaCtx {
 public:
 #ifdef HAVE_CUDA
     CUcontext pthrCudaCtx;
+    int myDevId;
 
     nixlUcxCudaCtx() {
         pthrCudaCtx = NULL;
+        myDevId = -1;
     }
 #endif
     void cudaResetCtxPtr();
@@ -81,6 +83,13 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
 
     was_updated = false;
 
+    if (expected_dev == -1)
+        return -1;
+
+    // incorrect dev id from first registration
+    if (myDevId != -1 && expected_dev != myDevId)
+        return -1;
+
     ret = cudaQueryAddr(address, is_dev, dev, ctx);
     if (ret) {
         return ret;
@@ -107,6 +116,7 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
 
     pthrCudaCtx = ctx;
     was_updated = true;
+    myDevId = expected_dev;
 
     return 0;
 }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -91,7 +91,6 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
         return 0;
     }
 
-    assert(dev == expected_dev);
     if (dev != expected_dev) {
         /* TODO: proper error codes */
         return -1;
@@ -158,7 +157,6 @@ int nixlUcxEngine::vramUpdateCtx(void *address, uint32_t  devId, bool &restart_r
     }
 
     ret = cudaCtx->cudaUpdateCtxPtr(address, devId, was_updated);
-    assert(!ret);
     if (ret) {
         return ret;
     }
@@ -559,8 +557,9 @@ nixl_status_t nixlUcxEngine::registerMem (const nixlBlobDesc &mem,
 
     if (nixl_mem == VRAM_SEG) {
         bool need_restart;
-        if (vramUpdateCtx((void*)mem.addr, mem.devId, need_restart)){
-            //TODO Log out
+        if (vramUpdateCtx((void*)mem.addr, mem.devId, need_restart)) {
+            return NIXL_ERR_NOT_SUPPORTED;
+            //TODO Add to logging
         }
         if (need_restart) {
             progressThreadRestart();

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -83,6 +83,7 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
 
     was_updated = false;
 
+    /* TODO: proper error codes and log outputs through this method */
     if (expected_dev == -1)
         return -1;
 
@@ -101,14 +102,12 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
 
     if (dev != expected_dev) {
         // User provided address that does not match dev_id
-        /* TODO: proper error codes */
         return -1;
     }
 
     if (pthrCudaCtx) {
         // Context was already set previously, and does not match new context
         if (pthrCudaCtx != ctx) {
-            /* TODO: proper error codes */
             return -1;
         }
         return 0;

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -16,7 +16,6 @@
  */
 #include "ucx_backend.h"
 #include "serdes/serdes.h"
-#include <cassert>
 
 #ifdef HAVE_CUDA
 
@@ -92,16 +91,16 @@ int nixlUcxCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &was_
     }
 
     if (dev != expected_dev) {
+        // User provided address that does not match dev_id
         /* TODO: proper error codes */
         return -1;
     }
 
     if (pthrCudaCtx) {
-        // Context was already set previously
-        assert(pthrCudaCtx == ctx);
+        // Context was already set previously, and does not match new context
         if (pthrCudaCtx != ctx) {
-            // Fatal error
-            abort();
+            /* TODO: proper error codes */
+            return -1;
         }
         return 0;
     }


### PR DESCRIPTION
Agent/UCX: regiterMem does best effort across backends, and ucx errors out on second gpu
 * UCX below version 1.19 can only have a single worker per GPU, so if it's instantiated instead of UCX-MO, and memory from a second GPU gets registered, it would error out. Previously there were asserts to do this check, now it returns error.
 * registerMem in Agent was was all or nothing, now it tries to and returns error if even not a single backend could register.
 * Now user can instantiate both UCX and UCX-MO. For the first GPU, UCX will accept the registrations, for more only UCX-MO will accept. During time of transfer, if they belong to that GPU, UCX will be used (if it was instantiated first), otherwise UCX-MO.
 * This behavior will be deprecated when 1.19 becomes available, where for UCX below version 1.19 we use UCX-MO, and for after we use base UCX without the error checks added in this PR.