### PR TITLE
meson: add nixl_example to meson system

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -40,6 +40,7 @@ echo "==== Running C++ tests ===="
 cd ${INSTALL_DIR}
 ./bin/desc_example
 ./bin/agent_example
+./bin/nixl_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
 ./bin/ucx_backend_multi

--- a/examples/cpp/meson.build
+++ b/examples/cpp/meson.build
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nixl_example = executable('nixl_example',
+           'nixl_example.cpp',
+           dependencies: [nixl_dep, nixl_infra, ucx_backend_dep, ucx_dep],
+           include_directories: [nixl_inc_dirs, utils_inc_dirs],
+           link_with: [serdes_lib],
+           install: true)

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+subdir('cpp')

--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,7 @@ subdir('src')
 
 if get_option('buildtype') != 'release'
   subdir('test')
+  subdir('examples')
 endif
 
 if get_option('install_headers')


### PR DESCRIPTION
This example wasn't part of meson, but it does work still. 