### PR TITLE
fix buggy logics in check_remote_xfer_done

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -316,8 +316,8 @@ class nixl_agent:
 
         if remote_agent_name in self.notifs:
             for msg in self.notifs[remote_agent_name]:
-                if lookup_msg in msg:
-                    message = lookup_msg
+                if str(lookup_msg) in str(msg):
+                    message = msg
                     found = True
                     break
         if message:


### PR DESCRIPTION
two bugs:
1. str and bytes mismatch
2. `message` is removed from notifs below so it should be `msg` instead of `lookup_msg`