### PR TITLE
CI: Add Doxygen documentation build support

### DIFF
--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -64,7 +64,8 @@ apt-get -qq install -y curl \
                              libpci-dev \
                              uuid-dev \
                              ibverbs-utils \
-                             libibmad-dev
+                             libibmad-dev \
+                             doxygen
 
 curl -fSsL "https://github.com/openucx/ucx/tarball/v1.18.0" | tar xz
 ( \
@@ -96,7 +97,7 @@ export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 # UCX transfers and can cause contention with local collectives.
 export UCX_TLS=^cuda_ipc
 
-meson setup nixl_build --prefix=${INSTALL_DIR} -Ducx_path=${UCX_INSTALL_DIR} -Dstatic_plugins=UCX
+meson setup nixl_build --prefix=${INSTALL_DIR} -Ducx_path=${UCX_INSTALL_DIR} -Dstatic_plugins=UCX -Dbuild_docs=true
 cd nixl_build && ninja && ninja install
 
 # TODO(kapila): Copy the nixl.pc file to the install directory if needed.

--- a/Doxyfile
+++ b/Doxyfile
@@ -79,7 +79,7 @@ PROJECT_ICON           =
 # entered, it will be relative to the location where Doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./docs/doxygen/
+OUTPUT_DIRECTORY       = @DOXYGEN_OUTPUT_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES then Doxygen will create up to 4096
 # sub-directories (in 2 levels) under the output directory of each output format

--- a/README.md
+++ b/README.md
@@ -72,6 +72,44 @@ $ ninja
 $ ninja install
 ```
 
+### Build Options
+
+NIXL supports several build options that can be specified during the meson setup phase:
+
+```bash
+# Basic build setup with default options
+$ meson setup <name_of_build_dir>
+
+# Setup with custom options (example)
+$ meson setup <name_of_build_dir> \
+    -Dbuild_docs=true \           # Build Doxygen documentation
+    -Ducx_path=/path/to/ucx \     # Custom UCX installation path
+    -Dinstall_headers=true \      # Install development headers
+    -Ddisable_gds_backend=false   # Enable GDS backend
+```
+
+Common build options:
+- `build_docs`: Build Doxygen documentation (default: false)
+- `ucx_path`: Path to UCX installation (default: system path)
+- `install_headers`: Install development headers (default: true)
+- `disable_gds_backend`: Disable GDS backend (default: false)
+- `cudapath_inc`, `cudapath_lib`: Custom CUDA paths
+- `static_plugins`: Comma-separated list of plugins to build statically
+
+### Building Documentation
+
+If you have Doxygen installed, you can build the documentation:
+
+```bash
+# Configure with documentation enabled
+$ meson setup <name_of_build_dir> -Dbuild_docs=true
+$ cd <name_of_build_dir>
+$ ninja
+
+# Documentation will be generated in <name_of_build_dir>/html
+# After installation (ninja install), documentation will be available in <prefix>/share/doc/nixl/
+```
+
 ### pybind11 Python Interface
 The pybind11 bindings for the public facing NIXL API are available in src/bindings/python. These bindings implement the headers in the src/api/cpp directory.
 

--- a/meson.build
+++ b/meson.build
@@ -101,3 +101,35 @@ if get_option('install_headers')
   install_headers('src/core/agent_data.h', install_dir: prefix_inc)
   install_headers('src/infra/mem_section.h', install_dir: prefix_inc)
 endif
+
+# Doxygen documentation
+if get_option('build_docs')
+  doxygen = find_program('doxygen', required: false)
+  if not doxygen.found()
+    error('Doxygen not found, but documentation requested')
+  endif
+
+  docs_dir = join_paths(meson.current_build_dir(), 'docs')
+  doxyfile = join_paths(meson.current_source_dir(), 'Doxyfile')
+  doxygen_output_dir = join_paths(docs_dir, 'doxygen')
+
+  # Create the output directory
+  run_command('mkdir', '-p', doxygen_output_dir, check: true)
+
+  # Configure Doxyfile with the correct output directory
+  configure_file(
+    input: doxyfile,
+    output: 'Doxyfile.configured',
+    configuration: {
+      'DOXYGEN_OUTPUT_DIR': doxygen_output_dir,
+    }
+  )
+
+  custom_target('docs',
+    output: 'docs',
+    command: [doxygen, join_paths(meson.current_build_dir(), 'Doxyfile.configured')],
+    install: true,
+    install_dir: join_paths(prefix_path),
+    build_by_default: true
+  )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -21,3 +21,4 @@ option('cudapath_inc', type: 'string', value: '', description: 'Include path for
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
+option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')


### PR DESCRIPTION
- Add build_docs option to meson_options.txt
- Add Doxygen documentation build configuration in meson.build
- Update README.md with build options and documentation instructions
- Add documentation build location information