### PR TITLE
ci: Enable external contributor flow for NIXL repo

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,1 @@
+enabled: true

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -3,9 +3,8 @@ name: NVIDIA NIXL Validation
 on:
   push:
     branches:
-      - main
-
-  pull_request:
+    - main
+    - "pull-request/[0-9]+"
 
 jobs:
   mirror_repo:

--- a/.github/workflows/external_contributor.yaml
+++ b/.github/workflows/external_contributor.yaml
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: External Contributor
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  pr_reminder:
+    if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reminder to run full CI on PR
+        uses: actions/github-script@v7
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CONTRIBUTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { REPOSITORY, CONTRIBUTOR } = process.env
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `👋 Hi ${CONTRIBUTOR}! Thank you for contributing to ${REPOSITORY}.\n\n` +
+                'Your PR reviewers will review your contribution then trigger the CI to test your changes.\n\n' +
+                '🚀'
+            })
+      - name: Adding Label to PR
+        uses: actions/github-script@v7
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CONTRIBUTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { REPOSITORY, CONTRIBUTOR } = process.env
+
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["external-contribution"]
+            });


### PR DESCRIPTION
NIXL's CI is currently inside the NVIDIA network and security protections require external contributions to be reviewed before they run on the internal network. Using `copy-pr-bot` we are able to meet those security requirements.

The bot examines the commits on the PR since branching from main checking for both commit author's membership in the ai-dynamo organization and for a signature that is verifiable (through it's registration on GitHub). In the event that both of those requirements are filled, you are on the happy path and no additional work is required.
If either of those verifications fails, GitLab CI will not run for that commit and will need to manually be triggered by a member of the ai-dynamo organization by adding a the comment `/ok to test`.

## What do I have to do to be on the happy path?
Here are some instructions for setting up signed commits. Much is cribbed from [GitHub's recommendations](https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key)

Step 1) Generate your GPG key
```
gpg --default-new-key-algo rsa4096 --gen-key
```
🗒️ Save the password you enter here, you will need it for keyring authorization

Step 2) Get your GPG key id
```
gpg --list-secret-keys --keyid-format=long
```
This will generate something like below. In this example we will want to copy `ABCDCEF0123456789`
```
/Users/hsaturleyhal/.gnupg/pubring.kbx
--------------------------------------
sec   rsa4096/ABCDCEF0123456789 2025-03-04 [SC] [expires: 2029-03-04]
      DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
uid                 [ultimate] NVIDIA Github Signing Key Laptop <hsaturleyhal@nvidia.com>
ssb   rsa4096/0011001100110011 2025-03-04 [E] [expires: 2029-03-04]
```

Step 3) Associate key with git user
```
git config --global --unset gpg.format # clear out previous keys
git config --global user.signingkey ABCDCEF0123456789 # Replace with your keyid from Step 2
git config --global commit.gpgsign true # always sign commits
git config --global tag.gpgSign true # always sign tags
```

Step 4) Export your public key
```
gpg --armor --export ABCDCEF0123456789 # Replace with your keyid from Step 2
```
🗒️ Copy this public key block for use with GitHub

Step 5) Add your public key to GitHub
* Navigate to [Profile -> Settings -> SSH and GPG keys](https://github.com/settings/keys)
* Click New GPG key
* Name it and paste in your public GPG key from the Step 4

Step 5b) [optional] Turn on "Vigilant mode"
* Navigate to [Profile -> Settings -> SSH and GPG keys](https://github.com/settings/keys)
* Select Flag unsigned commits as unverified

Step 6) Test sign a commit
```
cd path/to/nixl
git checkout -b test/signed_commits main
touch test.file
git add test.file
git commit -s -m "verify signature"
```
It should prompt for you for your GPG password, enter the password used to create the GPG key in Step 1.

Step 7) Verify Functionality
```
git log --show-signature --pretty=full -1
If you have done everything right you should see output like below:
commit e3079c4899d5072c0a1633cae809c8c584745965 (HEAD -> test/signed_commits)
gpg: Signature made Thu Mar 13 22:45:50 2025 EDT
gpg:                using RSA key 728784A81EC352BE13F69A1846513AEF9B73B285
gpg: Good signature from "nv fake registered <hsaturleyhal@nvidia.com>" [ultimate]
Author: Harrison King Saturley-Hall <hsaturleyhal@nvidia.com>
Commit: Harrison King Saturley-Hall <hsaturleyhal@nvidia.com>

    verify signature

    Signed-off-by: Harrison King Saturley-Hall <hsaturleyhal@nvidia.com>
```