### PR TITLE
Implement multi-threading support

### DIFF
--- a/src/api/cpp/nixl_params.h
+++ b/src/api/cpp/nixl_params.h
@@ -35,6 +35,9 @@ class nixlAgentConfig {
         bool     useListenThread;
         /** @var Port for listener thread to use */
         int      listenPort;
+        /** @var synchronization mode for multi-threaded environment execution */
+        nixl_thread_sync_t syncMode;
+
 
     public:
 
@@ -62,15 +65,18 @@ class nixlAgentConfig {
          * @param port               specify port for listener thread to listen on
          * @param pthr_delay_us      Optional delay for pthread in us
          * @param pthr_delay_us      Optional delay for listener thread in us
+         * @param sync_mode          Thread synchronization mode
          */
         nixlAgentConfig (const bool use_prog_thread,
                          const bool use_listen_thread=false,
                          const int port=0,
                          const uint64_t pthr_delay_us=0,
-                         const uint64_t lthr_delay_us = 100000) :
+                         const uint64_t lthr_delay_us = 100000,
+                         nixl_thread_sync_t sync_mode=nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT) :
                          useProgThread(use_prog_thread),
                          useListenThread(use_listen_thread),
                          listenPort(port),
+                         syncMode(sync_mode),
                          pthrDelay(pthr_delay_us),
                          lthrDelay(lthr_delay_us) { }
 
@@ -87,6 +93,7 @@ class nixlAgentConfig {
         ~nixlAgentConfig () = default;
 
     friend class nixlAgent;
+    friend class nixlAgentData;
 };
 
 #endif

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -63,6 +63,16 @@ typedef enum {
 } nixl_status_t;
 
 /**
+ * @enum nixl_thread_sync_t
+ * @brief An enumeration of supported synchronization modes for NIXL
+ */
+enum class nixl_thread_sync_t {
+    NIXL_THREAD_SYNC_NONE,
+    NIXL_THREAD_SYNC_STRICT,
+    NIXL_THREAD_SYNC_DEFAULT = NIXL_THREAD_SYNC_NONE,
+};
+
+/**
  * @namespace nixlEnumStrings
  * @brief     This namespace to get string representation
  *            of different enums

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -20,6 +20,7 @@
 #include "common/str_tools.h"
 #include "mem_section.h"
 #include "stream/metadata_stream.h"
+#include "sync.h"
 
 constexpr int default_comm_port = 8888;
 
@@ -42,6 +43,7 @@ class nixlAgentData {
     private:
         std::string     name;
         nixlAgentConfig config;
+        nixlLock        lock;
 
         // some handle that can be used to instantiate an object from the lib
         std::map<std::string, void*> backendLibs;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -60,7 +60,8 @@ std::string nixlEnumStrings::statusStr (const nixl_status_t &status) {
 /*** nixlAgentData constructor/destructor, as part of nixlAgent's ***/
 nixlAgentData::nixlAgentData(const std::string &name,
                              const nixlAgentConfig &cfg) :
-                                   name(name), config(cfg) {
+                                   name(name), config(cfg), lock(cfg.syncMode)
+{
         memorySection = new nixlLocalSection();
 }
 
@@ -114,6 +115,7 @@ nixlAgent::~nixlAgent() {
 
 nixl_status_t
 nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {
+    NIXL_LOCK_GUARD(data->lock);
     auto& plugin_manager = nixlPluginManager::getInstance();
     plugins = plugin_manager.getLoadedPluginNames();
     return NIXL_SUCCESS;
@@ -125,6 +127,8 @@ nixlAgent::getPluginParams (const nixl_backend_t &type,
                             nixl_b_params_t &params) const {
 
     // TODO: unify to uppercase/lowercase and do ltrim/rtrim for type
+
+    NIXL_LOCK_GUARD(data->lock);
 
     // First try to get options from a loaded plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
@@ -160,6 +164,7 @@ nixlAgent::getBackendParams (const nixlBackendH* backend,
     if (!backend)
         return NIXL_ERR_INVALID_PARAM;
 
+    NIXL_LOCK_GUARD(data->lock);
     mems   = backend->engine->getSupportedMems();
     params = backend->engine->getCustomParams();
     return NIXL_SUCCESS;
@@ -177,6 +182,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     std::string           str;
     backend_list_t*       backend_list;
 
+    NIXL_LOCK_GUARD(data->lock);
     // Registering same type of backend is not supported, unlikely and prob error
     if (data->backendEngines.count(type)!=0)
         return NIXL_ERR_INVALID_PARAM;
@@ -257,6 +263,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
     nixl_status_t   ret;
     unsigned int    count = 0;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_list = &data->memToBackend[descs.getType()];
         if (backend_list->empty())
@@ -309,6 +316,7 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
     backend_set_t     backend_set;
     nixl_status_t     ret, bad_ret=NIXL_SUCCESS;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_set_t* avail_backends;
         avail_backends = data->memorySection->queryBackends(
@@ -340,6 +348,7 @@ nixlAgent::makeConnection(const std::string &remote_agent,
     std::set<nixl_backend_t> backend_set;
     int count = 0;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (data->remoteBackends.count(remote_agent) == 0)
         return NIXL_ERR_NOT_FOUND;
 
@@ -384,6 +393,7 @@ nixlAgent::prepXferDlist (const std::string &agent_name,
     int            count = 0;
     bool           init_side = (agent_name == NIXL_INIT_AGENT);
 
+    NIXL_LOCK_GUARD(data->lock);
     // When central KV is supported, still it should return error,
     // just we can add a call to fetchRemoteMD for next time
     if (!init_side && (data->remoteSections.count(agent_name) == 0))
@@ -469,6 +479,7 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
     if ((!local_side->isLocal) || (remote_side->isLocal))
         return NIXL_ERR_INVALID_PARAM;
 
+    NIXL_LOCK_GUARD(data->lock);
     // The remote was invalidated in between prepXferDlist and this call
     if (data->remoteSections.count(remote_side->remoteAgent) == 0) {
         delete req_hndl;
@@ -621,6 +632,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     req_hndl = nullptr;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (data->remoteSections.count(remote_agent) == 0)
         return NIXL_ERR_NOT_FOUND;
 
@@ -736,6 +748,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
     if (!req_hndl)
         return NIXL_ERR_INVALID_PARAM;
 
+    NIXL_LOCK_GUARD(data->lock);
     // Check if the remote was invalidated before post/repost
     if (data->remoteSections.count(req_hndl->remoteAgent) == 0) {
         delete req_hndl;
@@ -790,6 +803,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 nixl_status_t
 nixlAgent::getXferStatus (nixlXferReqH *req_hndl) {
 
+    NIXL_LOCK_GUARD(data->lock);
     // If the status is done, no need to recheck.
     if (req_hndl->status != NIXL_SUCCESS) {
         // Check if the remote was invalidated before completion
@@ -808,6 +822,7 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) {
 nixl_status_t
 nixlAgent::queryXferBackend(const nixlXferReqH* req_hndl,
                             nixlBackendH* &backend) const {
+    NIXL_LOCK_GUARD(data->lock);
     backend = data->backendHandles[req_hndl->engine->getType()];
     return NIXL_SUCCESS;
 }
@@ -815,6 +830,7 @@ nixlAgent::queryXferBackend(const nixlXferReqH* req_hndl,
 nixl_status_t
 nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) {
 
+    NIXL_LOCK_GUARD(data->lock);
     //attempt to cancel request
     if(req_hndl->status == NIXL_IN_PROG) {
         req_hndl->status = req_hndl->engine->checkXfer(
@@ -839,6 +855,7 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) {
 
 nixl_status_t
 nixlAgent::releasedDlistH (nixlDlistH* dlist_hndl) const {
+    NIXL_LOCK_GUARD(data->lock);
     delete dlist_hndl;
     return NIXL_SUCCESS;
 }
@@ -850,6 +867,7 @@ nixlAgent::getNotifs(nixl_notifs_t &notif_map,
     nixl_status_t   ret, bad_ret=NIXL_SUCCESS;
     backend_list_t* backend_list;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_list = &data->notifEngines;
         if (backend_list->empty())
@@ -900,6 +918,7 @@ nixlAgent::genNotif(const std::string &remote_agent,
     nixlBackendEngine* backend = nullptr;
     backend_list_t*    backend_list;
 
+    NIXL_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_list = &data->notifEngines;
         if (backend_list->empty())
@@ -935,10 +954,13 @@ nixlAgent::genNotif(const std::string &remote_agent,
 
 nixl_status_t
 nixlAgent::getLocalMD (nixl_blob_t &str) const {
-    // data->connMD was populated when the backend was created
-    size_t conn_cnt = data->connMD.size();
+    size_t conn_cnt;
     nixl_backend_t nixl_backend;
     nixl_status_t ret;
+
+    NIXL_LOCK_GUARD(data->lock);
+    // data->connMD was populated when the backend was created
+    conn_cnt = data->connMD.size();
 
     if (conn_cnt == 0) // Error, no backend supports remote
         return NIXL_ERR_INVALID_PARAM;
@@ -981,6 +1003,8 @@ nixlAgent::getLocalPartialMD(nixl_reg_dlist_t &descs,
     backend_list_t tmp_list;
     backend_list_t *backend_list;
     nixl_status_t ret;
+
+    NIXL_LOCK_GUARD(data->lock);
 
     if (!extra_params || extra_params->backends.size() == 0) {
         if (descs.descCount() != 0) {
@@ -1111,6 +1135,7 @@ nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
     nixlBackendEngine* eng;
     nixl_status_t ret;
 
+    NIXL_LOCK_GUARD(data->lock);
     ret = sd.importStr(remote_metadata);
     if(ret)
         return ret;
@@ -1188,6 +1213,8 @@ nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
 
 nixl_status_t
 nixlAgent::invalidateRemoteMD(const std::string &remote_agent) {
+    NIXL_LOCK_GUARD(data->lock);
+
     if (remote_agent == data->name)
         return NIXL_ERR_INVALID_PARAM;
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -115,7 +115,6 @@ nixlAgent::~nixlAgent() {
 
 nixl_status_t
 nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {
-    NIXL_LOCK_GUARD(data->lock);
     auto& plugin_manager = nixlPluginManager::getInstance();
     plugins = plugin_manager.getLoadedPluginNames();
     return NIXL_SUCCESS;
@@ -127,8 +126,6 @@ nixlAgent::getPluginParams (const nixl_backend_t &type,
                             nixl_b_params_t &params) const {
 
     // TODO: unify to uppercase/lowercase and do ltrim/rtrim for type
-
-    NIXL_LOCK_GUARD(data->lock);
 
     // First try to get options from a loaded plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
@@ -146,6 +143,8 @@ nixlAgent::getPluginParams (const nixl_backend_t &type,
     if (plugin_handle) {
         params = plugin_handle->getBackendOptions();
         mems   = plugin_handle->getBackendMems();
+
+        NIXL_LOCK_GUARD(data->lock);
 
         // We don't keep the plugin loaded if we didn't have it before
         if (data->backendEngines.count(type) == 0) {

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -49,27 +49,27 @@ nixlPluginHandle::~nixlPluginHandle() {
     }
 }
 
-nixlBackendEngine* nixlPluginHandle::createEngine(const nixlBackendInitParams* init_params) {
+nixlBackendEngine* nixlPluginHandle::createEngine(const nixlBackendInitParams* init_params) const {
     if (plugin_ && plugin_->create_engine) {
         return plugin_->create_engine(init_params);
     }
     return nullptr;
 }
 
-void nixlPluginHandle::destroyEngine(nixlBackendEngine* engine) {
+void nixlPluginHandle::destroyEngine(nixlBackendEngine* engine) const {
     if (plugin_ && plugin_->destroy_engine && engine) {
         plugin_->destroy_engine(engine);
     }
 }
 
-const char* nixlPluginHandle::getName() {
+const char* nixlPluginHandle::getName() const {
     if (plugin_ && plugin_->get_plugin_name) {
         return plugin_->get_plugin_name();
     }
     return "unknown";
 }
 
-const char* nixlPluginHandle::getVersion() {
+const char* nixlPluginHandle::getVersion() const {
     if (plugin_ && plugin_->get_plugin_version) {
         return plugin_->get_plugin_version();
     }
@@ -113,7 +113,7 @@ std::map<nixl_backend_t, std::string> loadPluginList(const std::string& filename
     return plugins;
 }
 
-std::shared_ptr<nixlPluginHandle> nixlPluginManager::loadPluginFromPath(const std::string& plugin_path) {
+std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPluginFromPath(const std::string& plugin_path) {
     // Open the plugin file
     void* handle = dlopen(plugin_path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (!handle) {
@@ -150,7 +150,7 @@ std::shared_ptr<nixlPluginHandle> nixlPluginManager::loadPluginFromPath(const st
     }
 
     // Create and store the plugin handle
-    auto plugin_handle = std::make_shared<nixlPluginHandle>(handle, plugin);
+    auto plugin_handle = std::make_shared<const nixlPluginHandle>(handle, plugin);
 
     return plugin_handle;
 }
@@ -224,7 +224,7 @@ void nixlPluginManager::addPluginDirectory(const std::string& directory) {
     discoverPluginsFromDir(directory);
 }
 
-std::shared_ptr<nixlPluginHandle> nixlPluginManager::loadPlugin(const std::string& plugin_name) {
+std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPlugin(const std::string& plugin_name) {
     // Check if the plugin is already loaded
     // Static Plugins are preloaded so return handle
     auto it = loaded_plugins_.find(plugin_name);
@@ -301,7 +301,7 @@ void nixlPluginManager::unloadPlugin(const nixl_backend_t& plugin_name) {
     loaded_plugins_.erase(plugin_name);
 }
 
-std::shared_ptr<nixlPluginHandle> nixlPluginManager::getPlugin(const nixl_backend_t& plugin_name) {
+std::shared_ptr<const nixlPluginHandle> nixlPluginManager::getPlugin(const nixl_backend_t& plugin_name) {
     auto it = loaded_plugins_.find(plugin_name);
     if (it != loaded_plugins_.end()) {
         return it->second;
@@ -309,7 +309,7 @@ std::shared_ptr<nixlPluginHandle> nixlPluginManager::getPlugin(const nixl_backen
     return nullptr;
 }
 
-nixl_b_params_t nixlPluginHandle::getBackendOptions() {
+nixl_b_params_t nixlPluginHandle::getBackendOptions() const {
     nixl_b_params_t params;
     if (plugin_ && plugin_->get_backend_options) {
         return plugin_->get_backend_options();
@@ -317,7 +317,7 @@ nixl_b_params_t nixlPluginHandle::getBackendOptions() {
     return params; // Return empty params if not implemented
 }
 
-nixl_mem_list_t nixlPluginHandle::getBackendMems() {
+nixl_mem_list_t nixlPluginHandle::getBackendMems() const {
     nixl_mem_list_t mems;
     if (plugin_ && plugin_->get_backend_mems) {
         return plugin_->get_backend_mems();
@@ -346,7 +346,7 @@ void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginC
     nixlBackendPlugin* plugin = info.createFunc();
     if (plugin) {
         // Register the loaded plugin
-        auto plugin_handle = std::make_shared<nixlPluginHandle>(nullptr, plugin);
+        auto plugin_handle = std::make_shared<const nixlPluginHandle>(nullptr, plugin);
         loaded_plugins_[name] = plugin_handle;
     }
 }

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -27,7 +27,8 @@
 #include <iostream>
 #include <string>
 #include <map>
-#include <mutex>
+
+using lock_guard = const std::lock_guard<std::mutex>;
 
 // pluginHandle implementation
 nixlPluginHandle::nixlPluginHandle(void* handle, nixlBackendPlugin* plugin)
@@ -159,6 +160,8 @@ std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPluginFromPath(co
 void nixlPluginManager::loadPluginsFromList(const std::string& filename) {
     auto plugins = loadPluginList(filename);
 
+    lock_guard lg(lock);
+
     for (const auto& pair : plugins) {
         const std::string& name = pair.first;
         const std::string& path = pair.second;
@@ -209,20 +212,27 @@ void nixlPluginManager::addPluginDirectory(const std::string& directory) {
         return;
     }
 
-    // Check if directory is already in the list
-    for (const auto& dir : plugin_dirs_) {
-        if (dir == directory) {
-            std::cout << "WARNING: Plugin directory already registered: " << directory << std::endl;
-            return;
+    {
+        lock_guard lg(lock);
+
+        // Check if directory is already in the list
+        for (const auto& dir : plugin_dirs_) {
+            if (dir == directory) {
+                std::cout << "WARNING: Plugin directory already registered: " << directory << std::endl;
+                return;
+            }
         }
+
+        // Prioritize the new directory by inserting it at the beginning
+        plugin_dirs_.insert(plugin_dirs_.begin(), directory);
     }
 
-    // Prioritize the new directory by inserting it at the beginning
-    plugin_dirs_.insert(plugin_dirs_.begin(), directory);
     discoverPluginsFromDir(directory);
 }
 
 std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPlugin(const std::string& plugin_name) {
+    lock_guard lg(lock);
+
     // Check if the plugin is already loaded
     // Static Plugins are preloaded so return handle
     auto it = loaded_plugins_.find(plugin_name);
@@ -296,10 +306,15 @@ void nixlPluginManager::unloadPlugin(const nixl_backend_t& plugin_name) {
             return;
         }
     }
+
+    lock_guard lg(lock);
+
     loaded_plugins_.erase(plugin_name);
 }
 
 std::shared_ptr<const nixlPluginHandle> nixlPluginManager::getPlugin(const nixl_backend_t& plugin_name) {
+    lock_guard lg(lock);
+
     auto it = loaded_plugins_.find(plugin_name);
     if (it != loaded_plugins_.end()) {
         return it->second;
@@ -324,6 +339,8 @@ nixl_mem_list_t nixlPluginHandle::getBackendMems() const {
 }
 
 std::vector<nixl_backend_t> nixlPluginManager::getLoadedPluginNames() {
+    lock_guard lg(lock);
+
     std::vector<nixl_backend_t> names;
     for (const auto& pair : loaded_plugins_) {
         names.push_back(pair.first);
@@ -332,6 +349,8 @@ std::vector<nixl_backend_t> nixlPluginManager::getLoadedPluginNames() {
 }
 
 void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator) {
+    lock_guard lg(lock);
+
     nixlStaticPluginInfo info;
     info.name = name;
     info.createFunc = creator;

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -333,9 +333,6 @@ std::vector<nixl_backend_t> nixlPluginManager::getLoadedPluginNames() {
     return names;
 }
 
-// Static Plugin Helpers
-std::vector<nixlStaticPluginInfo> nixlPluginManager::static_plugins_;
-
 void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator) {
     nixlStaticPluginInfo info;
     info.name = name;
@@ -351,7 +348,7 @@ void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginC
     }
 }
 
-std::vector<nixlStaticPluginInfo>& nixlPluginManager::getStaticPlugins() {
+const std::vector<nixlStaticPluginInfo>& nixlPluginManager::getStaticPlugins() {
     return static_plugins_;
 }
 

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <string>
 #include <map>
+#include <mutex>
 
 // pluginHandle implementation
 nixlPluginHandle::nixlPluginHandle(void* handle, nixlBackendPlugin* plugin)
@@ -184,17 +185,14 @@ nixlPluginManager::nixlPluginManager() {
         plugin_dirs_.insert(plugin_dirs_.begin(), plugin_dir);  // Insert at the beginning for priority
         discoverPluginsFromDir(plugin_dir);
     }
+
+    registerBuiltinPlugins();
 }
 
 nixlPluginManager& nixlPluginManager::getInstance() {
+    // Meyers singleton initialization is safe in multi-threaded environment.
+    // Consult standard [stmt.dcl] chapter for details.
     static nixlPluginManager instance;
-
-    // Only register built-in plugins once
-    static bool registered = false;
-    if (!registered) {
-        instance.registerBuiltinPlugins();
-        registered = true;
-    }
 
     return instance;
 }

--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -67,6 +67,7 @@ private:
     std::vector<nixlStaticPluginInfo> static_plugins_;
 
     void registerBuiltinPlugins();
+    void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);
 
     // Private constructor for singleton pattern
     nixlPluginManager();
@@ -105,7 +106,6 @@ public:
     void addPluginDirectory(const std::string& directory);
 
     // Static Plugin Helpers
-    void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);
     const std::vector<nixlStaticPluginInfo>& getStaticPlugins();
 };
 

--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -28,6 +28,12 @@
 class nixlBackendEngine;
 struct nixlBackendInitParams;
 
+/**
+ * This class represents a NIXL plugin and is used to create plugin instances. nixlPluginHandle
+ * attributes are modified only in the constructor and destructor and remain unchanged during normal
+ * operation, e.g., query operations and plugin instance creation. This allows using it in
+ * multi-threading environments without lock protection.
+ */
 class nixlPluginHandle {
 private:
     void* handle_;         // Handle to the dynamically loaded library
@@ -37,12 +43,12 @@ public:
     nixlPluginHandle(void* handle, nixlBackendPlugin* plugin);
     ~nixlPluginHandle();
 
-    nixlBackendEngine* createEngine(const nixlBackendInitParams* init_params);
-    void destroyEngine(nixlBackendEngine* engine);
-    const char* getName();
-    const char* getVersion();
-    nixl_b_params_t getBackendOptions();
-    nixl_mem_list_t getBackendMems();
+    nixlBackendEngine* createEngine(const nixlBackendInitParams* init_params) const;
+    void destroyEngine(nixlBackendEngine* engine) const;
+    const char* getName() const;
+    const char* getVersion() const;
+    nixl_b_params_t getBackendOptions() const;
+    nixl_mem_list_t getBackendMems() const;
 };
 
 // Creator Function for static plugins
@@ -56,7 +62,7 @@ struct nixlStaticPluginInfo {
 
 class nixlPluginManager {
 private:
-    std::map<nixl_backend_t, std::shared_ptr<nixlPluginHandle>> loaded_plugins_;
+    std::map<nixl_backend_t, std::shared_ptr<const nixlPluginHandle>> loaded_plugins_;
     std::vector<std::string> plugin_dirs_;
 
     // Static Plugins
@@ -75,12 +81,12 @@ public:
     nixlPluginManager(const nixlPluginManager&) = delete;
     nixlPluginManager& operator=(const nixlPluginManager&) = delete;
 
-    std::shared_ptr<nixlPluginHandle> loadPluginFromPath(const std::string& plugin_path);
+    std::shared_ptr<const nixlPluginHandle> loadPluginFromPath(const std::string& plugin_path);
 
     void loadPluginsFromList(const std::string& filename);
 
     // Load a specific plugin
-    std::shared_ptr<nixlPluginHandle> loadPlugin(const nixl_backend_t& plugin_name);
+    std::shared_ptr<const nixlPluginHandle> loadPlugin(const nixl_backend_t& plugin_name);
 
     // Search a directory for plugins
     void discoverPluginsFromDir(const std::string& dirpath);
@@ -89,7 +95,7 @@ public:
     void unloadPlugin(const nixl_backend_t& plugin_name);
 
     // Get a plugin handle
-    std::shared_ptr<nixlPluginHandle> getPlugin(const nixl_backend_t& plugin_name);
+    std::shared_ptr<const nixlPluginHandle> getPlugin(const nixl_backend_t& plugin_name);
 
     // Get all loaded plugin names
     std::vector<nixl_backend_t> getLoadedPluginNames();

--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -64,9 +64,7 @@ class nixlPluginManager {
 private:
     std::map<nixl_backend_t, std::shared_ptr<const nixlPluginHandle>> loaded_plugins_;
     std::vector<std::string> plugin_dirs_;
-
-    // Static Plugins
-    static std::vector<nixlStaticPluginInfo> static_plugins_;
+    std::vector<nixlStaticPluginInfo> static_plugins_;
 
     void registerBuiltinPlugins();
 
@@ -108,7 +106,7 @@ public:
 
     // Static Plugin Helpers
     void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);
-    static std::vector<nixlStaticPluginInfo>& getStaticPlugins();
+    const std::vector<nixlStaticPluginInfo>& getStaticPlugins();
 };
 
 #endif // __PLUGIN_MANAGER_H

--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <mutex>
 #include "backend/backend_plugin.h"
 
 // Forward declarations
@@ -65,6 +66,7 @@ private:
     std::map<nixl_backend_t, std::shared_ptr<const nixlPluginHandle>> loaded_plugins_;
     std::vector<std::string> plugin_dirs_;
     std::vector<nixlStaticPluginInfo> static_plugins_;
+    std::mutex lock;
 
     void registerBuiltinPlugins();
     void registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator);

--- a/src/core/sync.h
+++ b/src/core/sync.h
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SYNC_H
+#define SYNC_H
+#include "common/util.h"
+#include "nixl_params.h"
+#include <mutex>
+
+class nixlLock {
+    public:
+        nixlLock(const nixl_thread_sync_t sync_mode): syncMode(sync_mode)
+        {}
+
+        void lock() {
+            if (syncMode == nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT) {
+                m.lock();
+            }
+        }
+
+        void unlock() {
+            if (syncMode == nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT) {
+                m.unlock();
+            }
+        }
+
+    private:
+        nixl_thread_sync_t syncMode;
+        std::mutex m;
+};
+
+#define NIXL_LOCK_GUARD(lock) const std::lock_guard<nixlLock> UNIQUE_NAME(lock_guard) (lock)
+
+#endif /* SYNC_H */

--- a/src/utils/common/util.h
+++ b/src/utils/common/util.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef UTIL_H
+#define UTIL_H
+
+#define CONCAT(a, b) CONCAT_0(a, b)
+#define CONCAT_0(a, b) a ## b
+#define UNIQUE_NAME(name) CONCAT(name, __COUNTER__)
+
+#endif /* UTIL_H */

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -45,3 +45,19 @@ test_exe = executable('gtest',
 )
 
 test('gtest', test_exe, args: [plugin_dirs_arg])
+
+if get_option('b_sanitize').split(',').contains('thread')
+    test_env = environment()
+    test_env.set('TSAN_OPTIONS', 'halt_on_error=1')
+    test_env.set('NIXL_PLUGIN_DIR', mocks_dep.get_variable('path'))
+
+    mt_test_exe = executable('mt_test',
+        sources : ['main.cpp', 'multi_threading.cpp'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        cpp_args : cpp_flags,
+        dependencies : [nixl_dep, nixl_infra, cuda_dep, gtest_dep],
+        link_with: [nixl_build_lib],
+    )
+
+    test('mt_test', mt_test_exe, is_parallel: false, env: test_env)
+endif

--- a/test/gtest/mocks/mock_dram_engine.cpp
+++ b/test/gtest/mocks/mock_dram_engine.cpp
@@ -17,89 +17,98 @@
 #include "mock_dram_engine.h"
 
 namespace mocks {
-MockDramBackendEngine::MockDramBackendEngine(
-    const nixlBackendInitParams *init_params)
-    : nixlBackendEngine(init_params) {}
 
 MockDramBackendEngine::~MockDramBackendEngine() {}
 
-bool MockDramBackendEngine::supportsRemote() const { return true; }
-bool MockDramBackendEngine::supportsLocal() const { return true; }
-bool MockDramBackendEngine::supportsNotif() const { return false; }
-bool MockDramBackendEngine::supportsProgTh() const { return false; };
-
-nixl_mem_list_t MockDramBackendEngine::getSupportedMems() const {
-  return nixl_mem_list_t{DRAM_SEG};
-}
-
-nixl_status_t MockDramBackendEngine::registerMem(const nixlBlobDesc &,
-                                                 const nixl_mem_t &,
-                                                 nixlBackendMD *&) {
+nixl_status_t MockDramBackendEngine::registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem,
+                                                nixlBackendMD *&out) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
 
-nixl_status_t MockDramBackendEngine::deregisterMem(nixlBackendMD *) {
+nixl_status_t MockDramBackendEngine::deregisterMem(nixlBackendMD *meta) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::connect(const std::string &) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::disconnect(const std::string &) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::unloadMD(nixlBackendMD *) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::prepXfer(const nixl_xfer_op_t &,
-                                              const nixl_meta_dlist_t &,
-                                              const nixl_meta_dlist_t &,
-                                              const std::string &,
-                                              nixlBackendReqH *&,
-                                              const nixl_opt_b_args_t *) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::postXfer(const nixl_xfer_op_t &,
-                                              const nixl_meta_dlist_t &,
-                                              const nixl_meta_dlist_t &,
-                                              const std::string &,
-                                              nixlBackendReqH *&,
-                                              const nixl_opt_b_args_t *) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::checkXfer(nixlBackendReqH *) {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::releaseReqH(nixlBackendReqH *) {
-  return NIXL_SUCCESS;
-};
 
-nixl_status_t MockDramBackendEngine::getPublicData(const nixlBackendMD *,
-                                                   std::string &) const {
-  return NIXL_SUCCESS;
-};
-nixl_status_t MockDramBackendEngine::getConnInfo(std::string &) const {
+nixl_status_t MockDramBackendEngine::connect(const std::string &remote_agent) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::loadRemoteConnInfo(const std::string &,
-                                                        const std::string &) {
+
+nixl_status_t MockDramBackendEngine::disconnect(const std::string &remote_agent) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::loadRemoteMD(const nixlBlobDesc &,
-                                                  const nixl_mem_t &,
-                                                  const std::string &,
-                                                  nixlBackendMD *&) {
+
+nixl_status_t MockDramBackendEngine::unloadMD(nixlBackendMD *input) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::loadLocalMD(nixlBackendMD *,
-                                                 nixlBackendMD *&) {
+
+nixl_status_t MockDramBackendEngine::prepXfer(const nixl_xfer_op_t &operation,
+                                             const nixl_meta_dlist_t &local,
+                                             const nixl_meta_dlist_t &remote,
+                                             const std::string &remote_agent,
+                                             nixlBackendReqH *&handle,
+                                             const nixl_opt_b_args_t *opt_args) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::getNotifs(notif_list_t &) {
+
+nixl_status_t MockDramBackendEngine::postXfer(const nixl_xfer_op_t &operation,
+                                             const nixl_meta_dlist_t &local,
+                                             const nixl_meta_dlist_t &remote,
+                                             const std::string &remote_agent,
+                                             nixlBackendReqH *&handle,
+                                             const nixl_opt_b_args_t *opt_args) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-nixl_status_t MockDramBackendEngine::genNotif(const std::string &,
-                                              const std::string &) {
+
+nixl_status_t MockDramBackendEngine::checkXfer(nixlBackendReqH *handle) {
+  sharedState++;
   return NIXL_SUCCESS;
 }
-int MockDramBackendEngine::progress() { return 0; }
+
+nixl_status_t MockDramBackendEngine::releaseReqH(nixlBackendReqH *handle) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+nixl_status_t MockDramBackendEngine::loadRemoteConnInfo(const std::string &remote_agent,
+                                                       const std::string &remote_conn_info) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+nixl_status_t MockDramBackendEngine::loadRemoteMD(const nixlBlobDesc &input,
+                                                 const nixl_mem_t &nixl_mem,
+                                                 const std::string &remote_agent,
+                                                 nixlBackendMD *&output) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+nixl_status_t MockDramBackendEngine::loadLocalMD(nixlBackendMD *input,
+                                                nixlBackendMD *&output) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+nixl_status_t MockDramBackendEngine::getNotifs(notif_list_t &notif_list) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+nixl_status_t MockDramBackendEngine::genNotif(const std::string &remote_agent,
+                                             const std::string &msg) {
+  sharedState++;
+  return NIXL_SUCCESS;
+}
+
+int MockDramBackendEngine::progress() {
+  sharedState++;
+  return 0;
+}
 } // namespace mocks

--- a/test/gtest/multi_threading.cpp
+++ b/test/gtest/multi_threading.cpp
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "nixl.h"
+#include "plugin_manager.h"
+#include <thread>
+#include <filesystem>
+
+namespace gtest {
+namespace multi_threading {
+
+class MultiThreadingTestFixture : public testing::Test {
+protected:
+    uintptr_t addr = 0;
+    size_t len = 1024;
+    uint64_t dev_id = 0;
+
+    nixlAgent createAgent() {
+        nixlAgentConfig cfg(false, false, 0, 0, 100000, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+        return nixlAgent("test_agent", cfg);
+    }
+
+    nixl_opt_args_t createExtraParams(nixlBackendH* backend) {
+        nixl_opt_args_t extra_params;
+        extra_params.backends = {backend};
+        return extra_params;
+    }
+
+    nixlBackendH* verifyMockDramBackendCreation(nixlAgent& agent) {
+        nixlBackendH* backend_handle = nullptr;
+        nixl_b_params_t params;
+        nixl_status_t status = agent.createBackend("MOCK_DRAM", params, backend_handle);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+        EXPECT_NE(backend_handle, nullptr);
+        return backend_handle;
+    }
+
+    void verifyMemoryRegistration(nixlAgent& agent, const nixl_opt_args_t& extra_params) {
+        nixlBlobDesc blob(addr, len, dev_id, "");
+        nixlDescList<nixlBlobDesc> desc_list(DRAM_SEG);
+        desc_list.addDesc(blob);
+
+        nixl_status_t status = agent.registerMem(desc_list, &extra_params);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+    }
+
+    void verifyTransfer(nixlAgent& agent, const nixl_opt_args_t& extra_params) {
+        nixlXferReqH* xfer_req = nullptr;
+        nixlDescList<nixlBasicDesc> src_list(DRAM_SEG);
+        nixlDescList<nixlBasicDesc> dst_list(DRAM_SEG);
+
+        nixlBasicDesc basic_desc(addr, len, dev_id);
+        src_list.addDesc(basic_desc);
+        dst_list.addDesc(basic_desc);
+
+        nixl_status_t status = agent.createXferReq(NIXL_WRITE, src_list, dst_list, "test_agent", xfer_req, &extra_params);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+        EXPECT_NE(xfer_req, nullptr);
+
+        status = agent.postXferReq(xfer_req);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+
+        status = agent.getXferStatus(xfer_req);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+
+        status = agent.releaseXferReq(xfer_req);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+    }
+};
+
+TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadAgent) {
+    auto transfer_sequence = [&]() {
+        nixlAgent agent = createAgent();
+        nixlBackendH* backend = verifyMockDramBackendCreation(agent);
+        nixl_opt_args_t extra_params = createExtraParams(backend);
+
+        verifyMemoryRegistration(agent, extra_params);
+        verifyTransfer(agent, extra_params);
+    };
+
+    std::thread t1(transfer_sequence);
+    std::thread t2(transfer_sequence);
+
+    t1.join();
+    t2.join();
+}
+
+TEST_F(MultiThreadingTestFixture, ConcurrentAddPlugingDirWithPerThreadAgent) {
+    auto transfer_sequence = [&]() {
+        nixlAgent agent = createAgent();
+        nixlBackendH* backend = verifyMockDramBackendCreation(agent);
+        nixl_opt_args_t extra_params = createExtraParams(backend);
+
+        using namespace std::filesystem;
+        path dir_path = temp_directory_path() / "nixl_mt_test_plugin_dir";
+        create_directory(dir_path);
+        nixlPluginManager::getInstance().addPluginDirectory(dir_path);
+
+        verifyMemoryRegistration(agent, extra_params);
+        verifyTransfer(agent, extra_params);
+    };
+
+    std::thread t1(transfer_sequence);
+    std::thread t2(transfer_sequence);
+
+    t1.join();
+    t2.join();
+}
+
+TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadMemory) {
+    nixlAgent agent = createAgent();
+    nixlBackendH* backend = verifyMockDramBackendCreation(agent);
+    nixl_opt_args_t extra_params = createExtraParams(backend);
+
+    auto transfer_sequence = [&]() {
+        verifyMemoryRegistration(agent, extra_params);
+        verifyTransfer(agent, extra_params);
+    };
+
+    std::thread t1(transfer_sequence);
+    std::thread t2(transfer_sequence);
+
+    t1.join();
+    t2.join();
+}
+
+TEST_F(MultiThreadingTestFixture, ConcurrentTransfers) {
+    nixlAgent agent = createAgent();
+    nixlBackendH* backend = verifyMockDramBackendCreation(agent);
+    nixl_opt_args_t extra_params = createExtraParams(backend);
+
+    verifyMemoryRegistration(agent, extra_params);
+
+    auto transfer_sequence = [&]() {
+        verifyTransfer(agent, extra_params);
+    };
+
+    std::thread t1(transfer_sequence);
+    std::thread t2(transfer_sequence);
+
+    t1.join();
+    t2.join();
+}
+
+TEST_F(MultiThreadingTestFixture, RegisterMemWithMockDram) {
+    nixlAgent agent = createAgent();
+    nixlBackendH* backend = verifyMockDramBackendCreation(agent);
+    nixl_opt_args_t extra_params = createExtraParams(backend);
+
+    verifyMemoryRegistration(agent, extra_params);
+    verifyTransfer(agent, extra_params);
+}
+
+} // namespace mt
+} // namespace gtest

--- a/test/gtest/plugin_manager.cpp
+++ b/test/gtest/plugin_manager.cpp
@@ -47,7 +47,7 @@ class LoadSinglePluginTestFixture
     : public testing::TestWithParam<PluginDesc> {
 protected:
   nixlPluginManager &plugin_manager_ = nixlPluginManager::getInstance();
-  std::shared_ptr<nixlPluginHandle> plugin_handle_;
+  std::shared_ptr<const nixlPluginHandle> plugin_handle_;
 
   void SetUp() override {
 #if !TEST_ALL_PLUGINS
@@ -73,7 +73,7 @@ class LoadMultiplePluginsTestFixture
     : public testing::TestWithParam<std::vector<PluginDesc>> {
 protected:
   nixlPluginManager &plugin_manager_ = nixlPluginManager::getInstance();
-  std::vector<std::shared_ptr<nixlPluginHandle>> plugin_handles_;
+  std::vector<std::shared_ptr<const nixlPluginHandle>> plugin_handles_;
 
   void SetUp() override {
     for (const auto &plugin : GetParam()) {
@@ -101,7 +101,7 @@ protected:
   bool AreAllLoaded() {
     return all_of(
         plugin_handles_.begin(), plugin_handles_.end(),
-        [](std::shared_ptr<nixlPluginHandle> ptr) { return ptr != nullptr; });
+        [](std::shared_ptr<const nixlPluginHandle> ptr) { return ptr != nullptr; });
   }
 };
 

--- a/test/nixl/test_plugin.cpp
+++ b/test/nixl/test_plugin.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
 
     // Print list of static plugins available
     std::cout << "Available static plugins:" << std::endl;
-    for (const auto& plugin : nixlPluginManager::getStaticPlugins()) {
+    for (const auto& plugin : plugin_manager.getStaticPlugins()) {
         std::cout << " - " << plugin.name << std::endl;
         staticPlugs.insert(plugin.name);
     }


### PR DESCRIPTION
Current NIXL implementation sidesteps any considerations of executing in multi-threaded environment by leaving it up to the user to ensure that access to nixlAgent instance is synchronized. Extend this by adding a strict synchronization mode while also preserving existing mode but making it explicit.

To continue using NIXL with exactly the same performance set configuration variable disable_mt=true which statically removes all locking at build time.

When NIXL is compiled with multi-threading enabled still allow dynamic configurations via nixlAgentConfig->syncMode field:

- When set to NIXL_SYNC_NONE no locking is performed and behavior is similar as before this change with the small difference that dynamic check is performed every time the lock would be taken with strict model.

- When set to NIXL_SYNC_STRICT all nixlAgent API methods are fully synchronized with internal exclusive lock.

In order to allow dynamic configuration at runtime the lock implemented as a thin BasicLockable-compatible wrapper around std::mutex that accepts sync_mode parameter to its constructor and skip locking/unlocking the mutex when synchronization mode is not strict. To allow static configuration at build time the lock is compiled out and the macro that is used to create a lock guard for the lock is set to no-op.