### PR TITLE
Agent API: New method to get partial MD and allow partial MD loads

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -365,6 +365,26 @@ class nixlAgent {
         getLocalMD (nixl_blob_t &str) const;
 
         /**
+         * @brief  Get partial metadata blob for this agent, to be given to other agents.
+         *         If `descs` is empty, only backends' connection info is included in the metadata,
+         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
+         *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
+         *         and if `extra_params->includeConnInfo` is true, the connection info of the
+         *         backends supporting the memory type is also included.
+         *         If `extra_params->backends` is non-empty, only the descriptors supported by the
+         *         backends in the list and the backends' connection info are included in the metadata.
+         *
+         * @param  descs         [in]  Descriptor list to include in the metadata
+         * @param  str           [out] The serialized metadata blob
+         * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
+         * @return nixl_status_t       Error code if call was not successful
+         */
+        nixl_status_t
+        getLocalPartialMD(nixl_reg_dlist_t  &descs,
+                          nixl_blob_t &str,
+                          const nixl_opt_args_t* extra_params = nullptr) const;
+
+        /**
          * @brief  Load other agent's metadata and unpack it internally. Now the local
          *         agent can initiate transfers towards the remote agent.
          *

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -134,6 +134,12 @@ class nixlAgentOptionalArgs {
          * @var makeXferReq boolean to skip merging consecutive descriptors, used in makeXferReq.
          */
         bool skipDescMerge = false;
+
+        /**
+         * @var includeConnInfo boolean to include connection information in the metadata,
+         *                      used in getLocalPartialMD.
+         */
+        bool includeConnInfo = false;
 };
 /**
  * @brief A typedef for a nixlAgentOptionalArgs

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -53,12 +53,13 @@ class nixlAgentData {
 
         // Bookkeping for local connection metadata and user handles per backend
         std::unordered_map<nixl_backend_t, nixlBackendH*> backendHandles;
-        std::unordered_map<nixl_backend_t, std::string>   connMD;
+        std::unordered_map<nixl_backend_t, nixl_blob_t>   connMD;
 
         // Local section, and Remote sections and their available common backends
         nixlLocalSection*                                        memorySection;
 
-        std::unordered_map<std::string, std::set<nixl_backend_t>,
+        std::unordered_map<std::string,
+                           std::unordered_map<nixl_backend_t, nixl_blob_t>,
                            std::hash<std::string>, strEqual>     remoteBackends;
         std::unordered_map<std::string, nixlRemoteSection*,
                            std::hash<std::string>, strEqual>     remoteSections;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -272,8 +272,8 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
     for (size_t i=0; i<backend_list->size(); ++i) {
         nixlBackendEngine* backend = (*backend_list)[i];
         // meta_descs use to be passed to loadLocalData
-        nixl_meta_dlist_t meta_descs(descs.getType(), false);
-        ret = data->memorySection->addDescList(descs, backend, meta_descs);
+        nixl_sec_dlist_t sec_descs(descs.getType(), false);
+        ret = data->memorySection->addDescList(descs, backend, sec_descs);
         if (ret == NIXL_SUCCESS) {
             if (backend->supportsLocal()) {
                 if (data->remoteSections.count(data->name) == 0)
@@ -281,7 +281,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
                           new nixlRemoteSection(data->name);
 
                 ret = data->remoteSections[data->name]->loadLocalData(
-                                                        meta_descs, backend);
+                                                        sec_descs, backend);
                 if (ret == NIXL_SUCCESS)
                     count++;
                 else

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1001,7 +1001,7 @@ nixlAgent::getLocalPartialMD(nixl_reg_dlist_t &descs,
     }
 
     // First find all relevant engines and their conn info.
-    // Best effort, ignore if no conn info.
+    // Best effort, ignore if no conn info (meaning backend doesn't support remote).
     backend_set_t selected_engines;
     std::vector<typename decltype(data->connMD)::iterator> found_iters;
     for (const auto &backend : *backend_list) {

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -285,7 +285,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
                 if (ret == NIXL_SUCCESS)
                     count++;
                 else
-                    data->memorySection->remDescList(meta_descs, backend);
+                    data->memorySection->remDescList(descs, backend);
             } else {
                 count++;
             }
@@ -308,7 +308,6 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
 
     backend_set_t     backend_set;
     nixl_status_t     ret, bad_ret=NIXL_SUCCESS;
-    nixl_xfer_dlist_t trimmed = descs.trim();
 
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_set_t* avail_backends;
@@ -325,15 +324,7 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
 
     // Doing best effort, and returning err if any
     for (auto & backend : backend_set) {
-        nixl_meta_dlist_t resp(descs.getType(),
-                               descs.isSorted());
-
-        // Now just populating the metadata part, inside remDescList,
-        // getIndex is used to make sure exact match
-        ret = data->memorySection->populate(trimmed, backend, resp);
-        if (ret != NIXL_SUCCESS)
-            bad_ret = ret;
-        ret = data->memorySection->remDescList(resp, backend);
+        ret = data->memorySection->remDescList(descs, backend);
         if (ret != NIXL_SUCCESS)
             bad_ret = ret;
     }

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -66,7 +66,7 @@ class nixlLocalSection : public nixlMemSection {
                                    nixl_meta_dlist_t &remote_self);
 
         // Each nixlBasicDesc should be same as original registration region
-        nixl_status_t remDescList (const nixl_meta_dlist_t &mem_elms,
+        nixl_status_t remDescList (const nixl_reg_dlist_t &mem_elms,
                                    nixlBackendEngine* backend);
 
         nixl_status_t serialize(nixlSerDes* serializer) const;

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -44,6 +44,8 @@ public:
     using nixlMetaDesc::nixlMetaDesc;
 
     nixl_blob_t serialize() const {
+        // Serialize only the meta blob. metadataP is private so we don't include it.
+        // The other side will deserialize it as nixlBlobDesc.
         return nixlBasicDesc::serialize() + metaBlob;
     }
 

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -79,9 +79,6 @@ class nixlMemSection {
 
 
 class nixlLocalSection : public nixlMemSection {
-    private:
-        nixl_status_t serializeSections(nixlSerDes* serializer,
-                                        const section_map_t &sections) const;
     public:
         nixl_status_t addDescList (const nixl_reg_dlist_t &mem_elms,
                                    nixlBackendEngine* backend,

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -67,6 +67,10 @@ class nixlLocalSection : public nixlMemSection {
 
         nixl_status_t serialize(nixlSerDes* serializer) const;
 
+        nixl_status_t serializePartial(nixlSerDes* serializer,
+                                       const backend_set_t &backends,
+                                       const nixl_reg_dlist_t &mem_elms) const;
+
         ~nixlLocalSection();
 };
 

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -30,12 +30,13 @@
 typedef std::pair<nixl_mem_t, nixlBackendEngine*>              section_key_t;
 typedef std::set<nixlBackendEngine*>                           backend_set_t;
 typedef std::unordered_map<nixl_backend_t, nixlBackendEngine*> backend_map_t;
+typedef std::map<section_key_t,   nixl_meta_dlist_t*>          section_map_t;
 
 
 class nixlMemSection {
     protected:
         std::array<backend_set_t, FILE_SEG+1>         memToBackend;
-        std::map<section_key_t,   nixl_meta_dlist_t*> sectionMap;
+        section_map_t                                 sectionMap;
 
     public:
         nixlMemSection () {};
@@ -56,6 +57,9 @@ class nixlLocalSection : public nixlMemSection {
         nixl_reg_dlist_t getStringDesc (
                                const nixlBackendEngine* backend,
                                const nixl_meta_dlist_t &d_list) const;
+
+        nixl_status_t serializeSections(nixlSerDes* serializer,
+                                        const section_map_t &sections) const;
     public:
         nixl_status_t addDescList (const nixl_reg_dlist_t &mem_elms,
                                    nixlBackendEngine* backend,

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include "nixl.h"
 #include "nixl_descriptors.h"
+#include "mem_section.h"
 #include "backend/backend_aux.h"
 #include "serdes/serdes.h"
 
@@ -165,8 +166,8 @@ nixlDescList<T>::nixlDescList(nixlSerDes* deserializer) {
     if (str.size()==0)
         return;
 
-    // nixlMetaDesc should be internal and not be serialized
-    if (std::is_same<nixlMetaDesc, T>::value)
+    // nixlMetaDesc and nixlSectionDesc should be internal and not be serialized
+    if (std::is_same<nixlMetaDesc, T>::value || std::is_same<nixlSectionDesc, T>::value)
         return;
 
     if (deserializer->getBuf("t", &type, sizeof(type)))
@@ -369,7 +370,7 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
     // descriptor. std::string_view(typeid(T).name()) is compiler dependent
     if (std::is_same<nixlBasicDesc, T>::value)
         ret = serializer->addStr("nixlDList", "nixlBDList");
-    else if (std::is_same<nixlBlobDesc, T>::value)
+    else if (std::is_same<nixlBlobDesc, T>::value || std::is_same<nixlSectionDesc, T>::value)
         ret = serializer->addStr("nixlDList", "nixlSDList");
     else
         return NIXL_ERR_INVALID_PARAM;
@@ -395,7 +396,7 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
                                  reinterpret_cast<const char*>(descs.data()),
                                  n_desc * sizeof(nixlBasicDesc)));
         if (ret) return ret;
-    } else { // already checked it can be only nixlBlobDesc
+    } else { // already checked it can be only nixlBlobDesc or nixlSectionDesc
         for (auto & elm : descs) {
             ret = serializer->addStr("", elm.serialize());
             if (ret) return ret;
@@ -432,6 +433,7 @@ bool operator==(const nixlDescList<T> &lhs, const nixlDescList<T> &rhs) {
 template class nixlDescList<nixlBasicDesc>;
 template class nixlDescList<nixlMetaDesc>;
 template class nixlDescList<nixlBlobDesc>;
+template class nixlDescList<nixlSectionDesc>;
 
 template bool operator==<nixlBasicDesc> (const nixlDescList<nixlBasicDesc> &lhs,
                                          const nixlDescList<nixlBasicDesc> &rhs);
@@ -439,3 +441,5 @@ template bool operator==<nixlMetaDesc>  (const nixlDescList<nixlMetaDesc> &lhs,
                                          const nixlDescList<nixlMetaDesc> &rhs);
 template bool operator==<nixlBlobDesc>(const nixlDescList<nixlBlobDesc> &lhs,
                                        const nixlDescList<nixlBlobDesc> &rhs);
+template bool operator==<nixlSectionDesc>(const nixlDescList<nixlSectionDesc> &lhs,
+                                          const nixlDescList<nixlSectionDesc> &rhs);

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -370,6 +370,7 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
     // descriptor. std::string_view(typeid(T).name()) is compiler dependent
     if (std::is_same<nixlBasicDesc, T>::value)
         ret = serializer->addStr("nixlDList", "nixlBDList");
+    // We serialize SectionDesc the same as BlobDesc so it will be deserialized as BlobDesc on the other side
     else if (std::is_same<nixlBlobDesc, T>::value || std::is_same<nixlSectionDesc, T>::value)
         ret = serializer->addStr("nixlDList", "nixlSDList");
     else

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -371,9 +371,9 @@ nixl_status_t nixlRemoteSection::addDescList (
     nixlBasicDesc *p = &out;
     nixl_status_t ret;
     for (int i=0; i<mem_elms.descCount(); ++i) {
-        // TODO: remote might change the metadata, have to keep stringDesc to compare
-        //       if we support partial updates. Also Can add overlap checks (erroneous)
-        if (target->getIndex((const nixlBasicDesc) mem_elms[i]) < 0) {
+        // TODO: Can add overlap checks (erroneous)
+        int idx = target->getIndex(static_cast<nixlBasicDesc>(mem_elms[i]));
+        if (idx < 0) {
             ret = backend->loadRemoteMD(mem_elms[i], nixl_mem, agentName, out.metadataP);
             // In case of errors, no need to remove the previous entries
             // Agent will delete the full object.
@@ -382,6 +382,11 @@ nixl_status_t nixlRemoteSection::addDescList (
             *p = mem_elms[i]; // Copy the basic desc part
             out.metaBlob = mem_elms[i].metaInfo;
             target->addDesc(out);
+        } else {
+            const nixl_blob_t &prev_meta_info = (*target)[idx].metaBlob;
+            // TODO: Support metadata updates
+            if (prev_meta_info != mem_elms[i].metaInfo)
+                return NIXL_ERR_NOT_ALLOWED;
         }
     }
     return NIXL_SUCCESS;

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -20,6 +20,7 @@
 #include "nixl_descriptors.h"
 #include "mem_section.h"
 #include "backend/backend_engine.h"
+#include "nixl_types.h"
 #include "serdes/serdes.h"
 
 /*** Class nixlMemSection implementation ***/
@@ -50,7 +51,7 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
         return NIXL_ERR_NOT_FOUND;
 
     nixlBasicDesc *p;
-    nixl_meta_dlist_t* base = it->second;
+    nixl_sec_dlist_t* base = it->second;
     resp.resize(query.descCount());
 
     if (!base->isSorted()) {
@@ -77,7 +78,7 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
 
         if (q_sorted) {
             int s_index, q_index, size;
-            const nixlMetaDesc *s;
+            const nixlSectionDesc *s;
 
             size = base->descCount();
             s_index = 0;
@@ -145,35 +146,10 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
 
 /*** Class nixlLocalSection implementation ***/
 
-nixl_reg_dlist_t nixlLocalSection::getStringDesc (
-                             const nixlBackendEngine* backend,
-                             const nixl_meta_dlist_t &d_list) const {
-    nixl_status_t ret;
-    nixlBlobDesc element;
-    nixlBasicDesc *p = &element;
-    nixl_reg_dlist_t output_desclist(d_list.getType(),
-                                     d_list.isSorted());
-
-    // The string information of each registered block are updated by
-    // required serialized metadata provided by the backend
-    for (int i=0; i<d_list.descCount(); ++i) {
-        *p = (nixlBasicDesc) d_list[i];
-        ret = backend->getPublicData(d_list[i].metadataP, element.metaInfo);
-        if(ret != NIXL_SUCCESS){
-            //something has gone wrong
-            output_desclist.clear();
-            return output_desclist;
-        }
-
-        output_desclist.addDesc(element);
-    }
-    return output_desclist;
-}
-
 // Calls into backend engine to register the memories in the desc list
 nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
                                              nixlBackendEngine* backend,
-                                             nixl_meta_dlist_t &remote_self) {
+                                             nixl_sec_dlist_t &remote_self) {
 
     if (!backend)
         return NIXL_ERR_INVALID_PARAM;
@@ -183,39 +159,40 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
 
     auto it = sectionMap.find(sec_key);
     if (it==sectionMap.end()) { // New desc list
-        sectionMap[sec_key] = new nixl_meta_dlist_t(nixl_mem, true);
+        sectionMap[sec_key] = new nixl_sec_dlist_t(nixl_mem, true);
         memToBackend[nixl_mem].insert(backend);
     }
-    nixl_meta_dlist_t *target = sectionMap[sec_key];
+    nixl_sec_dlist_t *target = sectionMap[sec_key];
 
     // Add entries to the target list
-    nixlMetaDesc local_meta, self_meta;
-    nixlBasicDesc *lp = &local_meta;
-    nixlBasicDesc *rp = &self_meta;
-    nixl_status_t ret1, ret2=NIXL_SUCCESS;
-    int index;
+    nixlSectionDesc local_sec, self_sec;
+    nixlBasicDesc *lp = &local_sec;
+    nixlBasicDesc *rp = &self_sec;
+    nixl_status_t ret;
 
-    for (int i=0; i<mem_elms.descCount(); ++i) {
+    int i;
+    for (i = 0; i < mem_elms.descCount(); ++i) {
         // TODO: For now trusting the user, but there can be a more checks mode
         //       where we find overlaps and split the memories or warn the user
-        ret1 = backend->registerMem(mem_elms[i], nixl_mem, local_meta.metadataP);
+        ret = backend->registerMem(mem_elms[i], nixl_mem, local_sec.metadataP);
+        if (ret != NIXL_SUCCESS)
+            break;
 
-        if ((ret1==NIXL_SUCCESS) && backend->supportsLocal()) {
-            ret2 = backend->loadLocalMD(local_meta.metadataP, self_meta.metadataP);
-        }
-
-        if ((ret1!=NIXL_SUCCESS) || (ret2!=NIXL_SUCCESS)) {
-            for (int j=0; j<i; ++j) {
-                index = target->getIndex(mem_elms[j]);
-                backend->deregisterMem
-                    ((*(const nixl_meta_dlist_t*)target)[index].metadataP);
-                target->remDesc(index);
+        if (backend->supportsLocal()) {
+            ret = backend->loadLocalMD(local_sec.metadataP, self_sec.metadataP);
+            if (ret != NIXL_SUCCESS) {
+                backend->deregisterMem(local_sec.metadataP);
+                break;
             }
-            remote_self.clear();
-            if (ret1!=NIXL_SUCCESS)
-                return ret1;
-            else
-                return ret2;
+        }
+        if (backend->supportsRemote()) {
+            ret = backend->getPublicData(local_sec.metadataP, self_sec.metaBlob);
+            if (ret != NIXL_SUCCESS) {
+                if (backend->supportsLocal() && self_sec.metadataP != local_sec.metadataP)
+                    backend->unloadMD(self_sec.metadataP);
+                backend->deregisterMem(local_sec.metadataP);
+                break;
+            }
         }
 
         *lp = mem_elms[i]; // Copy the basic desc part
@@ -223,14 +200,30 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
              (nixl_mem == FILE_SEG)) && (lp->len==0))
             lp->len = SIZE_MAX; // File has no range limit
 
-        target->addDesc(local_meta);
+        target->addDesc(local_sec);
 
         if (backend->supportsLocal()) {
             *rp = *lp;
-            remote_self.addDesc(self_meta);
+            remote_self.addDesc(self_sec);
         }
     }
-    return NIXL_SUCCESS;
+
+    // Abort in case of error
+    if (ret != NIXL_SUCCESS) {
+        for (int j = 0; j < i; ++j) {
+            int index = target->getIndex(mem_elms[j]);
+
+            if (backend->supportsLocal()) {
+                int self_index = remote_self.getIndex(mem_elms[j]);
+                if (self_index >= 0 && remote_self[self_index].metadataP != (*target)[index].metadataP)
+                    backend->unloadMD(remote_self[self_index].metadataP);
+            }
+            backend->deregisterMem((*target)[index].metadataP);
+            target->remDesc(index);
+        }
+        remote_self.clear();
+    }
+    return ret;
 }
 
 // Per each nixlBasicDesc, the full region that got registered should be deregistered
@@ -243,7 +236,7 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
     auto it = sectionMap.find(sec_key);
     if (it==sectionMap.end())
         return NIXL_ERR_NOT_FOUND;
-    nixl_meta_dlist_t *target = it->second;
+    nixl_sec_dlist_t *target = it->second;
 
     // First check if the mem_elms are present in the list,
     // don't deregister anything in case any is missing.
@@ -279,15 +272,14 @@ nixl_status_t nixlLocalSection::serializeSections(nixlSerDes* serializer,
     ret = serializer->addBuf("nixlSecElms", &seg_count, sizeof(seg_count));
     if (ret) return ret;
 
-    for (const auto &[sec_key, m_desc] : sections) {
+    for (const auto &[sec_key, dlist] : sections) {
         nixlBackendEngine* eng = sec_key.second;
         if (!eng->supportsRemote())
             continue;
 
-        nixl_reg_dlist_t s_desc = getStringDesc(eng, *m_desc);
         ret = serializer->addStr("bknd", eng->getType());
         if (ret) return ret;
-        ret = s_desc.serialize(serializer);
+        ret = dlist->serialize(serializer);
         if (ret) return ret;
     }
 
@@ -318,8 +310,8 @@ nixl_status_t nixlLocalSection::serializePartial(nixlSerDes* serializer,
 
         // TODO: consider section_map_t to be a map of unique_ptr or instance of nixl_meta_dlist_t.
         //       This will avoid the need to delete the nixl_sec_dlist_t instances.
-        const nixl_meta_dlist_t *base = it->second;
-        nixl_meta_dlist_t *resp = new nixl_meta_dlist_t(nixl_mem, mem_elms.isSorted());
+        const nixl_sec_dlist_t *base = it->second;
+        nixl_sec_dlist_t *resp = new nixl_sec_dlist_t(nixl_mem, mem_elms.isSorted());
         for (const auto &desc : mem_elms) {
             int index = base->getIndex(desc);
             if (index < 0) {
@@ -342,15 +334,11 @@ nixl_status_t nixlLocalSection::serializePartial(nixlSerDes* serializer,
 }
 
 nixlLocalSection::~nixlLocalSection() {
-    nixl_meta_dlist_t* m_desc;
-    nixlBackendEngine* eng;
-
-    for (auto &seg : sectionMap) {
-        eng    = seg.first.second;
-        m_desc = seg.second;
-        for (auto & elm : *m_desc)
+    for (auto &[sec_key, dlist] : sectionMap) {
+        nixlBackendEngine* eng = sec_key.second;
+        for (auto & elm : *dlist)
             eng->deregisterMem(elm.metadataP);
-        delete m_desc;
+        delete dlist;
     }
     // nixlMemSection destructor will clean up the rest
 }
@@ -373,13 +361,13 @@ nixl_status_t nixlRemoteSection::addDescList (
     nixl_mem_t nixl_mem   = mem_elms.getType();
     section_key_t sec_key = std::make_pair(nixl_mem, backend);
     if (sectionMap.count(sec_key) == 0)
-        sectionMap[sec_key] = new nixl_meta_dlist_t(nixl_mem, true);
+        sectionMap[sec_key] = new nixl_sec_dlist_t(nixl_mem, true);
     memToBackend[nixl_mem].insert(backend); // Fine to overwrite, it's a set
-    nixl_meta_dlist_t *target = sectionMap[sec_key];
+    nixl_sec_dlist_t *target = sectionMap[sec_key];
 
 
     // Add entries to the target list.
-    nixlMetaDesc out;
+    nixlSectionDesc out;
     nixlBasicDesc *p = &out;
     nixl_status_t ret;
     for (int i=0; i<mem_elms.descCount(); ++i) {
@@ -392,6 +380,7 @@ nixl_status_t nixlRemoteSection::addDescList (
             if (ret<0)
                 return ret;
             *p = mem_elms[i]; // Copy the basic desc part
+            out.metaBlob = mem_elms[i].metaInfo;
             target->addDesc(out);
         }
     }
@@ -425,7 +414,7 @@ nixl_status_t nixlRemoteSection::loadRemoteData (nixlSerDes* deserializer,
 }
 
 nixl_status_t nixlRemoteSection::loadLocalData (
-                                 const nixl_meta_dlist_t& mem_elms,
+                                 const nixl_sec_dlist_t& mem_elms,
                                  nixlBackendEngine* backend) {
 
     if (mem_elms.descCount()==0) // Shouldn't happen
@@ -435,9 +424,9 @@ nixl_status_t nixlRemoteSection::loadLocalData (
     section_key_t sec_key = std::make_pair(nixl_mem, backend);
 
     if (sectionMap.count(sec_key) == 0)
-        sectionMap[sec_key] = new nixl_meta_dlist_t(nixl_mem, true);
+        sectionMap[sec_key] = new nixl_sec_dlist_t(nixl_mem, true);
     memToBackend[nixl_mem].insert(backend); // Fine to overwrite, it's a set
-    nixl_meta_dlist_t *target = sectionMap[sec_key];
+    nixl_sec_dlist_t *target = sectionMap[sec_key];
 
     for (auto & elm: mem_elms)
         target->addDesc(elm);
@@ -446,15 +435,11 @@ nixl_status_t nixlRemoteSection::loadLocalData (
 }
 
 nixlRemoteSection::~nixlRemoteSection() {
-    nixl_meta_dlist_t* m_desc;
-    nixlBackendEngine* eng;
-
-    for (auto &seg : sectionMap) {
-        eng    = seg.first.second;
-        m_desc = seg.second;
-        for (auto & elm : *m_desc)
+    for (auto &[sec_key, dlist] : sectionMap) {
+        nixlBackendEngine* eng = sec_key.second;
+        for (auto & elm : *dlist)
             eng->unloadMD(elm.metadataP);
-        delete m_desc;
+        delete dlist;
     }
     // nixlMemSection destructor will clean up the rest
 }

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -186,7 +186,7 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
             }
         }
         if (backend->supportsRemote()) {
-            ret = backend->getPublicData(local_sec.metadataP, self_sec.metaBlob);
+            ret = backend->getPublicData(local_sec.metadataP, local_sec.metaBlob);
             if (ret != NIXL_SUCCESS) {
                 // A backend might use the same object for both initiator/target
                 // side of a transfer, so no need for unloadMD in that case.

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -264,8 +264,9 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlLocalSection::serializeSections(nixlSerDes* serializer,
-                                                  const section_map_t &sections) const {
+namespace {
+nixl_status_t serializeSections(nixlSerDes* serializer,
+                                const section_map_t &sections) {
     nixl_status_t ret;
 
     size_t seg_count = sections.size();
@@ -285,6 +286,7 @@ nixl_status_t nixlLocalSection::serializeSections(nixlSerDes* serializer,
 
     return NIXL_SUCCESS;
 }
+};
 
 nixl_status_t nixlLocalSection::serialize(nixlSerDes* serializer) const {
     return serializeSections(serializer, sectionMap);

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -188,7 +188,8 @@ nixl_status_t nixlLocalSection::addDescList (const nixl_reg_dlist_t &mem_elms,
         if (backend->supportsRemote()) {
             ret = backend->getPublicData(local_sec.metadataP, self_sec.metaBlob);
             if (ret != NIXL_SUCCESS) {
-                // If self MD is the same local MD, it will be by deregisterMem
+                // A backend might use the same object for both initiator/target
+                // side of a transfer, so no need for unloadMD in that case.
                 if (backend->supportsLocal() && self_sec.metadataP != local_sec.metadataP)
                     backend->unloadMD(self_sec.metadataP);
                 backend->deregisterMem(local_sec.metadataP);

--- a/test/nixl/agent_example.cpp
+++ b/test/nixl/agent_example.cpp
@@ -266,13 +266,13 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
         assert(status == NIXL_SUCCESS);
         assert(remote_name == agent2);
 
-        // Make sure registered descriptors are updated
+        // Make sure loaded descriptors are updated
         nixlDlistH *dst_side;
         status = A1->prepXferDlist(agent2, dst_mem_lists[update].trim(), dst_side, &extra_params1);
         assert(status == NIXL_SUCCESS);
         assert(dst_side != nullptr);
 
-        // Make sure unregistered descriptors are not updated
+        // Make sure non-loaded descriptors are not updated
         for (int invalid_idx = update + 1; invalid_idx < NUM_UPDATES; invalid_idx++) {
             status = A1->prepXferDlist(agent2, dst_mem_lists[invalid_idx].trim(), dst_side, &extra_params1);
             assert(status != NIXL_SUCCESS);

--- a/test/nixl/agent_example.cpp
+++ b/test/nixl/agent_example.cpp
@@ -221,7 +221,9 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
     // Test metadata update with only backends and empty descriptor list
     std::cout << "Metadata update - backends only\n";
 
-    A1->invalidateRemoteMD(agent2); // precaution, don't care about return value
+    // Agent2 might have already been previously loaded.
+    // Invalidate it just in case but don't care either way.
+    A1->invalidateRemoteMD(agent2);
 
     nixl_reg_dlist_t empty_dlist(DRAM_SEG);
     std::string partial_meta;
@@ -272,7 +274,7 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
         assert(status == NIXL_SUCCESS);
         assert(dst_side != nullptr);
 
-        // Make sure non-loaded descriptors are not updated
+        // Make sure not-loaded descriptors are not updated
         for (int invalid_idx = update + 1; invalid_idx < NUM_UPDATES; invalid_idx++) {
             status = A1->prepXferDlist(agent2, dst_mem_lists[invalid_idx].trim(), dst_side, &extra_params1);
             assert(status != NIXL_SUCCESS);

--- a/test/nixl/agent_example.cpp
+++ b/test/nixl/agent_example.cpp
@@ -172,6 +172,201 @@ void test_side_perf(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend, nixlBac
     free(dst_buf);
 }
 
+nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1, nixlBackendH* backend2) {
+    std::cout << "Starting partialMdTest\n";
+
+    nixl_status_t status;
+    nixl_opt_args_t extra_params1, extra_params2;
+    extra_params1.backends.push_back(backend1);
+    extra_params2.backends.push_back(backend2);
+
+    const int NUM_BUFFERS = 4;
+    const int NUM_UPDATES = 3;
+    const size_t BUF_SIZE = 1024;
+
+    // Allocate memory for the test
+    void* src_bufs[NUM_UPDATES][NUM_BUFFERS];
+    void* dst_bufs[NUM_UPDATES][NUM_BUFFERS];
+
+    // Create mem_lists for updates - using std::vector instead of C-style arrays
+    std::vector<nixl_reg_dlist_t> src_mem_lists(NUM_UPDATES, nixl_reg_dlist_t(DRAM_SEG));
+    std::vector<nixl_reg_dlist_t> dst_mem_lists(NUM_UPDATES, nixl_reg_dlist_t(DRAM_SEG));
+
+    // Allocate buffers and create memory descriptors
+    for (int update_idx = 0; update_idx < NUM_UPDATES; update_idx++) {
+        for (int buf_idx = 0; buf_idx < NUM_BUFFERS; buf_idx++) {
+            src_bufs[update_idx][buf_idx] = calloc(1, BUF_SIZE);
+            dst_bufs[update_idx][buf_idx] = calloc(1, BUF_SIZE);
+
+            nixlBlobDesc src_desc((uintptr_t)src_bufs[update_idx][buf_idx], BUF_SIZE, 0);
+            nixlBlobDesc dst_desc((uintptr_t)dst_bufs[update_idx][buf_idx], BUF_SIZE, 0);
+
+            src_mem_lists[update_idx].addDesc(src_desc);
+            dst_mem_lists[update_idx].addDesc(dst_desc);
+
+            // Fill source buffers with test pattern
+            memset(src_bufs[update_idx][buf_idx], 0xbb, BUF_SIZE);
+        }
+    }
+
+    // Register memory for each update
+    for (int update = 0; update < NUM_UPDATES; update++) {
+        status = A1->registerMem(src_mem_lists[update], &extra_params1);
+        assert(status == NIXL_SUCCESS);
+
+        status = A2->registerMem(dst_mem_lists[update], &extra_params2);
+        assert(status == NIXL_SUCCESS);
+    }
+
+    // Test metadata update with only backends and empty descriptor list
+    std::cout << "Metadata update - backends only\n";
+
+    A1->invalidateRemoteMD(agent2); // precaution, don't care about return value
+
+    nixl_reg_dlist_t empty_dlist(DRAM_SEG);
+    std::string partial_meta;
+    status = A2->getLocalPartialMD(empty_dlist, partial_meta, NULL);
+    assert(status == NIXL_SUCCESS);
+    assert(partial_meta.size() > 0);
+
+    std::string remote_name;
+    status = A1->loadRemoteMD(partial_meta, remote_name);
+    assert(status == NIXL_SUCCESS);
+    assert(remote_name == agent2);
+
+    // Make sure unregistered descriptors are not updated
+    for (int update = 0; update < NUM_UPDATES; update++) {
+        nixlDlistH *dst_side;
+        status = A1->prepXferDlist(agent2, dst_mem_lists[update].trim(), dst_side, &extra_params1);
+        assert(status != NIXL_SUCCESS);
+        assert(dst_side == nullptr);
+    }
+
+    // Invalidate remote agent metadata to make sure we received connection info
+    status = A1->invalidateRemoteMD(agent2);
+    assert(status == NIXL_SUCCESS);
+    std::cout << "Metadata update - backends only completed\n";
+
+    // Main test loop - update metadata multiple times
+    // and verify those that are not updatedare invalid on remote side.
+    extra_params2.includeConnInfo = false;
+    for (int update = 0; update < NUM_UPDATES; update++) {
+        // Toggle includeConnInfo to test that it doesn't affect metadata update
+        extra_params2.includeConnInfo = !extra_params2.includeConnInfo;
+
+        std::cout << "Metadata update #" << update << "\n";
+        // Get partial metadata from A2
+        status = A2->getLocalPartialMD(dst_mem_lists[update], partial_meta, &extra_params2);
+        assert(status == NIXL_SUCCESS);
+        assert(partial_meta.size() > 0);
+
+        // Load the partial metadata into A1
+        std::string remote_name;
+        status = A1->loadRemoteMD(partial_meta, remote_name);
+        assert(status == NIXL_SUCCESS);
+        assert(remote_name == agent2);
+
+        // Make sure registered descriptors are updated
+        nixlDlistH *dst_side;
+        status = A1->prepXferDlist(agent2, dst_mem_lists[update].trim(), dst_side, &extra_params1);
+        assert(status == NIXL_SUCCESS);
+        assert(dst_side != nullptr);
+
+        // Make sure unregistered descriptors are not updated
+        for (int invalid_idx = update + 1; invalid_idx < NUM_UPDATES; invalid_idx++) {
+            status = A1->prepXferDlist(agent2, dst_mem_lists[invalid_idx].trim(), dst_side, &extra_params1);
+            assert(status != NIXL_SUCCESS);
+            assert(dst_side == nullptr);
+        }
+        std::cout << "Metadata update #" << update << " completed\n";
+    }
+
+    // Prepare transfer dlists of all descriptors and buffers
+    nixl_xfer_dlist_t src_xfer_list(DRAM_SEG), dst_xfer_list(DRAM_SEG);
+
+    for (int update_idx = 0; update_idx < NUM_UPDATES; update_idx++) {
+        nixl_xfer_dlist_t tmp_src_list = src_mem_lists[update_idx].trim();
+        nixl_xfer_dlist_t tmp_dst_list = dst_mem_lists[update_idx].trim();
+
+        for (int buf_idx = 0; buf_idx < NUM_BUFFERS; buf_idx++) {
+            src_xfer_list.addDesc(tmp_src_list[buf_idx]);
+            dst_xfer_list.addDesc(tmp_dst_list[buf_idx]);
+        }
+    }
+
+    // Prepare for transfers of all descriptors and buffers
+    nixlDlistH *src_side, *dst_side;
+
+    status = A1->prepXferDlist(NIXL_INIT_AGENT, src_xfer_list, src_side, &extra_params1);
+    assert(status == NIXL_SUCCESS);
+
+    status = A1->prepXferDlist(agent2, dst_xfer_list, dst_side, &extra_params1);
+    assert(status == NIXL_SUCCESS);
+
+    std::cout << "Transfer preparation completed\n";
+
+    // Perform a single transfer for all descriptors and buffers
+    std::vector<int> indices;
+    for (int i = 0; i < NUM_UPDATES * NUM_BUFFERS; i++) {
+        indices.push_back(i);
+    }
+
+    nixlXferReqH *req;
+    extra_params1.notifMsg = "partialMdTest_notification";
+    extra_params1.hasNotif = true;
+
+    // Create and post the transfer request
+    status = A1->makeXferReq(NIXL_WRITE, src_side, indices, dst_side, indices, req, &extra_params1);
+    assert(status == NIXL_SUCCESS);
+
+    nixl_status_t xfer_status = A1->postXferReq(req);
+
+    // Wait for transfer completion
+    while (xfer_status != NIXL_SUCCESS) {
+        if (xfer_status != NIXL_SUCCESS) xfer_status = A1->getXferStatus(req);
+        assert (xfer_status >= 0);
+    }
+
+    // Verify transfer results
+    for (int update_idx = 0; update_idx < NUM_UPDATES; update_idx++) {
+        for (int buf_idx = 0; buf_idx < NUM_BUFFERS; buf_idx++) {
+            check_buf(dst_bufs[update_idx][buf_idx], BUF_SIZE);
+        }
+    }
+
+    std::cout << "Transfer verification completed\n";
+
+    // Cleanup
+    status = A1->releaseXferReq(req);
+    assert(status == NIXL_SUCCESS);
+
+    status = A1->releasedDlistH(src_side);
+    assert(status == NIXL_SUCCESS);
+
+    status = A1->releasedDlistH(dst_side);
+    assert(status == NIXL_SUCCESS);
+
+    // Deregister memory
+    for (int update = 0; update < NUM_UPDATES; update++) {
+        status = A1->deregisterMem(src_mem_lists[update], &extra_params1);
+        assert(status == NIXL_SUCCESS);
+
+        status = A2->deregisterMem(dst_mem_lists[update], &extra_params2);
+        assert(status == NIXL_SUCCESS);
+    }
+
+    // Free allocated memory
+    for (int update_idx = 0; update_idx < NUM_UPDATES; update_idx++) {
+        for (int buf_idx = 0; buf_idx < NUM_BUFFERS; buf_idx++) {
+            free(src_bufs[update_idx][buf_idx]);
+            free(dst_bufs[update_idx][buf_idx]);
+        }
+    }
+
+    std::cout << "partialMdTest completed successfully\n";
+    return NIXL_SUCCESS;
+}
+
 nixl_status_t sideXferTest(nixlAgent* A1, nixlAgent* A2, nixlXferReqH* src_handle, nixlBackendH* dst_backend) {
     std::cout << "Starting sideXferTest\n";
 
@@ -526,6 +721,10 @@ int main()
     n_notifs = 0;
 
     std::cout << "Transfer verified\n";
+
+    std::cout << "performing partialMdTest with backends " << ucx1 << " " << ucx2 << "\n";
+    ret1 = partialMdTest(&A1, &A2, ucx1, ucx2);
+    assert (ret1 == NIXL_SUCCESS);
 
     std::cout << "performing sideXferTest with backends " << ucx1 << " " << ucx2 << "\n";
     ret1 = sideXferTest(&A1, &A2, req_handle, ucx2);


### PR DESCRIPTION
* This allows one agent to notify remote agents about new memory regions
* This allows guardrails between agents so that each remote agent can transfer only to a subset of regions.
* Introducing new internal nixlSectionDesc which is used to cache the remote metadata blob to make sure an existing remote descriptor did not change its metadata during a new loadRemoteMD.