### PR TITLE
Descriptors: changed devID from 32-bits to 64-bits

### DIFF
--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -36,7 +36,7 @@ class nixlBasicDesc {
         /** @var Buffer Length */
         size_t    len;
         /** @var deviceID/blockID/fileID */
-        uint32_t  devId;
+        uint64_t  devId;
 
         /**
          * @brief Default constructor for nixlBasicDesc
@@ -52,7 +52,7 @@ class nixlBasicDesc {
          */
         nixlBasicDesc(const uintptr_t &addr,
                       const size_t &len,
-                      const uint32_t &dev_id);
+                      const uint64_t &dev_id);
         /**
          * @brief Deserializer constructor for nixlBasicDesc with
          *        serialized blob of another nixlBasicDesc
@@ -111,13 +111,6 @@ class nixlBasicDesc {
          */
         bool overlaps (const nixlBasicDesc &query) const;
         /**
-         * @brief Copy Metadata from one descriptor to another.
-         *        No meta info in BasicDesc, so empty implementation
-         *
-         * @param desc   nixlBasicDesc Object
-         */
-        void copyMeta (const nixlBasicDesc &desc) {};
-        /**
          * @brief Serialize descriptor into a blob
          */
         nixl_blob_t serialize() const;
@@ -151,7 +144,7 @@ class nixlBlobDesc : public nixlBasicDesc {
          * @param meta_info Metadata blob
          */
          nixlBlobDesc(const uintptr_t &addr, const size_t &len,
-                      const uint32_t &dev_id, const nixl_blob_t &meta_info);
+                      const uint64_t &dev_id, const nixl_blob_t &meta_info);
         /**
          * @brief Constructor for nixlBlobDesc from nixlBasicDesc and metadata blob
          *

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -163,7 +163,7 @@ PYBIND11_MODULE(_bindings, m) {
         .def(py::init([](nixl_mem_t mem, std::vector<py::tuple> descs, bool sorted) {
                 nixl_xfer_dlist_t new_list(mem, sorted, descs.size());
                 for(long unsigned int i = 0; i<descs.size(); i++)
-                    new_list[i] = nixlBasicDesc(descs[i][0].cast<uintptr_t>(), descs[i][1].cast<size_t>(), descs[i][2].cast<uint32_t>());
+                    new_list[i] = nixlBasicDesc(descs[i][0].cast<uintptr_t>(), descs[i][1].cast<size_t>(), descs[i][2].cast<uint64_t>());
                 if (sorted) new_list.verifySorted();
                 return new_list;
             }), py::arg("type"), py::arg("descs"), py::arg("sorted")=false)
@@ -173,8 +173,8 @@ PYBIND11_MODULE(_bindings, m) {
         .def("isSorted", &nixl_xfer_dlist_t::isSorted)
         .def(py::self == py::self)
         .def("__getitem__", [](nixl_xfer_dlist_t &list, unsigned int i) ->
-              std::tuple<uintptr_t, size_t, uint32_t> {
-                    std::tuple<uintptr_t, size_t, uint32_t> ret;
+              std::tuple<uintptr_t, size_t, uint64_t> {
+                    std::tuple<uintptr_t, size_t, uint64_t> ret;
                     nixlBasicDesc desc = list[i];
                     std::get<0>(ret) = desc.addr;
                     std::get<1>(ret) = desc.len;
@@ -182,17 +182,17 @@ PYBIND11_MODULE(_bindings, m) {
                     return ret;
               })
         .def("__setitem__", [](nixl_xfer_dlist_t &list, unsigned int i, const py::tuple &desc) {
-                list[i] = nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint32_t>());
+                list[i] = nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>());
             })
         .def("addDesc", [](nixl_xfer_dlist_t &list, const py::tuple &desc) {
-                list.addDesc(nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint32_t>()));
+                list.addDesc(nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>()));
             })
         .def("append", [](nixl_xfer_dlist_t &list, const py::tuple &desc) {
-                list.addDesc(nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint32_t>()));
+                list.addDesc(nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>()));
             })
         .def("index", [](nixl_xfer_dlist_t &list, const py::tuple &desc) {
                 int ret = (nixl_status_t) list.getIndex(nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(),
-                                                  desc[2].cast<uint32_t>()));
+                                                  desc[2].cast<uint64_t>()));
                 if(ret < 0) throw_nixl_exception((nixl_status_t) ret);
                 return (int) ret;
             })
@@ -220,7 +220,7 @@ PYBIND11_MODULE(_bindings, m) {
         .def(py::init([](nixl_mem_t mem, std::vector<py::tuple> descs, bool sorted) {
                 nixl_reg_dlist_t new_list(mem, sorted, descs.size());
                 for(long unsigned int i = 0; i<descs.size(); i++)
-                    new_list[i] = nixlBlobDesc(descs[i][0].cast<uintptr_t>(), descs[i][1].cast<size_t>(), descs[i][2].cast<uint32_t>(), descs[i][3].cast<std::string>());
+                    new_list[i] = nixlBlobDesc(descs[i][0].cast<uintptr_t>(), descs[i][1].cast<size_t>(), descs[i][2].cast<uint64_t>(), descs[i][3].cast<std::string>());
                 if (sorted) new_list.verifySorted();
                 return new_list;
             }), py::arg("type"), py::arg("descs"), py::arg("sorted")=false)
@@ -230,8 +230,8 @@ PYBIND11_MODULE(_bindings, m) {
         .def("isSorted", &nixl_reg_dlist_t::isSorted)
         .def(py::self == py::self)
         .def("__getitem__", [](nixl_reg_dlist_t &list, unsigned int i) ->
-              std::tuple<uintptr_t, size_t, uint32_t, std::string> {
-                    std::tuple<uintptr_t, size_t, uint32_t, std::string> ret;
+              std::tuple<uintptr_t, size_t, uint64_t, std::string> {
+                    std::tuple<uintptr_t, size_t, uint64_t, std::string> ret;
                     nixlBlobDesc desc = list[i];
                     std::get<0>(ret) = desc.addr;
                     std::get<1>(ret) = desc.len;
@@ -240,19 +240,19 @@ PYBIND11_MODULE(_bindings, m) {
                     return ret;
               })
         .def("__setitem__", [](nixl_reg_dlist_t &list, unsigned int i, const py::tuple &desc) {
-                list[i] = nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint32_t>(), desc[3].cast<std::string>());
+                list[i] = nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>(), desc[3].cast<std::string>());
             })
         .def("addDesc", [](nixl_reg_dlist_t &list, const py::tuple &desc) {
                 list.addDesc(nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(),
-                                            desc[2].cast<uint32_t>(),desc[3].cast<std::string>()));
+                                            desc[2].cast<uint64_t>(),desc[3].cast<std::string>()));
             })
         .def("append", [](nixl_reg_dlist_t &list, const py::tuple &desc) {
                 list.addDesc(nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(),
-                                            desc[2].cast<uint32_t>(),desc[3].cast<std::string>()));
+                                            desc[2].cast<uint64_t>(),desc[3].cast<std::string>()));
             })
         .def("index", [](nixl_reg_dlist_t &list, const py::tuple &desc) {
                 int ret = list.getIndex(nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(),
-                                                  desc[2].cast<uint32_t>(),desc[3].cast<std::string>()));
+                                                  desc[2].cast<uint64_t>(),desc[3].cast<std::string>()));
                 if(ret < 0) throw_nixl_exception((nixl_status_t) ret);
                 return ret;
             })

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -152,7 +152,7 @@ void nixlUcxEngine::vramInitCtx()
     cudaCtx = new nixlUcxCudaCtx;
 }
 
-int nixlUcxEngine::vramUpdateCtx(void *address, uint32_t  devId, bool &restart_reqd)
+int nixlUcxEngine::vramUpdateCtx(void *address, uint64_t  devId, bool &restart_reqd)
 {
     int ret;
     bool was_updated;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -142,7 +142,7 @@ class nixlUcxEngine : public nixlBackendEngine {
 
         void vramInitCtx();
         void vramFiniCtx();
-        int vramUpdateCtx(void *address, uint32_t  devId, bool &restart_reqd);
+        int vramUpdateCtx(void *address, uint64_t devId, bool &restart_reqd);
         int vramApplyCtx();
 
         // Threading infrastructure

--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -75,7 +75,7 @@ nixlUcxMoEngine::getEngCnt()
 }
 
 int32_t
-nixlUcxMoEngine::getEngIdx(nixl_mem_t type, uint32_t devId)
+nixlUcxMoEngine::getEngIdx(nixl_mem_t type, uint64_t devId)
 {
     switch (type) {
     case VRAM_SEG:

--- a/src/plugins/ucx_mo/ucx_mo_backend.h
+++ b/src/plugins/ucx_mo/ucx_mo_backend.h
@@ -128,7 +128,7 @@ private:
     uint32_t _gpuCnt;
     int setEngCnt(uint32_t host_engines);
     uint32_t getEngCnt();
-    int32_t getEngIdx(nixl_mem_t type, uint32_t devId);
+    int32_t getEngIdx(nixl_mem_t type, uint64_t devId);
     std::string getEngName(const std::string &baseName, uint32_t eidx);
     std::string getEngBase(const std::string &engName);
     bool pthrOn;

--- a/test/nixl/desc_example.cpp
+++ b/test/nixl/desc_example.cpp
@@ -81,7 +81,6 @@ int main()
     nixlBasicDesc buff3 (buff2);
     nixlBasicDesc buff4;
     buff4 = buff1;
-    buff4.copyMeta (buff2);
     nixlBasicDesc buff5 (1980,21,3);
     nixlBasicDesc buff6 (1010,30,4);
     nixlBasicDesc buff7 (1010,30,0);


### PR DESCRIPTION
* In serialized form of nixlBasicDesc, it was using 24 bytes anyways on 64-bit systems, so no memory savings, while going to u64 can be useful for some backends.
* Also used constexpr as we moved to c++17, and now empty copyMeta can be removed from nixlBasicDesc.