### PR TITLE
Descriptors: code reorg and clean up

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -103,12 +103,6 @@ class nixlMetaDesc : public nixlBasicDesc {
                           (lhs.metadataP == rhs.metadataP));
         }
 
-        // Main use case is to take the BasicDesc from another object, so just
-        // the metadata part is separately copied here, used in DescList
-        inline void copyMeta (const nixlMetaDesc &meta) {
-            this->metadataP = meta.metadataP;
-        }
-
         inline void print(const std::string &suffix) const {
             nixlBasicDesc::print(", Backend ptr val: " +
                                  std::to_string((uintptr_t)metadataP) + suffix);

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -149,7 +149,8 @@ class nixlAgent {
          *           - For loopback descriptors, it is set to local agent's name, indicating that
          *             this is for a loopback (local) transfer to be uued for remote_side handle
          *         If a list of backends hints is provided (via extra_params), the preparation
-         *         is limited to the specified backends.
+         *         is limited to the specified backends. If `descs` has the sorted flag, that
+         *         enables an optimization to speed up the preparation process.
          *
          * @param  agent_name       Agent name as a string for preparing xfer handle
          * @param  descs            The descriptor list to be prepared for transfer requests
@@ -204,6 +205,8 @@ class nixlAgent {
          *         pre-processing done in the preparation step. If a list of backends hints is
          *         provided (via extra_params), the selection is limited to the specified backends.
          *         Optionally, a notification message can also be provided through extra_params.
+         *         If `local_descs` or `remote_descs` have the sorted flag, that enables an
+         *         optimization to speed up the preparation process.
          *
          * @param  operation      Operation for transfer (e.g., NIXL_WRITE)
          * @param  local_descs    Local descriptor list

--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -171,10 +171,6 @@ class nixlBlobDesc : public nixlBasicDesc {
          */
         nixl_blob_t serialize() const;
         /**
-         * @brief Copy nixlBlobDesc metadata from one object to another
-         */
-        void copyMeta (const nixlBlobDesc &info);
-        /**
          * @brief Print nixlBlobDesc for debugging purpose
          *
          * @param suffix gets prepended to the descriptor print
@@ -308,24 +304,6 @@ class nixlDescList {
          *        Can throw std::out_of_range exception.
          */
         void remDesc(const int &index);
-        /**
-         * @brief Populate the `resp` nixlDescList by adding metadata to
-         *        each element of `query` nixlDescList which has descriptors
-         *        of type nixlBasicDesc (no metadata). Per each descriptor in
-         *        `query`, an descriptor within current object is found that
-         *        covers the descriptor in `query`, and the metadata of the
-         *        found descriptor is added to the `query` descriptor and added
-         *        to the `resp` nixlDescList.
-         *        If the `query` is sorted and is going to be populated against
-         *        a sorted list, that enables an optimization to be in linear time.
-         *
-         * @param  query      nixlDescList object, made from nixlBasicDesc, as input query
-         * @param  resp [out] populated response for the query, based on the current object
-         *
-         * @return nixl_status_t Error code if population was not successful
-         */
-        nixl_status_t populate(const nixlDescList<nixlBasicDesc> &query,
-                               nixlDescList<T> &resp) const;
         /**
          * @brief Convert a nixlDescList with metadata by trimming it to a
          *        nixlDescList of nixlBasicDesc elements

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -20,7 +20,7 @@
 #include <stdexcept>
 #include "nixl.h"
 #include "nixl_descriptors.h"
-#include "backend/backend_engine.h"
+#include "backend/backend_aux.h"
 #include "serdes/serdes.h"
 
 /*** Class nixlBasicDesc implementation ***/
@@ -135,10 +135,6 @@ nixl_blob_t nixlBlobDesc::serialize() const {
     return nixlBasicDesc::serialize() + metaInfo;
 }
 
-void nixlBlobDesc::copyMeta (const nixlBlobDesc &info){
-    this->metaInfo = info.metaInfo;
-}
-
 void nixlBlobDesc::print(const std::string &suffix) const {
     nixlBasicDesc::print(", Metadata: " + metaInfo + suffix);
 }
@@ -170,7 +166,7 @@ nixlDescList<T>::nixlDescList(nixlSerDes* deserializer) {
         return;
 
     // nixlMetaDesc should be internal and not be serialized
-    if ((str == "nixlMDList") || (std::is_same<nixlMetaDesc, T>::value))
+    if (std::is_same<nixlMetaDesc, T>::value)
         return;
 
     if (deserializer->getBuf("t", &type, sizeof(type)))
@@ -213,17 +209,19 @@ nixlDescList<T>::nixlDescList(nixlSerDes* deserializer) {
 // Getter
 template <class T>
 inline const T& nixlDescList<T>::operator[](unsigned int index) const {
-    if (index >= descs.size())
-        throw std::out_of_range("Index is out of range");
+    // To be added only in debug mode
+    // if (index >= descs.size())
+    //     throw std::out_of_range("Index is out of range");
     return descs[index];
 }
 
 // Setter
 template <class T>
 inline T& nixlDescList<T>::operator[](unsigned int index) {
-    if (index >= descs.size())
-        throw std::out_of_range("Index is out of range");
-    sorted = false;
+    // To be added only in debug mode
+    // if (index >= descs.size())
+    //     throw std::out_of_range("Index is out of range");
+    // sorted = false;
     return descs[index];
 }
 
@@ -294,8 +292,9 @@ void nixlDescList<T>::remDesc (const int &index){
 
 template <class T>
 void nixlDescList<T>::resize (const size_t &count) {
-    if (count > descs.size())
-        sorted = false;
+    // To be added only in debug mode
+    // if (count > descs.size())
+    //     sorted = false;
     descs.resize(count);
 }
 
@@ -320,124 +319,22 @@ bool nixlDescList<T>::verifySorted() {
 }
 
 template <class T>
-nixl_status_t nixlDescList<T>::populate (const nixlDescList<nixlBasicDesc> &query,
-                                         nixlDescList<T> &resp) const {
-    // Populate only makes sense when there is extra metadata
-    if constexpr (std::is_same<nixlBasicDesc, T>::value) {
-        return NIXL_ERR_INVALID_PARAM;
-    } else {
-        if ((type != query.getType()) || (type != resp.type))
-            return NIXL_ERR_INVALID_PARAM;
-
-        // 1-to-1 mapping cannot hold
-        if (query.isSorted() != resp.sorted)
-            return NIXL_ERR_INVALID_PARAM;
-
-        T new_elm;
-        nixlBasicDesc *p = &new_elm;
-        int count = 0, last_found = 0;
-        int s_index, q_index, size;
-        bool found, q_sorted = query.isSorted();
-        const nixlBasicDesc *q, *s;
-
-        resp.resize(query.descCount());
-
-        if (!sorted) {
-            for (int i=0; i<query.descCount(); ++i)
-                for (auto & elm : descs)
-                    if (elm.covers(query[i])){
-                        *p = query[i];
-                        new_elm.copyMeta(elm);
-                        resp.descs[i]=new_elm;
-                        count++;
-                        break;
-                    }
-
-            if (query.descCount()==count) {
-                return NIXL_SUCCESS;
-            } else {
-                resp.clear();
-                return NIXL_ERR_UNKNOWN;
-            }
-        } else {
-            if (q_sorted) {
-                size = (int) descs.size();
-                s_index = 0;
-                q_index = 0;
-
-                while (q_index<query.descCount()){
-                    s = &descs[s_index];
-                    q = &query[q_index];
-                    if ((*s).covers(*q)) {
-                        *p = *q;
-                        new_elm.copyMeta(descs[s_index]); // needs const nixlBasicDesc&
-                        resp.descs[q_index] = new_elm;
-                        q_index++;
-                    } else {
-                        s_index++;
-                        // if (*q < descs[s_index]) ||
-                        if (s_index==size) {
-                            resp.clear();
-                            return NIXL_ERR_UNKNOWN;
-                        }
-                    }
-                }
-
-                resp.sorted = true; // Should be redundant
-                return NIXL_SUCCESS;
-
-            } else {
-                for (int i=0; i<query.descCount(); ++i) {
-                    found = false;
-                    q = &query[i];
-                    auto itr = std::lower_bound(descs.begin() + last_found,
-                                                descs.end(), *q);
-
-                    // Same start address case
-                    if (itr != descs.end()){
-                        if ((*itr).covers(*q)) {
-                            found = true;
-                        }
-                    }
-
-                    // query starts starts later, try previous entry
-                    if ((!found) && (itr != descs.begin())){
-                        itr = std::prev(itr , 1);
-                        if ((*itr).covers(*q)) {
-                            found = true;
-                        }
-                    }
-
-                    if (found) {
-                        *p = *q;
-                        new_elm.copyMeta(*itr);
-                        resp.descs[i] = new_elm;
-                    } else {
-                        resp.clear();
-                        return NIXL_ERR_UNKNOWN;
-                    }
-                }
-                resp.sorted = query.isSorted(); // Update as resize resets it
-                return NIXL_SUCCESS;
-            }
-        }
-    }
-}
-
-template <class T>
 nixlDescList<nixlBasicDesc> nixlDescList<T>::trim() const {
 
-    // Potential optimization for (std::is_same<nixlBasicDesc, T>::value)
-    nixlDescList<nixlBasicDesc> trimmed(type, sorted);
-    nixlBasicDesc* p;
+    if constexpr (std::is_same<nixlBasicDesc, T>::value) {
+        return *this;
+    } else {
+        nixlDescList<nixlBasicDesc> trimmed(type, sorted);
+        nixlBasicDesc* p;
 
-    for (auto & elm: descs) {
-        p = (nixlBasicDesc*) (&elm);
-        trimmed.addDesc(*p);
+        for (auto & elm: descs) {
+            p = (nixlBasicDesc*) (&elm);
+            trimmed.addDesc(*p);
+        }
+
+        // No failure scenario
+        return trimmed;
     }
-
-    // No failure scenario
-    return trimmed;
 }
 
 template <class T>
@@ -468,6 +365,8 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
     if (std::is_same<nixlMetaDesc, T>::value)
         return NIXL_ERR_INVALID_PARAM;
 
+    // For now very few descriptor types, if needed can add a name method to each
+    // descriptor. std::string_view(typeid(T).name()) is compiler dependent
     if (std::is_same<nixlBasicDesc, T>::value)
         ret = serializer->addStr("nixlDList", "nixlBDList");
     else if (std::is_same<nixlBlobDesc, T>::value)
@@ -489,8 +388,9 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
     if (n_desc==0)
         return NIXL_SUCCESS; // Unusual, but supporting it
 
+    // Optimization for nixlBasicDesc,
+    // contiguous in memory, so no need for per elm serialization
     if (std::is_same<nixlBasicDesc, T>::value) {
-        // Contiguous in memory, so no need for per elm serialization
         ret = serializer->addStr("", std::string(
                                  reinterpret_cast<const char*>(descs.data()),
                                  n_desc * sizeof(nixlBasicDesc)));

--- a/test/nixl/desc_example.cpp
+++ b/test/nixl/desc_example.cpp
@@ -306,19 +306,6 @@ int main()
     nixl_reg_dlist_t dlist24 (DRAM_SEG, false);
     nixl_reg_dlist_t dlist25 (DRAM_SEG, false);
 
-    dlist20.populate (dlist10, dlist21);
-    dlist20.populate (dlist11, dlist22);
-    dlist20.populate (dlist12, dlist23);
-    dlist20.populate (dlist13, dlist24);
-    dlist20.populate (dlist14, dlist25);
-
-    std::cout << "\n";
-    dlist21.print();
-    dlist22.print();
-    dlist23.print();
-    dlist24.print();
-    dlist25.print();
-
     testPerf();
 
     delete ser_des;


### PR DESCRIPTION
* Moved populate from descriptors to mem section.
* The enabled removal of copyMeta methods. They were only used in that method.
* Commented out some extra checks that should be done only in debug mode when added.
* Added few comments to nixl.h to clarify how sorted can be used, now that the populate method is removed.