### PR TITLE
Debug Infra: Fix NIXL log level

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -86,9 +86,6 @@ if actual_log_level == 'auto'
   endif
 endif
 
-# Add define for the determined log level
-add_project_arguments('-DLOG_LEVEL_' + actual_log_level.to_upper() , language: 'cpp')
-
 # Configure Abseil log stripping and NDEBUG for release builds
 if get_option('buildtype') == 'release'
     # Map our log levels to Abseil severity integers

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -22,7 +22,7 @@ option('cudapath_lib', type: 'string', value: '', description: 'Library path for
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
-option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, warning for release builds)')
+option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 
 # Tests
 option('test_all_plugins', type: 'boolean', value: false, description: 'Testing all plugins in addition to the mocks..')

--- a/src/utils/common/nixl_log.cpp
+++ b/src/utils/common/nixl_log.cpp
@@ -66,24 +66,6 @@ void InitializeNixlLogging()
             invalid_env_var = true;
         }
     }
-    if (env_log_level == nullptr || invalid_env_var) {
-        // Use the level set at compile time
-        #if defined(LOG_LEVEL_TRACE)
-            level_to_use = "TRACE";
-        #elif defined(LOG_LEVEL_DEBUG)
-            level_to_use = "DEBUG";
-        #elif defined(LOG_LEVEL_INFO)
-            level_to_use = "INFO";
-        #elif defined(LOG_LEVEL_WARN)
-            level_to_use = "WARN";
-        #elif defined(LOG_LEVEL_ERROR)
-            level_to_use = "ERROR";
-        #elif defined(LOG_LEVEL_FATAL)
-            level_to_use = "FATAL";
-        #else
-            // Fall back to kDefaultLogLevel
-        #endif
-    }
 
     // Apply the settings
     auto it = kLogLevelMap.find(level_to_use);


### PR DESCRIPTION
Currently, `INFO` is used by default for release builds and `TRACE` for debug builds. Both `INFO` and `TRACE` should be available as the maximum log levels for release and debug builds respectively, but the default level should be set to `WARN`.