### PR TITLE
refactor: Prefer "using" over "typedef" guideline implementation

### DIFF
--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -338,11 +338,11 @@ class nixlDescList {
  * @brief A typedef for a nixlDescList<nixlBasicDesc>
  *        used for creating transfer descriptor lists
  */
-typedef nixlDescList<nixlBasicDesc> nixl_xfer_dlist_t;
+using nixl_xfer_dlist_t = nixlDescList<nixlBasicDesc>;
 /**
  * @brief A typedef for a nixlDescList<nixlBlobDesc>
  *        used for creating registratoin descriptor lists
  */
-typedef nixlDescList<nixlBlobDesc>  nixl_reg_dlist_t;
+using nixl_reg_dlist_t = nixlDescList<nixlBlobDesc>;
 
 #endif

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -36,19 +36,19 @@ class nixlAgentData;
  * @brief  An enumeration of segment types for NIXL
  *         FILE_SEG must be last
  */
-typedef enum {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG} nixl_mem_t;
+enum nixl_mem_t {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG};
 
 /**
  * @enum   nixl_xfer_op_t
  * @brief  An enumeration of different transfer types for NIXL
  */
-typedef enum {NIXL_READ, NIXL_WRITE} nixl_xfer_op_t;
+enum nixl_xfer_op_t {NIXL_READ, NIXL_WRITE};
 
 /**
  * @enum   nixl_status_t
  * @brief  An enumeration of status values and error codes for NIXL
  */
-typedef enum {
+enum nixl_status_t {
     NIXL_IN_PROG = 1,
     NIXL_SUCCESS = 0,
     NIXL_ERR_NOT_POSTED = -1,
@@ -60,7 +60,7 @@ typedef enum {
     NIXL_ERR_REPOST_ACTIVE = -7,
     NIXL_ERR_UNKNOWN = -8,
     NIXL_ERR_NOT_SUPPORTED = -9
-} nixl_status_t;
+};
 
 /**
  * @enum nixl_thread_sync_t
@@ -89,7 +89,7 @@ namespace nixlEnumStrings {
 /**
  * @brief A typedef for a std::string to identify nixl backends
  */
-typedef std::string nixl_backend_t;
+using nixl_backend_t = std::string;
 
 /**
  * @brief A typedef for a std::string as nixl blob
@@ -97,24 +97,24 @@ typedef std::string nixl_backend_t;
  *        with specified length. Giving it a new name to be clear in the API and
  *        preventing users to think it's a string and call c_str().
  */
-typedef std::string nixl_blob_t;
+using nixl_blob_t = std::string;
 
 /**
  * @brief A typedef for a std::vector<nixl_mem_t> to create nixl_mem_list_t objects.
  */
-typedef std::vector<nixl_mem_t> nixl_mem_list_t;
+using nixl_mem_list_t = std::vector<nixl_mem_t>;
 
 /**
  * @brief A typedef for a  std::unordered_map<std::string, std::string>
  *        to hold nixl_b_params_t .
  */
-typedef std::unordered_map<std::string, std::string> nixl_b_params_t;
+using nixl_b_params_t = std::unordered_map<std::string, std::string>;
 
 /**
  * @brief A typedef for a  std::unordered_map<std::string, std::vector<nixl_blob_t>>
  *        to hold nixl_notifs_t (nixl notifications)
  */
-typedef std::unordered_map<std::string, std::vector<nixl_blob_t>> nixl_notifs_t;
+using nixl_notifs_t = std::unordered_map<std::string, std::vector<nixl_blob_t>>;
 
 /**
  * @brief A constant to define the default communication port.

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -22,20 +22,20 @@
 #include "stream/metadata_stream.h"
 #include "sync.h"
 
-typedef std::vector<nixlBackendEngine*> backend_list_t;
+using backend_list_t = std::vector<nixlBackendEngine*>;
 
 //Internal typedef to define metadata communication request types
 //To be extended with ETCD operations
-typedef enum { SOCK_SEND, SOCK_FETCH, SOCK_INVAL } nixl_comm_t;
+enum nixl_comm_t { SOCK_SEND, SOCK_FETCH, SOCK_INVAL };
 
 //Command to be sent to listener thread from NIXL API
 // 1) Command type
 // 2) IP Address
 // 3) Port
 // 4) Metadata to send (for sendLocalMD calls)
-typedef std::tuple<nixl_comm_t, std::string, int, nixl_blob_t> nixl_comm_req_t;
+using nixl_comm_req_t = std::tuple<nixl_comm_t, std::string, int, nixl_blob_t>;
 
-typedef std::pair<std::string, int> nixl_socket_peer_t;
+using nixl_socket_peer_t = std::pair<std::string, int>;
 
 class nixlAgentData {
     private:

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -27,9 +27,9 @@
 #include "nixl.h"
 #include "backend/backend_engine.h"
 
-typedef std::pair<nixl_mem_t, nixlBackendEngine*>              section_key_t;
-typedef std::set<nixlBackendEngine*>                           backend_set_t;
-typedef std::unordered_map<nixl_backend_t, nixlBackendEngine*> backend_map_t;
+using section_key_t = std::pair<nixl_mem_t, nixlBackendEngine*>;
+using backend_set_t = std::set<nixlBackendEngine*>;
+using backend_map_t = std::unordered_map<nixl_backend_t, nixlBackendEngine*>;
 
 /**
  * @brief Section descriptor for nixl
@@ -58,8 +58,8 @@ public:
     }
 };
 
-typedef nixlDescList<nixlSectionDesc>               nixl_sec_dlist_t;
-typedef std::map<section_key_t, nixl_sec_dlist_t*>  section_map_t;
+using nixl_sec_dlist_t = nixlDescList<nixlSectionDesc>;
+using section_map_t = std::map<section_key_t, nixl_sec_dlist_t*>;
 
 class nixlMemSection {
     protected:

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -32,7 +32,7 @@
 #include "ucx/ucx_utils.h"
 #include "common/list_elem.h"
 
-typedef enum {CONN_CHECK, NOTIF_STR, DISCONNECT} ucx_cb_op_t;
+enum ucx_cb_op_t {CONN_CHECK, NOTIF_STR, DISCONNECT};
 
 struct nixl_ucx_am_hdr {
     ucx_cb_op_t op;

--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -78,7 +78,7 @@ private:
         }
     };
 
-    typedef std::vector<std::vector<dlMatrixElem>> dl_matrix_t;
+    using dl_matrix_t = std::vector<std::vector<dlMatrixElem>>;
 
     dl_matrix_t dlMatrix;
 

--- a/src/plugins/ucx_mo/ucx_mo_backend.h
+++ b/src/plugins/ucx_mo/ucx_mo_backend.h
@@ -97,8 +97,8 @@ private:
     // UCX backends data
     std::vector<nixlBackendEngine*> engines;
     // Map of agent name to saved nixlUcxConnection info
-    typedef std::map<std::string, nixlUcxMoConnection> remote_conn_map_t;
-    typedef remote_conn_map_t::iterator remote_comm_it_t;
+    using remote_conn_map_t = std::map<std::string, nixlUcxMoConnection>;
+    using remote_comm_it_t = remote_conn_map_t::iterator;
     remote_conn_map_t remoteConnMap;
 
     // Memory helper

--- a/src/utils/common/nixl_time.h
+++ b/src/utils/common/nixl_time.h
@@ -23,10 +23,10 @@ namespace nixlTime {
 
     using namespace std::chrono;
 
-    typedef uint64_t ns_t;
-    typedef uint64_t us_t;
-    typedef uint64_t ms_t;
-    typedef uint64_t sec_t;
+    using ns_t = uint64_t;
+    using us_t = uint64_t;
+    using ms_t = uint64_t;
+    using sec_t = uint64_t;
 
     static inline ns_t getNs() {
         return duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count();

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -24,12 +24,13 @@ extern "C"
 
 #include "nixl.h"
 
-typedef enum {
+enum nixl_ucx_mt_t {
     NIXL_UCX_MT_SINGLE,
     NIXL_UCX_MT_CTX,
     NIXL_UCX_MT_WORKER,
     NIXL_UCX_MT_MAX
-} nixl_ucx_mt_t;
+};
+
 class nixlUcxEp {
 private:
     ucp_ep_h  eph;
@@ -56,7 +57,7 @@ public:
     friend class nixlUcxWorker;
 };
 
-typedef void * nixlUcxReq;
+using nixlUcxReq = void*;
 
 class nixlUcxContext {
 private:
@@ -65,7 +66,7 @@ private:
     nixl_ucx_mt_t mt_type;
 public:
 
-    typedef void req_cb_t(void *request);
+    using req_cb_t = void(void *request);
     nixlUcxContext(std::vector<std::string> devices,
                    size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
                    nixl_ucx_mt_t mt_type);


### PR DESCRIPTION
Apply `Prefer "using" over "typedef"` guidelines in src/ This commit doesn't change functionality, it is strictly visual.