### PR TITLE
Agent API: support unloading parital remote MD

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -328,6 +328,7 @@ class nixlAgent {
 
         /**
          * @brief  Get partial metadata blob for this agent, to be given to other agents.
+         *         `op` determines whether the metadata will be used for loading or unloading on the remote.
          *         If `descs` is empty, only backends' connection info is included in the metadata,
          *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
          *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
@@ -337,12 +338,14 @@ class nixlAgent {
          *         backends in the list and the backends' connection info are included in the metadata.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
+         * @param  op            [in]  Operation to include in the metadata (load/unload)
          * @param  str           [out] The serialized metadata blob
          * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
          * @return nixl_status_t       Error code if call was not successful
          */
         nixl_status_t
         getLocalPartialMD(const nixl_reg_dlist_t &descs,
+                          nixl_md_op_t op,
                           nixl_blob_t &str,
                           const nixl_opt_args_t* extra_params = nullptr) const;
 
@@ -384,7 +387,8 @@ class nixlAgent {
         sendLocalMD (const nixl_opt_args_t* extra_params = nullptr) const;
 
         /**
-         * @brief  Send partial metadata blob for this agent to peer or central metadata server
+         * @brief  Send partial metadata blob for this agent to peer or central metadata server.
+         *         `op` determines whether the metadata will be used for loading or unloading on the remote.
          *         If `descs` is empty, only backends' connection info is included in the metadata,
          *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
          *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
@@ -402,6 +406,7 @@ class nixlAgent {
          */
         nixl_status_t
         sendLocalPartialMD(const nixl_reg_dlist_t &descs,
+                           nixl_md_op_t op,
                            const nixl_opt_args_t* extra_params = nullptr) const;
 
         /**

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -328,7 +328,6 @@ class nixlAgent {
 
         /**
          * @brief  Get partial metadata blob for this agent, to be given to other agents.
-         *         `op` determines whether the metadata will be used for loading or unloading on the remote.
          *         If `descs` is empty, only backends' connection info is included in the metadata,
          *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
          *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
@@ -336,16 +335,16 @@ class nixlAgent {
          *         backends supporting the memory type is also included.
          *         If `extra_params->backends` is non-empty, only the descriptors supported by the
          *         backends in the list and the backends' connection info are included in the metadata.
+         *         If `extra_params->metadataForUnload` is true, return metadata for unloading on the remote.
+         *         If used for unloading, this should be called before deregisterMem.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
-         * @param  op            [in]  Operation to include in the metadata (load/unload)
          * @param  str           [out] The serialized metadata blob
          * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
          * @return nixl_status_t       Error code if call was not successful
          */
         nixl_status_t
         getLocalPartialMD(const nixl_reg_dlist_t &descs,
-                          nixl_md_op_t op,
                           nixl_blob_t &str,
                           const nixl_opt_args_t* extra_params = nullptr) const;
 
@@ -388,7 +387,6 @@ class nixlAgent {
 
         /**
          * @brief  Send partial metadata blob for this agent to peer or central metadata server.
-         *         `op` determines whether the metadata will be used for loading or unloading on the remote.
          *         If `descs` is empty, only backends' connection info is included in the metadata,
          *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
          *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
@@ -398,6 +396,8 @@ class nixlAgent {
          *         backends in the list and the backends' connection info are included in the metadata.
          *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer.
          *         If 'extra_params->port' can be set in addition to IP address, or will default to default_comm_port.
+         *         If `extra_params->metadataForUnload` is true, return metadata for unloading on the remote.
+         *         If used for unloading, this should be called before deregisterMem.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
          * @param  str           [out] The serialized metadata blob
@@ -406,7 +406,6 @@ class nixlAgent {
          */
         nixl_status_t
         sendLocalPartialMD(const nixl_reg_dlist_t &descs,
-                           nixl_md_op_t op,
                            const nixl_opt_args_t* extra_params = nullptr) const;
 
         /**

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -45,6 +45,12 @@ typedef enum {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG} nixl_mem_t;
 typedef enum {NIXL_READ, NIXL_WRITE} nixl_xfer_op_t;
 
 /**
+ * @enum   nixl_md_op_t
+ * @brief  An enumeration of different metadata handling operation types for NIXL
+ */
+typedef enum {NIXL_MD_OP_LOAD, NIXL_MD_OP_UNLOAD} nixl_md_op_t;
+
+/**
  * @enum   nixl_status_t
  * @brief  An enumeration of status values and error codes for NIXL
  */

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -45,12 +45,6 @@ typedef enum {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG} nixl_mem_t;
 typedef enum {NIXL_READ, NIXL_WRITE} nixl_xfer_op_t;
 
 /**
- * @enum   nixl_md_op_t
- * @brief  An enumeration of different metadata handling operation types for NIXL
- */
-typedef enum {NIXL_MD_OP_LOAD, NIXL_MD_OP_UNLOAD} nixl_md_op_t;
-
-/**
  * @enum   nixl_status_t
  * @brief  An enumeration of status values and error codes for NIXL
  */
@@ -161,6 +155,12 @@ class nixlAgentOptionalArgs {
          *                      used in getLocalPartialMD.
          */
         bool includeConnInfo = false;
+
+        /**
+         * @var metadataForUnload boolean to indicate that the metadata is for unloading,
+         *                        used in getLocalPartialMD and sendLocalPartialMD.
+         */
+        bool metadataForUnload = false;
 
         /**
          * @var ipAddr Used to specify the IP address of a remote peer for metadata transfer.

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -508,7 +508,7 @@ PYBIND11_MODULE(_bindings, m) {
                         extra_params.backends.push_back((nixlBackendH*) backend);
                     extra_params.includeConnInfo = inc_conn_info;
 
-                    throw_nixl_exception(agent.getLocalPartialMD(descs, NIXL_MD_OP_LOAD, ret_str, &extra_params));
+                    throw_nixl_exception(agent.getLocalPartialMD(descs, ret_str, &extra_params));
                     return py::bytes(ret_str);
                 }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}))
         .def("loadRemoteMD", [](nixlAgent &agent, const std::string &remote_metadata) -> py::bytes {
@@ -538,7 +538,7 @@ PYBIND11_MODULE(_bindings, m) {
                     extra_params.ipAddr = ip_addr;
                     extra_params.port = port;
 
-                    throw_nixl_exception(agent.sendLocalPartialMD(descs, NIXL_MD_OP_LOAD, &extra_params));
+                    throw_nixl_exception(agent.sendLocalPartialMD(descs, &extra_params));
                 }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}), py::arg("ip_addr") = std::string(""), py::arg("port") = 0)
         .def("fetchRemoteMD", [](nixlAgent &agent, std::string remote_agent, std::string ip_addr, int port){
                     nixl_opt_args_t extra_params;

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -508,7 +508,7 @@ PYBIND11_MODULE(_bindings, m) {
                         extra_params.backends.push_back((nixlBackendH*) backend);
                     extra_params.includeConnInfo = inc_conn_info;
 
-                    throw_nixl_exception(agent.getLocalPartialMD(descs, ret_str, &extra_params));
+                    throw_nixl_exception(agent.getLocalPartialMD(descs, NIXL_MD_OP_LOAD, ret_str, &extra_params));
                     return py::bytes(ret_str);
                 }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}))
         .def("loadRemoteMD", [](nixlAgent &agent, const std::string &remote_metadata) -> py::bytes {
@@ -538,7 +538,7 @@ PYBIND11_MODULE(_bindings, m) {
                     extra_params.ipAddr = ip_addr;
                     extra_params.port = port;
 
-                    throw_nixl_exception(agent.sendLocalPartialMD(descs, &extra_params));
+                    throw_nixl_exception(agent.sendLocalPartialMD(descs, NIXL_MD_OP_LOAD, &extra_params));
                 }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}), py::arg("ip_addr") = std::string(""), py::arg("port") = 0)
         .def("fetchRemoteMD", [](nixlAgent &agent, std::string remote_agent, std::string ip_addr, int port){
                     nixl_opt_args_t extra_params;

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -96,6 +96,8 @@ class nixlAgentData {
         void enqueueCommWork(nixl_comm_req_t request);
         void getCommWork(std::vector<nixl_comm_req_t> &req_list);
 
+        nixl_status_t unloadRemoteMD(nixlSerDes &sd, const std::string &remote_agent);
+
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);
         ~nixlAgentData();
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1021,15 +1021,11 @@ nixlAgent::getLocalMD (nixl_blob_t &str) const {
 
 nixl_status_t
 nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
-                             nixl_md_op_t op,
                              nixl_blob_t &str,
                              const nixl_opt_args_t* extra_params) const {
     backend_list_t tmp_list;
     backend_list_t *backend_list;
     nixl_status_t ret;
-
-    if (op != NIXL_MD_OP_LOAD && op != NIXL_MD_OP_UNLOAD)
-        return NIXL_ERR_INVALID_PARAM;
 
     NIXL_LOCK_GUARD(data->lock);
 
@@ -1068,7 +1064,8 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
     if(ret)
         return ret;
 
-    ret = sd.addStr("Op", op == NIXL_MD_OP_LOAD ? "Load" : "Unload");
+    ret = sd.addStr("Op",
+                    (extra_params && extra_params->metadataForUnload) ? "Unload" : "Load");
     if(ret)
         return ret;
 
@@ -1327,10 +1324,9 @@ nixlAgent::sendLocalMD (const nixl_opt_args_t* extra_params) const {
 
 nixl_status_t
 nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
-                              nixl_md_op_t op,
                               const nixl_opt_args_t* extra_params) const {
     nixl_blob_t myMD;
-    nixl_status_t ret = getLocalPartialMD(descs, op, myMD, extra_params);
+    nixl_status_t ret = getLocalPartialMD(descs, myMD, extra_params);
     if(ret < 0) return ret;
 
     // If IP is provided, use socket-based communication

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -105,18 +105,28 @@ class nixlRemoteSection : public nixlMemSection {
     private:
         std::string agentName;
 
-        nixl_status_t addDescList (
-                           const nixl_reg_dlist_t &mem_elms,
-                           nixlBackendEngine *backend);
+        nixl_status_t addDescList (const nixl_reg_dlist_t &mem_elms,
+                                   nixlBackendEngine *backend);
+
+        nixl_status_t remDescList (const nixl_reg_dlist_t &mem_elms,
+                                   nixlBackendEngine *backend);
     public:
         nixlRemoteSection (const std::string &agent_name);
 
         nixl_status_t loadRemoteData (nixlSerDes* deserializer,
                                       backend_map_t &backendToEngineMap);
 
+        nixl_status_t unloadRemoteData (nixlSerDes* deserializer,
+                                        backend_map_t &backendToEngineMap);
+
+        void unloadBackend (nixlBackendEngine* backend);
+
         // When adding self as a remote agent for local operations
         nixl_status_t loadLocalData (const nixl_sec_dlist_t& mem_elms,
                                      nixlBackendEngine* backend);
+
+        bool empty() const { return sectionMap.empty(); }
+
         ~nixlRemoteSection();
 };
 

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -23,6 +23,7 @@
 #include <array>
 #include <string>
 #include <set>
+#include <memory>
 #include "nixl_descriptors.h"
 #include "nixl.h"
 #include "backend/backend_engine.h"
@@ -58,8 +59,8 @@ public:
     }
 };
 
-typedef nixlDescList<nixlSectionDesc>               nixl_sec_dlist_t;
-typedef std::map<section_key_t, nixl_sec_dlist_t*>  section_map_t;
+typedef nixlDescList<nixlSectionDesc>                              nixl_sec_dlist_t;
+typedef std::map<section_key_t, std::unique_ptr<nixl_sec_dlist_t>> section_map_t;
 
 class nixlMemSection {
     protected:

--- a/test/nixl/agent_example.cpp
+++ b/test/nixl/agent_example.cpp
@@ -227,7 +227,7 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
 
     nixl_reg_dlist_t empty_dlist(DRAM_SEG);
     std::string partial_meta;
-    status = A2->getLocalPartialMD(empty_dlist, NIXL_MD_OP_LOAD, partial_meta, NULL);
+    status = A2->getLocalPartialMD(empty_dlist, partial_meta, NULL);
     assert(status == NIXL_SUCCESS);
     assert(partial_meta.size() > 0);
 
@@ -258,7 +258,7 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
 
         std::cout << "Metadata update #" << update << "\n";
         // Get partial metadata from A2
-        status = A2->getLocalPartialMD(dst_mem_lists[update], NIXL_MD_OP_LOAD, partial_meta, &extra_params2);
+        status = A2->getLocalPartialMD(dst_mem_lists[update], partial_meta, &extra_params2);
         assert(status == NIXL_SUCCESS);
         assert(partial_meta.size() > 0);
 
@@ -364,12 +364,13 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
 
     // Unload metadata one dlist at a time in reverse order and verify results
     extra_params2.includeConnInfo = false;
+    extra_params2.metadataForUnload = true;
     for (int update = NUM_UPDATES - 1; update >= 0; update--) {
         std::cout << "Metadata unload #" << update << "\n";
 
         // Get partial metadata for unload from A2
         std::string partial_meta;
-        status = A2->getLocalPartialMD(dst_mem_lists[update], NIXL_MD_OP_UNLOAD, partial_meta, &extra_params2);
+        status = A2->getLocalPartialMD(dst_mem_lists[update], partial_meta, &extra_params2);
         assert(status == NIXL_SUCCESS);
         assert(partial_meta.size() > 0);
 
@@ -409,7 +410,9 @@ nixl_status_t partialMdTest(nixlAgent* A1, nixlAgent* A2, nixlBackendH* backend1
 
     // Unload connection info
     partial_meta.clear();
-    status = A2->getLocalPartialMD(empty_dlist, NIXL_MD_OP_UNLOAD, partial_meta, NULL);
+    extra_params2.includeConnInfo = true;
+    extra_params2.metadataForUnload = true;
+    status = A2->getLocalPartialMD(empty_dlist, partial_meta, &extra_params2);
     assert(status == NIXL_SUCCESS);
     assert(partial_meta.size() > 0);
 


### PR DESCRIPTION
- New API enum nixl_md_op_t as argument for getLocaPartialMD and sendLocalPartialMD to indicate if the MD is meant for remote load or unload.
- In loadRemoteMD load or unload based on the serialized op.
- Update nixlMemSection::sectionMap to hold unique_ptrs instead of raw ptrs for easier memory management.