### PR TITLE
AGENT: Use std::unique_ptr for agent data

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -24,6 +24,7 @@
 #include "nixl_types.h"
 #include "nixl_params.h"
 #include "nixl_descriptors.h"
+#include <memory>
 
 /**
  * @class nixlAgent
@@ -32,7 +33,7 @@
 class nixlAgent {
     private:
         /** @var  data  The members in agent class wrapped into single nixlAgentData member. */
-        nixlAgentData* data;
+        std::unique_ptr<nixlAgentData> data;
 
     public:
         /*** Initialization and Registering Methods ***/
@@ -49,6 +50,10 @@ class nixlAgent {
          * @brief Destructor for nixlAgent object
          */
         ~nixlAgent ();
+
+        /* Declare move operations (needed because we declared a destructor) */
+        nixlAgent(nixlAgent&&) noexcept;
+        nixlAgent &operator=(nixlAgent&&) noexcept;
 
         /**
          * @brief  Discover the available supported plugins found in the plugin paths

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -96,6 +96,7 @@ class nixlAgentData {
         void enqueueCommWork(nixl_comm_req_t request);
         void getCommWork(std::vector<nixl_comm_req_t> &req_list);
 
+    public:
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);
         ~nixlAgentData();
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -72,6 +72,8 @@ nixlAgentData::nixlAgentData(const std::string &name,
         NIXL_DEBUG << "NIXL ETCD is disabled";
     }
 #endif // HAVE_ETCD
+    if (name.empty())
+        throw std::invalid_argument("Agent needs a name");
 
     memorySection = new nixlLocalSection();
 }
@@ -98,13 +100,9 @@ nixlAgentData::~nixlAgentData() {
 }
 
 /*** nixlAgent implementation ***/
-nixlAgent::nixlAgent(const std::string &name,
-                     const nixlAgentConfig &cfg) {
-    if (name.size() == 0)
-        throw std::invalid_argument("Agent needs a name");
-
-    data = new nixlAgentData(name, cfg);
-
+nixlAgent::nixlAgent(const std::string &name, const nixlAgentConfig &cfg) :
+    data(std::make_unique<nixlAgentData>(name, cfg))
+{
     if(cfg.useListenThread) {
         int my_port = cfg.listenPort;
         if(my_port == 0) my_port = default_comm_port;
@@ -114,12 +112,13 @@ nixlAgent::nixlAgent(const std::string &name,
 
     if (data->useEtcd || cfg.useListenThread) {
         data->commThreadStop = false;
-        data->commThread = std::thread(&nixlAgentData::commWorker, data, this);
+        data->commThread =
+            std::thread(&nixlAgentData::commWorker, data.get(), this);
     }
 }
 
 nixlAgent::~nixlAgent() {
-    if (data->useEtcd || data->config.useListenThread) {
+    if (data && (data->useEtcd || data->config.useListenThread)) {
         data->commThreadStop = true;
         if(data->commThread.joinable()) data->commThread.join();
 
@@ -127,9 +126,11 @@ nixlAgent::~nixlAgent() {
             if(data->listener) delete data->listener;
         }
     }
-
-    delete data;
 }
+
+// Define move operations in CPP file to avoid exposing nixlAgentData in header
+nixlAgent::nixlAgent(nixlAgent &&other) noexcept = default;
+nixlAgent& nixlAgent::operator=(nixlAgent &&other) noexcept = default;
 
 nixl_status_t
 nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {


### PR DESCRIPTION
## Why
Use move semantics for nixlAgentData
