### PR TITLE
BUILD: Add stdc++fs link flag to for std::filesystem

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -40,6 +40,7 @@ nixl_lib = library('nixl',
                    'nixl_plugin_manager.cpp',
                    'nixl_listener.cpp',
                    include_directories: [ nixl_inc_dirs, utils_inc_dirs ],
+                   link_args: ['-lstdc++fs'],
                    dependencies: nixl_lib_deps,
                    install: true)
 


### PR DESCRIPTION
On some systems (such as RedHat 8.6) it's needed to fix compilation.