### PR TITLE
NIXLBench: Add ctrl-c handling for etcd cleanup

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -164,21 +164,6 @@ static std::unique_ptr<xferBenchWorker> createWorker(int *argc, char ***argv) {
     }
 }
 
-static int *sigTerminate;
-
-static void signalHandler(int signal) {
-    static const char msg[] = "Ctrl-C received, exiting...\n";
-    constexpr int stdout_fd = 1;
-    constexpr int max_count = 1;
-    auto size = write(stdout_fd, msg, sizeof(msg) - 1);
-    (void)size;
-
-    (*sigTerminate)++;
-    if (*sigTerminate > max_count) {
-        std::_Exit(EXIT_FAILURE);
-    }
-}
-
 int main(int argc, char *argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
@@ -195,8 +180,7 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    sigTerminate = worker_ptr->signal_ptr();
-    std::signal(SIGINT, signalHandler);
+    std::signal(SIGINT, worker_ptr->signalHandler);
 
     // Ensure all processes are ready before exchanging metadata
     ret = worker_ptr->synchronizeStart();

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -168,11 +168,13 @@ static int *sigTerminate;
 
 static void signalHandler(int signal) {
     static const char msg[] = "Ctrl-C received, exiting...\n";
-    auto size = write(1, msg, sizeof(msg) - 1);
+    constexpr int stdout_fd = 1;
+    constexpr int max_count = 1;
+    auto size = write(stdout_fd, msg, sizeof(msg) - 1);
     (void)size;
 
     (*sigTerminate)++;
-    if (*sigTerminate > 2) {
+    if (*sigTerminate > max_count) {
         std::_Exit(EXIT_FAILURE);
     }
 }

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -28,7 +28,8 @@
 #define ETCD_EP_DEFAULT "http://localhost:2379"
 
 // ETCD Runtime implementation
-xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int size) {
+xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int size,
+                                 int *terminate_input) {
 
     std::string use_etcd_ep = ETCD_EP_DEFAULT;
 
@@ -37,8 +38,8 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int si
         use_etcd_ep = etcd_endpoints;
     }
 
-    // Namespace for XFER benchmark
-    namespace_prefix = "xferbench/";
+    namespace_prefix = "xferbench/"; // Namespace for XFER benchmark
+    terminate = terminate_input;
 
     // Connect to ETCD
     try {
@@ -50,7 +51,7 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int si
     }
 
     // Registration process - get a unique rank
-    std::string lock_key = namespace_prefix + "lock";
+    std::string lock_key = key("lock");
 
     // Try to acquire a lock for registration
     auto lock_response = client->lock(lock_key).get();
@@ -60,7 +61,7 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int si
     }
 
     // Get the current size - number of processes that have registered
-    auto size_response = client->get(namespace_prefix + "size").get();
+    auto size_response = client->get(key("size")).get();
     if (size_response.error_code() == 0) {
         my_rank = std::stoi(size_response.value().as_string());
     } else {
@@ -71,8 +72,8 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int si
     global_size = size;
 
     // Update registration information
-    client->put(namespace_prefix + "size", std::to_string(my_rank + 1)).get();
-    client->put(namespace_prefix + "rank/" + std::to_string(my_rank), "active").get();
+    client->put(key("size"), std::to_string(my_rank + 1)).get();
+    client->put(key("rank", my_rank), "active").get();
 
     // Release the lock
     client->unlock(lock_response.lock_key()).get();
@@ -87,19 +88,8 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int si
 }
 
 xferBenchEtcdRT::~xferBenchEtcdRT() {
-    // Deregister
-    client->rm(namespace_prefix + "rank/" + std::to_string(my_rank)).get();
-
-    // Deregister the size only for rank 0
-    if (my_rank == 0) {
-        client->rm(namespace_prefix + "size").get();
-
-        // Deregister the barrier
-        client->rmdir(namespace_prefix + "barrier", true).get();
-
-        // Deregister namespace prefix
-        client->rmdir(namespace_prefix, true).get();
-    }
+    // All ranks delete, as of them could be missing if ETCD state is confused
+    client->rmdir(key(""), true).get();
 }
 
 int xferBenchEtcdRT::getRank() const {
@@ -134,7 +124,7 @@ int xferBenchEtcdRT::sendInt(int* buffer, int dest_rank) {
         const int MAX_RETRIES = 60; // 1 minute timeout
         bool ack_received = false;
 
-        while (!ack_received && retries < MAX_RETRIES) {
+        while (!ack_received && retries < retry(MAX_RETRIES)) {
             auto ack_response = client->get(ack_key).get();
             if (ack_response.error_code() == 0 && ack_response.value().as_string() == "received") {
                 ack_received = true;
@@ -169,7 +159,7 @@ int xferBenchEtcdRT::recvInt(int* buffer, int src_rank) {
     const int MAX_RETRIES = 60; // 1 minute timeout
     bool data_received = false;
 
-    while (!data_received && retries < MAX_RETRIES) {
+    while (!data_received && retries < retry(MAX_RETRIES)) {
         auto response = client->get(msg_key).get();
         if (response.error_code() == 0) {
             // Get the value directly as a string
@@ -227,7 +217,7 @@ int xferBenchEtcdRT::sendChar(char* buffer, size_t count, int dest_rank) {
         const int MAX_RETRIES = 60; // 1 minute timeout
         bool ack_received = false;
 
-        while (!ack_received && retries < MAX_RETRIES) {
+        while (!ack_received && retries < retry(MAX_RETRIES)) {
             auto ack_response = client->get(ack_key).get();
             if (ack_response.error_code() == 0 && ack_response.value().as_string() == "received") {
                 ack_received = true;
@@ -263,7 +253,7 @@ int xferBenchEtcdRT::recvChar(char* buffer, size_t count, int src_rank) {
     const int MAX_RETRIES = 60; // 1 minute timeout
     bool data_received = false;
 
-    while (!data_received && retries < MAX_RETRIES) {
+    while (!data_received && retries < retry(MAX_RETRIES)) {
         // First check if metadata exists
         auto meta_response = client->get(msg_key).get();
         if (meta_response.error_code() == 0) {
@@ -307,7 +297,7 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
     try {
         // Use a random ID for this reduction operation
         std::string reduce_id = std::to_string(std::time(nullptr)) + "-" + std::to_string(std::rand());
-        std::string reduce_key = namespace_prefix + "reduce/" + reduce_id;
+        std::string reduce_key = key("reduce/" + reduce_id);
         std::string value_key = reduce_key + "/rank-" + std::to_string(my_rank);
 
         // Contribute our value directly as a string
@@ -325,7 +315,7 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
             int expected = global_size - 1; // Excluding ourselves
             int retries = 0;
 
-            while (received < expected && retries < 30) {
+            while (received < expected && retries < retry(30)) {
                 auto response = client->ls(reduce_key).get();
                 if (response.error_code() == 0) {
                     for (const auto& kv : response.keys()) {
@@ -378,7 +368,7 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
 int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
     try {
         // Create a unique key for this barrier
-        std::string barrier_key = namespace_prefix + "barrier/" + barrier_id;
+        std::string barrier_key = key("barrier/" + barrier_id);
         std::string count_key = barrier_key + "/count";
         std::string ready_key = barrier_key + "/ready";
 
@@ -402,7 +392,7 @@ int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
         int retries = 0;
         int expected_count = global_size;
 
-        while (!barrier_complete && retries < 30) { // 5 minutes timeout (300 seconds)
+        while (!barrier_complete && retries < retry(30)) { // 5 minutes timeout (300 seconds)
             resp = client->get(count_key).get();
             if (resp.error_code() == 0) {
                 current_count = std::stoi(resp.value().as_string());
@@ -438,7 +428,7 @@ int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
         retries = 0;
         bool ready = false;
 
-        while (!ready && retries < 60) { // 1 minute timeout
+        while (!ready && retries < retry(60)) { // 1 minute timeout
             resp = client->get(ready_key).get();
             if (resp.error_code() == 0 && resp.value().as_string() == "true") {
                 ready = true;
@@ -474,7 +464,7 @@ int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
 int xferBenchEtcdRT::broadcastInt(int* buffer, size_t count, int root_rank) {
     try {
         // Create a unique key for this broadcast operation
-        std::string bcast_key = namespace_prefix + "bcast/int/" + std::to_string(root_rank);
+        std::string bcast_key  = key("bcast/int", root_rank);
         std::string barrier_id = "bcast_int_" + std::to_string(root_rank);
 
         // First phase: root process puts the value in etcd
@@ -493,7 +483,7 @@ int xferBenchEtcdRT::broadcastInt(int* buffer, size_t count, int root_rank) {
             const int MAX_RETRIES = 10;
             bool data_received = false;
 
-            while (!data_received && retries < MAX_RETRIES) {
+            while (!data_received && retries < retry(MAX_RETRIES)) {
                 auto response = client->get(bcast_key).get();
                 if (response.error_code() == 0) {
                     std::string value_str = response.value().as_string();

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -311,7 +311,7 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
             int expected = global_size - 1; // Excluding ourselves
             int retries = 0;
 
-            while (received < expected && retries < retry(30)) {
+            while (received < expected && should_retry(retries, 30)) {
                 auto response = client->ls(reduce_key).get();
                 if (response.error_code() == 0) {
                     for (const auto& kv : response.keys()) {
@@ -388,7 +388,7 @@ int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
         int retries = 0;
         int expected_count = global_size;
 
-        while (!barrier_complete && retries < retry(30)) { // 5 minutes timeout (300 seconds)
+        while (!barrier_complete && should_retry(retries, 30)) {
             resp = client->get(count_key).get();
             if (resp.error_code() == 0) {
                 current_count = std::stoi(resp.value().as_string());
@@ -424,7 +424,7 @@ int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
         retries = 0;
         bool ready = false;
 
-        while (!ready && retries < retry(60)) { // 1 minute timeout
+        while (!ready && should_retry(retries)) {
             resp = client->get(ready_key).get();
             if (resp.error_code() == 0 && resp.value().as_string() == "true") {
                 ready = true;

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -58,7 +58,9 @@ private:
     int *terminate;
 
     bool error() const { return terminate != nullptr && *terminate; };
-    int retry(int value) const { return error() ? 0 : value; };
+    bool should_retry(int value, int max = 60) const {
+	    return !error() && value < max;
+    }
 
     std::string key(std::string name, int rank = -1) const {
         std::string suffix;

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -48,13 +48,8 @@ private:
     std::string namespace_prefix;
     std::unique_ptr<etcd::Client> client;
 
-    // Rank information
-    int my_rank;
+    int my_rank; // Rank information
     int global_size;
-
-    std::string makeKey(const std::string& operation, int src,
-		    	int dst, xferBenchEtcdMsgType type = XFER_BENCH_ETCD_MSG_TYPE_INT);
-
     int *terminate;
 
     bool error() const { return terminate != nullptr && *terminate; };
@@ -62,7 +57,10 @@ private:
 	    return !error() && value < max;
     }
 
-    std::string key(std::string name, int rank = -1) const {
+    std::string makeTypedKey(const std::string& operation, int src, int dst,
+                             xferBenchEtcdMsgType type = XFER_BENCH_ETCD_MSG_TYPE_INT);
+
+    std::string makeKey(std::string name, int rank = -1) const {
         std::string suffix;
 
         if (rank > -1) {

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -55,8 +55,24 @@ private:
     std::string makeKey(const std::string& operation, int src,
 		    	int dst, xferBenchEtcdMsgType type = XFER_BENCH_ETCD_MSG_TYPE_INT);
 
+    int *terminate;
+
+    bool error() const { return terminate != nullptr && *terminate; };
+    int retry(int value) const { return error() ? 0 : value; };
+
+    std::string key(std::string name, int rank = -1) const {
+        std::string suffix;
+
+        if (rank > -1) {
+            suffix = "/" + std::to_string(rank);
+        }
+
+        return namespace_prefix + name + suffix;
+    }
+
 public:
-    xferBenchEtcdRT(const std::string& etcd_endpoints, const int size);
+    xferBenchEtcdRT(const std::string& etcd_endpoints, const int size,
+                    int *terminate = nullptr);
     ~xferBenchEtcdRT();
 
     int getRank() const;

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -19,7 +19,7 @@
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/utils.h"
 
-static xferBenchRT *createRT(int *argc, char ***argv) {
+static xferBenchRT *createRT(int *terminate) {
     if (XFERBENCH_RT_ETCD == xferBenchConfig::runtime_type) {
         int total = 2;
         if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
@@ -29,25 +29,23 @@ static xferBenchRT *createRT(int *argc, char ***argv) {
         if (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend) {
             total = 1;
         }
-        return new xferBenchEtcdRT(xferBenchConfig::etcd_endpoints, total);
+        return new xferBenchEtcdRT(xferBenchConfig::etcd_endpoints, total, terminate);
     }
+
     std::cerr << "Invalid runtime: " << xferBenchConfig::runtime_type << std::endl;
     exit(EXIT_FAILURE);
-    return nullptr;
 }
 
 xferBenchWorker::xferBenchWorker(int *argc, char ***argv) {
-    int rank;
+    terminate = 0;
 
-    // Create the RT
-    rt = createRT(argc, argv);
-
+    rt = createRT(&terminate);
     if (!rt) {
-	std::cerr << "Failed to create runtime object" << std::endl;
-	exit(EXIT_FAILURE);
+        std::cerr << "Failed to create runtime object" << std::endl;
+        exit(EXIT_FAILURE);
     }
 
-    rank = rt->getRank();
+    int rank = rt->getRank();
 
     if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
         if (rank >= 0 && rank < xferBenchConfig::num_initiator_dev) {

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -19,6 +19,8 @@
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/utils.h"
 
+#include <unistd.h>
+
 static xferBenchRT *createRT(int *terminate) {
     if (XFERBENCH_RT_ETCD == xferBenchConfig::runtime_type) {
         int total = 2;
@@ -79,4 +81,18 @@ bool xferBenchWorker::isInitiator() {
 
 bool xferBenchWorker::isTarget() {
     return ("target" == name);
+}
+
+int xferBenchWorker::terminate = 0;
+
+void xferBenchWorker::signalHandler(int signal) {
+    static const char msg[] = "Ctrl-C received, exiting...\n";
+    constexpr int stdout_fd = 1;
+    constexpr int max_count = 1;
+    auto size = write(stdout_fd, msg, sizeof(msg) - 1);
+    (void)size;
+
+    if (++terminate > max_count) {
+        std::_Exit(EXIT_FAILURE);
+    }
 }

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -29,6 +29,8 @@ class xferBenchWorker {
     protected:
         std::string name;
         xferBenchRT *rt;
+        int terminate;
+
     public:
         xferBenchWorker(int *argc, char ***argv);
         virtual ~xferBenchWorker();
@@ -36,6 +38,8 @@ class xferBenchWorker {
         std::string getName() const;
         bool isInitiator();
         bool isTarget();
+        int* signal_ptr() { return &terminate; }
+        bool signaled() const { return terminate != 0; }
 
         // Memory management
         virtual std::vector<std::vector<xferBenchIOV>> allocateMemory(int num_threads) = 0;

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -29,7 +29,7 @@ class xferBenchWorker {
     protected:
         std::string name;
         xferBenchRT *rt;
-        int terminate;
+        static int terminate;
 
     public:
         xferBenchWorker(int *argc, char ***argv);
@@ -38,8 +38,8 @@ class xferBenchWorker {
         std::string getName() const;
         bool isInitiator();
         bool isTarget();
-        int* signal_ptr() { return &terminate; }
         bool signaled() const { return terminate != 0; }
+        static void signalHandler(int signal);
 
         // Memory management
         virtual std::vector<std::vector<xferBenchIOV>> allocateMemory(int num_threads) = 0;


### PR DESCRIPTION
Clean-up any ETCD state in case of interruption, we can only proceed once/while all ranks are present.

Issue observed with one instance being restarted:
```
$ nixlbench
Connecting to ETCD at http://localhost:2379
ETCD Runtime: Registered as rank 10 item 11 of 2
Init nixl worker, dev all rank 10, type target, hostname rock
Waiting for all processes to start... (expecting 2 total: 1 initiators and 1 targets)
```