### PR TITLE
NIXLBench: Persist environment until all ranks complete

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -211,6 +211,11 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    ret = worker_ptr->synchronize(); // Make sure environment is not used anymore
+    if (0 != ret) {
+        return EXIT_FAILURE;
+    }
+
     gflags::ShutDownCommandLineFlags();
 
     return EXIT_SUCCESS;

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -36,6 +36,10 @@ static xferBenchRT *createRT(int *argc, char ***argv) {
     return nullptr;
 }
 
+int xferBenchWorker::synchronize() {
+    return rt->barrier("sync");
+}
+
 xferBenchWorker::xferBenchWorker(int *argc, char ***argv) {
     int rank;
 

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -36,6 +36,7 @@ class xferBenchWorker {
         std::string getName() const;
         bool isInitiator();
         bool isTarget();
+        int synchronize();
 
         // Memory management
         virtual std::vector<std::vector<xferBenchIOV>> allocateMemory(int num_threads) = 0;


### PR DESCRIPTION
Persist the environment until all ranks are done using it. For instance, the target can be waiting for etcd to get() the `/ack`, under `xferBenchEtcdRT::sendChar` from `xferBenchNixlWorker::exchangeIOV`, posted by the initiator (rank 0) which raced to exit and already destroyed it.