### PR TITLE
meson: don't require liburing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,15 @@ pip install nixl
 ### Ubuntu:
 
 `$ sudo apt install build-essential cmake pkg-config`
+
+If you want to build POSIX plugin:
 `$ sudo apt install liburing-dev`
 
 ### Fedora:
 
 `$ sudo dnf install gcc-c++ cmake pkg-config`
+
+If you want to build POSIX plugin:
 `$ sudo dnf install liburing-devel`
 
 ### Python

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -17,7 +17,14 @@ ucx_backend_inc_dirs = include_directories('./ucx')
 
 subdir('ucx')
 subdir('ucx_mo')
-subdir('posix')
+
+liburing_dep = dependency('liburing', required: false)
+
+if liburing_dep.found()
+    subdir('posix')
+else
+    message('liburing dependency not found, will not build POSIX backend')
+endif
 
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and cuda_dep.found()


### PR DESCRIPTION
I should have caught this the first time, we don't have to make liburing a requirement, some users might not have sudo privilege to install it. 