### PR TITLE
CI: disable POSIX CI test

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -41,9 +41,6 @@ env
 nvidia-smi topo -m || true
 ibv_devinfo || true
 
-apt-get -qq update
-apt-get -qq install liburing-dev
-
 echo "==== Running C++ tests ===="
 cd ${INSTALL_DIR}
 ./bin/desc_example
@@ -51,7 +48,10 @@ cd ${INSTALL_DIR}
 ./bin/nixl_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
-./bin/nixl_posix_test
+
+# POSIX test disabled until we solve io_uring and Docker compatibility
+#./bin/nixl_posix_test
+
 ./bin/ucx_backend_multi
 ./bin/serdes_test
 ./bin/gtest

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update -y && \
     libgrpc-dev \
     libgrpc++-dev \
     libprotobuf-dev \
+    liburing-dev \
     protobuf-compiler-grpc \
     libcpprest-dev \
     etcd-server \
@@ -39,8 +40,6 @@ WORKDIR /workspace
 RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git &&\
 	cd etcd-cpp-apiv3 && mkdir build && cd build && \
 	cmake .. && make -j$(nproc) && make install
-
-RUN apt install liburing-dev
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/src/plugins/posix/README.md
+++ b/src/plugins/posix/README.md
@@ -21,3 +21,22 @@ This plugin uses liburing as an I/O backend for NIXL.
 
 # Install
 sudo apt install liburing-dev
+
+# Running with Docker
+Docker by default blocks io_uring syscalls to the host system. These need to be explicitly enabled when running NIXL agents that use the posix plugin in Docker.
+
+## Create a seccomp json file
+
+```bash
+$> wget https://github.com/moby/moby/blob/master/profiles/seccomp/default.json
+
+# Add the following to the section, syscalls:names in default.json
+# "io_uring_setup",
+# "io_uring_enter",
+# "io_uring_register",
+# "io_uring_sync"
+
+# Run docker with the new seccomp json file
+
+$> docker run --security-opt seccomp=default.json -it --runtime=runc ... <imageid>
+```


### PR DESCRIPTION
Disabling this test until we can figure out io_uring and Docker compatibility, and also fixing the Dockerfile