### PR TITLE
Add Blossom workflow for vulnerability scan per PR

### DIFF
--- a/.github/workflows/blossom_scan.yml
+++ b/.github/workflows/blossom_scan.yml
@@ -1,0 +1,93 @@
+# A workflow to trigger ci on hybrid infra (github + self hosted runner)
+name: Blossom-CI
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "runs-on argument"
+        required: false
+      args:
+        description: "argument"
+        required: false
+
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  issues: write
+  pull-requests: write
+  repository-projects: write
+  statuses: write
+
+jobs:
+  Authorization:
+    name: Authorization
+    runs-on: blossom
+    outputs:
+      args: ${{ env.args }}
+    env:
+      OPERATION: "AUTH"
+      REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO_KEY_DATA: ${{ secrets.BLOSSOM_KEY }}
+
+    # This job only runs for pull request comments
+    if: |
+      github.event.comment.body == '/build' &&
+      (github.actor == 'Alexey-Rivkin' || github.actor == 'dpressle' || github.actor == 'Ranjeet-Nvidia')
+    steps:
+      - name: Check if comment is issued by authorized person
+        run: blossom-ci
+
+  Vulnerability-scan:
+    name: Vulnerability scan
+    needs: [Authorization]
+    runs-on: ubuntu-latest          # per the example
+    # runs-on: vulnerability-scan   # per docs
+    env:
+      REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO_KEY_DATA: ${{ secrets.BLOSSOM_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ fromJson(needs.Authorization.outputs.args).repo }}
+          ref: ${{ fromJson(needs.Authorization.outputs.args).ref }}
+          lfs: "true"
+
+      # repo specific steps
+      - name: Run build script with custom install directories
+        run: |
+          .gitlab/build.sh ./nixl_install ./ucx_install
+
+      - name: Run blossom action
+        uses: NVIDIA/blossom-action@main
+        with:
+          args1: ${{ fromJson(needs.Authorization.outputs.args).args1 }}
+          args2: ${{ fromJson(needs.Authorization.outputs.args).args2 }}
+          args3: ${{ fromJson(needs.Authorization.outputs.args).args3 }}
+
+  Job-trigger:
+    name: Start ci job
+    needs: [Vulnerability-scan]
+    runs-on: blossom
+    env:
+      OPERATION: "START-CI-JOB"
+      CI_SERVER: ${{ secrets.CI_SERVER }}
+      REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Start ci job
+        run: blossom-ci
+
+  Upload-Log:
+    name: Upload log
+    runs-on: blossom
+    if: github.event_name == 'workflow_dispatch'
+    env:
+      OPERATION: "POST-PROCESSING"
+      CI_SERVER: ${{ secrets.CI_SERVER }}
+      REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Jenkins log for pull request ${{ fromJson(github.event.inputs.args).pr }} (click here)
+        run: blossom-ci

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -10,7 +10,7 @@ jobs:
   mirror_repo:
     name: Mirror Repository to GitLab
     environment: GITLAB
-    runs-on: self-hosted
+    runs-on: gitlab
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
     name: Trigger CI Pipeline
     environment: GITLAB
     needs: mirror_repo
-    runs-on: self-hosted
+    runs-on: gitlab
     steps:
     - name: Trigger Pipeline
       run: |


### PR DESCRIPTION
## What?
Add a workflow for vulnerability scanning at Blossom CI per PR.

## Why?
Enhances security by implementing automated malware scanning on PRs before code is merged, following NVIDIA's security best practices.

## How?
Added blossom_scan.yml workflow with four jobs:
1. Authorization: Verifies authorized users
2. Vulnerability scan: Performs malware scanning
3. Job-trigger: Starts custom CI job after security checks
4. Upload-Log : Posts logs to GitHub

Note: Requires Blossom SRE team coordination to configure enterprise GitHub runners, enable malware scanning, and complete onboarding. An nvbug ticket has been created for this configuration.