### PR TITLE
CI: Change default runner labels for NIXL validation workflow

### DIFF
--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -10,7 +10,7 @@ jobs:
   mirror_repo:
     name: Mirror Repository to GitLab
     environment: GITLAB
-    runs-on: self-hosted
+    runs-on: gitlab
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -21,7 +21,7 @@ jobs:
     name: Trigger CI Pipeline
     environment: GITLAB
     needs: mirror_repo
-    runs-on: self-hosted
+    runs-on: gitlab
     steps:
     - name: Trigger Pipeline
       run: |


### PR DESCRIPTION
## What?
Replace the default `self-hosted` label with a custom `gitlab` label in the NVIDIA NIXL Validation workflow.

## Why?
The `self-hosted` label is automatically assigned to all self-hosted GitHub runners and can't be removed.
We've added a new runner on Blossom infrastructure with a different toolchain.
To avoid workflow conflicts, we need to distinguish Gitlab and Blossom runners using separate labels.

