### PR TITLE
pytest: add more fixtures and unit tests for API features

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -37,6 +37,7 @@ export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/x86_64-linux-gnu/plugins
 
 pip3 install --break-system-packages .
 pip3 install --break-system-packages pytest
+pip3 install --break-system-packages pytest-timeout
 pip3 install --break-system-packages zmq
 
 echo "==== Running python tests ===="

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -371,26 +371,22 @@ class nixl_agent:
         skip_desc_merge: bool = False,
     ) -> nixl_xfer_handle:
         op = self.nixl_ops[operation]
-        if op:
-            handle_list = []
-            for backend_string in backends:
-                handle_list.append(self.backends[backend_string])
+        handle_list = []
+        for backend_string in backends:
+            handle_list.append(self.backends[backend_string])
 
-            handle = self.agent.makeXferReq(
-                op,
-                local_xfer_side,
-                local_indices,
-                remote_xfer_side,
-                remote_indices,
-                notif_msg,
-                handle_list,
-                skip_desc_merge,
-            )
+        handle = self.agent.makeXferReq(
+            op,
+            local_xfer_side,
+            local_indices,
+            remote_xfer_side,
+            remote_indices,
+            notif_msg,
+            handle_list,
+            skip_desc_merge,
+        )
 
-            return handle
-        else:
-            raise nixlBind.nixlInvalidParamError("Invalid op code")
-            return nixlBind.nixlInvalidParamError
+        return handle
 
     """
     @brief  Initialize a transfer operation. This is a combined API, to create a transfer request
@@ -419,19 +415,15 @@ class nixl_agent:
         backends: list[str] = [],
     ) -> nixl_xfer_handle:
         op = self.nixl_ops[operation]
-        if op:
-            handle_list = []
-            for backend_string in backends:
-                handle_list.append(self.backends[backend_string])
+        handle_list = []
+        for backend_string in backends:
+            handle_list.append(self.backends[backend_string])
 
-            handle = self.agent.createXferReq(
-                op, local_descs, remote_descs, remote_agent, notif_msg, handle_list
-            )
+        handle = self.agent.createXferReq(
+            op, local_descs, remote_descs, remote_agent, notif_msg, handle_list
+        )
 
-            return handle
-        else:
-            raise nixlBind.nixlInvalidParamError("Invalid op code")
-            return nixlBind.nixlInvalidParamError
+        return handle
 
     """
     @brief  Initiate a data transfer operation.
@@ -748,6 +740,9 @@ class nixl_agent:
 
         if isinstance(descs, nixlBind.nixlXferDList):
             return descs
+        elif isinstance(descs, nixlBind.nixlRegDList):
+            print("RegList type detected for transfer, please use XferList")
+            new_descs = None
         elif isinstance(descs[0], tuple):
             if mem_type is not None and len(descs[0]) == 3:
                 new_descs = nixlBind.nixlXferDList(
@@ -788,9 +783,6 @@ class nixl_agent:
             new_descs = nixlBind.nixlXferDList(
                 self.nixl_mems[mem_type], dlist, is_sorted
             )
-        elif isinstance(descs, nixlBind.nixlRegDList):
-            print("RegList type detected for transfer, please use XferList")
-            new_descs = None
         else:
             new_descs = None
 
@@ -820,6 +812,9 @@ class nixl_agent:
 
         if isinstance(descs, nixlBind.nixlRegDList):
             return descs
+        elif isinstance(descs, nixlBind.nixlXferDList):
+            print("XferList type detected for registration, please use RegList")
+            new_descs = None
         elif isinstance(descs[0], tuple):
             if mem_type is not None and len(descs[0]) == 4:
                 new_descs = nixlBind.nixlRegDList(
@@ -860,9 +855,6 @@ class nixl_agent:
             new_descs = nixlBind.nixlRegDList(
                 self.nixl_mems[mem_type], dlist, is_sorted
             )
-        elif isinstance(descs, nixlBind.nixlXferDList):
-            print("XferList type detected for registration, please use RegList")
-            new_descs = None
         else:
             new_descs = None
 

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -19,9 +19,15 @@ import pytest
 
 import nixl._bindings as bindings
 import nixl._utils as utils
-from nixl._api import nixl_agent
+from nixl._api import nixl_agent, nixl_agent_config
 
 # NIXL pytest fixtures
+
+
+@pytest.fixture()
+def one_empty_agent():
+    config = nixl_agent_config(backends=[])
+    return nixl_agent(str(uuid.uuid4()), config)
 
 
 @pytest.fixture
@@ -34,7 +40,69 @@ def two_ucx_agents():
     return (nixl_agent(str(uuid.uuid4())), nixl_agent(str(uuid.uuid4())))
 
 
-def test_invalid_backend_name(one_ucx_agent):
+@pytest.fixture
+def two_connected_ucx_agents():
+    agent1, agent2 = (nixl_agent(str(uuid.uuid4())), nixl_agent(str(uuid.uuid4())))
+    agent1.add_remote_agent(agent2.get_agent_metadata())
+    agent2.add_remote_agent(agent1.get_agent_metadata())
+    yield (agent1, agent2)
+    agent1.remove_remote_agent(agent2.name)
+    agent2.remove_remote_agent(agent1.name)
+
+
+@pytest.fixture
+def one_reg_list():
+    return bindings.nixlRegDList(bindings.DRAM_SEG)
+
+
+@pytest.fixture
+def one_xfer_list():
+    return bindings.nixlXferDList(bindings.DRAM_SEG)
+
+
+@pytest.fixture
+def two_xfer_lists():
+    return (
+        bindings.nixlXferDList(bindings.DRAM_SEG),
+        bindings.nixlXferDList(bindings.DRAM_SEG),
+    )
+
+
+def test_empty_agent_name():
+    # pybind11 std::invalid_argument translates to python ValueError
+    with pytest.raises(ValueError):
+        nixl_agent("")
+
+
+def test_instantiate_all():
+    agent1 = nixl_agent("test", nixl_conf=None, instantiate_all=True)
+
+    assert len(agent1.plugin_list) == len(agent1.backends)
+
+
+def test_make_invalid_op(one_empty_agent, two_xfer_lists):
+    # Only READ/WRITE are supported
+    with pytest.raises(KeyError):
+        one_empty_agent.make_prepped_xfer("RD", 0, [], 0, [])
+
+    list1, list2 = two_xfer_lists
+    with pytest.raises(KeyError):
+        one_empty_agent.initialize_xfer("WR", list1, list2, "nobody")
+
+
+def test_invalid_plugin_name(one_ucx_agent):
+    # "UVX" is a typo for "UCX"
+    plugin_mems = one_ucx_agent.get_plugin_mem_types("UVX")
+    plugin_params = one_ucx_agent.get_plugin_params("UVX")
+
+    backend_mems = one_ucx_agent.get_backend_mem_types("UVX")
+    backend_params = one_ucx_agent.get_backend_mem_types("UVX")
+
+    assert len(plugin_mems) == 0 and len(plugin_params) == 0
+    assert len(backend_mems) == 0 and len(backend_params) == 0
+
+
+def test_invalid_backend_name_creation(one_ucx_agent):
     # "UVX" is a typo for "UCX"
     with pytest.raises(bindings.nixlNotFoundError):
         one_ucx_agent.create_backend("UVX")
@@ -51,6 +119,60 @@ def test_metadata_pass(two_ucx_agents):
 
     passed_name = agent2.add_remote_agent(agent1.get_agent_metadata())
     assert passed_name == agent1.name.encode()
+
+
+@pytest.mark.timeout(5)
+def test_empty_notif_tag(two_connected_ucx_agents):
+    agent1, agent2 = two_connected_ucx_agents
+
+    agent1.send_notif(agent2.name, b"whatever")
+
+    found = False
+    while not found:
+        # empty bytes will consume any message
+        found = agent2.check_remote_xfer_done(agent1.name, b"")
+
+
+def test_improper_get_xfer_descs(one_empty_agent, one_reg_list):
+    # xfer list should be 3-tuple, not 4-tuple
+    bad_list = [(1, 2, 3, 4)]
+    ok_list = [(1, 2, 3)]
+
+    ret = one_empty_agent.get_xfer_descs(bad_list)
+    assert ret is None
+
+    # With 3-tuple list, mem_type must be specified
+    ret = one_empty_agent.get_xfer_descs(ok_list, mem_type=None)
+    assert ret is None
+
+    # Invalid memory types will give a key error
+    with pytest.raises(KeyError):
+        ret = one_empty_agent.get_xfer_descs(ok_list, mem_type="V-RAM")
+
+    # Passing reg list will not work
+    ret = one_empty_agent.get_xfer_descs(one_reg_list)
+    assert ret is None
+
+
+def test_improper_get_reg_descs(one_empty_agent, one_xfer_list):
+    # reg list should be 4-tuple, not 3-tuple
+    bad_list = [(1, 2, 3)]
+    ok_list = [(1, 2, 3, 4)]
+
+    ret = one_empty_agent.get_reg_descs(bad_list)
+    assert ret is None
+
+    # With 4-tuple list, mem_type must be specified
+    ret = one_empty_agent.get_reg_descs(ok_list, mem_type=None)
+    assert ret is None
+
+    # Invalid memory types will give a key error
+    with pytest.raises(KeyError):
+        ret = one_empty_agent.get_reg_descs(ok_list, mem_type="V-RAM")
+
+    # Passing reg list will not work
+    ret = one_empty_agent.get_reg_descs(one_xfer_list)
+    assert ret is None
 
 
 # monkeypatch limits scope of env change to this test

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -74,6 +74,9 @@ def test_empty_agent_name():
         nixl_agent("")
 
 
+# This test passses locally, but fails in CI because GDS is confused about CUDA installation.
+# Skipping until we have a CI that is compatible with GDS.
+@pytest.mark.skip
 def test_instantiate_all():
     agent1 = nixl_agent("test", nixl_conf=None, instantiate_all=True)
 


### PR DESCRIPTION
Explore some extra pytest features and edge cases inside the API, with two API fixes:

The op lookup in initializing a transfer would return throw a KeyError exception, so there's no point in following it with an if statement.

Putting an empty nixlList of the wrong type into get_xfer_descs or get_reg_descs would create a seg fault, because we are dereferencing the first item in an empty list. By checking for both of these first, we can avoid this. 