### PR TITLE
UCX: Fix potential memory leak with genNotif()

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -198,21 +198,13 @@ class nixlUcxIntReq : public nixlLinkElem<nixlUcxIntReq> {
     private:
         int _completed;
     public:
-        std::string *amBuffer;
+        std::unique_ptr<std::string> amBuffer;
 
         nixlUcxIntReq() : nixlLinkElem() {
             _completed = 0;
-            amBuffer = NULL;
         }
 
-        ~nixlUcxIntReq() {
-            _completed = 0;
-            if (amBuffer) {
-                delete amBuffer;
-            }
-        }
-
-        bool is_complete() { return _completed; }
+        bool is_complete() const { return _completed; }
         void completed() { _completed = 1; }
 };
 
@@ -927,7 +919,6 @@ nixl_status_t nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
                                            const std::string &msg, nixlUcxReq &req)
 {
     nixlSerDes ser_des;
-    std::string *ser_msg;
     nixlUcxConnection conn;
     // TODO - temp fix, need to have an mpool
     static struct nixl_ucx_am_hdr hdr;
@@ -949,22 +940,16 @@ nixl_status_t nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
     ser_des.addStr("name", localAgent);
     ser_des.addStr("msg", msg);
     // TODO: replace with mpool for performance
-    ser_msg = new std::string(ser_des.exportStr());
 
+    auto buffer = std::make_unique<std::string>(std::move(ser_des.exportStr()));
     ret = uw->sendAm(conn.ep, NOTIF_STR,
                      &hdr, sizeof(struct nixl_ucx_am_hdr),
-                     (void*) ser_msg->data(), ser_msg->size(),
+                     (void*)buffer->data(), buffer->size(),
                      flags, req);
 
     if (ret == NIXL_IN_PROG) {
         nixlUcxIntReq* nReq = (nixlUcxIntReq*)req;
-        if (nReq->amBuffer) {
-            delete nReq->amBuffer;
-        }
-
-        nReq->amBuffer = ser_msg;
-    } else {
-        delete ser_msg;
+        nReq->amBuffer = std::move(buffer);
     }
     return ret;
 }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -958,6 +958,10 @@ nixl_status_t nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
 
     if (ret == NIXL_IN_PROG) {
         nixlUcxIntReq* nReq = (nixlUcxIntReq*)req;
+        if (nReq->amBuffer) {
+            delete nReq->amBuffer;
+        }
+
         nReq->amBuffer = ser_msg;
     } else {
         delete ser_msg;

--- a/src/utils/serdes/serdes.cpp
+++ b/src/utils/serdes/serdes.cpp
@@ -116,8 +116,7 @@ nixl_status_t nixlSerDes::getBuf(const std::string &tag, void *buf, ssize_t len)
 
 /* Ser/Des buffer management */
 std::string nixlSerDes::exportStr() const {
-	std::string ret_str = workingStr;
-    return ret_str;
+    return workingStr;
 }
 
 nixl_status_t nixlSerDes::importStr(const std::string &sdbuf) {

--- a/src/utils/serdes/serdes.cpp
+++ b/src/utils/serdes/serdes.cpp
@@ -29,7 +29,7 @@ std::string nixlSerDes::_bytesToString(const void *buf, ssize_t size) {
 }
 
 void nixlSerDes::_stringToBytes(void* fill_buf, const std::string &s, ssize_t size){
-    s.copy(reinterpret_cast<char*>(fill_buf), size); 
+    s.copy(reinterpret_cast<char*>(fill_buf), size);
 }
 
 /* Ser/Des for Strings */
@@ -50,12 +50,12 @@ std::string nixlSerDes::getStr(const std::string &tag){
     if(workingStr.compare(des_offset, tag.size(), tag) != 0){
        //incorrect tag
        return "";
-    } 
+    }
     ssize_t len;
 
     //skip tag
     des_offset += tag.size();
-    
+
     //get len
     //_stringToBytes(&len, workingStr.data() + des_offset, sizeof(ssize_t));
     _stringToBytes(&len, workingStr.substr(des_offset, sizeof(ssize_t)), sizeof(ssize_t));
@@ -63,7 +63,7 @@ std::string nixlSerDes::getStr(const std::string &tag){
 
     //get string
     std::string ret = workingStr.substr(des_offset, len);
-    
+
     //move past string plus | delimiter
     des_offset += len + 1;
 
@@ -85,7 +85,7 @@ ssize_t nixlSerDes::getBufLen(const std::string &tag) const{
     if(workingStr.compare(des_offset, tag.size(), tag) != 0){
        //incorrect tag
        return -1;
-    } 
+    }
 
     ssize_t len;
 
@@ -101,7 +101,7 @@ nixl_status_t nixlSerDes::getBuf(const std::string &tag, void *buf, ssize_t len)
        //incorrect tag
        return NIXL_ERR_MISMATCH;
     }
-    
+
     //skip over tag and size, which we assume has been read previously
     des_offset += tag.size() + sizeof(ssize_t);
 
@@ -120,11 +120,11 @@ std::string nixlSerDes::exportStr() const {
 }
 
 nixl_status_t nixlSerDes::importStr(const std::string &sdbuf) {
- 
+
     if(sdbuf.compare(0, 11, "nixlSerDes|") != 0){
        //incorrect tag
        return NIXL_ERR_MISMATCH;
-    }    
+    }
 
     workingStr = sdbuf;
     mode = DESERIALIZE;

--- a/src/utils/serdes/serdes.cpp
+++ b/src/utils/serdes/serdes.cpp
@@ -32,8 +32,8 @@ void nixlSerDes::_stringToBytes(void* fill_buf, const std::string &s, ssize_t si
     s.copy(reinterpret_cast<char*>(fill_buf), size);
 }
 
-/* Ser/Des for Strings */
-nixl_status_t nixlSerDes::addStr(const std::string &tag, const std::string &str){
+// Strings serialization
+nixl_status_t nixl
 
     size_t len = str.size();
 
@@ -70,7 +70,7 @@ std::string nixlSerDes::getStr(const std::string &tag){
     return ret;
 }
 
-/* Ser/Des for Byte buffers */
+// Byte buffers serialization
 nixl_status_t nixlSerDes::addBuf(const std::string &tag, const void* buf, ssize_t len){
 
     workingStr.append(tag);
@@ -114,7 +114,7 @@ nixl_status_t nixlSerDes::getBuf(const std::string &tag, void *buf, ssize_t len)
     return NIXL_SUCCESS;
 }
 
-/* Ser/Des buffer management */
+// Buffer management serialization
 std::string nixlSerDes::exportStr() const {
     return workingStr;
 }

--- a/src/utils/serdes/serdes.cpp
+++ b/src/utils/serdes/serdes.cpp
@@ -33,7 +33,7 @@ void nixlSerDes::_stringToBytes(void* fill_buf, const std::string &s, ssize_t si
 }
 
 // Strings serialization
-nixl_status_t nixl
+nixl_status_t nixlSerDes::addStr(const std::string &tag, const std::string &str){
 
     size_t len = str.size();
 


### PR DESCRIPTION
In UCX plugin, requests are always kept constructed. When marked completed, they are always destructed/constructed before release. For `genNotif()`, they are returned to UCX with a valid `amBuffer`. When UCX provides it again to the user, `amBuffer` is not used anymore but still allocated, so we need to free it before overwriting it.