### PR TITLE
NIXLBench: Bug fixes to properly create desclist and calculate stat + read support for nvshmem worker

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -185,7 +185,7 @@ if nvshmem_available
                  ]
 
     if etcd_available
-        nvcc_args += ['-letcd-cpp-api']
+        nvcc_args += ['-letcd-cpp-api', '-lcpprest']
         etcd_rt = meson.current_build_dir() + '/src/runtime/etcd/libetcd_rt.a.p/etcd_rt.cpp.o'
         nvcc_cmd_files += etcd_rt
     endif

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -389,7 +389,7 @@ void xferBenchUtils::printStatsHeader() {
     std::cout << std::string(80, '-') << std::endl;
 }
 
-void xferBenchUtils::printStats(size_t block_size, size_t batch_size, double total_duration) {
+void xferBenchUtils::printStats(bool is_target, size_t block_size, size_t batch_size, double total_duration) {
     size_t total_data_transferred = 0;
     double avg_latency = 0, throughput = 0, throughput_gib = 0, throughput_gb = 0;
     double totalbw = 0;
@@ -402,7 +402,7 @@ void xferBenchUtils::printStats(size_t block_size, size_t batch_size, double tot
 
     // TODO: We can avoid this by creating a sub-communicator across initiator ranks
     // if (isTarget() && IS_PAIRWISE_AND_SG() && rt->getSize() > 2) { - Fix this isTarget can not be called here
-    if (IS_PAIRWISE_AND_SG() && rt->getSize() > 2) {
+    if (is_target && IS_PAIRWISE_AND_SG() && rt->getSize() > 2) {
         rt->reduceSumDouble(&throughput_gb, &totalbw, 0);
         return;
     }

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -145,7 +145,7 @@ class xferBenchUtils {
 
         static void checkConsistency(std::vector<std::vector<xferBenchIOV>> &desc_lists);
         static void printStatsHeader();
-        static void printStats(size_t block_size, size_t batch_size,
+        static void printStats(bool is_target, size_t block_size, size_t batch_size,
 			                   double total_duration);
 };
 

--- a/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
@@ -137,7 +137,11 @@ static int execTransfer(const std::vector<std::vector<xferBenchIOV>> &local_iovs
         for (size_t i = 0; i < local_iov.size(); i++) {
             auto &local = local_iov[i];
             auto &remote = remote_iov[i];
-            nvshmemx_putmem_on_stream((void *)remote.addr, (void *)local.addr, local.len, target_rank, stream);
+            if (XFERBENCH_OP_WRITE == xferBenchConfig::op_type) {
+                nvshmemx_putmem_on_stream((void *)remote.addr, (void *)local.addr, local.len, target_rank, stream);
+            } else if (XFERBENCH_OP_READ == xferBenchConfig::op_type) {
+                nvshmemx_getmem_on_stream((void *)remote.addr, (void *)local.addr, local.len, target_rank, stream);
+            }
         }
         nvshmemx_quiet_on_stream(stream);
     }

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -79,6 +79,10 @@ std::string xferBenchWorker::getName() const {
     return name;
 }
 
+bool xferBenchWorker::isMasterRank() {
+    return (0 == rt->getRank());
+}
+
 bool xferBenchWorker::isInitiator() {
     return ("initiator" == name);
 }

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -36,6 +36,7 @@ class xferBenchWorker {
         virtual ~xferBenchWorker();
 
         std::string getName() const;
+        bool isMasterRank();
         bool isInitiator();
         bool isTarget();
         int synchronize();


### PR DESCRIPTION
* Enable READ support for NVSHMEM
* Introduce synchronization to properly calculate time
  * Introduce sync after (i)exchangeIOV and (ii)Warmup is complete
* Bug fix during printStats and createTransferDescLists
  * Pass isTarget in printStats to restrict target processes from reducing result across procs (Temp fix)
  * Fix createTransferDescLists to provide address within range with RR pattern
* Add cpprest lib during nvcc compilation for NVSHMEM