### PR TITLE
Agent: small fixes to commWorker

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -123,6 +123,12 @@ nixlAgent::~nixlAgent() {
         data->commThreadStop = true;
         if(data->commThread.joinable()) data->commThread.join();
 
+        // Close remaining connections from comm thread
+        for (auto &[remote, fd] : data->remoteSockets) {
+            shutdown(fd, SHUT_RDWR);
+            close(fd);
+        }
+
         if(data->config.useListenThread) {
             if(data->listener) delete data->listener;
         }
@@ -1216,14 +1222,14 @@ nixlAgent::sendLocalMD (const nixl_opt_args_t* extra_params) const {
 
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, myMD));
+        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
         return NIXL_SUCCESS;
     }
 
 #if HAVE_ETCD
     // If no IP is provided, use etcd (now via thread)
     if (data->useEtcd) {
-        data->enqueueCommWork(std::make_tuple(ETCD_SEND, data->name + "/metadata", 0, myMD));
+        data->enqueueCommWork(std::make_tuple(ETCD_SEND, data->name + "/metadata", 0, std::move(myMD)));
         return NIXL_SUCCESS;
     }
     return NIXL_ERR_INVALID_PARAM;
@@ -1241,14 +1247,14 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
 
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, myMD));
+        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
         return NIXL_SUCCESS;
     }
 
 #if HAVE_ETCD
     // If no IP is provided, use etcd (now via thread)
     if (data->useEtcd) {
-        data->enqueueCommWork(std::make_tuple(ETCD_SEND, data->name + "/partial_metadata", 0, myMD));
+        data->enqueueCommWork(std::make_tuple(ETCD_SEND, data->name + "/partial_metadata", 0, std::move(myMD)));
         return NIXL_SUCCESS;
     }
     return NIXL_ERR_INVALID_PARAM;


### PR DESCRIPTION
* NIXL_LOG doesn't require std::endl
* Replace std::cerr with NIXL_ERROR
* Avoid unnecesary copies with references and move semantics
* commThreadStop should be volatile
* Close remote sockets in Agent destructor for cleaning in case of exceptions
* Wrap static functions in nixl_listener.cpp inside unnamed namespace