### PR TITLE
UCX: Fix worker address query to enable cuda-ipc

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -294,9 +294,7 @@ int nixlUcxWorker::epAddr(uint64_t &addr, size_t &size)
     ucs_status_t status;
     void* new_addr;
 
-    wattr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS |
-                       UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS;
-    wattr.address_flags = UCP_WORKER_ADDRESS_FLAG_NET_ONLY;
+    wattr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
     status = ucp_worker_query(worker, &wattr);
     if (UCS_OK != status) {
         // TODO: printf


### PR DESCRIPTION
When worker address is fetched with `UCP_WORKER_ADDRESS_FLAG_NET_ONLY` flag it does not include cuda_ipc address on the systems without MNNVL support. Also it disables some transports which may be beneficial for host memory (cma, knem)
