### PR TITLE
Docker build and test fixes

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -58,6 +58,7 @@ RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 WORKDIR /workspace/nixl
+COPY . /workspace/nixl
 
 # LD_LIBRARY_PATH is needed for auditwheel to find libcuda.so.1
 # Set incorrectly to `compat/lib` in cuda-dl-base image
@@ -67,8 +68,6 @@ ENV VIRTUAL_ENV=/workspace/nixl/.venv
 RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
     # pybind11 pip install needed for ubuntu 22.04
     uv pip install --upgrade meson pybind11 patchelf
-
-COPY . /workspace/nixl
 
 RUN rm -rf build && \
     mkdir build && \

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -256,9 +256,9 @@ TEST_P(TestTransfer, RandomSizes)
 {
     // Tuple fields are: size, count, repeat
     constexpr std::array<std::tuple<size_t, size_t, size_t>, 3> test_cases = {
-        {{4096, 8, 10},
-         {32768, 64, 100},
-         {1000000, 100, 1000}}
+        {{4096, 8, 3},
+         {32768, 64, 3},
+         {1000000, 100, 3}}
     };
 
     for (const auto &[size, count, repeat] : test_cases) {

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -36,7 +36,7 @@
 namespace {
     const size_t page_size = sysconf(_SC_PAGESIZE);
 
-    constexpr int default_num_transfers = 4 * 1024;
+    constexpr int default_num_transfers = 1024;
     constexpr size_t default_transfer_size = 1 * 512 * 1024; // 512KB
     constexpr char test_phrase[] = "NIXL Storage Test Pattern 2025 POSIX";
     constexpr size_t test_phrase_len = sizeof(test_phrase) - 1; // -1 to exclude null terminator


### PR DESCRIPTION
- Copying user nixl directory after setting venv will overwrite it with whatever happened to be on host repo directory '.venv' directory. Move repo copy command before venv setup.
- Tests are convenient way for developers to quickly validate incremental changes to the code and should run in few seconds most in the default configuration on a laptop. Adjust defaults to sane values.