### PR TITLE
Mark subset of data path methods with 'const' modifier

### DIFF
--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -112,7 +112,7 @@ class nixlBackendEngine {
                                         const std::string &remote_agent,
                                         nixlBackendReqH* &handle,
                                         const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) = 0;
+                                       ) const = 0;
 
         // Posting a request, which completes the async handle creation and posts it
         virtual nixl_status_t postXfer (const nixl_xfer_op_t &operation,
@@ -121,13 +121,13 @@ class nixlBackendEngine {
                                         const std::string &remote_agent,
                                         nixlBackendReqH* &handle,
                                         const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) = 0;
+                                       ) const = 0;
 
         // Use a handle to progress backend engine and see if a transfer is completed or not
-        virtual nixl_status_t checkXfer(nixlBackendReqH* handle) = 0;
+        virtual nixl_status_t checkXfer(nixlBackendReqH* handle) const = 0;
 
         //Backend aborts the transfer if necessary, and destructs the relevant objects
-        virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) = 0;
+        virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) const = 0;
 
 
         // *** Needs to be implemented if supportsRemote() is true *** //
@@ -174,7 +174,7 @@ class nixlBackendEngine {
         virtual nixl_status_t getNotifs(notif_list_t &notif_list) { return NIXL_ERR_BACKEND; }
 
         // Generates a standalone notification, not bound to a transfer.
-        virtual nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) {
+        virtual nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) const {
             return NIXL_ERR_BACKEND;
         }
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -254,7 +254,7 @@ class nixlAgent {
          * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
          */
         nixl_status_t
-        getXferStatus (nixlXferReqH* req_hndl);
+        getXferStatus (nixlXferReqH* req_hndl) const;
 
         /**
          * @brief  Query the backend associated with `req_hndl`. E.g., if for genNotif
@@ -276,7 +276,7 @@ class nixlAgent {
          * @return nixl_status_t Error code if call was not successful
          */
         nixl_status_t
-        releaseXferReq (nixlXferReqH* req_hndl);
+        releaseXferReq (nixlXferReqH* req_hndl) const;
 
         /**
          * @brief  Release the prepared descriptor list handle `dlist_hndl`
@@ -319,7 +319,7 @@ class nixlAgent {
         nixl_status_t
         genNotif (const std::string &remote_agent,
                   const nixl_blob_t &msg,
-                  const nixl_opt_args_t* extra_params = nullptr);
+                  const nixl_opt_args_t* extra_params = nullptr) const;
 
         /*** Metadata handling through side channel ***/
         /**

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -829,7 +829,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 }
 
 nixl_status_t
-nixlAgent::getXferStatus (nixlXferReqH *req_hndl) {
+nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
 
     NIXL_LOCK_GUARD(data->lock);
     // If the status is done, no need to recheck.
@@ -856,7 +856,7 @@ nixlAgent::queryXferBackend(const nixlXferReqH* req_hndl,
 }
 
 nixl_status_t
-nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) {
+nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
     NIXL_LOCK_GUARD(data->lock);
     //attempt to cancel request
@@ -941,7 +941,7 @@ nixlAgent::getNotifs(nixl_notifs_t &notif_map,
 nixl_status_t
 nixlAgent::genNotif(const std::string &remote_agent,
                     const nixl_blob_t &msg,
-                    const nixl_opt_args_t* extra_params) {
+                    const nixl_opt_args_t* extra_params) const {
 
     nixlBackendEngine* backend = nullptr;
     backend_list_t*    backend_list;

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -172,7 +172,7 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
                                        const nixl_meta_dlist_t &remote,
                                        const std::string &remote_agent,
                                        nixlBackendReqH* &handle,
-                                       const nixl_opt_b_args_t* opt_args)
+                                       const nixl_opt_b_args_t* opt_args) const
 {
     nixlGdsBackendReqH* gds_handle = new nixlGdsBackendReqH();
     size_t buf_cnt = local.descCount();
@@ -273,7 +273,7 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
-nixlGdsIOBatch* nixlGdsEngine::getBatchFromPool(unsigned int size) {
+nixlGdsIOBatch* nixlGdsEngine::getBatchFromPool(unsigned int size) const {
     const std::lock_guard<std::mutex> lock(batch_pool_lock);
     // Use a pre-allocated batch if available
     if (!batch_pool.empty()) {
@@ -286,7 +286,7 @@ nixlGdsIOBatch* nixlGdsEngine::getBatchFromPool(unsigned int size) {
     return nullptr;
 }
 
-void nixlGdsEngine::returnBatchToPool(nixlGdsIOBatch* batch) {
+void nixlGdsEngine::returnBatchToPool(nixlGdsIOBatch* batch) const {
     const std::lock_guard<std::mutex> lock(batch_pool_lock);
     // Only keep up to batch_pool_size batches
         batch_pool.push_back(batch);
@@ -297,7 +297,7 @@ nixl_status_t nixlGdsEngine::postXfer(const nixl_xfer_op_t &operation,
                                       const nixl_meta_dlist_t &remote,
                                       const std::string &remote_agent,
                                       nixlBackendReqH* &handle,
-                                      const nixl_opt_b_args_t* opt_args)
+                                      const nixl_opt_b_args_t* opt_args) const
 {
     nixlGdsBackendReqH* gds_handle = (nixlGdsBackendReqH*)handle;
 
@@ -334,7 +334,7 @@ nixl_status_t nixlGdsEngine::postXfer(const nixl_xfer_op_t &operation,
 
 nixl_status_t nixlGdsEngine::createAndSubmitBatch(const std::vector<GdsTransferRequestH>& requests,
                                                   size_t start_idx, size_t batch_size,
-                                                  std::vector<nixlGdsIOBatch*>& batch_list)
+                                                  std::vector<nixlGdsIOBatch*>& batch_list) const
 {
     nixlGdsIOBatch* batch = getBatchFromPool(batch_size);
     if (!batch) {
@@ -368,7 +368,7 @@ nixl_status_t nixlGdsEngine::createAndSubmitBatch(const std::vector<GdsTransferR
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlGdsEngine::checkXfer(nixlBackendReqH* handle)
+nixl_status_t nixlGdsEngine::checkXfer(nixlBackendReqH* handle) const
 {
     nixlGdsBackendReqH *gds_handle = (nixlGdsBackendReqH *)handle;
 
@@ -396,7 +396,7 @@ nixl_status_t nixlGdsEngine::checkXfer(nixlBackendReqH* handle)
     return status;
 }
 
-nixl_status_t nixlGdsEngine::releaseReqH(nixlBackendReqH* handle)
+nixl_status_t nixlGdsEngine::releaseReqH(nixlBackendReqH* handle) const
 {
 
     nixlGdsBackendReqH *gds_handle = (nixlGdsBackendReqH *) handle;

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -274,6 +274,7 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
 }
 
 nixlGdsIOBatch* nixlGdsEngine::getBatchFromPool(unsigned int size) {
+    const std::lock_guard<std::mutex> lock(batch_pool_lock);
     // Use a pre-allocated batch if available
     if (!batch_pool.empty()) {
         nixlGdsIOBatch* batch = batch_pool.back();
@@ -286,6 +287,7 @@ nixlGdsIOBatch* nixlGdsEngine::getBatchFromPool(unsigned int size) {
 }
 
 void nixlGdsEngine::returnBatchToPool(nixlGdsIOBatch* batch) {
+    const std::lock_guard<std::mutex> lock(batch_pool_lock);
     // Only keep up to batch_pool_size batches
         batch_pool.push_back(batch);
 }

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <list>
 #include <vector>
+#include <mutex>
 #include "gds_utils.h"
 #include "backend/backend_engine.h"
 
@@ -87,6 +88,8 @@ class nixlGdsEngine : public nixlBackendEngine {
     private:
         gdsUtil *gds_utils;
         std::unordered_map<int, gdsFileHandle> gds_file_map;
+
+        std::mutex batch_pool_lock;
         std::list<nixlGdsIOBatch*> batch_pool;
         unsigned int batch_pool_size;  // Renamed from pool_size
         unsigned int batch_limit;      // Added for configurable batch limit

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -89,17 +89,17 @@ class nixlGdsEngine : public nixlBackendEngine {
         gdsUtil *gds_utils;
         std::unordered_map<int, gdsFileHandle> gds_file_map;
 
-        std::mutex batch_pool_lock;
-        std::list<nixlGdsIOBatch*> batch_pool;
+        mutable std::mutex batch_pool_lock;
+        mutable std::list<nixlGdsIOBatch*> batch_pool;
         unsigned int batch_pool_size;  // Renamed from pool_size
         unsigned int batch_limit;      // Added for configurable batch limit
         unsigned int max_request_size; // Added for configurable request size
 
-        nixlGdsIOBatch* getBatchFromPool(unsigned int size);
-        void returnBatchToPool(nixlGdsIOBatch* batch);
+        nixlGdsIOBatch* getBatchFromPool(unsigned int size) const;
+        void returnBatchToPool(nixlGdsIOBatch* batch) const;
         nixl_status_t createAndSubmitBatch(const std::vector<GdsTransferRequestH>& requests,
                                            size_t start_idx, size_t batch_size,
-                                           std::vector<nixlGdsIOBatch*>& batch_list);
+                                           std::vector<nixlGdsIOBatch*>& batch_list) const;
         nixl_status_t createBatches(const nixl_xfer_op_t &operation,
                                    const nixl_meta_dlist_t &local,
                                    const nixl_meta_dlist_t &remote,
@@ -160,16 +160,16 @@ class nixlGdsEngine : public nixlBackendEngine {
                               const nixl_meta_dlist_t &remote,
                               const std::string &remote_agent,
                               nixlBackendReqH* &handle,
-                              const nixl_opt_b_args_t* opt_args=nullptr);
+                              const nixl_opt_b_args_t* opt_args=nullptr) const;
 
         nixl_status_t postXfer(const nixl_xfer_op_t &operation,
                               const nixl_meta_dlist_t &local,
                               const nixl_meta_dlist_t &remote,
                               const std::string &remote_agent,
                               nixlBackendReqH* &handle,
-                              const nixl_opt_b_args_t* opt_args=nullptr);
+                              const nixl_opt_b_args_t* opt_args=nullptr) const;
 
-        nixl_status_t checkXfer(nixlBackendReqH* handle);
-        nixl_status_t releaseReqH(nixlBackendReqH* handle);
+        nixl_status_t checkXfer(nixlBackendReqH* handle) const;
+        nixl_status_t releaseReqH(nixlBackendReqH* handle) const;
 };
 #endif

--- a/src/plugins/mooncake/mooncake_backend.h
+++ b/src/plugins/mooncake/mooncake_backend.h
@@ -77,24 +77,24 @@ class nixlMooncakeEngine : public nixlBackendEngine {
                                 const nixl_meta_dlist_t &remote,
                                 const std::string &remote_agent,
                                 nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+                                const nixl_opt_b_args_t* opt_args=nullptr) const;
 
         nixl_status_t postXfer (const nixl_xfer_op_t &operation,
                                 const nixl_meta_dlist_t &local,
                                 const nixl_meta_dlist_t &remote,
                                 const std::string &remote_agent,
                                 nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+                                const nixl_opt_b_args_t* opt_args=nullptr) const;
 
-        nixl_status_t checkXfer (nixlBackendReqH* handle);
-        nixl_status_t releaseReqH(nixlBackendReqH* handle);
+        nixl_status_t checkXfer (nixlBackendReqH* handle) const;
+        nixl_status_t releaseReqH(nixlBackendReqH* handle) const;
 
     private:
         struct AgentInfo {
             int segment_id;
         };
 
-        std::mutex mutex_;
+        mutable std::mutex mutex_;
         transfer_engine_t engine_;
         std::string local_agent_name_;
         std::unordered_map<uint64_t, nixlMooncakeBackendMD *> mem_reg_info_;

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -226,7 +226,7 @@ bool nixlPosixEngine::validatePrepXferParams(const nixl_xfer_op_t &operation,
                                              const nixl_meta_dlist_t &local,
                                              const nixl_meta_dlist_t &remote,
                                              const std::string &remote_agent,
-                                             const std::string &local_agent) {
+                                             const std::string &local_agent) const {
     if (remote_agent != local_agent) {
         NIXL_ERROR << absl::StrFormat("Error: Remote agent must match the requesting agent (%s). Got %s",
                                        local_agent, remote_agent);
@@ -270,7 +270,7 @@ nixl_status_t nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
                                         const nixl_meta_dlist_t &remote,
                                         const std::string &remote_agent,
                                         nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args) {
+                                        const nixl_opt_b_args_t* opt_args) const {
     if (!validatePrepXferParams(operation, local, remote, remote_agent, localAgent)) {
         return NIXL_ERR_INVALID_PARAM;
     }
@@ -300,7 +300,7 @@ nixl_status_t nixlPosixEngine::postXfer(const nixl_xfer_op_t &operation,
                                         const nixl_meta_dlist_t &remote,
                                         const std::string &remote_agent,
                                         nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args) {
+                                        const nixl_opt_b_args_t* opt_args) const {
     nixl_status_t status = NIXL_SUCCESS;
 
     status = static_cast<nixlPosixBackendReqH*>(handle)->postXfer();
@@ -309,11 +309,11 @@ nixl_status_t nixlPosixEngine::postXfer(const nixl_xfer_op_t &operation,
     return status;
 }
 
-nixl_status_t nixlPosixEngine::checkXfer(nixlBackendReqH* handle) {
+nixl_status_t nixlPosixEngine::checkXfer(nixlBackendReqH* handle) const {
     return static_cast<nixlPosixBackendReqH*>(handle)->checkXfer();
 }
 
-nixl_status_t nixlPosixEngine::releaseReqH(nixlBackendReqH* handle) {
+nixl_status_t nixlPosixEngine::releaseReqH(nixlBackendReqH* handle) const {
     delete static_cast<nixlPosixBackendReqH*>(handle);
     return NIXL_SUCCESS;
 }

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -76,7 +76,7 @@ private:
                                 const nixl_meta_dlist_t &local,
                                 const nixl_meta_dlist_t &remote,
                                 const std::string &remote_agent,
-                                const std::string &local_agent);
+                                const std::string &local_agent) const ;
 
 public:
     nixlPosixEngine(const nixlBackendInitParams* init_params);
@@ -129,17 +129,17 @@ public:
                            const nixl_meta_dlist_t &remote,
                            const std::string &remote_agent,
                            nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t* opt_args=nullptr);
+                           const nixl_opt_b_args_t* opt_args=nullptr) const;
 
     nixl_status_t postXfer(const nixl_xfer_op_t &operation,
                            const nixl_meta_dlist_t &local,
                            const nixl_meta_dlist_t &remote,
                            const std::string &remote_agent,
                            nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t* opt_args=nullptr);
+                           const nixl_opt_b_args_t* opt_args=nullptr) const;
 
-    nixl_status_t checkXfer(nixlBackendReqH* handle);
-    nixl_status_t releaseReqH(nixlBackendReqH* handle);
+    nixl_status_t checkXfer(nixlBackendReqH* handle) const;
+    nixl_status_t releaseReqH(nixlBackendReqH* handle) const;
 };
 
 #endif // POSIX_BACKEND_H

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -239,7 +239,7 @@ static void _internalRequestReset(nixlUcxIntReq *req) {
 class nixlUcxBackendH : public nixlBackendReqH {
 private:
     nixlUcxIntReq head;
-    nixlUcxEngine &eng;
+    const nixlUcxEngine &eng;
     size_t worker_id;
 
     // Notification to be sent after completion of all requests
@@ -256,7 +256,7 @@ public:
         return notif;
     }
 
-    nixlUcxBackendH(nixlUcxEngine &eng_, size_t worker_id_): eng(eng_), worker_id(worker_id_) {}
+    nixlUcxBackendH(const nixlUcxEngine &eng_, size_t worker_id_): eng(eng_), worker_id(worker_id_) {}
 
     void append(nixlUcxIntReq *req) {
         head.link(req);
@@ -846,7 +846,7 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
                                        const nixl_meta_dlist_t &remote,
                                        const std::string &remote_agent,
                                        nixlBackendReqH* &handle,
-                                       const nixl_opt_b_args_t* opt_args)
+                                       const nixl_opt_b_args_t* opt_args) const
 {
     /* TODO: try to get from a pool first */
     nixlUcxBackendH *intHandle = new nixlUcxBackendH(*this, getWorkerId());
@@ -860,7 +860,7 @@ nixl_status_t nixlUcxEngine::postXfer (const nixl_xfer_op_t &operation,
                                        const nixl_meta_dlist_t &remote,
                                        const std::string &remote_agent,
                                        nixlBackendReqH* &handle,
-                                       const nixl_opt_b_args_t* opt_args)
+                                       const nixl_opt_b_args_t* opt_args) const
 {
     size_t lcnt = local.descCount();
     size_t rcnt = remote.descCount();
@@ -932,7 +932,7 @@ nixl_status_t nixlUcxEngine::postXfer (const nixl_xfer_op_t &operation,
     return ret;
 }
 
-nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle)
+nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
 {
     nixlUcxBackendH *intHandle = (nixlUcxBackendH *)handle;
     size_t workerId = intHandle->getWorkerId();
@@ -953,7 +953,7 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle)
     return status;
 }
 
-nixl_status_t nixlUcxEngine::releaseReqH(nixlBackendReqH* handle)
+nixl_status_t nixlUcxEngine::releaseReqH(nixlBackendReqH* handle) const
 {
     nixlUcxBackendH *intHandle = (nixlUcxBackendH *)handle;
     nixl_status_t status = intHandle->release();
@@ -980,7 +980,7 @@ int nixlUcxEngine::progress() {
 nixl_status_t nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
                                            const std::string &msg,
                                            nixlUcxReq &req,
-                                           size_t worker_id)
+                                           size_t worker_id) const
 {
     nixlSerDes ser_des;
     // TODO - temp fix, need to have an mpool
@@ -1095,7 +1095,7 @@ nixl_status_t nixlUcxEngine::getNotifs(notif_list_t &notif_list)
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlUcxEngine::genNotif(const std::string &remote_agent, const std::string &msg)
+nixl_status_t nixlUcxEngine::genNotif(const std::string &remote_agent, const std::string &msg) const
 {
     nixl_status_t ret;
     nixlUcxReq req;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -174,7 +174,7 @@ class nixlUcxEngine : public nixlBackendEngine {
         nixl_status_t notifSendPriv(const std::string &remote_agent,
                                     const std::string &msg,
                                     nixlUcxReq &req,
-                                    size_t worker_id);
+                                    size_t worker_id) const;
         void notifProgress();
         void notifCombineHelper(notif_list_t &src, notif_list_t &tgt);
         void notifProgressCombineHelper(notif_list_t &src, notif_list_t &tgt);
@@ -220,22 +220,22 @@ class nixlUcxEngine : public nixlBackendEngine {
                                 const nixl_meta_dlist_t &remote,
                                 const std::string &remote_agent,
                                 nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+                                const nixl_opt_b_args_t* opt_args=nullptr) const;
 
         nixl_status_t postXfer (const nixl_xfer_op_t &operation,
                                 const nixl_meta_dlist_t &local,
                                 const nixl_meta_dlist_t &remote,
                                 const std::string &remote_agent,
                                 nixlBackendReqH* &handle,
-                                const nixl_opt_b_args_t* opt_args=nullptr);
+                                const nixl_opt_b_args_t* opt_args=nullptr) const;
 
-        nixl_status_t checkXfer (nixlBackendReqH* handle);
-        nixl_status_t releaseReqH(nixlBackendReqH* handle);
+        nixl_status_t checkXfer (nixlBackendReqH* handle) const;
+        nixl_status_t releaseReqH(nixlBackendReqH* handle) const;
 
         int progress();
 
         nixl_status_t getNotifs(notif_list_t &notif_list);
-        nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg);
+        nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) const;
 
         //public function for UCX worker to mark connections as connected
         nixl_status_t checkConn(const std::string &remote_agent);

--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -148,7 +148,7 @@ nixlUcxMoEngine::getEngIdx(nixl_mem_t type, uint64_t devId)
 }
 
 string
-nixlUcxMoEngine::getEngName(const string &baseName, uint32_t eidx)
+nixlUcxMoEngine::getEngName(const string &baseName, uint32_t eidx) const
 {
     return baseName + ":" + to_string(eidx);
 }
@@ -486,7 +486,7 @@ nixlUcxMoEngine::prepXfer (const nixl_xfer_op_t &operation,
                            const nixl_meta_dlist_t &remote,
                            const std::string &remote_agent,
                            nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t *opt_args)
+                           const nixl_opt_b_args_t *opt_args) const
 {
     size_t lidx, ridx;
     size_t lidx_max, ridx_max;
@@ -507,11 +507,11 @@ nixlUcxMoEngine::prepXfer (const nixl_xfer_op_t &operation,
     }
 
     // Check that remote agent is known
-    remote_comm_it_t it = remoteConnMap.find(remote_agent);
+    const auto it = remoteConnMap.find(remote_agent);
     if(it == remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
-    nixlUcxMoConnection &conn = it->second;
+    const nixlUcxMoConnection &conn = it->second;
 
     /* Allocate request and fill communication distribution matrix */
     size_t l_eng_cnt = engines.size();
@@ -616,7 +616,7 @@ nixlUcxMoEngine::postXfer (const nixl_xfer_op_t &operation,
                            const nixl_meta_dlist_t &remote,
                            const std::string &remote_agent,
                            nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t *opt_args)
+                           const nixl_opt_b_args_t *opt_args) const
 {
     nixlUcxMoRequestH *req = (nixlUcxMoRequestH *)handle;
     bool in_progress = false;
@@ -684,7 +684,7 @@ nixlUcxMoEngine::postXfer (const nixl_xfer_op_t &operation,
 }
 
 nixl_status_t
-nixlUcxMoEngine::checkXfer (nixlBackendReqH *handle)
+nixlUcxMoEngine::checkXfer (nixlBackendReqH *handle) const
 {
     nixlUcxMoRequestH *req = (nixlUcxMoRequestH *)handle;
     nixl_status_t out_ret = NIXL_SUCCESS;
@@ -730,7 +730,7 @@ nixlUcxMoEngine::checkXfer (nixlBackendReqH *handle)
 }
 
 nixl_status_t
-nixlUcxMoEngine::releaseReqH(nixlBackendReqH* handle)
+nixlUcxMoEngine::releaseReqH(nixlBackendReqH* handle) const
 {
     nixlUcxMoRequestH *req = (nixlUcxMoRequestH *)handle;
     nixl_status_t out_ret = NIXL_SUCCESS;
@@ -773,7 +773,7 @@ nixlUcxMoEngine::getNotifs(notif_list_t &notif_list)
 }
 
 nixl_status_t
-nixlUcxMoEngine::genNotif(const string &remote_agent, const string &msg)
+nixlUcxMoEngine::genNotif(const string &remote_agent, const string &msg) const
 {
     return engines[0]->genNotif(getEngName(remote_agent, 0), msg);
 }

--- a/src/plugins/ucx_mo/ucx_mo_backend.h
+++ b/src/plugins/ucx_mo/ucx_mo_backend.h
@@ -91,7 +91,7 @@ private:
     int setEngCnt(uint32_t host_engines);
     uint32_t getEngCnt();
     int32_t getEngIdx(nixl_mem_t type, uint64_t devId);
-    std::string getEngName(const std::string &baseName, uint32_t eidx);
+    std::string getEngName(const std::string &baseName, uint32_t eidx) const;
     std::string getEngBase(const std::string &engName);
     bool pthrOn;
 
@@ -149,21 +149,21 @@ public:
                             const nixl_meta_dlist_t &remote,
                             const std::string &remote_agent,
                             nixlBackendReqH* &handle,
-                            const nixl_opt_b_args_t* opt_args=nullptr);
+                            const nixl_opt_b_args_t* opt_args=nullptr) const;
 
     nixl_status_t postXfer (const nixl_xfer_op_t &operation,
                             const nixl_meta_dlist_t &local,
                             const nixl_meta_dlist_t &remote,
                             const std::string &remote_agent,
                             nixlBackendReqH* &handle,
-                            const nixl_opt_b_args_t* opt_args=nullptr);
-    nixl_status_t checkXfer (nixlBackendReqH* handle);
-    nixl_status_t releaseReqH(nixlBackendReqH* handle);
+                            const nixl_opt_b_args_t* opt_args=nullptr) const;
+    nixl_status_t checkXfer (nixlBackendReqH* handle) const;
+    nixl_status_t releaseReqH(nixlBackendReqH* handle) const;
 
     int progress();
 
     nixl_status_t getNotifs(notif_list_t &notif_list);
-    nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg);
+    nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) const;
 
     //public function for UCX worker to mark connections as connected
     nixl_status_t checkConn(const std::string &remote_agent);

--- a/test/gtest/mocks/mock_dram_engine.cpp
+++ b/test/gtest/mocks/mock_dram_engine.cpp
@@ -51,8 +51,8 @@ nixl_status_t MockDramBackendEngine::prepXfer(const nixl_xfer_op_t &operation,
                                              const nixl_meta_dlist_t &remote,
                                              const std::string &remote_agent,
                                              nixlBackendReqH *&handle,
-                                             const nixl_opt_b_args_t *opt_args) {
-  sharedState++;
+                                             const nixl_opt_b_args_t *opt_args) const {
+  assert(sharedState > 0);
   return NIXL_SUCCESS;
 }
 
@@ -61,18 +61,19 @@ nixl_status_t MockDramBackendEngine::postXfer(const nixl_xfer_op_t &operation,
                                              const nixl_meta_dlist_t &remote,
                                              const std::string &remote_agent,
                                              nixlBackendReqH *&handle,
-                                             const nixl_opt_b_args_t *opt_args) {
-  sharedState++;
+                                             const nixl_opt_b_args_t *opt_args) const {
+  assert(sharedState > 0);
   return NIXL_SUCCESS;
 }
 
-nixl_status_t MockDramBackendEngine::checkXfer(nixlBackendReqH *handle) {
-  sharedState++;
+nixl_status_t MockDramBackendEngine::checkXfer(nixlBackendReqH *handle) const {
+  assert(sharedState > 0);
   return NIXL_SUCCESS;
 }
 
-nixl_status_t MockDramBackendEngine::releaseReqH(nixlBackendReqH *handle) {
-  sharedState++;
+nixl_status_t MockDramBackendEngine::releaseReqH(nixlBackendReqH *handle) const {
+
+  assert(sharedState > 0);
   return NIXL_SUCCESS;
 }
 
@@ -102,8 +103,8 @@ nixl_status_t MockDramBackendEngine::getNotifs(notif_list_t &notif_list) {
 }
 
 nixl_status_t MockDramBackendEngine::genNotif(const std::string &remote_agent,
-                                             const std::string &msg) {
-  sharedState++;
+                                             const std::string &msg) const {
+  assert(sharedState > 0);
   return NIXL_SUCCESS;
 }
 

--- a/test/gtest/mocks/mock_dram_engine.h
+++ b/test/gtest/mocks/mock_dram_engine.h
@@ -59,15 +59,15 @@ public:
                          const nixl_meta_dlist_t &remote,
                          const std::string &remote_agent,
                          nixlBackendReqH *&handle,
-                         const nixl_opt_b_args_t *opt_args) override;
+                         const nixl_opt_b_args_t *opt_args) const override;
   nixl_status_t postXfer(const nixl_xfer_op_t &operation,
                          const nixl_meta_dlist_t &local,
                          const nixl_meta_dlist_t &remote,
                          const std::string &remote_agent,
                          nixlBackendReqH *&handle,
-                         const nixl_opt_b_args_t *opt_args) override;
-  nixl_status_t checkXfer(nixlBackendReqH *handle) override;
-  nixl_status_t releaseReqH(nixlBackendReqH *handle) override;
+                         const nixl_opt_b_args_t *opt_args) const override;
+  nixl_status_t checkXfer(nixlBackendReqH *handle) const override;
+  nixl_status_t releaseReqH(nixlBackendReqH *handle) const override;
   nixl_status_t getPublicData(const nixlBackendMD *meta, std::string &str) const override {
     assert(sharedState > 0);
     return NIXL_SUCCESS;
@@ -85,7 +85,7 @@ public:
   nixl_status_t loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output);
   nixl_status_t getNotifs(notif_list_t &notif_list) override;
   nixl_status_t genNotif(const std::string &remote_agent,
-                         const std::string &msg) override;
+                         const std::string &msg) const override;
   int progress() override;
 
 private:


### PR DESCRIPTION
In C++ marking method as 'const' doesn't automatically guarantee thread-safety but allows compiler to catch obvious shared state modifications which is a good first step towards making contributors consider thread safety when implementing new backends or modifying existing ones. This series marks subset of agent data path methods (reateXferReq, postXferReq, getXferStatus, releaseXferReq, genNotif) and the backend methods that they call (prepXfer, postXfer, checkXfer, releaseReqH, genNotif) as const, including laying the groundwork to make the change compile/work:

- Refactor GDS backend to extract mutable state into dedicated class that protects its data with mutex.
- Mooncake already implements its own locking. Make the lock mutable to allow taking it from const methods. Also, cosmetic change to use iterator to access connected_agents_ elements instead of operator[] to allow using it from const methods.
- Perform simple cosmetic changes in ucx and ucx_mo to use const references and const iterators from the data path methods to make them compatible with 'const' modifier.
