### PR TITLE
Refactor UCX progress thread to remove busy-polling

### DIFF
--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <condition_variable>
 #include <atomic>
+#include <poll.h>
 
 #include "nixl.h"
 #include "backend/backend_engine.h"
@@ -114,10 +115,10 @@ class nixlUcxEngine : public nixlBackendEngine {
         std::mutex pthrActiveLock;
         std::condition_variable pthrActiveCV;
         bool pthrActive;
-        std::atomic_bool pthrStop;
         bool pthrOn;
         std::thread pthr;
-        nixlTime::us_t pthrDelay;
+        int pthrControlPipe[2];
+        std::vector<pollfd> pollFds;
 
         /* CUDA data*/
         std::unique_ptr<nixlUcxCudaCtx> cudaCtx;

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -318,7 +318,8 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
                                size_t req_size,
                                nixlUcxContext::req_cb_t init_cb,
                                nixlUcxContext::req_cb_t fini_cb,
-                               nixl_ucx_mt_t __mt_type)
+                               nixl_ucx_mt_t __mt_type,
+                               bool prog_thread)
 {
     ucp_params_t ucp_params;
     ucp_config_t *ucp_config;
@@ -328,6 +329,9 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
 
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
     ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64 | UCP_FEATURE_AM;
+    if (prog_thread)
+        ucp_params.features |= UCP_FEATURE_WAKEUP;
+
     switch(mt_type) {
     case NIXL_UCX_MT_SINGLE:
         ucp_params.mt_workers_shared = 0;

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -131,7 +131,7 @@ public:
     using req_cb_t = void(void *request);
     nixlUcxContext(std::vector<std::string> devices,
                    size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
-                   nixl_ucx_mt_t mt_type);
+                   nixl_ucx_mt_t mt_type, bool prog_thread);
     ~nixlUcxContext();
 
     static bool mtLevelIsSupproted(nixl_ucx_mt_t mt_type);
@@ -169,6 +169,9 @@ public:
 
     void reqRelease(nixlUcxReq req);
     void reqCancel(nixlUcxReq req);
+
+    /* Worker access */
+    ucp_worker_h getWorker() const { return worker; }
 };
 
 #endif

--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -658,7 +658,10 @@ int main()
 #ifdef HAVE_CUDA
     int dev_ids[2] = { 0 , 0 };
     int n_vram_dev;
-    cudaGetDeviceCount(&n_vram_dev);
+    if (cudaGetDeviceCount(&n_vram_dev) != cudaSuccess) {
+        std::cout << "Call to cudaGetDeviceCount failed, assuming 0 devices";
+        n_vram_dev = 0;
+    }
 
     std::cout << "Detected " << n_vram_dev << " CUDA devices" << std::endl;
     if (n_vram_dev > 1) {

--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -688,7 +688,10 @@ int main()
 #ifdef HAVE_CUDA
     int dev_ids[2] = { 0 , 0 };
     int n_vram_dev;
-    cudaGetDeviceCount(&n_vram_dev);
+    if (cudaGetDeviceCount(&n_vram_dev) != cudaSuccess) {
+        std::cout << "Call to cudaGetDeviceCount failed, assuming 0 devices";
+        n_vram_dev = 0;
+    }
 
     std::cout << "Detected " << n_vram_dev << " CUDA devices" << std::endl;
     if (n_vram_dev > 1) {

--- a/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
+++ b/test/unit/plugins/ucx_mo/ucx_mo_backend_test.cpp
@@ -562,7 +562,10 @@ int main()
 int ndevices = NUM_WORKERS;
 #ifdef HAVE_CUDA
     int n_vram_dev;
-    cudaGetDeviceCount(&n_vram_dev);
+    if (cudaGetDeviceCount(&n_vram_dev) != cudaSuccess) {
+        std::cout << "Call to cudaGetDeviceCount failed, assuming 0 devices";
+        n_vram_dev = 0;
+    }
     std::cout << "Detected " << n_vram_dev << " CUDA devices" << std::endl;
 #endif
 

--- a/test/unit/utils/ucx/ucx_am_test.cpp
+++ b/test/unit/utils/ucx/ucx_am_test.cpp
@@ -88,8 +88,8 @@ int main()
     devs.push_back("mlx5_0");
 
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE),
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE)
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false),
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false)
     };
 
     nixlUcxWorker w[2] = {

--- a/test/unit/utils/ucx/ucx_worker_test.cpp
+++ b/test/unit/utils/ucx/ucx_worker_test.cpp
@@ -86,8 +86,8 @@ int main()
     // in CI it would be goot to test both SHM and IB
     //devs.push_back("mlx5_0");
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE),
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE)
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false),
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false)
     };
 
     nixlUcxWorker w[2] = {


### PR DESCRIPTION
Instead of busy-polling use functionality provided by UCX that exposes file descriptors that can be monitored for events with standard UNIX APIs. Implement following changes:

 - When progress thread is enabled also enable UCP feature that exposes file descriptors for wake up.

 - In UCX progress thread arm every worker for wake up via file descriptor and sleep while waiting for events with poll().

 - Use eventfd file descriptor to wake up the thread for cancellation.
