### PR TITLE
feat: add ARM (aarch64) build support for nixl-sys

### DIFF
--- a/src/bindings/rust/build.rs
+++ b/src/bindings/rust/build.rs
@@ -20,7 +20,15 @@ fn main() {
     let nixl_root_path =
         env::var("NIXL_PREFIX").unwrap_or_else(|_| "/opt/nvidia/nvda_nixl".to_string());
     let nixl_include_path = format!("{}/include", nixl_root_path);
-    let nixl_lib_path = format!("{}/lib/x86_64-linux-gnu", nixl_root_path);
+
+    // Determine architecture based on target
+    let arch = match env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_else(|_| "x86_64".to_string()).as_str() {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        other => panic!("Unsupported architecture: {}", other),
+    };
+
+    let nixl_lib_path = format!("{}/lib/{}-linux-gnu", nixl_root_path, arch);
 
     // Tell cargo to look for shared libraries in the specified directories
     println!("cargo:rustc-link-search={}", nixl_lib_path);


### PR DESCRIPTION
support for building NIXL Rust bindings on arm64 architectures. 

CARGO_CFG_TARGET_ARCH is set automatically during cargo builds
https://doc.rust-lang.org/cargo/reference/environment-variables.html

closes: #298 
closes: OPS-62