### PR TITLE
Agent: Improve MD fetch and invalidate flow in ETCD mode using watchers

### DIFF
--- a/examples/cpp/nixl_etcd_example.cpp
+++ b/examples/cpp/nixl_etcd_example.cpp
@@ -317,6 +317,13 @@ int main() {
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
 
+    // 5. Fetch metadata with invalid label. This should not block forever and print error message.
+    std::cout << "\n5. Fetching metadata with invalid label...\n";
+    status = A2.fetchRemoteMD("INVALID_AGENT", &fetch_params);
+    assert(status == NIXL_SUCCESS);
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
     free(addr1);
     free(addr2);
 

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -306,14 +306,14 @@ public:
                 return;
             }
             const auto &event = response.events()[0];
-            if (event.event_type() == etcd::Event::EventType::PUT) {
-                NIXL_ERROR << "Unexpected PUT: " << event.kv().key()
-                           << " (rev " << event.kv().modified_index() << ") = " << event.kv().as_string();
-
-            } else if (event.event_type() == etcd::Event::EventType::DELETE_) {
-                NIXL_DEBUG << "DELETE: " << event.kv().key() << " (rev " << event.kv().modified_index() << ")";
+            if (event.event_type() == etcd::Event::EventType::DELETE_) {
+                NIXL_DEBUG << "Watcher DELETE: " << event.kv().key()
+                           << " (rev " << event.kv().modified_index() << ")";
                 std::lock_guard<std::mutex> lock(invalidated_agents_mutex);
                 invalidated_agents.push_back(agent_name);
+            } else {
+                NIXL_ERROR << "Watcher for " << event.kv().key() << " received unexpected event from etcd: "
+                           << event.event_type();
             }
         };
 

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -214,7 +214,8 @@ public:
 
             if (response.is_ok()) {
                 metadata = response.value().as_string();
-                NIXL_DEBUG << "Successfully fetched key: " << metadata_key << " (rev " << response.value().modified_index() << ")";
+                NIXL_DEBUG << "Successfully fetched key: " << metadata_key
+                           << " (rev " << response.value().modified_index() << ")";
                 return NIXL_SUCCESS;
             } else {
                 NIXL_ERROR << "Failed to fetch key: " << metadata_key << " from etcd: " << response.error_message();
@@ -294,7 +295,8 @@ public:
         // DELETE events are enqueued to be deleted in commWorker (can't be done inside the Watcher callback)
         auto process_response = [this, agent_name](etcd::Response response) -> void {
             if (!response.is_ok()) {
-                NIXL_ERROR << "Watcher failed to watch agent " << agent_name << " from etcd: " << response.error_message();
+                NIXL_ERROR << "Watcher failed to watch agent " << agent_name
+                           << " from etcd: " << response.error_message();
                 return;
             }
             NIXL_DEBUG << "Watcher received " << response.events().size() << " events from etcd";
@@ -484,8 +486,9 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
                     if (ret != NIXL_SUCCESS) {
                         NIXL_ERROR << "Failed to load remote metadata: " << ret;
                         break;
-                    }else if (remote_agent_from_md != remote_agent) {
-                        NIXL_ERROR << "Metadata mismatch for agent: " << remote_agent << " from md: " << remote_agent_from_md;
+                    } else if (remote_agent_from_md != remote_agent) {
+                        NIXL_ERROR << "Metadata mismatch for agent: " << remote_agent
+                                   << " from md: " << remote_agent_from_md;
                         break;
                     }
                     NIXL_DEBUG << "Successfully loaded metadata for agent: " << remote_agent;

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -277,9 +277,6 @@ public:
         nixl_status_t ret = fetchMetadataFromEtcd(remote_agent, metadata_label, remote_metadata);
         if (ret == NIXL_SUCCESS) {
             return NIXL_SUCCESS;
-        } else if (ret == NIXL_ERR_INVALID_PARAM) {
-            NIXL_ERROR << "Metadata was invalidated for agent: " << remote_agent;
-            return NIXL_ERR_INVALID_PARAM;
         }
 
         std::string metadata_key = makeKey(remote_agent, metadata_label);

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -356,7 +356,7 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
         // first, accept new connections
         int new_fd = 0;
 
-        while(new_fd != -1 && config.useListenThread && !useEtcd) {
+        while(new_fd != -1 && config.useListenThread) {
             new_fd = listener->acceptClient();
             nixl_socket_peer_t accepted_client;
 

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -99,137 +99,224 @@ ssize_t recvCommMessage(int fd, std::string &msg){
 }
 
 #if HAVE_ETCD
-// Helper function to create etcd key
-static std::string makeEtcdKey(const std::string& agent_name,
-                                const std::string& namespace_prefix,
-                                const std::string& metadata_type) {
-    std::stringstream ss;
-    ss << namespace_prefix << "/" << agent_name << "/" << metadata_type;
-    return ss.str();
-}
+class nixlEtcdClient {
+private:
+    std::unique_ptr<etcd::Client> etcd;
+    std::string namespace_prefix;
 
-// Store metadata in etcd
-static nixl_status_t storeMetadataInEtcd(const std::string& agent_name,
-                                   const std::string& namespace_prefix,
-                                   std::unique_ptr<etcd::Client>& client,
-                                   const std::string& metadata_type,
-                                   const nixl_blob_t& metadata) {
-    // Check if etcd client is available
-    if (!client) {
-        NIXL_ERROR << "ETCD client not available";
-        return NIXL_ERR_NOT_SUPPORTED;
+    // Helper function to create etcd key
+    std::string makeKey(const std::string& agent_name,
+                        const std::string& metadata_type) {
+        std::stringstream ss;
+        ss << namespace_prefix << "/" << agent_name << "/" << metadata_type;
+        return ss.str();
     }
 
-    try {
-        // Create key for metadata
-        std::string metadata_key = makeEtcdKey(agent_name, namespace_prefix, metadata_type);
-
-        // Store metadata in etcd
-        etcd::Response response = client->put(metadata_key, metadata).get();
-
-        if (response.is_ok()) {
-            NIXL_DEBUG << "Successfully stored " << metadata_type << " in etcd with key: " << metadata_key << " (rev " << response.value().modified_index() << ")";
-            return NIXL_SUCCESS;
-        } else {
-            NIXL_ERROR << "Failed to store " << metadata_type << " in etcd: " << response.error_message();
-            return NIXL_ERR_BACKEND;
-        }
-    } catch (const std::exception& e) {
-        NIXL_ERROR << "Error sending " << metadata_type << " to etcd: " << e.what();
-        return NIXL_ERR_BACKEND;
-    }
-}
-
-// Remove all agent's metadata from etcd
-static nixl_status_t removeMetadataFromEtcd(const std::string& agent_name,
-                                            const std::string& namespace_prefix,
-                                            std::unique_ptr<etcd::Client>& client) {
-    // Check if etcd client is available
-    if (!client) {
-        NIXL_ERROR << "ETCD client not available";
-        return NIXL_ERR_NOT_SUPPORTED;
-    }
-
-    try {
-        // Create key for metadata with agent's prefix
-        std::string agent_prefix = makeEtcdKey(agent_name, namespace_prefix, "");
-
-        // Remove all keys for the agent from etcd
-        etcd::Response response = client->rmdir(agent_prefix, true).get();
-
-        if (response.is_ok()) {
-            NIXL_DEBUG << "Successfully removed " << response.values().size()
-                       << " etcd keys for agent: " << agent_name;
-            return NIXL_SUCCESS;
-        } else {
-            NIXL_ERROR << "Warning: Failed to remove etcd keys for agent: "
-                       << agent_name << " : " << response.error_message();
-            return NIXL_ERR_BACKEND;
-        }
-    } catch (const std::exception& e) {
-        NIXL_ERROR << "Exception removing etcd keys for agent: " << agent_name << " : " << e.what();
-        return NIXL_ERR_BACKEND;
-    }
-}
-
-// Fetch metadata from etcd
-static nixl_status_t fetchMetadataFromEtcd(const std::string& agent_name,
-                                     const std::string& namespace_prefix,
-                                     std::unique_ptr<etcd::Client>& client,
-                                     const std::string& metadata_type,
-                                     nixl_blob_t& metadata) {
-    // Check if etcd client is available
-    if (!client) {
-        NIXL_ERROR << "ETCD client not available";
-        return NIXL_ERR_NOT_SUPPORTED;
-    }
-
-    // Create key for agent's metadata
-    std::string metadata_key = makeEtcdKey(agent_name, namespace_prefix, metadata_type);
-    try {
-        // First check if the key is marked as invalid
-        std::string invalid_key = makeEtcdKey(agent_name, namespace_prefix, invalid_label);
-        etcd::Response invalid_check = client->get(invalid_key).get();
-
-        if (invalid_check.is_ok()) {
-            // Key is marked as invalid, delete both keys
-            NIXL_INFO << "Agent " << agent_name << " is marked as invalid, removing all keys";
-            removeMetadataFromEtcd(agent_name, namespace_prefix, client);
-            return NIXL_ERR_INVALID_PARAM;
-        }
-
-        // Fetch metadata from etcd
-        etcd::Response response = client->get(metadata_key).get();
-
-        if (response.is_ok()) {
-            metadata = response.value().as_string();
-            NIXL_DEBUG << "Successfully fetched key: " << metadata_key << " (rev " << response.value().modified_index() << ")";
-            return NIXL_SUCCESS;
-        } else {
-            NIXL_ERROR << "Failed to fetch key: " << metadata_key << " from etcd: " << response.error_message();
-            return NIXL_ERR_NOT_FOUND;
-        }
-    } catch (const std::exception& e) {
-        NIXL_ERROR << "Error fetching key: " << metadata_key << " from etcd: " << e.what();
-        return NIXL_ERR_UNKNOWN;
-    }
-}
-
-// Create etcd client with specified endpoints or from environment variable
-static std::unique_ptr<etcd::Client> createEtcdClient(std::string etcd_endpoints) {
-    try {
+public:
+    nixlEtcdClient() {
+        const char* etcd_endpoints = std::getenv("NIXL_ETCD_ENDPOINTS");
         // Sanity check
-        if (etcd_endpoints.size() == 0) {
+        if (!etcd_endpoints || strlen(etcd_endpoints) == 0) {
             throw std::runtime_error("No etcd endpoints provided");
         }
 
-        // Create and return new etcd client
-        return std::make_unique<etcd::Client>(etcd_endpoints);
-    } catch (const std::exception& e) {
-        NIXL_ERROR << "Error creating etcd client: " << e.what();
-        return nullptr;
+        try {
+            // Create and return new etcd client
+            etcd = std::make_unique<etcd::Client>(etcd_endpoints);
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Error creating etcd client: " << e.what();
+            return;
+        }
+        NIXL_DEBUG << "Created etcd client to endpoints: " << etcd_endpoints;
+
+        const char* etcd_namespace = std::getenv("NIXL_ETCD_NAMESPACE");
+        namespace_prefix = etcd_namespace ? etcd_namespace : NIXL_ETCD_NAMESPACE_DEFAULT;
+
+        NIXL_DEBUG << "Using etcd namespace for agents: " << namespace_prefix;
     }
-}
+
+    // Store metadata in etcd
+    nixl_status_t storeMetadataInEtcd(const std::string& agent_name,
+                                      const std::string& metadata_type,
+                                      const nixl_blob_t& metadata) {
+        // Check if etcd client is available
+        if (!etcd) {
+            NIXL_ERROR << "ETCD client not available";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        try {
+            // Create key for metadata
+            std::string metadata_key = makeKey(agent_name, metadata_type);
+
+            // Store metadata in etcd
+            etcd::Response response = etcd->put(metadata_key, metadata).get();
+
+            if (response.is_ok()) {
+                NIXL_DEBUG << "Successfully stored " << metadata_type << " in etcd with key: " << metadata_key
+                           << " (rev " << response.value().modified_index() << ")";
+                return NIXL_SUCCESS;
+            } else {
+                NIXL_ERROR << "Failed to store " << metadata_type << " in etcd: " << response.error_message();
+                return NIXL_ERR_BACKEND;
+            }
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Error sending " << metadata_type << " to etcd: " << e.what();
+            return NIXL_ERR_BACKEND;
+        }
+    }
+
+    // Remove all agent's metadata from etcd
+    nixl_status_t removeMetadataFromEtcd(const std::string& agent_name) {
+        // Check if etcd client is available
+        if (!etcd) {
+            NIXL_ERROR << "ETCD client not available";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        try {
+            // Create key for metadata with agent's prefix
+            std::string agent_prefix = makeKey(agent_name, "");
+
+            // Remove all keys for the agent from etcd
+            etcd::Response response = etcd->rmdir(agent_prefix, true).get();
+
+            if (response.is_ok()) {
+                NIXL_DEBUG << "Successfully removed " << response.values().size()
+                           << " etcd keys for agent: " << agent_name;
+                return NIXL_SUCCESS;
+            } else {
+                NIXL_ERROR << "Warning: Failed to remove etcd keys for agent: "
+                           << agent_name << " : " << response.error_message();
+                return NIXL_ERR_BACKEND;
+            }
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Exception removing etcd keys for agent: " << agent_name << " : " << e.what();
+            return NIXL_ERR_BACKEND;
+        }
+    }
+
+    // Fetch metadata from etcd
+    nixl_status_t fetchMetadataFromEtcd(const std::string& agent_name,
+                                        const std::string& metadata_type,
+                                        nixl_blob_t& metadata) {
+        // Check if etcd client is available
+        if (!etcd) {
+            NIXL_ERROR << "ETCD client not available";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        // Create key for agent's metadata
+        std::string metadata_key = makeKey(agent_name, metadata_type);
+        try {
+            // First check if the key is marked as invalid
+            std::string invalid_key = makeKey(agent_name, invalid_label);
+            etcd::Response invalid_check = etcd->get(invalid_key).get();
+
+            if (invalid_check.is_ok()) {
+                // Key is marked as invalid, delete both keys
+                NIXL_INFO << "Agent " << agent_name << " is marked as invalid, removing all keys";
+                removeMetadataFromEtcd(agent_name);
+                return NIXL_ERR_INVALID_PARAM;
+            }
+
+            // Fetch metadata from etcd
+            etcd::Response response = etcd->get(metadata_key).get();
+
+            if (response.is_ok()) {
+                metadata = response.value().as_string();
+                NIXL_DEBUG << "Successfully fetched key: " << metadata_key << " (rev " << response.value().modified_index() << ")";
+                return NIXL_SUCCESS;
+            } else {
+                NIXL_ERROR << "Failed to fetch key: " << metadata_key << " from etcd: " << response.error_message();
+                return NIXL_ERR_NOT_FOUND;
+            }
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Error fetching key: " << metadata_key << " from etcd: " << e.what();
+            return NIXL_ERR_UNKNOWN;
+        }
+    }
+
+    // Fetch metadata from etcd or wait for it to be available
+    nixl_status_t fetchOrWaitForMetadataFromEtcd(const std::string& remote_agent,
+                                                 const std::string& metadata_label,
+                                                 nixl_blob_t& remote_metadata) {
+        nixl_status_t ret = fetchMetadataFromEtcd(remote_agent, metadata_label, remote_metadata);
+        if (ret == NIXL_SUCCESS) {
+            return NIXL_SUCCESS;
+        } else if (ret == NIXL_ERR_INVALID_PARAM) {
+            NIXL_ERROR << "Metadata was invalidated for agent: " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        // Create key for agent's metadata
+        std::string metadata_key = makeKey(remote_agent, metadata_label);
+        // Key not found, set up a watch
+        NIXL_DEBUG << "Metadata not found, setting up watch for: " << metadata_key;
+
+        try {
+
+            // Get current index to watch from
+            etcd::Response response = etcd->get(metadata_key).get();
+            int64_t watch_index = response.index();
+            // Set up watch
+            etcd::Response watch_response = etcd->watch(metadata_key, watch_index).get();
+
+            if (watch_response.is_ok()) {
+                if (watch_response.action() == "delete") {
+                    NIXL_ERROR << "Watch response: metadata deleted for agent: " << remote_agent;
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                remote_metadata = watch_response.value().as_string();
+                NIXL_DEBUG << "Watch response: metadata fetched for agent: " << remote_agent;
+                return NIXL_SUCCESS;
+            } else {
+                NIXL_ERROR << "Watch failed: " << watch_response.error_message();
+            }
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Error watching etcd: " << e.what();
+        }
+
+        return NIXL_ERR_UNKNOWN;
+    }
+
+    // Mark agent's metadata as invalid in etcd
+    nixl_status_t invalidateMetadataInEtcd(const std::string& agent_name) {
+        // Check if etcd client is available
+        if (!etcd) {
+            NIXL_ERROR << "ETCD client not available";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        try {
+            // Mark agent's metadata as invalid instead of removing it
+            std::string agent_prefix = makeKey(agent_name, "");
+            std::string invalid_key = makeKey(agent_name, invalid_label);
+
+            // Check if the agent has any keys in etcd first. 1 key is enough to confirm.
+            etcd::Response check_response = etcd->keys(agent_prefix, 1).get();
+            if (check_response.is_ok() && check_response.keys().size() > 0) {
+                // Mark the agent's metadata as invalid by creating an invalid marker
+                etcd::Response response1 = etcd->put(invalid_key, "invalid").get();
+                if (response1.is_ok()) {
+                    NIXL_DEBUG << "Successfully marked metadata as invalid for agent: " << agent_name;
+                    return NIXL_SUCCESS;
+                } else {
+                    NIXL_ERROR << "Warning: Failed to mark metadata as invalid for agent: "
+                               << agent_name << " : " << response1.error_message();
+                    return NIXL_ERR_BACKEND;
+                }
+            } else {
+                NIXL_DEBUG << "Agent " << agent_name << " has no keys in etcd, skipping invalidation";
+                return NIXL_SUCCESS;
+            }
+        } catch (const std::exception& e) {
+            NIXL_ERROR << "Error marking metadata as invalid for agent: "
+                       << agent_name << " : " << e.what();
+            return NIXL_ERR_BACKEND;
+        }
+    }
+};
 #endif // HAVE_ETCD
 
 } // unnamed namespace
@@ -237,24 +324,11 @@ static std::unique_ptr<etcd::Client> createEtcdClient(std::string etcd_endpoints
 void nixlAgentData::commWorker(nixlAgent* myAgent){
 
 #if HAVE_ETCD
-        auto etcdclient = std::unique_ptr<etcd::Client>(nullptr);
-        std::string etcd_endpoints;
-        std::string namespace_prefix;
-
-        // useEtcd is set in nixlAgent constructor and is true if NIXL_ETCD_ENDPOINTS is set
-        if(useEtcd) {
-            etcd_endpoints = std::string(std::getenv("NIXL_ETCD_ENDPOINTS"));
-            etcdclient = createEtcdClient(etcd_endpoints);
-
-            NIXL_DEBUG << "Created etcd client to " << etcd_endpoints;
-
-            if (std::getenv("NIXL_ETCD_NAMESPACE")) {
-                namespace_prefix = std::string(std::getenv("NIXL_ETCD_NAMESPACE"));
-            } else {
-                namespace_prefix = NIXL_ETCD_NAMESPACE_DEFAULT;
-            }
-            NIXL_DEBUG << "Using etcd namespace for agents: " << namespace_prefix;
-        }
+    std::unique_ptr<nixlEtcdClient> etcdClient = nullptr;
+    // useEtcd is set in nixlAgent constructor and is true if NIXL_ETCD_ENDPOINTS is set
+    if(useEtcd) {
+        etcdClient = std::make_unique<nixlEtcdClient>();
+    }
 #endif // HAVE_ETCD
 
     while(!(commThreadStop)) {
@@ -361,7 +435,7 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
                     const std::string &metadata_label = req_ip;
 
                     // Use local storeMetadataInEtcd function
-                    nixl_status_t ret = storeMetadataInEtcd(name, namespace_prefix, etcdclient, metadata_label, my_MD);
+                    nixl_status_t ret = etcdClient->storeMetadataInEtcd(name, metadata_label, my_MD);
                     if (ret != NIXL_SUCCESS) {
                         NIXL_ERROR << "Failed to store metadata in etcd: " << ret;
                     }
@@ -378,57 +452,24 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
 
                     // First try a direct get
                     nixl_blob_t remote_metadata;
-                    nixl_status_t ret = fetchMetadataFromEtcd(remote_agent, namespace_prefix, etcdclient, metadata_label, remote_metadata);
-
-                    if (ret == NIXL_SUCCESS) {
-                        // Load the metadata
-                        std::string remote_agent_from_md;
-                        ret = myAgent->loadRemoteMD(remote_metadata, remote_agent_from_md);
-                        if (ret == NIXL_SUCCESS) {
-                            if (remote_agent_from_md != remote_agent) {
-                                NIXL_ERROR << "Metadata mismatch for agent: " << remote_agent << " from md: " << remote_agent_from_md;
-                                break;
-                            }
-                            NIXL_DEBUG << "Successfully loaded metadata for agent: " << remote_agent;
-                        } else {
-                            NIXL_ERROR << "Failed to load remote metadata: " << ret;
-                        }
-                    } else if (ret == NIXL_ERR_INVALID_PARAM) {
-                        NIXL_DEBUG << "Metadata was invalidated for agent: " << remote_agent;
-                    } else {
-                        // Key not found, set up a watch
-                        NIXL_DEBUG << "Metadata not found, setting up watch for agent: " << remote_agent;
-
-                        try {
-                            // Create key for agent's metadata
-                            std::string metadata_key = makeEtcdKey(remote_agent, namespace_prefix, "metadata");
-
-                            // Get current index to watch from
-                            etcd::Response response = etcdclient->get(metadata_key).get();
-                            int64_t watch_index = response.index();
-                            // Set up watch
-                            etcd::Response watch_response = etcdclient->watch(metadata_key, watch_index).get();
-
-                            if (watch_response.is_ok()) {
-                                std::string remote_md = watch_response.value().as_string();
-                                std::string remote_agent_from_md;
-                                ret = myAgent->loadRemoteMD(remote_md, remote_agent_from_md);
-                                if (ret != NIXL_SUCCESS) {
-                                    NIXL_ERROR << "Failed to load remote metadata from watch: " << ret;
-                                    if (remote_agent_from_md != remote_agent) {
-                                        NIXL_ERROR << "Metadata mismatch for agent: " << remote_agent << " from md: " << remote_agent_from_md;
-                                        break;
-                                    }
-                                } else {
-                                    NIXL_DEBUG << "Successfully loaded metadata from watch for agent: " << remote_agent;
-                                }
-                            } else {
-                                NIXL_ERROR << "Watch failed: " << watch_response.error_message();
-                            }
-                        } catch (const std::exception& e) {
-                            NIXL_ERROR << "Error watching etcd: " << e.what();
-                        }
+                    nixl_status_t ret = etcdClient->fetchOrWaitForMetadataFromEtcd(remote_agent, metadata_label,
+                                                                                   remote_metadata);
+                    if (ret != NIXL_SUCCESS) {
+                        NIXL_ERROR << "Failed to fetch metadata from etcd: " << ret;
+                        break;
                     }
+
+                    std::string remote_agent_from_md;
+                    ret = myAgent->loadRemoteMD(remote_metadata, remote_agent_from_md);
+                    if (ret != NIXL_SUCCESS) {
+                        NIXL_ERROR << "Failed to load remote metadata: " << ret;
+                        break;
+                    }else if (remote_agent_from_md != remote_agent) {
+                        NIXL_ERROR << "Metadata mismatch for agent: " << remote_agent << " from md: " << remote_agent_from_md;
+                        break;
+                    }
+                    NIXL_DEBUG << "Successfully loaded metadata for agent: " << remote_agent;
+
                     break;
                 }
                 case ETCD_INVAL:
@@ -437,28 +478,9 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
                         throw std::runtime_error("ETCD is not enabled");
                     }
 
-                    try {
-                        // Mark agent's metadata as invalid instead of removing it
-                        std::string agent_prefix = makeEtcdKey(name, namespace_prefix, "");
-                        std::string invalid_key = makeEtcdKey(name, namespace_prefix, invalid_label);
-
-                        // Check if the agent has any keys in etcd first. 1 key is enough to confirm.
-                        etcd::Response check_response = etcdclient->keys(agent_prefix, 1).get();
-                        if (check_response.is_ok() && check_response.keys().size() > 0) {
-                            // Mark the agent's metadata as invalid by creating an invalid marker
-                            etcd::Response response1 = etcdclient->put(invalid_key, "invalid").get();
-                            if (response1.is_ok()) {
-                                NIXL_DEBUG << "Successfully marked metadata as invalid for agent: " << name;
-                            } else {
-                                NIXL_ERROR << "Warning: Failed to mark metadata as invalid for agent: "
-                                           << name << " : " << response1.error_message();
-                            }
-                        } else {
-                            NIXL_DEBUG << "Agent " << name << " has no keys in etcd, skipping invalidation";
-                        }
-                    } catch (const std::exception& e) {
-                        NIXL_ERROR << "Error marking metadata as invalid for agent: "
-                                   << name << " : " << e.what();
+                    nixl_status_t ret = etcdClient->invalidateMetadataInEtcd(name);
+                    if (ret != NIXL_SUCCESS) {
+                        NIXL_ERROR << "Failed to invalidate metadata in etcd: " << ret;
                     }
                     break;
                 }


### PR DESCRIPTION
* Refactor commWorker to move all ETCD functionality into new class nixlEtcdClient.
* When watching for specific key we try to fetch, avoid trying to loadRemoteMD on deletion events.
* Implement timeout when setting a watcher after trying to fetch a non-existing key.
* Setup watchers on prefix of remote agent after fetching its metadata.
* invalidateLocalMD will remove all keys with agent's prefix, then all remote watchers will be notified and invalidateRemoteMD.
* Relevant tests depend on PR [315](https://github.com/ai-dynamo/nixl/pull/315)