### PR TITLE
Agent: Bug fix: delete agent move semantics due to commWorker

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -51,9 +51,9 @@ class nixlAgent {
          */
         ~nixlAgent ();
 
-        /* Declare move operations (needed because we declared a destructor) */
-        nixlAgent(nixlAgent&&) noexcept;
-        nixlAgent &operator=(nixlAgent&&) noexcept;
+        /* It is unsafe to move nixlAgent object */
+        nixlAgent(nixlAgent&&) noexcept = delete;
+        nixlAgent &operator=(nixlAgent&&) noexcept = delete;
 
         /**
          * @brief  Discover the available supported plugins found in the plugin paths

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -135,10 +135,6 @@ nixlAgent::~nixlAgent() {
     }
 }
 
-// Define move operations in CPP file to avoid exposing nixlAgentData in header
-nixlAgent::nixlAgent(nixlAgent &&other) noexcept = default;
-nixlAgent& nixlAgent::operator=(nixlAgent &&other) noexcept = default;
-
 nixl_status_t
 nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {
     auto& plugin_manager = nixlPluginManager::getInstance();


### PR DESCRIPTION
* commWorker thread holds a pointer to myAgent.
* After move operation this pointer is not valid anymore.
* If we hold this pointer inside AgentData it would still not be safe to update it during agent move since they are different threads.