### PR TITLE
Implement new synchronization read-write locking mode

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -51,6 +51,7 @@ class nixlBackendInitParams {
 
         bool              enableProgTh;
         nixlTime::us_t    pthrDelay;
+        nixl_thread_sync_t syncMode;
 };
 
 // Pure virtual class to have a common pointer type

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -70,6 +70,7 @@ enum nixl_status_t {
 enum class nixl_thread_sync_t {
     NIXL_THREAD_SYNC_NONE,
     NIXL_THREAD_SYNC_STRICT,
+    NIXL_THREAD_SYNC_RW,
     NIXL_THREAD_SYNC_DEFAULT = NIXL_THREAD_SYNC_NONE,
 };
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -213,6 +213,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.customParams = const_cast<nixl_b_params_t*>(&params);
     init_params.enableProgTh = data->config.useProgThread;
     init_params.pthrDelay    = data->config.pthrDelay;
+    init_params.syncMode     = data->config.syncMode;
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -654,7 +654,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     req_hndl = nullptr;
 
-    NIXL_LOCK_GUARD(data->lock);
+    NIXL_SHARED_LOCK_GUARD(data->lock);
     if (data->remoteSections.count(remote_agent) == 0)
     {
         return NIXL_ERR_NOT_FOUND;
@@ -772,7 +772,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
     if (!req_hndl)
         return NIXL_ERR_INVALID_PARAM;
 
-    NIXL_LOCK_GUARD(data->lock);
+    NIXL_SHARED_LOCK_GUARD(data->lock);
     // Check if the remote was invalidated before post/repost
     if (data->remoteSections.count(req_hndl->remoteAgent) == 0) {
         delete req_hndl;
@@ -827,7 +827,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 nixl_status_t
 nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
 
-    NIXL_LOCK_GUARD(data->lock);
+    NIXL_SHARED_LOCK_GUARD(data->lock);
     // If the status is done, no need to recheck.
     if (req_hndl->status == NIXL_IN_PROG) {
         // Check if the remote was invalidated before completion
@@ -854,7 +854,7 @@ nixlAgent::queryXferBackend(const nixlXferReqH* req_hndl,
 nixl_status_t
 nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
-    NIXL_LOCK_GUARD(data->lock);
+    NIXL_SHARED_LOCK_GUARD(data->lock);
     //attempt to cancel request
     if(req_hndl->status == NIXL_IN_PROG) {
         req_hndl->status = req_hndl->engine->checkXfer(
@@ -942,7 +942,7 @@ nixlAgent::genNotif(const std::string &remote_agent,
     nixlBackendEngine* backend = nullptr;
     backend_list_t*    backend_list;
 
-    NIXL_LOCK_GUARD(data->lock);
+    NIXL_SHARED_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
         backend_list = &data->notifEngines;
         if (backend_list->empty())

--- a/src/core/sync.h
+++ b/src/core/sync.h
@@ -18,7 +18,7 @@
 #define SYNC_H
 #include "common/util.h"
 #include "nixl_params.h"
-#include <mutex>
+#include "absl/synchronization/mutex.h"
 
 class nixlLock {
     public:
@@ -27,19 +27,19 @@ class nixlLock {
 
         void lock() {
             if (syncMode == nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT) {
-                m.lock();
+                m.Lock();
             }
         }
 
         void unlock() {
             if (syncMode == nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT) {
-                m.unlock();
+                m.Unlock();
             }
         }
 
     private:
         nixl_thread_sync_t syncMode;
-        std::mutex m;
+        absl::Mutex m;
 };
 
 #define NIXL_LOCK_GUARD(lock) const std::lock_guard<nixlLock> UNIQUE_NAME(lock_guard) (lock)

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -475,8 +475,8 @@ nixlUcxEngine::nixlUcxEngine (const nixlBackendInitParams* init_params)
         numWorkers = 1;
 
     uc = std::make_shared<nixlUcxContext>(devs, sizeof(nixlUcxIntReq),
-                                          _internalRequestInit, _internalRequestFini, NIXL_UCX_MT_WORKER,
-                                          pthrOn);
+                                          _internalRequestInit, _internalRequestFini,
+                                          pthrOn, numWorkers, init_params->syncMode);
     for (unsigned int i = 0; i < numWorkers; i++)
         uws.emplace_back(std::make_unique<nixlUcxWorker>(uc));
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <condition_variable>
 #include <atomic>
+#include <poll.h>
 
 #include "nixl.h"
 #include "backend/backend_engine.h"
@@ -114,10 +115,10 @@ class nixlUcxEngine : public nixlBackendEngine {
         std::mutex pthrActiveLock;
         std::condition_variable pthrActiveCV;
         bool pthrActive;
-        std::atomic_bool pthrStop;
         bool pthrOn;
         std::thread pthr;
-        nixlTime::us_t pthrDelay;
+        int pthrControlPipe[2];
+        std::vector<pollfd> pollFds;
 
         /* CUDA data*/
         std::unique_ptr<nixlUcxCudaCtx> cudaCtx;

--- a/src/utils/common/meson.build
+++ b/src/utils/common/meson.build
@@ -18,6 +18,7 @@ absl_log_dep = abseil_proj.get_variable('absl_log_dep')
 absl_strings_dep = abseil_proj.get_variable('absl_strings_dep')
 absl_status_dep = abseil_proj.get_variable('absl_status_dep')
 absl_strings_dep = abseil_proj.get_variable('absl_strings_dep')
+absl_synchronization_dep = abseil_proj.get_variable('absl_synchronization_dep')
 
 nixl_common_inc = include_directories('.')
 
@@ -26,6 +27,7 @@ nixl_common_deps = [
     absl_strings_dep,
     absl_status_dep,
     absl_strings_dep,
+    absl_synchronization_dep,
 ]
 
 # Define a shared library for common utilities

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -318,32 +318,26 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
                                size_t req_size,
                                nixlUcxContext::req_cb_t init_cb,
                                nixlUcxContext::req_cb_t fini_cb,
-                               nixl_ucx_mt_t __mt_type,
-                               bool prog_thread)
+                               bool prog_thread,
+                               unsigned long num_workers,
+                               nixl_thread_sync_t sync_mode)
 {
     ucp_params_t ucp_params;
     ucp_config_t *ucp_config;
     ucs_status_t status = UCS_OK;
 
-    mt_type = __mt_type;
+    // With strict synchronization model nixlAgent serializes access to backends, with more
+    // permissive models backends need to account for concurrent access and ensure their internal
+    // state is properly protected. Progress thread creates internal concurrency in UCX backend
+    // irrespective of nixlAgent synchronization model.
+    mt_type = (sync_mode >= nixl_thread_sync_t::NIXL_THREAD_SYNC_RW || prog_thread) ?
+        NIXL_UCX_MT_WORKER : NIXL_UCX_MT_SINGLE;
 
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
     ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64 | UCP_FEATURE_AM;
     if (prog_thread)
         ucp_params.features |= UCP_FEATURE_WAKEUP;
-
-    switch(mt_type) {
-    case NIXL_UCX_MT_SINGLE:
-        ucp_params.mt_workers_shared = 0;
-        break;
-    case NIXL_UCX_MT_WORKER:
-    case NIXL_UCX_MT_CTX:
-        ucp_params.mt_workers_shared = 1;
-        break;
-    default:
-        assert(mt_type < NIXL_UCX_MT_MAX);
-        abort();
-    }
+    ucp_params.mt_workers_shared = num_workers > 1 ? 1 : 0;
 
     if (req_size) {
         ucp_params.request_size = req_size;

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -318,7 +318,8 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
                                size_t req_size,
                                nixlUcxContext::req_cb_t init_cb,
                                nixlUcxContext::req_cb_t fini_cb,
-                               nixl_ucx_mt_t __mt_type)
+                               nixl_ucx_mt_t __mt_type,
+                               bool prog_thread)
 {
     ucp_params_t ucp_params;
     ucp_config_t *ucp_config;
@@ -328,6 +329,9 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
 
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
     ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64 | UCP_FEATURE_AM;
+    if (prog_thread)
+        ucp_params.features |= UCP_FEATURE_WAKEUP;
+
     switch(mt_type) {
     case NIXL_UCX_MT_SINGLE:
         ucp_params.mt_workers_shared = 0;

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -131,7 +131,8 @@ public:
     using req_cb_t = void(void *request);
     nixlUcxContext(std::vector<std::string> devices,
                    size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
-                   nixl_ucx_mt_t mt_type, bool prog_thread);
+                   bool prog_thread, unsigned long num_workers,
+                   nixl_thread_sync_t sync_mode);
     ~nixlUcxContext();
 
     static bool mtLevelIsSupproted(nixl_ucx_mt_t mt_type);

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -131,7 +131,7 @@ public:
     using req_cb_t = void(void *request);
     nixlUcxContext(std::vector<std::string> devices,
                    size_t req_size, req_cb_t init_cb, req_cb_t fini_cb,
-                   nixl_ucx_mt_t mt_type);
+                   nixl_ucx_mt_t mt_type, bool prog_thread);
     ~nixlUcxContext();
 
     static bool mtLevelIsSupproted(nixl_ucx_mt_t mt_type);
@@ -169,6 +169,9 @@ public:
 
     void reqRelease(nixlUcxReq req);
     void reqCancel(nixlUcxReq req);
+
+    /* Worker access */
+    ucp_worker_h getWorker() const { return worker; }
 };
 
 #endif

--- a/test/gtest/mocks/mock_dram_engine.h
+++ b/test/gtest/mocks/mock_dram_engine.h
@@ -74,6 +74,7 @@ public:
   }
   nixl_status_t getConnInfo(std::string &str) const override {
     assert(sharedState > 0);
+    str = "MockDramBackendEngineConnInfo";
     return NIXL_SUCCESS;
   }
   nixl_status_t loadRemoteConnInfo(const std::string &remote_agent,

--- a/test/gtest/multi_threading.cpp
+++ b/test/gtest/multi_threading.cpp
@@ -28,10 +28,12 @@ protected:
     uintptr_t addr = 0;
     size_t len = 1024;
     uint64_t dev_id = 0;
+    std::string local_agent_name = "test_agent";
+    std::string remote_agent_name = "remote_agent";
 
-    nixlAgent createAgent() {
+    nixlAgent createAgent(const std::string &name) {
         nixlAgentConfig cfg(false, false, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
-        return nixlAgent("test_agent", cfg);
+        return nixlAgent(name, cfg);
     }
 
     nixl_opt_args_t createExtraParams(nixlBackendH* backend) {
@@ -84,7 +86,7 @@ protected:
 
 TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadAgent) {
     auto transfer_sequence = [&]() {
-        nixlAgent agent = createAgent();
+        nixlAgent agent = createAgent(local_agent_name);
         nixlBackendH* backend = verifyMockDramBackendCreation(agent);
         nixl_opt_args_t extra_params = createExtraParams(backend);
 
@@ -101,7 +103,7 @@ TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadAgent) {
 
 TEST_F(MultiThreadingTestFixture, ConcurrentAddPlugingDirWithPerThreadAgent) {
     auto transfer_sequence = [&]() {
-        nixlAgent agent = createAgent();
+        nixlAgent agent = createAgent(local_agent_name);
         nixlBackendH* backend = verifyMockDramBackendCreation(agent);
         nixl_opt_args_t extra_params = createExtraParams(backend);
 
@@ -122,7 +124,7 @@ TEST_F(MultiThreadingTestFixture, ConcurrentAddPlugingDirWithPerThreadAgent) {
 }
 
 TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadMemory) {
-    nixlAgent agent = createAgent();
+    nixlAgent agent = createAgent(local_agent_name);
     nixlBackendH* backend = verifyMockDramBackendCreation(agent);
     nixl_opt_args_t extra_params = createExtraParams(backend);
 
@@ -139,7 +141,7 @@ TEST_F(MultiThreadingTestFixture, ConcurrentTransfersWithPerThreadMemory) {
 }
 
 TEST_F(MultiThreadingTestFixture, ConcurrentTransfers) {
-    nixlAgent agent = createAgent();
+    nixlAgent agent = createAgent(local_agent_name);
     nixlBackendH* backend = verifyMockDramBackendCreation(agent);
     nixl_opt_args_t extra_params = createExtraParams(backend);
 
@@ -156,8 +158,35 @@ TEST_F(MultiThreadingTestFixture, ConcurrentTransfers) {
     t2.join();
 }
 
+TEST_F(MultiThreadingTestFixture, GenerateNotification) {
+    nixlAgent local_agent = createAgent(local_agent_name);
+    nixlBackendH* backend = verifyMockDramBackendCreation(local_agent);
+    nixlAgent remote_agent = createAgent(remote_agent_name);
+    verifyMockDramBackendCreation(remote_agent);
+    nixl_opt_args_t extra_params = createExtraParams(backend);
+
+    verifyMemoryRegistration(local_agent, extra_params);
+
+    std::string md;
+    nixl_status_t status = remote_agent.getLocalMD(md);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    status = local_agent.loadRemoteMD(md, remote_agent_name);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    auto transfer_sequence = [&]() {
+        nixl_status_t status = local_agent.genNotif(remote_agent_name, "hello!");
+        EXPECT_EQ(status, NIXL_SUCCESS);
+    };
+
+    std::thread t1(transfer_sequence);
+    std::thread t2(transfer_sequence);
+
+    t1.join();
+    t2.join();
+}
+
 TEST_F(MultiThreadingTestFixture, RegisterMemWithMockDram) {
-    nixlAgent agent = createAgent();
+    nixlAgent agent = createAgent(local_agent_name);
     nixlBackendH* backend = verifyMockDramBackendCreation(agent);
     nixl_opt_args_t extra_params = createExtraParams(backend);
 

--- a/test/gtest/multi_threading.cpp
+++ b/test/gtest/multi_threading.cpp
@@ -30,7 +30,7 @@ protected:
     uint64_t dev_id = 0;
 
     nixlAgent createAgent() {
-        nixlAgentConfig cfg(false, false, 0, 0, 100000, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+        nixlAgentConfig cfg(false, false, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
         return nixlAgent("test_agent", cfg);
     }
 

--- a/test/gtest/multi_threading.cpp
+++ b/test/gtest/multi_threading.cpp
@@ -32,7 +32,7 @@ protected:
     std::string remote_agent_name = "remote_agent";
 
     nixlAgent createAgent(const std::string &name) {
-        nixlAgentConfig cfg(false, false, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+        nixlAgentConfig cfg(false, false, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_RW);
         return nixlAgent(name, cfg);
     }
 

--- a/test/nixl/nixl_test.cpp
+++ b/test/nixl/nixl_test.cpp
@@ -204,7 +204,7 @@ static void initiatorThread(nixlAgent &agent, nixl_opt_args_t *extra_params,
 }
 
 static void runTarget(const std::string &ip, int port) {
-    nixlAgentConfig cfg(true, true, port, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+    nixlAgentConfig cfg(true, true, port, nixl_thread_sync_t::NIXL_THREAD_SYNC_RW);
 
     std::cout << "Starting Agent for target\n";
     nixlAgent agent(target, cfg);
@@ -227,7 +227,7 @@ static void runTarget(const std::string &ip, int port) {
 }
 
 static void runInitiator(const std::string &target_ip, int target_port) {
-    nixlAgentConfig cfg(true, true, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+    nixlAgentConfig cfg(true, true, 0, nixl_thread_sync_t::NIXL_THREAD_SYNC_RW);
 
     std::cout << "Starting Agent for initiator\n";
     nixlAgent agent(initiator, cfg);

--- a/test/unit/utils/ucx/ucx_am_test.cpp
+++ b/test/unit/utils/ucx/ucx_am_test.cpp
@@ -88,8 +88,8 @@ int main()
     devs.push_back("mlx5_0");
 
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE),
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE)
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false),
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false)
     };
 
     nixlUcxWorker w[2] = {

--- a/test/unit/utils/ucx/ucx_am_test.cpp
+++ b/test/unit/utils/ucx/ucx_am_test.cpp
@@ -88,8 +88,10 @@ int main()
     devs.push_back("mlx5_0");
 
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false),
-        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, NIXL_UCX_MT_SINGLE, false)
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, false, 1,
+                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE),
+        std::make_shared<nixlUcxContext>(devs, 0, nullptr, nullptr, false, 1,
+                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE)
     };
 
     nixlUcxWorker w[2] = {

--- a/test/unit/utils/ucx/ucx_worker_test.cpp
+++ b/test/unit/utils/ucx/ucx_worker_test.cpp
@@ -86,8 +86,8 @@ int main()
     // in CI it would be goot to test both SHM and IB
     //devs.push_back("mlx5_0");
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE),
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE)
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false),
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false)
     };
 
     nixlUcxWorker w[2] = {

--- a/test/unit/utils/ucx/ucx_worker_test.cpp
+++ b/test/unit/utils/ucx/ucx_worker_test.cpp
@@ -86,8 +86,10 @@ int main()
     // in CI it would be goot to test both SHM and IB
     //devs.push_back("mlx5_0");
     std::shared_ptr<nixlUcxContext> c[2] = {
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false),
-        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, NIXL_UCX_MT_SINGLE, false)
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, false, 1,
+                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE),
+        std::make_shared<nixlUcxContext>(devs, sizeof(requestData), nixlUcxRequestInit, nullptr, false, 1,
+                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE)
     };
 
     nixlUcxWorker w[2] = {


### PR DESCRIPTION
First, preparatory commits implementing new test and extending POSIX file backend with locking.

Then, the new sync mode implementation that changes existing NIXL agent mutex from std to Abseil implementation which supports both regular exclusive locking and read-write modes. Add new 'RW' sync mode and take the lock in the read mode in a subset of NIXL data-path APIs (reateXferReq, postXferReq, getXferStatus, releaseXferReq, genNotif).

On top of that perform small UCX Context class refactoring to initialize UCX context and workers with the most appropriate setting according to the configuration requested by the user (sync mode, progress thread on/off, number of workers).