### PR TITLE
Agent: Bug fix: apply timeout to socket connection and add gtests for md exchange

### DIFF
--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -522,7 +522,10 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
                     std::string remote_agent;
                     ret = myAgent->loadRemoteMD(remote_md, remote_agent);
                     if(ret != NIXL_SUCCESS) {
-                        throw std::runtime_error("loadRemoteMD in listener thread failed, critically failing\n");
+                        NIXL_ERROR << "loadRemoteMD in listener thread failed for md from peer "
+                                   << socket_iter->first.first << ":" << socket_iter->first.second
+                                   << " with error " << ret;
+                        continue;
                     }
                     // not sure what to do with remote_agent
                 } else if(header == "SEND") {
@@ -535,7 +538,8 @@ void nixlAgentData::commWorker(nixlAgent* myAgent){
                     myAgent->invalidateRemoteMD(remote_agent);
                     break;
                 } else {
-                    throw std::runtime_error("Received socket message with bad header" + header + ", critically failing\n");
+                    NIXL_ERROR << "Received socket message with bad header" + header + " from peer "
+                               << socket_iter->first.first << ":" << socket_iter->first.second;
                 }
             }
 

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -42,7 +42,7 @@ endif
 cpp_flags += '-DBUILD_DIR="' + meson.project_build_root() + '"'
 
 test_exe = executable('gtest',
-    sources : ['main.cpp', 'plugin_manager.cpp', 'error_handling.cpp', 'test_transfer.cpp'],
+    sources : ['main.cpp', 'plugin_manager.cpp', 'error_handling.cpp', 'test_transfer.cpp', 'metadata_exchange.cpp'],
     include_directories: [nixl_inc_dirs, utils_inc_dirs],
     cpp_args : cpp_flags,
     dependencies : [nixl_dep, cuda_dep, gtest_dep, absl_strings_dep, absl_time_dep],

--- a/test/gtest/metadata_exchange.cpp
+++ b/test/gtest/metadata_exchange.cpp
@@ -1,0 +1,299 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "nixl.h"
+#include "common.h"
+
+namespace gtest {
+namespace metadata_exchange {
+
+class MemBuffer {
+public:
+    MemBuffer(size_t size) :
+        vec_(size)
+    {
+    }
+
+    operator uintptr_t() const
+    {
+        return reinterpret_cast<uintptr_t>(vec_.data());
+    }
+
+    nixlBasicDesc getBasicDesc() const
+    {
+        return nixlBasicDesc(static_cast<uintptr_t>(*this), vec_.size(), dev_id_);
+    }
+
+    nixlBlobDesc getBlobDesc() const
+    {
+        return nixlBlobDesc(getBasicDesc(), "");
+    }
+
+    size_t getSize() const
+    {
+        return vec_.size();
+    }
+
+private:
+    std::vector<std::byte> vec_;
+    constexpr static uint64_t dev_id_ = 0;
+};
+
+class MetadataExchangeTestFixture : public testing::Test {
+
+    struct AgentContext {
+        std::unique_ptr<nixlAgent> agent;
+        const std::string name;
+        const int port;
+        nixlBackendH *backend_handle = nullptr;
+        std::vector<MemBuffer> buffers;
+
+        AgentContext(std::unique_ptr<nixlAgent> agent, std::string name, int port) :
+            agent(std::move(agent)), name(std::move(name)), port(port)
+        {
+        }
+
+        void createAgentBackend()
+        {
+            ASSERT_EQ(agent->createBackend("UCX", {}, backend_handle), NIXL_SUCCESS);
+            ASSERT_NE(backend_handle, nullptr);
+        }
+
+        void initAndRegisterBuffers(size_t count, size_t size)
+        {
+            for (size_t i = 0; i < count; i++) {
+                buffers.emplace_back(size);
+            }
+
+            nixl_reg_dlist_t dlist(DRAM_SEG);
+            for (const auto &buffer : buffers) {
+                dlist.addDesc(buffer.getBlobDesc());
+            }
+
+            ASSERT_EQ(agent->registerMem(dlist), NIXL_SUCCESS);
+        }
+    };
+
+protected:
+
+    void SetUp() override
+    {
+        // Get random port between 10000 and 65535
+        int port_base = 10000 + (std::rand() % (65535 - 10000 + 1));
+
+        // Create two agents
+        for (int i = 0; i < 2; i++) {
+            int port = port_base + i;
+            std::string name = "agent_" + std::to_string(i);
+            nixlAgentConfig cfg(false, true, port, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+
+            auto agent = std::make_unique<nixlAgent>(name, cfg);
+
+            agents_.emplace_back(std::move(agent), std::move(name), port);
+        }
+    }
+
+    void TearDown() override
+    {
+        agents_.clear();
+    }
+
+    std::vector<AgentContext> agents_;
+};
+
+TEST_F(MetadataExchangeTestFixture, GetLocalAndLoadRemote)
+{
+    for (size_t i = 0; i < agents_.size(); i++)
+        agents_[i].createAgentBackend();
+
+    size_t count = (std::rand() % 10) + 2;
+    size_t size = (std::rand() % 1024) + 1;
+    for (size_t i = 0; i < agents_.size(); i++)
+        agents_[i].initAndRegisterBuffers(count, size);
+
+    nixl_xfer_dlist_t dlist(DRAM_SEG);
+    for (const auto &buffer : agents_[1].buffers) {
+        dlist.addDesc(buffer.getBasicDesc());
+    }
+
+    std::string remote_name;
+    nixl_blob_t md;
+
+    auto &src = agents_[1];
+    auto &dst = agents_[0];
+
+    ASSERT_EQ(src.agent->getLocalMD(md), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+    ASSERT_EQ(remote_name, src.name);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, dlist), NIXL_SUCCESS);
+
+    // Invalidate
+    ASSERT_EQ(dst.agent->invalidateRemoteMD(src.name), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, dlist), NIXL_ERR_NOT_FOUND);
+
+    // Remote does not exist so cannot invalidate
+    ASSERT_NE(dst.agent->invalidateRemoteMD(src.name), NIXL_SUCCESS);
+}
+
+TEST_F(MetadataExchangeTestFixture, LoadRemoteWithErrors)
+{
+    auto &src = agents_[0];
+    auto &dst = agents_[1];
+
+    src.createAgentBackend();
+    src.initAndRegisterBuffers(3, 1024);
+
+    std::string remote_name;
+    nixl_blob_t md;
+
+    ASSERT_EQ(src.agent->getLocalMD(md), NIXL_SUCCESS);
+
+    // No backend on dst agent
+    ASSERT_NE(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+
+    ASSERT_NE(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
+
+    dst.createAgentBackend();
+
+    // Invalid metadata
+    ASSERT_NE(dst.agent->loadRemoteMD("invalid", remote_name), NIXL_SUCCESS);
+
+    // Remote does not exist so cannot invalidate
+    ASSERT_NE(dst.agent->invalidateRemoteMD(src.name), NIXL_SUCCESS);
+}
+
+TEST_F(MetadataExchangeTestFixture, GetLocalPartialAndLoadRemote)
+{
+    for (size_t i = 0; i < agents_.size(); i++)
+        agents_[i].createAgentBackend();
+
+    size_t count = (std::rand() % 10) + 2;
+    size_t size = (std::rand() % 1024) + 1;
+    for (size_t i = 0; i < agents_.size(); i++)
+        agents_[i].initAndRegisterBuffers(count, size);
+
+    auto &src = agents_[0];
+    auto &dst = agents_[1];
+
+    std::string remote_name;
+    nixl_blob_t md;
+
+    // Step 1: Get and load connection info
+
+    ASSERT_EQ(src.agent->getLocalPartialMD({DRAM_SEG}, md, nullptr), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+    ASSERT_EQ(remote_name, src.name);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
+
+    // Step 2: Get partial metadata for agent 0 buffers except the last one
+
+    nixl_reg_dlist_t valid_descs(DRAM_SEG);
+    for (size_t i = 0; i < src.buffers.size() - 1; i++) {
+        valid_descs.addDesc(src.buffers[i].getBlobDesc());
+    }
+    nixl_reg_dlist_t invalid_descs(DRAM_SEG);
+    invalid_descs.addDesc(src.buffers.back().getBlobDesc());
+
+    ASSERT_EQ(src.agent->getLocalPartialMD(valid_descs, md, nullptr), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+    ASSERT_EQ(remote_name, src.name);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, valid_descs.trim()), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, invalid_descs.trim()), NIXL_ERR_NOT_FOUND);
+
+    ASSERT_EQ(dst.agent->invalidateRemoteMD(src.name), NIXL_SUCCESS);
+
+    // Step 3: Get and load again but with extra params
+
+    nixl_opt_args_t extra_params;
+    extra_params.backends.push_back(src.backend_handle);
+    extra_params.includeConnInfo = true;
+
+    ASSERT_EQ(src.agent->getLocalPartialMD(valid_descs, md, &extra_params), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+    ASSERT_EQ(remote_name, src.name);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, valid_descs.trim()), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, invalid_descs.trim()), NIXL_ERR_NOT_FOUND);
+}
+
+TEST_F(MetadataExchangeTestFixture, GetLocalPartialWithErrors)
+{
+    auto &src = agents_[0];
+    auto &dst = agents_[1];
+
+    src.createAgentBackend();
+
+    size_t count = (std::rand() % 10) + 1;
+    size_t size = (std::rand() % 1024) + 1;
+    src.initAndRegisterBuffers(count, size);
+
+    std::string remote_name;
+    nixl_blob_t md;
+
+    // Case 1: Use unregistered descriptors
+    MemBuffer unregistered_buffer(1024);
+    nixl_reg_dlist_t unregistered_descs(DRAM_SEG);
+    unregistered_descs.addDesc(unregistered_buffer.getBlobDesc());
+
+    ASSERT_NE(src.agent->getLocalPartialMD(unregistered_descs, md, nullptr), NIXL_SUCCESS);
+
+    // Case 2: Attempt to load connection info on agent without backend
+
+    ASSERT_EQ(src.agent->getLocalPartialMD({DRAM_SEG}, md, nullptr), NIXL_SUCCESS);
+
+    // Agent 1 has no backend
+    ASSERT_NE(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+
+    // Case 3: Attempt to load metadata without connection info
+
+    dst.createAgentBackend();
+
+    nixl_reg_dlist_t valid_descs(DRAM_SEG);
+    for (const auto& buffer : src.buffers) {
+        valid_descs.addDesc(buffer.getBlobDesc());
+    }
+
+    ASSERT_EQ(src.agent->getLocalPartialMD(valid_descs, md, nullptr), NIXL_SUCCESS);
+
+    // Agent 1 has no connection info of agent 0
+    ASSERT_NE(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+
+    // Case 4: Attempt to reload connection info with changed metadata
+
+    md.clear();
+    ASSERT_EQ(src.agent->getLocalPartialMD({DRAM_SEG}, md, nullptr), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+    ASSERT_EQ(remote_name, src.name);
+
+    // Change the metadata before loading
+    md[100] += 1;
+    ASSERT_NE(dst.agent->loadRemoteMD(md, remote_name), NIXL_SUCCESS);
+}
+
+} // namespace metadata_exchange
+} // namespace gtest


### PR DESCRIPTION
* Before, if the remote does not exist or is never ready, the commWorker
   blocks forever.
* This commit allows to try connection for 1 second and fail after
   timeout.
* Also avoid throwing exception on failures during handling of remote
   messages.
* New gtest fixture for metadata exchange tests using get/load and
   send/fetch with sockets. ETCD mode in a separate PR.