### PR TITLE
UCX: Set a CUDA context when loading remote MD from listener thread

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -55,8 +55,6 @@ public:
 class nixlUcxCudaDevicePrimaryCtx {
 #ifndef HAVE_CUDA
 public:
-
-    nixlUcxCudaDevicePrimaryCtx(int ordinal) {}
     bool push() { return false; }
     void pop() {};
 #else

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -55,21 +55,21 @@ public:
 class nixlUcxCudaDevicePrimaryCtx {
 #ifndef HAVE_CUDA
 public:
+
     nixlUcxCudaDevicePrimaryCtx(int ordinal) {}
     bool push() { return false; }
     void pop() {};
 #else
-    int m_ordinal;
-    CUdevice m_device;
-    CUcontext m_context;
+    static constexpr int defaultCudaDeviceOrdinal = 0;
+    int m_ordinal{defaultCudaDeviceOrdinal};
+    CUdevice m_device{CU_DEVICE_INVALID};
+    CUcontext m_context{nullptr};
 public:
-    nixlUcxCudaDevicePrimaryCtx(int ordinal)
-        : m_ordinal(ordinal), m_context(nullptr) {}
 
     bool push() {
         CUcontext context;
 
-        CUresult res = cuCtxGetCurrent(&context);
+        const auto res = cuCtxGetCurrent(&context);
         if (res != CUDA_SUCCESS || context != nullptr) {
             return false;
         }
@@ -593,7 +593,7 @@ nixlUcxEngine::nixlUcxEngine (const nixlBackendInitParams* init_params)
         cuda_addr_wa = true;
     }
 
-    m_cudaPrimaryCtx = std::make_shared<nixlUcxCudaDevicePrimaryCtx>(0);
+    m_cudaPrimaryCtx = std::make_shared<nixlUcxCudaDevicePrimaryCtx>();
     vramInitCtx();
     progressThreadStart();
 }

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -103,7 +103,9 @@ class nixlUcxPublicMetadata : public nixlBackendMD {
 // will be part of NIXL installation - we can have
 // HAVE_CUDA in h-files
 class nixlUcxCudaCtx;
-class nixlUcxCudaCtxRetained;
+class nixlUcxCudaDevicePrimaryCtx;
+using nixlUcxCudaDevicePrimaryCtxPtr = std::shared_ptr<nixlUcxCudaDevicePrimaryCtx>;
+
 class nixlUcxEngine : public nixlBackendEngine {
     private:
         /* UCX data */
@@ -126,7 +128,7 @@ class nixlUcxEngine : public nixlBackendEngine {
         bool cuda_addr_wa;
 
         // Context to use when current context is missing
-        std::unique_ptr<nixlUcxCudaCtxRetained> m_cudaCtxRetained;
+        nixlUcxCudaDevicePrimaryCtxPtr m_cudaPrimaryCtx;
 
         /* Notifications */
         notif_list_t notifMainList;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -103,6 +103,7 @@ class nixlUcxPublicMetadata : public nixlBackendMD {
 // will be part of NIXL installation - we can have
 // HAVE_CUDA in h-files
 class nixlUcxCudaCtx;
+class nixlUcxCudaCtxRetained;
 class nixlUcxEngine : public nixlBackendEngine {
     private:
         /* UCX data */
@@ -121,8 +122,11 @@ class nixlUcxEngine : public nixlBackendEngine {
         std::vector<pollfd> pollFds;
 
         /* CUDA data*/
-        std::unique_ptr<nixlUcxCudaCtx> cudaCtx;
+        std::unique_ptr<nixlUcxCudaCtx> cudaCtx; // Context matching specific device
         bool cuda_addr_wa;
+
+        // Context to use when current context is missing
+        std::unique_ptr<nixlUcxCudaCtxRetained> m_cudaCtxRetained;
 
         /* Notifications */
         notif_list_t notifMainList;

--- a/src/utils/stream/metadata_stream.cpp
+++ b/src/utils/stream/metadata_stream.cpp
@@ -67,6 +67,14 @@ nixlMDStreamListener::~nixlMDStreamListener() {
 void nixlMDStreamListener::setupListener() {
     setupStream();
 
+    int opt = 1;
+    if (setsockopt(socketFd, SOL_SOCKET, SO_REUSEADDR,
+                   &opt, sizeof(opt)) < 0) {
+        std::cerr << "setsockopt(REUSEADDR) failed while setting up listener for MD\n";
+        closeStream();
+        return;
+    }
+
     if (bind(socketFd, (struct sockaddr*)&listenerAddr,
              sizeof(listenerAddr)) < 0) {
         std::cerr << "Socket Bind failed while setting up listener for MD\n";

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -22,17 +22,18 @@ if not gtest_dep.found()
     subdir_done()
 endif
 
-if cuda_dep.found()
-    cuda_dependencies = [cuda_dep]
-else
-    cuda_dependencies = []
-endif
-
 subdir('mocks')
 
 plugin_dirs_arg = '--tests_plugin_dirs=' + mocks_dep.get_variable('path')
 
 cpp_flags = []
+
+if cuda_dep.found()
+    cpp_flags += '-DHAVE_CUDA'
+    cuda_dependencies = [cuda_dep]
+else
+    cuda_dependencies = []
+endif
 
 if get_option('test_all_plugins')
   cpp_flags+='-DTEST_ALL_PLUGINS'

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <cuda_runtime.h>
+
 namespace gtest {
 
 class MemBuffer : std::shared_ptr<void> {
@@ -54,9 +56,13 @@ public:
 private:
     static void *allocate(size_t size, nixl_mem_t mem_type)
     {
+        void *ptr;
+
         switch (mem_type) {
         case DRAM_SEG:
             return malloc(size);
+        case VRAM_SEG:
+            return cudaSuccess == cudaMalloc(&ptr, size)? ptr : nullptr;
         default:
             return nullptr; // TODO
         }
@@ -68,6 +74,9 @@ private:
         case DRAM_SEG:
             free(ptr);
             break;
+        case VRAM_SEG:
+            cudaFree(ptr);
+            break;
         default:
             return; // TODO
         }
@@ -78,18 +87,26 @@ private:
 
 class TestTransfer : public testing::TestWithParam<std::string> {
 protected:
-    static nixlAgentConfig getConfig()
+    static nixlAgentConfig getConfig(int listen_port)
     {
-        return nixlAgentConfig(false, false, 0,
+        return nixlAgentConfig(false, listen_port > 0, listen_port,
                                nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT, 0,
                                100000);
     }
 
+    static int getPort(int i)
+    {
+        return 9000 + i;
+    }
+
     void SetUp() override
     {
+        cudaSetDevice(0);
+
         // Create two agents
         for (size_t i = 0; i < 2; i++) {
-            agents.emplace_back(std::make_unique<nixlAgent>(getAgentName(i), getConfig()));
+            agents.emplace_back(std::make_unique<nixlAgent>(getAgentName(i),
+                                                            getConfig(getPort(i))));
             nixlBackendH *backend_handle = nullptr;
             nixl_status_t status = agents.back()->createBackend(getBackendName(), {},
                                                                 backend_handle);
@@ -108,6 +125,29 @@ protected:
         return GetParam();
     }
 
+    static nixl_opt_args_t extra_params_ip(int remote)
+    {
+        nixl_opt_args_t extra_params;
+
+        extra_params.ipAddr = "127.0.0.1";
+        extra_params.port   = getPort(remote);
+        return extra_params;
+    }
+
+    nixl_status_t fetchRemoteMD(int local = 0, int remote = 1)
+    {
+        auto extra_params = extra_params_ip(remote);
+
+        return agents[local]->fetchRemoteMD(getAgentName(remote),
+                                            &extra_params);
+    }
+
+    nixl_status_t checkRemoteMD(int local = 0, int remote = 1)
+    {
+        nixl_xfer_dlist_t descs(DRAM_SEG);
+        return agents[local]->checkRemoteMD(getAgentName(remote), descs);
+    }
+
     template<typename Desc>
     nixlDescList<Desc>
     makeDescList(const std::vector<MemBuffer> &buffers, nixl_mem_t mem_type)
@@ -124,6 +164,23 @@ protected:
     {
         auto reg_list = makeDescList<nixlBlobDesc>(buffers, mem_type);
         agent.registerMem(reg_list);
+    }
+
+    void exchangeMDIP()
+    {
+        for (size_t i = 0; i < agents.size(); i++) {
+            for (size_t j = 0; j < agents.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+
+                auto status = fetchRemoteMD(i, j);
+                ASSERT_EQ(NIXL_SUCCESS, status);
+                do {
+                    status = checkRemoteMD(i, j);
+                } while (status != NIXL_SUCCESS);
+            }
+        }
     }
 
     void exchangeMD()
@@ -181,21 +238,26 @@ protected:
         EXPECT_EQ(notif_list.front(), NOTIF_MSG);
     }
 
-    void doTransfer(nixlAgent &from, const std::string &from_name,
-                    nixlAgent &to, const std::string &to_name, size_t size,
-                    size_t count, size_t repeat, nixl_mem_t src_mem_type,
-                    nixl_mem_t dst_mem_type)
+    void createRegisteredMem(nixlAgent& agent,
+                             size_t size, size_t count,
+                             nixl_mem_t mem_type,
+                             std::vector<MemBuffer>& out)
     {
-        std::vector<MemBuffer> src_buffers, dst_buffers;
-        for (size_t i = 0; i < count; i++) {
-            src_buffers.emplace_back(size, src_mem_type);
-            dst_buffers.emplace_back(size, dst_mem_type);
+        while (count-- != 0) {
+            out.emplace_back(size, mem_type);
         }
 
-        registerMem(from, src_buffers, src_mem_type);
-        registerMem(to, dst_buffers, dst_mem_type);
-        exchangeMD();
+        registerMem(agent, out, mem_type);
+    }
 
+    void doTransfer(nixlAgent &from, const std::string &from_name,
+                    nixlAgent &to, const std::string &to_name, size_t size,
+                    size_t count, size_t repeat,
+                    nixl_mem_t src_mem_type,
+                    std::vector<MemBuffer> src_buffers,
+                    nixl_mem_t dst_mem_type,
+                    std::vector<MemBuffer> dst_buffers)
+    {
         nixl_opt_args_t extra_params;
         extra_params.hasNotif = true;
         extra_params.notifMsg = NOTIF_MSG;
@@ -262,9 +324,33 @@ TEST_P(TestTransfer, RandomSizes)
     };
 
     for (const auto &[size, count, repeat] : test_cases) {
+        std::vector<MemBuffer> src_buffers, dst_buffers;
+
+        createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
+        createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+
+        exchangeMD();
         doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
-                   size, count, repeat, DRAM_SEG, DRAM_SEG);
+                   size, count, repeat,
+                   DRAM_SEG, src_buffers,
+                   DRAM_SEG, dst_buffers);
     }
+}
+
+TEST_P(TestTransfer, remoteMDFromSocket)
+{
+    std::vector<MemBuffer> src_buffers, dst_buffers;
+    constexpr size_t size = 16 * 1024;
+    constexpr size_t count = 4;
+
+    createRegisteredMem(getAgent(0), size, count, VRAM_SEG, src_buffers);
+    createRegisteredMem(getAgent(1), size, count, VRAM_SEG, dst_buffers);
+
+    exchangeMDIP();
+    doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
+               size, count, 1,
+               VRAM_SEG, src_buffers,
+               VRAM_SEG, dst_buffers);
 }
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestTransfer, testing::Values("UCX"));


### PR DESCRIPTION
When using listener thread to load remote metadata, UCX plugin fails to import some keys because the CUDA context is missing. Make sure to use one and retain it. Assumption is that we only need it when using VRAM memory, UCX anyways detects the correct device when actually using memory/keys. If no context exist/context is inactive, the retain call will keep it until backend is destroyed.