### PR TITLE
UCX: set multi flag in read/write for ucx backend

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -241,7 +241,8 @@ nixl_status_t nixlUcxEp::read(uint64_t raddr, nixlUcxRkey &rk,
     }
 
     ucp_request_param_t param = {
-        .op_attr_mask = UCP_OP_ATTR_FIELD_MEMH,
+        .op_attr_mask = UCP_OP_ATTR_FIELD_MEMH |
+                        UCP_OP_ATTR_FLAG_MULTI_SEND,
         .memh         = mem.memh,
     };
 
@@ -265,7 +266,8 @@ nixl_status_t nixlUcxEp::write(void *laddr, nixlUcxMem &mem,
     }
 
     ucp_request_param_t param = {
-        .op_attr_mask = UCP_OP_ATTR_FIELD_MEMH,
+        .op_attr_mask = UCP_OP_ATTR_FIELD_MEMH |
+                        UCP_OP_ATTR_FLAG_MULTI_SEND,
         .memh         = mem.memh,
     };
 


### PR DESCRIPTION
When passing  `UCP_OP_ATTR_FLAG_MULTI_SEND`, ucx will optimize protocol selection for best bandwidth.
It could improve the performance for small message size.