### PR TITLE
Agent API: update sendLocalPartialMD to require label in etcd mode and update python bindings with label

### DIFF
--- a/examples/cpp/nixl_etcd_example.cpp
+++ b/examples/cpp/nixl_etcd_example.cpp
@@ -26,7 +26,8 @@
 const std::string ETCD_ENDPOINT = "http://localhost:2379";
 const std::string AGENT1_NAME = "EtcdAgent1";
 const std::string AGENT2_NAME = "EtcdAgent2";
-const std::string PARTIAL_LABEL = "conn_info";
+const std::string PARTIAL_LABEL_1 = "conn_info_1";
+const std::string PARTIAL_LABEL_2 = "conn_info_2";
 
 void printStatus(const std::string& operation, nixl_status_t status) {
     std::cout << operation << ": " << nixlEnumStrings::statusStr(status) << std::endl;
@@ -265,11 +266,11 @@ int main() {
     nixl_opt_args_t conn_params1, conn_params2;
     conn_params1.includeConnInfo = true;
     conn_params1.backends.push_back(ucx1);
-    conn_params1.metadataLabel = PARTIAL_LABEL;
+    conn_params1.metadataLabel = PARTIAL_LABEL_1;
 
     conn_params2.includeConnInfo = true;
     conn_params2.backends.push_back(ucx2);
-    conn_params2.metadataLabel = PARTIAL_LABEL;
+    conn_params2.metadataLabel = PARTIAL_LABEL_1;
 
     // Send partial metadata
     status = A1.sendLocalPartialMD(empty_dlist1, &conn_params1);
@@ -278,15 +279,17 @@ int main() {
     status = A2.sendLocalPartialMD(empty_dlist2, &conn_params2);
     assert(status == NIXL_SUCCESS);
 
-    // Send once partial with default label
-    status = A1.sendLocalPartialMD(empty_dlist1, nullptr);
+    // Send once partial with different label
+    conn_params1.metadataLabel = PARTIAL_LABEL_2;
+    status = A1.sendLocalPartialMD(empty_dlist1, &conn_params1);
     assert(status == NIXL_SUCCESS);
 
-    status = A2.sendLocalPartialMD(empty_dlist2, nullptr);
+    conn_params2.metadataLabel = PARTIAL_LABEL_2;
+    status = A2.sendLocalPartialMD(empty_dlist2, &conn_params2);
     assert(status == NIXL_SUCCESS);
 
     nixl_opt_args_t fetch_params;
-    fetch_params.metadataLabel = PARTIAL_LABEL;
+    fetch_params.metadataLabel = PARTIAL_LABEL_1;
     status = A1.fetchRemoteMD(AGENT2_NAME, &fetch_params);
     assert(status == NIXL_SUCCESS);
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -415,10 +415,11 @@ class nixlAgent {
          *         backends supporting the memory type is also included.
          *         If `extra_params->backends` is non-empty, only the descriptors supported by the
          *         backends in the list and the backends' connection info are included in the metadata.
-         *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer.
+         *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer, otherwise
+         *         it will be sent to the central metadata server, if supported.
          *         If 'extra_params->port' can be set in addition to IP address, or will default to default_comm_port.
-         *         If 'extra_params->metadataLabel' is set, it will be used as the label of the partial metadata
-         *         to be sent. Otherwise, the default label of the partial metadata will be used for sending.
+         *         The 'extra_params->metadataLabel' is required when sending to a central metadata server and
+         *         ignored when sending to a peer.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
          * @param  str           [out] The serialized metadata blob
@@ -430,7 +431,10 @@ class nixlAgent {
                            const nixl_opt_args_t* extra_params = nullptr) const;
 
         /**
-         * @brief  Fetch other agent's metadata and unpack it internally.
+         * @brief  Fetch other agent's metadata from a peer or central metadata server,
+         *         then unpack it internally. When fetching from a peer, only the full metadata
+         *         is supported. When fetching from a central metadata server, the metadataLabel
+         *         can be specified to fetch partial metadata.
          *
          * @param  remote_name   Name of remote agent to fetch from ETCD or socket.
          * @param  extra_params  Only to optionally specify IP address and/or port.

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -664,11 +664,14 @@ class nixl_agent:
         backends: list[str] = [],
         ip_addr: str = "",
         port: int = DEFAULT_COMM_PORT,
+        label: str = "",
     ):
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
-        self.agent.sendLocalPartialMD(descs, inc_conn_info, handle_list, ip_addr, port)
+        self.agent.sendLocalPartialMD(
+            descs, inc_conn_info, handle_list, ip_addr, port, label
+        )
 
     """
     @brief Request metadata be retrieved from central metadata server or sent by peer.
@@ -682,8 +685,9 @@ class nixl_agent:
         remote_agent: str,
         ip_addr: str = "",
         port: int = DEFAULT_COMM_PORT,
+        label: str = "",
     ):
-        self.agent.fetchRemoteMD(remote_agent, ip_addr, port)
+        self.agent.fetchRemoteMD(remote_agent, ip_addr, port, label)
 
     """
     @brief Invalidate your own metadata in the central metadata server, or from a specific peer.

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -640,22 +640,27 @@ class nixl_agent:
     @brief Send all of your metadata to a peer or central metadata server.
 
     @param ip_addr If specified, will only send metadata to one peer by IP address.
-    @param port    If specified, will try to send to specific port.
+                   Otherwise, metadata will be sent to central metadata server, if supported.
+    @param port    If specified next to ip_addr, will try to send to this specific port of a peer.
+                   Ignored when sending to a central metadata server.
     """
 
     def send_local_metadata(self, ip_addr: str = "", port: int = DEFAULT_COMM_PORT):
         self.agent.sendLocalMD(ip_addr, port)
 
     """
-    @brief Send partial metadata of the local agent.
+    @brief Send partial metadata of the local agent to a peer or central metadata server.
 
     @param descs         The list of descriptors to include metadata about.
                          List can be empty if only trying to send connection info.
     @param inc_conn_info Whether to include connection info in the metadata.
     @param backends      List of backends to consider when constructing partial metadata.
     @param ip_addr       If specified, will only send metadata to one peer by IP address.
-    @param port          If specified, will try to send to specific port.
+                         Otherwise, metadata will be sent to central metadata server, if supported.
+    @param port          If specified next to ip_addr, will try to send to this specific port of a peer.
+                         Ignored when sending to a central metadata server.
     @param label         Label to use for the metadata when sending to central metadata server.
+                         Ignored when sending to a peer.
     """
 
     def send_partial_agent_metadata(

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -655,6 +655,7 @@ class nixl_agent:
     @param backends      List of backends to consider when constructing partial metadata.
     @param ip_addr       If specified, will only send metadata to one peer by IP address.
     @param port          If specified, will try to send to specific port.
+    @param label         Label to use for the metadata when sending to central metadata server.
     """
 
     def send_partial_agent_metadata(

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -535,7 +535,7 @@ PYBIND11_MODULE(_bindings, m) {
                     throw_nixl_exception(agent.sendLocalMD(&extra_params));
                 }, py::arg("ip_addr") = std::string(""), py::arg("port") = 0 )
 
-        .def("sendLocalPartialMD", [](nixlAgent &agent, nixl_reg_dlist_t descs, bool inc_conn_info, std::vector<uintptr_t> backends, std::string ip_addr, int port) {
+        .def("sendLocalPartialMD", [](nixlAgent &agent, nixl_reg_dlist_t descs, bool inc_conn_info, std::vector<uintptr_t> backends, std::string ip_addr, int port, std::string label) {
                     std::string ret_str("");
 
                     nixl_opt_args_t extra_params;
@@ -545,17 +545,19 @@ PYBIND11_MODULE(_bindings, m) {
                     extra_params.includeConnInfo = inc_conn_info;
                     extra_params.ipAddr = ip_addr;
                     extra_params.port = port;
+                    extra_params.metadataLabel = label;
 
                     throw_nixl_exception(agent.sendLocalPartialMD(descs, &extra_params));
-                }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}), py::arg("ip_addr") = std::string(""), py::arg("port") = 0)
-        .def("fetchRemoteMD", [](nixlAgent &agent, std::string remote_agent, std::string ip_addr, int port){
+                }, py::arg("descs"), py::arg("inc_conn_info") = false, py::arg("backends") = std::vector<uintptr_t>({}), py::arg("ip_addr") = std::string(""), py::arg("port") = 0, py::arg("label") = std::string(""))
+        .def("fetchRemoteMD", [](nixlAgent &agent, std::string remote_agent, std::string ip_addr, int port, std::string label){
                     nixl_opt_args_t extra_params;
 
                     extra_params.ipAddr = ip_addr;
                     extra_params.port = port;
+                    extra_params.metadataLabel = label;
 
                     throw_nixl_exception(agent.fetchRemoteMD(remote_agent, &extra_params));
-                }, py::arg("remote_agent"), py::arg("ip_addr") = std::string(""), py::arg("port") = 0 )
+                }, py::arg("remote_agent"), py::arg("ip_addr") = std::string(""), py::arg("port") = 0, py::arg("label") = std::string(""))
         .def("invalidateLocalMD", [](nixlAgent &agent, std::string ip_addr, int port){
                     nixl_opt_args_t extra_params;
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1286,10 +1286,11 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
 #if HAVE_ETCD
     // If no IP is provided, use etcd (now via thread)
     if (data->useEtcd) {
-        std::string metadata_label = extra_params && !extra_params->metadataLabel.empty() ?
-                                     extra_params->metadataLabel :
-                                     default_partial_metadata_label;
-        data->enqueueCommWork(std::make_tuple(ETCD_SEND, std::move(metadata_label), 0, std::move(myMD)));
+        if (!extra_params || extra_params->metadataLabel.empty()) {
+            NIXL_ERROR << "Metadata label is required for etcd send of local partial metadata";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        data->enqueueCommWork(std::make_tuple(ETCD_SEND, extra_params->metadataLabel, 0, std::move(myMD)));
         return NIXL_SUCCESS;
     }
     return NIXL_ERR_INVALID_PARAM;

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -29,7 +29,6 @@
 #endif // HAVE_ETCD
 
 const std::string default_metadata_label = "metadata";
-const std::string default_partial_metadata_label = "partial_metadata";
 
 namespace {
 


### PR DESCRIPTION
* Enforce metadataLabel as a must for sendLocalPartialMD when sending to etcd server
* Update python API and bindings to include the label for sendLocalPartialMD and fetchRemoteMD
* Update partial_md_example.py to work with etcd when available