### PR TITLE
one to one mapping from thread to ucx_worker for better performance

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -123,6 +123,9 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
                 }
             }
         }
+        if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCX)) {
+            backend_params["num_workers"] = std::to_string(xferBenchConfig::num_threads);
+        }
 
         if (gethostname(hostname, 256)) {
             std::cerr << "Failed to get hostname" << std::endl;
@@ -165,7 +168,10 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
         exit(EXIT_FAILURE);
     }
 
-    agent->createBackend(backend_name, backend_params, backend_engine);
+    if (agent->createBackend(backend_name, backend_params, backend_engine) != NIXL_SUCCESS) {
+        std::cerr << "Backend creation fail: " << xferBenchConfig::backend << std::endl;
+        exit(EXIT_FAILURE);
+    }
 }
 
 xferBenchNixlWorker::~xferBenchNixlWorker() {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -124,7 +124,7 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
             }
         }
         if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCX)) {
-            backend_params["num_workers"] = std::to_string(xferBenchConfig::num_threads);
+            backend_params["num_dedicated_workers"] = std::to_string(xferBenchConfig::num_threads);
         }
 
         if (gethostname(hostname, 256)) {

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -459,8 +459,9 @@ void nixlUcxEngine::progressFunc()
             } while (status == NIXL_IN_PROG);
             NIXL_ASSERT(status == NIXL_SUCCESS) << ", status: " << status;
 
-            if (made_progress && !wid)
+            if (made_progress && wid == recvNotifWorkerId) {
                 notifProgress();
+            }
         }
         timeout = false;
 
@@ -556,8 +557,21 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams *init_params)
         devs = str_split((*custom_params)["device_list"], ", ");
 
     const auto num_workers_iter = custom_params->find("num_workers");
-    if (num_workers_iter == custom_params->end() || !absl::SimpleAtoi(num_workers_iter->second, &numWorkers))
-        numWorkers = 1;
+    if (num_workers_iter == custom_params->end() ||
+        !absl::SimpleAtoi(num_workers_iter->second, &numWorkers)) {
+        // Default to have 1 shared worker and 0 dedicated worker
+        numWorkers = 0;
+    }
+
+    const auto num_shared_iter = custom_params->find("num_shared_workers");
+    if (num_shared_iter == custom_params->end() ||
+        !absl::SimpleAtoi(num_shared_iter->second, &numSharedWorkers)) {
+        numSharedWorkers = 1;
+    }
+
+    if (numWorkers + numSharedWorkers == 0) {
+        throw std::invalid_argument("Total number of workers must be greater than 0");
+    }
 
     ucp_err_handling_mode_t err_handling_mode;
     const auto err_handling_mode_it =
@@ -576,11 +590,29 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams *init_params)
                                           numWorkers,
                                           init_params->syncMode);
 
-    for (size_t i = 0; i < numWorkers; i++) {
-        uws.emplace_back(std::make_unique<nixlUcxWorker>(*uc, err_handling_mode));
+    for (size_t i = 0; i < numSharedWorkers; i++) {
+        uws.emplace_back(std::make_unique<nixlUcxWorker>(*uc, err_handling_mode, true));
     }
 
-    workerAddr = uws.front()->epAddr();
+    for (size_t i = 0; i < numWorkers; i++) {
+        uws.emplace_back(std::make_unique<nixlUcxWorker>(*uc, err_handling_mode, false));
+        freeWorkers.push(i + numSharedWorkers);
+    }
+
+    const auto &uw = uws.front();
+    workerAddr = uw->epAddr();
+    recvNotifWorkerId = 0; // First worker from the list
+
+    if (workerAddr.empty()) {
+        NIXL_ERROR << "Failed to get UCX worker address";
+        initErr = true;
+        return;
+    }
+
+    if (initThreadMapping() != NIXL_SUCCESS) {
+        initErr = true;
+        return;
+    }
 
     if (pthrOn) {
         for (auto &uw: uws) {
@@ -628,6 +660,7 @@ nixlUcxEngine::~nixlUcxEngine() {
     }
 
     vramFiniCtx();
+    destroyThreadMapping();
 }
 
 /****************************************
@@ -932,8 +965,14 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
                                        nixlBackendReqH* &handle,
                                        const nixl_opt_b_args_t* opt_args) const
 {
+    size_t worker_id;
+    nixl_status_t status = getWorkerIdWithPreference(false, worker_id);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
     /* TODO: try to get from a pool first */
-    nixlUcxBackendH *intHandle = new nixlUcxBackendH(*this, getWorkerId());
+    nixlUcxBackendH *intHandle = new nixlUcxBackendH(*this, worker_id);
 
     handle = (nixlBackendReqH*)intHandle;
     return NIXL_SUCCESS;
@@ -1205,14 +1244,19 @@ nixl_status_t nixlUcxEngine::genNotif(const std::string &remote_agent, const std
 {
     nixl_status_t ret;
     nixlUcxReq req;
-    size_t wid = getWorkerId();
 
-    ret = notifSendPriv(remote_agent, msg, req, wid);
+    size_t worker_id;
+    ret = getWorkerIdWithPreference(true, worker_id);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    ret = notifSendPriv(remote_agent, msg, req, worker_id);
 
     switch(ret) {
     case NIXL_IN_PROG:
         /* do not track the request */
-        getWorker(wid)->reqRelease(req);
+        uws[worker_id]->reqRelease(req);
     case NIXL_SUCCESS:
         break;
     default:
@@ -1220,4 +1264,105 @@ nixl_status_t nixlUcxEngine::genNotif(const std::string &remote_agent, const std
         return ret;
     }
     return NIXL_SUCCESS;
+}
+
+/****************************************
+ * Thread to worker mapping
+ *****************************************/
+
+void
+nixlUcxEngine::threadMapDestructor(void *arg) {
+    auto worker_info = static_cast<nixlUcxWorkerInfo *>(arg);
+
+    /* When a thread exits, disassociate it from the worker,
+     * so that the worker could be reused by another thread.
+     */
+    worker_info->engine->pushFreeWorker(worker_info->workerId);
+
+    // TODO: memory leak if engine obj is destroy before thread exit?
+    delete worker_info;
+}
+
+nixl_status_t
+nixlUcxEngine::initThreadMapping() {
+    int err = pthread_key_create(&keyThreadToWorker, threadMapDestructor);
+    if (err) {
+        NIXL_ERROR << "Failed to create keyThreadToWorker, err:" << err;
+        return NIXL_ERR_BACKEND;
+    }
+    return NIXL_SUCCESS;
+}
+
+void
+nixlUcxEngine::destroyThreadMapping() {
+    int err = pthread_key_delete(keyThreadToWorker);
+    if (err) {
+        NIXL_WARN << "Failed to delete keyThreadToWorker, err:" << err;
+    }
+}
+
+nixl_status_t
+nixlUcxEngine::getFreeDedicatedWorkerId(size_t &worker_id) const {
+    const std::lock_guard<std::mutex> lock(workersMutex);
+    if (freeWorkers.empty()) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    worker_id = freeWorkers.front();
+    freeWorkers.pop();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxEngine::getDedicatedWorkerId(size_t &worker_id) const {
+    auto worker_info = static_cast<nixlUcxWorkerInfo *>(pthread_getspecific(keyThreadToWorker));
+    if (worker_info != nullptr) {
+        worker_id = worker_info->workerId;
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t status = getFreeDedicatedWorkerId(worker_id);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    worker_info = new nixlUcxWorkerInfo(this, worker_id);
+    if (worker_info == nullptr) {
+        pushFreeWorker(worker_id);
+        NIXL_ERROR << "Failed to allocate nixlUcxWorkerInfo";
+        return NIXL_ERR_BACKEND;
+    }
+
+    int err = pthread_setspecific(keyThreadToWorker, worker_info);
+    if (err) {
+        delete worker_info;
+        pushFreeWorker(worker_id);
+        NIXL_ERROR << "Failed to set keyThreadToWorker, workerId:" << worker_id << "err:" << err;
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxEngine::getSharedWorkerId(size_t &worker_id) const {
+    if (numSharedWorkers == 0) {
+        /* no shared workers */
+        return NIXL_ERR_BACKEND;
+    }
+
+    worker_id = std::hash<std::thread::id>{}(std::this_thread::get_id()) % numSharedWorkers;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxEngine::getWorkerIdWithPreference(bool prefer_shared, size_t &worker_id) const {
+    nixl_status_t status =
+        prefer_shared ? getSharedWorkerId(worker_id) : getDedicatedWorkerId(worker_id);
+    if (status == NIXL_SUCCESS) {
+        return status;
+    }
+
+    // If the preferred worker type is not available, get the other type
+    return prefer_shared ? getDedicatedWorkerId(worker_id) : getSharedWorkerId(worker_id);
 }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -626,7 +626,6 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams *init_params)
 
     // TODO: in case of UCX error handling is enabled, we can clean up AM based connections error
     //       handling, if user requested disabled error handling, we dont care about it.
-    auto &uw = uws.front();
     uw->regAmCallback(CONN_CHECK, connectionCheckAmCb, this);
     uw->regAmCallback(DISCONNECT, connectionTermAmCb, this);
     uw->regAmCallback(NOTIF_STR, notifAmCb, this);

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -36,7 +36,7 @@ using namespace std;
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {
     nixl_b_params_t params = {
-        {"ucx_devices", ""}, {"num_workers", "0"}, {"num_shared_workers", "1"}};
+        {"ucx_devices", ""}, {"num_workers", "1"}, {"num_dedicated_workers", "0"}};
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -495,7 +495,9 @@ nixlUcxWorker::createUcpWorker(const nixlUcxContext &ctx, bool is_shared) {
     return worker;
 }
 
-nixlUcxWorker::nixlUcxWorker(const nixlUcxContext &ctx, ucp_err_handling_mode_t err_handling_mode, bool is_shared)
+nixlUcxWorker::nixlUcxWorker(const nixlUcxContext &ctx,
+                             ucp_err_handling_mode_t err_handling_mode,
+                             bool is_shared)
     : worker(createUcpWorker(ctx, is_shared), &ucp_worker_destroy),
       err_handling_mode_(err_handling_mode) {}
 

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -35,7 +35,8 @@ using namespace std;
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {
-    nixl_b_params_t params = {{"ucx_devices", ""}, {"num_workers", "0"}, {"num_shared_workers", "1"}};
+    nixl_b_params_t params = {
+        {"ucx_devices", ""}, {"num_workers", "0"}, {"num_shared_workers", "1"}};
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -176,8 +176,8 @@ class nixlUcxWorker {
 public:
     explicit nixlUcxWorker(
         const nixlUcxContext &,
-        ucp_err_handling_mode_t ucp_err_handling_mode = UCP_ERR_HANDLING_MODE_NONE);
-
+        ucp_err_handling_mode_t ucp_err_handling_mode = UCP_ERR_HANDLING_MODE_NONE,
+        bool is_shared = false);
     nixlUcxWorker( nixlUcxWorker&& ) = delete;
     nixlUcxWorker( const nixlUcxWorker& ) = delete;
     void operator=( nixlUcxWorker&& ) = delete;
@@ -205,7 +205,7 @@ public:
 
 private:
     [[nodiscard]] static ucp_worker *
-    createUcpWorker(const nixlUcxContext &);
+    createUcpWorker(const nixlUcxContext &, bool);
 
     const std::unique_ptr<ucp_worker, void (*)(ucp_worker *)> worker;
     ucp_err_handling_mode_t err_handling_mode_;


### PR DESCRIPTION
Previously, each thread choose ucx_worker by using a hash of thread id. Most of the time, this would lead to multiple thread using the same ucx_worker and cause contention.

Additionally, added an argument "threading_mode" for user to choose the threading mode that used by UCX.