### PR TITLE
LISTENER: Add connection creation for invalidation message

### DIFF
--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -40,6 +40,7 @@ enum nixl_comm_t {
     SOCK_SEND,
     SOCK_FETCH,
     SOCK_INVAL,
+    SOCK_MAX,
 #if HAVE_ETCD
     ETCD_SEND,
     ETCD_FETCH,

--- a/test/gtest/metadata_exchange.cpp
+++ b/test/gtest/metadata_exchange.cpp
@@ -359,10 +359,16 @@ TEST_F(MetadataExchangeTestFixture, SocketFetchRemoteAndInvalidateLocal)
     fetch_args.port = src.port;
 
     ASSERT_EQ(dst.agent->fetchRemoteMD(src.name, &fetch_args), NIXL_SUCCESS);
-
     std::this_thread::sleep_for(sleep_time);
-
     ASSERT_EQ(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
+
+    nixl_opt_args_t invalidate_args;
+    invalidate_args.ipAddr = dst.ip;
+    invalidate_args.port = dst.port;
+
+    ASSERT_EQ(src.agent->invalidateLocalMD(&invalidate_args), NIXL_SUCCESS);
+    std::this_thread::sleep_for(sleep_time);
+    ASSERT_NE(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
 }
 
 TEST_F(MetadataExchangeTestFixture, SocketSendPartialLocal)


### PR DESCRIPTION
Also create a connected socket if needed when invalidating MD on a remote agent, as RPCs are sent unidirectionally for all messages.