### PR TITLE
UCX: set rma rails to 2 for ucx backend.

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -364,6 +364,7 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
         ucp_config_modify(ucp_config, "NET_DEVICES", dev_str.c_str());
     }
 
+    ucp_config_modify(ucp_config, "MAX_RMA_RAILS", "2");
     status = ucp_init(&ucp_params, ucp_config, &ctx);
     if (status != UCS_OK) {
         /* TODO: proper cleanup */


### PR DESCRIPTION
Set `UCX_MAX_RMA_RAILS` to 2 (default is 1) to allow ucx to use maximum 2 ports for RMA operations.
It could make ucx backend get better performance when using a bond type interface.