### PR TITLE
Gtest transfer test improvements

### DIFF
--- a/test/gtest/mem_buffer.h
+++ b/test/gtest/mem_buffer.h
@@ -46,6 +46,11 @@ public:
         return buffer_.size();
     }
 
+    void
+    zero() {
+        std::fill(buffer_.begin(), buffer_.end(), 0);
+    }
+
 private:
     std::vector<uint8_t> buffer_;
 };
@@ -114,6 +119,11 @@ public:
     size_t
     size() const {
         return size_;
+    }
+
+    void
+    zero() {
+        // TODO
     }
 
 private:

--- a/test/gtest/mem_buffer.h
+++ b/test/gtest/mem_buffer.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MEM_BUFFER_H
+#define MEM_BUFFER_H
+
+#include "nixl_types.h"
+#include <cstdint>
+
+namespace gtest {
+
+template<nixl_mem_t MemType> class MemBuffer;
+
+template<> class MemBuffer<DRAM_SEG> {
+public:
+    MemBuffer(size_t size) : buffer_(size) {}
+
+    uintptr_t
+    data() const {
+        return reinterpret_cast<uintptr_t>(buffer_.data());
+    }
+
+    size_t
+    size() const {
+        return buffer_.size();
+    }
+
+private:
+    std::vector<uint8_t> buffer_;
+};
+
+} // namespace gtest
+
+#ifdef HAVE_CUDA
+
+#include <cuda_runtime.h>
+
+namespace gtest {
+
+template<> class MemBuffer<VRAM_SEG> {
+public:
+    MemBuffer(size_t size) : size_(size) {
+        cudaError_t err = cudaMalloc(&buffer_, size);
+        if (err != cudaSuccess) {
+            throw std::runtime_error("Failed to allocate CUDA memory");
+        }
+    }
+
+    ~MemBuffer() {
+        if (buffer_) {
+            cudaFree(buffer_);
+        }
+    }
+
+    MemBuffer(const MemBuffer &) = delete;
+    MemBuffer &
+    operator=(const MemBuffer &) = delete;
+
+    MemBuffer(MemBuffer &&other) noexcept : buffer_(other.buffer_), size_(other.size_) {
+        other.buffer_ = nullptr;
+        other.size_ = 0;
+    }
+
+    MemBuffer &
+    operator=(MemBuffer &&other) noexcept {
+        if (this != &other) {
+            if (buffer_) {
+                cudaFree(buffer_);
+            }
+            buffer_ = other.buffer_;
+            size_ = other.size_;
+            other.buffer_ = nullptr;
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
+    uintptr_t
+    data() const {
+        return reinterpret_cast<uintptr_t>(buffer_);
+    }
+
+    size_t
+    size() const {
+        return size_;
+    }
+
+private:
+    void *buffer_ = nullptr;
+    size_t size_;
+};
+
+} // namespace gtest
+
+#endif // HAVE_CUDA
+
+
+#endif /* MEM_BUFFER_H */

--- a/test/gtest/mem_buffer.h
+++ b/test/gtest/mem_buffer.h
@@ -29,6 +29,13 @@ template<> class MemBuffer<DRAM_SEG> {
 public:
     MemBuffer(size_t size) : buffer_(size) {}
 
+    MemBuffer(std::vector<uint8_t> &&data) : buffer_(std::move(data)) {}
+
+    bool
+    operator==(const MemBuffer<DRAM_SEG> &other) const {
+        return buffer_ == other.buffer_;
+    }
+
     uintptr_t
     data() const {
         return reinterpret_cast<uintptr_t>(buffer_.data());
@@ -60,6 +67,10 @@ public:
         }
     }
 
+    MemBuffer(std::vector<uint8_t> &&data) : MemBuffer(data.size()) {
+        // TODO
+    }
+
     ~MemBuffer() {
         if (buffer_) {
             cudaFree(buffer_);
@@ -87,6 +98,12 @@ public:
             other.size_ = 0;
         }
         return *this;
+    }
+
+    bool
+    operator==(const MemBuffer<VRAM_SEG> &other) const {
+        // TODO
+        return true;
     }
 
     uintptr_t

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -31,6 +31,7 @@
 #include <functional>
 #include <random>
 #include <set>
+#include <thread>
 
 #ifdef HAVE_CUDA
 #include <cuda_runtime.h>
@@ -47,7 +48,7 @@ protected:
         return nixlAgentConfig(true,
                                listen_port > 0,
                                listen_port,
-                               nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT,
+                               nixl_thread_sync_t::NIXL_THREAD_SYNC_RW,
                                0,
                                100000);
     }
@@ -55,6 +56,17 @@ protected:
     static int getPort(int i)
     {
         return 9000 + i;
+    }
+
+    nixl_b_params_t getBackendParams()
+    {
+        nixl_b_params_t params;
+
+        if (getBackendName() == "UCX" || getBackendName() == "UCX_MO") {
+            params["num_workers"] = "2";
+        }
+
+        return params;
     }
 
     void SetUp() override
@@ -68,7 +80,7 @@ protected:
             agents.emplace_back(std::make_unique<nixlAgent>(getAgentName(i),
                                                             getConfig(getPort(i))));
             nixlBackendH *backend_handle = nullptr;
-            nixl_status_t status = agents.back()->createBackend(getBackendName(), {},
+            nixl_status_t status = agents.back()->createBackend(getBackendName(), getBackendParams(),
                                                                 backend_handle);
             ASSERT_EQ(status, NIXL_SUCCESS);
             EXPECT_NE(backend_handle, nullptr);
@@ -190,6 +202,107 @@ protected:
     }
 
     template<nixl_mem_t LocalMemType, nixl_mem_t RemoteMemType>
+    std::pair<std::vector<std::vector<MemBuffer<LocalMemType>>>,
+              std::vector<std::vector<MemBuffer<RemoteMemType>>>>
+    initThreadBuffers(nixlAgent &from,
+                      nixlAgent &to,
+                      size_t num_threads,
+                      size_t count,
+                      size_t size,
+                      nixl_xfer_op_t mode) {
+        std::vector<std::vector<MemBuffer<LocalMemType>>> thread_local_buffers(num_threads);
+        std::vector<std::vector<MemBuffer<RemoteMemType>>> thread_remote_buffers(num_threads);
+        for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+            for (size_t i = 0; i < count; i++) {
+                if (mode == NIXL_WRITE) {
+                    thread_local_buffers[thread_id].emplace_back(
+                            createRandomData<LocalMemType>(size));
+                    thread_remote_buffers[thread_id].emplace_back(size);
+                } else {
+                    thread_local_buffers[thread_id].emplace_back(size);
+                    thread_remote_buffers[thread_id].emplace_back(
+                            createRandomData<RemoteMemType>(size));
+                }
+            }
+            registerMem(from, thread_local_buffers[thread_id]);
+            registerMem(to, thread_remote_buffers[thread_id]);
+        }
+        return {std::move(thread_local_buffers), std::move(thread_remote_buffers)};
+    }
+
+    template<nixl_mem_t LocalMemType, nixl_mem_t RemoteMemType>
+    void
+    validateThreadBuffers(
+            const std::vector<std::vector<MemBuffer<LocalMemType>>> &thread_local_buffers,
+            const std::vector<std::vector<MemBuffer<RemoteMemType>>> &thread_remote_buffers,
+            size_t num_threads,
+            size_t count) {
+        for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+            for (size_t i = 0; i < count; i++) {
+                EXPECT_EQ(thread_local_buffers[thread_id][i], thread_remote_buffers[thread_id][i])
+                        << "Transfer validation failed for thread " << thread_id << " buffer " << i;
+            }
+        }
+    }
+
+    std::vector<std::vector<std::string>>
+    initThreadNotifications(size_t num_threads, size_t count, size_t batch_size) {
+        std::vector<std::vector<std::string>> thread_notifs(num_threads);
+        for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+            for (size_t batch_start = 0; batch_start < count; batch_start += batch_size) {
+                size_t batch_idx = batch_start / batch_size;
+                std::string notif =
+                        absl::StrFormat("notification_thread_%zu_batch_%zu", thread_id, batch_idx);
+                thread_notifs[thread_id].push_back(notif);
+            }
+        }
+        return thread_notifs;
+    }
+
+    void
+    validateNotifications(const nixl_notifs_t &notif_map,
+                          const std::string &from_name,
+                          const std::vector<std::vector<std::string>> &thread_notifs) {
+        std::set<std::string> expected_msgs;
+        for (const auto &thread_notif_list : thread_notifs) {
+            expected_msgs.insert(thread_notif_list.begin(), thread_notif_list.end());
+        }
+
+        EXPECT_EQ(notif_map.count(from_name), 1)
+                << "Expected notifications from " << from_name << " to be in notifications map";
+        auto &notif_list = notif_map.at(from_name);
+        EXPECT_EQ(notif_list.size(), expected_msgs.size())
+                << "Expected " << expected_msgs.size() << " notifications, got "
+                << notif_list.size();
+
+        std::set<std::string> remaining_msgs = expected_msgs;
+        for (const auto &msg : notif_list) {
+            EXPECT_TRUE(remaining_msgs.erase(msg) > 0)
+                    << "Unexpected or duplicate notification: " << msg;
+        }
+        EXPECT_TRUE(remaining_msgs.empty())
+                << "Missing " << remaining_msgs.size() << " notifications";
+    }
+
+    template<nixl_mem_t LocalMemType, nixl_mem_t RemoteMemType>
+    void
+    zeroBuffers(std::vector<std::vector<MemBuffer<LocalMemType>>> &thread_local_buffers,
+                std::vector<std::vector<MemBuffer<RemoteMemType>>> &thread_remote_buffers,
+                size_t num_threads,
+                size_t count,
+                nixl_xfer_op_t mode) {
+        for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+            for (size_t i = 0; i < count; i++) {
+                if (mode == NIXL_WRITE) {
+                    thread_remote_buffers[thread_id][i].zero();
+                } else {
+                    thread_local_buffers[thread_id][i].zero();
+                }
+            }
+        }
+    }
+
+    template<nixl_mem_t LocalMemType, nixl_mem_t RemoteMemType>
     void
     doTransfer(nixlAgent &from,
                const std::string &from_name,
@@ -198,81 +311,54 @@ protected:
                size_t size,
                size_t count,
                size_t batch_size,
-               size_t repeat,
                nixl_xfer_op_t mode,
                std::function<void()> setup_md,
-               const std::vector<std::string> &expected_notifs) {
-        std::vector<MemBuffer<LocalMemType>> local_buffers;
-        std::vector<MemBuffer<RemoteMemType>> remote_buffers;
-        for (size_t i = 0; i < count; i++) {
-            if (mode == NIXL_WRITE) {
-                local_buffers.emplace_back(createRandomData<LocalMemType>(size));
-                remote_buffers.emplace_back(size);
-            } else {
-                local_buffers.emplace_back(size);
-                remote_buffers.emplace_back(createRandomData<RemoteMemType>(size));
-            }
-        }
-
-        registerMem(from, local_buffers);
-        registerMem(to, remote_buffers);
-        setup_md();
-
+               const std::vector<std::string> &expected_notifs,
+               const std::vector<MemBuffer<LocalMemType>> &local_buffers,
+               const std::vector<MemBuffer<RemoteMemType>> &remote_buffers) {
         auto start_time = absl::Now();
         size_t total_transferred = 0;
         size_t notif_idx = 0;
 
-        for (size_t i = 0; i < repeat; i++) {
-            for (size_t batch_start = 0; batch_start < count; batch_start += batch_size) {
-                size_t batch_end = std::min(batch_start + batch_size, count);
+        for (size_t batch_start = 0; batch_start < count; batch_start += batch_size) {
+            size_t batch_end = std::min(batch_start + batch_size, count);
 
-                nixl_opt_args_t extra_params;
-                extra_params.hasNotif = true;
-                extra_params.notifMsg = expected_notifs[notif_idx++];
+            nixl_opt_args_t extra_params;
+            extra_params.hasNotif = true;
+            extra_params.notifMsg = expected_notifs[notif_idx++];
 
-                nixlXferReqH *xfer_req = nullptr;
-                nixl_status_t status = from.createXferReq(
-                        mode,
-                        makeDescList<nixlBasicDesc, LocalMemType>(local_buffers.begin() + batch_start,
-                                                                  local_buffers.begin() + batch_end),
-                        makeDescList<nixlBasicDesc, RemoteMemType>(
-                                remote_buffers.begin() + batch_start,
-                                remote_buffers.begin() + batch_end),
-                        to_name,
-                        xfer_req,
-                        &extra_params);
-                ASSERT_EQ(status, NIXL_SUCCESS);
-                EXPECT_NE(xfer_req, nullptr);
+            nixlXferReqH *xfer_req = nullptr;
+            nixl_status_t status = from.createXferReq(
+                    mode,
+                    makeDescList<nixlBasicDesc, LocalMemType>(local_buffers.begin() + batch_start,
+                                                              local_buffers.begin() + batch_end),
+                    makeDescList<nixlBasicDesc, RemoteMemType>(remote_buffers.begin() + batch_start,
+                                                               remote_buffers.begin() + batch_end),
+                    to_name,
+                    xfer_req,
+                    &extra_params);
+            ASSERT_EQ(status, NIXL_SUCCESS);
+            EXPECT_NE(xfer_req, nullptr);
 
-                status = from.postXferReq(xfer_req);
-                ASSERT_GE(status, NIXL_SUCCESS);
+            status = from.postXferReq(xfer_req);
+            ASSERT_GE(status, NIXL_SUCCESS);
 
-                waitForXfer(from, from_name, to, xfer_req);
+            waitForXfer(from, from_name, to, xfer_req);
 
-                status = from.getXferStatus(xfer_req);
-                EXPECT_EQ(status, NIXL_SUCCESS);
+            status = from.getXferStatus(xfer_req);
+            EXPECT_EQ(status, NIXL_SUCCESS);
 
-                // Verify transfer was successful for this batch
-                for (size_t j = batch_start; j < batch_end; j++) {
-                    EXPECT_EQ(local_buffers[j], remote_buffers[j])
-                            << "Transfer validation failed for buffer " << j;
-                }
+            status = from.releaseXferReq(xfer_req);
+            EXPECT_EQ(status, NIXL_SUCCESS);
 
-                status = from.releaseXferReq(xfer_req);
-                EXPECT_EQ(status, NIXL_SUCCESS);
-
-                total_transferred += (batch_end - batch_start) * size;
-            }
+            total_transferred += (batch_end - batch_start) * size;
         }
 
         auto total_time = absl::ToDoubleSeconds(absl::Now() - start_time);
         auto bandwidth = total_transferred / total_time / (1024 * 1024 * 1024);
         Logger() << (mode == NIXL_WRITE ? "Write" : "Read") << " transfer: " << size << "x" << count
-                 << "x" << repeat << "=" << total_transferred << " bytes in " << total_time
-                 << " seconds "
+                 << "=" << total_transferred << " bytes in " << total_time << " seconds "
                  << "(" << bandwidth << " GB/s)";
-
-        invalidateMD();
     }
 
     template<nixl_mem_t LocalMemType, nixl_mem_t RemoteMemType>
@@ -285,43 +371,53 @@ protected:
                 size_t count,
                 size_t batch_size,
                 size_t repeat,
+                size_t num_threads,
                 nixl_xfer_op_t mode,
-                std::function<void()> metadataSetup) {
-        std::vector<std::string> expected_notifs;
-        for (size_t i = 0; i < repeat; i++) {
-            for (size_t batch_start = 0; batch_start < count; batch_start += batch_size) {
-                size_t batch_idx = batch_start / batch_size;
-                expected_notifs.push_back(absl::StrFormat("notification_%zu", batch_idx));
+                std::function<void()> setup_md) {
+        auto [thread_local_buffers, thread_remote_buffers] =
+                initThreadBuffers<LocalMemType, RemoteMemType>(
+                        from, to, num_threads, count, size, mode);
+        setup_md();
+
+        auto base_thread_notifs = initThreadNotifications(num_threads, count, batch_size);
+
+        for (size_t repeat_idx = 0; repeat_idx < repeat; ++repeat_idx) {
+            zeroBuffers<LocalMemType, RemoteMemType>(
+                    thread_local_buffers, thread_remote_buffers, num_threads, count, mode);
+
+            std::vector<std::thread> threads;
+            for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+                threads.emplace_back([&, thread_id]() {
+                    doTransfer<LocalMemType, RemoteMemType>(from,
+                                                            from_name,
+                                                            to,
+                                                            to_name,
+                                                            size,
+                                                            count,
+                                                            batch_size,
+                                                            mode,
+                                                            setup_md,
+                                                            base_thread_notifs[thread_id],
+                                                            thread_local_buffers[thread_id],
+                                                            thread_remote_buffers[thread_id]);
+                });
             }
+
+            for (auto &thread : threads) {
+                thread.join();
+            }
+
+            validateThreadBuffers<LocalMemType, RemoteMemType>(
+                    thread_local_buffers, thread_remote_buffers, num_threads, count);
+
+            nixl_notifs_t notif_map;
+            nixl_status_t status = to.getNotifs(notif_map);
+            ASSERT_EQ(status, NIXL_SUCCESS);
+
+            validateNotifications(notif_map, from_name, base_thread_notifs);
         }
 
-        doTransfer<LocalMemType, RemoteMemType>(from,
-                                                from_name,
-                                                to,
-                                                to_name,
-                                                size,
-                                                count,
-                                                batch_size,
-                                                repeat,
-                                                mode,
-                                                metadataSetup,
-                                                expected_notifs);
-
-        nixl_notifs_t notif_map;
-        nixl_status_t status = to.getNotifs(notif_map);
-        ASSERT_EQ(status, NIXL_SUCCESS);
-
-        auto &notif_list = notif_map[from_name];
-        EXPECT_EQ(notif_list.size(), expected_notifs.size())
-                << "Expected " << expected_notifs.size() << " notifications, got "
-                << notif_list.size();
-
-        std::set<std::string> expected_msgs(expected_notifs.begin(), expected_notifs.end());
-
-        for (const auto &msg : notif_list) {
-            EXPECT_TRUE(expected_msgs.find(msg) != expected_msgs.end())
-                    << "Unexpected notification message: " << msg;
-        }
+        invalidateMD();
     }
 
     nixlAgent &getAgent(size_t idx)
@@ -363,11 +459,11 @@ private:
 };
 
 TEST_P(TestTransfer, RandomSizes) {
-    // Tuple fields are: size, count, batch_size, repeat
-    constexpr std::array<std::tuple<size_t, size_t, size_t, size_t>, 4> test_cases = {
-            {{40, 1000, 1, 1}, {4096, 128, 32, 3}, {32768, 32, 4, 3}, {1000000, 8, 1, 3}}};
+    // Tuple fields are: size, count, batch_size, repeat, num_threads
+    constexpr std::array<std::tuple<size_t, size_t, size_t, size_t, size_t>, 4> test_cases = {
+            {{40, 250, 1, 1, 4}, {4096, 32, 2, 2, 4}, {32768, 16, 2, 2, 4}, {1000000, 8, 1, 2, 4}}};
 
-    for (const auto &[size, count, batch_size, repeat] : test_cases) {
+    for (const auto &[size, count, batch_size, repeat, num_threads] : test_cases) {
         doTransfers<DRAM_SEG, DRAM_SEG>(getAgent(0),
                                         getAgentName(0),
                                         getAgent(1),
@@ -376,6 +472,7 @@ TEST_P(TestTransfer, RandomSizes) {
                                         count,
                                         batch_size,
                                         repeat,
+                                        num_threads,
                                         NIXL_WRITE,
                                         [this]() { exchangeMD(); });
         doTransfers<DRAM_SEG, DRAM_SEG>(getAgent(0),
@@ -386,6 +483,7 @@ TEST_P(TestTransfer, RandomSizes) {
                                         count,
                                         batch_size,
                                         repeat,
+                                        num_threads,
                                         NIXL_READ,
                                         [this]() { exchangeMD(); });
     }
@@ -404,6 +502,7 @@ TEST_P(TestTransfer, remoteMDFromSocket) {
                                         count,
                                         1,
                                         1,
+                                        1,
                                         NIXL_WRITE,
                                         [this]() { exchangeMDIP(); });
     } else {
@@ -413,6 +512,7 @@ TEST_P(TestTransfer, remoteMDFromSocket) {
                                         getAgentName(1),
                                         size,
                                         count,
+                                        1,
                                         1,
                                         1,
                                         NIXL_WRITE,

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -260,6 +260,24 @@ protected:
     }
 
     void
+    waitForNotifications(nixlAgent &to,
+                         const std::string &from_name,
+                         size_t expected_count,
+                         nixl_notifs_t &notif_map) {
+        // Loop to attempt to get all notifications from agent from_name with exponential retry
+        // backoff
+        for (size_t attempt = 0; attempt < 10; ++attempt) {
+            nixl_status_t status = to.getNotifs(notif_map);
+            ASSERT_EQ(status, NIXL_SUCCESS);
+            auto notifs_from = notif_map.find(from_name);
+            if (notifs_from != notif_map.end() && notifs_from->second.size() == expected_count) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1 << attempt));
+        }
+    }
+
+    void
     validateNotifications(const nixl_notifs_t &notif_map,
                           const std::string &from_name,
                           const std::vector<std::vector<std::string>> &thread_notifs) {
@@ -420,6 +438,42 @@ protected:
         invalidateMD();
     }
 
+    void
+    doNotificationTest(nixlAgent &from,
+                       const std::string &from_name,
+                       nixlAgent &to,
+                       const std::string &to_name,
+                       size_t num_threads,
+                       size_t notifications_per_thread,
+                       size_t repeat) {
+        auto thread_notifs = initThreadNotifications(num_threads, notifications_per_thread, 1);
+
+        exchangeMD();
+
+        for (size_t repeat_idx = 0; repeat_idx < repeat; ++repeat_idx) {
+
+            std::vector<std::thread> threads;
+            for (size_t thread_id = 0; thread_id < num_threads; ++thread_id) {
+                threads.emplace_back([&, thread_id]() {
+                    for (const auto &notif : thread_notifs[thread_id]) {
+                        nixl_status_t status = from.genNotif(to_name, notif);
+                        ASSERT_EQ(status, NIXL_SUCCESS);
+                    }
+                });
+            }
+
+            for (auto &thread : threads) {
+                thread.join();
+            }
+
+            nixl_notifs_t notif_map;
+            waitForNotifications(to, from_name, num_threads * notifications_per_thread, notif_map);
+            validateNotifications(notif_map, from_name, thread_notifs);
+        }
+
+        invalidateMD();
+    }
+
     nixlAgent &getAgent(size_t idx)
     {
         return *agents[idx];
@@ -518,6 +572,20 @@ TEST_P(TestTransfer, remoteMDFromSocket) {
                                         NIXL_WRITE,
                                         [this]() { exchangeMDIP(); });
     }
+}
+
+TEST_P(TestTransfer, NotificationOnly) {
+    constexpr size_t num_threads = 4;
+    constexpr size_t notifications_per_thread = 10000;
+    constexpr size_t repeat = 3;
+
+    doNotificationTest(getAgent(0),
+                       getAgentName(0),
+                       getAgent(1),
+                       getAgentName(1),
+                       num_threads,
+                       notifications_per_thread,
+                       repeat);
 }
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestTransfer, testing::Values("UCX"));

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -124,8 +124,8 @@ protected:
     nixlDescList<Desc>
     makeDescList(Iter begin, Iter end) {
         nixlDescList<Desc> desc_list(MemType);
-        for (auto it = begin; it != end; ++it) {
-            desc_list.addDesc(Desc(it->data(), it->size(), DEV_ID));
+        for (; begin != end; ++begin) {
+            desc_list.addDesc(Desc(begin->data(), begin->size(), DEV_ID));
         }
         return desc_list;
     }


### PR DESCRIPTION
First, refactor the code without changing functionality:

- Extract MemBuffer into dedicated file for re-usability. Make it a proper template parameterized by memory type.
- Make memory type a template parameter over the whole test call chain.

Second, implement multiple improvements in existing test coverage:

- Allow executing test with different batch sizes (number of descriptors in a single Xfer request).
- Allow specifying transfer operation mode and test with both NIXL_WRITE and NIXL_READ.
- Use unique notification message for every Xfer request instead of reusing the same hardcoded one.
- Allow executing test data path loop on specified number of threads.

Third, add new test that validates genNotif() in multi-threaded environment.