### PR TITLE
Use NIXL logging macros consistently

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -718,8 +718,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
                      remote_descs, backend, *handle->targetDescs);
 
         if ((ret1 == NIXL_SUCCESS) && (ret2 == NIXL_SUCCESS)) {
-            // For Logging:
-            // std::cout << "Selected backend: " << backend->getType() << "\n";
+            NIXL_INFO << "Selected backend: " << backend->getType();
             handle->engine = backend;
             break;
         }

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <fcntl.h>
-#include <iostream>
 #include "nixl.h"
 #include "common/nixl_time.h"
 #include "common/str_tools.h"

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -19,13 +19,11 @@
 #include "nixl.h"
 #include "common/nixl_log.h"
 #include <dlfcn.h>
-#include <iostream>
 #include <filesystem>
 #include <dirent.h>
 #include <unistd.h>  // For access() and F_OK
 #include <cstdlib>  // For getenv
 #include <fstream>
-#include <iostream>
 #include <string>
 #include <map>
 
@@ -277,8 +275,8 @@ void nixlPluginManager::discoverPluginsFromDir(const std::string& dirpath) {
     std::error_code ec;
     std::filesystem::directory_iterator dir_iter(dir_path, ec);
     if (ec) {
-        std::cerr << "Error accessing directory(" << dir_path << "):"
-                  << ec.message() << std::endl;
+        NIXL_ERROR << "Error accessing directory(" << dir_path << "):"
+                   << ec.message();
         return;
     }
 
@@ -361,7 +359,7 @@ void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginC
 
     //Static Plugins are considered pre-loaded
     nixlBackendPlugin* plugin = info.createFunc();
-    NIXL_DEBUG << "Loading static plugin: " << name << std::endl;
+    NIXL_DEBUG << "Loading static plugin: " << name;
     if (plugin) {
         // Register the loaded plugin
         auto plugin_handle = std::make_shared<const nixlPluginHandle>(nullptr, plugin);

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <algorithm>
-#include <iostream>
 #include <functional>
 #include <stdexcept>
 #include "nixl.h"
@@ -23,6 +22,7 @@
 #include "mem_section.h"
 #include "backend/backend_aux.h"
 #include "serdes/serdes.h"
+#include "common/nixl_log.h"
 
 /*** Class nixlBasicDesc implementation ***/
 
@@ -89,8 +89,8 @@ nixl_blob_t nixlBasicDesc::serialize() const {
 }
 
 void nixlBasicDesc::print(const std::string &suffix) const {
-    std::cout << "LOG: Desc (" << addr << ", " << len
-              << ") from devID " << devId << suffix << "\n";
+    NIXL_INFO << "Desc (" << addr << ", " << len
+              << ") from devID " << devId << suffix;
 }
 
 
@@ -409,10 +409,9 @@ nixl_status_t nixlDescList<T>::serialize(nixlSerDes* serializer) const {
 
 template <class T>
 void nixlDescList<T>::print() const {
-    std::cout << "LOG: DescList of mem type " << type
-              << (sorted ? "sorted" : "unsorted") << "\n";
+    NIXL_INFO << "DescList of mem type " << type
+              << (sorted ? "sorted" : "unsorted");
     for (auto & elm : descs) {
-        std::cout << "    ";
         elm.print("");
     }
 }

--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <iostream>
 #include "gds_utils.h"
+#include "common/nixl_log.h"
 
 nixl_status_t gdsUtil::registerFileHandle(int fd,
                                           size_t size,
@@ -31,7 +31,7 @@ nixl_status_t gdsUtil::registerFileHandle(int fd,
 
     status = cuFileHandleRegister(&handle, &descr);
     if (status.err != CU_FILE_SUCCESS) {
-        std::cerr << "file register error:" << std::endl;
+        NIXL_ERROR << "file register error:";
         return NIXL_ERR_BACKEND;
     }
 
@@ -51,7 +51,7 @@ nixl_status_t gdsUtil::registerBufHandle(void *ptr,
 
     status = cuFileBufRegister(ptr, size, flags);
     if (status.err != CU_FILE_SUCCESS) {
-        std::cerr << "Warning: Buffer registration failed - will use compat mode\n";
+        NIXL_WARN << "Warning: Buffer registration failed - will use compat mode";
     }
     return NIXL_SUCCESS;
 }
@@ -62,7 +62,7 @@ nixl_status_t gdsUtil::openGdsDriver()
 
     err = cuFileDriverOpen();
     if (err.err != CU_FILE_SUCCESS) {
-        std::cerr << "Error initializing GPU Direct Storage driver\n";
+        NIXL_ERROR << "Error initializing GPU Direct Storage driver";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;
@@ -84,7 +84,7 @@ nixl_status_t gdsUtil::deregisterBufHandle(void *ptr)
 
     status = cuFileBufDeregister(ptr);
     if (status.err != CU_FILE_SUCCESS) {
-        std::cerr << "Error De-Registering Buffer\n";
+        NIXL_ERROR << "Error De-Registering Buffer";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;
@@ -100,7 +100,7 @@ nixlGdsIOBatch::nixlGdsIOBatch(unsigned int size)
 
     err = cuFileBatchIOSetUp(&batch_handle, size);
     if (err.err != 0) {
-        std::cerr << "Error in setting up Batch\n";
+        NIXL_ERROR << "Error in setting up Batch";
         init_err = err;
     }
 }
@@ -113,7 +113,7 @@ nixlGdsIOBatch::~nixlGdsIOBatch()
             delete[] io_batch_params;
             cuFileBatchIODestroy(batch_handle);
     } else {
-            std::cerr<<"Attempting to delete a batch before completion\n";
+            NIXL_ERROR << "Attempting to delete a batch before completion";
     }
 }
 
@@ -147,7 +147,7 @@ nixl_status_t nixlGdsIOBatch::cancelBatch()
 
     err = cuFileBatchIOCancel(batch_handle);
     if (err.err != 0) {
-        std::cerr << "Error in canceling batch\n";
+        NIXL_ERROR << "Error in canceling batch";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;
@@ -160,7 +160,7 @@ nixl_status_t nixlGdsIOBatch::submitBatch(int flags)
     err = cuFileBatchIOSubmit(batch_handle, batch_size,
                               io_batch_params, flags);
     if (err.err != 0) {
-        std::cerr << "Error in setting up Batch\n" << std::endl;
+        NIXL_ERROR << "Error in setting up Batch";
         return NIXL_ERR_BACKEND;
     }
     return NIXL_SUCCESS;
@@ -174,7 +174,7 @@ nixl_status_t nixlGdsIOBatch::checkStatus()
     errBatch = cuFileBatchIOGetStatus(batch_handle, nr, &nr,
                                       io_batch_events, NULL);
     if (errBatch.err != 0) {
-        std::cerr << "Error in IO Batch Get Status" << std::endl;
+        NIXL_ERROR << "Error in IO Batch Get Status";
         current_status = NIXL_ERR_BACKEND;
     }
 

--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #include <cassert>
-#include <iostream>
 #include <cctype>
 #include <atomic>
 #include <errno.h>
@@ -33,7 +32,7 @@ nixlHf3fsEngine::nixlHf3fsEngine (const nixlBackendInitParams* init_params)
 
     this->initErr = false;
     if (hf3fs_utils->openHf3fsDriver() == NIXL_ERR_BACKEND) {
-        std::cerr << "Error opening HF3FS driver" << std::endl;
+        NIXL_ERROR << "Error opening HF3FS driver";
         this->initErr = true;
     }
 

--- a/src/plugins/hf3fs/hf3fs_utils.cpp
+++ b/src/plugins/hf3fs/hf3fs_utils.cpp
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <iostream>
 #include "hf3fs_utils.h"
 #include <cstring>
 #include <cerrno>

--- a/src/plugins/hf3fs/meson.build
+++ b/src/plugins/hf3fs/meson.build
@@ -21,14 +21,13 @@ threefs_dep = declare_dependency(
   include_directories : include_directories(threefs_inc_path))
 
 # Get Abseil dependencies
-absl_log_dep = dependency('absl_log', required: true)
 
 if 'HF3FS' in static_plugins
   hf3fs_backend_lib = static_library('HF3FS',
                     'hf3fs_utils.cpp', 'hf3fs_utils.h',
                     'hf3fs_backend.cpp', 'hf3fs_backend.h',
                     'hf3fs_plugin.cpp',
-                    dependencies: [nixl_infra, threefs_dep, absl_log_dep],
+                    dependencies: [nixl_infra, threefs_dep, nixl_common_dep],
                     include_directories: [nixl_inc_dirs, utils_inc_dirs],
                     install: false,
                     cpp_args : compile_flags,
@@ -38,7 +37,7 @@ else
                     'hf3fs_utils.cpp', 'hf3fs_utils.h',
                     'hf3fs_backend.cpp', 'hf3fs_backend.h',
                     'hf3fs_plugin.cpp',
-                    dependencies: [nixl_infra, threefs_dep, absl_log_dep],
+                    dependencies: [nixl_infra, threefs_dep, nixl_common_dep],
                     include_directories: [nixl_inc_dirs, utils_inc_dirs],
                     install: true,
                     cpp_args : ['-fPIC'],

--- a/src/utils/stream/meson.build
+++ b/src/utils/stream/meson.build
@@ -15,8 +15,8 @@
 
 stream_lib = library('stream',
            'metadata_stream.cpp', 'metadata_stream.h',
-           include_directories: nixl_inc_dirs,
-           dependencies: thread_dep,
+           include_directories: [nixl_inc_dirs, utils_inc_dirs],
+           dependencies: [thread_dep, nixl_common_dep],
            install: true)
 
 stream_interface = declare_dependency(link_with: stream_lib)

--- a/src/utils/stream/metadata_stream.cpp
+++ b/src/utils/stream/metadata_stream.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 #include "metadata_stream.h"
-#include <iostream>
 #include <unistd.h>
 #include <cstring>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include "common/nixl_log.h"
 
 nixlMetadataStream::nixlMetadataStream(int port): port(port), socketFd(-1) {
     memset(&listenerAddr, 0, sizeof(listenerAddr));
@@ -34,7 +34,7 @@ bool nixlMetadataStream::setupStream() {
 
     socketFd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (socketFd == -1) {
-        std::cerr << "failed to create stream socket for listener";
+        NIXL_ERROR << "failed to create stream socket for listener";
         return false;
     }
 
@@ -70,33 +70,32 @@ void nixlMDStreamListener::setupListener() {
     int opt = 1;
     if (setsockopt(socketFd, SOL_SOCKET, SO_REUSEADDR,
                    &opt, sizeof(opt)) < 0) {
-        std::cerr << "setsockopt(REUSEADDR) failed while setting up listener for MD\n";
+        NIXL_ERROR << "setsockopt(REUSEADDR) failed while setting up listener for MD";
         closeStream();
         return;
     }
 
     if (bind(socketFd, (struct sockaddr*)&listenerAddr,
              sizeof(listenerAddr)) < 0) {
-        std::cerr << "Socket Bind failed while setting up listener for MD\n";
+        NIXL_ERROR << "Socket Bind failed while setting up listener for MD";
         closeStream();
         return;
     }
 
     if (listen(socketFd, 128) < 0) {
-        std::cerr << "Listening failed for stream Socket: "
-                  << socketFd  << "\n";
+        NIXL_ERROR << "Listening failed for stream Socket: "
+                   << socketFd;
         closeStream();
         return;
     }
-    std::cout << "MD listener is listening on port "
-              << port << "...\n";
+    NIXL_INFO << "MD listener is listening on port "
+              << port << "...";
 }
 
 int nixlMDStreamListener::acceptClient() {
         csock = accept(socketFd, NULL, NULL);
         if (csock < 0 && errno != EAGAIN) {
-            std::cerr << "Cannot accept client connection\n"
-                      << strerror(errno) << std::endl;
+            NIXL_ERROR << "Cannot accept client connection: " << strerror(errno);
         }
         return csock;
 }
@@ -106,11 +105,10 @@ void nixlMDStreamListener::acceptClientsAsync() {
     while(true) {
         int clientSocket = accept(socketFd, NULL, NULL);
         if (clientSocket < 0) {
-            std::cerr << "Cannot accept client connection\n"
-                      << strerror(errno) << std::endl;
+            NIXL_ERROR << "Cannot accept client connection: " << strerror(errno);
             continue;
         }
-        std::cout << "Client connected.\n";
+        NIXL_INFO << "Client connected.";
         std::thread clientThread(&nixlMDStreamListener::recvFromClients,
                                  this, clientSocket);
         clientThread.detach();
@@ -127,9 +125,9 @@ std::string nixlMDStreamListener::recvFromClient() {
         if (bytes_read > 0) {
                 recvData = std::string(buffer, bytes_read);
         } else if (bytes_read == 0) {
-                std::cout << "Client Disconnectd" <<std::endl;
+                NIXL_INFO << "Client Disconnected";
         } else {
-                std::cerr << "Error receiving data" << std::endl;
+                NIXL_ERROR << "Error receiving data";
         }
         return recvData;
 }
@@ -145,10 +143,10 @@ void nixlMDStreamListener::recvFromClients(int clientSocket) {
               std::string ack = "Message received";
               send(clientSocket, ack.c_str(), ack.size(), 0);
               std::string recv_message(buffer);
-              std::cout << "Message Received" << recv_message <<"\n";
+              NIXL_INFO << "Message Received" << recv_message;
         }
         close(clientSocket);
-        std::cout << "Client Disconnected\n";
+        NIXL_INFO << "Client Disconnected";
 }
 
 void nixlMDStreamListener::startListenerForClient() {
@@ -180,18 +178,18 @@ bool nixlMDStreamClient::setupClient() {
 
     if (inet_pton(AF_INET, listenerAddress.c_str(),
                   &listenerAddr.sin_addr) <= 0) {
-        perror("Invalid address/ Address not supported");
+        NIXL_ERROR << "Invalid address/ Address not supported: " << strerror(errno);
         return false;
     }
 
     if (connect(socketFd, (struct sockaddr*)&listenerAddr,
                 sizeof(listenerAddr)) < 0) {
-        std::cerr << "Connection Failed: "<< strerror(errno) << std::endl;
+        NIXL_ERROR << "Connection Failed: "<< strerror(errno);
         closeStream();
         return false;
     }
-    std::cout << "Connected to listener at "
-              << listenerAddress << ":" << port << "\n";
+    NIXL_INFO << "Connected to listener at "
+              << listenerAddress << ":" << port;
     return true;
 }
 
@@ -202,7 +200,7 @@ bool nixlMDStreamClient::connectListener() {
 
 void nixlMDStreamClient::sendData(const std::string &data) {
     if (send(socketFd, data.c_str(), data.size(), 0) < 0) {
-        std::cerr << "Send failed\n";
+        NIXL_ERROR << "Send failed";
     }
 }
 


### PR DESCRIPTION
Replace remanining cout/cerr calls in src with proper logging macros