### PR TITLE
Fix missing common/status.h compile error in 3fs plugin - 0.3.0

### DIFF
--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -20,8 +20,8 @@
 #include <atomic>
 #include <errno.h>
 #include "hf3fs_backend.h"
+#include "hf3fs_log.h"
 #include "common/str_tools.h"
-#include "common/status.h"
 #include "common/nixl_log.h"
 
 #define NUM_CQES 1024
@@ -75,7 +75,7 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
             status = hf3fs_utils->registerFileHandle(fd, &ret);
             if (status != NIXL_SUCCESS) {
                 delete md;
-                NIXL_LOG_AND_RETURN_IF_ERROR(status,
+                HF3FS_LOG_RETURN(status,
                     absl::StrFormat("Error - failed to register file handle %d", fd));
             }
             md->handle.fd = fd;
@@ -85,7 +85,7 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
             break;
         case VRAM_SEG:
         default:
-            NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_BACKEND, "Error - type not supported");
+            HF3FS_LOG_RETURN(NIXL_ERR_BACKEND, "Error - type not supported");
     }
 
     out = (nixlBackendMD*) md;
@@ -100,7 +100,7 @@ nixl_status_t nixlHf3fsEngine::deregisterMem (nixlBackendMD* meta)
     } else if (md->type == DRAM_SEG) {
         return NIXL_SUCCESS;
     } else {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_BACKEND, "Error - type not supported");
+        HF3FS_LOG_RETURN(NIXL_ERR_BACKEND, "Error - type not supported");
     }
     return NIXL_SUCCESS;
 }
@@ -155,12 +155,12 @@ nixl_status_t nixlHf3fsEngine::prepXfer (const nixl_xfer_op_t &operation,
         file_list = &remote;
         mem_list = &local;
     } else {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM, "Error: No file descriptors");
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM, "Error: No file descriptors");
     }
 
     if ((buf_cnt != file_cnt) ||
         ((operation != NIXL_READ) && (operation != NIXL_WRITE)))  {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM,
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
             "Error: Count mismatch or invalid operation selection");
     }
 
@@ -171,7 +171,7 @@ nixl_status_t nixlHf3fsEngine::prepXfer (const nixl_xfer_op_t &operation,
     auto status = hf3fs_utils->createIOR(&hf3fs_handle->ior, file_cnt, is_read);
     if (status != NIXL_SUCCESS) {
         delete hf3fs_handle;
-        NIXL_LOG_AND_RETURN_IF_ERROR(status, "Error: Failed to create IOR");
+        HF3FS_LOG_RETURN(status, "Error: Failed to create IOR");
     }
 
     for (int i = 0; i < file_cnt; i++) {
@@ -225,8 +225,7 @@ cleanup_handle:
     // Clean up previously created IOs in the list
     cleanupIOList(hf3fs_handle);
     delete hf3fs_handle;
-    NIXL_LOG_AND_RETURN_IF_ERROR(nixl_err, nixl_mesg);
-    return nixl_err;
+    HF3FS_LOG_RETURN(nixl_err, nixl_mesg);
 }
 
 nixl_status_t nixlHf3fsEngine::postXfer (const nixl_xfer_op_t &operation,
@@ -240,11 +239,11 @@ nixl_status_t nixlHf3fsEngine::postXfer (const nixl_xfer_op_t &operation,
     nixl_status_t        status;
 
     if (hf3fs_handle->io_list.empty()) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM, "Error: empty io list");
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM, "Error: empty io list");
     }
 
     if (UINT_MAX - hf3fs_handle->num_ios < hf3fs_handle->io_list.size()) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_NOT_ALLOWED, "Error: more than UINT_MAX ios");
+        HF3FS_LOG_RETURN(NIXL_ERR_NOT_ALLOWED, "Error: more than UINT_MAX ios");
     }
 
     for (auto it = hf3fs_handle->io_list.begin(); it != hf3fs_handle->io_list.end(); ++it) {
@@ -252,13 +251,13 @@ nixl_status_t nixlHf3fsEngine::postXfer (const nixl_xfer_op_t &operation,
         status = hf3fs_utils->prepIO(&hf3fs_handle->ior, &io->iov, io->iov.base,
                                      io->offset, io->size, io->fd, io->is_read, io);
         if (status != NIXL_SUCCESS) {
-            NIXL_LOG_AND_RETURN_IF_ERROR(status, "Error: Failed to prepare IO");
+            HF3FS_LOG_RETURN(status, "Error: Failed to prepare IO");
         }
     }
 
     status = hf3fs_utils->postIOR(&hf3fs_handle->ior);
     if (status != NIXL_SUCCESS) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(status, "Error: Failed to post IOR");
+        HF3FS_LOG_RETURN(status, "Error: Failed to post IOR");
     }
 
     // postXfer may be called multiple times, so we need to check if the thread is already running
@@ -266,7 +265,7 @@ nixl_status_t nixlHf3fsEngine::postXfer (const nixl_xfer_op_t &operation,
         hf3fs_handle->io_status.thread = new std::thread(waitForIOsThread, hf3fs_handle,
                                                          hf3fs_utils);
         if (hf3fs_handle->io_status.thread == nullptr) {
-            NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_BACKEND, "Error: Failed to create io thread");
+            HF3FS_LOG_RETURN(NIXL_ERR_BACKEND, "Error: Failed to create io thread");
         }
     }
 
@@ -340,19 +339,19 @@ void nixlHf3fsEngine::waitForIOsThread(void* handle, void *utils)
 nixl_status_t nixlHf3fsEngine::checkXfer(nixlBackendReqH* handle) const
 {
     if (handle == nullptr) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM, "Error: handle is null in checkXfer");
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM, "Error: handle is null in checkXfer");
     }
 
     nixlHf3fsBackendReqH *hf3fs_handle = (nixlHf3fsBackendReqH *) handle;
 
     // Check if IOR is initialized
     if (&hf3fs_handle->ior == nullptr) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM,
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
             "Error: IOR is not initialized in checkXfer");
     }
 
     if (hf3fs_handle->io_status.thread == nullptr) {
-        NIXL_LOG_AND_RETURN_IF_ERROR(NIXL_ERR_INVALID_PARAM,
+        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
             "Error: io thread is not initialized in checkXfer");
     }
 
@@ -360,7 +359,7 @@ nixl_status_t nixlHf3fsEngine::checkXfer(nixlBackendReqH* handle) const
         nixl_status_t error_status = hf3fs_handle->io_status.error_status;
         std::string error_message = hf3fs_handle->io_status.error_message;
         cleanupIOThread(hf3fs_handle);
-        NIXL_LOG_AND_RETURN_IF_ERROR(error_status, error_message);
+        HF3FS_LOG_RETURN(error_status, error_message);
     }
 
     if (hf3fs_handle->completed_ios < hf3fs_handle->num_ios) {

--- a/src/plugins/hf3fs/hf3fs_log.h
+++ b/src/plugins/hf3fs/hf3fs_log.h
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef HF3FS_LOG_H
+#define HF3FS_LOG_H
+
+#include <absl/strings/str_format.h>
+#include "common/nixl_log.h"
+
+#define HF3FS_LOG_RETURN(error_code, message) \
+    do { \
+        NIXL_ERROR << absl::StrFormat("HF3FS error: %d - %s", (error_code), (message)); \
+        return error_code; \
+    } while (0)
+
+#endif // HF3FS_LOG_H


### PR DESCRIPTION
* Fix missing common/status.h compile error

* add hf3fs_log.h

* add newline at end of file

* trim trailing white space

* Prefix error with HF3FS error

---------