### PR TITLE
fix: consistent naming for NIXL KV Bench (#378)

### DIFF
--- a/benchmark/kvbench/examples/model_llama_3_1_8b.yaml
+++ b/benchmark/kvbench/examples/model_llama_3_1_8b.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-model: 'LLAMA3.1_8B'
+model_name: 'LLAMA3.1_8B'
 num_layers: 32
 num_query_heads_with_mha: 32
 query_head_dimension: 128

--- a/benchmark/kvbench/models/deepseek_r1.py
+++ b/benchmark/kvbench/models/deepseek_r1.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import math
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml  # type: ignore
 from models.model_config import ModelConfig
@@ -40,13 +40,13 @@ class DeepSeekR1(BaseModelArch):
         rope_mla_dimension: int,
         mla_latent_vector_dimension: int,
         num_model_params: int,
-        model_config: ModelConfig,
+        model_config: Optional[ModelConfig] = None,
     ):
         """
         Initialize a DeepSeek-R1 model architecture.
 
         Args:
-            model (str): The model identifier.
+            model_name (str): The model identifier.
             num_layers (int): Number of transformer layers.
             num_query_heads (int): Number of query heads.
             query_head_dimension (int): Dimension of each query head.
@@ -57,7 +57,7 @@ class DeepSeekR1(BaseModelArch):
         """
 
         self.model_name = model_name
-        self.model_config = model_config
+        self.model_config = model_config or ModelConfig()
         self.num_layers = num_layers
         self.num_query_heads = num_query_heads
         self.query_head_dimension = query_head_dimension
@@ -116,7 +116,7 @@ class DeepSeekR1(BaseModelArch):
             Dict[str, Any]: A dictionary containing all model configuration parameters.
         """
         return {
-            "model": self.model.lower(),
+            "model_name": self.model_name.lower(),
             "num_layers": self.num_layers,
             "num_query_heads": self.num_query_heads,
             "query_head_dimension": self.query_head_dimension,

--- a/benchmark/kvbench/models/llama3_1.py
+++ b/benchmark/kvbench/models/llama3_1.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml  # type: ignore
 from models.model_config import ModelConfig
@@ -37,13 +37,13 @@ class Llama3_1(BaseModelArch):
         query_head_dimension: int,
         gqa_num_queries_in_group: int,
         num_model_params: int,
-        model_config: ModelConfig,
+        model_config: Optional[ModelConfig] = None,
     ):
         """
         Initialize a Llama 3.1 model architecture.
 
         Args:
-            model (str): The model identifier.
+            model_name (str): The model identifier.
             num_layers (int): Number of transformer layers.
             num_query_heads_with_mha (int): Number of query heads with multi-head attention.
             query_head_dimension (int): Dimension of each query head.
@@ -51,7 +51,7 @@ class Llama3_1(BaseModelArch):
             num_model_params (int): Total number of model parameters.
         """
         self.model_name = model_name
-        self.model_config = model_config
+        self.model_config = model_config or ModelConfig()
         self.num_layers = num_layers
         self.num_query_heads_with_mha = num_query_heads_with_mha
         self.query_head_dimension = query_head_dimension
@@ -101,7 +101,7 @@ class Llama3_1(BaseModelArch):
             Dict[str, Any]: A dictionary containing all model configuration parameters.
         """
         return {
-            "model": self.model.lower(),
+            "model_name": self.model_name.lower(),
             "num_layers": self.num_layers,
             "num_query_heads_with_mha": self.num_query_heads_with_mha,
             "query_head_dimension": self.query_head_dimension,

--- a/benchmark/kvbench/models/models.py
+++ b/benchmark/kvbench/models/models.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import yaml  # type: ignore
 from models.model_config import ModelConfig
@@ -88,7 +88,9 @@ class BaseModelArch(ABC):
         raise NotImplementedError("Subclasses must implement this method")
 
     @classmethod
-    def from_yaml(cls, yaml_path: str, model_config: None) -> "BaseModelArch":
+    def from_yaml(
+        cls, yaml_path: str, model_config: Optional[ModelConfig] = None
+    ) -> "BaseModelArch":
         """
         Create a model architecture instance from a YAML configuration file.
 
@@ -106,7 +108,7 @@ class BaseModelArch(ABC):
         with open(yaml_path, "r") as f:
             config = yaml.safe_load(f)
             filtered_dict = {k: v for k, v in config.items() if v is not None}
-            model_name = filtered_dict.get("model")
+            model_name = filtered_dict.get("model_name")
 
             if model_name is None:
                 raise ValueError("Model name is None")


### PR DESCRIPTION
* fix naming issues and revert model_config to an optional param in model architectures

* adding optional for model_config

* fix ci issues