### PR TITLE
nixlbench: enable VMM CUDA memory allocation

### DIFF
--- a/benchmark/kvbench/README.md
+++ b/benchmark/kvbench/README.md
@@ -137,6 +137,7 @@ These arguments are used by both `plan` and `profile` commands:
 | `--etcd-endpoints` | ETCD server URL for coordination (default: http://localhost:2379) |
 | `--storage_enable_direct` | Enable direct I/O for GDS operations |
 | `--gds_filepath` | File path for GDS operations |
+| `--enable_vmm` | Enable VMM memory allocation when DRAM is requested |
 
 ## Command Descriptions
 

--- a/benchmark/kvbench/commands/args.py
+++ b/benchmark/kvbench/commands/args.py
@@ -153,3 +153,8 @@ def add_nixl_bench_args(subparser: argparse.ArgumentParser):
     subparser.add_argument(
         "--gds_filepath", type=str, help="(File path for GDS operations"
     )
+    subparser.add_argument(
+        "--enable_vmm",
+        action="store_true",
+        help="Enable VMM memory allocation when DRAM is requested",
+    )

--- a/benchmark/kvbench/commands/nixlbench.py
+++ b/benchmark/kvbench/commands/nixlbench.py
@@ -38,6 +38,7 @@ class NIXLBench:
         storage_enable_direct=False,
         gds_filepath="",
         initiator_seg_type="DRAM",
+        enable_vmm=False,
         max_batch_size=None,
         max_block_size=None,
         mode="SG",
@@ -68,6 +69,7 @@ class NIXLBench:
             etcd_endpoints (str, optional): ETCD endpoints for runtime. Defaults to "http://localhost:2379".
             storage_enable_direct (bool, optional): Whether to enable direct I/O for storage operations. Defaults to False.
             gds_filepath (str, optional): Path for GDS file. Defaults to "".
+            enable_vmm (bool, optional): Whether to use VMM memory allocation. Defaults to False.
             initiator_seg_type (str, optional): Type of initiator segment. Defaults to "DRAM".
             max_batch_size (int, optional): Maximum batch size for testing. Defaults to model_config value.
             max_block_size (int, optional): Maximum block size for testing. Defaults to tp_size * isl.
@@ -95,6 +97,7 @@ class NIXLBench:
         self.etcd_endpoints = etcd_endpoints
         self.storage_enable_direct = storage_enable_direct
         self.gds_filepath = gds_filepath
+        self.enable_vmm = enable_vmm
         self.initiator_seg_type = initiator_seg_type
         self.max_batch_size = max_batch_size
         self.max_block_size = max_block_size
@@ -182,6 +185,7 @@ class NIXLBench:
             "etcd_endpoints": self.etcd_endpoints,
             "storage_enable_direct": self.storage_enable_direct,
             "gds_filepath": self.gds_filepath,
+            "enable_vmm": self.enable_vmm,
             "initiator_seg_type": self.initiator_seg_type,
             "max_batch_size": self.max_batch_size,
             "max_block_size": self.max_block_size,
@@ -220,6 +224,7 @@ class NIXLBench:
             "etcd_endpoints": "http://localhost:2379",
             "storage_enable_direct": False,
             "gds_filepath": "",
+            "enable_vmm": False,
             "initiator_seg_type": "DRAM",
             "max_batch_size": 1,  # ios per gpu
             "max_block_size": 67108864,  # io size

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -76,7 +76,7 @@ meson configure /path/to/build/dir
 
 ```
 --backend NAME             # Communication backend [UCX, UCX_MO] (default: UCX)
---worker_type NAME	   # Worker to use to transfer data [nixl, nvshmem] (default: nixl)
+--worker_type NAME         # Worker to use to transfer data [nixl, nvshmem] (default: nixl)
 --initiator_seg_type TYPE  # Memory segment type for initiator [DRAM, VRAM] (default: DRAM)
 --target_seg_type TYPE     # Memory segment type for target [DRAM, VRAM] (default: DRAM)
 --scheme NAME              # Communication scheme [pairwise, manytoone, onetomany, tp] (default: pairwise)
@@ -90,13 +90,14 @@ meson configure /path/to/build/dir
 --max_batch_size SIZE      # Maximum batch size (default: 1)
 --num_iter NUM             # Number of iterations (default: 1000)
 --warmup_iter NUM          # Number of warmup iterations (default: 100)
---num_threads NUM	   # Number of threads used by benchmark (default: 1)
+--num_threads NUM          # Number of threads used by benchmark (default: 1)
 --num_initiator_dev NUM    # Number of devices in initiator processes (default: 1)
 --num_target_dev NUM       # Number of devices in target processes (default: 1)
 --enable_pt                # Enable progress thread
 --device_list LIST         # Comma-separated device names (default: all)
---runtime_type NAME	   # Type of runtime to use [ETCD] (default: ETCD)
+--runtime_type NAME        # Type of runtime to use [ETCD] (default: ETCD)
 --etcd-endpoints URL       # ETCD server URL for coordination (default: http://localhost:2379)
+--enable_vmm               # Enable VMM memory allocation when DRAM is requested
 ```
 
 ### Using ETCD for Coordination

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -74,6 +74,15 @@ else
     cuda_available = true
 endif
 
+cuda_fabric_available = false
+if cuda_available
+    if cpp.has_header_symbol('cuda.h', 'CU_MEM_HANDLE_TYPE_FABRIC',
+                             args: cuda_inc_path != '' ? '-I' + cuda_inc_path : [])
+        cuda_fabric_available = true
+    endif
+endif
+
+
 # UCX
 ucx_dep = dependency('ucx')
 
@@ -118,6 +127,10 @@ if cuda_available
     add_project_arguments('-DHAVE_CUDA', language: 'cpp')
 endif
 
+if cuda_fabric_available
+    add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')
@@ -130,6 +143,7 @@ configure_file(
         'HAVE_ETCD': etcd_available ? '1' : '0',
         'HAVE_NVSHMEM': nvshmem_available ? '1' : '0',
         'HAVE_CUDA': cuda_available ? '1' : '0',
+        'HAVE_CUDA_FABRIC': cuda_fabric_available ? '1' : '0',
     },
     install: true,
     install_dir: get_option('includedir') / 'nixlbench'

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -64,6 +64,7 @@ DEFINE_int32(num_files, 1, "Number of files used by benchmark");
 DEFINE_int32(num_initiator_dev, 1, "Number of device in initiator process");
 DEFINE_int32(num_target_dev, 1, "Number of device in target process");
 DEFINE_bool(enable_pt, false, "Enable Progress Thread (only used with nixl worker)");
+DEFINE_bool(enable_vmm, false, "Enable VMM memory allocation when DRAM is requested");
 // GDS options - only used when backend is GDS
 DEFINE_string(gds_filepath, "", "File path for GDS operations (only used with GDS backend)");
 DEFINE_int32(gds_batch_pool_size, 32, "Batch pool size for GDS operations (default: 32, only used with GDS backend)");
@@ -101,6 +102,7 @@ int xferBenchConfig::num_iter = 0;
 int xferBenchConfig::warmup_iter = 0;
 int xferBenchConfig::num_threads = 0;
 bool xferBenchConfig::enable_pt = false;
+bool xferBenchConfig::enable_vmm = false;
 std::string xferBenchConfig::device_list = "";
 std::string xferBenchConfig::etcd_endpoints = "";
 std::string xferBenchConfig::gds_filepath = "";
@@ -121,6 +123,7 @@ int xferBenchConfig::loadFromFlags() {
         backend = FLAGS_backend;
         enable_pt = FLAGS_enable_pt;
         device_list = FLAGS_device_list;
+        enable_vmm = FLAGS_enable_vmm;
 
         // Load GDS-specific configurations if backend is GDS
         if (backend == XFERBENCH_BACKEND_GDS) {
@@ -254,6 +257,8 @@ void xferBenchConfig::printConfig() {
                   << enable_pt << std::endl;
         std::cout << std::left << std::setw(60) << "Device list (--device_list=dev1,dev2,...)" << ": "
                   << device_list << std::endl;
+        std::cout << std::left << std::setw(60) << "Enable VMM (--enable_vmm=[0,1])" << ": "
+                  << enable_vmm << std::endl;
 
         // Print GDS options if backend is GDS
         if (backend == XFERBENCH_BACKEND_GDS) {

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -125,6 +125,13 @@ int xferBenchConfig::loadFromFlags() {
         device_list = FLAGS_device_list;
         enable_vmm = FLAGS_enable_vmm;
 
+#if !HAVE_CUDA_FABRIC
+        if (enable_vmm) {
+            std::cerr << "VMM is not supported in CUDA version " << CUDA_VERSION << std::endl;
+            return -1;
+        }
+#endif
+
         // Load GDS-specific configurations if backend is GDS
         if (backend == XFERBENCH_BACKEND_GDS) {
             gds_filepath = FLAGS_gds_filepath;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -124,6 +124,7 @@ class xferBenchConfig {
         static std::string device_list;
         static std::string etcd_endpoints;
         static std::string gds_filepath;
+        static bool enable_vmm;
         static int num_files;
         static std::string posix_api_type;
         static std::string posix_filepath;
@@ -142,8 +143,14 @@ public:
     uintptr_t addr;
     size_t len;
     int devId;
+    size_t padded_size;
+    unsigned long long handle;
 
-    xferBenchIOV(uintptr_t a, size_t l, int d) : addr(a), len(l), devId(d) {}
+    xferBenchIOV(uintptr_t a, size_t l, int d) :
+        addr(a), len(l), devId(d), padded_size(len), handle(0) {}
+
+    xferBenchIOV(uintptr_t a, size_t l, int d, size_t p, unsigned long long h) :
+        addr(a), len(l), devId(d), padded_size(p), handle(h) {}
 };
 
 class xferBenchUtils {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -32,17 +32,11 @@
 #include <utils/serdes/serdes.h>
 #include <omp.h>
 
-#define USE_VMM 0
 #define ROUND_UP(value, granularity) ((((value) + (granularity) - 1) / (granularity)) * (granularity))
 
 static uintptr_t gds_running_ptr = 0x0;
 static std::vector<std::vector<xferBenchIOV>> gds_remote_iovs;
 static std::vector<std::vector<xferBenchIOV>> storage_remote_iovs;
-
-#if HAVE_CUDA
-static size_t __attribute__((unused)) padded_size = 0;
-static CUmemGenericAllocationHandle __attribute__((unused)) handle;
-#endif
 
 #define CHECK_NIXL_ERROR(result, message)                                         \
     do {                                                                          \
@@ -222,72 +216,88 @@ std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescDram(size_t buffer
 }
 
 #if HAVE_CUDA
-static std::optional<xferBenchIOV> getVramDesc(int devid, size_t buffer_size,
-                                 bool isInit)
+static std::optional<xferBenchIOV>
+getVramDescCuda(int devid, size_t buffer_size, uint8_t memset_value)
 {
     void *addr;
-
-    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
-#if !USE_VMM
     CHECK_CUDA_ERROR(cudaMalloc(&addr, buffer_size), "Failed to allocate CUDA buffer");
-    if (isInit) {
-        CHECK_CUDA_ERROR(cudaMemset(addr, XFERBENCH_INITIATOR_BUFFER_ELEMENT, buffer_size), "Failed to set device");
+    CHECK_CUDA_ERROR(cudaMemset(addr, memset_value, buffer_size), "Failed to set device memory" );
 
-    } else {
-        CHECK_CUDA_ERROR(cudaMemset(addr, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size), "Failed to set device");
-    }
-#else
+    return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size, devid);
+}
+
+#if CUDA_VERSION >= 12020
+static std::optional<xferBenchIOV>
+getVramDescCudaVmm(int devid, size_t buffer_size, uint8_t memset_value)
+{
     CUdeviceptr addr = 0;
-    size_t granularity = 0;
     CUmemAllocationProp prop = {};
     CUmemAccessDesc access = {};
 
     prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-    // prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
     prop.allocFlags.gpuDirectRDMACapable = 1;
     prop.location.id = devid;
     prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    // prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
 
     // Get the allocation granularity
+    size_t granularity = 0;
     CHECK_CUDA_DRIVER_ERROR(cuMemGetAllocationGranularity(&granularity,
-                         &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
-                         "Failed to get allocation granularity");
+                            &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM),
+                            "Failed to get allocation granularity");
     std::cout << "Granularity: " << granularity << std::endl;
 
-    padded_size = ROUND_UP(buffer_size, granularity);
+    size_t padded_size = ROUND_UP(buffer_size, granularity);
+    CUmemGenericAllocationHandle handle;
     CHECK_CUDA_DRIVER_ERROR(cuMemCreate(&handle, padded_size, &prop, 0),
-                         "Failed to create allocation");
+                            "Failed to create allocation");
 
     // Reserve the memory address
     CHECK_CUDA_DRIVER_ERROR(cuMemAddressReserve(&addr, padded_size,
-                         granularity, 0, 0), "Failed to reserve address");
+                                                granularity, 0, 0),
+                            "Failed to reserve address");
 
     // Map the memory
     CHECK_CUDA_DRIVER_ERROR(cuMemMap(addr, padded_size, 0, handle, 0),
-                         "Failed to map memory");
+                            "Failed to map memory");
 
     std::cout << "Address: " << std::hex << std::showbase << addr
               << " Buffer size: " << std::dec << buffer_size
               << " Padded size: " << std::dec << padded_size << std::endl;
+
     // Set the memory access rights
     access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     access.location.id = devid;
     access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
     CHECK_CUDA_DRIVER_ERROR(cuMemSetAccess(addr, buffer_size, &access, 1),
-        "Failed to set access");
+                            "Failed to set access");
 
     // Set memory content based on role
-    if (isInit) {
-        CHECK_CUDA_DRIVER_ERROR(cuMemsetD8(addr, XFERBENCH_INITIATOR_BUFFER_ELEMENT, buffer_size),
-            "Failed to set device memory to XFERBENCH_INITIATOR_BUFFER_ELEMENT");
-    } else {
-        CHECK_CUDA_DRIVER_ERROR(cuMemsetD8(addr, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size),
-            "Failed to set device memory to XFERBENCH_TARGET_BUFFER_ELEMENT");
-    }
-#endif /* !USE_VMM */
+    CHECK_CUDA_DRIVER_ERROR(cuMemsetD8(addr, memset_value, buffer_size),
+                            "Failed to set VMM device memory");
 
-    return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size, devid);
+    return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size,
+                                       devid, padded_size, handle);
+}
+#endif /* CUDA_VERSION >= 12020 */
+
+static std::optional<xferBenchIOV> getVramDesc(int devid, size_t buffer_size,
+                                               bool isInit)
+{
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
+    uint8_t memset_value = isInit ? XFERBENCH_INITIATOR_BUFFER_ELEMENT :
+                                    XFERBENCH_TARGET_BUFFER_ELEMENT;
+
+    if (xferBenchConfig::enable_vmm) {
+#if CUDA_VERSION >= 12020
+        return getVramDescCudaVmm(devid, buffer_size, memset_value);
+#else
+        std::cerr << "VMM is not supported in CUDA version " << CUDA_VERSION << std::endl;
+        exit(EXIT_FAILURE);
+#endif
+    } else {
+        return getVramDescCuda(devid, buffer_size, memset_value);
+    }
 }
 
 std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescVram(size_t buffer_size, int mem_dev_id) {
@@ -376,15 +386,18 @@ void xferBenchNixlWorker::cleanupBasicDescDram(xferBenchIOV &iov) {
 #if HAVE_CUDA
 void xferBenchNixlWorker::cleanupBasicDescVram(xferBenchIOV &iov) {
     CHECK_CUDA_ERROR(cudaSetDevice(iov.devId), "Failed to set device");
-#if !USE_VMM
-    CHECK_CUDA_ERROR(cudaFree((void *)iov.addr), "Failed to deallocate CUDA buffer");
-#else
-    CHECK_CUDA_DRIVER_ERROR(cuMemUnmap(iov.addr, iov.len),
-                         "Failed to unmap memory");
-    CHECK_CUDA_DRIVER_ERROR(cuMemRelease(handle),
-                         "Failed to release memory");
-    CHECK_CUDA_DRIVER_ERROR(cuMemAddressFree(iov.addr, padded_size), "Failed to free reserved address");
-#endif
+
+    if (xferBenchConfig::enable_vmm) {
+        CHECK_CUDA_DRIVER_ERROR(cuMemUnmap(iov.addr, iov.len),
+                                "Failed to unmap memory");
+        CHECK_CUDA_DRIVER_ERROR(cuMemRelease(iov.handle),
+                                "Failed to release memory");
+        CHECK_CUDA_DRIVER_ERROR(cuMemAddressFree(iov.addr, iov.padded_size),
+                                "Failed to free reserved address");
+    } else {
+        CHECK_CUDA_ERROR(cudaFree((void *)iov.addr),
+                                  "Failed to deallocate CUDA buffer");
+    }
 }
 #endif /* HAVE_CUDA */
 

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -291,13 +291,9 @@ static std::optional<xferBenchIOV> getVramDesc(int devid, size_t buffer_size,
     if (xferBenchConfig::enable_vmm) {
 #if HAVE_CUDA_FABRIC
         return getVramDescCudaVmm(devid, buffer_size, memset_value);
-#else
-        std::cerr << "VMM is not supported in CUDA version " << CUDA_VERSION << std::endl;
-        exit(EXIT_FAILURE);
 #endif
-    } else {
-        return getVramDescCuda(devid, buffer_size, memset_value);
     }
+    return getVramDescCuda(devid, buffer_size, memset_value);
 }
 
 std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescVram(size_t buffer_size, int mem_dev_id) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -226,7 +226,7 @@ getVramDescCuda(int devid, size_t buffer_size, uint8_t memset_value)
     return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size, devid);
 }
 
-#if CUDA_VERSION >= 12020
+#if HAVE_CUDA_FABRIC
 static std::optional<xferBenchIOV>
 getVramDescCudaVmm(int devid, size_t buffer_size, uint8_t memset_value)
 {
@@ -279,7 +279,7 @@ getVramDescCudaVmm(int devid, size_t buffer_size, uint8_t memset_value)
     return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size,
                                        devid, padded_size, handle);
 }
-#endif /* CUDA_VERSION >= 12020 */
+#endif /* HAVE_CUDA_FABRIC */
 
 static std::optional<xferBenchIOV> getVramDesc(int devid, size_t buffer_size,
                                                bool isInit)
@@ -289,7 +289,7 @@ static std::optional<xferBenchIOV> getVramDesc(int devid, size_t buffer_size,
                                     XFERBENCH_TARGET_BUFFER_ELEMENT;
 
     if (xferBenchConfig::enable_vmm) {
-#if CUDA_VERSION >= 12020
+#if HAVE_CUDA_FABRIC
         return getVramDescCudaVmm(devid, buffer_size, memset_value);
 #else
         std::cerr << "VMM is not supported in CUDA version " << CUDA_VERSION << std::endl;


### PR DESCRIPTION
This PR enables VMM CUDA memory allocation in NIXL to allow MNNVL communication