### PR TITLE
nixlbench: Add deps for IB devices

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -52,7 +52,8 @@ RUN echo "INFO: Starting custom UCX build..." && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         autoconf automake libtool pkg-config make g++ \
-        libnuma-dev librdmacm-dev ibverbs-providers && \
+        libnuma-dev librdmacm-dev ibverbs-providers libibverbs-dev rdma-core \
+        ibverbs-utils libibumad-dev && \
     echo "INFO: Removing pre-existing UCX installations..." && \
     rm -rf /usr/local/ucx /opt/hpcx/ucx && \
     cd /workspace/ucx && \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get update -y && \
     build-essential
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev
+    --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
+    libnuma-dev librdmacm-dev ibverbs-providers
 
 WORKDIR /workspace
 RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git &&\


### PR DESCRIPTION
This PR incorporates a few fixes:
- ARM64 fix and GDS path fix is done in https://github.com/ai-dynamo/nixl/pull/408
- Install required dependencies for IB in nixlbench Dockerfile
