### PR TITLE
Build and container fixes for aarch64

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -73,9 +73,10 @@ FROM ucx_${UCX}_image AS ucx_image
 
 # --- Stage 4: Final Image Assembly ---
 # Re-declare ARGs needed in this final stage
+ARG ARCH="x86_64"
 ARG DEFAULT_PYTHON_VERSION
 ARG WHL_PYTHON_VERSIONS="3.12"
-ARG WHL_PLATFORM="manylinux_2_39_x86_64"
+ARG WHL_PLATFORM="manylinux_2_39_$ARCH"
 
 WORKDIR /workspace
 RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git &&\
@@ -104,9 +105,9 @@ RUN rm -rf build && \
     ninja && \
     ninja install
 
-ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
-RUN echo "/usr/local/nixl/lib/x86_64-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
-    echo "/usr/local/nixl/lib/x86_64-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/$ARCH-linux-gnu/plugins
+RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
+    echo "/usr/local/nixl/lib/$ARCH-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
 # Create the wheel

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -18,6 +18,7 @@ ARG BASE_IMAGE_TAG="25.03-cuda12.8-devel-ubuntu24.04"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 
+ARG ARCH="x86_64"
 ARG DEFAULT_PYTHON_VERSION="3.12"
 
 RUN apt-get update -y && \
@@ -57,13 +58,16 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
     RUST_VERSION=1.86.0 \
-    RUSTARCH=x86_64-unknown-linux-gnu
+    RUSTARCH=${ARCH}-unknown-linux-gnu
 
-RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
-    echo "a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f *rustup-init" | sha256sum -c - && \
+# Download rustup-init and its checksum for the target architecture
+RUN wget --tries=3 --waitretry=5 \
+    "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" \
+    "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init.sha256" && \
+    sha256sum -c rustup-init.sha256 && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
-    rm rustup-init && \
+    rm rustup-init* && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 WORKDIR /workspace/nixl
@@ -110,16 +114,16 @@ RUN rm -rf build && \
     ninja install
 
 ENV NIXL_PREFIX=/usr/local/nixl
-ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/x86_64-linux-gnu/plugins
-RUN echo "/usr/local/nixl/lib/x86_64-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
-    echo "/usr/local/nixl/lib/x86_64-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib/$ARCH-linux-gnu/plugins
+RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
+    echo "/usr/local/nixl/lib/$ARCH-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
 RUN cd src/bindings/rust && cargo build --release --locked
 
 # Create the wheel
 ARG WHL_PYTHON_VERSIONS="3.12"
-ARG WHL_PLATFORM="manylinux_2_39_x86_64"
+ARG WHL_PLATFORM="manylinux_2_39_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
         uv build --wheel --out-dir /tmp/dist --python $PYTHON_VERSION; \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,7 +19,7 @@ option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD Li
 option('disable_gds_backend', type : 'boolean', value : false, description : 'disable gds backend')
 option('disable_mooncake_backend', type : 'boolean', value : false, description : 'disable mooncake backend')
 option('install_headers', type : 'boolean', value : true, description : 'install headers')
-option('gds_path', type: 'string', value: '/usr/local/cuda/targets/x86_64-linux/', description: 'Path to GDS CuFile install')
+option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path to GDS CuFile install')
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')

--- a/src/plugins/cuda_gds/meson.build
+++ b/src/plugins/cuda_gds/meson.build
@@ -15,7 +15,7 @@
 
 gds_path = get_option('gds_path')
 if gds_path != ''
-    gds_lib_path = gds_path + '/lib'
+    gds_lib_path = gds_path + '/lib64'
     gds_inc_path = gds_path + '/include'
     cufile_dep = declare_dependency(
         link_args: ['-L' + gds_lib_path, '-lcufile'],


### PR DESCRIPTION
Set default GDS path to point to CUDA install directory and use point lib and include to symlinks instead of hardcoding architecture-specific values.

Currently build scripts and Docker build files assume that the container is built on x86_64 Linux host (by not specifying a platform which makes docker default to host architecture, hardcoding 'x86_64' in several places, etc.), which makes it impossible to create either x86_64 or aarch64 container on Arm host or aarch64 container on x86 host.

Configure target architecture via 'ARCH' docker variable. Set it to x86 by default in docker files (for any users that use it directly) and to host architecture in build-container.sh and nixlbench build.sh. Allow user to specify ARCH value via '--arch' CLI parameter, set docker build platform value accordingly and pass the value to docker build as a build arg.

Fixes NIX-14