### PR TITLE
Fix for UCX build with IB dependencies

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=ucx . /workspace/ucx
 RUN echo "INFO: Starting custom UCX build..." && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        autoconf automake libtool pkg-config make g++ \
+        --reinstall autoconf automake libtool pkg-config make g++ \
         libnuma-dev librdmacm-dev ibverbs-providers libibverbs-dev rdma-core \
         ibverbs-utils libibumad-dev && \
     echo "INFO: Removing pre-existing UCX installations..." && \


### PR DESCRIPTION
In PR https://github.com/ai-dynamo/nixl/pull/407 we introduced required packages for IB module of UCX to build.
However during review process I removed option `--reinstall` that is required for build to complete.
This PR adds this option back