### PR TITLE
Add JSON output support with --output_format and --output_json_file flags

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -72,6 +72,10 @@ RUN echo "INFO: Starting custom UCX build..." && \
 # This stage selects the correct UCX image based on the UCX argument
 FROM ucx_${UCX}_image AS ucx_image
 
+RUN mkdir -p /usr/include/nlohmann && \
+    curl -sL https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp \
+    -o /usr/include/nlohmann/json.hpp
+
 # --- Stage 4: Final Image Assembly ---
 # Re-declare ARGs needed in this final stage
 ARG ARCH="x86_64"

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -180,10 +180,6 @@ int main(int argc, char *argv[]) {
 
     xferBenchConfig::output_format = FLAGS_output_format;
 
-    if (xferBenchConfig::output_format == "json") {
-        return 0;
-    }
-
     int ret = xferBenchConfig::loadFromFlags();
     if (0 != ret) {
         return EXIT_FAILURE;

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -29,6 +29,8 @@
 #include <unistd.h>
 #include <memory>
 #include <csignal>
+#include "json.hpp"
+using json = nlohmann::json;
 
 static std::pair<size_t, size_t> getStrideScheme(xferBenchWorker &worker, int num_threads) {
     int initiator_device, target_device;
@@ -175,6 +177,12 @@ static std::unique_ptr<xferBenchWorker> createWorker(int *argc, char ***argv) {
 
 int main(int argc, char *argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    xferBenchConfig::output_format = FLAGS_output_format;
+
+    if (xferBenchConfig::output_format == "json") {
+        return 0;
+    }
 
     int ret = xferBenchConfig::loadFromFlags();
     if (0 != ret) {

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -29,8 +29,9 @@
 #include <unistd.h>
 #include <memory>
 #include <csignal>
-#include "json.hpp"
+#include "nlohmann/json.hpp"
 using json = nlohmann::json;
+DECLARE_string(output_format);
 
 static std::pair<size_t, size_t> getStrideScheme(xferBenchWorker &worker, int num_threads) {
     int initiator_device, target_device;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -26,8 +26,9 @@
 #if HAVE_CUDA
 #include <cuda_runtime.h>
 #endif
-#include "json.hpp"
+#include "nlohmann/json.hpp"
 using json = nlohmann::json;
+#include <fstream>
 
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/utils.h"
@@ -40,7 +41,6 @@ DEFINE_string(runtime_type, XFERBENCH_RT_ETCD, "Runtime type to use for communic
 DEFINE_string(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem]");
 DEFINE_string(backend, XFERBENCH_BACKEND_UCX, "Name of communication backend [UCX, UCX_MO, GDS, POSIX] \
               (only used with nixl worker)");
-DEFINE_string(output_format, "text", "Output format for benchmark results [text, json]");
 DEFINE_string(initiator_seg_type, XFERBENCH_SEG_TYPE_DRAM, "Type of memory segment for initiator \
               [DRAM, VRAM]");
 DEFINE_string(target_seg_type, XFERBENCH_SEG_TYPE_DRAM, "Type of memory segment for target \
@@ -84,6 +84,7 @@ DEFINE_string(etcd_endpoints, "http://localhost:2379", "ETCD server endpoints fo
 DEFINE_string(posix_api_type, XFERBENCH_POSIX_API_AIO, "API type for POSIX operations [AIO, URING] (only used with POSIX backend)");
 DEFINE_string(posix_filepath, "", "File path for POSIX operations (only used with POSIX backend)");
 DEFINE_bool(storage_enable_direct, false, "Enable direct I/O for storage operations (only used with POSIX backend)");
+DEFINE_string(output_format, "text", "Output format for benchmark results [text, json]");
 DEFINE_string(output_json_file, "", "Path to write JSON result output (optional)");
 
 std::string xferBenchConfig::runtime_type = "";
@@ -117,6 +118,8 @@ int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
 std::string xferBenchConfig::posix_filepath = "";
 bool xferBenchConfig::storage_enable_direct = false;
+std::string xferBenchConfig::output_format = "";
+std::string xferBenchConfig::output_json_file = "";
 
 int xferBenchConfig::loadFromFlags() {
     runtime_type = FLAGS_runtime_type;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -130,6 +130,8 @@ int xferBenchConfig::loadFromFlags() {
         // Load GDS-specific configurations if backend is GDS
         if (backend == XFERBENCH_BACKEND_GDS) {
             gds_filepath = FLAGS_gds_filepath;
+            gds_batch_pool_size = FLAGS_gds_batch_pool_size;
+            gds_batch_limit = FLAGS_gds_batch_limit;
             num_files = FLAGS_num_files;
             storage_enable_direct = FLAGS_storage_enable_direct;
             gds_batch_pool_size = FLAGS_gds_batch_pool_size;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -134,7 +134,8 @@ class xferBenchConfig {
         static int gds_batch_pool_size;
         static int gds_batch_limit;
         static std::string output_format;
-
+        static std::string output_json_file;
+        
         static int loadFromFlags();
         static void printConfig();
         static std::vector<std::string> parseDeviceList();

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -26,7 +26,7 @@
 #include <vector>
 #include <optional>
 #include "runtime/runtime.h"
-#include "json.hpp"
+#include "nlohmann/json.hpp"
 using json = nlohmann::json;
 
 #if HAVE_CUDA

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -131,6 +131,8 @@ class xferBenchConfig {
         static std::string posix_api_type;
         static std::string posix_filepath;
         static bool storage_enable_direct;
+        static int gds_batch_pool_size;
+        static int gds_batch_limit;
         static std::string output_format;
 
         static int loadFromFlags();

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -102,6 +102,7 @@ using json = nlohmann::json;
                               XFERBENCH_MODE_SG == xferBenchConfig::mode)
 #define IS_PAIRWISE_AND_MG() (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
                               XFERBENCH_MODE_MG == xferBenchConfig::mode)
+
 class xferBenchConfig {
     public:
         static std::string runtime_type;
@@ -139,6 +140,7 @@ class xferBenchConfig {
         static int loadFromFlags();
         static void printConfig();
         static std::vector<std::string> parseDeviceList();
+        static json to_json();
 };
 
 // Generic IOV descriptor class independent of NIXL

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -26,10 +26,13 @@
 #include <vector>
 #include <optional>
 #include "runtime/runtime.h"
+#include "json.hpp"
+using json = nlohmann::json;
 
 #if HAVE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
+
 
 #define CHECK_CUDA_ERROR(result, message)                                           \
     do {                                                                            \
@@ -128,8 +131,7 @@ class xferBenchConfig {
         static std::string posix_api_type;
         static std::string posix_filepath;
         static bool storage_enable_direct;
-        static int gds_batch_pool_size;
-        static int gds_batch_limit;
+        static std::string output_format;
 
         static int loadFromFlags();
         static void printConfig();


### PR DESCRIPTION
This PR adds two CLI flags to support structured output:

* `--output_format=[text|json]`:
  Allows switching between traditional text output and JSON format. When set to `json`, verbose console configuration info is suppressed.

* `--output_json_file=<path>`:
  Optionally writes the JSON output to a specified file.

This improves integration with downstream tools and simplifies automated parsing. Default behavior remains unchanged.
