### PR TITLE
.GITHUB: added PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## What?
+_Describe what this PR is doing._
+
+## Why?
+_Justification for the PR. If there is an existing issue/bug, please reference it. For
+bug fixes, the 'Why?' and 'What?' can be merged into a single item._
+
+## How?
+_It is optional, but for complex PRs, please provide information about the design,
+architecture, approach, etc._


### PR DESCRIPTION
## What?
Added a PR template

## Why?
To encourage contributors to document their changes and add a short explanation for the suggested PR.
