### PR TITLE
nixlbench: Add libgtest dependency to build gtest

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update -y && \
     libgrpc-dev \
     libgrpc++-dev \
     libprotobuf-dev \
+    libgtest-dev \
     protobuf-compiler-grpc \
     libcpprest-dev \
     etcd-server \


### PR DESCRIPTION
Adding libgtest-dev dependency to the nixlbench container, which is required dependency for gtest build