### PR TITLE
NIXL: set env vars for best EFA performance

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -98,7 +98,7 @@ get_options() {
             ;;
         --ucx-upstream)
             # Master branch (v1.20) also containing EFA SRD support
-            UCX_REF=7ec95b95e524a87e81cac92f5ca8523e3966b16b
+            UCX_REF=b3cfe4dba239e48aa7c2322c879beeafbe1bfda5
             ;;
         --arch)
             if [ "$2" ]; then

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -98,7 +98,7 @@ get_options() {
             ;;
         --ucx-upstream)
             # Master branch (v1.20) also containing EFA SRD support
-            UCX_REF=b3cfe4dba239e48aa7c2322c879beeafbe1bfda5
+            UCX_REF=9d2b88a1f67faf9876f267658bd077b379b8bb76
             ;;
         --arch)
             if [ "$2" ]; then

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -58,8 +58,8 @@ void ucx_modify_config(ucp_config_t *config, std::string_view key,
 
     ucs_status_t status = ucp_config_modify(config, key.data(), value.data());
     if (status != UCS_OK) {
-        NIXL_ERROR << "Failed to modify UCX config: " << key << "=" << value
-                   << ": " << ucs_status_string(status);
+        NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value
+                  << ": " << ucs_status_string(status);
     } else {
         NIXL_DEBUG << "Applied UCX config from " << (env_val ? "env var" : "NIXL")
                    << ": " << key << "=" << value;

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -412,11 +412,12 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     ucx_modify_config(ucp_config, "ADDRESS_VERSION", "v2");
     ucx_modify_config(ucp_config, "RNDV_THRESH", "inf");
 
-    if (major_version >= 1 && minor_version >= 19) {
+    unsigned ucp_version = UCP_VERSION(major_version, minor_version);
+    if (ucp_version >= UCP_VERSION(1, 19)) {
         ucx_modify_config(ucp_config, "MAX_COMPONENT_MDS", "32");
     }
 
-    if (major_version >= 1 && minor_version >= 20) {
+    if (ucp_version >= UCP_VERSION(1, 20)) {
         ucx_modify_config(ucp_config, "MAX_RMA_RAILS", "4");
     } else {
         ucx_modify_config(ucp_config, "MAX_RMA_RAILS", "2");

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -411,8 +411,10 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     ucx_modify_config(ucp_config, "RNDV_THRESH", "inf");
 
     // Set 4 RMA lanes for UCX 1.20 and above, and 2 otherwise
+    unsigned major_version, minor_version, release_number;
+    ucp_get_version(&major_version, &minor_version, &release_number);
     ucx_modify_config(ucp_config, "MAX_RMA_RAILS",
-                      (UCP_API_MAJOR >= 1 && UCP_API_MINOR >= 20) ? "4" : "2");
+                      (major_version >= 1 && minor_version >= 20) ? "4" : "2");
 
     status = ucp_init(&ucp_params, ucp_config, &ctx);
     if (status != UCS_OK) {

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -211,4 +211,7 @@ private:
 
 nixl_status_t ucx_status_to_nixl(ucs_status_t status);
 
+void ucx_modify_config(ucp_config_t *config, std::string_view key,
+                       std::string_view value);
+
 #endif


### PR DESCRIPTION
## What?
Set env vars in NIXL plugin for best EFA performance.

## Why?
The best performance in EFA is achieved by using 4 RMA lanes, but on low message sizes this leads to significant performance degradations. Recent UCX PR (https://github.com/openucx/ucx/pull/10723) fixes this issue by adding MIN_RMA_CHUNK.

## How?
Performance impact of this change is documented here: https://confluence.nvidia.com/pages/viewpage.action?pageId=4004524984