### PR TITLE
NIXL: set env vars for best EFA performance (#459)

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -98,7 +98,7 @@ get_options() {
             ;;
         --ucx-upstream)
             # Master branch (v1.20) also containing EFA SRD support
-            UCX_REF=7ec95b95e524a87e81cac92f5ca8523e3966b16b
+            UCX_REF=9d2b88a1f67faf9876f267658bd077b379b8bb76
             ;;
         --arch)
             if [ "$2" ]; then

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -211,4 +211,7 @@ private:
 
 nixl_status_t ucx_status_to_nixl(ucs_status_t status);
 
+void ucx_modify_config(ucp_config_t *config, std::string_view key,
+                       std::string_view value);
+
 #endif


### PR DESCRIPTION
## What?
Set env vars in NIXL UCX backend

## Why?
* Best EFA performance using multiple rails and chunk sizes

## How?
* Updated UCX sha1 ref containing MIN_RMA_CHUNK
* ERROR -> WARN
* Set MDS only for UCX >= 1.19