### PR TITLE
Python: Fixed bad cast OBJ_SEG cast in nixl_bindings.cpp

### DIFF
--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -135,7 +135,7 @@ PYBIND11_MODULE(_bindings, m) {
         .value("DRAM_SEG", DRAM_SEG)
         .value("VRAM_SEG", VRAM_SEG)
         .value("BLK_SEG", BLK_SEG)
-        .value("OBJ_SEG", BLK_SEG)
+        .value("OBJ_SEG", OBJ_SEG)
         .value("FILE_SEG", FILE_SEG)
         .export_values();
 


### PR DESCRIPTION
## What?
Fixed a typo resulting in a bad cast.
