### PR TITLE
AWS: Remove job retries and add GH metadata tags

### DIFF
--- a/contrib/aws-efa/aws_test.sh
+++ b/contrib/aws-efa/aws_test.sh
@@ -78,7 +78,6 @@ JOB_ID=$(aws batch submit-job \
     --job-definition "NIXL-Ubuntu-JD" \
     --job-queue ucx-nxil-jq \
     --eks-properties-override file://./aws_vars.json \
-    --retry-strategy '{"attempts":3}' \
     --query 'jobId' --output text)
 
 # Function to wait for a specific job status

--- a/contrib/aws-efa/aws_test.sh
+++ b/contrib/aws-efa/aws_test.sh
@@ -109,6 +109,7 @@ wait_for_status() {
 echo "Waiting for job to start running (timeout: 30m)..."
 if ! wait_for_status "RUNNING" 1800 10; then
     echo "Job failed to start"
+    aws batch describe-jobs --jobs "$JOB_ID" --query 'jobs[0].[status,statusReason]' --output table
     exit 1
 fi
 

--- a/contrib/aws-efa/aws_test.sh
+++ b/contrib/aws-efa/aws_test.sh
@@ -70,6 +70,16 @@ export AWS_CMD="${setup_cmd} && ${build_cmd} && ${test_cmd}"
 envsubst < aws_vars.template > aws_vars.json
 jq . aws_vars.json >/dev/null
 
+# Build tags JSON for AWS
+TAGS_JSON=$(jq -n '{
+    github_ref: env.GITHUB_REF,
+    github_repository: env.GITHUB_REPOSITORY,
+    github_run_number: env.GITHUB_RUN_NUMBER,
+    github_run_id: env.GITHUB_RUN_ID,
+    github_job_url: "\(env.GITHUB_SERVER_URL)/\(env.GITHUB_REPOSITORY)/actions/runs/\(env.GITHUB_RUN_ID)",
+    container_image: env.CONTAINER_IMAGE
+}')
+
 # Submit AWS job
 aws eks update-kubeconfig --name ucx-ci
 JOB_NAME="NIXL_${GITHUB_RUN_NUMBER:-$RANDOM}"
@@ -78,6 +88,7 @@ JOB_ID=$(aws batch submit-job \
     --job-definition "NIXL-Ubuntu-JD" \
     --job-queue ucx-nxil-jq \
     --eks-properties-override file://./aws_vars.json \
+    --tags "$TAGS_JSON" \
     --query 'jobId' --output text)
 
 # Function to wait for a specific job status


### PR DESCRIPTION
## What?
Removes automatic retry on AWS job failures, adds GitHub metadata tags for traceability, and improves diagnostics when jobs fail to start.

## Why?
- Failed tests were retrying 3 times, wasting AWS resources
- No way to link AWS jobs back to GitHub Actions runs
- No visibility into why jobs get stuck in RUNNABLE state

## How?
- Remove `--retry-strategy '{"attempts":3}'` 
- Add tags with GitHub context and direct link to Actions run
- Show job status/reason on startup timeout

### Sample resulting tags:

```
$ aws batch describe-jobs --jobs "$JOB_ID" --query 'jobs[0].tags' --output table
-------------------------------------------------------------------------------------
|                                   DescribeJobs                                    |
+--------------------+--------------------------------------------------------------+
|  container_image   |  nvcr.io/nvidia/pytorch:25.02-py3                            |
|  github_job_url    |  https://github.com/ai-dynamo/nixl/actions/runs/15701204753  |
|  github_ref        |  refs/heads/pull-request/467                                 |
|  github_repository |  ai-dynamo/nixl                                              |
|  github_run_id     |  15701204753                                                 |
|  github_run_number |  995                                                         |
+--------------------+--------------------------------------------------------------+