### PR TITLE
build: Add wheel-base to pass the the wheel building platform.

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -61,6 +61,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --wheel-base)
+            if [ "$2" ]; then
+                WHL_BASE=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --os)
             if [ "$2" ]; then
                 OS=$2
@@ -128,8 +136,10 @@ get_options() {
 
     if [[ $OS == "ubuntu22" ]]; then
         BASE_IMAGE_TAG=24.10-cuda12.6-devel-ubuntu22.04
-        WHL_PLATFORM=manylinux_2_34_${ARCH}
+        WHL_BASE=${WHL_BASE:-manylinux_2_34}
     fi
+
+    WHL_PLATFORM=${WHL_BASE}_${ARCH}
 
     if [ -z "$TAG" ]; then
         TAG="--tag nixl:${VERSION}"
@@ -152,6 +162,7 @@ show_help() {
     echo "usage: build-container.sh"
     echo "  [--base base image]"
     echo "  [--base-image-tag base image tag]"
+    echo "  [--wheel-base base platform for wheel builds]"
     echo "  [--no-cache disable docker build cache]"
     echo "  [--os [ubuntu24|ubuntu22] to select Ubuntu version]"
     echo "  [--tag tag for image]"

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -111,7 +111,6 @@ get_options() {
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
-                WHL_PLATFORM=${WHL_BASE}_${ARCH}
                 shift
             else
                 missing_requirement $1


### PR DESCRIPTION
## What?
Add the --wheel-base option to build-container.sh to specify the platform identifier used for building Python wheels e.g. manylinux_2_28.

Test pipeline: nixl-ci/30214570