### PR TITLE
fix mem_type in gtest/test_transfer.cpp

### DIFF
--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -40,7 +40,7 @@ class MemBuffer : std::shared_ptr<void> {
 public:
     MemBuffer(size_t size, nixl_mem_t mem_type = DRAM_SEG) :
         std::shared_ptr<void>(allocate(size, mem_type),
-                              [&mem_type](void *ptr) {
+                              [mem_type](void *ptr) {
                                   release(ptr, mem_type);
                               }),
         size(size)


### PR DESCRIPTION
As described in issue: https://github.com/ai-dynamo/nixl/issues/470, the lambda captures the reference (i.e., address) of the variable mem_type that exists in the constructor's stack frame. However, this captured reference becomes invalid once the constructor finishes and the stack frame is destroyed. 

```
    MemBuffer(size_t size, nixl_mem_t mem_type = DRAM_SEG) :
        std::shared_ptr<void>(allocate(size, mem_type),
                              [&mem_type](void *ptr) {
                                  release(ptr, mem_type);
                              }),
```
Replace [&mem_type] with [mem_type] fixed it. GTest completed successfully
