### PR TITLE
contrib: Remove the lib.real from the LD_LIBRARY path (#466)

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -90,8 +90,9 @@ COPY --from=nixlbench . /workspace/nixlbench
 
 WORKDIR /workspace/nixl
 
-# LD_LIBRARY_PATH is needed for auditwheel to find libcuda.so.1
-# Set incorrectly to `compat/lib` in cuda-dl-base image
+# This is only to find libcuda.so.1 correctly for build, removed once done
+RUN ln -sf "/usr/local/cuda/compat/lib.real" "/usr/local/cuda/compat/lib"
+ARG OLD_LD_PATH=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:/usr/local/lib:$LD_LIBRARY_PATH
 
 ENV VIRTUAL_ENV=/workspace/nixl/.venv
@@ -120,6 +121,10 @@ RUN uv pip install auditwheel && \
     uv run auditwheel repair /tmp/dist/nixl-*cp31*.whl --plat $WHL_PLATFORM --wheel-dir /workspace/nixl/dist
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl
+
+# Remove the cuda setup
+RUN rm -f /usr/local/cuda/compat/lib
+ENV LD_LIBRARY_PATH=$OLD_LD_PATH
 
 WORKDIR /workspace/nixlbench
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -76,8 +76,9 @@ RUN wget --tries=3 --waitretry=5 \
 WORKDIR /workspace/nixl
 COPY . /workspace/nixl
 
-# LD_LIBRARY_PATH is needed for auditwheel to find libcuda.so.1
-# Set incorrectly to `compat/lib` in cuda-dl-base image
+# This is only to find libcuda.so.1 correctly for build, removed once done
+RUN ln -sf "/usr/local/cuda/compat/lib.real" "/usr/local/cuda/compat/lib"
+ARG OLD_LD_PATH=${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:/usr/local/lib:$LD_LIBRARY_PATH
 
 ENV VIRTUAL_ENV=/workspace/nixl/.venv
@@ -150,3 +151,7 @@ RUN uv pip install auditwheel && \
     uv run auditwheel repair /tmp/dist/nixl-*cp31*.whl --plat $WHL_PLATFORM --wheel-dir /workspace/nixl/dist
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl
+
+# Remove the cuda setup
+RUN rm -f /usr/local/cuda/compat/lib
+ENV LD_LIBRARY_PATH=$OLD_LD_PATH

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -90,9 +90,10 @@ RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-# LD_LIBRARY_PATH is needed for auditwheel to find libcuda.so.1
-# Set incorrectly to `compat/lib` in cuda-dl-base image
-ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
+# This is only to find libcuda.so.1 correctly for build, removed once done
+RUN ln -sf "/usr/local/cuda/compat/lib.real" "/usr/local/cuda/compat/lib"
+ARG OLD_LD_PATH=${LD_LIBRARY_PATH}
+ENV LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:/usr/local/lib:$LD_LIBRARY_PATH
 
 ENV CUDA_PATH=/usr/local/cuda
 
@@ -163,3 +164,7 @@ RUN uv pip install auditwheel && \
     uv run auditwheel repair /tmp/dist/nixl-*cp3*.whl --plat $WHL_PLATFORM --wheel-dir /workspace/nixl/dist
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl
+
+# Remove the cuda setup
+RUN rm -f /usr/local/cuda/compat/lib
+ENV LD_LIBRARY_PATH=$OLD_LD_PATH


### PR DESCRIPTION
## What?
Remove the lib.real from the LD_LIBRARY path

## Why?
Keeping lib.real in the env var LD_LIBRARY_PATH makes a mess for the CUDA scripts to setup the symlinks for the nvidia runtime. This can cause the error 803 to be displayed.

Unfortunately, we need the libcuda.so.1 when repairing the wheel, so move the ENV command there and restore the old LD_LIBRARY_PATH after finishing.
