### PR TITLE
clang: Add clang format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,71 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: All
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: false
+  BeforeLambdaBody: false
+  IndentBraces: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: true
+ColumnLimit: 100
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: Inner
+
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Right
+ReferenceAlignment: Right
+ReflowComments: true
+SortIncludes: false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: NonEmptyParentheses
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+UseTab: Never
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,13 +38,16 @@ repos:
         args: ["--max-line-length=88", "--select=C,E,F,W,B,B950", "--extend-ignore=E203,E501,W503"]
         types_or: [python, cython]
 
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v16.0.5
-    hooks:
-      - id: clang-format
-        types_or: [c, c++, cuda, proto, textproto, java]
-        args: ["-fallback-style=none", "-style=file", "-i"]
-        files: \.(cpp|h|cc|c)$
+# Removed to allow clang format to proceed and PRs to pass pre-commit and CI.
+# Once Clang format checker is enabled in CI, conformance will be mandatory.
+# See: https://clang.llvm.org/docs/ClangFormat.html#vim-integration for integrating clang-formatting.
+#  - repo: https://github.com/pre-commit/mirrors-clang-format
+#    rev: v16.0.5
+#    hooks:
+#      - id: clang-format
+#        types_or: [c, c++, cuda, proto, textproto, java]
+#        args: ["-fallback-style=none", "-style=file", "-i"]
+#        files: \.(cpp|h|cc|c)$
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4


### PR DESCRIPTION
## What?
Adds .clang-format file. Disable clang formatter in pre-commit until the CI clang format checker is ready.

## Why?
Required for formatting code correctly.