### PR TITLE
feat: Enable build with stub api in rust bindings

### DIFF
--- a/src/bindings/rust/Cargo.toml
+++ b/src/bindings/rust/Cargo.toml
@@ -26,6 +26,9 @@ readme = "README.md"
 links = "nixl"
 build = "build.rs"
 
+[features]
+stub-api = []
+
 [dependencies]
 thiserror = { version = "2" }
 tracing = { version = "0.1" }

--- a/src/bindings/rust/README.md
+++ b/src/bindings/rust/README.md
@@ -25,6 +25,20 @@ The bindings can be built using Cargo, Rust's package manager:
 cargo build
 ```
 
+### Building with Stubs (No NIXL Library Required)
+
+You can compile the bindings using stub implementations that don't require the actual NIXL library to be installed. This is useful for:
+- Development environments where NIXL isn't available
+- CI/CD pipelines
+- Building documentation
+
+```bash
+# Build with stub API
+cargo build --features stub-api
+```
+
+**Important**: When using stubs, any attempt to actually call NIXL functions at runtime will print an error message and abort the program. The stubs are only meant for compilation, not execution.
+
 ### Environment Variables
 
 - `NIXL_PREFIX`: Path to the NIXL installation (default: `/opt/nvidia/nvda_nixl`)
@@ -46,3 +60,5 @@ Note that multithreading is disabled because NIXL might deadlock.
 ```bash
 cargo test -- --test-threads=1
 ```
+
+**Note**: Tests cannot be run with the `stub-api` feature as they require actual NIXL functionality.

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -41,7 +41,7 @@ struct nixl_capi_notif_map_s { /* empty */ };
 nixl_capi_status_t
 nixl_capi_stub_abort()
 {
-  printf("nixl error: detected use of the NIXL C API's stub; please update the LD_LIBRARY_PATH to include the nixl library\n");
+  printf("nixl error: detected use of the NIXL C API's stub; if you want to use NIXL, don't use the stub-api feature.\n");
   std::abort();
   return NIXL_CAPI_ERROR_EXCEPTION;
 }
@@ -243,7 +243,7 @@ nixl_capi_get_backend_params(
 
 // Transfer descriptor list functions
 nixl_capi_status_t
-nixl_capi_create_xfer_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_xfer_dlist_t* dlist)
+nixl_capi_create_xfer_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_xfer_dlist_t* dlist, bool sorted)
 {
   return nixl_capi_stub_abort();
 }
@@ -286,7 +286,7 @@ nixl_capi_xfer_dlist_resize(nixl_capi_xfer_dlist_t dlist, size_t new_size)
 
 // Registration descriptor list functions
 nixl_capi_status_t
-nixl_capi_create_reg_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_reg_dlist_t* dlist)
+nixl_capi_create_reg_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_reg_dlist_t* dlist, bool sorted)
 {
   return nixl_capi_stub_abort();
 }


### PR DESCRIPTION
In Dynamo, we need to run commands like `cargo check` on the block manager in CI. The block manager requires the `nixl-sys` crate. Because of this, we have to build inside a container where NIXL is installed, even when we don't need to call any of the functions. This MR adds a `stub-api` feature that stubs out all api functions, so we can build the block manager even when NIXL itself isn't installed.