### PR TITLE
Object storage plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ subprojects/packagecache/
 
 # AWS EFA test files
 contrib/aws-efa/aws_vars.json
+
+# Asio
+subprojects/asio-1.30.2/

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ subprojects/packagecache/
 contrib/aws-efa/aws_vars.json
 
 # Asio
-subprojects/asio-1.30.2/
+subprojects/asio-*

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -44,7 +44,8 @@ RUN apt-get update -y && \
     libz-dev \
     flex \
     libgtest-dev \
-    build-essential
+    build-essential \
+    libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev # aws-sdk-cpp dependencies
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
     --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
@@ -54,6 +55,10 @@ WORKDIR /workspace
 RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git &&\
 	cd etcd-cpp-apiv3 && mkdir build && cd build && \
 	cmake .. && make -j$(nproc) && make install
+RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1.11.581 && \
+    mkdir aws_sdk_build && cd aws_sdk_build && \
+    cmake ../aws-sdk-cpp/ -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3" -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    make -j$(nproc) && make install
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -33,6 +33,10 @@ if 'POSIX' in static_plugins
     nixl_lib_deps += [ posix_backend_interface ]
 endif
 
+if 'OBJ' in static_plugins
+    nixl_lib_deps += [ obj_backend_interface ]
+endif
+
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and 'GDS' in static_plugins
     nixl_lib_deps += [ gds_backend_interface, cuda_dep ]

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -401,4 +401,8 @@ void nixlPluginManager::registerBuiltinPlugins() {
 #endif // DISABLE_GPUNETIO_BACKEND
 #endif // STATIC_PLUGIN_GPUNETIO
 
+#ifdef STATIC_PLUGIN_OBJ
+        extern nixlBackendPlugin *createStaticObjPlugin();
+        registerStaticPlugin ("OBJ", createStaticObjPlugin);
+#endif // STATIC_PLUGIN_OBJ
 }

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -19,6 +19,7 @@ subdir('ucx')
 subdir('ucx_mo')
 
 subdir('posix')  # Always try to build POSIX backend, it will handle its own dependencies
+subdir('obj')  # Always try to build Obj backend, it will handle its own dependencies
 
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and cuda_dep.found()

--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -1,0 +1,183 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL Object Storage Plugin
+
+This backend provides AWS S3 object storage using aws-sdk-cpp version 1.11.
+
+## Dependencies
+
+This backend requires aws-sdk-cpp version 1.11 to be installed. Example CLI to compile from sources:
+
+```bash
+# Ubuntu/Debian
+apt-get install -y libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev
+git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1.11.581 && mkdir sdk_build && cd sdk_build && cmake ../aws-sdk-cpp/ -DCMAKE_BUILD_TYPE=Release -DBUILD_ONLY="s3" -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=/usr/local && make -j && make install
+```
+
+## Configuration
+
+The Object Storage backend supports configuration through two mechanisms: backend parameter maps passed during backend creation, and environment variables for system-wide settings. Backend parameters take precedence over environment variables.
+
+### Backend Parameters
+
+Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creating the backend instance. The Object Storage backend supports AWS S3-compatible storage and accepts the following parameters:
+
+| Parameter | Description | Default | Required |
+|-----------|-------------|---------|----------|
+| `access_key` | AWS access key ID for authentication | - | No* |
+| `secret_key` | AWS secret access key for authentication | - | No* |
+| `session_token` | AWS session token for temporary credentials | - | No |
+| `bucket` | S3 bucket name for operations | - | Yes** |
+| `endpoint_override` | Custom S3 endpoint URL | - | No |
+| `scheme` | HTTP scheme (`http` or `https`) | `https` | No |
+| `region` | AWS region for the S3 service | `us-east-1` | No |
+| `use_virtual_addressing` | Use virtual-hosted-style addressing (`true`/`false`) | `false` | No |
+
+\* If `access_key` and `secret_key` are not provided, the AWS SDK will attempt to use default credential providers (IAM roles, environment variables, credential files, etc.)
+
+\** If `bucket` parameter is not provided, the `AWS_DEFAULT_BUCKET` environment variable will be used as fallback.
+
+### Environment Variables
+
+The following environment variables are supported for Object Storage configuration:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `AWS_DEFAULT_BUCKET` | Default S3 bucket name when not specified in parameters | `my-default-bucket` |
+
+Standard AWS SDK environment variables are also supported when credentials are not provided via backend parameters. For a complete list and detailed documentation, see the [AWS CLI Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) documentation.
+
+Common AWS SDK environment variables include:
+
+| Variable | Description |
+|----------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key ID |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
+| `AWS_SESSION_TOKEN` | AWS session token for temporary credentials |
+| `AWS_REGION` | Default AWS region |
+| `AWS_PROFILE` | AWS credential profile to use |
+
+### Configuration Priority
+
+Configuration values are resolved in the following priority order (highest to lowest):
+
+1. **Backend Parameters**: Values passed directly in the backend parameter map
+2. **Environment Variables**: AWS SDK environment variables and `AWS_DEFAULT_BUCKET`
+3. **AWS Credential Chain**: Default AWS credential providers (IAM roles, credential files, etc.)
+4. **Default Values**: Built-in default values
+
+### Configuration Examples
+
+#### Minimal Configuration (using IAM role)
+
+```cpp
+nixl_b_params_t params = {{"bucket", "my-bucket"}};
+agent.createBackend("obj", params);
+```
+
+#### Full Configuration with Explicit Credentials
+
+```cpp
+nixl_b_params_t params = {
+    {"access_key", "AKIAIOSFODNN7EXAMPLE"},
+    {"secret_key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+    {"bucket", "inference-data"},
+    {"region", "us-west-2"},
+    {"use_virtual_addressing", "true"}
+};
+agent.createBackend("obj", params);
+```
+
+#### Custom S3-Compatible Endpoint
+
+```cpp
+nixl_b_params_t params = {
+    {"access_key", "minioadmin"},
+    {"secret_key", "minioadmin"},
+    {"bucket", "test-bucket"},
+    {"endpoint_override", "http://localhost:9000"},
+    {"scheme", "http"},
+    {"region", "us-east-1"},
+    {"use_virtual_addressing", "false"}
+};
+agent.createBackend("obj", params);
+```
+
+#### Environment Variable Configuration
+
+```bash
+export AWS_DEFAULT_BUCKET=my-inference-bucket
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_REGION=us-west-2
+```
+
+```cpp
+// Minimal parameter map when using environment variables
+nixl_b_params_t params = {{"use_virtual_addressing", "true"}};
+agent.createBackend("obj", params);
+```
+
+#### Using AWS Profiles
+
+```bash
+export AWS_PROFILE=production
+```
+
+```cpp
+nixl_b_params_t params = {
+    {"bucket", "production-bucket"},
+    {"region", "us-east-1"}
+};
+agent.createBackend("obj", params);
+```
+
+## Transfer Operations
+
+The Object Storage backend supports read and write operations between local memory and S3 objects. Here are the key aspects of transfer operations:
+
+### Device ID to Object Key Mapping
+
+- Each object in S3 is identified by a unique object key
+- The backend maintains a mapping between device IDs (`devId`) and object keys
+- When registering memory:
+  - If `metaInfo` is provided in the blob descriptor, it is used as the object key
+  - Otherwise, the device ID is converted to a string and used as the object key
+- This mapping is used during transfer operations to locate the correct S3 object
+
+### Read Operations
+
+- Read operations support reading from a specific offset within an object
+- The offset is specified in the remote metadata's `addr` field
+- The read operation will fetch data starting from this offset
+- The amount of data read is determined by the `len` field in the local metadata
+
+### Write Operations
+
+- Write operations currently do not support offsets
+- Attempting to write with a non-zero offset will result in an error
+- The entire object is written at once
+- The data to write is taken from the local memory buffer specified in the local metadata
+
+### Asynchronous Operations
+
+- All transfer operations are asynchronous
+- The backend uses a thread pool executor for handling async operations
+- Operation completion is tracked through the request handle
+- The `checkXfer` function can be used to poll for operation completion
+- The request handle must be released using `releaseReqH` after the operation is complete

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+obj_sources = [
+    'obj_backend.cpp',
+    'obj_backend.h',
+    'obj_plugin.cpp',
+    'obj_s3_client.cpp',
+    'obj_s3_client.h',
+]
+
+aws_s3 = dependency('aws-cpp-sdk-s3', static: false, required: false)
+if aws_s3.found()
+    # By default aws-cpp-sdk sets c++11 compile flag for the whole project
+    partial_aws_s3 = aws_s3.partial_dependency(compile_args: false, includes: true, link_args: true, links: true)
+    plugin_deps += [partial_aws_s3]
+else
+    subdir_done()
+endif
+plugin_deps += [dependency('asio', required: true)]
+
+if 'OBJ' in static_plugins
+    obj_backend_lib = static_library(
+        'OBJ',
+        obj_sources,
+        dependencies: plugin_deps,
+        cpp_args: compile_defs + compile_flags,
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: false,
+        name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
+else
+    obj_backend_lib = shared_library(
+        'OBJ',
+        obj_sources,
+        dependencies: plugin_deps,
+        cpp_args: compile_defs + ['-fPIC'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: true,
+        name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
+        install_dir: plugin_install_dir)
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+            'echo "OBJ=' + obj_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+            check: true
+        )
+    endif
+endif
+
+obj_backend_interface = declare_dependency(link_with: obj_backend_lib)

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -169,10 +169,6 @@ nixlObjEngine::postXfer (const nixl_xfer_op_t &operation,
         const auto &local_desc = local[i];
         const auto &remote_desc = remote[i];
 
-        NIXL_ASSERT (local_desc.len == remote_desc.len)
-            << "Size mismatch for descriptor " << i << ": local=" << local_desc.len
-            << ", remote=" << remote_desc.len;
-
         auto obj_key_search = dev_id_to_obj_key_.find (remote_desc.devId);
         if (obj_key_search == dev_id_to_obj_key_.end()) {
             NIXL_ERROR << "No object key found for device ID: " << remote_desc.devId;

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -40,6 +40,11 @@ isValidPrepXferParams (const nixl_xfer_op_t &operation,
                        const nixl_meta_dlist_t &remote,
                        const std::string &remote_agent,
                        const std::string &local_agent) {
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << absl::StrFormat ("Error: Invalid operation type: %d", operation);
+        return false;
+    }
+
     if (remote_agent != local_agent) {
         NIXL_ERROR << absl::StrFormat (
             "Error: Remote agent must match the requesting agent (%s). Got %s",
@@ -210,7 +215,7 @@ nixlObjEngine::postXfer (const nixl_xfer_op_t &operation,
                                             status_promise->set_value (success ? NIXL_SUCCESS :
                                                                                  NIXL_ERR_BACKEND);
                                         });
-        else if (operation == NIXL_READ)
+        else
             s3_client_->GetObjectAsync (obj_key_search->second,
                                         data_ptr,
                                         data_len,
@@ -219,8 +224,6 @@ nixlObjEngine::postXfer (const nixl_xfer_op_t &operation,
                                             status_promise->set_value (success ? NIXL_SUCCESS :
                                                                                  NIXL_ERR_BACKEND);
                                         });
-        else
-            return NIXL_ERR_INVALID_PARAM;
     }
 
     return NIXL_IN_PROG;

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -24,6 +24,8 @@
 #include <vector>
 #include <chrono>
 
+namespace {
+
 bool
 isValidPrepXferParams (const nixl_xfer_op_t &operation,
                        const nixl_meta_dlist_t &local,
@@ -90,6 +92,8 @@ public:
     uint64_t dev_id;
     std::string obj_key;
 };
+
+} // namespace
 
 // -----------------------------------------------------------------------------
 // Obj Engine Implementation

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -1,0 +1,225 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "obj_backend.h"
+#include "common/nixl_log.h"
+#include "nixl_types.h"
+#include <absl/strings/str_format.h>
+#include <memory>
+#include <future>
+#include <vector>
+#include <chrono>
+
+bool
+isValidPrepXferParams (const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       const std::string &remote_agent,
+                       const std::string &local_agent) {
+    if (remote_agent != local_agent) {
+        NIXL_ERROR << absl::StrFormat (
+            "Error: Remote agent must match the requesting agent (%s). Got %s",
+            local_agent,
+            remote_agent);
+        return false;
+    }
+
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat ("Error: Local memory type must be DRAM_SEG, got %d",
+                                       local.getType());
+        return false;
+    }
+
+    if (remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << absl::StrFormat ("Error: Remote memory type must be OBJ_SEG, got %d",
+                                       remote.getType());
+        return false;
+    }
+
+    return true;
+}
+
+class nixlObjBackendReqH : public nixlBackendReqH {
+public:
+    nixlObjBackendReqH() = default;
+    ~nixlObjBackendReqH() = default;
+
+    std::vector<std::future<nixl_status_t>> status_futures_;
+
+    nixl_status_t
+    getOverallStatus() {
+        while (!status_futures_.empty()) {
+            if (status_futures_.back().wait_for (std::chrono::seconds (0)) ==
+                std::future_status::ready) {
+                auto current_status = status_futures_.back().get();
+                if (current_status != NIXL_SUCCESS) {
+                    status_futures_.clear();
+                    return current_status;
+                }
+                status_futures_.pop_back();
+            } else {
+                return NIXL_IN_PROG;
+            }
+        }
+
+        return NIXL_SUCCESS;
+    }
+};
+
+class nixlObjMetadata : public nixlBackendMD {
+public:
+    nixlObjMetadata(nixl_mem_t nixl_mem, uint64_t dev_id, std::string obj_key)
+        : nixlBackendMD (true), nixl_mem (nixl_mem), dev_id (dev_id), obj_key (obj_key) {}
+    ~nixlObjMetadata() = default;
+
+    nixl_mem_t nixl_mem;
+    uint64_t dev_id;
+    std::string obj_key;
+};
+
+// -----------------------------------------------------------------------------
+// Obj Engine Implementation
+// -----------------------------------------------------------------------------
+
+nixlObjEngine::nixlObjEngine (const nixlBackendInitParams *init_params)
+    : nixlBackendEngine (init_params),
+      executor_ (std::make_shared<AsioThreadPoolExecutor> (std::thread::hardware_concurrency())),
+      s3_client_ (std::make_shared<AwsS3Client> (init_params->customParams, executor_)) {
+    NIXL_INFO << "Object storage backend initialized with S3 client wrapper";
+}
+
+nixlObjEngine::nixlObjEngine (const nixlBackendInitParams *init_params,
+                              std::shared_ptr<IS3Client> s3_client)
+    : nixlBackendEngine (init_params),
+      executor_ (std::make_shared<AsioThreadPoolExecutor> (std::thread::hardware_concurrency())),
+      s3_client_ (s3_client) {
+    s3_client_->setExecutor (executor_);
+
+    NIXL_INFO << "Object storage backend initialized with injected S3 client";
+}
+
+nixlObjEngine::~nixlObjEngine() {
+    executor_->WaitUntilStopped();
+}
+
+nixl_status_t
+nixlObjEngine::registerMem (const nixlBlobDesc &mem,
+                            const nixl_mem_t &nixl_mem,
+                            nixlBackendMD *&out) {
+    if (nixl_mem != OBJ_SEG) return NIXL_SUCCESS;
+
+    std::unique_ptr<nixlObjMetadata> obj_md = std::make_unique<nixlObjMetadata> (
+        nixl_mem, mem.devId, mem.metaInfo.empty() ? std::to_string (mem.devId) : mem.metaInfo);
+    dev_id_to_obj_key_[mem.devId] = obj_md->obj_key;
+
+    out = obj_md.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlObjEngine::deregisterMem (nixlBackendMD *meta) {
+    nixlObjMetadata *obj_md = static_cast<nixlObjMetadata *> (meta);
+    if (obj_md) {
+        std::unique_ptr<nixlObjMetadata> obj_md_ptr = std::unique_ptr<nixlObjMetadata> (obj_md);
+        dev_id_to_obj_key_.erase (obj_md->dev_id);
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlObjEngine::prepXfer (const nixl_xfer_op_t &operation,
+                         const nixl_meta_dlist_t &local,
+                         const nixl_meta_dlist_t &remote,
+                         const std::string &remote_agent,
+                         nixlBackendReqH *&handle,
+                         const nixl_opt_b_args_t *opt_args) const {
+    if (!isValidPrepXferParams (operation, local, remote, remote_agent, localAgent))
+        return NIXL_ERR_INVALID_PARAM;
+
+    auto req_h = std::make_unique<nixlObjBackendReqH>();
+    handle = req_h.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlObjEngine::postXfer (const nixl_xfer_op_t &operation,
+                         const nixl_meta_dlist_t &local,
+                         const nixl_meta_dlist_t &remote,
+                         const std::string &remote_agent,
+                         nixlBackendReqH *&handle,
+                         const nixl_opt_b_args_t *opt_args) const {
+    nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *> (handle);
+
+    for (int i = 0; i < local.descCount(); ++i) {
+        const auto &local_desc = local[i];
+        const auto &remote_desc = remote[i];
+
+        NIXL_ASSERT (local_desc.len == remote_desc.len)
+            << "Size mismatch for descriptor " << i << ": local=" << local_desc.len
+            << ", remote=" << remote_desc.len;
+
+        auto obj_key_search = dev_id_to_obj_key_.find (remote_desc.devId);
+        if (obj_key_search == dev_id_to_obj_key_.end()) {
+            NIXL_ERROR << "No object key found for device ID: " << remote_desc.devId;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        auto status_promise = std::make_shared<std::promise<nixl_status_t>>();
+        req_h->status_futures_.push_back (status_promise->get_future());
+
+        uintptr_t data_ptr = local_desc.addr;
+        size_t data_len = local_desc.len;
+        size_t offset = remote_desc.addr;
+
+        if (operation == NIXL_WRITE)
+            s3_client_->PutObjectAsync (obj_key_search->second,
+                                        data_ptr,
+                                        data_len,
+                                        offset,
+                                        [status_promise] (bool success) {
+                                            status_promise->set_value (success ? NIXL_SUCCESS :
+                                                                                 NIXL_ERR_BACKEND);
+                                        });
+        else if (operation == NIXL_READ)
+            s3_client_->GetObjectAsync (obj_key_search->second,
+                                        data_ptr,
+                                        data_len,
+                                        offset,
+                                        [status_promise] (bool success) {
+                                            status_promise->set_value (success ? NIXL_SUCCESS :
+                                                                                 NIXL_ERR_BACKEND);
+                                        });
+        else
+            return NIXL_ERR_INVALID_PARAM;
+    }
+
+    return NIXL_IN_PROG;
+}
+
+nixl_status_t
+nixlObjEngine::checkXfer (nixlBackendReqH *handle) const {
+    nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *> (handle);
+    return req_h->getOverallStatus();
+}
+
+nixl_status_t
+nixlObjEngine::releaseReqH (nixlBackendReqH *handle) const {
+    nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *> (handle);
+    delete req_h;
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -1,0 +1,113 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBJ_BACKEND_H
+#define OBJ_BACKEND_H
+
+#include "obj_executor.h"
+#include "obj_s3_client.h"
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include "backend/backend_engine.h"
+
+class nixlObjEngine : public nixlBackendEngine {
+public:
+    nixlObjEngine (const nixlBackendInitParams *init_params);
+    nixlObjEngine (const nixlBackendInitParams *init_params, std::shared_ptr<IS3Client> s3_client);
+    virtual ~nixlObjEngine();
+
+    bool
+    supportsRemote() const override {
+        return false;
+    }
+
+    bool
+    supportsLocal() const override {
+        return true;
+    }
+
+    bool
+    supportsNotif() const override {
+        return false;
+    }
+
+    bool
+    supportsProgTh() const override {
+        return false;
+    }
+
+    nixl_mem_list_t
+    getSupportedMems() const override {
+        return {OBJ_SEG, DRAM_SEG};
+    }
+
+    nixl_status_t
+    registerMem (const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem (nixlBackendMD *meta) override;
+
+    nixl_status_t
+    connect (const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    disconnect (const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    unloadMD (nixlBackendMD *input) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    prepXfer (const nixl_xfer_op_t &operation,
+              const nixl_meta_dlist_t &local,
+              const nixl_meta_dlist_t &remote,
+              const std::string &remote_agent,
+              nixlBackendReqH *&handle,
+              const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    postXfer (const nixl_xfer_op_t &operation,
+              const nixl_meta_dlist_t &local,
+              const nixl_meta_dlist_t &remote,
+              const std::string &remote_agent,
+              nixlBackendReqH *&handle,
+              const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer (nixlBackendReqH *handle) const override;
+    nixl_status_t
+    releaseReqH (nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    loadLocalMD (nixlBackendMD *input, nixlBackendMD *&output) override {
+        output = input;
+        return NIXL_SUCCESS;
+    }
+
+private:
+    std::shared_ptr<AsioThreadPoolExecutor> executor_;
+    std::shared_ptr<IS3Client> s3_client_;
+    std::unordered_map<uint64_t, std::string> dev_id_to_obj_key_;
+};
+
+#endif // OBJ_BACKEND_H

--- a/src/plugins/obj/obj_executor.h
+++ b/src/plugins/obj/obj_executor.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBJ_EXECUTOR_H
+#define OBJ_EXECUTOR_H
+
+#include <aws/core/utils/threading/Executor.h>
+#include <asio.hpp>
+#include <functional>
+
+class AsioThreadPoolExecutor : public Aws::Utils::Threading::Executor {
+public:
+    explicit AsioThreadPoolExecutor (std::size_t num_threads) : pool_ (num_threads) {}
+
+    void
+    WaitUntilStopped() override {
+        pool_.stop();
+        pool_.join();
+    }
+
+    void
+    WaitUntilIdle() {
+        pool_.wait();
+    }
+
+protected:
+    bool
+    SubmitToThread (std::function<void()> &&task) override {
+        asio::post (pool_, std::move (task));
+        return true;
+    }
+
+private:
+    asio::thread_pool pool_;
+};
+
+#endif // OBJ_EXECUTOR_H

--- a/src/plugins/obj/obj_plugin.cpp
+++ b/src/plugins/obj/obj_plugin.cpp
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nixl_types.h"
+#include "obj_backend.h"
+#include "backend/backend_plugin.h"
+#include "common/nixl_log.h"
+
+namespace {
+
+[[nodiscard]] nixlBackendEngine *
+create_obj_engine (const nixlBackendInitParams *init_params) {
+    try {
+        return new nixlObjEngine (init_params);
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to create obj engine: " << e.what();
+        return nullptr;
+    }
+}
+
+void
+destroy_obj_engine (nixlBackendEngine *engine) {
+    delete engine;
+}
+
+[[nodiscard]] const char *
+get_plugin_name() {
+    return "OBJ";
+}
+
+[[nodiscard]] const char *
+get_plugin_version() {
+    return "0.1.0";
+}
+
+[[nodiscard]] nixl_b_params_t
+get_backend_options() {
+    nixl_b_params_t params;
+    params["access_key"] = "AWS access key ID (required)";
+    params["secret_key"] = "AWS secret access key (required)";
+    params["session_token"] = "AWS session token (optional)";
+    return params;
+}
+
+[[nodiscard]] nixl_mem_list_t
+get_backend_mems() {
+    return {DRAM_SEG, OBJ_SEG};
+}
+
+nixlBackendPlugin plugin = {NIXL_PLUGIN_API_VERSION,
+                            create_obj_engine,
+                            destroy_obj_engine,
+                            get_plugin_name,
+                            get_plugin_version,
+                            get_backend_options,
+                            get_backend_mems};
+} // namespace
+
+#ifdef STATIC_PLUGIN_OBJ
+
+nixlBackendPlugin *
+createStaticObjPlugin() {
+    return &plugin; // Return the static plugin instance
+}
+
+#else // !STATIC_PLUGIN_OBJ
+
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
+nixl_plugin_init() {
+    return &plugin;
+}
+
+extern "C" NIXL_PLUGIN_EXPORT void
+nixl_plugin_fini() {}
+
+#endif // !STATIC_PLUGIN_OBJ

--- a/src/plugins/obj/obj_s3_client.cpp
+++ b/src/plugins/obj/obj_s3_client.cpp
@@ -84,7 +84,7 @@ createAWSCredentials (nixl_b_params_t *custom_params) {
 }
 
 bool
-getUserVirtualAddressing (nixl_b_params_t *custom_params) {
+getUseVirtualAddressing (nixl_b_params_t *custom_params) {
     if (!custom_params) return false;
 
     auto virtual_addressing_it = custom_params->find ("use_virtual_addressing");
@@ -135,7 +135,7 @@ AwsS3Client::AwsS3Client (nixl_b_params_t *custom_params,
     if (executor) config.executor = executor;
 
     auto credentials_opt = ::createAWSCredentials (custom_params);
-    bool use_virtual_addressing = ::getUserVirtualAddressing (custom_params);
+    bool use_virtual_addressing = ::getUseVirtualAddressing (custom_params);
     bucket_name_ = Aws::String (::getBucketName (custom_params));
 
     if (credentials_opt.has_value())
@@ -211,11 +211,11 @@ AwsS3Client::GetObjectAsync (std::string_view key,
 
     s3_client_->GetObjectAsync (
         request,
-        [callback, stream_factory] (
-            const Aws::S3::S3Client *client,
-            const Aws::S3::Model::GetObjectRequest &req,
-            const Aws::S3::Model::GetObjectOutcome &outcome,
-            const std::shared_ptr<const Aws::Client::AsyncCallerContext> &context) {
+        [callback,
+         stream_factory] (const Aws::S3::S3Client *client,
+                          const Aws::S3::Model::GetObjectRequest &req,
+                          const Aws::S3::Model::GetObjectOutcome &outcome,
+                          const std::shared_ptr<const Aws::Client::AsyncCallerContext> &context) {
             callback (outcome.IsSuccess());
         },
         nullptr);

--- a/src/plugins/obj/obj_s3_client.cpp
+++ b/src/plugins/obj/obj_s3_client.cpp
@@ -1,0 +1,212 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "obj_s3_client.h"
+#include <optional>
+#include <string>
+#include <stdexcept>
+#include <aws/core/utils/stream/PreallocatedStreamBuf.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <absl/strings/str_format.h>
+#include "nixl_types.h"
+
+namespace {
+
+Aws::Client::ClientConfiguration
+createClientConfiguration (nixl_b_params_t *custom_params) {
+    Aws::Client::ClientConfiguration config;
+
+    if (!custom_params) return config;
+
+    auto endpoint_override_it = custom_params->find ("endpoint_override");
+    if (endpoint_override_it != custom_params->end())
+        config.endpointOverride = endpoint_override_it->second;
+
+    auto scheme_it = custom_params->find ("scheme");
+    if (scheme_it != custom_params->end()) {
+        if (scheme_it->second == "http")
+            config.scheme = Aws::Http::Scheme::HTTP;
+        else if (scheme_it->second == "https")
+            config.scheme = Aws::Http::Scheme::HTTPS;
+        else
+            throw std::runtime_error ("Invalid scheme: " + scheme_it->second);
+    }
+
+    auto region_it = custom_params->find ("region");
+    if (region_it != custom_params->end()) config.region = region_it->second;
+
+    return config;
+}
+
+std::optional<Aws::Auth::AWSCredentials>
+createAWSCredentials (nixl_b_params_t *custom_params) {
+    if (!custom_params) return std::nullopt;
+
+    std::string access_key, secret_key, session_token;
+
+    auto access_key_it = custom_params->find ("access_key");
+    if (access_key_it != custom_params->end()) access_key = access_key_it->second;
+
+    auto secret_key_it = custom_params->find ("secret_key");
+    if (secret_key_it != custom_params->end()) secret_key = secret_key_it->second;
+
+    auto session_token_it = custom_params->find ("session_token");
+    if (session_token_it != custom_params->end()) session_token = session_token_it->second;
+
+    if (access_key.empty() || secret_key.empty()) return std::nullopt;
+
+    if (session_token.empty()) return Aws::Auth::AWSCredentials (access_key, secret_key);
+
+    return Aws::Auth::AWSCredentials (access_key, secret_key, session_token);
+}
+
+bool
+getUserVirtualAddressing (nixl_b_params_t *custom_params) {
+    if (!custom_params) return false;
+
+    auto virtual_addressing_it = custom_params->find ("use_virtual_addressing");
+    if (virtual_addressing_it != custom_params->end()) {
+        const std::string &value = virtual_addressing_it->second;
+        if (value == "true")
+            return true;
+        else if (value == "false")
+            return false;
+        else
+            throw std::runtime_error ("Invalid value for use_virtual_addressing: '" + value +
+                                      "'. Must be 'true' or 'false'");
+    }
+
+    return false;
+}
+
+std::string
+getBucketName (nixl_b_params_t *custom_params) {
+    if (custom_params) {
+        auto bucket_it = custom_params->find ("bucket");
+        if (bucket_it != custom_params->end() && !bucket_it->second.empty()) {
+            return bucket_it->second;
+        }
+    }
+
+    const char *env_bucket = std::getenv ("AWS_DEFAULT_BUCKET");
+    if (env_bucket && env_bucket[0] != '\0') return std::string (env_bucket);
+    throw std::runtime_error ("Bucket name not found. Please provide 'bucket' in custom_params or "
+                              "set AWS_DEFAULT_BUCKET environment variable");
+}
+
+} // namespace
+
+AwsS3Client::AwsS3Client (nixl_b_params_t *custom_params,
+                          std::shared_ptr<Aws::Utils::Threading::Executor> executor)
+    : aws_options_ (
+          []() {
+              auto *opts = new Aws::SDKOptions();
+              Aws::InitAPI (*opts);
+              return opts;
+          }(),
+          [] (Aws::SDKOptions *opts) {
+              Aws::ShutdownAPI (*opts);
+              delete opts;
+          }) {
+    auto config = ::createClientConfiguration (custom_params);
+    if (executor) config.executor = executor;
+
+    auto credentials_opt = ::createAWSCredentials (custom_params);
+    bool use_virtual_addressing = ::getUserVirtualAddressing (custom_params);
+    bucket_name_ = Aws::String (::getBucketName (custom_params));
+
+    if (credentials_opt.has_value())
+        s3_client_ = std::make_unique<Aws::S3::S3Client> (
+            credentials_opt.value(),
+            config,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
+            use_virtual_addressing);
+    else
+        s3_client_ = std::make_unique<Aws::S3::S3Client> (
+            config,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
+            use_virtual_addressing);
+}
+
+void
+AwsS3Client::setExecutor (std::shared_ptr<Aws::Utils::Threading::Executor> executor) {
+    throw std::runtime_error ("AwsS3Client::setExecutor() not supported - AWS SDK doesn't allow "
+                              "changing executor after client creation");
+}
+
+void
+AwsS3Client::PutObjectAsync (std::string_view key,
+                             uintptr_t data_ptr,
+                             size_t data_len,
+                             size_t offset,
+                             PutObjectCallback callback) {
+    // AWS S3 doesn't support partial put operations with offset
+    if (offset != 0) {
+        callback (false);
+        return;
+    }
+
+    Aws::S3::Model::PutObjectRequest request;
+    request.WithBucket (bucket_name_).WithKey (Aws::String (key));
+
+    auto preallocated_stream_buf = Aws::MakeShared<Aws::Utils::Stream::PreallocatedStreamBuf> (
+        "PutObjectStreamBuf", reinterpret_cast<unsigned char *> (data_ptr), data_len);
+    auto data_stream =
+        Aws::MakeShared<Aws::IOStream> ("PutObjectInputStream", preallocated_stream_buf.get());
+    request.SetBody (data_stream);
+
+    s3_client_->PutObjectAsync (
+        request,
+        [callback, preallocated_stream_buf, data_stream] (
+            const Aws::S3::S3Client *client,
+            const Aws::S3::Model::PutObjectRequest &req,
+            const Aws::S3::Model::PutObjectOutcome &outcome,
+            const std::shared_ptr<const Aws::Client::AsyncCallerContext> &context) {
+            callback (outcome.IsSuccess());
+        },
+        nullptr);
+}
+
+void
+AwsS3Client::GetObjectAsync (std::string_view key,
+                             uintptr_t data_ptr,
+                             size_t data_len,
+                             size_t offset,
+                             GetObjectCallback callback) {
+    Aws::S3::Model::GetObjectRequest request;
+    request.WithBucket (bucket_name_).WithKey (Aws::String (key));
+
+    if (offset > 0)
+        request.SetRange (absl::StrFormat ("bytes=%d-%d", offset, offset + data_len - 1));
+
+    s3_client_->GetObjectAsync (
+        request,
+        [callback, data_ptr, data_len] (
+            const Aws::S3::S3Client *client,
+            const Aws::S3::Model::GetObjectRequest &req,
+            const Aws::S3::Model::GetObjectOutcome &outcome,
+            const std::shared_ptr<const Aws::Client::AsyncCallerContext> &context) {
+            if (outcome.IsSuccess()) {
+                auto &stream = outcome.GetResult().GetBody();
+                stream.seekg (0, std::ios::beg);
+                stream.read (reinterpret_cast<char *> (data_ptr), data_len);
+            }
+            callback (outcome.IsSuccess());
+        },
+        nullptr);
+}

--- a/src/plugins/obj/obj_s3_client.cpp
+++ b/src/plugins/obj/obj_s3_client.cpp
@@ -19,9 +19,17 @@
 #include <optional>
 #include <string>
 #include <stdexcept>
+#include <cstdlib>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/PutObjectResult.h>
+#include <aws/s3/model/GetObjectResult.h>
+#include <aws/core/http/Scheme.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/Outcome.h>
 #include <aws/core/utils/stream/PreallocatedStreamBuf.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
-#include <aws/s3/model/GetObjectRequest.h>
 #include <absl/strings/str_format.h>
 #include "nixl_types.h"
 

--- a/src/plugins/obj/obj_s3_client.h
+++ b/src/plugins/obj/obj_s3_client.h
@@ -20,19 +20,10 @@
 
 #include <functional>
 #include <memory>
-#include <cstdint>
 #include <string_view>
-#include <cstdlib>
+#include <cstdint>
 #include <aws/s3/S3Client.h>
-#include <aws/s3/model/PutObjectRequest.h>
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/PutObjectResult.h>
-#include <aws/s3/model/GetObjectResult.h>
-#include <aws/core/utils/Outcome.h>
-#include <aws/core/client/ClientConfiguration.h>
-#include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
-#include <aws/core/http/Scheme.h>
 #include <aws/core/Aws.h>
 #include "nixl_types.h"
 

--- a/src/plugins/obj/obj_s3_client.h
+++ b/src/plugins/obj/obj_s3_client.h
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OBJ_S3_CLIENT_H
+#define OBJ_S3_CLIENT_H
+
+#include <functional>
+#include <memory>
+#include <cstdint>
+#include <string_view>
+#include <cstdlib>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/PutObjectResult.h>
+#include <aws/s3/model/GetObjectResult.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/auth/AWSCredentials.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include <aws/core/http/Scheme.h>
+#include <aws/core/Aws.h>
+#include "nixl_types.h"
+
+using PutObjectCallback = std::function<void (bool success)>;
+using GetObjectCallback = std::function<void (bool success)>;
+
+/**
+ * Abstract interface for S3 client operations.
+ * Provides async operations for PutObject and GetObject.
+ */
+class IS3Client {
+public:
+    virtual ~IS3Client() = default;
+
+    /**
+     * Set the executor for async operations.
+     * @param executor The executor to use for async operations
+     */
+    virtual void
+    setExecutor (std::shared_ptr<Aws::Utils::Threading::Executor> executor) = 0;
+
+    /**
+     * Asynchronously put an object to S3.
+     * @param key The object key
+     * @param data_ptr Pointer to the data to upload
+     * @param data_len Length of the data in bytes
+     * @param offset Offset within the object
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    PutObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    PutObjectCallback callback) = 0;
+
+    /**
+     * Asynchronously get an object from S3.
+     * @param key The object key
+     * @param data_ptr Pointer to the buffer to store the downloaded data
+     * @param data_len Maximum length of data to read
+     * @param offset Offset within the object to start reading from
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    GetObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    GetObjectCallback callback) = 0;
+};
+
+/**
+ * Concrete implementation of IS3Client using AWS SDK S3Client.
+ */
+class AwsS3Client : public IS3Client {
+public:
+    /**
+     * Constructor that creates an AWS S3Client from custom parameters.
+     * @param custom_params Custom parameters containing S3 configuration
+     * @param executor Optional executor for async operations
+     */
+    AwsS3Client (nixl_b_params_t *custom_params,
+                 std::shared_ptr<Aws::Utils::Threading::Executor> executor = nullptr);
+
+    void
+    setExecutor (std::shared_ptr<Aws::Utils::Threading::Executor> executor) override;
+
+    void
+    PutObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    PutObjectCallback callback) override;
+
+    void
+    GetObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    GetObjectCallback callback) override;
+
+private:
+    std::unique_ptr<Aws::SDKOptions, std::function<void (Aws::SDKOptions *)>> aws_options_;
+    std::unique_ptr<Aws::S3::S3Client> s3_client_;
+    Aws::String bucket_name_;
+};
+
+#endif // OBJ_S3_CLIENT_H

--- a/subprojects/asio.wrap
+++ b/subprojects/asio.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = asio-1.30.2
+source_url = https://sourceforge.net/projects/asio/files/asio/1.30.2%20%28Stable%29/asio-1.30.2.tar.gz/download
+source_filename = asio-1.30.2.tar.gz
+source_hash = 12e7bb4dada8bc1191de9d550a59ee658ce4e645ffc97c911c099ab4e8699d55
+patch_filename = asio_1.30.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/asio_1.30.2-2/get_patch
+patch_hash = 8bed3693016874b097e4d902c4ca8daf1b6abf1b5a56b0c5c02827d4e0747ddb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/asio_1.30.2-2/asio-1.30.2.tar.gz
+wrapdb_version = 1.30.2-2
+
+[provide]
+asio = asio_dep

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -22,6 +22,7 @@ if not gtest_dep.found()
     subdir_done()
 endif
 
+subdir('unit')
 subdir('mocks')
 
 plugin_dirs_arg = '--tests_plugin_dirs=' + mocks_dep.get_variable('path')

--- a/test/gtest/unit/main.cpp
+++ b/test/gtest/unit/main.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+namespace gtest {
+
+int
+RunTests (int argc, char **argv) {
+    testing::InitGoogleTest (&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+} // namespace gtest
+
+int
+main (int argc, char **argv) {
+    return gtest::RunTests (argc, argv);
+}

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+unit_test_deps = [
+    nixl_dep,
+    gtest_dep,
+]
+
+aws_s3 = dependency('aws-cpp-sdk-s3', static: false, required: false)
+if aws_s3.found()
+    subdir('obj')
+    unit_test_deps += [obj_unit_test_dep]
+endif
+
+unit_test_exe = executable('unit',
+    sources : [
+        'main.cpp',
+    ],
+    cpp_args : cpp_args,
+    dependencies : unit_test_deps,
+    include_directories: [
+        nixl_inc_dirs,
+        utils_inc_dirs,
+    ],
+    link_with: [nixl_build_lib],
+    install : true
+)
+
+test('unit', unit_test_exe)

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+obj_unit_test_dep = declare_dependency(
+    sources: [
+        'obj.cpp',
+    ],
+    include_directories: [
+        nixl_inc_dirs,
+        '../../../../src/plugins/obj',
+    ],
+    dependencies: [
+        aws_s3.partial_dependency(compile_args: false, includes: true, link_args: true, links: true),
+        dependency('asio', required: true),
+    ],
+    link_with: obj_backend_lib,
+)

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -129,15 +129,9 @@ protected:
         ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
 
         nixl_meta_dlist_t local_descs (DRAM_SEG);
-        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG);
 
         std::vector<char> test_buffer (1024);
-
-        if (operation == NIXL_WRITE) {
-            for (size_t i = 0; i < test_buffer.size(); ++i) {
-                test_buffer[i] = static_cast<char> ('X' + (i % 3));
-            }
-        }
 
         nixlMetaDesc local_meta_desc (
             reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), 1);
@@ -211,8 +205,8 @@ protected:
         ASSERT_EQ (obj_engine_->registerMem (remote_desc1, OBJ_SEG, remote_metadata1),
                    NIXL_SUCCESS);
 
-        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
-        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+        nixl_meta_dlist_t local_descs (DRAM_SEG);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG);
 
         nixlMetaDesc local_meta_desc0 (reinterpret_cast<uintptr_t> (test_buffer0.data()),
                                        test_buffer0.size(),
@@ -275,8 +269,8 @@ protected:
         nixlBackendMD *remote_metadata = nullptr;
         ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
 
-        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
-        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+        nixl_meta_dlist_t local_descs (DRAM_SEG);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG);
 
         nixlMetaDesc local_meta_desc (
             reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), local_desc.devId);
@@ -387,14 +381,10 @@ TEST_F (ObjTestFixture, CancelTransfer) {
     ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
     ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
 
-    nixl_meta_dlist_t local_descs (DRAM_SEG, false);
-    nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+    nixl_meta_dlist_t local_descs (DRAM_SEG);
+    nixl_meta_dlist_t remote_descs (OBJ_SEG);
 
     std::vector<char> test_buffer (1024);
-    for (size_t i = 0; i < test_buffer.size(); ++i) {
-        test_buffer[i] = static_cast<char> ('T' + (i % 3));
-    }
-
     nixlMetaDesc local_meta_desc (
         reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), 1);
     local_descs.addDesc (local_meta_desc);
@@ -448,8 +438,8 @@ TEST_F (ObjTestFixture, ReadFromOffset) {
     nixlBackendMD *remote_metadata = nullptr;
     ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
 
-    nixl_meta_dlist_t local_descs (DRAM_SEG, false);
-    nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+    nixl_meta_dlist_t local_descs (DRAM_SEG);
+    nixl_meta_dlist_t remote_descs (OBJ_SEG);
 
     const size_t offset = 256;
     const size_t length = 512;

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -128,7 +128,7 @@ protected:
         ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
         ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
 
-        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+        nixl_meta_dlist_t local_descs (DRAM_SEG);
         nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
 
         std::vector<char> test_buffer (1024);
@@ -491,11 +491,11 @@ TEST_F (ObjTestFixture, AsyncWriteTransferWithControlledExecution) {
 }
 
 TEST_F (ObjTestFixture, MultiDescriptorWrite) {
-    testMultiDescriptorTransfer (NIXL_READ);
+    testMultiDescriptorTransfer (NIXL_WRITE);
 }
 
 TEST_F (ObjTestFixture, MultiDescriptorRead) {
-    testMultiDescriptorTransfer (NIXL_WRITE);
+    testMultiDescriptorTransfer (NIXL_READ);
 }
 
 TEST_F (ObjTestFixture, AsyncReadTransferFailureIsHandled) {

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -1,0 +1,509 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "nixl_types.h"
+#include <memory>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include "obj_s3_client.h"
+#include "obj_backend.h"
+#include "obj_executor.h"
+
+namespace gtest::obj {
+
+class MockS3Client : public IS3Client {
+private:
+    bool simulate_success_ = true;
+    std::shared_ptr<AsioThreadPoolExecutor> executor_;
+    std::vector<std::function<void()>> pending_callbacks_;
+
+public:
+    void
+    setSimulateSuccess (bool success) {
+        simulate_success_ = success;
+    }
+
+    void
+    setExecutor (std::shared_ptr<Aws::Utils::Threading::Executor> executor) override {
+        executor_ = std::dynamic_pointer_cast<AsioThreadPoolExecutor> (executor);
+    }
+
+    void
+    PutObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    PutObjectCallback callback) override {
+        pending_callbacks_.push_back ([callback, this]() { callback (simulate_success_); });
+    }
+
+    void
+    GetObjectAsync (std::string_view key,
+                    uintptr_t data_ptr,
+                    size_t data_len,
+                    size_t offset,
+                    GetObjectCallback callback) override {
+        pending_callbacks_.push_back ([callback, data_ptr, data_len, offset, this]() {
+            if (simulate_success_ && data_ptr && data_len > 0) {
+                char *buffer = reinterpret_cast<char *> (data_ptr);
+                for (size_t i = 0; i < data_len; ++i) {
+                    buffer[i] = static_cast<char> ('A' + ((i + offset) % 26));
+                }
+            }
+            callback (simulate_success_);
+        });
+    }
+
+    void
+    execAsync() {
+        for (auto &callback : pending_callbacks_) {
+            executor_->Submit ([callback]() { callback(); });
+        }
+        pending_callbacks_.clear();
+        executor_->WaitUntilIdle();
+    }
+
+    size_t
+    getPendingCount() const {
+        return pending_callbacks_.size();
+    }
+
+    bool
+    hasExecutor() const {
+        return executor_ != nullptr;
+    }
+};
+
+class ObjTestFixture : public testing::Test {
+protected:
+    std::unique_ptr<nixlObjEngine> obj_engine_;
+    std::shared_ptr<MockS3Client> mock_s3_client_;
+    nixlBackendInitParams init_params_;
+    nixl_b_params_t custom_params_;
+
+    void
+    SetUp() override {
+        init_params_.localAgent = "test-agent";
+        init_params_.type = "OBJ";
+        init_params_.customParams = &custom_params_;
+        init_params_.enableProgTh = false;
+        init_params_.pthrDelay = 0;
+        init_params_.syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW;
+
+        mock_s3_client_ = std::make_shared<MockS3Client>();
+
+        // Initialize nixlObjEngine with the mock IS3Client
+        // The engine will create its own executor and call setExecutor on the mock client
+        obj_engine_ = std::make_unique<nixlObjEngine> (&init_params_, mock_s3_client_);
+    }
+
+    void
+    testAsyncTransferWithControlledExecution (nixl_xfer_op_t operation) {
+        mock_s3_client_->setSimulateSuccess (true);
+
+        nixlBlobDesc local_desc, remote_desc;
+        local_desc.devId = 1;
+        remote_desc.devId = 2;
+        remote_desc.metaInfo = (operation == NIXL_READ) ? "test-read-key" : "test-write-key";
+
+        nixlBackendMD *local_metadata = nullptr;
+        nixlBackendMD *remote_metadata = nullptr;
+
+        ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+        ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+
+        std::vector<char> test_buffer (1024);
+
+        if (operation == NIXL_WRITE) {
+            for (size_t i = 0; i < test_buffer.size(); ++i) {
+                test_buffer[i] = static_cast<char> ('X' + (i % 3));
+            }
+        }
+
+        nixlMetaDesc local_meta_desc (
+            reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), 1);
+        local_descs.addDesc (local_meta_desc);
+
+        nixlMetaDesc remote_meta_desc (0, test_buffer.size(), 2);
+        remote_descs.addDesc (remote_meta_desc);
+
+        nixlBackendReqH *handle = nullptr;
+
+        ASSERT_EQ (
+            obj_engine_->prepXfer (
+                operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE (handle, nullptr);
+
+        nixl_status_t status = obj_engine_->postXfer (
+            operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+        EXPECT_EQ (mock_s3_client_->getPendingCount(), 1);
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+
+        mock_s3_client_->execAsync();
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_EQ (status, NIXL_SUCCESS);
+
+        if (operation == NIXL_READ) {
+            EXPECT_EQ (test_buffer[0], 'A');
+        }
+
+        obj_engine_->releaseReqH (handle);
+        obj_engine_->deregisterMem (local_metadata);
+        obj_engine_->deregisterMem (remote_metadata);
+    }
+
+    void
+    testMultiDescriptorTransfer (nixl_xfer_op_t operation) {
+        mock_s3_client_->setSimulateSuccess (true);
+
+        std::vector<char> test_buffer0 (1024);
+        std::vector<char> test_buffer1 (1024);
+        if (operation == NIXL_WRITE) {
+            for (size_t i = 0; i < test_buffer0.size(); ++i) {
+                test_buffer0[i] = static_cast<char> ('X' + (i % 3));
+            }
+            for (size_t i = 0; i < test_buffer1.size(); ++i) {
+                test_buffer1[i] = static_cast<char> ('x' + (i % 3));
+            }
+        }
+
+        nixlBlobDesc local_desc0, local_desc1;
+        local_desc0.devId = 1;
+        local_desc1.devId = 1;
+        nixlBackendMD *local_metadata0 = nullptr;
+        nixlBackendMD *local_metadata1 = nullptr;
+
+        ASSERT_EQ (obj_engine_->registerMem (local_desc0, DRAM_SEG, local_metadata0), NIXL_SUCCESS);
+        ASSERT_EQ (obj_engine_->registerMem (local_desc1, DRAM_SEG, local_metadata1), NIXL_SUCCESS);
+
+        nixlBlobDesc remote_desc0, remote_desc1;
+        remote_desc0.devId = 2;
+        remote_desc1.devId = 3;
+        remote_desc0.metaInfo = (operation == NIXL_READ) ? "test-read-key0" : "test-write-key0";
+        remote_desc1.metaInfo = (operation == NIXL_READ) ? "test-read-key1" : "test-write-key1";
+        nixlBackendMD *remote_metadata0 = nullptr;
+        nixlBackendMD *remote_metadata1 = nullptr;
+
+        ASSERT_EQ (obj_engine_->registerMem (remote_desc0, OBJ_SEG, remote_metadata0),
+                   NIXL_SUCCESS);
+        ASSERT_EQ (obj_engine_->registerMem (remote_desc1, OBJ_SEG, remote_metadata1),
+                   NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+
+        nixlMetaDesc local_meta_desc0 (reinterpret_cast<uintptr_t> (test_buffer0.data()),
+                                       test_buffer0.size(),
+                                       local_desc0.devId);
+        nixlMetaDesc local_meta_desc1 (reinterpret_cast<uintptr_t> (test_buffer1.data()),
+                                       test_buffer1.size(),
+                                       local_desc1.devId);
+        local_descs.addDesc (local_meta_desc0);
+        local_descs.addDesc (local_meta_desc1);
+
+        nixlMetaDesc remote_meta_desc0 (0, test_buffer0.size(), remote_desc0.devId);
+        nixlMetaDesc remote_meta_desc1 (0, test_buffer1.size(), remote_desc1.devId);
+        remote_descs.addDesc (remote_meta_desc0);
+        remote_descs.addDesc (remote_meta_desc1);
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ (
+            obj_engine_->prepXfer (
+                operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE (handle, nullptr);
+
+        nixl_status_t status = obj_engine_->postXfer (
+            operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+        EXPECT_EQ (mock_s3_client_->getPendingCount(), 2);
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+
+        mock_s3_client_->execAsync();
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_EQ (status, NIXL_SUCCESS);
+
+        if (operation == NIXL_READ) {
+            EXPECT_EQ (test_buffer0[0], 'A');
+            EXPECT_EQ (test_buffer1[0], 'A');
+        }
+
+        obj_engine_->releaseReqH (handle);
+        obj_engine_->deregisterMem (local_metadata0);
+        obj_engine_->deregisterMem (local_metadata1);
+        obj_engine_->deregisterMem (remote_metadata0);
+        obj_engine_->deregisterMem (remote_metadata1);
+    }
+
+    void
+    testAsyncTransferFailureIsHandled (nixl_xfer_op_t operation) {
+        mock_s3_client_->setSimulateSuccess (false);
+
+        std::vector<char> test_buffer (1024, 'Z');
+
+        nixlBlobDesc local_desc;
+        local_desc.devId = 1;
+        nixlBackendMD *local_metadata = nullptr;
+        ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+        nixlBlobDesc remote_desc;
+        remote_desc.devId = 2;
+        remote_desc.metaInfo = "test-fail-key";
+        nixlBackendMD *remote_metadata = nullptr;
+        ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+        nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+
+        nixlMetaDesc local_meta_desc (
+            reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), local_desc.devId);
+        nixlMetaDesc remote_meta_desc (0, test_buffer.size(), remote_desc.devId);
+        local_descs.addDesc (local_meta_desc);
+        remote_descs.addDesc (remote_meta_desc);
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ (
+            obj_engine_->prepXfer (
+                operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE (handle, nullptr);
+
+        nixl_status_t status = obj_engine_->postXfer (
+            operation, local_descs, remote_descs, init_params_.localAgent, handle, nullptr);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+        EXPECT_EQ (mock_s3_client_->getPendingCount(), 1);
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_EQ (status, NIXL_IN_PROG);
+
+        mock_s3_client_->execAsync();
+        status = obj_engine_->checkXfer (handle);
+        EXPECT_NE (status, NIXL_SUCCESS); // Should not succeed
+
+        obj_engine_->releaseReqH (handle);
+        obj_engine_->deregisterMem (local_metadata);
+        obj_engine_->deregisterMem (remote_metadata);
+    }
+};
+
+TEST_F (ObjTestFixture, EngineInitialization) {
+    ASSERT_NE (obj_engine_, nullptr);
+    EXPECT_EQ (obj_engine_->getType(), "OBJ");
+    EXPECT_TRUE (obj_engine_->supportsLocal());
+    EXPECT_FALSE (obj_engine_->supportsRemote());
+    EXPECT_FALSE (obj_engine_->supportsNotif());
+    EXPECT_FALSE (obj_engine_->supportsProgTh());
+
+    // Verify that the executor was properly set on the mock S3 client by the engine constructor
+    EXPECT_TRUE (mock_s3_client_->hasExecutor());
+}
+
+TEST_F (ObjTestFixture, GetSupportedMems) {
+    auto supported_mems = obj_engine_->getSupportedMems();
+    EXPECT_EQ (supported_mems.size(), 2);
+    EXPECT_TRUE (std::find (supported_mems.begin(), supported_mems.end(), OBJ_SEG) !=
+                 supported_mems.end());
+    EXPECT_TRUE (std::find (supported_mems.begin(), supported_mems.end(), DRAM_SEG) !=
+                 supported_mems.end());
+}
+
+TEST_F (ObjTestFixture, RegisterMemoryObjSeg) {
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 42;
+    mem_desc.metaInfo = "test-object-key";
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = obj_engine_->registerMem (mem_desc, OBJ_SEG, metadata);
+
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    EXPECT_NE (metadata, nullptr);
+
+    status = obj_engine_->deregisterMem (metadata);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+}
+
+TEST_F (ObjTestFixture, RegisterMemoryObjSegWithoutKey) {
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 99;
+    mem_desc.metaInfo = ""; // Empty key - engine will generate a key
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = obj_engine_->registerMem (mem_desc, OBJ_SEG, metadata);
+
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    EXPECT_NE (metadata, nullptr);
+
+    status = obj_engine_->deregisterMem (metadata);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+}
+
+TEST_F (ObjTestFixture, RegisterMemoryDramSeg) {
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 123;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = obj_engine_->registerMem (mem_desc, DRAM_SEG, metadata);
+
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    EXPECT_EQ (metadata, nullptr);
+
+    status = obj_engine_->deregisterMem (metadata);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+}
+
+TEST_F (ObjTestFixture, CancelTransfer) {
+    mock_s3_client_->setSimulateSuccess (true);
+
+    nixlBlobDesc local_desc, remote_desc;
+    local_desc.devId = 1;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "test-cancel-key";
+
+    nixlBackendMD *local_metadata = nullptr;
+    nixlBackendMD *remote_metadata = nullptr;
+
+    ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+    ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+    nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+
+    std::vector<char> test_buffer (1024);
+    for (size_t i = 0; i < test_buffer.size(); ++i) {
+        test_buffer[i] = static_cast<char> ('T' + (i % 3));
+    }
+
+    nixlMetaDesc local_meta_desc (
+        reinterpret_cast<uintptr_t> (test_buffer.data()), test_buffer.size(), 1);
+    local_descs.addDesc (local_meta_desc);
+
+    nixlMetaDesc remote_meta_desc (0, test_buffer.size(), 2);
+    remote_descs.addDesc (remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+
+    ASSERT_EQ (obj_engine_->prepXfer (
+                   NIXL_WRITE, local_descs, remote_descs, init_params_.localAgent, handle, nullptr),
+               NIXL_SUCCESS);
+    ASSERT_NE (handle, nullptr);
+
+    nixl_status_t status = obj_engine_->postXfer (
+        NIXL_WRITE, local_descs, remote_descs, init_params_.localAgent, handle, nullptr);
+    EXPECT_EQ (status, NIXL_IN_PROG);
+    EXPECT_EQ (mock_s3_client_->getPendingCount(), 1);
+
+    status = obj_engine_->checkXfer (handle);
+    EXPECT_EQ (status, NIXL_IN_PROG);
+
+    // Cancel the transfer before completion by releasing the handle
+    // This simulates the cancellation behavior from nixlAgent::releaseXferReq
+    status = obj_engine_->releaseReqH (handle);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    mock_s3_client_->execAsync();
+
+    // After cancellation/release, we can't check the transfer status anymore
+    // as the handle has been released. This verifies that cancelling pending
+    // async tasks is handled correctly by properly cleaning up resources.
+    status = obj_engine_->deregisterMem (local_metadata);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    status = obj_engine_->deregisterMem (remote_metadata);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+}
+
+TEST_F (ObjTestFixture, ReadFromOffset) {
+    mock_s3_client_->setSimulateSuccess (true);
+
+    std::vector<char> test_buffer (1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ (obj_engine_->registerMem (local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "test-offset-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ (obj_engine_->registerMem (remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs (DRAM_SEG, false);
+    nixl_meta_dlist_t remote_descs (OBJ_SEG, false);
+
+    const size_t offset = 256;
+    const size_t length = 512;
+    nixlMetaDesc local_meta_desc (
+        reinterpret_cast<uintptr_t> (test_buffer.data()), length, local_desc.devId);
+    nixlMetaDesc remote_meta_desc (offset, length, remote_desc.devId);
+    local_descs.addDesc (local_meta_desc);
+    remote_descs.addDesc (remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ (obj_engine_->prepXfer (
+                   NIXL_READ, local_descs, remote_descs, init_params_.localAgent, handle, nullptr),
+               NIXL_SUCCESS);
+    ASSERT_NE (handle, nullptr);
+
+    nixl_status_t status = obj_engine_->postXfer (
+        NIXL_READ, local_descs, remote_descs, init_params_.localAgent, handle, nullptr);
+    EXPECT_EQ (status, NIXL_IN_PROG);
+    EXPECT_EQ (mock_s3_client_->getPendingCount(), 1);
+    status = obj_engine_->checkXfer (handle);
+    EXPECT_EQ (status, NIXL_IN_PROG);
+
+    mock_s3_client_->execAsync();
+    status = obj_engine_->checkXfer (handle);
+    EXPECT_EQ (status, NIXL_SUCCESS);
+    EXPECT_EQ (test_buffer[0], 'A' + (offset % 26));
+
+    obj_engine_->releaseReqH (handle);
+    obj_engine_->deregisterMem (local_metadata);
+    obj_engine_->deregisterMem (remote_metadata);
+}
+
+TEST_F (ObjTestFixture, AsyncReadTransferWithControlledExecution) {
+    testAsyncTransferWithControlledExecution (NIXL_READ);
+}
+
+TEST_F (ObjTestFixture, AsyncWriteTransferWithControlledExecution) {
+    testAsyncTransferWithControlledExecution (NIXL_WRITE);
+}
+
+TEST_F (ObjTestFixture, MultiDescriptorWrite) {
+    testMultiDescriptorTransfer (NIXL_READ);
+}
+
+TEST_F (ObjTestFixture, MultiDescriptorRead) {
+    testMultiDescriptorTransfer (NIXL_WRITE);
+}
+
+TEST_F (ObjTestFixture, AsyncReadTransferFailureIsHandled) {
+    testAsyncTransferFailureIsHandled (NIXL_READ);
+}
+
+TEST_F (ObjTestFixture, AsyncWriteTransferFailureIsHandled) {
+    testAsyncTransferFailureIsHandled (NIXL_WRITE);
+}
+
+} // namespace gtest::obj

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -174,15 +174,6 @@ protected:
 
         std::vector<char> test_buffer0 (1024);
         std::vector<char> test_buffer1 (1024);
-        if (operation == NIXL_WRITE) {
-            for (size_t i = 0; i < test_buffer0.size(); ++i) {
-                test_buffer0[i] = static_cast<char> ('X' + (i % 3));
-            }
-            for (size_t i = 0; i < test_buffer1.size(); ++i) {
-                test_buffer1[i] = static_cast<char> ('x' + (i % 3));
-            }
-        }
-
         nixlBlobDesc local_desc0, local_desc1;
         local_desc0.devId = 1;
         local_desc1.devId = 1;

--- a/test/nixl/test_plugin.cpp
+++ b/test/nixl/test_plugin.cpp
@@ -64,8 +64,8 @@ int verify_plugin(std::string name, nixlPluginManager& plugin_manager)
 int main(int argc, char** argv) {
     char *plugindir = NULL;
     std::set<nixl_backend_t> staticPlugs;
-    std::set<std::string> plugins =
-        {"UCX", "GDS", "POSIX", "UCX_MO", "MOCK_BASIC", "MOCK_DRAM", "GPUNETIO"};
+    std::set<std::string> plugins = {
+        "UCX", "GDS", "POSIX", "UCX_MO", "MOCK_BASIC", "MOCK_DRAM", "GPUNETIO", "OBJ"};
 
     if (argc > 1 && (std::string(argv[1]) == "-h" || std::string(argv[1]) == "--help")) {
         print_usage(argv[0]);


### PR DESCRIPTION
## What?
Implement OBJ storage plugin for AWS S3 generic objects and accompanying tests.

## Why?
NIXL needs a plugin that can handle OBJ_SEG memory type. AWS S3 seems like an obvious first choice and meets customer demands.

## How?
Use AWS SDK async API for performance. Provide S3Client with executor based on Asio thread pool to establish an upper bound of resource usage (number of threads).

Validate the functionality with new Gtest-based _unit_ tests with mocked S3 wrapper. The tests don't have any external dependencies and can be executed with sanitizers enabled.
