### PR TITLE
SRC/BINDINGS/PYTHON: Fix handling of unsorted desc list passed with sorted=True

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -35,7 +35,7 @@ export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/lo
 export LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 export CPATH=${INSTALL_DIR}/include:$CPATH
 export PATH=${INSTALL_DIR}/bin:$PATH
-export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:${UCX_INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 
 pip3 install --break-system-packages .

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -35,7 +35,7 @@ export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/lo
 export LD_LIBRARY_PATH=/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 export CPATH=${INSTALL_DIR}/include:$CPATH
 export PATH=${INSTALL_DIR}/bin:$PATH
-export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:${UCX_INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 
 pip3 install --break-system-packages .

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -188,7 +188,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixl_xfer_dlist_t new_list(mem, sorted, n);
                 // We assume that the Nx3 array matches the nixlBasicDesc layout so we can simply memcpy
                 std::memcpy(&new_list[0], descs.data(), descs.size() * sizeof(uint64_t));
-                assert(!sorted || new_list.verifySorted());
+                if (sorted && !new_list.verifySorted()) {
+                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
+                }
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def(py::init([](nixl_mem_t mem, py::list descs, bool sorted) {
@@ -203,7 +205,9 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>());
                 }
-                assert(!sorted || new_list.verifySorted());
+                if (sorted && !new_list.verifySorted()) {
+                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
+                }
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def("getType", &nixl_xfer_dlist_t::getType)
@@ -272,6 +276,11 @@ PYBIND11_MODULE(_bindings, m) {
                         new_list[i] = nixlBlobDesc(buffer(i, 0), buffer(i, 1), buffer(i, 2), "");
                     }
                 }
+
+                if (sorted && !new_list.verifySorted()) {
+                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
+                }
+
                 return new_list;
         }))
         .def(py::init([](nixl_mem_t mem, py::list descs, bool sorted) {
@@ -286,7 +295,11 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>(), desc[3].cast<std::string>());
                 }
-                assert(!sorted || new_list.verifySorted());
+
+                if (sorted && !new_list.verifySorted()) {
+                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
+                }
+
                 return new_list;
             }), py::arg("type"), py::arg("descs"), py::arg("sorted")=false)
         .def("getType", &nixl_reg_dlist_t::getType)

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -21,7 +21,6 @@
 
 #include <tuple>
 #include <iostream>
-#include <cassert>
 
 #include "nixl.h"
 #include "serdes/serdes.h"
@@ -188,9 +187,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixl_xfer_dlist_t new_list(mem, sorted, n);
                 // We assume that the Nx3 array matches the nixlBasicDesc layout so we can simply memcpy
                 std::memcpy(&new_list[0], descs.data(), descs.size() * sizeof(uint64_t));
-                if (sorted && !new_list.verifySorted()) {
-                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
-                }
+
+                new_list.verifySorted();
+
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def(py::init([](nixl_mem_t mem, py::list descs, bool sorted) {
@@ -205,9 +204,9 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>());
                 }
-                if (sorted && !new_list.verifySorted()) {
-                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
-                }
+
+                new_list.verifySorted();
+
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def("getType", &nixl_xfer_dlist_t::getType)
@@ -277,9 +276,7 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                 }
 
-                if (sorted && !new_list.verifySorted()) {
-                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
-                }
+                new_list.verifySorted();
 
                 return new_list;
         }))
@@ -295,10 +292,7 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>(), desc[3].cast<std::string>());
                 }
-
-                if (sorted && !new_list.verifySorted()) {
-                    throw std::invalid_argument("descs must be sorted when 'sorted' passed as True");
-                }
+                new_list.verifySorted();
 
                 return new_list;
             }), py::arg("type"), py::arg("descs"), py::arg("sorted")=false)

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -312,6 +312,9 @@ bool nixlDescList<T>::verifySorted() {
 
     for (int i=0; i<size-1; ++i) {
         if (descs[i+1] < descs[i]) {
+            if (sorted) {
+                NIXL_WARN << "Descs are not sorted although sorted=True was passed, this may affect performance";
+            }
             sorted = false;
             return false;
         }


### PR DESCRIPTION
## What?
In python bindings - warn when an xferDList / regDList is created with sorted=True while it's not sorted

## Why?
We had an assertion for that, but they are not active in release builds.

## Desired Behavior
Nixl would print a warning message and treat the descriptors list as not sorted