### PR TITLE
NIXL/UCX: Added support for self notification

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -999,14 +999,10 @@ nixlAgent::genNotif(const std::string &remote_agent,
 
     bool localNotif = data->name == remote_agent;
     for (auto & eng: *backend_list) {
-        if (localNotif) {
-            if (eng->supportsLocal()) {
-                return eng->genNotif(remote_agent, msg);
-            }
-        } else {
-            if (data->remoteBackends[remote_agent].count(eng->getType()) != 0) {
-                return eng->genNotif(remote_agent, msg);
-            }
+        if ((localNotif && eng->supportsLocal()) ||
+            (!localNotif &&
+             data->remoteBackends[remote_agent].count(eng->getType()) != 0)) {
+            return eng->genNotif(remote_agent, msg);
         }
     }
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -978,41 +978,39 @@ nixlAgent::genNotif(const std::string &remote_agent,
                     const nixl_blob_t &msg,
                     const nixl_opt_args_t* extra_params) const {
 
-    nixlBackendEngine* backend = nullptr;
-    backend_list_t*    backend_list;
+    backend_list_t backend_list_value;
+    backend_list_t* backend_list;
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
-    if (!extra_params || extra_params->backends.size() == 0) {
+    if (!extra_params || extra_params->backends.empty()) {
         backend_list = &data->notifEngines;
         if (backend_list->empty())
             return NIXL_ERR_BACKEND;
     } else {
-        backend_list = new backend_list_t();
-        for (auto & elm : extra_params->backends)
+        backend_list = &backend_list_value;
+        for (auto &elm : extra_params->backends)
             if (elm->engine->supportsNotif())
                 backend_list->push_back(elm->engine);
 
         if (backend_list->empty()) {
-            delete backend_list;
             return NIXL_ERR_BACKEND;
         }
     }
 
+    bool localNotif = data->name == remote_agent;
     for (auto & eng: *backend_list) {
-        if (data->remoteBackends[remote_agent].count(
-                                 eng->getType()) != 0) {
-            backend = eng;
-            break;
+        if (localNotif) {
+            if (eng->supportsLocal()) {
+                return eng->genNotif(remote_agent, msg);
+            }
+        } else {
+            if (data->remoteBackends[remote_agent].count(eng->getType()) != 0) {
+                return eng->genNotif(remote_agent, msg);
+            }
         }
     }
 
-    if (extra_params && extra_params->backends.size() > 0)
-        delete backend_list;
-
-    if (backend)
-        return backend->genNotif(remote_agent, msg);
-    else
-        return NIXL_ERR_NOT_FOUND;
+    return NIXL_ERR_NOT_FOUND;
 }
 
 nixl_status_t

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1179,21 +1179,20 @@ nixlUcxEngine::notifAmCb(void *arg, const void *header,
 
     std::string ser_str( (char*) data, length);
     nixlUcxEngine* engine = (nixlUcxEngine*) arg;
-    std::string remote_name, msg;
 
     // send_am should be forcing EAGER protocol
     NIXL_ASSERT(!(param->recv_attr & UCP_AM_RECV_ATTR_FLAG_RNDV));
     NIXL_ASSERT(header_length == 0) << "header_length " << header_length;
 
     ser_des.importStr(ser_str);
-    remote_name = ser_des.getStr("name");
-    msg = ser_des.getStr("msg");
+    std::string remote_name = ser_des.getStr("name");
+    std::string msg = ser_des.getStr("msg");
 
     if (engine->isProgressThread()) {
         /* Append to the private list to allow batching */
-        engine->notifPthrPriv.push_back(std::make_pair(remote_name, msg));
+        engine->notifPthrPriv.push_back(std::make_pair(std::move(remote_name), std::move(msg)));
     } else {
-        engine->notifMainList.push_back(std::make_pair(remote_name, msg));
+        engine->notifMainList.push_back(std::make_pair(std::move(remote_name), std::move(msg)));
     }
 
     return UCS_OK;

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -464,6 +464,18 @@ TEST_P(TestTransfer, NotificationOnly) {
             getAgent(0), getAgentName(0), getAgent(1), getAgentName(1), repeat, num_threads);
 }
 
+TEST_P(TestTransfer, SelfNotification) {
+    // UCX_MO does not support local communication
+    if (getBackendName() == "UCX_MO") {
+        GTEST_SKIP() << "UCX_MO does not support local communication";
+    }
+
+    constexpr size_t repeat = 1;
+    constexpr size_t num_threads = 1;
+    doNotificationTest(
+            getAgent(0), getAgentName(0), getAgent(0), getAgentName(0), repeat, num_threads);
+}
+
 TEST_P(TestTransfer, ListenerCommSize) {
     std::vector<MemBuffer> buffers;
     createRegisteredMem(getAgent(1), 64, 10000, DRAM_SEG, buffers);

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -470,8 +470,8 @@ TEST_P(TestTransfer, SelfNotification) {
         GTEST_SKIP() << "UCX_MO does not support local communication";
     }
 
-    constexpr size_t repeat = 1;
-    constexpr size_t num_threads = 1;
+    constexpr size_t repeat = 100;
+    constexpr size_t num_threads = 4;
     doNotificationTest(
             getAgent(0), getAgentName(0), getAgent(0), getAgentName(0), repeat, num_threads);
 }


### PR DESCRIPTION
## What?
Added support for self notification for UCX backend, which is requested by TensorRT-LLM team.

## Why?
Currently NIXL agent supports transfer Request to itself, but doesn't support genNotif to itself.
Without this option they have to use fake transfer request with notification as a workaround.

## How?
- Changed genNotif to check for local name
- Few optimisations to avoid redundant string copies
- Few optimisations to avoid heap allocation/deallocation
- Added test for UCX backend