### PR TITLE
SRC/BINDINGS/PYTHON: Fix handling of unsorted desc list passed with s…

### DIFF
--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -21,7 +21,6 @@
 
 #include <tuple>
 #include <iostream>
-#include <cassert>
 
 #include "nixl.h"
 #include "serdes/serdes.h"
@@ -188,7 +187,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixl_xfer_dlist_t new_list(mem, sorted, n);
                 // We assume that the Nx3 array matches the nixlBasicDesc layout so we can simply memcpy
                 std::memcpy(&new_list[0], descs.data(), descs.size() * sizeof(uint64_t));
-                assert(!sorted || new_list.verifySorted());
+
+                new_list.verifySorted();
+
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def(py::init([](nixl_mem_t mem, py::list descs, bool sorted) {
@@ -203,7 +204,9 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBasicDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>());
                 }
-                assert(!sorted || new_list.verifySorted());
+
+                new_list.verifySorted();
+
                 return new_list;
             }), py::arg("type"), py::arg("descs").noconvert(), py::arg("sorted")=false)
         .def("getType", &nixl_xfer_dlist_t::getType)
@@ -272,6 +275,9 @@ PYBIND11_MODULE(_bindings, m) {
                         new_list[i] = nixlBlobDesc(buffer(i, 0), buffer(i, 1), buffer(i, 2), "");
                     }
                 }
+
+                new_list.verifySorted();
+
                 return new_list;
         }))
         .def(py::init([](nixl_mem_t mem, py::list descs, bool sorted) {
@@ -286,7 +292,8 @@ PYBIND11_MODULE(_bindings, m) {
                     }
                     new_list[i] = nixlBlobDesc(desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>(), desc[3].cast<std::string>());
                 }
-                assert(!sorted || new_list.verifySorted());
+                new_list.verifySorted();
+
                 return new_list;
             }), py::arg("type"), py::arg("descs"), py::arg("sorted")=false)
         .def("getType", &nixl_reg_dlist_t::getType)

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -23,6 +23,7 @@
 #include "mem_section.h"
 #include "backend/backend_aux.h"
 #include "serdes/serdes.h"
+#include "common/nixl_log.h"
 
 /*** Class nixlBasicDesc implementation ***/
 

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -311,6 +311,9 @@ bool nixlDescList<T>::verifySorted() {
 
     for (int i=0; i<size-1; ++i) {
         if (descs[i+1] < descs[i]) {
+            if (sorted) {
+                NIXL_WARN << "Descs are not sorted although sorted=True was passed, this may affect performance";
+            }
             sorted = false;
             return false;
         }


### PR DESCRIPTION
## What?
In python bindings - warn when an xferDList / regDList is created with sorted=True while it's not sorted
Fixes NIX-115.

## Why?
We had an assertion for that, but they are not active in release builds.

## Desired Behavior
Nixl would print a warning message and treat the descriptors list as not sorted