### PR TITLE
Compress wheel (#497)

### DIFF
--- a/contrib/wheel_add_ucx_plugins.py
+++ b/contrib/wheel_add_ucx_plugins.py
@@ -84,7 +84,9 @@ def create_wheel(wheel_path, temp_dir):
     """
     print(f"Creating wheel {wheel_path} from {temp_dir}")
     update_wheel_record_file(temp_dir)
-    with zipfile.ZipFile(wheel_path, "w") as zip_ref:
+    with zipfile.ZipFile(
+        wheel_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as zip_ref:
         for root, _, files in os.walk(temp_dir):
             for file in files:
                 abs_path = os.path.join(root, file)


### PR DESCRIPTION
## What?
Compress wheels after patching.

## Why?
`auditwheel repair` uses DEFLATE compression explicitly: https://github.com/pypa/auditwheel/blob/112180fbcce8112e8c262d2704c9f625156d59cc/src/auditwheel/tools.py#L148

We added an additional step that uses `zipfile.ZipFile` without specifying the compression method and level explicitly. By default it uses stored (no compression) and the wheel file grew from ~30 MB to 99 MB.

We should use compression the same as auditwheel.

Wheel size dropped to 28 MB.