### PR TITLE
BACKEND/UCX: enable error handling mode peer by default

### DIFF
--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -35,6 +35,8 @@ enum class nixl_ucx_mt_t {
     WORKER
 };
 
+constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
+
 template<typename Enum>
 [[nodiscard]] constexpr auto enumToInteger(const Enum e) noexcept
 {
@@ -209,14 +211,15 @@ private:
     ucp_err_handling_mode_t err_handling_mode_;
 };
 
-[[nodiscard]] static inline nixl_b_params_t get_ucx_backend_common_options() {
-    return {
-        { "ucx_devices", "" },
-        { "ucx_error_handling_mode", "none" }, // or "peer"
-        { "num_workers", "1" }
-    };
-}
+[[nodiscard]] nixl_b_params_t
+get_ucx_backend_common_options();
 
 nixl_status_t ucx_status_to_nixl(ucs_status_t status);
+
+[[nodiscard]] std::string_view
+ucx_err_mode_to_string(ucp_err_handling_mode_t t);
+
+[[nodiscard]] ucp_err_handling_mode_t
+ucx_err_mode_from_string(std::string_view s);
 
 #endif

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -24,7 +24,6 @@
 namespace gtest {
 namespace nixl {
     constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
-    constexpr const char* ucx_err_handling_mode_none = "none";
     constexpr const char* ucx_err_handling_mode_peer = "peer";
 
     static nixlBackendH* createUcxBackend(nixlAgent& agent, const std::string& backend_name)
@@ -41,9 +40,7 @@ namespace nixl {
         EXPECT_EQ(NIXL_SUCCESS, status);
 
         nixlBackendH* backend_handle = nullptr;
-        EXPECT_EQ(ucx_err_handling_mode_none,
-                  params[ucx_err_handling_mode_key]);
-        params[ucx_err_handling_mode_key] = ucx_err_handling_mode_peer;
+        EXPECT_EQ(ucx_err_handling_mode_peer, params[ucx_err_handling_mode_key]);
         status = agent.createBackend(*it, params, backend_handle);
         EXPECT_EQ(NIXL_SUCCESS, status);
         EXPECT_NE(nullptr, backend_handle);


### PR DESCRIPTION
## What?
enable error handling mode peer by default in UCX backend

## Why?
better error handling support
