### PR TITLE
EXAMPLES/CPP: Fixed includes.

### DIFF
--- a/examples/cpp/nixl_example.cpp
+++ b/examples/cpp/nixl_example.cpp
@@ -16,11 +16,11 @@
  */
 #include <iostream>
 #include <cassert>
+#include <cstring>
 
 #include <sys/time.h>
 
 #include "nixl.h"
-#include "ucx_backend.h"
 
 std::string agent1("Agent001");
 std::string agent2("Agent002");


### PR DESCRIPTION
## What?
Removed `#include "ucx_backend.h"`.

## Why?
https://github.com/ai-dynamo/nixl/issues/442
