### PR TITLE
UTILS/UCX: Added ucx::Config class.

### DIFF
--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+
+#include <stdexcept>
+
+#include <absl/strings/str_format.h>
+
+#include "common/nixl_log.h"
+
+namespace nixl {
+namespace ucx {
+    Config::Config() : config_ (readUcpConfig(), &ucp_config_release) {}
+
+    void
+    Config::modify (std::string_view key, std::string_view value, bool force) {
+        const char *env_val;
+        if (force) {
+            env_val = nullptr;
+        } else {
+            env_val = std::getenv (absl::StrFormat ("UCX_%s", key.data()).c_str());
+        }
+
+        value = env_val ? env_val : value;
+        const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
+        if (status != UCS_OK) {
+            NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value << ": "
+                      << ucs_status_string (status);
+        } else {
+            NIXL_DEBUG << "Applied UCX config from " << (env_val ? "env var" : "NIXL") << ": "
+                       << key << "=" << value;
+        }
+    }
+
+    ucp_config_t *
+    Config::readUcpConfig() {
+        ucp_config_t *config = nullptr;
+        const auto status = ucp_config_read (NULL, NULL, &config);
+        if (status != UCS_OK) {
+            const auto err_str =
+                std::string ("Failed to create UCX config: ") + ucs_status_string (status);
+            NIXL_ERROR << err_str;
+            throw std::runtime_error (err_str);
+        }
+        return config;
+    }
+} // namespace ucx
+} // namespace nixl

--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -24,7 +24,7 @@
 
 namespace nixl::ucx {
 void
-Config::modify (std::string_view key, std::string_view value) const {
+config::modify (std::string_view key, std::string_view value) const {
     const char *env_val = std::getenv (absl::StrFormat ("UCX_%s", key.data()).c_str());
     if (env_val) {
         NIXL_DEBUG << "UCX env var has already been set: " << key << "=" << env_val;
@@ -34,12 +34,12 @@ Config::modify (std::string_view key, std::string_view value) const {
 }
 
 void
-Config::modifyAlways (std::string_view key, std::string_view value) const {
+config::modifyAlways (std::string_view key, std::string_view value) const {
     modifyUcpConfig (key, value);
 }
 
 ucp_config_t *
-Config::readUcpConfig() {
+config::readUcpConfig() {
     ucp_config_t *config = nullptr;
     const auto status = ucp_config_read (NULL, NULL, &config);
     if (status != UCS_OK) {
@@ -52,7 +52,7 @@ Config::readUcpConfig() {
 }
 
 void
-Config::modifyUcpConfig (std::string_view key, std::string_view value) const {
+config::modifyUcpConfig (std::string_view key, std::string_view value) const {
     const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
     if (status != UCS_OK) {
         NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value << ": "

--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -24,7 +24,7 @@
 
 namespace nixl::ucx {
 void
-Config::modify (std::string_view key, std::string_view value) {
+Config::modify (std::string_view key, std::string_view value) const{
     const char *env_val = std::getenv (absl::StrFormat ("UCX_%s", key.data()).c_str());
     if (env_val) {
         NIXL_DEBUG << "UCX env var has already been set: " << key << "=" << env_val;
@@ -34,7 +34,7 @@ Config::modify (std::string_view key, std::string_view value) {
 }
 
 void
-Config::modifyAlways (std::string_view key, std::string_view value) {
+Config::modifyAlways (std::string_view key, std::string_view value) const {
     modifyUcpConfig (key, value);
 }
 
@@ -52,7 +52,7 @@ Config::readUcpConfig() {
 }
 
 void
-Config::modifyUcpConfig (std::string_view key, std::string_view value) {
+Config::modifyUcpConfig (std::string_view key, std::string_view value) const {
     const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
     if (status != UCS_OK) {
         NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value << ": "

--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -24,7 +24,7 @@
 
 namespace nixl::ucx {
 void
-Config::modify (std::string_view key, std::string_view value) const{
+Config::modify (std::string_view key, std::string_view value) const {
     const char *env_val = std::getenv (absl::StrFormat ("UCX_%s", key.data()).c_str());
     if (env_val) {
         NIXL_DEBUG << "UCX env var has already been set: " << key << "=" << env_val;

--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -33,32 +33,30 @@ isUcxEnvVarSet (std::string_view key) {
 }
 } // namespace
 
-namespace nixl {
-namespace ucx {
-    void
-    Config::modify (std::string_view key, std::string_view value, bool force) {
-        if (!force && isUcxEnvVarSet (key)) return;
+namespace nixl::ucx {
+void
+Config::modify (std::string_view key, std::string_view value, bool force) {
+    if (!force && isUcxEnvVarSet (key)) return;
 
-        const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
-        if (status != UCS_OK) {
-            NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value << ": "
-                      << ucs_status_string (status);
-        } else {
-            NIXL_DEBUG << "Modified UCX config: " << key << "=" << value;
-        }
+    const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
+    if (status != UCS_OK) {
+        NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value << ": "
+                  << ucs_status_string (status);
+    } else {
+        NIXL_DEBUG << "Modified UCX config: " << key << "=" << value;
     }
+}
 
-    ucp_config_t *
-    Config::readUcpConfig() {
-        ucp_config_t *config = nullptr;
-        const auto status = ucp_config_read (NULL, NULL, &config);
-        if (status != UCS_OK) {
-            const auto err_str =
-                std::string ("Failed to create UCX config: ") + ucs_status_string (status);
-            NIXL_ERROR << err_str;
-            throw std::runtime_error (err_str);
-        }
-        return config;
+ucp_config_t *
+Config::readUcpConfig() {
+    ucp_config_t *config = nullptr;
+    const auto status = ucp_config_read (NULL, NULL, &config);
+    if (status != UCS_OK) {
+        const auto err_str =
+            std::string ("Failed to create UCX config: ") + ucs_status_string (status);
+        NIXL_ERROR << err_str;
+        throw std::runtime_error (err_str);
     }
-} // namespace ucx
-} // namespace nixl
+    return config;
+}
+} // namespace nixl::ucx

--- a/src/utils/ucx/config.cpp
+++ b/src/utils/ucx/config.cpp
@@ -24,7 +24,7 @@
 
 namespace {
 [[nodiscard]] bool
-isEnvVarSet (std::string_view key) {
+isUcxEnvVarSet (std::string_view key) {
     const char *env_val = std::getenv (absl::StrFormat ("UCX_%s", key.data()).c_str());
     if (!env_val) return false;
 
@@ -37,7 +37,7 @@ namespace nixl {
 namespace ucx {
     void
     Config::modify (std::string_view key, std::string_view value, bool force) {
-        if (!force && isEnvVarSet (key)) return;
+        if (!force && isUcxEnvVarSet (key)) return;
 
         const auto status = ucp_config_modify (config_.get(), key.data(), value.data());
         if (status != UCS_OK) {

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -29,7 +29,7 @@ namespace nixl {
 namespace ucx {
     class Config {
     public:
-        Config();
+        Config() = default;
 
         [[nodiscard]] ucp_config_t *
         getUcpConfig() const noexcept {
@@ -43,7 +43,8 @@ namespace ucx {
         [[nodiscard]] static ucp_config_t *
         readUcpConfig();
 
-        const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_;
+        const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
+                                                                               &ucp_config_release};
     };
 } // namespace ucx
 } // namespace nixl

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_UTILS_UCX_CONFIG_H
+#define NIXL_SRC_UTILS_UCX_CONFIG_H
+
+#include <memory>
+#include <string_view>
+
+extern "C" {
+#include <ucp/api/ucp.h>
+}
+
+namespace nixl {
+namespace ucx {
+    class Config {
+    public:
+        Config();
+
+        Config (const Config &) = delete;
+        Config &
+        operator= (const Config &) = delete;
+        Config (Config &&) = delete;
+        Config &
+        operator= (Config &&) = delete;
+
+        [[nodiscard]] ucp_config_t *
+        getUcpConfig() const noexcept {
+            return config_.get();
+        }
+
+        void
+        modify (std::string_view name, std::string_view value, bool force = false);
+
+    private:
+        [[nodiscard]] static ucp_config_t *
+        readUcpConfig();
+
+        const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_;
+    };
+} // namespace ucx
+} // namespace nixl
+
+#endif

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -25,28 +25,26 @@ extern "C" {
 #include <ucp/api/ucp.h>
 }
 
-namespace nixl {
-namespace ucx {
-    class Config {
-    public:
-        Config() = default;
+namespace nixl::ucx {
+class Config {
+public:
+    Config() = default;
 
-        [[nodiscard]] ucp_config_t *
-        getUcpConfig() const noexcept {
-            return config_.get();
-        }
+    [[nodiscard]] ucp_config_t *
+    getUcpConfig() const noexcept {
+        return config_.get();
+    }
 
-        void
-        modify (std::string_view name, std::string_view value, bool force = false);
+    void
+    modify (std::string_view name, std::string_view value, bool force = false);
 
-    private:
-        [[nodiscard]] static ucp_config_t *
-        readUcpConfig();
+private:
+    [[nodiscard]] static ucp_config_t *
+    readUcpConfig();
 
-        const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
-                                                                               &ucp_config_release};
-    };
-} // namespace ucx
-} // namespace nixl
+    const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
+                                                                           &ucp_config_release};
+};
+} // namespace nixl::ucx
 
 #endif

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -47,9 +47,6 @@ private:
     [[nodiscard]] static ucp_config_t *
     readUcpConfig();
 
-    void
-    modifyUcpConfig (std::string_view key, std::string_view value) const;
-
     const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
                                                                            &ucp_config_release};
 };

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -31,13 +31,6 @@ namespace ucx {
     public:
         Config();
 
-        Config (const Config &) = delete;
-        Config &
-        operator= (const Config &) = delete;
-        Config (Config &&) = delete;
-        Config &
-        operator= (Config &&) = delete;
-
         [[nodiscard]] ucp_config_t *
         getUcpConfig() const noexcept {
             return config_.get();

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -26,9 +26,9 @@ extern "C" {
 }
 
 namespace nixl::ucx {
-class Config {
+class config {
 public:
-    Config() = default;
+    config() = default;
 
     [[nodiscard]] ucp_config_t *
     getUcpConfig() const noexcept {

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -35,12 +35,20 @@ public:
         return config_.get();
     }
 
+    // Modify the config if it is not already set via environment variable
     void
-    modify (std::string_view name, std::string_view value, bool force = false);
+    modify (std::string_view key, std::string_view value);
+
+    // Modify the config always
+    void
+    modifyAlways (std::string_view key, std::string_view value);
 
 private:
     [[nodiscard]] static ucp_config_t *
     readUcpConfig();
+
+    void
+    modifyUcpConfig (std::string_view key, std::string_view value);
 
     const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
                                                                            &ucp_config_release};

--- a/src/utils/ucx/config.h
+++ b/src/utils/ucx/config.h
@@ -37,18 +37,18 @@ public:
 
     // Modify the config if it is not already set via environment variable
     void
-    modify (std::string_view key, std::string_view value);
+    modify (std::string_view key, std::string_view value) const;
 
     // Modify the config always
     void
-    modifyAlways (std::string_view key, std::string_view value);
+    modifyAlways (std::string_view key, std::string_view value) const;
 
 private:
     [[nodiscard]] static ucp_config_t *
     readUcpConfig();
 
     void
-    modifyUcpConfig (std::string_view key, std::string_view value);
+    modifyUcpConfig (std::string_view key, std::string_view value) const;
 
     const std::unique_ptr<ucp_config_t, void (*) (ucp_config_t *)> config_{readUcpConfig(),
                                                                            &ucp_config_release};

--- a/src/utils/ucx/meson.build
+++ b/src/utils/ucx/meson.build
@@ -22,7 +22,7 @@ endif
 ucx_utils_inc_dirs = include_directories('.')
 
 ucx_utils_lib = library('ucx_utils',
-           'ucx_utils.cpp', 'ucx_utils.h',
+           'ucx_utils.cpp', 'ucx_utils.h', 'config.h', 'config.cpp',
            dependencies: ucx_utils_dep,
            include_directories: [ nixl_inc_dirs, utils_inc_dirs ],
            install: true)

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -381,12 +381,11 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     /* If requested, restrict the set of network devices */
     if (devs.size()) {
         /* TODO: check if this is the best way */
-        string dev_str;
-        unsigned int i;
-        for (i = 0; i < devs.size() - 1; i++) {
-            dev_str = dev_str + devs[i] + ":1,";
+        std::string dev_str;
+        for (const auto& dev : devs) {
+            dev_str += dev + ":1,";
         }
-        dev_str = dev_str + devs[i] + ":1";
+        dev_str.pop_back(); // to remove odd comma after the last device
         config.modify ("NET_DEVICES", dev_str.c_str(), true);
     }
 

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "ucx_utils.h"
+
 #include <exception>
 #include <vector>
 #include <string>
@@ -23,10 +25,9 @@
 
 #include <nixl_types.h>
 
-#include "serdes/serdes.h"
-
-#include "ucx_utils.h"
 #include "common/nixl_log.h"
+#include "config.h"
+#include "serdes/serdes.h"
 
 using namespace std;
 
@@ -48,22 +49,6 @@ nixl_status_t ucx_status_to_nixl(ucs_status_t status)
     default:
         NIXL_WARN << "Unexpected UCX error: " << ucs_status_string(status);
         return NIXL_ERR_BACKEND;
-    }
-}
-
-void ucx_modify_config(ucp_config_t *config, std::string_view key,
-                       std::string_view value)
-{
-    const char *env_val = std::getenv(absl::StrFormat("UCX_%s", key.data()).c_str());
-    value = env_val ? env_val : value;
-
-    ucs_status_t status = ucp_config_modify(config, key.data(), value.data());
-    if (status != UCS_OK) {
-        NIXL_WARN << "Failed to modify UCX config: " << key << "=" << value
-                  << ": " << ucs_status_string(status);
-    } else {
-        NIXL_DEBUG << "Applied UCX config from " << (env_val ? "env var" : "NIXL")
-                   << ": " << key << "=" << value;
     }
 }
 
@@ -361,8 +346,6 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
                                nixl_thread_sync_t sync_mode)
 {
     ucp_params_t ucp_params;
-    ucp_config_t *ucp_config;
-    ucs_status_t status = UCS_OK;
 
     // With strict synchronization model nixlAgent serializes access to backends, with more
     // permissive models backends need to account for concurrent access and ensure their internal
@@ -393,44 +376,42 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
         ucp_params.field_mask |= UCP_PARAM_FIELD_REQUEST_CLEANUP;
     }
 
-    ucp_config_read(NULL, NULL, &ucp_config);
+    nixl::ucx::Config config;
 
     /* If requested, restrict the set of network devices */
     if (devs.size()) {
         /* TODO: check if this is the best way */
-        string dev_str = "";
+        string dev_str;
         unsigned int i;
-        for(i=0; i < devs.size() - 1; i++) {
+        for (i = 0; i < devs.size() - 1; i++) {
             dev_str = dev_str + devs[i] + ":1,";
         }
         dev_str = dev_str + devs[i] + ":1";
-        ucp_config_modify(ucp_config, "NET_DEVICES", dev_str.c_str());
+        config.modify ("NET_DEVICES", dev_str.c_str(), true);
     }
 
     unsigned major_version, minor_version, release_number;
     ucp_get_version(&major_version, &minor_version, &release_number);
 
-    ucx_modify_config(ucp_config, "ADDRESS_VERSION", "v2");
-    ucx_modify_config(ucp_config, "RNDV_THRESH", "inf");
+    config.modify ("ADDRESS_VERSION", "v2");
+    config.modify ("RNDV_THRESH", "inf");
 
     unsigned ucp_version = UCP_VERSION(major_version, minor_version);
     if (ucp_version >= UCP_VERSION(1, 19)) {
-        ucx_modify_config(ucp_config, "MAX_COMPONENT_MDS", "32");
+        config.modify ("MAX_COMPONENT_MDS", "32");
     }
 
     if (ucp_version >= UCP_VERSION(1, 20)) {
-        ucx_modify_config(ucp_config, "MAX_RMA_RAILS", "4");
+        config.modify ("MAX_RMA_RAILS", "4");
     } else {
-        ucx_modify_config(ucp_config, "MAX_RMA_RAILS", "2");
+        config.modify ("MAX_RMA_RAILS", "2");
     }
 
-    status = ucp_init(&ucp_params, ucp_config, &ctx);
+    const auto status = ucp_init (&ucp_params, config.getUcpConfig(), &ctx);
     if (status != UCS_OK) {
-        /* TODO: proper cleanup */
-        // TODO: MSW_NET_ERROR(priv->net, "failed to ucp_init(%s)\n", ucs_status_string(status));
-        return;
+        throw std::runtime_error ("Failed to create UCX context: " +
+                                  std::string (ucs_status_string (status)));
     }
-    ucp_config_release(ucp_config);
 }
 
 nixlUcxContext::~nixlUcxContext()

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -382,11 +382,11 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     if (devs.size()) {
         /* TODO: check if this is the best way */
         std::string dev_str;
-        for (const auto& dev : devs) {
+        for (const auto &dev : devs) {
             dev_str += dev + ":1,";
         }
         dev_str.pop_back(); // to remove odd comma after the last device
-        config.modify ("NET_DEVICES", dev_str.c_str(), true);
+        config.modifyAlways ("NET_DEVICES", dev_str.c_str());
     }
 
     unsigned major_version, minor_version, release_number;

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -376,7 +376,7 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
         ucp_params.field_mask |= UCP_PARAM_FIELD_REQUEST_CLEANUP;
     }
 
-    nixl::ucx::Config config;
+    nixl::ucx::config config;
 
     /* If requested, restrict the set of network devices */
     if (devs.size()) {

--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -381,12 +381,12 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     /* If requested, restrict the set of network devices */
     if (devs.size()) {
         /* TODO: check if this is the best way */
-        std::string dev_str;
+        std::string devs_str;
         for (const auto &dev : devs) {
-            dev_str += dev + ":1,";
+            devs_str += dev + ":1,";
         }
-        dev_str.pop_back(); // to remove odd comma after the last device
-        config.modifyAlways ("NET_DEVICES", dev_str.c_str());
+        devs_str.pop_back(); // to remove odd comma after the last device
+        config.modifyAlways ("NET_DEVICES", devs_str.c_str());
     }
 
     unsigned major_version, minor_version, release_number;

--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -211,7 +211,4 @@ private:
 
 nixl_status_t ucx_status_to_nixl(ucs_status_t status);
 
-void ucx_modify_config(ucp_config_t *config, std::string_view key,
-                       std::string_view value);
-
 #endif


### PR DESCRIPTION
## What?
Added ucx::Config class.

Applied RAII style.
Fixed memory leak in case of the `ucp_init` failure.
Added error handling of `ucp_config_read`.

## Why?
Better resource management and error handling.

## How?
I've introduced new namespaces. And I'd also like to change `class nixlUcxContext`, `class nixlUcxWorker`, etc. to `class Context`, `class Worker`, etc. in `namespace nixl::ucx`
