### PR TITLE
Support read/write multiple files for storage backend in nixlbench

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -224,6 +224,30 @@ int xferBenchConfig::loadFromFlags() {
         return -1;
     }
 
+    if (XFERBENCH_BACKEND_GDS == backend ||
+        XFERBENCH_BACKEND_POSIX == backend) {
+        if (scheme != XFERBENCH_SCHEME_TP && scheme != XFERBENCH_SCHEME_PAIRWISE) {
+            std::cerr << "Storage backend only supports pairwise and tp scheme, ["
+                      << scheme << "] is not supported." << std::endl;
+            return -1;
+        }
+        if (scheme != XFERBENCH_SCHEME_TP && num_files % num_threads != 0) {
+            std::cerr << "Storage backend with scheme to assign whole file to"
+                      << " a thread must have num_files(" << num_files
+                      << ") divisible by num_threads(" << num_threads
+                      << ")"
+                      << std::endl;
+            return -1;
+        }
+        if (max_block_size * max_batch_size * num_files > total_buffer_size) {
+            std::cerr << "Incorrect buffer size configuration"
+                      << " max_block_size * max_batch_size * num_files >"
+                      << " total_buffer_size"
+                      << std::endl;
+            return -1;
+        }
+    }
+
     int partition = (num_threads * LARGE_BLOCK_SIZE_ITER_FACTOR);
     if (num_iter % partition) {
         num_iter += partition - (num_iter % partition);
@@ -512,6 +536,8 @@ void xferBenchUtils::printStats(bool is_target, size_t block_size, size_t batch_
     double totalbw = 0;
 
     int num_iter = xferBenchConfig::num_iter;
+    int num_files = xferBenchConfig::num_files;
+    int num_threads = xferBenchConfig::num_threads;
 
     if (block_size > LARGE_BLOCK_SIZE) {
         num_iter /= LARGE_BLOCK_SIZE_ITER_FACTOR;
@@ -529,6 +555,14 @@ void xferBenchUtils::printStats(bool is_target, size_t block_size, size_t batch_
     if (IS_PAIRWISE_AND_MG()) {
         total_data_transferred *= xferBenchConfig::num_initiator_dev; // In Bytes
         avg_latency /= xferBenchConfig::num_initiator_dev; // In microsec
+    }
+    if (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend ||
+        XFERBENCH_BACKEND_POSIX == xferBenchConfig::backend) {
+        if (XFERBENCH_SCHEME_TP == xferBenchConfig::scheme) {
+            total_data_transferred *= num_files * num_threads;
+        } else {
+            total_data_transferred *= num_files;
+        }
     }
 
     throughput = (((double) total_data_transferred / (1024 * 1024)) /

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -34,7 +34,6 @@
 
 #define ROUND_UP(value, granularity) ((((value) + (granularity) - 1) / (granularity)) * (granularity))
 
-static uintptr_t gds_running_ptr = 0x0;
 static std::vector<std::vector<xferBenchIOV>> gds_remote_iovs;
 static std::vector<std::vector<xferBenchIOV>> storage_remote_iovs;
 
@@ -209,7 +208,8 @@ std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescDram(size_t buffer
 
     addr = calloc(1, buffer_size);
     if (!addr) {
-        std::cerr << "Failed to allocate " << buffer_size << " bytes of DRAM memory" << std::endl;
+        std::cerr << "Failed to allocate " << buffer_size
+                  << " bytes of DRAM memory" << std::endl;
         return std::nullopt;
     }
 
@@ -362,8 +362,8 @@ static std::vector<int> createFileFds(std::string name, bool is_gds) {
     return fds;
 }
 
-std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, int fd, int mem_dev_id) {
-    auto ret = std::optional<xferBenchIOV>(std::in_place, (uintptr_t)gds_running_ptr, buffer_size, fd);
+std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, int fd) {
+    auto ret = std::optional<xferBenchIOV>(std::in_place, (uintptr_t)0, buffer_size, fd);
     // Fill up with data
     void *buf = (void *)malloc(buffer_size);
     if (!buf) {
@@ -371,9 +371,10 @@ std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescFile(size_t buffer
                   << " bytes of memory" << std::endl;
         return std::nullopt;
     }
+
     // File is always initialized with XFERBENCH_TARGET_BUFFER_ELEMENT
     memset(buf, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size);
-    int rc = pwrite(fd, buf, buffer_size, gds_running_ptr);
+    int rc = pwrite(fd, buf, buffer_size, 0);
     if (rc < 0) {
         std::cerr << "Failed to write to file: " << fd
                   << " with error: " << strerror(errno) << std::endl;
@@ -381,7 +382,6 @@ std::optional<xferBenchIOV> xferBenchNixlWorker::initBasicDescFile(size_t buffer
     }
     free(buf);
 
-    gds_running_ptr += (buffer_size * mem_dev_id);
 
     return ret;
 }
@@ -417,13 +417,6 @@ std::vector<std::vector<xferBenchIOV>> xferBenchNixlWorker::allocateMemory(int n
     size_t i, buffer_size, num_devices = 0;
     nixl_opt_args_t opt_args;
 
-    if (isInitiator()) {
-        num_devices = xferBenchConfig::num_initiator_dev;
-    } else if (isTarget()) {
-        num_devices = xferBenchConfig::num_target_dev;
-    }
-    buffer_size = xferBenchConfig::total_buffer_size / (num_devices * num_lists);
-
     opt_args.backends.push_back(backend_engine);
 
     if (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend ||
@@ -434,30 +427,35 @@ std::vector<std::vector<xferBenchIOV>> xferBenchNixlWorker::allocateMemory(int n
             std::cerr << "Failed to create " << ((is_gds) ? "GDS" : "POSIX") << " file" << std::endl;
             exit(EXIT_FAILURE);
         }
-        for (int list_idx = 0; list_idx < num_lists; list_idx++) {
-            std::vector<xferBenchIOV> iov_list;
-            for (i = 0; i < num_devices; i++) {
-                std::optional<xferBenchIOV> basic_desc;
-                basic_desc = initBasicDescFile(buffer_size, remote_fds[0], i);
-                if (basic_desc) {
-                    iov_list.push_back(basic_desc.value());
-                }
+
+        size_t num_files = xferBenchConfig::num_files;
+        size_t file_size = xferBenchConfig::total_buffer_size / num_files;
+        for (size_t f = 0; f < num_files; f++) {
+            std::optional<xferBenchIOV> basic_desc;
+            basic_desc = initBasicDescFile(file_size, remote_fds[f]);
+            if (basic_desc) {
+                remote_iovs.push_back(basic_desc.value());
             }
-            nixl_reg_dlist_t desc_list(FILE_SEG);
-            iovListToNixlRegDlist(iov_list, desc_list);
-            CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args),
-                        "registerMem failed");
-            remote_iovs.push_back(iov_list);
         }
-        // Reset the running pointer to 0
-        gds_running_ptr = 0x0;
+        nixl_reg_dlist_t desc_list(FILE_SEG);
+        iovListToNixlRegDlist(remote_iovs, desc_list);
+        CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args),
+                    "registerMem failed");
+
+        num_devices = 1;
+    } else {
+        if (isInitiator()) {
+            num_devices = xferBenchConfig::num_initiator_dev;
+        } else if (isTarget()) {
+            num_devices = xferBenchConfig::num_target_dev;
+        }
     }
+    buffer_size = xferBenchConfig::total_buffer_size / (num_devices * num_lists);
 
     for (int list_idx = 0; list_idx < num_lists; list_idx++) {
         std::vector<xferBenchIOV> iov_list;
         for (i = 0; i < num_devices; i++) {
             std::optional<xferBenchIOV> basic_desc;
-
             switch (seg_type) {
             case DRAM_SEG:
                 basic_desc = initBasicDescDram(buffer_size, i);
@@ -516,15 +514,13 @@ void xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>
 
     if (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend ||
         XFERBENCH_BACKEND_POSIX == xferBenchConfig::backend) {
-        for (auto &iov_list: remote_iovs) {
-            for (auto &iov: iov_list) {
-                cleanupBasicDescFile(iov);
-            }
-            nixl_reg_dlist_t desc_list(FILE_SEG);
-            iovListToNixlRegDlist(iov_list, desc_list);
-            CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args),
-                             "deregisterMem failed");
+        for (auto &iov: remote_iovs) {
+            cleanupBasicDescFile(iov);
         }
+        nixl_reg_dlist_t desc_list(FILE_SEG);
+        iovListToNixlRegDlist(remote_iovs, desc_list);
+        CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args),
+                         "deregisterMem failed");
     }
 }
 
@@ -589,16 +585,49 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     // Special case for GDS
     if (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend ||
         XFERBENCH_BACKEND_POSIX == xferBenchConfig::backend) {
-        for (auto &iov_list: local_iovs) {
-            std::vector<xferBenchIOV> remote_iov_list;
-            for (auto &iov: iov_list) {
-                std::optional<xferBenchIOV> basic_desc;
-                basic_desc = initBasicDescFile(iov.len, remote_fds[0], iov.devId);
-                if (basic_desc) {
-                    remote_iov_list.push_back(basic_desc.value());
+        size_t num_files = xferBenchConfig::num_files;
+        size_t batch_size;
+
+        if (XFERBENCH_SCHEME_TP == xferBenchConfig::scheme) {
+            size_t num_threads = xferBenchConfig::num_threads;
+            size_t unit_size = xferBenchConfig::total_buffer_size / (num_threads * num_files);
+            size_t base_offset = 0;
+            for (auto &iov_list: local_iovs) {
+                std::vector<xferBenchIOV> remote_iov_list;
+                batch_size = iov_list.size() / num_files;
+                for (size_t i = 0; i < num_files; i++) {
+                    size_t batch_offset = 0;
+                    for (size_t j = 0; j < batch_size; j++) {
+                        size_t iov_idx = i * batch_size + j;
+
+                        remote_iov_list.emplace_back(
+                            (uintptr_t)(base_offset + batch_offset),
+                            iov_list[iov_idx].len, remote_fds[i]);
+                        batch_offset += iov_list[iov_idx].len;
+                    }
                 }
+                res.push_back(remote_iov_list);
+                base_offset += unit_size;
             }
-            res.push_back(remote_iov_list);
+        } else {
+            size_t files_per_thread = num_files / local_iovs.size();
+            size_t i = 0;
+            for (auto &iov_list: local_iovs) {
+                std::vector<xferBenchIOV> remote_iov_list;
+                batch_size = iov_list.size() / files_per_thread;
+                for (size_t j = 0; j < files_per_thread; j++) {
+                    size_t batch_offset = 0;
+                    for (size_t k = 0; k < batch_size; k++) {
+                        size_t iov_idx = j * batch_size + k;
+                        remote_iov_list.emplace_back((uintptr_t)batch_offset,
+                            iov_list[iov_idx].len,
+                            remote_fds[j + i * files_per_thread]);
+                        batch_offset += iov_list[iov_idx].len;
+                    }
+                }
+                res.push_back(remote_iov_list);
+                i++;
+            }
         }
     } else {
         for (const auto &local_iov: local_iovs) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -35,7 +35,7 @@ class xferBenchNixlWorker: public xferBenchWorker {
         nixlBackendH* backend_engine;
         nixl_mem_t seg_type;
         std::vector<int> remote_fds;
-        std::vector<std::vector<xferBenchIOV>> remote_iovs;
+        std::vector<xferBenchIOV> remote_iovs;
     public:
         xferBenchNixlWorker(int *argc, char ***argv, std::vector<std::string> devices);
         ~xferBenchNixlWorker();  // Custom destructor to clean up resources
@@ -63,7 +63,7 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::optional<xferBenchIOV> initBasicDescVram(size_t buffer_size, int mem_dev_id);
         void cleanupBasicDescVram(xferBenchIOV &basic_desc);
 #endif
-        std::optional<xferBenchIOV> initBasicDescFile(size_t buffer_size, int fd, int mem_dev_id);
+        std::optional<xferBenchIOV> initBasicDescFile(size_t buffer_size, int fd);
         void cleanupBasicDescFile(xferBenchIOV &basic_desc);
 };
 


### PR DESCRIPTION
## What?
Add multiple files support in nixlbench when using storage backend

## Why?
To understand the performance of storage backend when read/write multiple files.

## How?
1. In allocateMemory
   - compute the maximum size a file could had and register the file once.
   - compute the maximum size a thread needed for its DRAM, and allocate 1 piece of memory with the max size for each thread
2. When creating the memory xfer_list in createTransferDescLists(), divide the memory to multiple transfer unit depends on the scheme.
   - If scheme=pairwise, each file will be assigned to 1 thread only, so we need to compute number of files per threads and divide the memory to the file per thread number.
   - If scheme=tp, each file will be divided to num_threads blocks and accessed by all threads. So, each thread memory will be divided to num_files block.
3. In exchangeIOV, we need to create the file xfer_list,
   - Based on the scheme, divide the file to the same number of transfer unit as the memory xfer_list, and assigned the fd to the transfer unit based on the scheme.
4. Finally, when computing the stats, current stats does not considered multiple files, so need to add it in too.
