### PR TITLE
PLUGIN/MOONCAKE: fix typos and minors in mooncake plugin

### DIFF
--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -405,4 +405,9 @@ void nixlPluginManager::registerBuiltinPlugins() {
         extern nixlBackendPlugin *createStaticObjPlugin();
         registerStaticPlugin ("OBJ", createStaticObjPlugin);
 #endif // STATIC_PLUGIN_OBJ
+
+#ifdef STATIC_PLUGIN_MOONCAKE
+        extern nixlBackendPlugin *createStaticObjPlugin();
+        registerStaticPlugin ("MOONCAKE", createStaticObjPlugin);
+#endif // STATIC_PLUGIN_MOONCAKE
 }

--- a/src/plugins/mooncake/mooncake_backend.h
+++ b/src/plugins/mooncake/mooncake_backend.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __UCX_BACKEND_H
-#define __UCX_BACKEND_H
+#ifndef __MOONCAKE_BACKEND_H
+#define __MOONCAKE_BACKEND_H
 
 #include <vector>
 #include <cstring>

--- a/src/plugins/mooncake/mooncake_plugin.cpp
+++ b/src/plugins/mooncake/mooncake_plugin.cpp
@@ -22,7 +22,7 @@
 static const char* PLUGIN_NAME = "Mooncake";
 static const char* PLUGIN_VERSION = "0.1.0";
 
-// Function to create a new UCX backend engine instance
+// Function to create a new Mooncake backend engine instance
 static nixlBackendEngine* create_mooncake_engine(const nixlBackendInitParams* init_params) {
     return new nixlMooncakeEngine(init_params);
 }
@@ -67,7 +67,7 @@ static nixlBackendPlugin plugin = {
     get_backend_mems
 };
 
-#ifdef STATIC_PLUGIN_UCX
+#ifdef STATIC_PLUGIN_MOONCAKE
 
 nixlBackendPlugin* createStaticUcxPlugin() {
     return &plugin; // Return the static plugin instance


### PR DESCRIPTION
## What?
1. Update the macro name in the mooncake files from "ucx" to "mooncake".
2. Add static plugin integration for Mooncake.

## Why?
Using the ucx macro name in the mooncake subdirectory will likely confuse users.

## How?
This PR fixes these issues.