### PR TITLE
CI: Build manylinux wheels

### DIFF
--- a/.ci/dockerfiles/Dockerfile.wheel-builder
+++ b/.ci/dockerfiles/Dockerfile.wheel-builder
@@ -1,0 +1,184 @@
+# NixL Wheel Builder Environment
+# This Dockerfile creates a pre-built environment for building Python wheels
+
+FROM harbor.mellanox.com/ucx/cuda:12.8-devel-manylinux--25.03
+
+ARG ARCH="x86_64"
+ARG UCX_REF="v1.19.x"
+ARG GRPC_VERSION="1.73.0"
+ARG CPPRESTSDK_VERSION="2.10.19"
+ARG OPENSSL_VERSION="3.0.16"
+ARG GDRCOPY_VERSION="2.5"
+ARG RUST_VERSION="1.86.0"
+ARG NPROC="4"
+
+# Install system packages
+RUN yum groupinstall -y 'Development Tools' && \
+    dnf install -y almalinux-release-synergy && \
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y \
+        boost \
+        boost-devel \
+        cmake \
+        git \
+        ninja-build \
+        python3 \
+        python3-devel \
+        python3-pip \
+        pkg-config \
+        curl \
+        wget \
+        which \
+        zlib-devel \
+        autoconf \
+        automake \
+        libtool \
+        m4 \
+        dkms \
+        libibverbs \
+        libibverbs-devel \
+        rdma-core \
+        rdma-core-devel \
+        libibumad \
+        libibumad-devel \
+        numactl-devel \
+        librdmacm-devel && \
+    dnf clean all
+
+# Build OpenSSL 3.x
+RUN yum install -y perl-IPC-Cmd perl-Test-Simple perl-Data-Dumper
+RUN cd /tmp && \
+    wget -q https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz && \
+    tar -xzf openssl-${OPENSSL_VERSION}.tar.gz && \
+    cd openssl-${OPENSSL_VERSION} && \
+    ./Configure --prefix=/usr/local/openssl3 --openssldir=/usr/local/openssl3 \
+        shared zlib linux-$ARCH && \
+    make -j${NPROC} && \
+    make install_sw && \
+    echo "/usr/local/openssl3/lib64" > /etc/ld.so.conf.d/openssl3.conf && \
+    echo "/usr/local/openssl3/lib" >> /etc/ld.so.conf.d/openssl3.conf && \
+    ldconfig && \
+    rm -rf /tmp/openssl-${OPENSSL_VERSION}*
+
+# Set environment variables to use the new OpenSSL
+ENV PKG_CONFIG_PATH="/usr/local/openssl3/lib64/pkgconfig:/usr/local/openssl3/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:$PKG_CONFIG_PATH"
+ENV OPENSSL_ROOT_DIR="/usr/local/openssl3"
+ENV OPENSSL_LIBRARIES="/usr/local/openssl3/lib64:/usr/local/openssl3/lib"
+ENV OPENSSL_INCLUDE_DIR="/usr/local/openssl3/include"
+
+# Set global CMAKE variables
+ENV CMAKE_BUILD_TYPE=Release
+ENV CMAKE_INSTALL_PREFIX=/usr/local
+
+# Build gRPC with OpenSSL 3
+WORKDIR /workspace
+
+RUN git clone --recurse-submodules -b v${GRPC_VERSION} --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
+    cd grpc && \
+    mkdir -p cmake/build && \
+    cd cmake/build && \
+    cmake -DgRPC_INSTALL=ON \
+        -DgRPC_BUILD_TESTS=OFF \
+        -DgRPC_ABSL_PROVIDER=module \
+        -DgRPC_CARES_PROVIDER=module \
+        -DgRPC_PROTOBUF_PROVIDER=module \
+        -DgRPC_RE2_PROVIDER=module \
+        -DgRPC_ZLIB_PROVIDER=module \
+        -DgRPC_SSL_PROVIDER=package ../.. && \
+    make -j${NPROC} && \
+    make install && \
+    cd /workspace && rm -rf grpc
+
+RUN git clone https://github.com/microsoft/cpprestsdk.git && \
+    cd cpprestsdk && \
+    git checkout v${CPPRESTSDK_VERSION} && \
+    mkdir build && cd build && \
+    git submodule update --init && \
+    cmake .. -DCPPREST_EXCLUDE_WEBSOCKETS=ON \
+        -DCPPREST_EXCLUDE_COMPRESSION=ON \
+        -DBUILD_SAMPLES=OFF \
+        -DBUILD_TESTS=OFF \
+        -DBoost_NO_BOOST_CMAKE=TRUE \
+        -DOPENSSL_ROOT_DIR=/usr/local/openssl3 \
+        -DOPENSSL_CRYPTO_LIBRARY=/usr/local/openssl3/lib64/libcrypto.so \
+        -DOPENSSL_SSL_LIBRARY=/usr/local/openssl3/lib64/libssl.so \
+        -DOPENSSL_INCLUDE_DIR=/usr/local/openssl3/include \
+        -DCMAKE_CXX_FLAGS="-Wno-error=format-truncation" && \
+    make -j${NPROC} cpprest && make install && \
+    cd /workspace && rm -rf cpprestsdk
+
+RUN git clone https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git && \
+    cd etcd-cpp-apiv3 && mkdir build && cd build && \
+    cmake .. && make -j${NPROC} && make install && \
+    cd /workspace && rm -rf etcd-cpp-apiv3
+
+# Remove existing UCX installations
+RUN rm -rf /usr/lib/ucx
+RUN rm -rf /opt/hpcx/ucx
+
+# Build gdrcopy (required for UCX with CUDA support)
+RUN cd /workspace && \
+    git clone https://github.com/NVIDIA/gdrcopy.git && \
+    cd gdrcopy/packages && \
+    git checkout v${GDRCOPY_VERSION} && \
+    CUDA=/usr/local/cuda ./build-rpm-packages.sh && \
+    rpm -Uvh gdrcopy-kmod-${GDRCOPY_VERSION}-1dkms.el8.noarch.rpm && \
+    rpm -Uvh gdrcopy-${GDRCOPY_VERSION}-1.el8.$ARCH.rpm && \
+    rpm -Uvh gdrcopy-devel-${GDRCOPY_VERSION}-1.el8.noarch.rpm
+
+# Build UCX
+RUN mkdir -p /usr/local/src && cd /usr/local/src && \
+     git clone https://github.com/openucx/ucx.git && \
+     cd ucx && 			     \
+     git checkout $UCX_REF &&	     \
+     ./autogen.sh && ./configure     \
+         --enable-shared             \
+         --disable-static            \
+         --disable-doxygen-doc       \
+         --enable-optimizations      \
+         --enable-cma                \
+         --enable-devel-headers      \
+         --with-cuda=/usr/local/cuda \
+         --with-verbs                \
+         --with-dm                   \
+         --with-gdrcopy=/usr/local   \
+         --with-efa                  \
+         --enable-mt &&              \
+     make -j${NPROC} &&                      \
+     make -j${NPROC} install-strip &&        \
+     ldconfig
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Install Rust for meson
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=${RUST_VERSION}
+
+RUN case "$ARCH" in \
+        aarch64) RUSTARCH=aarch64-unknown-linux-gnu ;; \
+        x86_64) RUSTARCH=x86_64-unknown-linux-gnu ;; \
+        *) echo "Unsupported architecture for Rust: $ARCH" && exit 1 ;; \
+    esac && \
+    wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.28.1/${RUSTARCH}/rustup-init" && \
+    case "$ARCH" in \
+        aarch64) RUSTUP_SHA256="c64b33db2c6b9385817ec0e49a84bcfe018ed6e328fe755c3c809580cc70ce7a" ;; \
+        x86_64) RUSTUP_SHA256="a3339fb004c3d0bb9862ba0bce001861fe5cbde9c10d16591eb3f39ee6cd3e7f" ;; \
+        *) echo "Unsupported architecture for Rust: $ARCH" && exit 1 ;; \
+    esac && \
+    echo "$RUSTUP_SHA256 *rustup-init" | sha256sum -c - && \
+    chmod +x rustup-init && \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${RUSTARCH} && \
+    rm rustup-init && \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+
+# Set library paths
+ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:/usr/local/openssl3/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+ENV CUDA_PATH="/usr/local/cuda"
+
+# Set working directory
+WORKDIR /workspace
+
+# Pre-install Python build tools for wheel building
+RUN uv pip install --system meson-python pybind11 patchelf auditwheel pyyaml pytest

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -1,0 +1,153 @@
+# Wheel Build Matrix Configuration for NixL CI Pipeline
+#
+# This file defines the wheel building matrix using ci-demo framework.
+# It builds and caches the wheel-builder image, then uses it to build wheels
+# for different Python versions and platforms.
+
+---
+job: nixl-wheel-build
+
+# Fail job if one of the steps fails or continue
+failFast: false
+
+timeout_minutes: 240
+
+taskName: "wheel-${python_version}-${platform}-${arch}-ucx-${UCX_VERSION}/${axis_index}"
+
+# Registry configuration for caching built images
+registry_host: urm.nvidia.com
+registry_path: /sw-nbu-swx-nixl-docker-local/base
+registry_auth: svc-nixl-artifactory-token
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: swx-media
+  limits: "{memory: 24Gi, cpu: 8000m}"
+  requests: "{memory: 18Gi, cpu: 8000m}"
+
+# ci-demo will automatically build the wheel-builder image from Dockerfile if needed
+runs_on_dockers:
+  - {file: '.ci/dockerfiles/Dockerfile.wheel-builder', name: 'nixl-wheel-builder', tag: 'ucx-${UCX_VERSION}', arch: 'x86_64', build_args: '--build-arg ARCH=x86_64 --build-arg UCX_REF=${UCX_VERSION} --build-arg NPROC=10'}
+  - {file: '.ci/dockerfiles/Dockerfile.wheel-builder', name: 'nixl-wheel-builder', tag: 'ucx-${UCX_VERSION}', arch: 'aarch64', build_args: '--build-arg ARCH=aarch64 --build-arg UCX_REF=${UCX_VERSION} --build-arg NPROC=10'}
+
+credentials:
+  - credentialsId: 'svc-nixl-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_USERNAME'
+    passwordVariable: 'ARTIFACTORY_PASSWORD'
+
+env:
+  MAIL_FROM: jenkins@nvidia.com
+  # Conservative parallelism for wheel building
+  MAKEFLAGS: "-j4"
+  # Artifactory configuration
+  ARTIFACTORY_HOST: "urm.nvidia.com"
+  ARTIFACTORY_REPO_PATH: "sw-nbu-swx-nixl-docker-local/base"
+
+matrix:
+  axes:
+    # Python versions to build wheels for
+    python_version:
+      - "3.9"
+      - "3.10"
+      - "3.11"
+      - "3.12"
+
+    # Wheel platforms
+    platform:
+      - "manylinux_2_28"
+
+    # Architecture
+    arch:
+      - x86_64
+      - aarch64
+
+steps:
+  - name: Setup Environment
+    run: |
+      echo "Building wheel for Python ${python_version} on ${platform}_${arch}"
+      df -h .
+      rm -rf build/ dist/ *.egg-info/
+
+  - name: Build and Create Wheel
+    run: |
+      # Build wheel (build tools are pre-installed in Docker image)
+      uv build --wheel --out-dir /tmp/dist --python ${python_version}
+
+      # Repair wheel with proper exclusions
+      uv run auditwheel repair \
+        --exclude libcuda.so.1 \
+        --exclude 'libssl*' \
+        --exclude 'libcrypto*' \
+        /tmp/dist/nixl-*cp3*.whl \
+        --plat "${platform}_${arch}" \
+        --wheel-dir dist
+
+      # Add UCX plugins to wheel
+      contrib/wheel_add_ucx_plugins.py --ucx-lib-dir /usr/local/lib64 dist/*.whl
+
+      echo "Final wheels created:"
+      ls -la dist/
+
+  - name: Test Wheel
+    run: |
+      # Test wheel installation
+      WHEEL=$(ls dist/nixl-*.whl | head -1)
+      uv pip install --system "$WHEEL"
+
+      # Basic import test to verify the wheel works
+      python -c "import nixl; print('NixL import successful')"
+
+      # Show wheel info for debugging
+      echo "Wheel info:"
+      uv pip show nixl
+
+  - name: Archive Artifacts
+    run: |
+      # Create structured artifact directory
+      ARTIFACT_DIR="artifacts-py${python_version}-${platform}-${arch}"
+      mkdir -p "$ARTIFACT_DIR"
+
+      # Copy wheel with descriptive naming
+      cp dist/*.whl "$ARTIFACT_DIR/"
+
+      # Create build info file for traceability
+      cat > "$ARTIFACT_DIR/build-info.txt" << EOF
+      Build timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+      Python version: ${python_version}
+      Platform: ${platform}
+      Architecture: ${arch}
+      UCX version: ${UCX_VERSION}
+      Build node: ${NODE_NAME:-unknown}
+      Build number: ${BUILD_NUMBER:-unknown}
+      EOF
+
+      echo "Artifacts created in $ARTIFACT_DIR:"
+      ls -la "$ARTIFACT_DIR/"
+
+archiveArtifacts: "artifacts-*/**"
+
+pipeline_stop:
+  shell: action
+  module: groovy
+  run: |
+    if (params.MAIL_TO) {
+        def jobStatus = currentBuild.result ?: 'SUCCESS'
+        def statusColor = jobStatus == 'SUCCESS' ? 'green' : 'red'
+
+        def userName = currentBuild.rawBuild.getCause(hudson.model.Cause.UserIdCause)?.userName ?: 'schedule'
+
+        mail(
+            from: env.MAIL_FROM,
+            to: params.MAIL_TO,
+            subject: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' - ${jobStatus}",
+            mimeType: 'text/html',
+            body: """
+                <p>Started by: <b>${userName}</b></p>
+                <p>Status: <span style="color: ${statusColor};"><b>${jobStatus}</b></span></p>
+                <p>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a></p>
+                <p>Build: <a href='${env.BUILD_URL}'>#${env.BUILD_NUMBER}</a></p>
+                <p>Console Output: <a href='${env.BUILD_URL}console'>Full Log</a></p>
+                <p>Matrix Config: Python ${python_version}, Platform ${platform}, Architecture ${arch}</p>
+            """
+        )
+    }

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -215,6 +215,71 @@
               tracking: true
               parent-credentials: true
       script-path: "{jjb_jenkinsfile}"
+# Template for the containers build job that handles multi-dockerfile builds
+- job-template:
+    name: "{jjb_proj}-build-test"  # Will be expanded to 'nixl-ci-build-test'
+    project-type: pipeline
+    folder: "{jjb_folder}"
+    disabled: false
+    properties:
+        - github:
+            url: "{jjb_gh_url}"
+        - build-discarder:
+            days-to-keep: 50
+            num-to-keep: 20
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}-build-test
+    description: Test job for multi-dockerfile matrix builds - Do NOT edit through Web GUI !
+    concurrent: true
+    sandbox: true
+    # Build job parameters
+    parameters:
+        - string:
+            name: "sha1"
+            default: "{jjb_branch}"    # Default to 'main' branch
+            description: "Commit to be checked, usually set by PR"
+        - string:
+            name: "githubData"
+            default: ""
+            description: "Variables from post"
+        - string:
+            name: "conf_file"
+            default: ".ci/jenkins/lib/build-wheel-matrix.yaml"  # Build matrix configuration
+            description: "Job config file"
+        - bool:
+            name: "build_dockers"
+            default: false
+            description: "Force rebuild docker containers"
+        - string:
+            name: "DEBUG"
+            default: 0
+            description: "Enable debug prints and traces, valid values are 0-9"
+        - string:
+            name: "UCX_VERSION"
+            default: "v1.19.x"
+            description: "UCX version to build (tag like v1.19.0, branch name, or commit hash)"
+    # SCM configuration for the test build job
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                credentials-id: ''
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                # Configure refspec to handle branches, PRs, and tags
+                refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
 # Project definition that instantiates the job templates
 # This section defines the actual jobs that will be created
@@ -223,10 +288,12 @@
     jjb_proj: 'nixl-ci'           # Project prefix for job names
     jjb_git: 'git@github.com:ai-dynamo/nixl.git'  # Repository URL
     jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'  # Main pipeline definition
+    jjb_folder: 'NIXL'            # Jenkins folder for organization
     jjb_branch: 'main'            # Default branch
     jjb_gh_url: 'https://github.com/ai-dynamo/nixl'  # GitHub web URL
     jobs:
-        - "{jjb_proj}-dispatcher"  # Create dispatcher job
-        - "{jjb_proj}-build"       # Create build job
-        - "{jjb_proj}-nixlbench-container-build"  # Create NIXLBench container build job
+        # - "{jjb_proj}-nixlbench-container-build"  # Create NIXLBench container build job
         # - "{jjb_proj}-test"      # Test job template (commented out)
+        # - "{jjb_proj}-dispatcher"  # Create dispatcher job
+        # - "{jjb_proj}-build"       # Create build job
+        - "{jjb_proj}-build-test"  # Create test job for multi-dockerfile builds


### PR DESCRIPTION
## What?
Add matrix axis to build both Ubuntu and manylinux Docker containers in the CI pipeline.

## Why?
Need manylinux containers for creating Python wheels with broader Linux compatibility, while keeping Ubuntu containers for development/testing.

## How?
- Add `container_type` matrix axis with `ubuntu` and `manylinux` values
- Conditionally select `contrib/Dockerfile.manylinux` when `container_type` is `manylinux`
- Results in 4 container builds: `{ubuntu,manylinux} × {x86_64,aarch64}`