### PR TITLE
cuda_gds: Reducing the number of default batches created to 16

### DIFF
--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -24,8 +24,8 @@
 #define DEFAULT_BATCH_LIMIT 128
 /** Setting the max request size to 16 MB */
 #define DEFAULT_MAX_REQUEST_SIZE (16 * 1024 * 1024)  // 16MB
-/** Create a batch pool of size 32 */
-#define DEFAULT_BATCH_POOL_SIZE 32
+/** Create a batch pool of size 16 */
+#define DEFAULT_BATCH_POOL_SIZE 16
 
 nixlGdsEngine::nixlGdsEngine(const nixlBackendInitParams* init_params)
     : nixlBackendEngine(init_params)


### PR DESCRIPTION
Exceeding number of batches can cause the GDS batches to run out of memory. Decreasing the default number of GDS batches created to facilitate creating multiple NIXL agents.

## What?
This PR is trying to reduce the default number of GDS batches as it can affect the number of NIXL agents that can be created as GDS batches in pool consume memory.
 
## Why?
Required for KVBM G3 use case where TP8 is a requirement.

## How?
Simple change to modify the default number of batches created at init.
