### PR TITLE
CI: Fix Jenkins job for NIXLBench container builds

### DIFF
--- a/.ci/jenkins/lib/nixlbench-container-build-matrix.yaml
+++ b/.ci/jenkins/lib/nixlbench-container-build-matrix.yaml
@@ -11,7 +11,7 @@ timeout_minutes: 240
 # Infrastructure
 kubernetes:
   cloud: il-ipp-blossom-prod
-  namespace: nbu-swx-nixl
+  namespace: swx-media
   limits: "{memory: 16Gi, cpu: 8000m}"
   requests: "{memory: 8Gi, cpu: 4000m}"
 


### PR DESCRIPTION
## What?
Fix Kubernetes namespace configuration for NIXLBench container build job.

## Why?
Jenkins job failing with "pods is forbidden" errors due to service account lacking permissions in `nbu-swx-nixl` namespace.

## How?
Change namespace from `nbu-swx-nixl` to `swx-media` where the Jenkins service account has required permissions.