### PR TITLE
[CI] add build wheel blossom ci job

### DIFF
--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -1,0 +1,483 @@
+# Build Wheel Matrix CI Job Documentation
+
+## Overview
+
+The Build Wheel Matrix CI job is a comprehensive continuous integration pipeline that builds NIXL Python wheels for multiple Python versions and architectures. This document explains how the CI job works with `contrib/Dockerfile.manylinux` and `contrib/build-wheel.sh` to create distributable Python packages.
+
+## Architecture
+
+The CI pipeline consists of four main components:
+
+1. **Jenkins Matrix Job** (`.ci/jenkins/lib/build-wheel-matrix.yaml`)
+2. **Container Build Script** (`contrib/build-container.sh`)
+3. **Docker Build Environment** (`contrib/Dockerfile.manylinux`)
+4. **Wheel Building Script** (`contrib/build-wheel.sh`)
+
+## Workflow Overview
+
+```
+┌─────────────────┐    ┌──────────────────┐    ┌──────────────────┐    ┌─────────────────┐
+│   Jenkins       │    │  build-          │    │   Dockerfile     │    │   build-        │
+│   Matrix Job    │───▶│  container.sh    │───▶│   .manylinux     │───▶│   wheel.sh      │
+│  (podman runner)│    │  (docker build)  │    │  (full build)    │    │  (wheel pkg)    │
+└─────────────────┘    └──────────────────┘    └──────────────────┘    └─────────────────┘
+```
+
+## 1. Jenkins Matrix Configuration
+
+### Job Structure
+- **Job Name**: `nixl-ci-build-wheel`
+- **Timeout**: 240 minutes
+- **Failure Behavior**: Continue on failure (`failFast: false`)
+- **Resources**: 24Gi memory, 16 CPU cores
+
+### Matrix Axes
+The job builds wheels for multiple combinations:
+
+**Python Versions:**
+- 3.12
+
+**Architectures:**
+- x86_64
+- aarch64
+
+**Manylinux Versions:**
+- 2_28
+
+### Docker Image Configuration
+```yaml
+runs_on_dockers:
+  - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+```
+
+The CI runner uses podman-in-container. `build-container.sh` is called inside this container and executes `docker build` (symlinked to podman) to build the wheel image using `contrib/Dockerfile.manylinux`.
+
+## 2. Docker Build Environment (`contrib/Dockerfile.manylinux`)
+
+### Multi-Stage Build Architecture
+
+The Dockerfile uses a multi-stage build approach with two main stages:
+
+```dockerfile
+# Stage 1: Base stage with all dependencies and build environment
+ARG BASE_IMAGE
+ARG BASE_IMAGE_TAG
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} as wheel-base
+
+# ... (dependency installation and build setup)
+
+# Stage 2: Default stage that builds and generates wheels
+FROM wheel-base
+# ... (NIXL build and wheel generation)
+```
+
+**Base Image**: `artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda:13.0-devel-manylinux--25.09`
+
+### Stage Usage Patterns
+
+#### CI Pipeline Usage (via build-container.sh)
+In the CI pipeline, `build-container.sh` is called with Artifactory base image and the target arch/Python version:
+
+```bash
+./contrib/build-container.sh \
+  --base-image 'artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda' \
+  --base-image-tag '13.0-devel-manylinux--25.09' \
+  --wheel-base "manylinux_${manylinux}" \
+  --python-versions "${python_version}" \
+  --arch ${arch} \
+  --dockerfile contrib/Dockerfile.manylinux
+```
+
+The script invokes `docker build` (symlinked to podman) with `BUILD_ARGS` assembled from those parameters, running a full Dockerfile.manylinux build that produces wheels inside the container.
+
+#### User Usage (Default Stage)
+Users can build the complete image without specifying a target:
+
+```bash
+docker build -f contrib/Dockerfile.manylinux .
+```
+
+This will:
+- Use the `wheel-base` stage as foundation
+- Build NIXL from source
+- Generate wheels for all configured Python versions
+- Install the wheel for testing
+
+**User Benefits:**
+- Self-contained build environment
+- Pre-built wheels ready for distribution
+- Complete testing environment
+- No need to run separate build steps
+
+### Key Dependencies Installed
+
+#### System Packages
+- Development tools (gcc, g++, cmake, ninja)
+- RDMA libraries (libibverbs, rdma-core)
+- Networking libraries (protobuf, gRPC)
+- Build tools (meson, pybind11, patchelf)
+
+#### OpenSSL 3.x
+Custom OpenSSL 3.0.16 build with proper library paths:
+```dockerfile
+ENV PKG_CONFIG_PATH="/usr/local/openssl3/lib64/pkgconfig:/usr/local/openssl3/lib/pkgconfig:$PKG_CONFIG_PATH"
+ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:/usr/local/openssl3/lib:$LD_LIBRARY_PATH"
+```
+
+#### gRPC and Dependencies
+- gRPC v1.73.0 with SSL support
+- Microsoft cpprestsdk
+- etcd-cpp-apiv3
+
+#### Rust Toolchain
+- Rust 1.86.0 for native dependencies
+- Architecture-specific toolchain setup
+
+#### UCX (Unified Communication X)
+- Custom UCX build with CUDA, verbs, and gdrcopy support
+- Optimized for high-performance networking
+
+### NIXL Build Process
+
+#### Environment Setup
+```dockerfile
+ENV VIRTUAL_ENV=/workspace/nixl/.venv
+RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
+    uv pip install --upgrade meson pybind11 patchelf
+```
+
+#### NIXL Compilation
+```dockerfile
+RUN rm -rf build && \
+    mkdir build && \
+    meson setup build/ --prefix=/usr/local/nixl --buildtype=release \
+    -Dcudapath_lib="/usr/local/cuda/lib64" \
+    -Dcudapath_inc="/usr/local/cuda/include" && \
+    cd build && \
+    ninja && \
+    ninja install
+```
+
+#### Library Configuration
+```dockerfile
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib64/:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/nixl/lib64/plugins:$LD_LIBRARY_PATH
+ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib64/plugins
+```
+
+### Default Stage Wheel Generation
+
+When building the complete image (default stage), the Dockerfile automatically generates wheels:
+
+```dockerfile
+# Create the wheel
+# No need to specifically add path to libcuda.so here, meson finds the stubs and links them
+ARG WHL_PYTHON_VERSIONS="3.9,3.10,3.11,3.12"
+ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
+RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
+    for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
+        ./contrib/build-wheel.sh \
+            --python-version $PYTHON_VERSION \
+            --platform $WHL_PLATFORM \
+            --ucx-plugins-dir /usr/lib64/ucx \
+            --nixl-plugins-dir $NIXL_PLUGIN_DIR \
+            --output-dir dist ; \
+    done
+
+RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl
+```
+
+**Default Stage Features:**
+- Builds wheels for all Python versions (3.9, 3.10, 3.11, 3.12)
+- Uses manylinux_2_28 platform tags
+- Installs the default Python version wheel for testing
+- Wheels are stored in `/workspace/nixl/dist/` directory
+
+## 3. Wheel Building Script (`contrib/build-wheel.sh`)
+
+### Purpose
+The script creates Python wheels that bundle all necessary native libraries and dependencies for distribution, with optional build ID versioning.
+
+### Key Features
+
+#### Argument Parsing
+```bash
+--python-version: Python version to build for (default: 3.12)
+--platform: Platform tag (default: manylinux_2_39_$ARCH)
+--output-dir: Output directory (default: dist)
+--ucx-plugins-dir: UCX plugins directory
+--nixl-plugins-dir: NIXL plugins directory
+```
+
+#### Environment Variables
+```bash
+CI_BUILD_NUMBER: Optional build ID to append to version (e.g., "68")
+NPROC: Number of parallel ninja jobs (default: 4)
+```
+
+#### Wheel Building Process
+
+1. **Version Modification with Build ID**
+   - Modifies `pyproject.toml` to include build number
+   - Example: `0.7.1` → `0.7.1+build.68`
+
+2. **UV Build with Ninja Control**
+   - Uses meson-python build backend
+   - Limits parallel compilation jobs
+   - Requires `ninja` in `pyproject.toml` build requirements
+
+3. **Auditwheel Repair**
+   - Excludes system libraries (CUDA, SSL, networking)
+   - Repairs wheel for manylinux compatibility
+   - Bundles necessary dependencies
+
+4. **UCX Plugin Integration**
+   - Adds UCX and NIXL plugins to the wheel
+   - Ensures high-performance networking capabilities
+
+## 4. CI Job Steps
+
+The CI pipeline consists of two sequential steps for each matrix combination:
+
+### Step 1: Prepare
+
+Sets up the podman container runtime and authenticates with Artifactory:
+
+- Removes conflicting container storage config files
+- Resets the podman system state (`podman system reset -f`)
+- Symlinks podman binary to `/usr/bin/docker` for compatibility with build scripts
+- Logs into Artifactory container registry using Jenkins credentials
+
+### Step 2: Build Wheel
+
+Builds the full NIXL container image (including wheel generation) via `build-container.sh`:
+
+- Calls `contrib/build-container.sh` with the Artifactory base image, target arch, manylinux platform, and Python version
+- The script invokes `docker build` (podman) with `contrib/Dockerfile.manylinux`, which:
+  - Installs all system dependencies (UCX, gRPC, CUDA tools, Rust toolchain, etc.)
+  - Builds NIXL from source with meson/ninja
+  - Runs `build-wheel.sh` to produce the Python wheel with auditwheel repair
+- Wheels are written to the `dist/` directory inside the container image
+
+
+## 5. Output and Artifacts
+
+### Generated Wheels
+The CI job produces wheels with naming convention including build ID:
+```
+nixl-cu{cuda_version}-{version}+build.{build_number}-cp{python_version_no_dots}-cp{python_version_no_dots}-{platform_tag}.whl
+```
+
+Examples:
+- `nixl-cu12-0.7.1+build.68-cp39-cp39-manylinux_2_28_x86_64.whl`
+- `nixl-cu12-0.7.1+build.68-cp312-cp312-manylinux_2_28_x86_64.whl`
+
+### Build Versioning
+The build system automatically appends the Jenkins build number to the package version as a PEP 440 compliant local version identifier:
+- Base version: `0.7.1`
+- With build ID: `0.7.1+build.68`
+
+This is handled by `contrib/tomlutil.py` which modifies `pyproject.toml` during the build:
+```python
+./contrib/tomlutil.py --wheel-name nixl-cu12 --build-id 68 pyproject.toml
+```
+
+**Benefits:**
+- Each CI build produces uniquely versioned wheels
+- Multiple builds can coexist in Artifactory
+- Easy to trace which CI build produced which wheel
+- PEP 440 compliant for proper pip handling
+
+### Wheel Contents
+- NIXL Python bindings
+- Native libraries (compiled with meson)
+- UCX plugins for high-performance networking
+- NIXL plugins for extended functionality
+- All dependencies bundled for manylinux compatibility
+
+## 6. Matrix Job Execution
+
+### Parallel Execution
+- Each matrix combination runs in parallel
+- Task naming: `${name}_${manylinux}/${arch}/python_${python_version}`
+- Total combinations: 2 (1 Python version × 2 architectures)
+
+### Resource Allocation
+- Each job gets 16Gi memory and 16 CPU cores
+- Kubernetes namespace: `nbu-swx-nixl`
+- Cloud provider: `il-ipp-blossom-prod`
+
+## 7. Artifactory Integration
+
+### PyPI Repository Configuration
+```yaml
+credentials:
+  - credentialsId: 'svc-nixl-new-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_USER'
+    passwordVariable: 'ARTIFACTORY_TOKEN'
+
+env:
+  ARTIFACTORY_PYPI_URL: https://artifactory.nvidia.com/artifactory/api/pypi/sw-nbu-sxw-nixl-pypi-local
+```
+
+### Wheel Upload Process
+Each matrix job uploads its wheels to Artifactory using `twine`:
+
+```bash
+twine upload \
+  --repository-url ${ARTIFACTORY_PYPI_URL} \
+  --username ${ARTIFACTORY_USER} \
+  --password ${ARTIFACTORY_TOKEN} \
+  --verbose \
+  $DIST_DIR/nixl*cp${python_version//./}*.whl
+```
+
+**Key Points:**
+- Each matrix job uploads only its specific wheels (filtered by Python version)
+- Wheels are uniquely named with build ID, preventing conflicts
+- Parallel uploads are safe due to unique wheel names
+- Credentials are managed via Jenkins credentials store
+
+### Installing from Artifactory
+
+Users can install wheels from Artifactory:
+
+```bash
+# Using pip with extra index
+pip install nixl-cu12 \
+  --extra-index-url https://artifactory.nvidia.com/artifactory/api/pypi/sw-nbu-sxw-nixl-pypi-local
+
+# Or configure in pip.conf
+[global]
+extra-index-url = https://artifactory.nvidia.com/artifactory/api/pypi/sw-nbu-sxw-nixl-pypi-local
+```
+
+## 8. Troubleshooting
+
+### Common Issues
+
+1. **Out of Memory (OOM) Errors**
+   - **Symptom**: `c++: fatal error: Killed signal terminated program cc1plus`
+   - **Cause**: Too many parallel compilation jobs exceeding available memory
+   - **Solution**: Reduce `NPROC` or increase memory allocation
+   - **Prevention**: Current config uses 24GB memory with `-j16` ninja jobs
+
+2. **Ninja Not Found**
+   - **Symptom**: `meson-python: error: Could not find ninja version 1.8.2 or newer`
+   - **Cause**: `ninja` not in isolated build environment
+   - **Solution**: Ensure `ninja` is in `pyproject.toml` `[build-system] requires`
+   - **Note**: Both Python `ninja` package and system `ninja-build` should be available
+
+3. **Meson Not Found**
+   - **Symptom**: `meson: command not found`
+   - **Cause**: Virtual environment not activated or PATH not set
+   - **Solution**: Ensure `export PATH="$VIRTUAL_ENV/bin:$PATH"` in all build steps
+
+4. **Build Failures**
+   - Check Docker image build logs
+   - Verify CUDA paths and library availability
+   - Ensure all dependencies are properly installed
+
+5. **Wheel Creation Issues**
+   - Verify Python version compatibility
+   - Check auditwheel repair logs
+   - Ensure UCX plugins are accessible
+   - Verify `pyproject.toml` has correct build requirements
+
+6. **Installation Test Failures**
+   - Check wheel compatibility with target platform
+   - Verify library dependencies are properly bundled
+   - Test wheel installation in clean environment
+
+7. **Artifactory Upload Failures**
+   - Verify credentials are correctly configured
+   - Check repository URL is accessible
+   - Ensure wheel naming follows PEP 440
+   - Review twine verbose output for detailed errors
+
+### Debugging Commands
+
+```bash
+# Check wheel contents
+unzip -l dist/nixl-*.whl
+
+# Verify library dependencies
+ldd /path/to/nixl/library.so
+
+# Test wheel installation
+uv pip install --force-reinstall dist/nixl-*.whl
+```
+
+## 9. Maintenance
+
+### Updating Dependencies
+- Modify `contrib/Dockerfile.manylinux` for system package updates
+- Update Python versions in matrix configuration
+- Test new dependencies in isolated environment
+
+### Adding New Architectures
+1. Update matrix axes in YAML configuration
+2. Ensure base Docker images support new architecture
+3. Test build process on target architecture
+4. Update wheel platform tags if needed
+
+### Performance Optimization
+- Adjust `NPROC` build argument for parallel compilation
+- Monitor resource usage and adjust Kubernetes limits
+- Consider caching strategies for faster builds
+
+## 10. Build Configuration Tools
+
+### tomlutil.py
+A utility script for modifying `pyproject.toml` during the build process:
+
+```bash
+# Set wheel name
+./contrib/tomlutil.py --wheel-name nixl-cu12 pyproject.toml
+
+# Add build ID to version
+./contrib/tomlutil.py --wheel-name nixl-cu12 --build-id 68 pyproject.toml
+
+# Both together
+./contrib/tomlutil.py --wheel-name nixl-cu12 --build-id 68 pyproject.toml
+```
+
+**Features:**
+- `--wheel-name`: Sets the package name (for CUDA variant naming)
+- `--build-id`: Appends build ID as PEP 440 local version identifier
+- Handles existing local version identifiers gracefully
+- Used automatically by `build-wheel.sh` when `CI_BUILD_NUMBER` is set
+
+### pyproject.toml Build Requirements
+
+Critical dependencies in `[build-system] requires`:
+```toml
+[build-system]
+requires = ["meson-python", "ninja", "pybind11", "patchelf", "pyyaml", "types-PyYAML", "pytest", "build", "setuptools"]
+build-backend = "mesonpy"
+```
+
+**Important:** The `ninja` package must be included for isolated build environments (used by `uv build`).
+
+
+## 11. Related Files
+
+- `.ci/jenkins/lib/build-wheel-matrix.yaml` - Main CI configuration
+- `contrib/Dockerfile.manylinux` - Docker build environment
+- `contrib/build-wheel.sh` - Wheel building script
+- `contrib/tomlutil.py` - Build configuration utility (supports --build-id)
+- `contrib/wheel_add_ucx_plugins.py` - UCX plugin integration
+- `pyproject.toml` - Python package configuration (must include `ninja` in build requirements)
+- `meson.build` - Native build configuration
+
+## 12. References
+
+- [ManyLinux Documentation](https://github.com/pypa/manylinux)
+- [Auditwheel Documentation](https://github.com/pypa/auditwheel)
+- [UV Package Manager](https://docs.astral.sh/uv/)
+- [Meson Build System](https://mesonbuild.com/)
+- [Meson Python](https://meson-python.readthedocs.io/)
+- [UCX Documentation](https://openucx.org/)
+- [Twine Documentation](https://twine.readthedocs.io/)
+- [PEP 440 - Version Identification](https://peps.python.org/pep-0440/)
+- [JFrog Artifactory PyPI Repositories](https://www.jfrog.com/confluence/display/JFROG/PyPI+Repositories)

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -1,0 +1,152 @@
+# Build Matrix Configuration for NIXL CI Pipeline
+#
+# This file defines the build matrix configuration for the NIXL CI pipeline in Jenkins.
+# It specifies the build environment, resources, and test matrix for continuous integration.
+#
+# =============================================================================
+# Multi-Stage Docker Build Integration
+# =============================================================================
+# This CI pipeline uses contrib/build-container.sh with contrib/Dockerfile.manylinux
+# to build wheels for specific Python versions and architectures in each matrix
+# combination. The script handles the multi-stage Docker build internally, using
+# the CUDA manylinux base image from Artifactory as the build environment.
+#
+# CI Usage: build-container.sh --base-image ... --wheel-base ... (builds and packages wheels)
+# User Usage: Full image build via build-container.sh (same script, different invocation)
+#
+# =============================================================================
+# Key Components:
+# =============================================================================
+# - Job Configuration: Defines timeout, failure behavior, and Kubernetes resources
+# - Docker Images: Specifies the container images used for different build stages
+#   - Uses contrib/Dockerfile.manylinux via contrib/build-container.sh
+#   - Base image: artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda:13.0-devel-manylinux--25.09
+# - Matrix Axes: Defines build variations (Python versions and architectures)
+# - Build Steps: Sequential steps for building, testing, and wheel generation
+#
+# =============================================================================
+# When Modified:
+# =============================================================================
+# - Adding/removing Docker images: Affects available build environments
+# - Modifying matrix axes: Changes build variations (e.g., adding architectures)
+# - Adjusting resource limits: Impacts build performance and resource allocation
+# - Adding/removing steps: Changes the build pipeline sequence
+# - Changing build-container.sh args: Affects Docker build behavior and base image selection
+#
+# Note: Changes to this file are tested as part of the PR CI flow no need to test them manually.
+
+---
+# =============================================================================
+# Job Configuration
+# =============================================================================
+job: nixl-ci-build-wheel
+
+# Fail job if one of the steps fails or continue
+# Set to false to allow matrix builds to continue even if some combinations fail
+failFast: false
+
+# Build timeout - 4 hours for complex multi-architecture builds
+timeout_minutes: 240
+
+# =============================================================================
+# Container Registry Configuration
+# =============================================================================
+# Harbor registry for storing build artifacts and base images
+registry_host: nbu-harbor.gtm.nvidia.com
+registry_path: /nixl
+registry_auth: nixl_harbor_credentials
+
+credentials:
+  - credentialsId: 'svc-nixl-new-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_USER'
+    passwordVariable: 'ARTIFACTORY_TOKEN'
+
+# =============================================================================
+# Kubernetes Resource Configuration
+# =============================================================================
+# High-performance build environment with substantial resources for complex builds
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  # 24GB memory and 16 CPU cores for parallel compilation and large builds
+  limits: '{memory: 24Gi, cpu: 16000m}'
+  requests: '{memory: 24Gi, cpu: 16000m}'
+
+# =============================================================================
+# Docker Build Configuration
+# =============================================================================
+# Uses podman-in-container (quay.io/podman/stable) as the build runner
+# build-container.sh runs podman/docker inside this container to build the wheel image
+runs_on_dockers:
+  - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+
+# =============================================================================
+# Build Matrix Configuration
+# =============================================================================
+# Defines the combinations of manylinux version and Python versions and architectures to build
+# Each combination runs in parallel
+matrix:
+  axes:
+    manylinux:
+      - "2_28"
+    # Python versions supported by NIXL
+    # Each version gets its own wheel with appropriate ABI tags
+    python_version:
+      - "3.12"
+    # Target architectures for wheel distribution
+    # x86_64: Intel/AMD 64-bit processors
+    # aarch64: ARM 64-bit processors (Apple Silicon, ARM servers)
+    arch:
+      - x86_64
+      - aarch64
+
+# =============================================================================
+# Environment and Build Steps
+# =============================================================================
+# Global environment variables for the build process
+env:
+  NPROC: 16
+  DOCKER_REGISTRY_HOST: 'artifactory.nvidia.com'
+  BASE_IMAGE: "${DOCKER_REGISTRY_HOST}/sw-nbu-swx-nixl-docker-local/base/cuda"
+  BASE_TAG: '13.0-devel-manylinux--25.09'
+
+steps:
+  # =============================================================================
+  # Step 1: Environment Preparation
+  # =============================================================================
+  # Set up podman environment
+  # This step runs sequentially (not in parallel) to avoid conflicts
+  - name: Prepare
+    credentialsId: 'svc-nixl-new-artifactory-token'
+    parallel: false
+    run: |
+      # Setup podman and dependencies
+      rm -f /etc/containers/storage.conf /usr/share/containers/storage.conf
+      podman system reset -f || true
+      ln -sfT $(type -p podman) /usr/bin/docker
+      # Login to Artifactory
+      echo "$ARTIFACTORY_TOKEN" | docker login "https://${DOCKER_REGISTRY_HOST}" -u "$ARTIFACTORY_USER" --password-stdin
+
+  # =============================================================================
+  # Step 2: Python Wheel Generation
+  # =============================================================================
+  # Create distributable Python wheels that bundle native libraries
+  # This step uses the build-wheel.sh script to package everything into wheels
+  - name: Build Wheel
+    parallel: false
+    run: |
+      set -x
+      export NPROC=$NPROC
+      ./contrib/build-container.sh \
+        --base-image "${BASE_IMAGE}" \
+        --base-image-tag "${BASE_TAG}" \
+        --wheel-base "manylinux_${manylinux}" \
+        --python-versions "${python_version}" \
+        --arch ${arch} \
+        --dockerfile contrib/Dockerfile.manylinux
+
+# =============================================================================
+# Task Naming Convention
+# =============================================================================
+# Unique identifier for each matrix combination
+taskName: '${name}_${manylinux}/${arch}/python_${python_version}'

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -125,6 +125,12 @@
                     string(name: 'sha1', value: githubHelper.getMergedSHA()),
                     string(name: 'githubData', value: VARIABLE_FROM_POST)
                 ], propagate: false, wait: true
+            }}, wheel: {{
+                def buildJob = 'nixl-ci-build-wheel'
+                build job: buildJob, parameters: [
+                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
+                    string(name: 'githubData', value: VARIABLE_FROM_POST)
+                ], propagate: false, wait: true
             }}
 
             githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.SUCCESS)
@@ -185,7 +191,7 @@
                 shallow-clone: false
                 do-not-fetch-tags: false
                 # Configure refspec to handle branches, PRs, and tags
-                refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+                refspec: "{jjb_gh_refspec}"
                 browser: githubweb
                 browser-url: "{jjb_git}"
                 # Handle git submodules
@@ -247,7 +253,7 @@
                 shallow-clone: false
                 do-not-fetch-tags: false
                 # Configure refspec to handle branches, PRs, and tags
-                refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+                refspec: "{jjb_gh_refspec}"
                 browser: githubweb
                 browser-url: "{jjb_git}"
                 # Handle git submodules
@@ -309,7 +315,7 @@
                 shallow-clone: false
                 do-not-fetch-tags: false
                 # Configure refspec to handle branches, PRs, and tags
-                refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+                refspec: "{jjb_gh_refspec}"
                 browser: githubweb
                 browser-url: "{jjb_git}"
                 # Handle git submodules
@@ -412,7 +418,7 @@
             branches: ['$NIXL_VERSION']
             shallow-clone: false
             do-not-fetch-tags: false
-            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*"
+            refspec: "{jjb_gh_refspec}"
             browser: githubweb
             browser-url: "{jjb_git}"
             submodule:
@@ -421,6 +427,65 @@
               tracking: true
               parent-credentials: true
       script-path: "{jjb_jenkinsfile}"
+
+# Template for the main build wheel job that performs the actual build wheel process
+- job-template:
+    name: "{jjb_proj}-build-wheel"      # Will be expanded to 'nixl-ci-build-wheel'
+    project-type: pipeline
+    disabled: false
+    properties:
+        # Similar properties as dispatcher job
+        - github:
+            url: "{jjb_gh_url}"
+        - build-discarder:
+            days-to-keep: 50
+            num-to-keep: 20
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}-build-wheel
+              conf_file=.ci/jenkins/lib/build-wheel-matrix.yaml
+    description: Do NOT edit this job through the Web GUI !
+    concurrent: true
+    sandbox: true
+    # Build job parameters
+    parameters:
+        - string:
+            name: "sha1"
+            default: "{jjb_branch}"    # Default to 'main' branch
+            description: "Commit to be checked, usually set by PR"
+        - string:
+            name: "githubData"
+            default: ""
+            description: "Variables from post"
+        - bool:
+            name: "build_dockers"
+            default: false
+            description: "Force rebuild docker containers"
+        - string:
+            name: "DEBUG"
+            default: 0
+            description: "Enable debug prints and traces, valid values are 0-9"
+    # SCM configuration for the build job
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                credentials-id: 'swx-jenkins_ssh_key'
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                # Configure refspec to handle branches, PRs, and tags
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
 # Project definition that instantiates the job templates
 # This section defines the actual jobs that will be created
@@ -431,9 +496,11 @@
     jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'  # Main pipeline definition
     jjb_branch: 'main'            # Default branch
     jjb_gh_url: 'https://github.com/ai-dynamo/nixl'  # GitHub web URL
+    jjb_gh_refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*'
     jobs:
         - "{jjb_proj}-dispatcher"  # Create dispatcher job
         - "{jjb_proj}-non-gpu"       # Create non-gpu job
         - "{jjb_proj}-build-container"  # Create container builder job
         - "{jjb_proj}-gpu"        # Create gpu job
         - "{jjb_proj}-dl-gpu"   # Create dl-gpu job for dlcluster.nvidia.com
+        - "{jjb_proj}-build-wheel"  # Create build wheel job

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -27,6 +27,7 @@ ARG URING_TAG="liburing-2.13"
 ARG BUILD_NIXL_EP="true"
 ARG ABSL_TAG="lts_2025_08_14"
 ARG GRPC_TAG="v1.73.0"
+ARG NPROC
 
 RUN yum groupinstall -y 'Development Tools' &&  \
     dnf install -y almalinux-release-synergy && \
@@ -70,7 +71,7 @@ RUN cd /tmp && \
     tar -xzf "hwloc-${HWLOC_VERSION}.tar.gz" && \
     cd "hwloc-${HWLOC_VERSION}" && \
     ./configure --prefix=/usr/local --disable-nvml && \
-    make -j"$(nproc)" && \
+    make -j"${NPROC:-$(nproc)}" && \
     make install && \
     ldconfig && \
     rm -rf "/tmp/hwloc-${HWLOC_VERSION}" "/tmp/hwloc-${HWLOC_VERSION}.tar.gz"
@@ -83,7 +84,7 @@ RUN cd /tmp && \
     cd openssl-3.0.16 && \
     ./Configure --prefix=/usr/local/openssl3 --openssldir=/usr/local/openssl3 \
         shared zlib linux-$ARCH && \
-    make -j$(nproc) && \
+    make -j${NPROC:-$(nproc)} && \
     make install_sw && \
     echo "/usr/local/openssl3/lib64" > /etc/ld.so.conf.d/openssl3.conf && \
     echo "/usr/local/openssl3/lib" >> /etc/ld.so.conf.d/openssl3.conf && \
@@ -111,7 +112,7 @@ RUN git clone https://github.com/abseil/abseil-cpp.git && \
         -DBUILD_SHARED_LIBS=ON \
         -DABSL_PROPAGATE_CXX_STD=ON \
         -DABSL_ENABLE_INSTALL=ON && \
-    make -j$(nproc) && \
+    make -j${NPROC:-$(nproc)} && \
     make install && \
     ldconfig
 
@@ -133,7 +134,7 @@ RUN git clone --recurse-submodules -b ${GRPC_TAG} --depth 1 --shallow-submodules
     -DgRPC_ABSL_PROVIDER=package \
     -DgRPC_PROTOBUF_PROVIDER=module \
     -DgRPC_ZLIB_PROVIDER=package ../.. && \
-    make -j$(nproc) && \
+    make -j10 && \
     make install && \
     ldconfig
 
@@ -145,14 +146,14 @@ RUN cd /workspace && \
     sed -i '/^find_dependency(cpprestsdk)$/d' etcd-cpp-api-config.in.cmake && \
     mkdir build && cd build && \
     cmake .. -DBUILD_ETCD_CORE_ONLY=ON -DCMAKE_BUILD_TYPE=Release -DETCD_CMAKE_CXX_STANDARD=17 && \
-    make -j$(nproc) && make install
+    make -j${NPROC:-$(nproc)} && make install
 
 # The base image libcurl is linked against openssl 1.x, so we need to build from source
 # in order to use openssl 3.x. This is needed to build aws-sdk-cpp.
 RUN wget https://curl.se/download/curl-8.5.0.tar.gz && \
     tar xzf curl-8.5.0.tar.gz && cd curl-8.5.0 && \
     ./configure --prefix=/usr/local --with-ssl=/usr/local/openssl3 --enable-shared && \
-    make -j$(nproc) && make install
+    make -j${NPROC:-$(nproc)} && make install
 
 RUN git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1.11.760
 RUN mkdir aws_sdk_build && cd aws_sdk_build && \
@@ -170,7 +171,7 @@ RUN git clone https://github.com/axboe/liburing.git && \
      cd liburing && \
      git checkout $URING_TAG && \
      ./configure --cc=gcc --cxx=g++ && \
-     make -j library && make liburing.pc && make install && \
+    make -j${NPROC:-$(nproc)} library && make liburing.pc && make install && \
      ldconfig && \
      cd ..
 
@@ -185,7 +186,7 @@ RUN git clone https://github.com/nvidia/gusli.git && \
 # Required for Azure SDK
 RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git --branch 2.15 && \
     cd libxml2 && \
-    ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh && make -j && \
+    ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh && make -j${NPROC:-$(nproc)} && \
     make install
 
 RUN git clone --depth 1 https://github.com/Azure/azure-sdk-for-cpp.git --branch azure-storage-blobs_12.15.0 && \
@@ -274,7 +275,7 @@ RUN wget --tries=3 --waitretry=5 --timeout=30 --read-timeout=60 \
                 --enable-cuda-dlopen \
                 --with-gdrcopy \
                 --enable-gdrcopy-dlopen && \
-    make -j$(nproc) && \
+    make -j${NPROC:-$(nproc)} && \
     make install && \
     ldconfig
 


### PR DESCRIPTION
## What?
Add wheel build in manylinux

## Why?
New CI build test

## How?
New blossom-ci pipeline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI pipeline to build and publish Python wheels across multiple Python versions, CPU architectures, and manylinux targets using matrixed build tasks.

* **Documentation**
  * Added a comprehensive Build Wheel Matrix CI guide covering configuration, build/test/publish flow, artifact naming/versioning, Docker usage, and troubleshooting.

* **Chores**
  * Made container builds respect configurable parallelism.
  * Added optional build-ID tagging for wheel versions and integrated the matrix build job into the dispatcher pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->