### PR TITLE
UCX: Do not fail registration in mem check

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -528,10 +528,8 @@ int nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t 
         }
 
         if (attr.mem_type == UCS_MEMORY_TYPE_HOST) {
-            NIXL_ERROR << "memory is detected as host, check that UCX is configured"
-                          " with CUDA support";
-            ucp_mem_unmap(ctx, mem.memh);
-            return -1;
+            NIXL_WARN << "memory is detected as host, check that UCX is configured"
+                         " with CUDA support";
         }
     }
 


### PR DESCRIPTION
## What?
Just print a warning when VRAM memory is not detected properly

## Why?
Wrong memory detection does not affect all uses-cases, sometimes it can work for inter-node jobs

