### PR TITLE
Unify wheel building

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -78,17 +78,7 @@ RUN wget --tries=3 --waitretry=5 \
     rm rustup-init* && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-WORKDIR /workspace/nixl
-COPY . /workspace/nixl
-
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
-ENV VIRTUAL_ENV=/workspace/nixl/.venv
-RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
-    # pybind11 pip install needed for ubuntu 22.04
-    uv pip install --upgrade meson pybind11 patchelf
-
-    # Add Mellanox repository and install packages
+# Add Mellanox repository and install packages
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "${ARCH}"; fi) && \
     export PKG_CONFIG_PATH="/opt/mellanox/doca/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:/opt/mellanox/dpdk/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" && \
     curl -fsSL https://linux.mellanox.com/public/repo/doca/3.0.0/ubuntu24.04/${ARCH_SUFFIX}/GPG-KEY-Mellanox.pub | \
@@ -101,6 +91,16 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else ech
         doca-sdk-common doca-sdk-dma doca-sdk-dpdk-bridge \
         doca-sdk-eth doca-sdk-flow doca-sdk-rdma doca-all \
         doca-sdk-gpunetio libdoca-sdk-gpunetio-dev
+
+WORKDIR /workspace/nixl
+COPY . /workspace/nixl
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+ENV VIRTUAL_ENV=/workspace/nixl/.venv
+RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
+    # pybind11 pip install needed for ubuntu 22.04
+    uv pip install --upgrade meson pybind11 patchelf
 
 RUN rm -rf /usr/lib/ucx
 RUN rm -rf /opt/hpcx/ucx
@@ -126,7 +126,6 @@ RUN cd /usr/local/src && \
      make -j install-strip &&        \
      ldconfig
 
-
 RUN rm -rf build && \
     mkdir build && \
     uv run meson setup build/ --prefix=/usr/local/nixl && \
@@ -142,17 +141,11 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 
 RUN cd src/bindings/rust && cargo build --release --locked
 
-# Create the wheel
-# No need to specifically add path to libcuda.so here, meson finds the stubs and links them
-ARG WHL_PYTHON_VERSIONS="3.12"
-ARG WHL_PLATFORM="manylinux_2_39_$ARCH"
-RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
-    for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
-        uv build --wheel --out-dir /tmp/dist --python $PYTHON_VERSION; \
-    done
-
-# Exclude libcuda.so.1 due to compatibility issues, should link with cuda driver library on host
-RUN uv pip install auditwheel && \
-    uv run auditwheel repair --exclude libcuda.so.1 /tmp/dist/nixl-*cp31*.whl --plat $WHL_PLATFORM --wheel-dir /workspace/nixl/dist
+RUN ./contrib/build-wheel.sh \
+    --python-version $DEFAULT_PYTHON_VERSION \
+    --platform manylinux_2_39_$ARCH \
+    --ucx-plugins-dir /usr/lib64/ucx \
+    --nixl-plugins-dir /usr/local/nixl/lib/$ARCH-linux-gnu/plugins \
+    --output-dir /workspace/nixl/dist
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -194,12 +194,12 @@ ARG WHL_PYTHON_VERSIONS="3.9,3.10,3.11,3.12"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
-        uv build --wheel --out-dir /tmp/dist --python $PYTHON_VERSION; \
+        ./contrib/build-wheel.sh \
+            --python-version $PYTHON_VERSION \
+            --platform $WHL_PLATFORM \
+            --ucx-plugins-dir /usr/lib64/ucx \
+            --nixl-plugins-dir $NIXL_PLUGIN_DIR \
+            --output-dir dist ; \
     done
-
-# Exclude libcuda.so.1 due to compatibility issues, should link with cuda driver library on host
-RUN uv pip install auditwheel && \
-    uv run auditwheel repair --exclude libcuda.so.1 --exclude 'libssl*' --exclude 'libcrypto*' /tmp/dist/nixl-*cp3*.whl --plat $WHL_PLATFORM --wheel-dir dist && \
-    contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir /usr/lib64/ucx --nixl-plugins-dir /usr/local/nixl/lib64/plugins dist/*.whl
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -200,6 +200,6 @@ RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
 # Exclude libcuda.so.1 due to compatibility issues, should link with cuda driver library on host
 RUN uv pip install auditwheel && \
     uv run auditwheel repair --exclude libcuda.so.1 --exclude 'libssl*' --exclude 'libcrypto*' /tmp/dist/nixl-*cp3*.whl --plat $WHL_PLATFORM --wheel-dir dist && \
-    contrib/wheel_add_ucx_plugins.py --ucx-lib-dir /usr/lib64 dist/*.whl
+    contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir /usr/lib64/ucx --nixl-plugins-dir /usr/local/nixl/lib64/plugins dist/*.whl
 
 RUN uv pip install dist/nixl-*cp${DEFAULT_PYTHON_VERSION//./}*.whl

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -15,16 +15,81 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
+# Parse arguments
+PYTHON_VERSION="3.12"
+ARCH=$(uname -m)
+WHL_PLATFORM="manylinux_2_39_$ARCH"
+UCX_PLUGINS_DIR="/usr/lib64/ucx"
+NIXL_PLUGINS_DIR="/usr/local/nixl/lib/$ARCH-linux-gnu/plugins"
+OUTPUT_DIR="dist"
 
-source $HOME/.local/bin/env
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --python-version)
+            PYTHON_VERSION=$2
+            shift
+            shift
+            ;;
+        --platform)
+            WHL_PLATFORM=$2
+            shift
+            shift
+            ;;
+        --output-dir)
+            OUTPUT_DIR=$2
+            shift
+            shift
+            ;;
+        --ucx-plugins-dir)
+            UCX_PLUGINS_DIR=$2
+            shift
+            shift
+            ;;
+        --nixl-plugins-dir)
+            NIXL_PLUGINS_DIR=$2
+            shift
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [--python-version <python-version>] [--platform <platform>] [--output-dir <output-dir>] [--ucx-plugins-dir <ucx-plugins-dir>] [--nixl-plugins-dir <nixl-plugins-dir>]"
+            echo "  --python-version: Python version to build the wheel for (default: $PYTHON_VERSION)"
+            echo "  --platform: Platform to build the wheel for (default: $WHL_PLATFORM)"
+            echo "  --output-dir: Directory to output the wheel to (default: $OUTPUT_DIR)"
+            echo "  --ucx-plugins-dir: Directory to find UCX plugins in (default: $UCX_PLUGINS_DIR)"
+            echo "  --nixl-plugins-dir: Directory to find NIXL plugins in (default: $NIXL_PLUGINS_DIR)"
+            echo "  --help: Show this help message"
+            echo ""
+            echo "Must be executed from the root of the NIXL repository."
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
 
-# install auditwheel
-pip3 install auditwheel
+set -e
+set -x
 
-# build the wheel
-uv build --wheel
+# Check for required dependencies
+if ! command -v uv &> /dev/null; then
+    echo "Required dependency: uv is not installed. Please install it from https://astral.sh/uv/install.sh"
+    exit 1
+fi
 
-# Fix up wheel
-auditwheel repair dist/nixl-*-cp31*.whl --plat manylinux_2_39_x86_64
+# Build the wheel
+TMP_DIR=$(mktemp -d)
+uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
+
+# Bundle libraries
+uv pip install auditwheel patchelf
+
+uv run auditwheel repair --exclude libcuda.so.1 --exclude 'libssl*' --exclude 'libcrypto*' $TMP_DIR/nixl-*.whl --plat $WHL_PLATFORM --wheel-dir $OUTPUT_DIR
+
+uv run ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $OUTPUT_DIR/*.whl
+
+# Clean up
+rm -rf "$TMP_DIR"
+

--- a/contrib/wheel_add_ucx_plugins.py
+++ b/contrib/wheel_add_ucx_plugins.py
@@ -211,6 +211,8 @@ def add_plugins(wheel_path, sys_plugins_dir, install_dirname):
     pkg_plugins_dir = os.path.join(pkg_libs_dir, install_dirname)
     print(f"Copying plugins from {sys_plugins_dir} to {pkg_plugins_dir}")
     copied_files = copytree(sys_plugins_dir, pkg_plugins_dir)
+    if not copied_files:
+        raise RuntimeError(f"No plugins found in {sys_plugins_dir}")
 
     # Patch all libs to load plugin deps from the wheel
     for fname in copied_files:

--- a/contrib/wheel_add_ucx_plugins.py
+++ b/contrib/wheel_add_ucx_plugins.py
@@ -197,7 +197,7 @@ def add_plugins(wheel_path, sys_plugins_dir, install_dirname):
     for fname in name_map.values():
         fpath = os.path.join(pkg_libs_dir, fname)
         rpath = os.popen(f"patchelf --print-rpath {fpath}").read().strip()
-        if '$ORIGIN' in rpath.split(":"):
+        if "$ORIGIN" in rpath.split(":"):
             continue
         if not rpath:
             rpath = "$ORIGIN"
@@ -274,9 +274,9 @@ def main():
         "wheel", type=str, nargs="+", help="Path to one or more wheel files"
     )
     args = parser.parse_args()
-    if '$ARCH' in args.nixl_plugins_dir:
+    if "$ARCH" in args.nixl_plugins_dir:
         arch = os.getenv("ARCH", os.uname().machine)
-        args.nixl_plugins_dir = args.nixl_plugins_dir.replace('$ARCH', arch)
+        args.nixl_plugins_dir = args.nixl_plugins_dir.replace("$ARCH", arch)
 
     for wheel_path in args.wheel:
         add_plugins(wheel_path, args.ucx_plugins_dir, "ucx")

--- a/contrib/wheel_add_ucx_plugins.py
+++ b/contrib/wheel_add_ucx_plugins.py
@@ -102,14 +102,15 @@ def get_repaired_lib_name_map(libs_dir):
     (like "libboost_atomic-fb1368c6.so.1.66.0").
     """
     name_map = {}
-    for fname in os.listdir(libs_dir):
+    for fname in sorted(os.listdir(libs_dir)):
         if (
             os.path.isfile(os.path.join(libs_dir, fname))
             and ".so" in fname
             and "-" in fname
         ):
-            base_name = fname.split("-")[0].replace("_", ".")
+            base_name = fname.split("-")[0]
             name_map[base_name] = fname
+            print(f"Found already bundled lib: {base_name} -> {fname}")
     return name_map
 
 
@@ -156,11 +157,31 @@ def get_lib_deps(lib_path):
     return ret
 
 
-def add_ucx_plugins(wheel_path, ucx_sys_lib_dir):
+def copytree(src, dst):
     """
-    Adds the UCX plugins from the system to the wheel.
-    The plugins are copied to the wheel's nixl.libs/ucx directory.
-    The plugins are patched to load their dependencies from the parent directory.
+    Copy a tree of files from @src directory to @dst directory.
+    Similar to shutil.copytree, but returns a list of all files copied.
+    Returns:
+        List of files copied.
+    """
+    copied_files = []
+    for root, dirs, files in os.walk(src):
+        rel_path = os.path.relpath(root, src)
+        dst_dir = os.path.join(dst, rel_path)
+        os.makedirs(dst_dir, exist_ok=True)
+        for file in files:
+            src_file = os.path.join(root, file)
+            dst_file = os.path.join(dst_dir, file)
+            shutil.copy2(src_file, dst_file)
+            copied_files.append(dst_file)
+    return copied_files
+
+
+def add_plugins(wheel_path, sys_plugins_dir, install_dirname):
+    """
+    Adds the plugins from @sys_dir to the wheel.
+    The plugins are copied to a subdirectory @install_dir relative to the wheel's nixl.libs.
+    The plugins are patched to load their dependencies from the wheel.
     The wheel file is then recreated.
     """
     temp_dir = extract_wheel(wheel_path)
@@ -169,17 +190,30 @@ def add_ucx_plugins(wheel_path, ucx_sys_lib_dir):
     if not os.path.exists(pkg_libs_dir):
         raise FileNotFoundError(f"nixl.libs directory not found in wheel: {wheel_path}")
 
+    print("Listing existing libs:")
     name_map = get_repaired_lib_name_map(pkg_libs_dir)
 
-    sys_plugins_dir = os.path.join(ucx_sys_lib_dir, "ucx")
-    pkg_plugins_dir = os.path.join(pkg_libs_dir, "ucx")
-    if os.path.exists(pkg_plugins_dir):
-        shutil.rmtree(pkg_plugins_dir)
-    print(f"Copying UCX plugins from {sys_plugins_dir} to {pkg_plugins_dir}")
-    shutil.copytree(sys_plugins_dir, pkg_plugins_dir)
+    # Ensure that all of them in name_map have RPATH set to $ORIGIN
+    for fname in name_map.values():
+        fpath = os.path.join(pkg_libs_dir, fname)
+        rpath = os.popen(f"patchelf --print-rpath {fpath}").read().strip()
+        if '$ORIGIN' in rpath.split(":"):
+            continue
+        if not rpath:
+            rpath = "$ORIGIN"
+        else:
+            rpath = "$ORIGIN:" + rpath
+        print(f"Setting rpath for {fpath} to {rpath}")
+        ret = os.system(f"patchelf --set-rpath '{rpath}' {fpath}")
+        if ret != 0:
+            raise RuntimeError(f"Failed to set rpath for {fpath}")
 
-    # Patch all libs to load UCX deps from parent directory
-    for fname in os.listdir(pkg_plugins_dir):
+    pkg_plugins_dir = os.path.join(pkg_libs_dir, install_dirname)
+    print(f"Copying plugins from {sys_plugins_dir} to {pkg_plugins_dir}")
+    copied_files = copytree(sys_plugins_dir, pkg_plugins_dir)
+
+    # Patch all libs to load plugin deps from the wheel
+    for fname in copied_files:
         print(f"Patching {fname}")
         fpath = os.path.join(pkg_plugins_dir, fname)
         if os.path.isfile(fpath) and ".so" in fname:
@@ -219,24 +253,34 @@ def add_ucx_plugins(wheel_path, ucx_sys_lib_dir):
 
     create_wheel(wheel_path, temp_dir)
     shutil.rmtree(temp_dir)
-    print(f"Added UCX plugins to wheel: {wheel_path}")
+    print(f"Added plugins to wheel: {wheel_path}")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--ucx-lib-dir",
+        "--ucx-plugins-dir",
         type=str,
-        help="Path to the UCX lib directory",
-        default="/usr/lib64",
+        help="Path to the UCX plugins directory",
+        default="/usr/lib64/ucx",
+    )
+    parser.add_argument(
+        "--nixl-plugins-dir",
+        type=str,
+        help="Path to the NIXL plugins directory",
+        default="/usr/local/nixl/lib/$ARCH-linux-gnu/plugins",
     )
     parser.add_argument(
         "wheel", type=str, nargs="+", help="Path to one or more wheel files"
     )
     args = parser.parse_args()
+    if '$ARCH' in args.nixl_plugins_dir:
+        arch = os.getenv("ARCH", os.uname().machine)
+        args.nixl_plugins_dir = args.nixl_plugins_dir.replace('$ARCH', arch)
 
     for wheel_path in args.wheel:
-        add_ucx_plugins(wheel_path, args.ucx_lib_dir)
+        add_plugins(wheel_path, args.ucx_plugins_dir, "ucx")
+        add_plugins(wheel_path, args.nixl_plugins_dir, "nixl")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What?
Unify the wheel building scripts across the repository.

## Why?
There is a sequence of commands that must be executed correctly and uniformly to result into creating the wheel correctly, including all deps, plugins and ensuring everything loads correctly on installation.

Therefore we move the logic to `contrib/build-wheel.sh` and invoke this script from all places.

This requires https://github.com/ai-dynamo/nixl/pull/540 to be merged first.