### PR TITLE
CODEOWNERS: Set default code owners to maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
+# Default owners are maintainers
+* @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
+
 # CI/CD
 /.github/ @ai-dynamo/Devops @ai-dynamo/nixl-devops
 /.ci/ @ai-dynamo/nixl-devops

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners are maintainers
-* @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
+* @ai-dynamo/nixl-maintainers
 
 # CI/CD
 /.github/ @ai-dynamo/Devops @ai-dynamo/nixl-devops


### PR DESCRIPTION
## Why?
Make sure a either a maintainer or a designated code owner approves any PR
