### PR TITLE
API: Applied naming conventions according to NIXL code style.

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -25,14 +25,15 @@
 
 // Might be removed to be decided by backend, or changed to high
 // level direction or so.
-typedef std::vector<std::pair<std::string, std::string>> notif_list_t;
+using notifList = std::vector<std::pair<std::string, std::string>>;
+using notif_list_t = notifList;
 
 
 struct nixlBackendOptionalArgs {
     // During postXfer, user might ask for a notification if supported
-    nixl_blob_t notifMsg;
-    bool        hasNotif = false;
-    nixl_blob_t customParam;
+    nixlBlob notifMsg;
+    bool hasNotif = false;
+    nixlBlob customParam;
 };
 
 using nixl_opt_b_args_t = nixlBackendOptionalArgs;
@@ -44,14 +45,14 @@ using nixl_opt_b_args_t = nixlBackendOptionalArgs;
 // from the user, we should make nixlBackendEngine/nixlAgent friend classes.
 class nixlBackendInitParams {
     public:
-        std::string       localAgent;
+        std::string localAgent;
 
-        nixl_backend_t    type;
-        nixl_b_params_t*  customParams;
+        nixlBackend type;
+        nixlBParams *customParams;
 
-        bool              enableProgTh;
-        nixlTime::us_t    pthrDelay;
-        nixl_thread_sync_t syncMode;
+        bool enableProgTh;
+        nixlTime::us_t pthrDelay;
+        nixlThreadSync syncMode;
 };
 
 // Pure virtual class to have a common pointer type
@@ -110,6 +111,7 @@ class nixlMetaDesc : public nixlBasicDesc {
         }
 };
 
-typedef nixlDescList<nixlMetaDesc> nixl_meta_dlist_t;
+using nixlMetaDlist = nixlDescList<nixlMetaDesc>;
+using nixl_meta_dlist_t = nixlMetaDlist;
 
 #endif

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -27,28 +27,30 @@
 class nixlBackendEngine {
     private:
         // Members that cannot be modified by a child backend and parent bookkeep
-        nixl_backend_t  backendType;
-        nixl_b_params_t customParams;
+        nixlBackend backendType;
+        nixlBParams customParams;
 
     protected:
         // Members that can be accessed by the child (localAgent cannot be modified)
         bool              initErr = false;
         const std::string localAgent;
 
-        [[nodiscard]] nixl_status_t setInitParam(const std::string &key, const std::string &value) {
-	    if (customParams.try_emplace(key,value).second) {
+        [[nodiscard]] nixlStatus
+        setInitParam(const std::string &key, const std::string &value) {
+            if (customParams.try_emplace(key, value).second) {
                 return NIXL_SUCCESS;
             }
-	    return NIXL_ERR_NOT_ALLOWED;
+            return NIXL_ERR_NOT_ALLOWED;
         }
 
-        [[nodiscard]] nixl_status_t getInitParam(const std::string &key, std::string &value) const {
-	    const auto iter = customParams.find(key);
+        [[nodiscard]] nixlStatus
+        getInitParam(const std::string &key, std::string &value) const {
+            const auto iter = customParams.find(key);
             if (iter != customParams.end()) {
                 value = iter->second;
                 return NIXL_SUCCESS;
-	    }
-	    return NIXL_ERR_INVALID_PARAM;
+            }
+            return NIXL_ERR_INVALID_PARAM;
         }
 
     public:
@@ -67,8 +69,14 @@ class nixlBackendEngine {
         virtual ~nixlBackendEngine() = default;
 
         bool getInitErr() const noexcept { return initErr; }
-        const nixl_backend_t& getType() const noexcept { return backendType; }
-        const nixl_b_params_t& getCustomParams() const noexcept { return customParams; }
+        const nixlBackend &
+        getType() const noexcept {
+            return backendType;
+        }
+        const nixlBParams &
+        getCustomParams() const noexcept {
+            return customParams;
+        }
 
         // The support function determine which methods are necessary by the child backend, and
         // if they're called by mistake, they will return error if not implemented by backend.
@@ -86,90 +94,98 @@ class nixlBackendEngine {
         // Determines if a backend supports progress thread.
         virtual bool supportsProgTh() const = 0;
 
-        virtual nixl_mem_list_t getSupportedMems() const = 0;  // TODO: Return by const-reference and mark noexcept?
+        virtual nixlMemList
+        getSupportedMems() const = 0; // TODO: Return by const-reference and mark noexcept?
 
 
         // *** Pure virtual methods that need to be implemented by any backend *** //
 
         // Register and deregister local memory
-        virtual nixl_status_t registerMem (const nixlBlobDesc &mem,
-                                           const nixl_mem_t &nixl_mem,
-                                           nixlBackendMD* &out) = 0;
-        virtual nixl_status_t deregisterMem (nixlBackendMD* meta) = 0;
+        virtual nixlStatus
+        registerMem(const nixlBlobDesc &mem, const nixlMemType &nixl_mem, nixlBackendMD *&out) = 0;
+        virtual nixlStatus
+        deregisterMem(nixlBackendMD *meta) = 0;
 
         // Make connection to a remote node identified by the name into loaded conn infos
         // Child might just return 0, if making proactive connections are not necessary.
         // An agent might need to connect to itself for local operations.
-        virtual nixl_status_t connect(const std::string &remote_agent) = 0;
-        virtual nixl_status_t disconnect(const std::string &remote_agent) = 0;
+        virtual nixlStatus
+        connect(const std::string &remote_agent) = 0;
+        virtual nixlStatus
+        disconnect(const std::string &remote_agent) = 0;
 
         // Remove loaded local or remtoe metadata for target
-        virtual nixl_status_t unloadMD (nixlBackendMD* input) = 0;
+        virtual nixlStatus
+        unloadMD(nixlBackendMD *input) = 0;
 
         // Preparing a request, which populates the async handle as desired
-        virtual nixl_status_t prepXfer (const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) const = 0;
+        virtual nixlStatus
+        prepXfer(const nixlXferOp &operation,
+                 const nixlMetaDlist &local,
+                 const nixlMetaDlist &remote,
+                 const std::string &remote_agent,
+                 nixlBackendReqH *&handle,
+                 const nixlBackendOptionalArgs *opt_args = nullptr) const = 0;
 
         // Estimate the cost (duration) of a transfer operation.
-        virtual nixl_status_t estimateXferCost(const nixl_xfer_op_t &operation,
-                                               const nixl_meta_dlist_t &local,
-                                               const nixl_meta_dlist_t &remote,
-                                               const std::string &remote_agent,
-                                               nixlBackendReqH* const &handle,
-                                               std::chrono::microseconds &duration,
-                                               std::chrono::microseconds &err_margin,
-                                               nixl_cost_t &method,
-                                               const nixl_opt_args_t* extra_params = nullptr) const
-        {
+        virtual nixlStatus
+        estimateXferCost(const nixlXferOp &operation,
+                         const nixlMetaDlist &local,
+                         const nixlMetaDlist &remote,
+                         const std::string &remote_agent,
+                         nixlBackendReqH *const &handle,
+                         std::chrono::microseconds &duration,
+                         std::chrono::microseconds &err_margin,
+                         nixlCost &method,
+                         const nixlAgentOptionalArgs *extra_params = nullptr) const {
             return NIXL_ERR_NOT_SUPPORTED;
         }
 
         // Posting a request, which completes the async handle creation and posts it
-        virtual nixl_status_t postXfer (const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) const = 0;
+        virtual nixlStatus
+        postXfer(const nixlXferOp &operation,
+                 const nixlMetaDlist &local,
+                 const nixlMetaDlist &remote,
+                 const std::string &remote_agent,
+                 nixlBackendReqH *&handle,
+                 const nixlBackendOptionalArgs *opt_args = nullptr) const = 0;
 
         // Use a handle to progress backend engine and see if a transfer is completed or not
-        virtual nixl_status_t checkXfer(nixlBackendReqH* handle) const = 0;
+        virtual nixlStatus
+        checkXfer(nixlBackendReqH *handle) const = 0;
 
         //Backend aborts the transfer if necessary, and destructs the relevant objects
-        virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) const = 0;
+        virtual nixlStatus
+        releaseReqH(nixlBackendReqH *handle) const = 0;
 
 
         // *** Needs to be implemented if supportsRemote() is true *** //
 
         // Gets serialized form of public metadata
-        virtual nixl_status_t getPublicData (const nixlBackendMD* meta,
-                                             std::string &str) const {
+        virtual nixlStatus
+        getPublicData(const nixlBackendMD *meta, std::string &str) const {
             return NIXL_ERR_BACKEND;
         };
 
         // Provide the required connection info for remote nodes, should be non-empty
-        virtual nixl_status_t getConnInfo(std::string &str) const {
+        virtual nixlStatus
+        getConnInfo(std::string &str) const {
             return NIXL_ERR_BACKEND;
         }
 
         // Deserialize from string the connection info for a remote node, if supported
         // The generated data should be deleted in nixlBackendEngine destructor
-        virtual nixl_status_t loadRemoteConnInfo (const std::string &remote_agent,
-                                                  const std::string &remote_conn_info) {
+        virtual nixlStatus
+        loadRemoteConnInfo(const std::string &remote_agent, const std::string &remote_conn_info) {
             return NIXL_ERR_BACKEND;
         }
 
         // Load remtoe metadata, if supported.
-        virtual nixl_status_t loadRemoteMD (const nixlBlobDesc &input,
-                                            const nixl_mem_t &nixl_mem,
-                                            const std::string &remote_agent,
-                                            nixlBackendMD* &output) {
+        virtual nixlStatus
+        loadRemoteMD(const nixlBlobDesc &input,
+                     const nixlMemType &nixl_mem,
+                     const std::string &remote_agent,
+                     nixlBackendMD *&output) {
             return NIXL_ERR_BACKEND;
         }
 
@@ -177,8 +193,8 @@ class nixlBackendEngine {
         // *** Needs to be implemented if supportsLocal() is true *** //
 
         // Provide the target metadata necessary for local operations, if supported
-        virtual nixl_status_t loadLocalMD (nixlBackendMD* input,
-                                           nixlBackendMD* &output) {
+        virtual nixlStatus
+        loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) {
             return NIXL_ERR_BACKEND;
         }
 
@@ -186,10 +202,14 @@ class nixlBackendEngine {
         // *** Needs to be implemented if supportsNotif() is true *** //
 
         // Populate an empty received notif list. Elements are released within backend then.
-        virtual nixl_status_t getNotifs(notif_list_t &notif_list) { return NIXL_ERR_BACKEND; }
+        virtual nixlStatus
+        getNotifs(notifList &notif_list) {
+            return NIXL_ERR_BACKEND;
+        }
 
         // Generates a standalone notification, not bound to a transfer.
-        virtual nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) const {
+        virtual nixlStatus
+        genNotif(const std::string &remote_agent, const std::string &msg) const {
             return NIXL_ERR_BACKEND;
         }
 

--- a/src/api/cpp/backend/backend_plugin.h
+++ b/src/api/cpp/backend/backend_plugin.h
@@ -41,10 +41,10 @@ public:
     const char* (*get_plugin_version)();
 
     // Function to get backend options
-    nixl_b_params_t (*get_backend_options)();
+    nixlBParams (*get_backend_options)();
 
     // Function to get supported backend mem types
-    nixl_mem_list_t (*get_backend_mems)();
+    nixlMemList (*get_backend_mems)();
 };
 
 // Macro to define exported C functions for the plugin

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -60,10 +60,10 @@ class nixlAgent {
          * @brief  Discover the available supported plugins found in the plugin paths
          *
          * @param  plugins [out] Vector of available backend plugins
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getAvailPlugins (std::vector<nixl_backend_t> &plugins);
+        nixlStatus
+        getAvailPlugins(std::vector<nixlBackend> &plugins);
 
         /**
          * @brief  Get the supported memory types, and init config parameters and their
@@ -72,12 +72,10 @@ class nixlAgent {
          * @param  type          Plugin backend type
          * @param  mems [out]    List of supported memory types for nixl by the plugin
          * @param  params [out]  List of init parameters and their values for the plugin
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getPluginParams (const nixl_backend_t &type,
-                         nixl_mem_list_t &mems,
-                         nixl_b_params_t &params) const;
+        nixlStatus
+        getPluginParams(const nixlBackend &type, nixlMemList &mems, nixlBParams &params) const;
         /**
          * @brief  Get the backend parameters after instantiation. This will be a comprehensive
          *         list, for instance the default values used for parameters that were not
@@ -86,12 +84,10 @@ class nixlAgent {
          * @param  backend       Backend type
          * @param  mems [out]    List of supported memory types for nixl by the backend
          * @param  params [out]  List of init parameters and their values for the backend
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getBackendParams (const nixlBackendH* backend,
-                          nixl_mem_list_t &mems,
-                          nixl_b_params_t &params) const;
+        nixlStatus
+        getBackendParams(const nixlBackendH *backend, nixlMemList &mems, nixlBParams &params) const;
 
         /**
          * @brief  Instantiate a backend engine object based on the corresponding parameters
@@ -99,23 +95,20 @@ class nixlAgent {
          * @param  type          Backend type
          * @param  params        Backend specific parameters
          * @param  backend [out] Backend handle for NIXL
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        createBackend (const nixl_backend_t &type,
-                       const nixl_b_params_t &params,
-                       nixlBackendH* &backend);
+        nixlStatus
+        createBackend(const nixlBackend &type, const nixlBParams &params, nixlBackendH *&backend);
         /**
          * @brief  Register a memory/storage with NIXL. If a list of backends hints is provided
          *         (via extra_params), the registration is limited to the specified backends.
          *
          * @param  descs         Descriptor list of the buffers to be registered
          * @param  extra_params  Optional additional parameters used in registering memory
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        registerMem (const nixl_reg_dlist_t &descs,
-                     const nixl_opt_args_t* extra_params = nullptr);
+        nixlStatus
+        registerMem(const nixlRegDlist &descs, const nixlAgentOptionalArgs *extra_params = nullptr);
 
         /**
          * @brief  Deregister a memory/storage from NIXL. If a list of backends hints is provided
@@ -124,11 +117,11 @@ class nixlAgent {
          *
          * @param  descs         Descriptor list of the buffers to be deregistered
          * @param  extra_params  Optional additional parameters used in deregistering memory
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        deregisterMem (const nixl_reg_dlist_t &descs,
-                       const nixl_opt_args_t* extra_params = nullptr);
+        nixlStatus
+        deregisterMem(const nixlRegDlist &descs,
+                      const nixlAgentOptionalArgs *extra_params = nullptr);
 
         /**
          * @brief  Make connection proactively, instead of at the time of the first transfer
@@ -136,11 +129,11 @@ class nixlAgent {
          *         (via extra_params), the connection is made for the specified backends.
          *
          * @param  remote_agent  Name of the remote agent
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        makeConnection (const std::string &remote_agent,
-                        const nixl_opt_args_t* extra_params = nullptr);
+        nixlStatus
+        makeConnection(const std::string &remote_agent,
+                       const nixlAgentOptionalArgs *extra_params = nullptr);
 
         /*** Transfer Request Preparation ***/
         /**
@@ -162,13 +155,13 @@ class nixlAgent {
          * @param  descs            The descriptor list to be prepared for transfer requests
          * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
          * @param  extra_params     Optional additional parameters used in preparing dlist handle
-         * @return nixl_status_t    Error code if call was not successful
+         * @return nixlStatus       Error code if call was not successful
          */
-        nixl_status_t
-        prepXferDlist (const std::string &agent_name,
-                       const nixl_xfer_dlist_t &descs,
-                       nixlDlistH* &dlist_hndl,
-                       const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        prepXferDlist(const std::string &agent_name,
+                      const nixlXferDlist &descs,
+                      nixlDlistH *&dlist_hndl,
+                      const nixlAgentOptionalArgs *extra_params = nullptr) const;
         /**
          * @brief  Make a transfer request `req_handl` by selecting indices from already
          *         prepared descriptor list handles. NIXL automatically determines the backend
@@ -183,16 +176,16 @@ class nixlAgent {
          * @param  remote_indices   Indices list to the remote prepared descriptor list handle
          * @param  req_handle [out] Transfer request handle output
          * @param  extra_params     Optional additional parameters used in making a transfer request
-         * @return nixl_status_t    Error code if call was not successful
+         * @return nixlStatus       Error code if call was not successful
          */
-        nixl_status_t
-        makeXferReq (const nixl_xfer_op_t &operation,
-                     const nixlDlistH* local_side,
-                     const std::vector<int> &local_indices,
-                     const nixlDlistH* remote_side,
-                     const std::vector<int> &remote_indices,
-                     nixlXferReqH* &req_hndl,
-                     const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        makeXferReq(const nixlXferOp &operation,
+                    const nixlDlistH *local_side,
+                    const std::vector<int> &local_indices,
+                    const nixlDlistH *remote_side,
+                    const std::vector<int> &remote_indices,
+                    nixlXferReqH *&req_hndl,
+                    const nixlAgentOptionalArgs *extra_params = nullptr) const;
         /**
          * @brief  A combined API, to create a transfer request from two descriptor lists.
          *         NIXL will prepare each side and create a transfer handle `req_hndl`.
@@ -220,15 +213,15 @@ class nixlAgent {
          * @param  remote_agent   Remote (or self) agent name for accessing the remote (local) data
          * @param  req_hndl [out] Transfer request handle output
          * @param  extra_params   Optional extra parameters used in creating a transfer request
-         * @return nixl_status_t  Error code if call was not successful
+         * @return nixlStatus     Error code if call was not successful
          */
-        nixl_status_t
-        createXferReq (const nixl_xfer_op_t &operation,
-                       const nixl_xfer_dlist_t &local_descs,
-                       const nixl_xfer_dlist_t &remote_descs,
-                       const std::string &remote_agent,
-                       nixlXferReqH* &req_hndl,
-                       const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        createXferReq(const nixlXferOp &operation,
+                      const nixlXferDlist &local_descs,
+                      const nixlXferDlist &remote_descs,
+                      const std::string &remote_agent,
+                      nixlXferReqH *&req_hndl,
+                      const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /*** Operations on prepared Transfer Request ***/
 
@@ -240,14 +233,14 @@ class nixlAgent {
          * @param err_margin   [out] Estimated error margin of the transfer
          * @param method       [out] Method to compute the cost estimate
          * @param extra_params Optional extra parameters
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus  Error code if call was not successful
          */
-        nixl_status_t
-        estimateXferCost(const nixlXferReqH* req_hndl,
+        nixlStatus
+        estimateXferCost(const nixlXferReqH *req_hndl,
                          std::chrono::microseconds &duration,
                          std::chrono::microseconds &err_margin,
-                         nixl_cost_t &method,
-                         const nixl_opt_args_t* extra_params = nullptr) const;
+                         nixlCost &method,
+                         const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Submit a transfer request `req_hndl` which initiates a transfer.
@@ -259,20 +252,20 @@ class nixlAgent {
          *
          * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
          * @param  extra_params  Optional extra parameters used in posting a transfer request
-         * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
+         * @return nixlStatus    NIXL_IN_PROG or error code if call was not successful
          */
-        nixl_status_t
-        postXferReq (nixlXferReqH* req_hndl,
-                     const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        postXferReq(nixlXferReqH *req_hndl,
+                    const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Check the status of transfer request `req_hndl`
          *
          * @param  req_hndl      Transfer request handle after postXferReq
-         * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
+         * @return nixlStatus    NIXL_IN_PROG or error code if call was not successful
          */
-        nixl_status_t
-        getXferStatus (nixlXferReqH* req_hndl) const;
+        nixlStatus
+        getXferStatus(nixlXferReqH *req_hndl) const;
 
         /**
          * @brief  Query the backend associated with `req_hndl`. E.g., if for genNotif
@@ -280,30 +273,29 @@ class nixlAgent {
          *
          * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
          * @param  backend [out] Output backend handle chosen for the transfer request
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        queryXferBackend (const nixlXferReqH* req_hndl,
-                          nixlBackendH* &backend) const;
+        nixlStatus
+        queryXferBackend(const nixlXferReqH *req_hndl, nixlBackendH *&backend) const;
 
         /**
          * @brief  Release the transfer request `req_hndl`. If the transfer is active,
          *         it will be canceled, or return an error if the transfer cannot be aborted.
          *
          * @param  req_hndl      Transfer request handle to be released
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        releaseXferReq (nixlXferReqH* req_hndl) const;
+        nixlStatus
+        releaseXferReq(nixlXferReqH *req_hndl) const;
 
         /**
          * @brief  Release the prepared descriptor list handle `dlist_hndl`
          *
          * @param  dlist_hndl    Prepared descriptor list handle to be released
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        releasedDlistH (nixlDlistH* dlist_hndl) const;
+        nixlStatus
+        releasedDlistH(nixlDlistH *dlist_hndl) const;
 
 
         /*** Notification Handling ***/
@@ -316,11 +308,10 @@ class nixlAgent {
          *
          * @param  notif_map     Input notifications list
          * @param  extra_params  Optional extra parameters used in getting notifications
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getNotifs (nixl_notifs_t &notif_map,
-                   const nixl_opt_args_t* extra_params = nullptr);
+        nixlStatus
+        getNotifs(nixlNotifs &notif_map, const nixlAgentOptionalArgs *extra_params = nullptr);
 
         /**
          * @brief  Generate a notification, not bound to a transfer, e.g., for control.
@@ -332,42 +323,43 @@ class nixlAgent {
          * @param  remote_agent  Remote agent name as string
          * @param  msg           Notification message to be sent
          * @param  extra_params  Optional extra parameters used in generating a standalone notif
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        genNotif (const std::string &remote_agent,
-                  const nixl_blob_t &msg,
-                  const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        genNotif(const std::string &remote_agent,
+                 const nixlBlob &msg,
+                 const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /*** Metadata handling through side channel ***/
         /**
          * @brief  Get metadata blob for this agent, to be given to other agents.
          *
          * @param  str [out]     The serialized metadata blob
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getLocalMD (nixl_blob_t &str) const;
+        nixlStatus
+        getLocalMD(nixlBlob &str) const;
 
         /**
          * @brief  Get partial metadata blob for this agent, to be given to other agents.
          *         If `descs` is empty, only backends' connection info is included in the metadata,
-         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
-         *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
-         *         and if `extra_params->includeConnInfo` is true, the connection info of the
-         *         backends supporting the memory type is also included.
-         *         If `extra_params->backends` is non-empty, only the descriptors supported by the
-         *         backends in the list and the backends' connection info are included in the metadata.
+         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory
+         *         type. If `descs` is non-empty, the metadata of the descriptors in the list are
+         *         included, and if `extra_params->includeConnInfo` is true, the connection info of
+         *         the backends supporting the memory type is also included. If
+         *         `extra_params->backends` is non-empty, only the descriptors supported by the
+         *         backends in the list and the backends' connection info are included in the
+         *         metadata.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
          * @param  str           [out] The serialized metadata blob
          * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
-         * @return nixl_status_t       Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        getLocalPartialMD(const nixl_reg_dlist_t &descs,
-                          nixl_blob_t &str,
-                          const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        getLocalPartialMD(const nixlRegDlist &descs,
+                          nixlBlob &str,
+                          const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Load other agent's metadata and unpack it internally. Now the local
@@ -375,11 +367,10 @@ class nixlAgent {
          *
          * @param  remote_metadata  Serialized metadata blob to be loaded
          * @param  agent_name [out] Agent name extracted from the loaded metadata blob
-         * @return nixl_status_t    Error code if call was not successful
+         * @return nixlStatus       Error code if call was not successful
          */
-        nixl_status_t
-        loadRemoteMD (const nixl_blob_t &remote_metadata,
-                      std::string &agent_name);
+        nixlStatus
+        loadRemoteMD(const nixlBlob &remote_metadata, std::string &agent_name);
 
         /**
          * @brief  Invalidate the remote agent metadata cached locally. This will
@@ -387,48 +378,51 @@ class nixlAgent {
          *         transfers can be initiated towards that agent.
          *
          * @param  remote_agent  Remote agent name to invalidate its metadata blob
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        invalidateRemoteMD (const std::string &remote_agent);
+        nixlStatus
+        invalidateRemoteMD(const std::string &remote_agent);
 
         /*** Metadata handling through direct channels (p2p socket and ETCD) ***/
         /**
          * @brief  Send your own agent metadata to a remote location.
          *
          * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer sending of your metadata.
+         *                       If IP is specified, this will enable peer to peer sending of your
+         *                       metadata.
          *                       If IP unspecified, this will send your data to the metadata server.
          *                       Port can be specified or defaults to default_comm_port.
          *
-         * @return nixl_status_t Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        sendLocalMD (const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        sendLocalMD(const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Send partial metadata blob for this agent to peer or central metadata server
          *         If `descs` is empty, only backends' connection info is included in the metadata,
-         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
-         *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
-         *         and if `extra_params->includeConnInfo` is true, the connection info of the
-         *         backends supporting the memory type is also included.
-         *         If `extra_params->backends` is non-empty, only the descriptors supported by the
-         *         backends in the list and the backends' connection info are included in the metadata.
-         *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer, otherwise
-         *         it will be sent to the central metadata server, if supported.
-         *         If 'extra_params->port' can be set in addition to IP address, or will default to default_comm_port.
-         *         The 'extra_params->metadataLabel' is required when sending to a central metadata server and
-         *         ignored when sending to a peer.
+         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory
+         *         type. If `descs` is non-empty, the metadata of the descriptors in the list are
+         *         included, and if `extra_params->includeConnInfo` is true, the connection info of
+         *         the backends supporting the memory type is also included. If
+         *         `extra_params->backends` is non-empty, only the descriptors supported by the
+         *         backends in the list and the backends' connection info are included in the
+         *         metadata. If 'extra_params->ip_addr' is set, the metadata will only be sent to
+         *         a single peer, otherwise it will be sent to the central metadata server, if
+         *         supported.
+         *         If 'extra_params->port' can be set in addition to IP address, or will default to
+         *         default_comm_port.
+         *         The 'extra_params->metadataLabel' is required when sending to a central metadata
+         *         server and ignored when sending to a peer.
          *
          * @param  descs         [in]  Descriptor list to include in the metadata
          * @param  str           [out] The serialized metadata blob
          * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
-         * @return nixl_status_t       Error code if call was not successful
+         * @return nixlStatus          Error code if call was not successful
          */
-        nixl_status_t
-        sendLocalPartialMD(const nixl_reg_dlist_t &descs,
-                           const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        sendLocalPartialMD(const nixlRegDlist &descs,
+                           const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Fetch other agent's metadata from a peer or central metadata server,
@@ -438,32 +432,33 @@ class nixlAgent {
          *
          * @param  remote_name   Name of remote agent to fetch from ETCD or socket.
          * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer fetching of metadata.
-         *                       If IP is unspecified, this will fetch from the metadata server.
-         *                       Port can be specified or defaults to default_comm_port.
-         *                       If metadataLabel is specified, it will be used as the label of the metadata
-         *                       to be fetched, which can be partial metadata. Otherwise, the default label
-         *                       of the full metadata will be used for fetching.
+         *                       If IP is specified, this will enable peer to peer fetching of
+         *                       metadata. If IP is unspecified, this will fetch from the
+         *                       metadata server. Port can be specified or defaults to
+         *                       default_comm_port. If metadataLabel is specified, it will be
+         *                       used as the label of the metadata to be fetched, which can be
+         *                       partial metadata. Otherwise, the default label of the full
+         *                       metadata will be used for fetching.
          *
-         * @return nixl_status_t    Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        fetchRemoteMD (const std::string remote_name,
-                       const nixl_opt_args_t* extra_params = nullptr);
+        nixlStatus
+        fetchRemoteMD(const std::string remote_name,
+                      const nixlAgentOptionalArgs *extra_params = nullptr);
 
         /**
          * @brief  Invalidate your own memory in one/all remote agent(s).
          *
          * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer invalidation of metadata.
-         *                       If IP is unspecified, this will invalidate all agent's labels
-         *                       from the metadata server.
-         *                       Port can be specified or defaults to default_comm_port.
+         *                       If IP is specified, this will enable peer to peer invalidation of
+         *                       metadata. If IP is unspecified, this will invalidate all agent's
+         *                       labels from the metadata server. Port can be specified or defaults
+         *                       to default_comm_port.
          *
-         * @return nixl_status_t    Error code if call was not successful
+         * @return nixlStatus    Error code if call was not successful
          */
-        nixl_status_t
-        invalidateLocalMD (const nixl_opt_args_t* extra_params = nullptr) const;
+        nixlStatus
+        invalidateLocalMD(const nixlAgentOptionalArgs *extra_params = nullptr) const;
 
         /**
          * @brief  Check if metadata is available for a remote agent.
@@ -471,12 +466,10 @@ class nixlAgent {
          *         can be specified; otherwise, empty `descs` can be passed.
          *
          * @param  str           Remote agent to check for
-         * @return nixl_status_t Error code, NOT_FOUND if metadata not found
+         * @return nixlStatus    Error code, NOT_FOUND if metadata not found
          */
-        nixl_status_t
-        checkRemoteMD (const std::string remote_name,
-                       const nixl_xfer_dlist_t &descs) const;
-
+        nixlStatus
+        checkRemoteMD(const std::string remote_name, const nixlXferDlist &descs) const;
 };
 
 #endif

--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -59,7 +59,7 @@ class nixlBasicDesc {
          *
          * @param str   Serialized Descriptor
          */
-        nixlBasicDesc(const nixl_blob_t &str); // deserializer
+        nixlBasicDesc(const nixlBlob &str); // deserializer
         /**
          * @brief Copy constructor for nixlBasicDesc
          *
@@ -113,7 +113,8 @@ class nixlBasicDesc {
         /**
          * @brief Serialize descriptor into a blob
          */
-        nixl_blob_t serialize() const;
+        nixlBlob
+        serialize() const;
         /**
          * @brief Print descriptor for debugging
          *
@@ -130,7 +131,7 @@ class nixlBasicDesc {
 class nixlBlobDesc : public nixlBasicDesc {
     public:
         /** @var blob for metadata information */
-        nixl_blob_t metaInfo;
+        nixlBlob metaInfo;
 
         /** @var Reuse parent constructor without the metadata */
         using nixlBasicDesc::nixlBasicDesc;
@@ -143,21 +144,23 @@ class nixlBlobDesc : public nixlBasicDesc {
          * @param devID     deviceID/BlockID/fileID
          * @param meta_info Metadata blob
          */
-         nixlBlobDesc(const uintptr_t &addr, const size_t &len,
-                      const uint64_t &dev_id, const nixl_blob_t &meta_info);
+        nixlBlobDesc(const uintptr_t &addr,
+                     const size_t &len,
+                     const uint64_t &dev_id,
+                     const nixlBlob &meta_info);
         /**
          * @brief Constructor for nixlBlobDesc from nixlBasicDesc and metadata blob
          *
          * @param desc      nixlBasicDesc object
          * @param meta_info Metadata blob
          */
-        nixlBlobDesc(const nixlBasicDesc &desc, const nixl_blob_t &meta_info);
+        nixlBlobDesc(const nixlBasicDesc &desc, const nixlBlob &meta_info);
         /**
          * @brief Deserializer constructor for nixlBlobDesc with serialized blob
          *
          * @param str   Serialized blob from another nixlBlobDesc
          */
-        nixlBlobDesc(const nixl_blob_t &str);
+        nixlBlobDesc(const nixlBlob &str);
         /**
          * @brief Operator overloading (==) to compare nixlBlobDesc objects
          *
@@ -169,7 +172,8 @@ class nixlBlobDesc : public nixlBasicDesc {
         /**
          * @brief Serialize nixlBlobDesc to a blob
          */
-        nixl_blob_t serialize() const;
+        nixlBlob
+        serialize() const;
         /**
          * @brief Print nixlBlobDesc for debugging purpose
          *
@@ -187,7 +191,7 @@ template<class T>
 class nixlDescList {
     private:
         /** @var NIXL memory type */
-        nixl_mem_t     type;
+        nixlMemType type;
         /** @var Flag for if list should be kept sorted
          *       Comparison is done based on nixlBasicDesc (<) operator which
          *       has comparison order of devID, then addr, then len.
@@ -204,9 +208,7 @@ class nixlDescList {
          * @param sorted       Flag to set sorted option (default = false)
          * @param init_size    initial size for descriptor list (default = 0)
          */
-        nixlDescList(const nixl_mem_t &type,
-                     const bool &sorted=false,
-                     const int &init_size=0);
+        nixlDescList(const nixlMemType &type, const bool &sorted = false, const int &init_size = 0);
         /**
          * @brief Deserializer constructor for nixlDescList from nixlSerDes object
          *        which serializes/deserializes our classes into/from blobs
@@ -234,7 +236,10 @@ class nixlDescList {
         /**
          * @brief      Get NIXL memory type for this DescList
          */
-        inline nixl_mem_t getType() const { return type; }
+        nixlMemType
+        getType() const {
+            return type;
+        }
         /**
          * @brief get sorted flag
          */
@@ -326,23 +331,32 @@ class nixlDescList {
         /**
          * @brief Serialize a descriptor list with nixlSerDes class
          * @param serializer nixlSerDes object to serialize nixlDescList
-         * @return nixl_status_t Error code if serialize was not successful
+         * @return nixlStatus Error code if serialize was not successful
          */
-        nixl_status_t serialize(nixlSerDes* serializer) const;
+        nixlStatus
+        serialize(nixlSerDes *serializer) const;
         /**
          * @brief Print the descriptor list for debugging
          */
         void print() const;
 };
 /**
- * @brief A typedef for a nixlDescList<nixlBasicDesc>
+ * @brief An alias for a nixlDescList<nixlBasicDesc>
  *        used for creating transfer descriptor lists
  */
-using nixl_xfer_dlist_t = nixlDescList<nixlBasicDesc>;
+using nixlXferDlist = nixlDescList<nixlBasicDesc>;
 /**
- * @brief A typedef for a nixlDescList<nixlBlobDesc>
+ * @deprecated Use nixlXferDlist instead
+ */
+using nixl_xfer_dlist_t = nixlXferDlist;
+/**
+ * @brief An alias for a nixlDescList<nixlBlobDesc>
  *        used for creating registratoin descriptor lists
  */
-using nixl_reg_dlist_t = nixlDescList<nixlBlobDesc>;
+using nixlRegDlist = nixlDescList<nixlBlobDesc>;
+/**
+ * @deprecated Use nixlRegDlist instead
+ */
+using nixl_reg_dlist_t = nixlRegDlist;
 
 #endif

--- a/src/api/cpp/nixl_params.h
+++ b/src/api/cpp/nixl_params.h
@@ -36,7 +36,7 @@ class nixlAgentConfig {
         /** @var Port for listener thread to use */
         int      listenPort;
         /** @var synchronization mode for multi-threaded environment execution */
-        nixl_thread_sync_t syncMode;
+        nixlThreadSync syncMode;
 
     public:
 
@@ -63,19 +63,19 @@ class nixlAgentConfig {
          * @param pthr_delay_us      Optional delay for pthread in us
          * @param lthr_delay_us      Optional delay for listener thread in us
          */
-        nixlAgentConfig (const bool use_prog_thread,
-                         const bool use_listen_thread=false,
-                         const int port=0,
-                         nixl_thread_sync_t sync_mode=nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT,
-                         unsigned int num_workers = 1,
-                         const uint64_t pthr_delay_us=0,
-                         const uint64_t lthr_delay_us = 100000) :
-                         useProgThread(use_prog_thread),
-                         useListenThread(use_listen_thread),
-                         listenPort(port),
-                         syncMode(sync_mode),
-                         pthrDelay(pthr_delay_us),
-                         lthrDelay(lthr_delay_us) { }
+        nixlAgentConfig(const bool use_prog_thread,
+                        const bool use_listen_thread = false,
+                        const int port = 0,
+                        nixlThreadSync sync_mode = nixlThreadSync::NIXL_THREAD_SYNC_DEFAULT,
+                        unsigned int num_workers = 1,
+                        const uint64_t pthr_delay_us = 0,
+                        const uint64_t lthr_delay_us = 100000)
+            : useProgThread(use_prog_thread),
+              useListenThread(use_listen_thread),
+              listenPort(port),
+              syncMode(sync_mode),
+              pthrDelay(pthr_delay_us),
+              lthrDelay(lthr_delay_us) {}
 
         /**
          * @brief Copy constructor for nixlAgentConfig object

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -32,23 +32,31 @@ class nixlAgentData;
 /*** NIXL memory type, operation and status enums ***/
 
 /**
- * @enum   nixl_mem_t
+ * @enum   nixlMemType
  * @brief  An enumeration of segment types for NIXL
  *         FILE_SEG must be last
  */
-enum nixl_mem_t {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG};
+enum nixlMemType { DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG };
+/**
+ * @deprecated Use nixlMemType instead
+ */
+using nixl_mem_t = nixlMemType;
 
 /**
- * @enum   nixl_xfer_op_t
+ * @enum   nixlXferOp
  * @brief  An enumeration of different transfer types for NIXL
  */
-enum nixl_xfer_op_t {NIXL_READ, NIXL_WRITE};
+enum nixlXferOp { NIXL_READ, NIXL_WRITE };
+/**
+ * @deprecated Use nixlXferOp instead
+ */
+using nixl_xfer_op_t = nixlXferOp;
 
 /**
- * @enum   nixl_status_t
+ * @enum   nixlStatus
  * @brief  An enumeration of status values and error codes for NIXL
  */
-enum nixl_status_t {
+enum nixlStatus {
     NIXL_IN_PROG = 1,
     NIXL_SUCCESS = 0,
     NIXL_ERR_NOT_POSTED = -1,
@@ -62,17 +70,25 @@ enum nixl_status_t {
     NIXL_ERR_NOT_SUPPORTED = -9,
     NIXL_ERR_REMOTE_DISCONNECT = -10
 };
+/**
+ * @deprecated Use nixlStatus instead
+ */
+using nixl_status_t = nixlStatus;
 
 /**
- * @enum nixl_thread_sync_t
+ * @enum nixlThreadSync
  * @brief An enumeration of supported synchronization modes for NIXL
  */
-enum class nixl_thread_sync_t {
+enum class nixlThreadSync {
     NIXL_THREAD_SYNC_NONE,
     NIXL_THREAD_SYNC_STRICT,
     NIXL_THREAD_SYNC_RW,
     NIXL_THREAD_SYNC_DEFAULT = NIXL_THREAD_SYNC_NONE,
 };
+/**
+ * @deprecated Use nixlThreadSync instead
+ */
+using nixl_thread_sync_t = nixlThreadSync;
 
 /**
  * @namespace nixlEnumStrings
@@ -80,43 +96,66 @@ enum class nixl_thread_sync_t {
  *            of different enums
  */
 namespace nixlEnumStrings {
-    std::string memTypeStr(const nixl_mem_t &mem);
-    std::string xferOpStr (const nixl_xfer_op_t &op);
-    std::string statusStr (const nixl_status_t &status);
-}
+std::string
+memTypeStr(const nixlMemType &mem);
+std::string
+xferOpStr(const nixlXferOp &op);
+std::string
+statusStr(const nixlStatus &status);
+} // namespace nixlEnumStrings
 
 
-/*** NIXL typedefs and defines used in the API ***/
+/*** NIXL aliases and constant expressions used in the API ***/
 
 /**
- * @brief A typedef for a std::string to identify nixl backends
+ * @brief An alias for a std::string to identify nixl backends
  */
-using nixl_backend_t = std::string;
+using nixlBackend = std::string;
+/**
+ * @deprecated Use nixlBackend instead
+ */
+using nixl_backend_t = nixlBackend;
 
 /**
- * @brief A typedef for a std::string as nixl blob
+ * @brief An alias for a std::string as nixl blob
  *        std::string supports \0 natively, so it can be looked as a void* of data,
  *        with specified length. Giving it a new name to be clear in the API and
  *        preventing users to think it's a string and call c_str().
  */
-using nixl_blob_t = std::string;
+using nixlBlob = std::string;
+/**
+ * @deprecated Use nixlBlob instead
+ */
+using nixl_blob_t = nixlBlob;
 
 /**
- * @brief A typedef for a std::vector<nixl_mem_t> to create nixl_mem_list_t objects.
+ * @brief An alias for a std::vector<nixlMemType> to create nixlMemList objects.
  */
-using nixl_mem_list_t = std::vector<nixl_mem_t>;
+using nixlMemList = std::vector<nixlMemType>;
+/**
+ * @deprecated Use nixlMemList instead
+ */
+using nixl_mem_list_t = nixlMemList;
 
 /**
- * @brief A typedef for a  std::unordered_map<std::string, std::string>
- *        to hold nixl_b_params_t .
+ * @brief An alias for a std::unordered_map<std::string, std::string>
+ *        to hold nixlBParams
  */
-using nixl_b_params_t = std::unordered_map<std::string, std::string>;
+using nixlBParams = std::unordered_map<std::string, std::string>;
+/**
+ * @deprecated Use nixlBParams instead
+ */
+using nixl_b_params_t = nixlBParams;
 
 /**
- * @brief A typedef for a  std::unordered_map<std::string, std::vector<nixl_blob_t>>
- *        to hold nixl_notifs_t (nixl notifications)
+ * @brief An alias for a  std::unordered_map<std::string, std::vector<nixlBlob>>
+ *        to hold nixlNotifs (nixl notifications)
  */
-using nixl_notifs_t = std::unordered_map<std::string, std::vector<nixl_blob_t>>;
+using nixlNotifs = std::unordered_map<std::string, std::vector<nixlBlob>>;
+/**
+ * @deprecated Use nixlNotifs instead
+ */
+using nixl_notifs_t = nixlNotifs;
 
 /**
  * @brief A constant to define the default communication port.
@@ -137,12 +176,16 @@ extern const std::string default_partial_metadata_label;
 
 
 /**
- * @enum nixl_cost_t
+ * @enum nixlCost
  * @brief An enumeration of cost types for transfer cost estimation.
  */
-enum class nixl_cost_t {
+enum class nixlCost {
     ANALYTICAL_BACKEND = 0, // Analytical backend cost estimate
 };
+/**
+ * @deprecated Use nixlCost instead
+ */
+using nixl_cost_t = nixlCost;
 
 /**
  * @struct nixlAgentOptionalArgs
@@ -160,7 +203,7 @@ struct nixlAgentOptionalArgs {
      * @var notifMsg A message to be used in createXferReq / makeXferReq / postXferReq,
      *               if a notification message is desired
      */
-    nixl_blob_t notifMsg;
+    nixlBlob notifMsg;
 
     /**
      * @var hasNotif boolean value to indicate that a notification is provided, or to
@@ -205,11 +248,10 @@ struct nixlAgentOptionalArgs {
     /**
      * @var Backend custom parameter
      */
-    nixl_blob_t customParam;
+    nixlBlob customParam;
 };
 /**
- * @brief A typedef for a nixlAgentOptionalArgs
- *        for providing extra optional arguments
+ * @deprecated Use nixlAgentOptionalArgs directly instead
  */
 using nixl_opt_args_t = nixlAgentOptionalArgs;
 

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -84,10 +84,11 @@ class TestErrorHandling : public testing::TestWithParam<std::string> {
         void fillRegList(nixl_xfer_dlist_t& dlist, nixlBasicDesc& desc) const;
         std::string getLocalMD() const;
         void loadRemoteMD(const std::string& remote_name);
-        nixl_status_t createXferReq(const nixl_xfer_op_t& op,
-                                    nixl_xfer_dlist_t& sReq_descs,
-                                    nixl_xfer_dlist_t& rReq_descs,
-                                    nixlXferReqH*& req_handle) const;
+        nixl_status_t
+        createXferReq(const nixlXferOp &op,
+                      nixl_xfer_dlist_t &sReq_descs,
+                      nixl_xfer_dlist_t &rReq_descs,
+                      nixlXferReqH *&req_handle) const;
         nixl_status_t postXferReq(nixlXferReqH* req_handle) const;
         nixl_status_t waitForCompletion(nixlXferReqH* req_handle);
         nixl_status_t waitForNotif(const std::string& expectedNotif);
@@ -109,13 +110,16 @@ protected:
     };
 
     TestErrorHandling();
-    template<TestType test_type, enum nixl_xfer_op_t op> void testXfer();
+    template<TestType test_type, nixlXferOp op>
+    void
+    testXfer();
 
 private:
     template<TestType test_type> bool isFailure(size_t iter);
     template<TestType test_type> size_t numIter();
     void exchangeMetaData();
-    nixlXferReqH* postXfer(enum nixl_xfer_op_t op, bool target_failure);
+    nixlXferReqH *
+    postXfer(nixlXferOp op, bool target_failure);
 
     ScopedEnv    m_env;
     Agent        m_Initiator;
@@ -156,10 +160,10 @@ void TestErrorHandling::Agent::loadRemoteMD(const std::string& remote_name) {
 }
 
 nixl_status_t
-TestErrorHandling::Agent::createXferReq(const nixl_xfer_op_t& op,
-                                     nixl_xfer_dlist_t& sReq_descs,
-                                     nixl_xfer_dlist_t& rReq_descs,
-                                     nixlXferReqH*& req_handle) const {
+TestErrorHandling::Agent::createXferReq(const nixlXferOp &op,
+                                        nixl_xfer_dlist_t &sReq_descs,
+                                        nixl_xfer_dlist_t &rReq_descs,
+                                        nixlXferReqH *&req_handle) const {
     nixl_opt_args_t extra_params = { .backends = {m_backend} };
     extra_params.notifMsg        = "notification";
     extra_params.hasNotif        = true;
@@ -214,8 +218,9 @@ TestErrorHandling::TestErrorHandling() : m_backend_name(GetParam())
     m_env.addVar("NIXL_PLUGIN_DIR", std::string(BUILD_DIR) + "/src/plugins/ucx");
 }
 
-template<TestErrorHandling::TestType test_type, enum nixl_xfer_op_t op>
-void TestErrorHandling::testXfer() {
+template<TestErrorHandling::TestType test_type, nixlXferOp op>
+void
+TestErrorHandling::testXfer() {
     m_Initiator.init("initiator", m_backend_name);
     m_Target.init("target", m_backend_name);
 
@@ -268,8 +273,8 @@ void TestErrorHandling::exchangeMetaData() {
     m_Target.loadRemoteMD(m_Initiator.getLocalMD());
 }
 
-nixlXferReqH*
-TestErrorHandling::postXfer(enum nixl_xfer_op_t op, bool target_failure) {
+nixlXferReqH *
+TestErrorHandling::postXfer(nixlXferOp op, bool target_failure) {
     EXPECT_TRUE(op == NIXL_WRITE || op == NIXL_READ);
 
     nixlBasicDesc sReq_src;


### PR DESCRIPTION
## What?
Applied naming conventions according to NIXL code style.
Deprecated old names keeping them as aliases to not break the API.
