### PR TITLE
clang-tidy: Add config to enforce naming style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,20 @@
+Checks: '-*,readability-identifier-naming'
+CheckOptions:
+    # Local variables and function arguments
+    - { key: readability-identifier-naming.LocalVariableCase, value: lower_case }
+    - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+    # Class, struct, union, and enum type names
+    - { key: readability-identifier-naming.ClassCase, value: camelBack }
+    - { key: readability-identifier-naming.StructCase, value: camelBack }
+    - { key: readability-identifier-naming.UnionCase, value: camelBack }
+    - { key: readability-identifier-naming.EnumCase, value: camelBack }
+    # Fields and methods for classes, structs, and unions
+    - { key: readability-identifier-naming.ClassMemberCase, value: camelBack }
+    - { key: readability-identifier-naming.StructMemberCase, value: camelBack }
+    - { key: readability-identifier-naming.UnionMemberCase, value: camelBack }
+    - { key: readability-identifier-naming.MethodCase, value: camelBack }
+    # Private class members (fields)
+    - { key: readability-identifier-naming.PrivateMemberCase, value: camelBack }
+    - { key: readability-identifier-naming.PrivateMemberSuffix, value: _ }
+    # Enum values (enumerators)
+    - { key: readability-identifier-naming.EnumConstantCase, value: UPPER_CASE }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,3 +18,9 @@ CheckOptions:
     - { key: readability-identifier-naming.PrivateMemberSuffix, value: _ }
     # Enum values (enumerators)
     - { key: readability-identifier-naming.EnumConstantCase, value: UPPER_CASE }
+    # For 'using' type aliases
+    - { key: readability-identifier-naming.TypeAliasCase, value: lower_case }
+    - { key: readability-identifier-naming.TypeAliasSuffix, value: _t }
+    # For 'typedef' type aliases
+    - { key: readability-identifier-naming.TypedefCase, value: lower_case }
+    - { key: readability-identifier-naming.TypedefSuffix, value: _t }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,7 @@ CheckOptions:
     - { key: readability-identifier-naming.ClassCase, value: camelBack }
     - { key: readability-identifier-naming.StructCase, value: camelBack }
     - { key: readability-identifier-naming.UnionCase, value: camelBack }
-    - { key: readability-identifier-naming.EnumCase, value: camelBack }
+    - { key: readability-identifier-naming.EnumCase, value: lower_case }
     # Fields and methods for classes, structs, and unions
     - { key: readability-identifier-naming.ClassMemberCase, value: camelBack }
     - { key: readability-identifier-naming.StructMemberCase, value: camelBack }


### PR DESCRIPTION
## What?
Create a config file for clang-tidy tool in order to enforce naming style of types, functions, and variables according to NIXL code style.

## Why?
Both [internal](https://github.com/ai-dynamo/nixl/pull/559#discussion_r2202896758) and [external](https://github.com/ai-dynamo/nixl/pull/494#discussion_r2167340898) contributors have often been naming types, functions, and variables incorrectly. Moreover, due to complex NIXL naming conventions these mistakes often slip past code review.

## How?
Clang-tidy is a tool readily available in Ubuntu and other distro's repositories similarly to clang-format that is already used by NIXL. Excerpt from the tool output with provided config on a NIXL source:

```
../../home/vladbu/src/nixl/src/plugins/ucx/ucx_backend.cpp:236:59: warning: invalid case style for parameter 'devId' [readability-identifier-naming]
  236 | int nixlUcxEngine::vramUpdateCtx(void *address, uint64_t  devId, bool &restart_reqd)
      |                                                           ^~~~~
      |                                                           dev_id
  237 | {
  238 |     int ret;
  239 |     bool was_updated;
  240 |
  241 |     restart_reqd = false;
  242 |
  243 |     if(!cuda_addr_wa) {
  244 |         // Nothing to do
  245 |         return 0;
  246 |     }
  247 |
  248 |     ret = cudaCtx->cudaUpdateCtxPtr(address, devId, was_updated);
      |                                              ~~~~~
      |                                              dev_id
../../home/vladbu/src/nixl/src/plugins/ucx/ucx_backend.cpp:288:14: warning: invalid case style for method 'is_complete' [readability-identifier-naming]
  288 |         bool is_complete() const { return _completed; }
      |              ^~~~~~~~~~~
      |              isComplete
../../home/vladbu/src/nixl/src/plugins/ucx/ucx_backend.cpp:322:12: warning: invalid case style for struct 'Notif' [readability-identifier-naming]
  322 |     struct Notif {
      |            ^~~~~
      |            notif
  323 |             std::string agent;
  324 |             nixl_blob_t payload;
  325 |             Notif(const std::string& remote_agent, const nixl_blob_t& msg)
      |             ~~~~~
      |             notif
  326 |                     : agent(remote_agent), payload(msg) {}
  327 |     };
  328 |     std::optional<Notif> notif;
      |                   ~~~~~
      |                   notif

```