### PR TITLE
Add support for parallel nixlbench tests

### DIFF
--- a/benchmark/kvbench/commands/args.py
+++ b/benchmark/kvbench/commands/args.py
@@ -174,6 +174,12 @@ def nixl_bench_args(func):
         type=bool,
         help="Enable VMM memory allocation when DRAM is requested",
     )(func)
+    func = click.option(
+        "--benchmark-name",
+        type=str,
+        help="Name of benchmark (default: default)",
+        default="default",
+    )(func)
     return func
 
 

--- a/benchmark/kvbench/commands/args.py
+++ b/benchmark/kvbench/commands/args.py
@@ -175,9 +175,9 @@ def nixl_bench_args(func):
         help="Enable VMM memory allocation when DRAM is requested",
     )(func)
     func = click.option(
-        "--benchmark-name",
+        "--benchmark-group",
         type=str,
-        help="Name of benchmark (default: default)",
+        help="Name of benchmark group (default: default). Use different names to run multiple benchmarks in parallel",
         default="default",
     )(func)
     return func

--- a/benchmark/kvbench/commands/nixlbench.py
+++ b/benchmark/kvbench/commands/nixlbench.py
@@ -59,7 +59,7 @@ class NIXLBench:
         total_buffer_size=None,
         warmup_iter=100,
         worker_type="nixl",
-        benchmark_name="default",
+        benchmark_group="default",
     ):
         """
         Initialize a NIXLBench instance with benchmark configuration.
@@ -67,7 +67,7 @@ class NIXLBench:
         Args:
             model (BaseModelArch): Model architecture specification.
             model_config (ModelConfig): Model runtime and system configuration.
-            benchmark_name (str, optional): Name of benchmark. Defaults to "default".
+            benchmark_group (str, optional): Name of benchmark group. Defaults to "default".
             backend (str, optional): Communication backend. Defaults to "UCX".
             check_consistency (bool, optional): Whether to check consistency. Defaults to False.
             device_list (str, optional): List of devices to use. Defaults to "all".
@@ -100,7 +100,7 @@ class NIXLBench:
         """
         self.model = model
         self.model_config = model_config
-        self.benchmark_name = benchmark_name
+        self.benchmark_group = benchmark_group
         self.backend = backend
         self.check_consistency = check_consistency
         self.device_list = device_list
@@ -226,7 +226,7 @@ class NIXLBench:
             dict: Dictionary containing all benchmark parameters.
         """
         return {
-            "benchmark_name": self.benchmark_name,
+            "benchmark_group": self.benchmark_group,
             "backend": self.backend,
             "check_consistency": self.check_consistency,
             "device_list": self.device_list,
@@ -299,7 +299,7 @@ class NIXLBench:
             "total_buffer_size": 8589934592,
             "warmup_iter": 100,
             "worker_type": "nixl",
-            "benchmark_name": "default",
+            "benchmark_group": "default",
         }
 
     def plan(self, format: str = "text"):

--- a/benchmark/kvbench/commands/nixlbench.py
+++ b/benchmark/kvbench/commands/nixlbench.py
@@ -59,6 +59,7 @@ class NIXLBench:
         total_buffer_size=None,
         warmup_iter=100,
         worker_type="nixl",
+        benchmark_name="default",
     ):
         """
         Initialize a NIXLBench instance with benchmark configuration.
@@ -66,6 +67,7 @@ class NIXLBench:
         Args:
             model (BaseModelArch): Model architecture specification.
             model_config (ModelConfig): Model runtime and system configuration.
+            benchmark_name (str, optional): Name of benchmark. Defaults to "default".
             backend (str, optional): Communication backend. Defaults to "UCX".
             check_consistency (bool, optional): Whether to check consistency. Defaults to False.
             device_list (str, optional): List of devices to use. Defaults to "all".
@@ -98,6 +100,7 @@ class NIXLBench:
         """
         self.model = model
         self.model_config = model_config
+        self.benchmark_name = benchmark_name
         self.backend = backend
         self.check_consistency = check_consistency
         self.device_list = device_list
@@ -223,6 +226,7 @@ class NIXLBench:
             dict: Dictionary containing all benchmark parameters.
         """
         return {
+            "benchmark_name": self.benchmark_name,
             "backend": self.backend,
             "check_consistency": self.check_consistency,
             "device_list": self.device_list,
@@ -295,6 +299,7 @@ class NIXLBench:
             "total_buffer_size": 8589934592,
             "warmup_iter": 100,
             "worker_type": "nixl",
+            "benchmark_name": "default",
         }
 
     def plan(self, format: str = "text"):

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -28,15 +28,16 @@
 #define ETCD_EP_DEFAULT "http://localhost:2379"
 
 // ETCD Runtime implementation
-xferBenchEtcdRT::xferBenchEtcdRT(const std::string& etcd_endpoints, const int size,
-                                 int *terminate_input) {
+xferBenchEtcdRT::xferBenchEtcdRT(const std::string& benchmark_name,
+                                 const std::string& etcd_endpoints,
+                                 const int size, int *terminate_input) {
     // Store parameters for later use in setup
     stored_etcd_endpoints = etcd_endpoints.empty() ? ETCD_EP_DEFAULT : etcd_endpoints;
     global_size = size;
     terminate = terminate_input;
 
     // Initialize other members
-    namespace_prefix = "xferbench/"; // Namespace for XFER benchmark
+    namespace_prefix = "xferbench/" + benchmark_name + "/"; // Namespace for XFER benchmark
     barrier_gen = 0;
     my_rank = -1; // Will be set in setup()
 

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -28,9 +28,10 @@
 #define ETCD_EP_DEFAULT "http://localhost:2379"
 
 // ETCD Runtime implementation
-xferBenchEtcdRT::xferBenchEtcdRT(const std::string& benchmark_name,
-                                 const std::string& etcd_endpoints,
-                                 const int size, int *terminate_input) {
+xferBenchEtcdRT::xferBenchEtcdRT(const std::string &benchmark_name,
+                                 const std::string &etcd_endpoints,
+                                 const int size,
+                                 int *terminate_input) {
     // Store parameters for later use in setup
     stored_etcd_endpoints = etcd_endpoints.empty() ? ETCD_EP_DEFAULT : etcd_endpoints;
     global_size = size;

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -28,7 +28,7 @@
 #define ETCD_EP_DEFAULT "http://localhost:2379"
 
 // ETCD Runtime implementation
-xferBenchEtcdRT::xferBenchEtcdRT(const std::string &benchmark_name,
+xferBenchEtcdRT::xferBenchEtcdRT(const std::string &benchmark_group,
                                  const std::string &etcd_endpoints,
                                  const int size,
                                  int *terminate_input) {
@@ -38,7 +38,7 @@ xferBenchEtcdRT::xferBenchEtcdRT(const std::string &benchmark_name,
     terminate = terminate_input;
 
     // Initialize other members
-    namespace_prefix = "xferbench/" + benchmark_name + "/"; // Namespace for XFER benchmark
+    namespace_prefix = "xferbench/" + benchmark_group + "/"; // Namespace for XFER benchmark
     barrier_gen = 0;
     my_rank = -1; // Will be set in setup()
 

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -46,7 +46,7 @@ private:
     // ETCD connection settings
     std::string stored_etcd_endpoints;
     std::string namespace_prefix;
-    std::string benchmark_name;
+    std::string benchmark_group;
     std::unique_ptr<etcd::Client> client;
 
     int my_rank; // Rank information
@@ -73,7 +73,7 @@ private:
     }
 
 public:
-    xferBenchEtcdRT(const std::string &benchmark_name,
+    xferBenchEtcdRT(const std::string &benchmark_group,
                     const std::string &etcd_endpoints,
                     const int size,
                     int *terminate = nullptr);

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -46,6 +46,7 @@ private:
     // ETCD connection settings
     std::string stored_etcd_endpoints;
     std::string namespace_prefix;
+    std::string benchmark_name;
     std::unique_ptr<etcd::Client> client;
 
     int my_rank; // Rank information
@@ -68,11 +69,13 @@ private:
             suffix = "/" + std::to_string(rank);
         }
 
-        return namespace_prefix + name + suffix;
+        return namespace_prefix + "/" + name + suffix;
     }
 
 public:
-    xferBenchEtcdRT(const std::string& etcd_endpoints, const int size,
+    xferBenchEtcdRT(const std::string& benchmark_name,
+                    const std::string& etcd_endpoints,
+                    const int size,
                     int *terminate = nullptr);
     ~xferBenchEtcdRT();
 

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -73,8 +73,8 @@ private:
     }
 
 public:
-    xferBenchEtcdRT(const std::string& benchmark_name,
-                    const std::string& etcd_endpoints,
+    xferBenchEtcdRT(const std::string &benchmark_name,
+                    const std::string &etcd_endpoints,
                     const int size,
                     int *terminate = nullptr);
     ~xferBenchEtcdRT();

--- a/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
@@ -26,7 +26,8 @@ PYBIND11_MODULE (etcd_runtime, m) {
     m.doc() = "Python bindings for ETCD runtime";
 
     py::class_<xferBenchEtcdRT> (m, "EtcdRuntime")
-        .def (py::init<const std::string &, const int, int *>(),
+        .def (py::init<const std::string &, const std::string &, const int, int *>(),
+              py::arg ("benchmark_name"),
               py::arg ("etcd_endpoints"),
               py::arg ("size"),
               py::arg ("terminate") = nullptr)

--- a/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
@@ -25,48 +25,48 @@ namespace py = pybind11;
 PYBIND11_MODULE (etcd_runtime, m) {
     m.doc() = "Python bindings for ETCD runtime";
 
-    py::class_<xferBenchEtcdRT> (m, "EtcdRuntime")
-        .def (py::init<const std::string &, const std::string &, const int, int *>(),
-              py::arg ("benchmark_name"),
-              py::arg ("etcd_endpoints"),
-              py::arg ("size"),
-              py::arg ("terminate") = nullptr)
-        .def ("setup", &xferBenchEtcdRT::setup)
-        .def ("get_rank", &xferBenchEtcdRT::getRank)
-        .def ("get_size", &xferBenchEtcdRT::getSize)
-        .def ("send_int",
-              [] (xferBenchEtcdRT &self, int value, int dest_rank) {
-                  return self.sendInt (&value, dest_rank);
-              })
-        .def ("recv_int",
-              [] (xferBenchEtcdRT &self, int src_rank) {
-                  int value;
-                  int result = self.recvInt (&value, src_rank);
-                  return py::make_tuple (result, value);
-              })
-        .def ("send_char",
-              [] (xferBenchEtcdRT &self, const std::string &data, int dest_rank) {
-                  return self.sendChar (const_cast<char *> (data.c_str()), data.size(), dest_rank);
-              })
-        .def ("recv_char",
-              [] (xferBenchEtcdRT &self, size_t count, int src_rank) {
-                  std::vector<char> buffer (count);
-                  int result = self.recvChar (buffer.data(), count, src_rank);
-                  std::string data (buffer.begin(), buffer.end());
-                  return py::make_tuple (result, data);
-              })
-        .def ("broadcast_int",
-              [] (xferBenchEtcdRT &self, py::array_t<int> buffer, int root_rank) {
-                  py::buffer_info buf_info = buffer.request();
-                  int *ptr = static_cast<int *> (buf_info.ptr);
-                  size_t count = buf_info.size;
-                  return self.broadcastInt (ptr, count, root_rank);
-              })
-        .def ("reduce_sum_double",
-              [] (xferBenchEtcdRT &self, double local_value, int dest_rank) {
-                  double global_value;
-                  int result = self.reduceSumDouble (&local_value, &global_value, dest_rank);
-                  return py::make_tuple (result, global_value);
-              })
-        .def ("barrier", &xferBenchEtcdRT::barrier);
+    py::class_<xferBenchEtcdRT>(m, "EtcdRuntime")
+        .def(py::init<const std::string &, const std::string &, const int, int *>(),
+             py::arg("benchmark_name"),
+             py::arg("etcd_endpoints"),
+             py::arg("size"),
+             py::arg("terminate") = nullptr)
+        .def("setup", &xferBenchEtcdRT::setup)
+        .def("get_rank", &xferBenchEtcdRT::getRank)
+        .def("get_size", &xferBenchEtcdRT::getSize)
+        .def("send_int",
+             [](xferBenchEtcdRT &self, int value, int dest_rank) {
+                 return self.sendInt(&value, dest_rank);
+             })
+        .def("recv_int",
+             [](xferBenchEtcdRT &self, int src_rank) {
+                 int value;
+                 int result = self.recvInt(&value, src_rank);
+                 return py::make_tuple(result, value);
+             })
+        .def("send_char",
+             [](xferBenchEtcdRT &self, const std::string &data, int dest_rank) {
+                 return self.sendChar(const_cast<char *>(data.c_str()), data.size(), dest_rank);
+             })
+        .def("recv_char",
+             [](xferBenchEtcdRT &self, size_t count, int src_rank) {
+                 std::vector<char> buffer(count);
+                 int result = self.recvChar(buffer.data(), count, src_rank);
+                 std::string data(buffer.begin(), buffer.end());
+                 return py::make_tuple(result, data);
+             })
+        .def("broadcast_int",
+             [](xferBenchEtcdRT &self, py::array_t<int> buffer, int root_rank) {
+                 py::buffer_info buf_info = buffer.request();
+                 int *ptr = static_cast<int *>(buf_info.ptr);
+                 size_t count = buf_info.size;
+                 return self.broadcastInt(ptr, count, root_rank);
+             })
+        .def("reduce_sum_double",
+             [](xferBenchEtcdRT &self, double local_value, int dest_rank) {
+                 double global_value;
+                 int result = self.reduceSumDouble(&local_value, &global_value, dest_rank);
+                 return py::make_tuple(result, global_value);
+             })
+        .def("barrier", &xferBenchEtcdRT::barrier);
 }

--- a/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/python_bindings.cpp
@@ -27,7 +27,7 @@ PYBIND11_MODULE (etcd_runtime, m) {
 
     py::class_<xferBenchEtcdRT>(m, "EtcdRuntime")
         .def(py::init<const std::string &, const std::string &, const int, int *>(),
-             py::arg("benchmark_name"),
+             py::arg("benchmark_group"),
              py::arg("etcd_endpoints"),
              py::arg("size"),
              py::arg("terminate") = nullptr)

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -33,10 +33,15 @@
 /**********
  * xferBench Config
  **********/
-DEFINE_string(benchmark_name, "default", "Name of benchmark. Use different names to run multiple benchmarks in parallel (Default: default)");
+DEFINE_string(benchmark_name,
+              "default",
+              "Name of benchmark. Use different names to run multiple benchmarks in parallel "
+              "(Default: default)");
 DEFINE_string(runtime_type, XFERBENCH_RT_ETCD, "Runtime type to use for communication [ETCD]");
 DEFINE_string(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem]");
-DEFINE_string(backend, XFERBENCH_BACKEND_UCX, "Name of communication backend [UCX, UCX_MO, GDS, POSIX, GPUNETIO] \
+DEFINE_string(backend,
+              XFERBENCH_BACKEND_UCX,
+              "Name of communication backend [UCX, UCX_MO, GDS, POSIX, GPUNETIO] \
               (only used with nixl worker)");
 DEFINE_string(initiator_seg_type, XFERBENCH_SEG_TYPE_DRAM, "Type of memory segment for initiator \
               [DRAM, VRAM]");
@@ -125,7 +130,8 @@ std::string xferBenchConfig::posix_api_type = "";
 std::string xferBenchConfig::filepath = "";
 bool xferBenchConfig::storage_enable_direct = false;
 
-int xferBenchConfig::loadFromFlags() {
+int
+xferBenchConfig::loadFromFlags() {
     benchmark_name = FLAGS_benchmark_name;
     runtime_type = FLAGS_runtime_type;
     worker_type = FLAGS_worker_type;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -33,9 +33,9 @@
 /**********
  * xferBench Config
  **********/
-DEFINE_string(benchmark_name,
+DEFINE_string(benchmark_group,
               "default",
-              "Name of benchmark. Use different names to run multiple benchmarks in parallel "
+              "Name of benchmark group. Use different names to run multiple benchmarks in parallel "
               "(Default: default)");
 DEFINE_string(runtime_type, XFERBENCH_RT_ETCD, "Runtime type to use for communication [ETCD]");
 DEFINE_string(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem]");
@@ -120,7 +120,7 @@ bool xferBenchConfig::enable_pt = false;
 bool xferBenchConfig::enable_vmm = false;
 std::string xferBenchConfig::device_list = "";
 std::string xferBenchConfig::etcd_endpoints = "";
-std::string xferBenchConfig::benchmark_name = "default";
+std::string xferBenchConfig::benchmark_group = "default";
 int xferBenchConfig::gds_batch_pool_size = 0;
 int xferBenchConfig::gds_batch_limit = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
@@ -132,7 +132,7 @@ bool xferBenchConfig::storage_enable_direct = false;
 
 int
 xferBenchConfig::loadFromFlags() {
-    benchmark_name = FLAGS_benchmark_name;
+    benchmark_group = FLAGS_benchmark_group;
     runtime_type = FLAGS_runtime_type;
     worker_type = FLAGS_worker_type;
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -33,6 +33,7 @@
 /**********
  * xferBench Config
  **********/
+DEFINE_string(benchmark_name, "default", "Name of benchmark. Use different names to run multiple benchmarks in parallel (Default: default)");
 DEFINE_string(runtime_type, XFERBENCH_RT_ETCD, "Runtime type to use for communication [ETCD]");
 DEFINE_string(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem]");
 DEFINE_string(backend, XFERBENCH_BACKEND_UCX, "Name of communication backend [UCX, UCX_MO, GDS, POSIX, GPUNETIO] \
@@ -114,6 +115,7 @@ bool xferBenchConfig::enable_pt = false;
 bool xferBenchConfig::enable_vmm = false;
 std::string xferBenchConfig::device_list = "";
 std::string xferBenchConfig::etcd_endpoints = "";
+std::string xferBenchConfig::benchmark_name = "default";
 int xferBenchConfig::gds_batch_pool_size = 0;
 int xferBenchConfig::gds_batch_limit = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
@@ -124,6 +126,7 @@ std::string xferBenchConfig::filepath = "";
 bool xferBenchConfig::storage_enable_direct = false;
 
 int xferBenchConfig::loadFromFlags() {
+    benchmark_name = FLAGS_benchmark_name;
     runtime_type = FLAGS_runtime_type;
     worker_type = FLAGS_worker_type;
 

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -126,6 +126,7 @@ class xferBenchConfig {
         static bool enable_pt;
         static std::string device_list;
         static std::string etcd_endpoints;
+        static std::string benchmark_name;
         static std::string filepath;
         static bool enable_vmm;
         static int num_files;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -126,7 +126,7 @@ class xferBenchConfig {
         static bool enable_pt;
         static std::string device_list;
         static std::string etcd_endpoints;
-        static std::string benchmark_name;
+        static std::string benchmark_group;
         static std::string filepath;
         static bool enable_vmm;
         static int num_files;

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -32,7 +32,8 @@ static xferBenchRT *createRT(int *terminate) {
             total = 1;
         }
         xferBenchEtcdRT *etcd_rt =
-            new xferBenchEtcdRT (xferBenchConfig::etcd_endpoints, total, terminate);
+            new xferBenchEtcdRT (xferBenchConfig::benchmark_name, xferBenchConfig::etcd_endpoints,
+                                 total, terminate);
         if (etcd_rt->setup() != 0) {
             std::cerr << "Failed to setup ETCD runtime" << std::endl;
             delete etcd_rt;

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -32,7 +32,7 @@ static xferBenchRT *createRT(int *terminate) {
             total = 1;
         }
         xferBenchEtcdRT *etcd_rt = new xferBenchEtcdRT(
-            xferBenchConfig::benchmark_name, xferBenchConfig::etcd_endpoints, total, terminate);
+            xferBenchConfig::benchmark_group, xferBenchConfig::etcd_endpoints, total, terminate);
         if (etcd_rt->setup() != 0) {
             std::cerr << "Failed to setup ETCD runtime" << std::endl;
             delete etcd_rt;

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -31,9 +31,8 @@ static xferBenchRT *createRT(int *terminate) {
         if (xferBenchConfig::isStorageBackend()) {
             total = 1;
         }
-        xferBenchEtcdRT *etcd_rt =
-            new xferBenchEtcdRT (xferBenchConfig::benchmark_name, xferBenchConfig::etcd_endpoints,
-                                 total, terminate);
+        xferBenchEtcdRT *etcd_rt = new xferBenchEtcdRT(
+            xferBenchConfig::benchmark_name, xferBenchConfig::etcd_endpoints, total, terminate);
         if (etcd_rt->setup() != 0) {
             std::cerr << "Failed to setup ETCD runtime" << std::endl;
             delete etcd_rt;


### PR DESCRIPTION
## What?
Allows multiple benchmarks to be executed at the same time.

## How?
Adds benchmark name to use separate namespaces for all metadata keys.