### PR TITLE
Added is_contiguous check to tensors.

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -798,23 +798,30 @@ class nixl_agent:
                 )
                 new_descs = None
         elif isinstance(descs, torch.Tensor):
-            mem_type = "cuda" if str(descs.device).startswith("cuda") else "cpu"
-            base_addr = descs.data_ptr()
-            region_len = descs.numel() * descs.element_size()
-            gpu_id = descs.get_device()
-            if gpu_id == -1:  # DRAM
-                gpu_id = 0
-            new_descs = nixlBind.nixlXferDList(
-                self.nixl_mems[mem_type],
-                [(base_addr, region_len, gpu_id)],
-                is_sorted,
-            )
+            if descs.is_contiguous():
+                mem_type = "cuda" if str(descs.device).startswith("cuda") else "cpu"
+                base_addr = descs.data_ptr()
+                region_len = descs.numel() * descs.element_size()
+                gpu_id = descs.get_device()
+                if gpu_id == -1:  # DRAM
+                    gpu_id = 0
+                new_descs = nixlBind.nixlXferDList(
+                    self.nixl_mems[mem_type],
+                    [(base_addr, region_len, gpu_id)],
+                    is_sorted,
+                )
+            else:
+                print("Please use a list of contiguous Tensors")
+                new_descs = None
         elif isinstance(descs[0], torch.Tensor):  # List[torch.Tensor]:
             tensor_type = descs[0].device
             dlist = np.zeros((len(descs), 3), dtype=np.uint64)
 
             for i in range(len(descs)):
                 if descs[i].device != tensor_type:
+                    return None
+                if not descs[i].is_contiguous():
+                    print("Please use a list of contiguous Tensors")
                     return None
                 base_addr = descs[i].data_ptr()
                 region_len = descs[i].numel() * descs[i].element_size()
@@ -885,23 +892,30 @@ class nixl_agent:
                 )
                 new_descs = None
         elif isinstance(descs, torch.Tensor):
-            mem_type = "cuda" if str(descs.device).startswith("cuda") else "cpu"
-            base_addr = descs.data_ptr()
-            region_len = descs.numel() * descs.element_size()
-            gpu_id = descs.get_device()
-            if gpu_id == -1:  # DRAM
-                gpu_id = 0
-            new_descs = nixlBind.nixlRegDList(
-                self.nixl_mems[mem_type],
-                [(base_addr, region_len, gpu_id, "")],
-                is_sorted,
-            )
+            if descs.is_contiguous():
+                mem_type = "cuda" if str(descs.device).startswith("cuda") else "cpu"
+                base_addr = descs.data_ptr()
+                region_len = descs.numel() * descs.element_size()
+                gpu_id = descs.get_device()
+                if gpu_id == -1:  # DRAM
+                    gpu_id = 0
+                new_descs = nixlBind.nixlRegDList(
+                    self.nixl_mems[mem_type],
+                    [(base_addr, region_len, gpu_id, "")],
+                    is_sorted,
+                )
+            else:
+                print("Please use a list of contiguous Tensors")
+                new_descs = None
         elif isinstance(descs[0], torch.Tensor):  # List[torch.Tensor]:
             tensor_type = descs[0].device
             dlist = np.zeros((len(descs), 3), dtype=np.uint64)
 
             for i in range(len(descs)):
                 if descs[i].device != tensor_type:
+                    return None
+                if not descs[i].is_contiguous():
+                    print("Please use a list of contiguous Tensors")
                     return None
                 base_addr = descs[i].data_ptr()
                 region_len = descs[i].numel() * descs[i].element_size()

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -15,10 +15,10 @@
 
 import uuid
 
-import pytest
-
 import nixl._bindings as bindings
 import nixl._utils as utils
+import pytest
+import torch
 from nixl._api import nixl_agent, nixl_agent_config
 
 # NIXL pytest fixtures
@@ -176,6 +176,19 @@ def test_improper_get_reg_descs(one_empty_agent, one_xfer_list):
     # Passing reg list will not work
     ret = one_empty_agent.get_reg_descs(one_xfer_list)
     assert ret is None
+
+
+def test_noncontiguous_tensor(one_empty_agent):
+
+    cont_tensor = torch.arange(8).reshape(2, 4)
+    non_cont_tensor = torch.transpose(cont_tensor, 0, 1)
+    assert non_cont_tensor.is_contiguous() is False
+
+    reg_descs = one_empty_agent.get_reg_descs(non_cont_tensor)
+    assert reg_descs is None
+
+    xfer_descs = one_empty_agent.get_xfer_descs(non_cont_tensor)
+    assert xfer_descs is None
 
 
 # monkeypatch limits scope of env change to this test

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -15,10 +15,11 @@
 
 import uuid
 
-import nixl._bindings as bindings
-import nixl._utils as utils
 import pytest
 import torch
+
+import nixl._bindings as bindings
+import nixl._utils as utils
 from nixl._api import nixl_agent, nixl_agent_config
 
 # NIXL pytest fixtures
@@ -179,7 +180,6 @@ def test_improper_get_reg_descs(one_empty_agent, one_xfer_list):
 
 
 def test_noncontiguous_tensor(one_empty_agent):
-
     cont_tensor = torch.arange(8).reshape(2, 4)
     non_cont_tensor = torch.transpose(cont_tensor, 0, 1)
     assert non_cont_tensor.is_contiguous() is False


### PR DESCRIPTION
## What?
Adds a check for tensors being contiguous for our python API.

## Why?
If the user passes a non-contiguous tensor during registration, it would proceed, but cause data corruption down the line.