### PR TITLE
NIXLBench: Align memory for O_DIRECT (#557)

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -122,6 +122,7 @@ int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
 std::string xferBenchConfig::filepath = "";
 bool xferBenchConfig::storage_enable_direct = false;
+long xferBenchConfig::page_size = sysconf(_SC_PAGESIZE);
 
 int xferBenchConfig::loadFromFlags() {
     runtime_type = FLAGS_runtime_type;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -134,6 +134,7 @@ class xferBenchConfig {
         static int gds_batch_pool_size;
         static int gds_batch_limit;
         static std::string gpunetio_device_list;
+        static long page_size;
 
         static int loadFromFlags();
         static void printConfig();


### PR DESCRIPTION
## What?
This PR provides support for O_DIRECT in NIXLBench.

## Why?
To provide a more accurate representation of storage access performance when using the POSIX Plugin

## How?
It aligns memory to the underlying page size using posix_memalign