### PR TITLE
ci: Add direct links to child jobs in dispatcher build description

### DIFF
--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -61,15 +61,25 @@
         try {{
             // Trigger the actual build and test jobs in parallel
             parallel build: {{
-                build job: 'nixl-ci-build', parameters: [
+                def build = build job: 'nixl-ci-build', parameters: [
                     string(name: 'sha1', value: githubHelper.getMergedSHA()),
                     string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ]
+                ], propagate: false
+                currentBuild.description += "<br>Job: <a href='${{build.absoluteUrl}}'>nixl-ci-build</a> Result: <b style='color:${{build.result == 'SUCCESS' ? 'green' : 'red'}}'>${{build.result}}</b>"
+                if (!build.resultIsBetterOrEqualTo('SUCCESS')) {{
+                  currentBuild.result = build.result
+                  error("Build CI failed")
+                }}
             }}, test: {{
-                build job: 'nixl-ci-test', parameters: [
+                def build = build job: 'nixl-ci-test', parameters: [
                     string(name: 'sha1', value: githubHelper.getMergedSHA()),
                     string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ]
+                ], propagate: false
+                currentBuild.description += "<br>Job: <a href='${{build.absoluteUrl}}'>nixl-ci-test</a> Result: <b style='color:${{build.result == 'SUCCESS' ? 'green' : 'red'}}'>${{build.result}}</b>"
+                if (!build.resultIsBetterOrEqualTo('SUCCESS')) {{
+                  currentBuild.result = build.result
+                  error("Test CI failed")
+                }}
             }},
             failFast: false  // Continue even if some parallel jobs fail
 


### PR DESCRIPTION
Improves developer experience by providing clickable links to failed child jobs (build/test) directly from the dispatcher job description.

## What?
Improve CI user experience

## Why?
We want to have 1 click simple access to dispatcher child job results

## How?
By adding html clickable url links in the dispatcher build page
