### PR TITLE
TEST/GTEST: TestTransfer/RandomSizes - use correct memory type instead of just DRAM

### DIFF
--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -282,8 +282,7 @@ protected:
     void
     deregisterMem(nixlAgent &agent,
                   const std::vector<MemBuffer> &buffers,
-                  nixl_mem_t mem_type) const
-    {
+                  nixl_mem_t mem_type) const {
         const auto desc_list = makeDescList<nixlBlobDesc>(buffers, mem_type);
         agent.deregisterMem(desc_list);
     }


### PR DESCRIPTION
## What?
Modified test to set VRAM_SEG as memory type when CUDA devices are being used

## Why?
1. RandomSizes test was failing with:
```cpp
cuMemHostRegister_v2(address, length, 0x01) failed: part or all of the requested memory range is already mapped
```
When trying to register CUDA memory as DRAM

2. Consistency with `remoteMDFromSocket` test

