### PR TITLE
fix: use `etcd_lib_path` path for etcd-cpp-api search

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,7 +91,7 @@ etcd_dep = dependency('etcd-cpp-api', required : false)
 etcd_inc_path = get_option('etcd_inc_path')
 etcd_lib_path = get_option('etcd_lib_path')
 if not etcd_dep.found() and etcd_lib_path != ''
-    etcd_lib = cpp.find_library('etcd-cpp-api')
+    etcd_lib = cpp.find_library('etcd-cpp-api', dirs: etcd_lib_path)
     if etcd_lib.found()
         if cpp.has_header('Client.hpp', args : '-I' + etcd_inc_path)
             etcd_inc = include_directories(etcd_inc_path, is_system: true)


### PR DESCRIPTION
If the user has provided the place where `etcd-cpp-api` is provided, then we need to pass this on to meson, otherwise the finding of the library fails.