### PR TITLE
fix: don't assume on library path construction in meson build file

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -47,7 +47,7 @@ if host_system != 'linux' or host_cpu_family not in ['x86_64', 'aarch64']
     error('This build only supports Linux on x86_64 or aarch64 architectures.')
 endif
 
-nixl_lib_path = nixl_path + '/lib/' + host_cpu_family + '-linux-gnu'
+nixl_lib_path = join_paths(nixl_path, get_option('libdir'))
 nixl_lib = cpp.find_library('nixl', dirs: [nixl_lib_path])
 nixl_build = cpp.find_library('nixl_build', dirs: [nixl_lib_path])
 nixl_serdes = cpp.find_library('serdes', dirs: [nixl_lib_path])


### PR DESCRIPTION
Meson's library install results in different paths:

Ubuntu: lib/x86-64-linux-gnu
RHEL: lib64

Don't assume we are on Ubuntu. Otherwise, linking fails on Red Hat.