### PR TITLE
obj: Add request checksum config toggle

### DIFF
--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -113,7 +113,8 @@ nixl_b_params_t params = {
     {"endpoint_override", "http://localhost:9000"},
     {"scheme", "http"},
     {"region", "us-east-1"},
-    {"use_virtual_addressing", "false"}
+    {"use_virtual_addressing", "false"},
+    {"req_checksum", "supported"}
 };
 agent.createBackend("obj", params);
 ```

--- a/src/plugins/obj/obj_s3_client.cpp
+++ b/src/plugins/obj/obj_s3_client.cpp
@@ -58,6 +58,19 @@ createClientConfiguration(nixl_b_params_t *custom_params) {
     auto region_it = custom_params->find("region");
     if (region_it != custom_params->end()) config.region = region_it->second;
 
+    auto req_checksum_it = custom_params->find("req_checksum");
+    if (req_checksum_it != custom_params->end()) {
+        if (req_checksum_it->second == "required")
+            config.checksumConfig.requestChecksumCalculation =
+                Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+        else if (req_checksum_it->second == "supported")
+            config.checksumConfig.requestChecksumCalculation =
+                Aws::Client::RequestChecksumCalculation::WHEN_SUPPORTED;
+        else
+            throw std::runtime_error("Invalid value for req_checksum: '" + req_checksum_it->second +
+                                     "'. Must be 'required' or 'supported'");
+    }
+
     return config;
 }
 


### PR DESCRIPTION
## What?
Allow users to configure AWS Request checksum setting.

## Why?
Some users encountered issues with using Obj plugin with endpoints that don't support STREAMING-UNSIGNED-PAYLOAD-TRAILER.

## How?
Via plugin custom params.

Fixes NIX-205
