### PR TITLE
Fix issue in registerMem for OBJ plugin

### DIFF
--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -146,6 +146,8 @@ nixlObjEngine::registerMem(const nixlBlobDesc &mem,
             nixl_mem, mem.devId, mem.metaInfo.empty() ? std::to_string(mem.devId) : mem.metaInfo);
         devIdToObjKey_[mem.devId] = obj_md->objKey;
         out = obj_md.release();
+    } else {
+        out = nullptr;
     }
 
     return NIXL_SUCCESS;


### PR DESCRIPTION
## What?
Fixed a bug in the registerMem function of the OBJ plugin.

## Why?
The previous implementation didn’t handle the metadata pointer correctly for memory types other than OBJ, potentially leaving it uninitialized. This could result in a segmentation fault during nixlObjEngine::deregisterMem when attempting to access it.

## How?
Explicitly set metadata output to nullptr for non-OBJ memory types to avoid undefined behavior.