### PR TITLE
plugins/ucx: Remove leftover cufile header

### DIFF
--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -26,7 +26,7 @@ if not disable_gds_backend and cuda_dep.found()
       subdir('cuda_gds')
 endif
 
-if taskflow_proj.found() and cuda_dep.found()
+if taskflow_proj.found() and cuda_dep.found() and not disable_gds_backend
       subdir('gds_mt')
 endif
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -28,6 +28,7 @@
 
 #ifdef HAVE_CUDA
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 
 #endif

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -29,7 +29,6 @@
 #ifdef HAVE_CUDA
 
 #include <cuda_runtime.h>
-#include <cufile.h>
 
 #endif
 

--- a/test/unit/utils/ucx/ucx_worker_test.cpp
+++ b/test/unit/utils/ucx/ucx_worker_test.cpp
@@ -27,8 +27,8 @@
 
 #ifdef USE_VRAM
 
+#include <cuda.h>
 #include <cuda_runtime.h>
-#include <cufile.h>
 
 int gpu_id = 0;
 


### PR DESCRIPTION
## What?
Remove unneeded header. Also extend build gds plugin flag to gds_mt.

## Why?
Cufile isnt required by UCX plugin/test.