### PR TITLE
NIXL UCX progress thread refactoring

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -22,6 +22,7 @@
 #include "nixl_types.h"
 #include "nixl_descriptors.h"
 #include "common/nixl_time.h"
+#include "absl/strings/numbers.h"
 
 // Might be removed to be decided by backend, or changed to high
 // level direction or so.
@@ -52,6 +53,18 @@ class nixlBackendInitParams {
         bool              enableProgTh;
         nixlTime::us_t    pthrDelay;
         nixl_thread_sync_t syncMode;
+
+        template <typename T>
+        T getOrDefault(const std::string &key, T defaultValue) const {
+            auto it = customParams->find(key);
+            if (it == customParams->end()) {
+                return defaultValue;
+            }
+
+            T result;
+            if constexpr (std::is_same_v<T, int>)
+                return absl::SimpleAtoi(it->second, &result) ? result : defaultValue;
+        }
 };
 
 // Pure virtual class to have a common pointer type

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -105,7 +105,7 @@ using nixlUcxCudaDevicePrimaryCtxPtr = std::shared_ptr<nixlUcxCudaDevicePrimaryC
 
 class nixlUcxEngine
     : public nixlBackendEngine {
-    private:
+    protected:
         /* UCX data */
         std::unique_ptr<nixlUcxContext> uc;
         std::vector<std::unique_ptr<nixlUcxWorker>> uws;
@@ -183,8 +183,11 @@ class nixlUcxEngine
         void notifProgress();
         void notifProgressCombineHelper(notif_list_t &src, notif_list_t &tgt);
 
+        nixlUcxEngine(const nixlBackendInitParams& init_params);
+
     public:
-        nixlUcxEngine(const nixlBackendInitParams* init_params);
+        static std::unique_ptr<nixlUcxEngine>
+        create(const nixlBackendInitParams &init_params);
         ~nixlUcxEngine();
 
         bool supportsRemote() const override { return true; }

--- a/src/plugins/ucx/ucx_plugin.cpp
+++ b/src/plugins/ucx/ucx_plugin.cpp
@@ -26,12 +26,7 @@ namespace
    const char* ucx_plugin_version = "0.1.0";
 
    [[nodiscard]] nixlBackendEngine* create_ucx_engine(const nixlBackendInitParams* init_params) {
-        try {
-            return new nixlUcxEngine(init_params);
-        } catch (const std::exception &e) {
-            NIXL_ERROR << "Failed to create UCX engine: " << e.what();
-            return nullptr;
-        }
+        return nixlUcxEngine::create(*init_params).release();
    }
 
    void destroy_ucx_engine(nixlBackendEngine *engine) {

--- a/src/plugins/ucx_mo/ucx_mo_backend.cpp
+++ b/src/plugins/ucx_mo/ucx_mo_backend.cpp
@@ -189,7 +189,7 @@ nixlUcxMoEngine::nixlUcxMoEngine(const nixlBackendInitParams* init_params):
     setEngCnt(num_ucx_engines);
     // Initialize required number of engines
     for (uint32_t i = 0; i < getEngCnt(); i++) {
-        auto e = std::make_unique<nixlUcxEngine>(init_params);
+        auto e = nixlUcxEngine::create(*init_params);
         if (e->getInitErr()) {
             this->initErr = true;
             // TODO: Log error

--- a/test/unit/plugins/ucx/ucx_backend_multi.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_multi.cpp
@@ -50,7 +50,7 @@ void test_thread(int id)
 
     std::cout << my_name << " Started\n";
 
-    ucx = (nixlBackendEngine*) new nixlUcxEngine (&init_params);
+    ucx = nixlUcxEngine::create(init_params).release();
 
     if(!USE_PTHREAD) ucx->progress();
 

--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -119,7 +119,7 @@ nixlBackendEngine *createEngine(std::string name, bool p_thread)
     init.customParams = &custom_params;
     init.type         = "UCX";
 
-    ucx = (nixlBackendEngine*) new nixlUcxEngine (&init);
+    ucx = nixlUcxEngine::create(init).release();
     assert(!ucx->getInitErr());
     if (ucx->getInitErr()) {
         std::cout << "Failed to initialize worker1" << std::endl;


### PR DESCRIPTION
## What?
Split nixlUcxThreadEngine into a separate subclass of nixlUcxEngine.

## Why?
This is a preparatory step to implement threadpool engine (https://github.com/ai-dynamo/nixl/pull/573).
The idea is to implement progress thread functionality in a separate subclass to split the concerns and follow single responsibility principle. With threadpool approach we don't need to use progress thread in it's current form, so it's desirable to keep them separate.
