### PR TITLE
CI: avoid running partial_md_example.py twice

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -68,6 +68,5 @@ cd examples/python
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port=1234&
 sleep 5
 python3 blocking_send_recv_example.py --mode="initiator" --ip=127.0.0.1 --port=1234
-python3 partial_md_example.py
 
 pkill etcd


### PR DESCRIPTION
## What?
Removed 2nd run of partial_md_example.py so it will run only once regularly and once with `--etcd` flag.
