### PR TITLE
obj: Implement queryMem API

### DIFF
--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -21,6 +21,7 @@
 #include <absl/strings/str_format.h>
 #include <memory>
 #include <future>
+#include <optional>
 #include <vector>
 #include <chrono>
 #include <algorithm>
@@ -160,6 +161,26 @@ nixlObjEngine::deregisterMem(nixlBackendMD *meta) {
     if (obj_md) {
         std::unique_ptr<nixlObjMetadata> obj_md_ptr = std::unique_ptr<nixlObjMetadata>(obj_md);
         devIdToObjKey_.erase(obj_md->devId);
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlObjEngine::queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const {
+    std::vector<nixl_blob_t> metadata;
+    metadata.reserve(descs.descCount());
+    for (auto &desc : descs)
+        metadata.emplace_back(desc.metaInfo);
+
+    try {
+        for (const auto &m : metadata)
+            resp.push_back(s3Client_->checkObjectExists(m) ? nixl_query_resp_t{nixl_b_params_t{}} :
+                                                             std::nullopt);
+    }
+    catch (const std::runtime_error &e) {
+        NIXL_ERROR << "Failed to query memory: " << e.what();
+        return NIXL_ERR_BACKEND;
     }
 
     return NIXL_SUCCESS;

--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -63,6 +63,9 @@ public:
     deregisterMem(nixlBackendMD *meta) override;
 
     nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
     connect(const std::string &remote_agent) override {
         return NIXL_SUCCESS;
     }

--- a/src/plugins/obj/obj_s3_client.h
+++ b/src/plugins/obj/obj_s3_client.h
@@ -74,6 +74,14 @@ public:
                    size_t data_len,
                    size_t offset,
                    get_object_callback_t callback) = 0;
+
+    /**
+     * Check if the object exists.
+     * @param key The object key
+     * @return true if the object exists, false otherwise
+     */
+    virtual bool
+    checkObjectExists(std::string_view key) = 0;
 };
 
 /**
@@ -105,6 +113,9 @@ public:
                    size_t data_len,
                    size_t offset,
                    get_object_callback_t callback) override;
+
+    bool
+    checkObjectExists(std::string_view key) override;
 
 private:
     std::unique_ptr<Aws::SDKOptions, std::function<void(Aws::SDKOptions *)>> awsOptions_;


### PR DESCRIPTION
## What?
Check whether object with specifying name exists. Don't return any object metadata for now.

## Why?
PR that introduced queryMem API didn't provide implementation for Obj plugin.

## How?
Use S3 HeadObject API.
