### PR TITLE
ci/gitlab: Add namespaces to etcd tests

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -58,6 +58,7 @@ uname -a || true
 
 echo "==== Running ETCD server ===="
 export NIXL_ETCD_ENDPOINTS="http://127.0.0.1:2379"
+export NIXL_ETCD_NAMESPACE="/nixl/test-"-`date +"%H:%M:%S:%N"`
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} &
 sleep 5
 

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -52,6 +52,7 @@ pip3 install --break-system-packages zmq
 
 echo "==== Running ETCD server ===="
 export NIXL_ETCD_ENDPOINTS="http://127.0.0.1:2379"
+export NIXL_ETCD_NAMESPACE="/nixl/test-"-`date +"%H:%M:%S:%N"`
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} &
 sleep 5
 


### PR DESCRIPTION
## What?
Use different etcd namespaces for CI tests

## Why?
Possible interfering between running test instances

## How?
Use the NIXL_ETCD_NAMESPACE env var