### PR TITLE
NIXLBENCH: Fix memory allocation for non OBJ/storage use case (#637) - 0.5.0

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -613,7 +613,9 @@ xferBenchNixlWorker::allocateMemory(int num_lists) {
             }
 
             if (basic_desc) {
-                basic_desc.value().metaInfo = remote_iovs[list_idx][i].metaInfo;
+                if (!remote_iovs.empty()) {
+                    basic_desc.value().metaInfo = remote_iovs[list_idx][i].metaInfo;
+                }
                 iov_list.push_back(basic_desc.value());
             }
         }


### PR DESCRIPTION
Cherry pick of https://github.com/ai-dynamo/nixl/pull/637

## What?
The regression is introduced in https://github.com/ai-dynamo/nixl/pull/607, which leads to segfault, and nixlbench is not usable for non OBJ/storage use cases

## Why?
remote_iovs are not populated in non OBJ/storage use cases
```
basic_desc.value().metaInfo = remote_iovs[list_idx][i].metaInfo;
```
