### PR TITLE
EXAMPLES/PYTHON: partial md example - fix test logic and warnings

### DIFF
--- a/examples/python/partial_md_example.py
+++ b/examples/python/partial_md_example.py
@@ -114,8 +114,12 @@ if __name__ == "__main__":
         target_strs2.append((addr1, buf_size, 0, "test"))
         malloc_addrs.append(addr1)
 
-    target_reg_descs1 = target_agent.get_reg_descs(target_strs1, "DRAM", is_sorted=False)
-    target_reg_descs2 = target_agent.get_reg_descs(target_strs2, "DRAM", is_sorted=False)
+    target_reg_descs1 = target_agent.get_reg_descs(
+        target_strs1, "DRAM", is_sorted=False
+    )
+    target_reg_descs2 = target_agent.get_reg_descs(
+        target_strs2, "DRAM", is_sorted=False
+    )
     target_xfer_descs1 = target_reg_descs1.trim()
     target_xfer_descs2 = target_reg_descs2.trim()
 
@@ -248,5 +252,3 @@ if __name__ == "__main__":
 
     del init_agent
     del target_agent
-
-    print("Test Complete.")

--- a/examples/python/partial_md_example.py
+++ b/examples/python/partial_md_example.py
@@ -114,8 +114,8 @@ if __name__ == "__main__":
         target_strs2.append((addr1, buf_size, 0, "test"))
         malloc_addrs.append(addr1)
 
-    target_reg_descs1 = target_agent.get_reg_descs(target_strs1, "DRAM", is_sorted=True)
-    target_reg_descs2 = target_agent.get_reg_descs(target_strs2, "DRAM", is_sorted=True)
+    target_reg_descs1 = target_agent.get_reg_descs(target_strs1, "DRAM", is_sorted=False)
+    target_reg_descs2 = target_agent.get_reg_descs(target_strs2, "DRAM", is_sorted=False)
     target_xfer_descs1 = target_reg_descs1.trim()
     target_xfer_descs2 = target_reg_descs2.trim()
 
@@ -132,7 +132,7 @@ if __name__ == "__main__":
         init_strs.append((addr1, buf_size, 0, "test"))
         malloc_addrs.append(addr1)
 
-    init_reg_descs = init_agent.get_reg_descs(init_strs, "DRAM", is_sorted=True)
+    init_reg_descs = init_agent.get_reg_descs(init_strs, "DRAM", is_sorted=False)
     init_xfer_descs = init_reg_descs.trim()
 
     assert init_agent.register_memory(init_reg_descs) is not None
@@ -207,7 +207,7 @@ if __name__ == "__main__":
         try:
             # initialize transfer mode
             xfer_handle_2 = init_agent.initialize_xfer(
-                "READ", init_xfer_descs, target_xfer_descs1, "target", b"UUID1"
+                "READ", init_xfer_descs, target_xfer_descs2, "target", b"UUID1"
             )
         except nixlNotFoundError:
             ready = False

--- a/examples/python/partial_md_example.py
+++ b/examples/python/partial_md_example.py
@@ -252,3 +252,5 @@ if __name__ == "__main__":
 
     del init_agent
     del target_agent
+
+    print("Test Complete.")


### PR DESCRIPTION
## What?
Fixing partial_md_example.py

## Why?
The test had 2 main issues:
1. Sending target_xfer_descs1 instead of target_xfer_descs2
2. Setting `is_sorted=True` while descriptors are not sorted by address, I set the flag to False. We can alternatively sort descriptors by address