### PR TITLE
RUST: Fix cargo package

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -134,6 +134,7 @@ RUN cd /usr/local/src && \
      make -j install-strip &&        \
      ldconfig
 
+ENV NIXL_PREFIX=$NIXL_PREFIX
 RUN rm -rf build && \
     mkdir build && \
     uv run meson setup build/ --prefix=$NIXL_PREFIX && \


### PR DESCRIPTION
Cherry-pick of https://github.com/ai-dynamo/nixl/pull/642

## What?

The rust build scripts assume that NIXL_PREFIX env var is present. We should export it in the Dockerfile.