### PR TITLE
Plugins should set rpath so that they can load their dependencies (#612)

### DIFF
--- a/src/plugins/cuda_gds/meson.build
+++ b/src/plugins/cuda_gds/meson.build
@@ -46,7 +46,8 @@ else
         install: true,
         cpp_args: ['-fPIC'],
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-        install_dir: plugin_install_dir)
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
             'echo "GDS=' + gds_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',

--- a/src/plugins/gds_mt/meson.build
+++ b/src/plugins/gds_mt/meson.build
@@ -46,7 +46,8 @@ else
         install: true,
         cpp_args: ['-fPIC'],
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-        install_dir: plugin_install_dir)
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
             'echo "GDS_MT=' + gds_mt_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',

--- a/src/plugins/gpunetio/meson.build
+++ b/src/plugins/gpunetio/meson.build
@@ -44,7 +44,8 @@ else
                cpp_args : compile_flags + ['-fPIC'],
                cuda_args : gpu_cuda_args,
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-               install_dir: plugin_install_dir)
+               install_dir: plugin_install_dir,
+               install_rpath: '$ORIGIN/..')
 
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',

--- a/src/plugins/hf3fs/meson.build
+++ b/src/plugins/hf3fs/meson.build
@@ -40,7 +40,8 @@ else
                     install: true,
                     cpp_args : ['-fPIC'],
                     name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-                    install_dir: plugin_install_dir)
+                    install_dir: plugin_install_dir,
+                    install_rpath: '$ORIGIN/..')
   if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
                     'echo "HF3FS=' + hf3fs_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',

--- a/src/plugins/mooncake/meson.build
+++ b/src/plugins/mooncake/meson.build
@@ -34,7 +34,8 @@ else
                install: true,
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-               install_dir: plugin_install_dir)
+               install_dir: plugin_install_dir,
+               install_rpath: '$ORIGIN/..')
 
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -49,7 +49,8 @@ else
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-        install_dir: plugin_install_dir)
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
             'echo "OBJ=' + obj_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',

--- a/src/plugins/posix/meson.build
+++ b/src/plugins/posix/meson.build
@@ -70,7 +70,8 @@ else
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-        install_dir: plugin_install_dir)
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',
             'echo "POSIX=' + posix_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',

--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -36,7 +36,8 @@ else
                install: true,
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-               install_dir: plugin_install_dir)
+               install_dir: plugin_install_dir,
+               install_rpath: '$ORIGIN/..')
 
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',

--- a/src/plugins/ucx_mo/meson.build
+++ b/src/plugins/ucx_mo/meson.build
@@ -39,7 +39,9 @@ else
                install: true,
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
-               install_dir: plugin_install_dir)
+               install_dir: plugin_install_dir,
+               # FIXME: normally plugins should not depend directly on each other
+               install_rpath: '$ORIGIN:$ORIGIN/..')
 
     if get_option('buildtype') == 'debug'
         run_command('sh', '-c',


### PR DESCRIPTION
Cherry-pick of #612
---------

## What?
Set rpath to $ORIGIN (plugin dir) and $ORIGIN/.. (nixl lib dir) for all plugins

## Why?
Some of the plugins do not load in the TRT-LLM image because LD_LIBRARY_PATH is not set to include the nixl directory; and some also need the plugin directory. But LD_LIBRARY_PATH should not be needed. Only the main nixl libs must be loadable; then when they dlopen() the plugins, the dependencies should be resolved automatically.

We set both current dir and parent dir because some plugins depend on other plugins; and all plugins depend on the nixl libs from the parent dir.
