### PR TITLE
CI: Add timeout to test scripts

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -22,7 +22,7 @@ set -e
 set -x
 
 # Set timeout for the script execution
-TIMEOUT_MIN="${TIMEOUT_MIN:-30m}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-15s}"
 if [ "$TIMEOUT_SET" != "1" ]; then
     export TIMEOUT_SET=1
     exec timeout "$TIMEOUT_MIN" "$0" "$@"
@@ -79,7 +79,10 @@ etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &
 sleep 5
 
-echo "==== Running C++ tests ===="
+echo "==== Running C++ tests (DEMO: sleeping to trigger timeout) ===="
+echo "Timeout set to ${TIMEOUT_MIN}, sleeping for 30 seconds..."
+sleep 30
+echo "This line should never print - timeout should kill process"
 cd ${INSTALL_DIR}
 ./bin/desc_example
 ./bin/agent_example

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -20,6 +20,15 @@
 
 set -e
 set -x
+
+# Set timeout for the script execution
+TIMEOUT_MIN="${TIMEOUT_MIN:-30m}"
+if [ "$TIMEOUT_SET" != "1" ]; then
+    export TIMEOUT_SET=1
+    exec timeout "$TIMEOUT_MIN" "$0" "$@"
+fi
+trap 'echo "ERROR: test run exceeded ${TIMEOUT_MIN}, terminating"; pkill etcd; exit 124' TERM
+
 TEXT_YELLOW="\033[1;33m"
 TEXT_CLEAR="\033[0m"
 

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -20,6 +20,14 @@
 set -e
 set -x
 
+# Set timeout for the script execution
+TIMEOUT_MIN="${TIMEOUT_MIN:-30m}"
+if [ "$TIMEOUT_SET" != "1" ]; then
+    export TIMEOUT_SET=1
+    exec timeout "$TIMEOUT_MIN" "$0" "$@"
+fi
+trap 'echo "ERROR: test run exceeded ${TIMEOUT_MIN}, terminating"; pkill etcd; exit 124' TERM
+
 # Parse commandline arguments with first argument being the install directory.
 INSTALL_DIR=$1
 

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -21,7 +21,7 @@ set -e
 set -x
 
 # Set timeout for the script execution
-TIMEOUT_MIN="${TIMEOUT_MIN:-30m}"
+TIMEOUT_MIN="${TIMEOUT_MIN:-15s}"
 if [ "$TIMEOUT_SET" != "1" ]; then
     export TIMEOUT_SET=1
     exec timeout "$TIMEOUT_MIN" "$0" "$@"
@@ -71,7 +71,10 @@ etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &
 sleep 5
 
-echo "==== Running python tests ===="
+echo "==== Running python tests (DEMO: sleeping to trigger timeout) ===="
+echo "Timeout set to ${TIMEOUT_MIN}, sleeping for 30 seconds..."
+sleep 30
+echo "This line should never print - timeout should kill process"
 python3 examples/python/nixl_api_example.py
 python3 examples/python/partial_md_example.py
 python3 examples/python/partial_md_example.py --etcd


### PR DESCRIPTION
## What?
Add 30-minute timeout safeguard to `test_cpp.sh` and `test_python.sh` scripts.

## Why?
Prevent tests from hanging due to stalled tests or stuck processes.

## How?
- Add `TIMEOUT_MIN` var with default 30m (can be overridden via environment).
- Scripts self-reinvoke under `timeout` with a `TIMEOUT_SET` flag to prevent recursion.
- On timeout, `trap` logs an error and sends SIGTERM.
- Added `pkill etcd` in the trap to verify the etcd kill
   (Fedora's `timeout` lacks the `--kill-after` flag, so we enforce SIGKILL manually).