### PR TITLE
NIXLBENCH: Install arch specific AWS CLI - 0.5.0

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -65,7 +65,7 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else ech
         doca-sdk-gpunetio libdoca-sdk-gpunetio-dev
 
 # Install AWS CLI
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && ./aws/install && rm -rf awscliv2.zip aws
 
 # --- Stage 2a: Represents using UCX from the base image ---


### PR DESCRIPTION
Cherry pick of #650

## What?
Fixes a dependency installation which was incorrectly hardcoded for x86_64.
