### PR TITLE
Handle UCS_ERR_CANCELED as NIXL_ERR_REMOTE_DISCONNECT

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -55,6 +55,7 @@ nixl_status_t ucx_status_to_nixl(ucs_status_t status)
     case UCS_ERR_NOT_CONNECTED:
     case UCS_ERR_CONNECTION_RESET:
     case UCS_ERR_ENDPOINT_TIMEOUT:
+    case UCS_ERR_CANCELED:
         return NIXL_ERR_REMOTE_DISCONNECT;
     case UCS_ERR_INVALID_PARAM:
         return NIXL_ERR_INVALID_PARAM;


### PR DESCRIPTION
## What?
Unrecognized error code in test failure for error handling on x86_64 + GPU.

## Why?

Failing test:

```
docker run --privileged  --device=/dev/infiniband  --net=host --ipc=host --gpus all  -e NVIDIA_VISIBLE_DEVICES=all -e NIXL_LOG_LEVEL=debug -e UCX_LOG_LEVEL=info db92b0bc4073  /usr/local/nixl/bin/gtest --gtest_filter=UCX/TestErrorHandling.LoadRemoteThenFail/0

==========
== CUDA ==
==========

NVIDIA Release  (build )
CUDA Version 12.8.1.012
Container image Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

Various files include modifications (c) NVIDIA CORPORATION & AFFILIATES.  All rights reserved.

GOVERNING TERMS: The software and materials are governed by the NVIDIA Software License Agreement
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/)
and the Product-Specific Terms for NVIDIA AI Products
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/).

Note: Google Test filter = UCX/TestErrorHandling.LoadRemoteThenFail/0
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from UCX/TestErrorHandling
[ RUN      ] UCX/TestErrorHandling.LoadRemoteThenFail/0
I0731 18:18:03.454256       1 nixl_agent.cpp:92] NIXL ETCD is disabled
I0731 18:18:03.454535       1 nixl_plugin_manager.cpp:197] Loading plugins from file: /workspace/nixl/build/pluginlist
I0731 18:18:03.552022       1 nixl_plugin_manager.cpp:206] Loading plugins from: /workspace/nixl/build/src/plugins/ucx
I0731 18:18:03.552188       1 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: UCX
I0731 18:18:03.552534       1 config.cpp:43] Modified UCX config: ADDRESS_VERSION=v2
I0731 18:18:03.552558       1 config.cpp:43] Modified UCX config: RNDV_THRESH=inf
I0731 18:18:03.552571       1 config.cpp:43] Modified UCX config: MAX_COMPONENT_MDS=32
I0731 18:18:03.552583       1 config.cpp:43] Modified UCX config: MAX_RMA_RAILS=2
I0731 18:18:03.981829       1 ucx_utils.cpp:143] ep 0x7f437c0210b0: state 0 -> 1
I0731 18:18:03.982074       1 nixl_agent.cpp:320] Created backend: UCX
I0731 18:18:03.987922       1 nixl_agent.cpp:92] NIXL ETCD is disabled
I0731 18:18:03.988069       1 config.cpp:43] Modified UCX config: ADDRESS_VERSION=v2
I0731 18:18:03.988090       1 config.cpp:43] Modified UCX config: RNDV_THRESH=inf
I0731 18:18:03.988104       1 config.cpp:43] Modified UCX config: MAX_COMPONENT_MDS=32
I0731 18:18:03.988117       1 config.cpp:43] Modified UCX config: MAX_RMA_RAILS=2
I0731 18:18:04.188327       1 ucx_utils.cpp:143] ep 0x7f436c0440b0: state 0 -> 1
I0731 18:18:04.188435       1 nixl_agent.cpp:320] Created backend: UCX
I0731 18:18:04.194282       1 nixl_agent.cpp:1236] Loading remote metadata for agent: target
I0731 18:18:04.199368       1 ucx_utils.cpp:143] ep 0x7f437c021108: state 0 -> 1
I0731 18:18:04.199590       1 nixl_agent.cpp:1236] Loading remote metadata for agent: initiator
I0731 18:18:04.203902       1 ucx_utils.cpp:143] ep 0x7f436c044108: state 0 -> 1
I0731 18:18:04.204032       1 nixl_agent.cpp:783] Selected backend: UCX
I0731 18:18:06.193300       1 ucx_utils.cpp:115] ep 0x7f437c021108: state 1, UCX error handling callback was invoked with status -80 (Endpoint timeout)
I0731 18:18:06.193402       1 ucx_utils.cpp:143] ep 0x7f437c021108: state 1 -> 2
W0731 18:18:06.197675       1 ucx_utils.cpp:62] Unexpected UCX error: Request canceled
[1753985883.552612] [soul01:1    :0]     ucp_context.c:2339 UCX  INFO  Version 1.19.0 (loaded from /lib/libucp.so.0)
[1753985883.968145] [soul01:1    :0]          parser.c:2368 UCX  INFO  UCX_* env variables: UCX_LOG_LEVEL=info UCX_RC_TIMEOUT=100us UCX_RC_RETRY_COUNT=4 UCX_UD_TIMEOUT=3s
[1753985883.969586] [soul01:1    :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_0 self cfg#1 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
[1753985883.988140] [soul01:1    :0]     ucp_context.c:2339 UCX  INFO  Version 1.19.0 (loaded from /lib/libucp.so.0)
[1753985884.176275] [soul01:1    :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_1 self cfg#1 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
[1753985884.195785] [soul01:1    :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_0 intra-node cfg#2 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
[1753985884.199463] [soul01:1    :1]      ucp_worker.c:1903 UCX  INFO    ucp_context_1 intra-node cfg#2 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
[1753985886.193981] [soul01:1    :0]     ib_mlx5_log.c:179  UCX  DIAG  Transport retry count exceeded on mlx5_0:1/IB (synd 0x15 vend 0x81 hw_synd 0/0)
[1753985886.193981] [soul01:1    :0]     ib_mlx5_log.c:179  UCX  DIAG  RC QP 0xd66 wqe[0]: SEND --e [va 0x7f43527fd600 len 33 lkey 0x1fa665] [rqpn 0xd68 dlid=24 sl=0 port=1 src_path_bits=0]
../test/gtest/error_handling.cpp:229: Failure
Expected equality of these values:
  NIXL_ERR_REMOTE_DISCONNECT
    Which is: -10
  status
    Which is: -3
```

Debug:

```
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from UCX/TestErrorHandling
[ RUN      ] UCX/TestErrorHandling.LoadRemoteThenFail/0
I0801 15:40:04.429156    1049 nixl_agent.cpp:92] NIXL ETCD is disabled
I0801 15:40:04.429405    1049 nixl_plugin_manager.cpp:197] Loading plugins from file: /workspace/nixl/build/pluginlist
warning: could not find '.gnu_debugaltlink' file for /lib/x86_64-linux-gnu/liblber.so.2
warning: could not find '.gnu_debugaltlink' file for /lib/x86_64-linux-gnu/liburing.so.2
I0801 15:40:05.041554    1049 nixl_plugin_manager.cpp:206] Loading plugins from: /workspace/nixl/build/src/plugins/ucx
I0801 15:40:05.041813    1049 nixl_plugin_manager.cpp:316] Discovered and loaded plugin: UCX
I0801 15:40:05.042197    1049 config.cpp:43] Modified UCX config: ADDRESS_VERSION=v2
I0801 15:40:05.042222    1049 config.cpp:43] Modified UCX config: RNDV_THRESH=inf
I0801 15:40:05.042235    1049 config.cpp:43] Modified UCX config: MAX_COMPONENT_MDS=32
I0801 15:40:05.042247    1049 config.cpp:43] Modified UCX config: MAX_RMA_RAILS=2
[1754062805.042276] [soul01:1049 :0]     ucp_context.c:2339 UCX  INFO  Version 1.19.0 (loaded from /lib/libucp.so.0)
[New Thread 0x7fffec5ff000 (LWP 1068)]
[New Thread 0x7fffe96c6000 (LWP 1069)]
[1754062805.557097] [soul01:1049 :0]          parser.c:2368 UCX  INFO  UCX_* env variables: UCX_LOG_LEVEL=info UCX_RC_TIMEOUT=100us UCX_RC_RETRY_COUNT=4 UCX_UD_TIMEOUT=3s
[New Thread 0x7fffddcb3000 (LWP 1070)]
[1754062805.558725] [soul01:1049 :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_0 self cfg#1 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
I0801 15:40:05.570833    1049 ucx_utils.cpp:143] ep 0x7fffe80550b0: state 0 -> 1
I0801 15:40:05.571123    1049 nixl_agent.cpp:320] Created backend: UCX
I0801 15:40:05.576864    1049 nixl_agent.cpp:92] NIXL ETCD is disabled
I0801 15:40:05.577031    1049 config.cpp:43] Modified UCX config: ADDRESS_VERSION=v2
I0801 15:40:05.577053    1049 config.cpp:43] Modified UCX config: RNDV_THRESH=inf
I0801 15:40:05.577066    1049 config.cpp:43] Modified UCX config: MAX_COMPONENT_MDS=32
I0801 15:40:05.577079    1049 config.cpp:43] Modified UCX config: MAX_RMA_RAILS=2
[1754062805.577101] [soul01:1049 :0]     ucp_context.c:2339 UCX  INFO  Version 1.19.0 (loaded from /lib/libucp.so.0)
[New Thread 0x7fffd14f3000 (LWP 1071)]
[1754062805.790176] [soul01:1049 :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_1 self cfg#1 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
I0801 15:40:05.801434    1049 ucx_utils.cpp:143] ep 0x7fffdc0070b0: state 0 -> 1
I0801 15:40:05.801550    1049 nixl_agent.cpp:320] Created backend: UCX
I0801 15:40:05.806927    1049 nixl_agent.cpp:1236] Loading remote metadata for agent: target
[1754062805.808177] [soul01:1049 :0]      ucp_worker.c:1903 UCX  INFO    ucp_context_0 intra-node cfg#2 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
I0801 15:40:05.811102    1049 ucx_utils.cpp:143] ep 0x7fffe8055108: state 0 -> 1
[1754062805.811199] [soul01:1049 :1]      ucp_worker.c:1903 UCX  INFO    ucp_context_1 intra-node cfg#2 rma(rc_mlx5/mlx5_0:1)  amo(rc_mlx5/mlx5_0:1)  am(rc_mlx5/mlx5_0:1 rc_mlx5/mlx5_0:1)  ka(ud_mlx5/mlx5_0:1)
I0801 15:40:05.811328    1049 nixl_agent.cpp:1236] Loading remote metadata for agent: initiator
I0801 15:40:05.814809    1049 ucx_utils.cpp:143] ep 0x7fffdc007108: state 0 -> 1
I0801 15:40:05.814940    1049 nixl_agent.cpp:783] Selected backend: UCX
[Thread 0x7fffd14f3000 (LWP 1071) exited]
I0801 15:40:07.895719    1049 ucx_utils.cpp:115] ep 0x7fffe8055108: state 1, UCX error handling callback was invoked with status -80 (Endpoint timeout)
I0801 15:40:07.895816    1049 ucx_utils.cpp:143] ep 0x7fffe8055108: state 1 -> 2
[1754062807.896151] [soul01:1049 :0]     ib_mlx5_log.c:179  UCX  DIAG  Transport retry count exceeded on mlx5_0:1/IB (synd 0x15 vend 0x81 hw_synd 0/0)
[1754062807.896151] [soul01:1049 :0]     ib_mlx5_log.c:179  UCX  DIAG  RC QP 0xe9d wqe[0]: SEND --e [va 0x7fffc57fd600 len 33 lkey 0x6e2a30] [rqpn 0xe9f dlid=24 sl=0 port=1 src_path_bits=0]
                                                                                                                                                                                                                                                                                        Thread 1 "gtest" hit Breakpoint 1, ucx_status_to_nixl (status=UCS_ERR_CANCELED) at ../src/utils/ucx/ucx_utils.cpp:62
62              NIXL_WARN << "Unexpected UCX error: " << ucs_status_string(status);
(gdb) p status
$1 = UCS_ERR_CANCELED
(gdb) bt
#0  ucx_status_to_nixl (status=UCS_ERR_CANCELED) at ../src/utils/ucx/ucx_utils.cpp:62
#1  0x00007fffef38a524 in nixlUcxBackendH::status (this=0x555555b66750) at ../src/plugins/ucx/ucx_backend.cpp:386
#2  0x00007fffef386dee in nixlUcxEngine::checkXfer (this=0x555555822b90, handle=0x555555b66750) at ../src/plugins/ucx/ucx_backend.cpp:1080
#3  0x00007ffff7eebb82 in nixlAgent::getXferStatus (this=0x5555557d7f30, req_hndl=0x555555b659b0) at ../src/core/nixl_agent.cpp:954
#4  0x000055555562602c in gtest::TestErrorHandling::Agent::waitForCompletion (this=0x5555557d9838, req_handle=0x555555b659b0) at ../test/gtest/error_handling.cpp:180
#5  0x000055555562bac0 in gtest::TestErrorHandling::testXfer<(gtest::TestErrorHandling::TestType)1, (nixl_xfer_op_t)1> (this=0x5555557d97d0) at ../test/gtest/error_handling.cpp:228
#6  0x00005555556274f6 in gtest::TestErrorHandling_LoadRemoteThenFail_Test::TestBody (this=0x5555557d97d0) at ../test/gtest/error_handling.cpp:317
#7  0x00005555556e720f in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#8  0x00005555556cf3a6 in testing::Test::Run() ()
#9  0x00005555556cf565 in testing::TestInfo::Run() ()
#10 0x00005555556cf74f in testing::TestSuite::Run() ()
#11 0x00005555556dd5bc in testing::internal::UnitTestImpl::RunAllTests() ()
#12 0x00005555556e78e7 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#13 0x00005555556cf948 in testing::UnitTest::Run() ()
#14 0x00005555555b2eef in RUN_ALL_TESTS () at /usr/include/gtest/gtest.h:2317
#15 0x00005555555b2c5d in gtest::RunTests (argc=1, argv=0x7fffffffdc28) at ../test/gtest/main.cpp:52
#16 0x00005555555b2c83 in main (argc=2, argv=0x7fffffffdc28) at ../test/gtest/main.cpp:56
```

The problem is that UCS_ERR_CANCELED is not mapped to any NIXL status codes in ucx_status_to_nixl. The code falls back to the generic NIXL_ERR_BACKEND which is then rejected by the test check.