### PR TITLE
testing: Refactor plugins gtest infra to support additional test cases

### DIFF
--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -44,8 +44,9 @@ public:
         for (auto &entry : buf_) {
             uint8_t expected_byte = start_byte++;
             if (entry != expected_byte) {
-                NIXL_ERROR << "Verification failed! local: " << entry
-                           << ", expected: " << expected_byte;
+                NIXL_ERROR << absl::StrFormat("Byte mismatch: actual=0x%x, expected=0x%x",
+                                              static_cast<int>(entry),
+                                              static_cast<int>(expected_byte));
                 return false;
             }
         }
@@ -105,8 +106,8 @@ public:
 
     void
     populateMetaDesc(nixlMetaDesc *desc, int entry_index, size_t entry_size) {
-        desc->addr = 0;
-        desc->len = len_;
+        desc->addr = entry_index * entry_size;
+        desc->len = entry_size;
         desc->devId = devId_;
         desc->metadataP = md_;
     }

--- a/test/gtest/plugins/obj_plugin.cpp
+++ b/test/gtest/plugins/obj_plugin.cpp
@@ -50,29 +50,35 @@ protected:
 };
 
 TEST_P(setupObjTestFixture, XferTest) {
+    transferMemConfig mem_cfg;
     transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, 1);
-    transfer.setLocalMem();
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, mem_cfg);
+    transfer.setupMems();
+    transfer.setSrcMem();
     transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
+    transfer.resetSrcMem();
     transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
+    transfer.checkSrcMem();
 }
 
 TEST_P(setupObjTestFixture, XferMultiBufsTest) {
+    transferMemConfig mem_cfg{.numBufs_ = 3};
     transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, 3);
-    transfer.setLocalMem();
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, mem_cfg);
+    transfer.setupMems();
+    transfer.setSrcMem();
     transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
+    transfer.resetSrcMem();
     transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
+    transfer.checkSrcMem();
 }
 
 TEST_P(setupObjTestFixture, queryMemTest) {
+    transferMemConfig mem_cfg{.numBufs_ = 3};
     transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, 3);
-    transfer.setLocalMem();
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, mem_cfg);
+    transfer.setupMems();
+    transfer.setSrcMem();
     transfer.testTransfer(NIXL_WRITE);
 
     nixl_reg_dlist_t descs(OBJ_SEG);


### PR DESCRIPTION
## What?
Refactored plugins GTest infrastructure to support more flexible test cases and flows.

## Why?
To make it easier to add and manage test variations (e.g., sizes, random data, edge cases) and reduce duplication.

## How?
Used transferMemConfig for configuration, added support for random buffers, and simplified test setup logic.
