### PR TITLE
Bugfix: Replace select() with poll() in connectToIP to prevent stack smashing

### DIFF
--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -59,22 +59,26 @@ int connectToIP(std::string ip_addr, int port) {
         return -1;
     }
 
-    // Use select to wait for connection with timeout
-    fd_set write_fds;
-    FD_ZERO(&write_fds);
-    FD_SET(ret_fd, &write_fds);
+    // Use poll to wait for connection with timeout
+    struct pollfd pfd;
+    pfd.fd = ret_fd;
+    pfd.events = POLLOUT;
+    pfd.revents = 0;
 
-    struct timeval tv;
-    tv.tv_sec = 1;
-    tv.tv_usec = 0;
-
-    ret = select(ret_fd + 1, NULL, &write_fds, NULL, &tv);
+    ret = poll(&pfd, 1, 1000); // 1000ms timeout
     if (ret <= 0) {
         if (ret < 0) {
-            NIXL_PERROR << "select failed for ip_addr: " << ip_addr << " and port: " << port;
+            NIXL_PERROR << "poll failed for ip_addr: " << ip_addr << " and port: " << port;
         } else {
-            NIXL_ERROR << "select timed out for ip_addr: " << ip_addr << " and port: " << port;
+            NIXL_ERROR << "poll timed out for ip_addr: " << ip_addr << " and port: " << port;
         }
+        close(ret_fd);
+        return -1;
+    }
+
+    if (!(pfd.revents & POLLOUT)) {
+        NIXL_ERROR << "poll returned but socket not ready for write for ip_addr: " << ip_addr
+                   << " and port: " << port;
         close(ret_fd);
         return -1;
     }


### PR DESCRIPTION
## What?
Fixed stack smashing detected crash in connectToIP() by replacing `select()` with `poll()`.

## Why?
The `select()` system call crashes when file descriptors exceed `FD_SETSIZE (1024)`. The crash occurred when `connectToIP()` received `fd>1024`, causing `FD_SET()` to write beyond the `fd_set` structure bounds.
According to the Linux manual: "All modern applications should instead use poll(2) or epoll(7), which do not suffer this limitation."
https://man7.org/linux/man-pages/man2/select.2.html

## How?
Replaced `select()` with `poll()` using` POLLOUT event` and `1000ms` timeout. Maintains identical functionality while supporting unlimited file descriptor numbers.
