### PR TITLE
AGENT/DATA: loadConnInfo and loadRemoteSections refactoring

### DIFF
--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -97,6 +97,12 @@ class nixlAgentData {
         void commWorker(nixlAgent* myAgent);
         void enqueueCommWork(nixl_comm_req_t request);
         void getCommWork(std::vector<nixl_comm_req_t> &req_list);
+        nixl_status_t
+        loadConnInfo(const std::string &remote_name,
+                     const nixl_backend_t &backend,
+                     const nixl_blob_t &conn_info);
+        nixl_status_t
+        loadRemoteSections(const std::string &remote_name, nixlSerDes &sd);
 
     public:
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);

--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -652,3 +652,55 @@ void nixlAgentData::getCommWork(std::vector<nixl_comm_req_t> &req_list){
     req_list = std::move(commQueue);
     commQueue.clear();
 }
+
+nixl_status_t
+nixlAgentData::loadConnInfo(const std::string &remote_name,
+                            const nixl_backend_t &backend,
+                            const nixl_blob_t &conn_info) {
+    if (backendEngines.count(backend) == 0) {
+        NIXL_ERROR << "Agent " << name << " does not support a remote backend: " << backend;
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    // No need to reload same conn info, error if it changed
+    if ((remoteBackends.count(remote_name) != 0) &&
+        (remoteBackends[remote_name].count(backend) != 0)) {
+        if (remoteBackends[remote_name][backend] != conn_info) {
+            return NIXL_ERR_NOT_ALLOWED;
+        }
+
+        return NIXL_SUCCESS;
+    }
+
+    nixlBackendEngine *eng = backendEngines[backend];
+    if (!eng->supportsRemote()) {
+        NIXL_ERROR << backend << " does not support remote operations";
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    const nixl_status_t ret = eng->loadRemoteConnInfo(remote_name, conn_info);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    remoteBackends[remote_name].emplace(backend, conn_info);
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlAgentData::loadRemoteSections(const std::string &remote_name, nixlSerDes &sd) {
+    if (remoteSections.count(remote_name) == 0) {
+        remoteSections[remote_name] = new nixlRemoteSection(remote_name);
+    }
+
+    const nixl_status_t ret = remoteSections[remote_name]->loadRemoteData(&sd, backendEngines);
+    // TODO: can be more graceful, if just the new MD blob was improper
+    if (ret != NIXL_SUCCESS) {
+        delete remoteSections[remote_name];
+        remoteSections.erase(remote_name);
+        remoteBackends.erase(remote_name);
+        return ret;
+    }
+
+    return NIXL_SUCCESS;
+}


### PR DESCRIPTION
## What?
Logical code movement to Agent::data` methods:
 - loadConnInfo
 - loadRemoteSections

## Why?
refactoring part of PR https://github.com/ai-dynamo/nixl/pull/509
PRed separately by request in https://github.com/ai-dynamo/nixl/pull/509#discussion_r2265137307
