### PR TITLE
BINDINGS/RUST: adding missing  Agent APIs - make_xfer_req, prepare_xfer_dlist, partial_md, query_xfer_backend

### DIFF
--- a/src/bindings/rust/src/descriptors.rs
+++ b/src/bindings/rust/src/descriptors.rs
@@ -18,10 +18,12 @@ use super::*;
 mod query;
 mod reg;
 mod xfer;
+mod xfer_dlist_handle;
 
 pub use query::{QueryResponse, QueryResponseIterator, QueryResponseList};
 pub use reg::RegDescList;
 pub use xfer::XferDescList;
+pub use xfer_dlist_handle::XferDlistHandle;
 
 /// Memory types supported by NIXL
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/bindings/rust/src/descriptors/xfer_dlist_handle.rs
+++ b/src/bindings/rust/src/descriptors/xfer_dlist_handle.rs
@@ -16,21 +16,26 @@
 use super::*;
 
 pub struct XferDlistHandle {
-    inner: NonNull<bindings::nixl_capi_xfer_dlist_s>,
+    inner: NonNull<bindings::nixl_capi_xfer_dlist_handle_s>,
     agent: NonNull<bindings::nixl_capi_agent_s>
 }
 
 impl XferDlistHandle {
-    pub(crate) fn new(inner: NonNull<bindings::nixl_capi_xfer_dlist_s>, 
+    pub(crate) fn new(inner: NonNull<bindings::nixl_capi_xfer_dlist_handle_s>,
                       agent: NonNull<bindings::nixl_capi_agent_s>) -> Self {
         Self { inner, agent }
+    }
+
+    pub(crate) fn handle(&self) -> *mut bindings::nixl_capi_xfer_dlist_handle_s {
+        self.inner.as_ptr()
     }
 }
 
 impl Drop for XferDlistHandle {
     fn drop(&mut self) {
         unsafe {
-            bindings::nixl_capi_release_xfer_dlist_handle(self.agent.as_ptr(), self.inner.as_ptr());
+            nixl_capi_release_xfer_dlist_handle(self.agent.as_ptr(),
+                                               self.inner.as_ptr());
         }
     }
 }

--- a/src/bindings/rust/src/descriptors/xfer_dlist_handle.rs
+++ b/src/bindings/rust/src/descriptors/xfer_dlist_handle.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+pub struct XferDlistHandle {
+    inner: NonNull<bindings::nixl_capi_xfer_dlist_s>,
+    agent: NonNull<bindings::nixl_capi_agent_s>
+}
+
+impl XferDlistHandle {
+    pub(crate) fn new(inner: NonNull<bindings::nixl_capi_xfer_dlist_s>, 
+                      agent: NonNull<bindings::nixl_capi_agent_s>) -> Self {
+        Self { inner, agent }
+    }
+}
+
+impl Drop for XferDlistHandle {
+    fn drop(&mut self) {
+        unsafe {
+            bindings::nixl_capi_release_xfer_dlist_handle(self.agent.as_ptr(), self.inner.as_ptr());
+        }
+    }
+}

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -69,7 +69,8 @@ use bindings::{
     nixl_capi_xfer_dlist_print, nixl_capi_reg_dlist_is_sorted, nixl_capi_gen_notif, nixl_capi_estimate_xfer_cost,
     nixl_capi_query_mem, nixl_capi_create_query_resp_list, nixl_capi_destroy_query_resp_list,
     nixl_capi_query_resp_list_size, nixl_capi_query_resp_list_has_value,
-    nixl_capi_query_resp_list_get_params,
+    nixl_capi_query_resp_list_get_params, nixl_capi_prep_xfer_dlist, nixl_capi_release_xfer_dlist_handle,
+    nixl_capi_make_xfer_req
 };
 
 // Re-export status codes
@@ -111,6 +112,8 @@ pub enum NixlError {
     RegDescListCreationFailed,
     #[error("Failed to add registration descriptor")]
     RegDescAddFailed,
+    #[error("Failed to create XferDlistHandle")]
+    FailedToCreateXferDlistHandle,
 }
 
 /// A safe wrapper around NIXL memory list

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -70,7 +70,8 @@ use bindings::{
     nixl_capi_query_mem, nixl_capi_create_query_resp_list, nixl_capi_destroy_query_resp_list,
     nixl_capi_query_resp_list_size, nixl_capi_query_resp_list_has_value,
     nixl_capi_query_resp_list_get_params, nixl_capi_prep_xfer_dlist, nixl_capi_release_xfer_dlist_handle,
-    nixl_capi_make_xfer_req
+    nixl_capi_make_xfer_req, nixl_capi_query_xfer_backend, nixl_capi_get_local_partial_md,
+    nixl_capi_send_local_partial_md
 };
 
 // Re-export status codes

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -37,6 +37,8 @@ struct nixl_capi_xfer_dlist_s { /* empty */ };
 struct nixl_capi_reg_dlist_s { /* empty */ };
 struct nixl_capi_xfer_req_s { /* empty */ };
 struct nixl_capi_notif_map_s { /* empty */ };
+struct nixl_capi_xfer_dlist_handle_s { /* empty */ };
+
 
 nixl_capi_status_t
 nixl_capi_stub_abort()
@@ -66,6 +68,30 @@ nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len)
 
 nixl_capi_status_t
 nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name)
+{
+  return nixl_capi_stub_abort();
+}
+
+nixl_capi_status_t
+nixl_capi_prep_xfer_dlist(nixl_capi_agent_t agent, const char* agent_name, nixl_capi_xfer_dlist_t descs,
+                          nixl_capi_xfer_dlist_handle_t dlist_handle, nixl_capi_opt_args_t opt_args)
+{
+  return nixl_capi_stub_abort();
+}
+
+nixl_capi_status_t
+nixl_capi_release_xfer_dlist_handle(nixl_capi_agent_t agent, nixl_capi_xfer_dlist_handle_t dlist_handle)
+{
+  return nixl_capi_stub_abort();
+}
+
+
+nixl_capi_status_t
+nixl_capi_make_xfer_req(
+    nixl_capi_agent_t agent, nixl_capi_xfer_op_t operation,
+    nixl_capi_xfer_dlist_handle_t local_descs, const int* local_indices, size_t local_indices_count, 
+    nixl_capi_xfer_dlist_handle_t remote_descs, const int* remote_indices, size_t remote_indices_count, 
+    nixl_capi_xfer_req_t* req_hndl, nixl_capi_opt_args_t opt_args)
 {
   return nixl_capi_stub_abort();
 }

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -67,6 +67,10 @@ struct nixl_capi_xfer_dlist_s {
   nixl_xfer_dlist_t* dlist;
 };
 
+struct nixl_capi_xfer_dlist_handle_s {
+  nixlDlistH* handle;
+};
+
 struct nixl_capi_reg_dlist_s {
   nixl_reg_dlist_t* dlist;
 };
@@ -1336,6 +1340,78 @@ nixl_capi_status_t nixl_capi_agent_make_connection(
     nixl_status_t ret = agent->inner->makeConnection(std::string(remote_agent),
                                                     opt_args ? &opt_args->args : nullptr);
     return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+  }
+  catch (...) {
+    return NIXL_CAPI_ERROR_BACKEND;
+  }
+}
+
+nixl_capi_status_t nixl_capi_prep_xfer_dlist(
+  nixl_capi_agent_t agent, const char* agent_name, nixl_capi_xfer_dlist_t descs, 
+  nixl_capi_xfer_dlist_handle_t dlist_handle, nixl_capi_opt_args_t opt_args)
+{
+  if (!agent || !agent_name || !descs || !dlist_handle) {
+    return NIXL_CAPI_ERROR_INVALID_PARAM;
+  }
+
+  try {
+    nixl_status_t ret = agent->inner->prepXferDlist(
+      std::string(agent_name), 
+      *descs->dlist, 
+      dlist_handle->handle, 
+      opt_args ? &opt_args->args : nullptr
+    );
+    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+  }
+  catch (...) {
+    return NIXL_CAPI_ERROR_BACKEND;
+  }
+}
+
+nixl_capi_status_t nixl_capi_release_xfer_dlist_handle(nixl_capi_agent_t agent, nixl_capi_xfer_dlist_handle_t dlist_handle)
+{
+  if (!agent || !dlist_handle) {
+    return NIXL_CAPI_ERROR_INVALID_PARAM;
+  }
+
+  try {
+    nixl_status_t ret = agent->inner->releasedDlistH(dlist_handle->handle);
+    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+  }
+  catch (...) {
+    return NIXL_CAPI_ERROR_BACKEND;
+  }
+}
+
+nixl_capi_status_t nixl_capi_make_xfer_req(
+    nixl_capi_agent_t agent, nixl_capi_xfer_op_t operation,
+    nixl_capi_xfer_dlist_handle_t local_descs, const int* local_indices, size_t local_indices_count, 
+    nixl_capi_xfer_dlist_handle_t remote_descs, const int* remote_indices, size_t remote_indices_count, 
+    nixl_capi_xfer_req_t* req_hndl, nixl_capi_opt_args_t opt_args)
+{
+  if (!agent || !local_descs || !remote_descs || !req_hndl) {
+    return NIXL_CAPI_ERROR_INVALID_PARAM;
+  }
+
+  try {
+    auto req = new nixl_capi_xfer_req_s;
+    nixl_status_t ret = agent->inner->makeXferReq(
+      static_cast<nixl_xfer_op_t>(operation),
+      local_descs->handle,
+      std::vector<int>(local_indices, local_indices + local_indices_count),
+      remote_descs->handle,
+      std::vector<int>(remote_indices, remote_indices + remote_indices_count),
+      req->req,
+      opt_args ? &opt_args->args : nullptr
+    );
+
+    if (ret != NIXL_SUCCESS) {
+      delete req;
+      return NIXL_CAPI_ERROR_BACKEND;
+    }
+
+    *req_hndl = req;
+    return NIXL_CAPI_SUCCESS;
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -56,6 +56,7 @@ struct nixl_capi_backend_s;
 struct nixl_capi_opt_args_s;
 struct nixl_capi_param_iter_s;
 struct nixl_capi_xfer_dlist_s;
+struct nixl_capi_xfer_dlist_handle_s;
 struct nixl_capi_reg_dlist_s;
 struct nixl_capi_xfer_req_s;
 struct nixl_capi_notif_map_s;
@@ -70,6 +71,7 @@ typedef struct nixl_capi_backend_s* nixl_capi_backend_t;
 typedef struct nixl_capi_opt_args_s* nixl_capi_opt_args_t;
 typedef struct nixl_capi_param_iter_s* nixl_capi_param_iter_t;
 typedef struct nixl_capi_xfer_dlist_s* nixl_capi_xfer_dlist_t;
+typedef struct nixl_capi_xfer_dlist_handle_s* nixl_capi_xfer_dlist_handle_t;
 typedef struct nixl_capi_reg_dlist_s* nixl_capi_reg_dlist_t;
 typedef struct nixl_capi_xfer_req_s* nixl_capi_xfer_req_t;
 typedef struct nixl_capi_notif_map_s* nixl_capi_notif_map_t;
@@ -163,6 +165,19 @@ nixl_capi_status_t nixl_capi_deregister_mem(
 
 nixl_capi_status_t nixl_capi_agent_make_connection(
     nixl_capi_agent_t agent, const char* remote_agent, nixl_capi_opt_args_t opt_args);
+
+nixl_capi_status_t nixl_capi_prep_xfer_dlist(
+    nixl_capi_agent_t agent, const char* agent_name, nixl_capi_xfer_dlist_t descs,
+    nixl_capi_xfer_dlist_handle_t dlist_hndl, nixl_capi_opt_args_t opt_args);
+
+nixl_capi_status_t nixl_capi_release_xfer_dlist_handle(
+    nixl_capi_agent_t agent, nixl_capi_xfer_dlist_handle_t dlist_handle);
+
+nixl_capi_status_t nixl_capi_make_xfer_req(
+    nixl_capi_agent_t agent, nixl_capi_xfer_op_t operation,
+    nixl_capi_xfer_dlist_handle_t local_descs, const int* local_indices, size_t local_indices_count,
+    nixl_capi_xfer_dlist_handle_t remote_descs, const int* remote_indices, size_t remote_indices_count,
+    nixl_capi_xfer_req_t* req_hndl, nixl_capi_opt_args_t opt_args);
 
 // Notification functions
 nixl_capi_status_t nixl_capi_get_notifs(

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -91,6 +91,11 @@ nixl_capi_status_t nixl_capi_destroy_agent(nixl_capi_agent_t agent);
 // Get local metadata as a byte array
 nixl_capi_status_t nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len);
 
+// Get local partial metadata as a byte array
+nixl_capi_status_t
+nixl_capi_get_local_partial_md(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t descs,
+    void** data, size_t* len, nixl_capi_opt_args_t opt_args);
+
 // Load remote metadata from a byte array
 nixl_capi_status_t nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name);
 
@@ -105,6 +110,10 @@ nixl_capi_status_t nixl_capi_check_remote_md(nixl_capi_agent_t agent, const char
 
 // Send local metadata to etcd
 nixl_capi_status_t nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
+
+// Send local partial metadata to etcd
+nixl_capi_status_t
+nixl_capi_send_local_partial_md(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t descs, nixl_capi_opt_args_t opt_args);
 
 // Fetch remote metadata from etcd
 nixl_capi_status_t nixl_capi_fetch_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_opt_args_t opt_args);
@@ -209,6 +218,9 @@ nixl_capi_status_t nixl_capi_post_xfer_req(
     nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args);
 
 nixl_capi_status_t nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl);
+
+nixl_capi_status_t nixl_capi_query_xfer_backend(
+    nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_backend_t* backend);
 
 nixl_capi_status_t nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req);
 


### PR DESCRIPTION
## What?
Add the following APIs to Rust bindings:

1. prep_xfer_dlist
2. make_xfer_req
3. query_xfer_backend
4. releasedDlistH (should be called from Drop)
5. get_local_partial_md
6. send_local_partial_md

## Why?
Well, so we will be able to use those APIs in libraries written in Rust, such as Dynamo
