### PR TITLE
NIXLBENCH: Set RW sync mode for UCX when num_threads > 1

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -81,13 +81,16 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
     std::string backend_name;
     nixl_b_params_t backend_params;
     bool enable_pt = xferBenchConfig::enable_pt;
+    nixl_thread_sync_t sync_mode = xferBenchConfig::num_threads > 1 ?
+        nixl_thread_sync_t::NIXL_THREAD_SYNC_RW :
+        nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT;
     char hostname[256];
     nixl_mem_list_t mems;
     std::vector<nixl_backend_t> plugins;
 
     rank = rt->getRank();
 
-    nixlAgentConfig dev_meta(enable_pt);
+    nixlAgentConfig dev_meta(enable_pt, false, 0, sync_mode);
 
     agent = new nixlAgent(name, dev_meta);
 

--- a/src/api/cpp/nixl_params.h
+++ b/src/api/cpp/nixl_params.h
@@ -63,19 +63,18 @@ class nixlAgentConfig {
          * @param pthr_delay_us      Optional delay for pthread in us
          * @param lthr_delay_us      Optional delay for listener thread in us
          */
-        nixlAgentConfig (const bool use_prog_thread,
-                         const bool use_listen_thread=false,
-                         const int port=0,
-                         nixl_thread_sync_t sync_mode=nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT,
-                         unsigned int num_workers = 1,
-                         const uint64_t pthr_delay_us=0,
-                         const uint64_t lthr_delay_us = 100000) :
-                         useProgThread(use_prog_thread),
-                         useListenThread(use_listen_thread),
-                         listenPort(port),
-                         syncMode(sync_mode),
-                         pthrDelay(pthr_delay_us),
-                         lthrDelay(lthr_delay_us) { }
+        nixlAgentConfig(const bool use_prog_thread,
+                        const bool use_listen_thread = false,
+                        const int port = 0,
+                        nixl_thread_sync_t sync_mode = nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT,
+                        const uint64_t pthr_delay_us = 0,
+                        const uint64_t lthr_delay_us = 100000)
+            : useProgThread(use_prog_thread),
+              useListenThread(use_listen_thread),
+              listenPort(port),
+              syncMode(sync_mode),
+              pthrDelay(pthr_delay_us),
+              lthrDelay(lthr_delay_us) {}
 
         /**
          * @brief Copy constructor for nixlAgentConfig object


### PR DESCRIPTION
## What?
nixlbench [crashes](https://github.com/ai-dynamo/nixl/issues/636) with UCX backend when `--num_threads` > 1

## Why?
NIXL sets proper UCX worker lock mode only when progress thread is set (`--enable_pt` option), but not when multiple threads are being used.