### PR TITLE
plugins/posix: Fix queue type message

### DIFF
--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -126,9 +126,8 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
     , queue_depth_(loc.descCount())
     , queue_type_(getQueueType(params)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
-        throw exception(
-            absl::StrFormat("Unsupported backend type: %s", to_string(queue_type_)),
-            NIXL_ERR_NOT_SUPPORTED);
+        throw exception(absl::StrFormat("Unsupported backend type: %s", to_string(queue_type_)),
+                        NIXL_ERR_NOT_SUPPORTED);
     }
 
     if (local.descCount() == 0 || remote.descCount() == 0) {
@@ -139,9 +138,8 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
 
     nixl_status_t status = initQueues();
     if (status != NIXL_SUCCESS) {
-        throw exception(
-            absl::StrFormat("Failed to initialize queues: %s", to_string(queue_type_)),
-            status);
+        throw exception(absl::StrFormat("Failed to initialize queues: %s", to_string(queue_type_)),
+                        status);
     }
 }
 
@@ -206,11 +204,13 @@ nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams* init_params)
     , queue_type_(getQueueType(init_params->customParams)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         initErr = true;
-        NIXL_ERROR << absl::StrFormat("Failed to initialize POSIX backend - requested backend not available: %s",
-                                      to_string(queue_type_));
+        NIXL_ERROR << absl::StrFormat(
+            "Failed to initialize POSIX backend - requested backend not available: %s",
+            to_string(queue_type_));
         return;
     }
-    NIXL_INFO << absl::StrFormat("POSIX backend initialized using %s backend", to_string(queue_type_));
+    NIXL_INFO << absl::StrFormat("POSIX backend initialized using %s backend",
+                                 to_string(queue_type_));
 }
 
 nixl_status_t nixlPosixEngine::registerMem(const nixlBlobDesc &mem,

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -127,7 +127,7 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
     , queue_type_(getQueueType(params)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         throw exception(
-            absl::StrFormat("Unsupported backend type: %s", queue_type_),
+            absl::StrFormat("Unsupported backend type: %s", to_string(queue_type_)),
             NIXL_ERR_NOT_SUPPORTED);
     }
 
@@ -140,7 +140,7 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
     nixl_status_t status = initQueues();
     if (status != NIXL_SUCCESS) {
         throw exception(
-            absl::StrFormat("Failed to initialize queues: %s", queue_type_),
+            absl::StrFormat("Failed to initialize queues: %s", to_string(queue_type_)),
             status);
     }
 }
@@ -156,7 +156,7 @@ nixl_status_t nixlPosixBackendReqH::initQueues() {
                 queue = QueueFactory::createUringQueue(queue_depth_, operation);
                 break;
             default:
-                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", queue_type_);
+                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
                 return NIXL_ERR_INVALID_PARAM;
         }
         return NIXL_SUCCESS;
@@ -207,10 +207,10 @@ nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams* init_params)
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         initErr = true;
         NIXL_ERROR << absl::StrFormat("Failed to initialize POSIX backend - requested backend not available: %s",
-                                      queue_type_);
+                                      to_string(queue_type_));
         return;
     }
-    NIXL_INFO << absl::StrFormat("POSIX backend initialized using %s backend", queue_type_);
+    NIXL_INFO << absl::StrFormat("POSIX backend initialized using %s backend", to_string(queue_type_));
 }
 
 nixl_status_t nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
@@ -248,7 +248,7 @@ nixl_status_t nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
                 params["use_uring"] = "true";
                 break;
             default:
-                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", queue_type_);
+                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
                 return NIXL_ERR_INVALID_PARAM;
         }
 

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -126,8 +126,7 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
     , queue_depth_(loc.descCount())
     , queue_type_(getQueueType(params)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
-        throw exception(absl::StrFormat("Unsupported backend type: %s", to_string(queue_type_)),
-                        NIXL_ERR_NOT_SUPPORTED);
+        throw exception(absl::StrFormat("Unsupported queue type"), NIXL_ERR_NOT_SUPPORTED);
     }
 
     if (local.descCount() == 0 || remote.descCount() == 0) {
@@ -205,11 +204,11 @@ nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams* init_params)
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         initErr = true;
         NIXL_ERROR << absl::StrFormat(
-            "Failed to initialize POSIX backend - requested backend not available: %s",
+            "Failed to initialize POSIX backend - requested queue type not available: %s",
             to_string(queue_type_));
         return;
     }
-    NIXL_INFO << absl::StrFormat("POSIX backend initialized using %s backend",
+    NIXL_INFO << absl::StrFormat("POSIX backend initialized using queue type: %s",
                                  to_string(queue_type_));
 }
 


### PR DESCRIPTION
## What?
Fix POSIX queue type messages

## Why?
Use to_string to convert queue type correctly.

Running nixl_posix_test you can now see:

```
export NIXL_LOG_LEVEL=INFO

============================================================
      NIXL STORAGE REPOST TEST STARTING (POSIX PLUGIN)
============================================================                                                                  
I0814 11:02:21.840475 3267797 posix_backend.cpp:212] POSIX backend initialized using queue type: URING
``` 