### PR TITLE
query_mem example fix

### DIFF
--- a/examples/python/query_mem_example.py
+++ b/examples/python/query_mem_example.py
@@ -59,7 +59,9 @@ if __name__ == "__main__":
 
         # Create an NIXL agent
         logger.info("Creating NIXL agent...")
-        config = nixl_agent_config(False, False, 0, [])
+        config = nixl_agent_config(
+            enable_prog_thread=False, enable_listen_thread=False, backends=[]
+        )
         agent = nixl_agent("example_agent", config)
 
         # Prepare a list of tuples as file paths in metaInfo field for querying.


### PR DESCRIPTION
## What?
The changes in PR 573 exposes an issue in query_mem examples, fixed it so CI can pass.