### PR TITLE
SRC/BINDINGS/RUST: Added get_local_partial_md and send_local_partial_md

### DIFF
--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -325,6 +325,51 @@ impl Agent {
         }
     }
 
+    /// Gets the local partial metadata as a byte array
+    ///
+    /// # Arguments
+    /// * `descs` - Registration descriptor list to get metadata for
+    /// * `opt_args` - Optional arguments for getting metadata
+    ///
+    /// # Returns
+    /// A byte array containing the local partial metadata
+    ///
+    pub fn get_local_partial_md(&self, descs: &RegDescList, opt_args: Option<&OptArgs>) -> Result<Vec<u8>, NixlError> {
+        tracing::trace!("Getting local partial metadata");
+        let mut data = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let inner_guard = self.inner.write().unwrap();
+        let status = unsafe {
+            nixl_capi_get_local_partial_md(
+                inner_guard.handle.as_ptr(),
+                descs.handle(),
+                &mut data,
+                &mut len,
+                opt_args.map_or(std::ptr::null_mut(), |args| args.inner.as_ptr()),
+            )
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => {
+                let bytes = unsafe {
+                    let slice = std::slice::from_raw_parts(data as *const u8, len);
+                    let vec = slice.to_vec();
+                    libc::free(data as *mut libc::c_void);
+                    vec
+                };
+                tracing::trace!(metadata.size = len, "Successfully retrieved local partial metadata");
+                Ok(bytes)
+            }
+            NIXL_CAPI_ERROR_INVALID_PARAM => {
+                tracing::error!(error = "invalid_param", "Failed to get local partial metadata");
+                Err(NixlError::InvalidParam)
+            }
+            _ => {
+                tracing::error!(error = "backend_error", "Failed to get local partial metadata");
+                Err(NixlError::BackendError)
+            }
+        }
+    }
+
     /// Loads remote metadata from a byte slice
     pub fn load_remote_md(&self, metadata: &[u8]) -> Result<String, NixlError> {
         tracing::trace!(metadata.size = metadata.len(), "Loading remote metadata");
@@ -479,6 +524,35 @@ impl Agent {
             }
         }
     }
+
+    /// Send this agent's partial metadata
+    ///
+    /// # Arguments
+    /// * `descs` - Registration descriptor list to send
+    /// * `opt_args` - Optional arguments for sending metadata
+    pub fn send_local_partial_md(&self, descs: &RegDescList, opt_args: Option<&OptArgs>) -> Result<(), NixlError> {
+        tracing::trace!("Sending local partial metadata to etcd");
+        let inner_guard = self.inner.write().unwrap();
+        let status = unsafe {
+            nixl_capi_send_local_partial_md(
+                inner_guard.handle.as_ptr(),
+                descs.handle(),
+                opt_args.map_or(std::ptr::null_mut(), |args| args.inner.as_ptr()),
+            )
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => {
+                tracing::trace!("Successfully sent local partial metadata to etcd");
+                Ok(())
+            }
+            NIXL_CAPI_ERROR_INVALID_PARAM => {
+                tracing::error!(error = "invalid_param", "Failed to send local partial metadata to etcd");
+                Err(NixlError::InvalidParam)
+            }
+            _ => Err(NixlError::BackendError)
+        }
+    }
+
 
     /// Fetch a remote agent's metadata from etcd
     ///

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -69,7 +69,8 @@ use bindings::{
     nixl_capi_xfer_dlist_print, nixl_capi_reg_dlist_is_sorted, nixl_capi_gen_notif, nixl_capi_estimate_xfer_cost,
     nixl_capi_query_mem, nixl_capi_create_query_resp_list, nixl_capi_destroy_query_resp_list,
     nixl_capi_query_resp_list_size, nixl_capi_query_resp_list_has_value,
-    nixl_capi_query_resp_list_get_params,
+    nixl_capi_query_resp_list_get_params, nixl_capi_get_local_partial_md,
+    nixl_capi_send_local_partial_md,
 };
 
 // Re-export status codes

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -1152,3 +1152,64 @@ fn test_query_mem_empty_list() {
         "Expected 0 responses for empty descriptor list"
     );
 }
+
+// Tests for get_local_partial_md API
+#[test]
+fn test_get_local_partial_md_success() {
+    let agent = setup_agent_with_backend("test_agent")
+        .expect("Failed to setup agent with backend");
+    // Create a registration descriptor list
+    let mut reg_descs = RegDescList::new(MemType::Dram, false)
+        .expect("Failed to create registration descriptor list");
+    reg_descs.add_desc(0x1000, 0x100, 0)
+        .expect("Failed to add descriptor");
+    // Get local partial metadata
+    let result = agent.get_local_partial_md(&reg_descs, None);
+    // Should succeed and return metadata
+    match result {
+        Ok(metadata) => {
+            assert!(!metadata.is_empty(), "Metadata should not be empty");
+            println!("Partial metadata size: {}", metadata.len());
+        }
+        Err(e) => {
+            // May fail if no partial metadata exists yet, which is acceptable
+            assert!(
+                matches!(e, NixlError::BackendError) || matches!(e, NixlError::InvalidParam),
+                "Expected BackendError or InvalidParam, got: {:?}", e
+            );
+        }
+    }
+}
+
+#[test]
+fn test_get_local_partial_md_empty_descs() {
+    let agent = setup_agent_with_backend("test_agent")
+        .expect("Failed to setup agent with backend");
+    // Create empty registration descriptor list
+    let reg_descs = RegDescList::new(MemType::Dram, false)
+        .expect("Failed to create registration descriptor list");
+    // Try with empty descriptor list (should fail)
+    let result = agent.get_local_partial_md(&reg_descs, None);
+    assert!(
+        result.is_err(),
+        "get_local_partial_md should fail with empty descriptor list"
+    );
+}
+
+// Tests for send_local_partial_md API
+#[test]
+fn test_send_local_partial_md_success() {
+    let agent = setup_agent_with_backend("test_agent")
+        .expect("Failed to setup agent with backend");
+    // Create a registration descriptor list
+    let mut reg_descs = RegDescList::new(MemType::Dram, false)
+        .expect("Failed to create registration descriptor list");
+    reg_descs.add_desc(0x1000, 0x100, 0)
+        .expect("Failed to add descriptor");
+    // Send local partial metadata
+    let result = agent.send_local_partial_md(&reg_descs, None);
+    assert!(
+        result.is_ok(),
+        "send_local_partial_md should succeed"
+    );
+}

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -156,6 +156,36 @@ nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len)
 }
 
 nixl_capi_status_t
+nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
+                               nixl_capi_reg_dlist_t descs,
+                               void **data,
+                               size_t *len,
+                               nixl_capi_opt_args_t opt_args) {
+    if (!agent || !descs || !data || !len) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        nixl_blob_t blob;
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixl_status_t ret = agent->inner->getLocalPartialMD(*descs->dlist, blob, args);
+        if (ret != NIXL_SUCCESS) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+        // Allocate memory for the blob data
+        void *blob_data = malloc(blob.size());
+        if (!blob_data) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+        // Copy the data
+        memcpy(blob_data, blob.data(), blob.size());
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
 nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name)
 {
   if (!agent || !data || !len || !agent_name) {
@@ -219,6 +249,23 @@ nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args)
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
   }
+}
+
+nixl_capi_status_t
+nixl_capi_send_local_partial_md(nixl_capi_agent_t agent,
+                                nixl_capi_reg_dlist_t descs,
+                                nixl_capi_opt_args_t opt_args) {
+    if (!agent || !descs) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixl_status_t ret = agent->inner->sendLocalPartialMD(*descs->dlist, args);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -89,6 +89,14 @@ nixl_capi_status_t nixl_capi_destroy_agent(nixl_capi_agent_t agent);
 // Get local metadata as a byte array
 nixl_capi_status_t nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len);
 
+// Get local partial metadata as a byte array
+nixl_capi_status_t
+nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
+                               nixl_capi_reg_dlist_t descs,
+                               void **data,
+                               size_t *len,
+                               nixl_capi_opt_args_t opt_args);
+
 // Load remote metadata from a byte array
 nixl_capi_status_t nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name);
 
@@ -103,6 +111,12 @@ nixl_capi_status_t nixl_capi_check_remote_md(nixl_capi_agent_t agent, const char
 
 // Send local metadata to etcd
 nixl_capi_status_t nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
+
+// Send local partial metadata to etcd
+nixl_capi_status_t
+nixl_capi_send_local_partial_md(nixl_capi_agent_t agent,
+	                            nixl_capi_reg_dlist_t descs,
+                                nixl_capi_opt_args_t opt_args);
 
 // Fetch remote metadata from etcd
 nixl_capi_status_t nixl_capi_fetch_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_opt_args_t opt_args);


### PR DESCRIPTION
## What?
Adding Rust bindings to the following Agent APIs

1. get_local_partial_md
2. send_local_partial_md

## Why?
Bindings to those APIs are missing, resulting in inconsistency with the CPP API.