### PR TITLE
Added enforcement for supportsNotif when supportsRemote.

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -856,9 +856,6 @@ execTransfer(nixlAgent *agent,
 
         if (xferBenchConfig::isStorageBackend()) {
             target = "initiator";
-        } else if (XFERBENCH_BACKEND_MOONCAKE == xferBenchConfig::backend) {
-            params.hasNotif = false;
-            target = "target";
         } else {
             params.notifMsg = "0xBEEF";
             params.hasNotif = true;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -312,6 +312,11 @@ nixlAgent::createBackend(const nixl_backend_t &type,
         }
 
         if (backend->supportsRemote()) {
+            if (!backend->supportsNotif()) {
+                delete backend;
+                return NIXL_ERR_BACKEND;
+            }
+
             ret = backend->getConnInfo(str);
             if (ret != NIXL_SUCCESS) {
                 delete backend;


### PR DESCRIPTION
Also removed the corner case from nixlbench for Mooncake now that it supports notifications.

## What?
Follow up PR to Mooncake supporting notifications, no need for an exception case and we can enforce the notification requirement for network backends.