### PR TITLE
CI: Add iproute2 dependency

### DIFF
--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -83,6 +83,7 @@ $SUDO apt-get -qq install -y curl \
                              pybind11-dev \
                              etcd-server \
                              net-tools \
+                             iproute2 \
                              pciutils \
                              libpci-dev \
                              uuid-dev \


### PR DESCRIPTION
## What?
Adds missing dependency in tests

## Why?

common.sh script uses the `ss` utility from iproute2 package to find unused port numbers for etcd:

```
# Check if the port is already in use
    while ss -tuln | grep -q :$next_port; do
        next_port=$((next_port + 1))
    done
```

Currently it is not always installed, so there are some errors logged in the CI 