### PR TITLE
Agent: Add getXferTelemetry API.

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -78,7 +78,7 @@ cd ${INSTALL_DIR}
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
-NIXL_TELEMETRY_ENABLE=y ./bin/agent_example &
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp ./bin/agent_example &
 sleep 1
 ./bin/telemetry_reader /tmp/Agent001 &
 telePID=$!

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -78,9 +78,9 @@ cd ${INSTALL_DIR}
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp ./bin/agent_example &
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=$PWD/telemetry ./bin/agent_example &
 sleep 1
-./bin/telemetry_reader /tmp/Agent001 &
+./bin/telemetry_reader $PWD/telemetry/Agent001 &
 telePID=$!
 sleep 6
 kill -s SIGINT $telePID

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -78,7 +78,7 @@ cd ${INSTALL_DIR}
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
-mkdir /tmp/telemetry_test
+mkdir -p /tmp/telemetry_test
 NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test ./bin/agent_example &
 sleep 1
 ./bin/telemetry_reader /tmp/telemetry_test/Agent001 &

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -78,9 +78,10 @@ cd ${INSTALL_DIR}
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 ./bin/ucx_mo_backend_test
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=$PWD/telemetry ./bin/agent_example &
+mkdir /tmp/telemetry_test
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test ./bin/agent_example &
 sleep 1
-./bin/telemetry_reader $PWD/telemetry/Agent001 &
+./bin/telemetry_reader /tmp/telemetry_test/Agent001 &
 telePID=$!
 sleep 6
 kill -s SIGINT $telePID

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -80,7 +80,7 @@ python3 query_mem_example.py
 
 # Running telemetry for the last test
 blocking_send_recv_port=$(get_next_tcp_port)
-mkdir /tmp/telemetry_test
+mkdir -p /tmp/telemetry_test
 
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port="$blocking_send_recv_port"&
 sleep 5

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -80,6 +80,7 @@ python3 query_mem_example.py
 
 # Running telemetry for the last test
 export NIXL_TELEMETRY_ENABLE=y
+export NIXL_TELEMETRY_DIR=/tmp
 blocking_send_recv_port=$(get_next_tcp_port)
 
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port="$blocking_send_recv_port"&

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -79,15 +79,14 @@ python3 partial_md_example.py --etcd
 python3 query_mem_example.py
 
 # Running telemetry for the last test
-export NIXL_TELEMETRY_ENABLE=y
-export NIXL_TELEMETRY_DIR=/tmp
 blocking_send_recv_port=$(get_next_tcp_port)
 
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port="$blocking_send_recv_port"&
 sleep 5
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=$PWD/telemetry \
 python3 blocking_send_recv_example.py --mode="initiator" --ip=127.0.0.1 --port="$blocking_send_recv_port"
 
-python3 telemetry_reader.py --telemetry_path /tmp/initiator &
+python3 telemetry_reader.py --telemetry_path $PWD/telemetry/initiator &
 telePID=$!
 sleep 6
 kill -s INT $telePID

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -80,13 +80,14 @@ python3 query_mem_example.py
 
 # Running telemetry for the last test
 blocking_send_recv_port=$(get_next_tcp_port)
+mkdir /tmp/telemetry_test
 
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port="$blocking_send_recv_port"&
 sleep 5
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=$PWD/telemetry \
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test \
 python3 blocking_send_recv_example.py --mode="initiator" --ip=127.0.0.1 --port="$blocking_send_recv_port"
 
-python3 telemetry_reader.py --telemetry_path $PWD/telemetry/initiator &
+python3 telemetry_reader.py --telemetry_path /tmp/telemetry_test/initiator &
 telePID=$!
 sleep 6
 kill -s INT $telePID

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -44,10 +44,12 @@ Telemetry is controlled by environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NIXL_TELEMETRY_ENABLE` | Enable telemetry collection | Disabled |
-| `NIXL_TELEMETRY_DIR` | Directory for telemetry files | `/tmp` |
+| `NIXL_TELEMETRY_DIR` | Directory for telemetry files | - |
 | `NIXL_TELEMETRY_BUFFER_SIZE` | Number of events in buffer | `4096` |
 | `NIXL_TELEMETRY_RUN_INTERVAL` | Flush interval (ms) | `100` |
 
+- NIXL_TELEMETRY_ENABLE can be set to y/yes/on/1 to be enabled, and n/no/off/0 (or not set) to be disabled,
+- If NIXL_TELEMETRY_ENABLE is set to enabled but NIXL_TELEMETRY_DIR is not set, no telemetry file is generated and NIXL_TELEMETRY_RUN_INTERVAL is not used.
 
 ## Telemetry File Format
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -289,6 +289,17 @@ class nixlAgent {
         nixl_status_t
         getXferStatus (nixlXferReqH* req_hndl) const;
 
+
+        /**
+         * @brief  Get the telemetry data associated with `req_hndl`.
+         *
+         * @param  req_hndl        Transfer request handle obtained from makeXferReq/createXferReq
+         * @param  telemetry [out] Output telemetry information
+         * @return nixl_status_t   Error code if call was not successful
+         */
+        nixl_status_t
+        getXferTelemetry(const nixlXferReqH *req_hndl, nixl_xfer_telem_t &telemetry) const;
+
         /**
          * @brief  Query the backend associated with `req_hndl`. E.g., if for genNotif
          *         the same backend as a transfer is desired.

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -264,13 +264,13 @@ struct nixlXferTelemetry {
     /**
      * @var totalBytes Amount of bytes transferred in the request
      */
-    size_t totalBytes = 0;
+    size_t totalBytes;
 
     /**
      * @var descCount Number of descriptors in the transfer request.
      *      If any merging of descriptors were performed, it will be reflected here.
      */
-    size_t descCount = 0;
+    size_t descCount;
 };
 
 /**

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -241,7 +241,7 @@ using chrono_point_t = std::chrono::steady_clock::time_point;
 constexpr auto min_chrono_time = std::chrono::steady_clock::time_point::min();
 
 /**
- * @brief A typedefs for a period of time
+ * @brief A typedefs for a period of time in microseconds
  */
 using chrono_period_t = std::chrono::microseconds;
 
@@ -258,29 +258,29 @@ struct nixlXferTelemetry {
     /**
      * @var startTime Time that the transfer was posted
      */
-    chrono_point_t startTime;
+    chrono_point_t startTime = min_chrono_time;
 
     /**
      * @var postDuration Time it took to do the post operation
      */
-    chrono_period_t postDuration;
+    chrono_period_t postDuration = chrono_period_t(0);
 
     /**
      * @var xferDuration Time it took to complete the transfer
      *      if checkXferReq is called late, that might impact this result
      */
-    chrono_period_t xferDuration;
+    chrono_period_t xferDuration = chrono_period_t(0);
 
     /**
      * @var totalBytes Amount of bytes transferred in the request
      */
-    size_t totalBytes;
+    size_t totalBytes = 0;
 
     /**
      * @var descCount Number of descriptors in the transfer request.
      *      If any merging of descriptors were performed, it will be reflected here.
      */
-    size_t descCount;
+    size_t descCount = 0;
 };
 
 /**

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -243,18 +243,13 @@ constexpr auto min_chrono_time = std::chrono::steady_clock::time_point::min();
 /**
  * @brief A typedefs for a period of time in microseconds
  */
-using chrono_period_t = std::chrono::microseconds;
+using chrono_period_us_t = std::chrono::microseconds;
 
 /**
  * @struct nixlXferTelemetry
  * @brief A structure for telemetry output from agent API
  */
 struct nixlXferTelemetry {
-    /**
-     * @var backendType Type of the backend performing the transfer
-     */
-    nixl_backend_t backendType;
-
     /**
      * @var startTime Time that the transfer was posted
      */
@@ -263,13 +258,13 @@ struct nixlXferTelemetry {
     /**
      * @var postDuration Time it took to do the post operation
      */
-    chrono_period_t postDuration = chrono_period_t(0);
+    chrono_period_us_t postDuration = chrono_period_us_t(0);
 
     /**
      * @var xferDuration Time it took to complete the transfer
      *      if checkXferReq is called late, that might impact this result
      */
-    chrono_period_t xferDuration = chrono_period_t(0);
+    chrono_period_us_t xferDuration = chrono_period_us_t(0);
 
     /**
      * @var totalBytes Amount of bytes transferred in the request

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -236,11 +236,6 @@ using nixlGpuXferReqH = void;
 using chrono_point_t = std::chrono::steady_clock::time_point;
 
 /**
- * @brief A constant indicating min chrono_point_t value
- */
-constexpr auto min_chrono_time = std::chrono::steady_clock::time_point::min();
-
-/**
  * @brief A typedefs for a period of time in microseconds
  */
 using chrono_period_us_t = std::chrono::microseconds;
@@ -253,18 +248,18 @@ struct nixlXferTelemetry {
     /**
      * @var startTime Time that the transfer was posted
      */
-    chrono_point_t startTime = min_chrono_time;
+    chrono_point_t startTime;
 
     /**
      * @var postDuration Time it took to do the post operation
      */
-    chrono_period_us_t postDuration = chrono_period_us_t(0);
+    chrono_period_us_t postDuration;
 
     /**
      * @var xferDuration Time it took to complete the transfer
      *      if checkXferReq is called late, that might impact this result
      */
-    chrono_period_us_t xferDuration = chrono_period_us_t(0);
+    chrono_period_us_t xferDuration;
 
     /**
      * @var totalBytes Amount of bytes transferred in the request

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <unordered_map>
 #include <optional>
+#include <chrono>
 
 
 /*** Forward declarations ***/
@@ -62,7 +63,8 @@ enum nixl_status_t {
     NIXL_ERR_UNKNOWN = -8,
     NIXL_ERR_NOT_SUPPORTED = -9,
     NIXL_ERR_REMOTE_DISCONNECT = -10,
-    NIXL_ERR_CANCELED = -11
+    NIXL_ERR_CANCELED = -11,
+    NIXL_ERR_NO_TELEMETRY = -12
 };
 
 /**
@@ -227,6 +229,65 @@ using nixl_opt_args_t = nixlAgentOptionalArgs;
  * @brief A typedef for a nixlGpuXferReqH
  */
 using nixlGpuXferReqH = void;
+
+/**
+ * @brief A typedefs for a point in time
+ */
+using chrono_point_t = std::chrono::steady_clock::time_point;
+
+/**
+ * @brief A constant indicating min chrono_point_t value
+ */
+constexpr auto min_chrono_time = std::chrono::steady_clock::time_point::min();
+
+/**
+ * @brief A typedefs for a period of time
+ */
+using chrono_period_t = std::chrono::microseconds;
+
+/**
+ * @struct nixlXferTelemetry
+ * @brief A structure for telemetry output from agent API
+ */
+struct nixlXferTelemetry {
+    /**
+     * @var backendType Type of the backend performing the transfer
+     */
+    nixl_backend_t backendType;
+
+    /**
+     * @var startTime Time that the transfer was posted
+     */
+    chrono_point_t startTime;
+
+    /**
+     * @var postDuration Time it took to do the post operation
+     */
+    chrono_period_t postDuration;
+
+    /**
+     * @var xferDuration Time it took to complete the transfer
+     *      if checkXferReq is called late, that might impact this result
+     */
+    chrono_period_t xferDuration;
+
+    /**
+     * @var totalBytes Amount of bytes transferred in the request
+     */
+    size_t totalBytes;
+
+    /**
+     * @var descCount Number of descriptors in the transfer request.
+     *      If any merging of descriptors were performed, it will be reflected here.
+     */
+    size_t descCount;
+};
+
+/**
+ * @brief A typedef for a nixlXferTelemetry
+ *        for telemetry output.
+ */
+using nixl_xfer_telem_t = nixlXferTelemetry;
 
 /**
  * @brief A define for an empty string, that indicates the descriptor list is being

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -617,6 +617,16 @@ class nixl_agent:
             return "ERR"
 
     """
+    @brief Get telemetry information of a transfer request.
+
+    @param handle Handle to the transfer operation, from make_prepped_xfer or initialize_xfer.
+    @return nixlXferTelemetry object
+    """
+
+    def get_xfer_telemetry(self, handle: nixl_xfer_handle) -> nixlBind.nixlXferTelemetry:
+        return self.agent.getXferTelemetry(handle)
+
+    """
     @brief Query the backend that was chosen for a transfer operation.
 
     @param handle Handle to the transfer operation.

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -618,6 +618,10 @@ class nixl_agent:
 
     """
     @brief Get telemetry information of a transfer request.
+           The output object has three time values fields in microseconds
+           (startTime, postDuration, xferDuration), as well as integer totalBytes transferred
+           for the request, and integer descCount representing number of descriptors involved
+           (for example if there was some merging of descriptors).
 
     @param handle Handle to the transfer operation, from make_prepped_xfer or initialize_xfer.
     @return nixlXferTelemetry object

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -623,7 +623,9 @@ class nixl_agent:
     @return nixlXferTelemetry object
     """
 
-    def get_xfer_telemetry(self, handle: nixl_xfer_handle) -> nixlBind.nixlXferTelemetry:
+    def get_xfer_telemetry(
+        self, handle: nixl_xfer_handle
+    ) -> nixlBind.nixlXferTelemetry:
         return self.agent.getXferTelemetry(handle)
 
     """

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -630,7 +630,7 @@ class nixl_agent:
     def get_xfer_telemetry(
         self, handle: nixl_xfer_handle
     ) -> nixlBind.nixlXferTelemetry:
-        return self.agent.getXferTelemetry(handle)
+        return self.agent.getXferTelemetry(handle._handle)
 
     """
     @brief Query the backend that was chosen for a transfer operation.

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -164,9 +164,16 @@ PYBIND11_MODULE(_bindings, m) {
 
     py::class_<nixl_xfer_telem_t>(m, "nixlXferTelemetry")
         .def(py::init<>())
-        .def_readonly("startTime", &nixl_xfer_telem_t::startTime)
-        .def_readonly("postDuration", &nixl_xfer_telem_t::postDuration)
-        .def_readonly("xferDuration", &nixl_xfer_telem_t::xferDuration)
+        .def_property_readonly("startTime",
+                               [](const nixl_xfer_telem_t &t) {
+                                   return std::chrono::duration_cast<chrono_period_us_t>(
+                                              t.startTime.time_since_epoch())
+                                       .count();
+                               })
+        .def_property_readonly("postDuration",
+                               [](const nixl_xfer_telem_t &t) { return t.postDuration.count(); })
+        .def_property_readonly("xferDuration",
+                               [](const nixl_xfer_telem_t &t) { return t.xferDuration.count(); })
         .def_readonly("totalBytes", &nixl_xfer_telem_t::totalBytes)
         .def_readonly("descCount", &nixl_xfer_telem_t::descCount);
 

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -65,14 +65,29 @@ public:
     nixlRepostActiveError(const char *what) : runtime_error(what) {}
 };
 
+class nixlUnknownError : public std::runtime_error {
+public:
+    nixlUnknownError(const char *what) : runtime_error(what) {}
+};
+
 class nixlNotSupportedError : public std::runtime_error {
 public:
     nixlNotSupportedError(const char *what) : runtime_error(what) {}
 };
 
-class nixlUnknownError : public std::runtime_error {
+class nixlRemoteDisconnectError : public std::runtime_error {
 public:
-    nixlUnknownError(const char *what) : runtime_error(what) {}
+    nixlRemoteDisconnectError(const char *what) : runtime_error(what) {}
+};
+
+class nixlCancelledError : public std::runtime_error {
+public:
+    nixlCancelledError(const char *what) : runtime_error(what) {}
+};
+
+class nixlNoTelemetryError : public std::runtime_error {
+public:
+    nixlNoTelemetryError(const char *what) : runtime_error(what) {}
 };
 
 void
@@ -108,6 +123,15 @@ throw_nixl_exception(const nixl_status_t &status) {
         break;
     case NIXL_ERR_NOT_SUPPORTED:
         throw nixlNotSupportedError(nixlEnumStrings::statusStr(status).c_str());
+        break;
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        throw nixlRemoteDisconnectError(nixlEnumStrings::statusStr(status).c_str());
+        break;
+    case NIXL_ERR_CANCELED:
+        throw nixlCancelledError(nixlEnumStrings::statusStr(status).c_str());
+        break;
+    case NIXL_ERR_NO_TELEMETRY:
+        throw nixlNoTelemetryError(nixlEnumStrings::statusStr(status).c_str());
         break;
     default:
         throw std::runtime_error("BAD_STATUS");
@@ -187,6 +211,9 @@ PYBIND11_MODULE(_bindings, m) {
     py::register_exception<nixlRepostActiveError>(m, "nixlRepostActiveError");
     py::register_exception<nixlUnknownError>(m, "nixlUnknownError");
     py::register_exception<nixlNotSupportedError>(m, "nixlNotSupportedError");
+    py::register_exception<nixlRemoteDisconnectError>(m, "nixlRemoteDisconnectError");
+    py::register_exception<nixlCancelledError>(m, "nixlCancelledError");
+    py::register_exception<nixlNoTelemetryError>(m, "nixlNoTelemetryError");
 
     py::class_<nixl_xfer_dlist_t>(m, "nixlXferDList")
         .def(py::init<nixl_mem_t, bool, int>(),

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -164,7 +164,6 @@ PYBIND11_MODULE(_bindings, m) {
 
     py::class_<nixl_xfer_telem_t>(m, "nixlXferTelemetry")
         .def(py::init<>())
-        .def_readonly("backendType", &nixl_xfer_telem_t::backendType)
         .def_readonly("startTime", &nixl_xfer_telem_t::startTime)
         .def_readonly("postDuration", &nixl_xfer_telem_t::postDuration)
         .def_readonly("xferDuration", &nixl_xfer_telem_t::xferDuration)

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -18,6 +18,7 @@
 #include <pybind11/stl.h>
 #include <pybind11/operators.h>
 #include <pybind11/numpy.h>
+#include <pybind11/chrono.h>
 
 #include <tuple>
 #include <iostream>
@@ -160,6 +161,16 @@ PYBIND11_MODULE(_bindings, m) {
         .value("NIXL_ERR_UNKNOWN", NIXL_ERR_UNKNOWN)
         .value("NIXL_ERR_NOT_SUPPORTED", NIXL_ERR_NOT_SUPPORTED)
         .export_values();
+
+    py::class_<nixl_xfer_telem_t>(m, "nixlXferTelemetry")
+        .def(py::init<>())
+        .def_readonly("backendType", &nixl_xfer_telem_t::backendType)
+        .def_readonly("startTime", &nixl_xfer_telem_t::startTime)
+        .def_readonly("postDuration", &nixl_xfer_telem_t::postDuration)
+        .def_readonly("xferDuration", &nixl_xfer_telem_t::xferDuration)
+        .def_readonly("totalBytes", &nixl_xfer_telem_t::totalBytes)
+        .def_readonly("descCount", &nixl_xfer_telem_t::descCount);
+
 
     py::register_exception<nixlNotPostedError>(m, "nixlNotPostedError");
     py::register_exception<nixlInvalidParamError>(m, "nixlInvalidParamError");
@@ -652,6 +663,16 @@ PYBIND11_MODULE(_bindings, m) {
                  throw_nixl_exception(ret);
                  return ret;
              })
+        .def(
+            "getXferTelemetry",
+            [](nixlAgent &agent, uintptr_t reqh) -> nixl_xfer_telem_t {
+                nixl_xfer_telem_t telemetry;
+                nixl_status_t ret =
+                    agent.getXferTelemetry((nixlXferReqH *)reqh, telemetry);
+                throw_nixl_exception(ret);
+                return telemetry;
+            },
+            py::arg("reqh"))
         .def("queryXferBackend",
              [](nixlAgent &agent, uintptr_t reqh) -> uintptr_t {
                  nixlBackendH *backend = nullptr;

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -667,8 +667,7 @@ PYBIND11_MODULE(_bindings, m) {
             "getXferTelemetry",
             [](nixlAgent &agent, uintptr_t reqh) -> nixl_xfer_telem_t {
                 nixl_xfer_telem_t telemetry;
-                nixl_status_t ret =
-                    agent.getXferTelemetry((nixlXferReqH *)reqh, telemetry);
+                nixl_status_t ret = agent.getXferTelemetry((nixlXferReqH *)reqh, telemetry);
                 throw_nixl_exception(ret);
                 return telemetry;
             },

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -65,6 +65,7 @@ class nixlAgentData {
         std::string     name;
         nixlAgentConfig config;
         nixlLock        lock;
+        bool telemetryEnabled = false;
 
         // some handle that can be used to instantiate an object from the lib
         std::map<std::string, void*> backendLibs;

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -19,6 +19,7 @@
 
 #include "common/str_tools.h"
 #include "mem_section.h"
+#include "telemetry.h"
 #include "stream/metadata_stream.h"
 #include "sync.h"
 
@@ -32,8 +33,6 @@ class SyncClient;
 
 #define NIXL_ETCD_NAMESPACE_DEFAULT "/nixl/agents/"
 #endif // HAVE_ETCD
-
-class nixlTelemetry;
 
 using backend_list_t = std::vector<nixlBackendEngine*>;
 
@@ -115,6 +114,11 @@ class nixlAgentData {
     public:
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);
         ~nixlAgentData();
+
+        inline void
+        addErrorTelemetry(nixl_status_t err_status) {
+            if (telemetry_) telemetry_->updateErrorCount(err_status);
+        }
 
     friend class nixlAgent;
 };

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -104,8 +104,8 @@ nixlXferReqH::updateRequestStats(std::unique_ptr<nixlTelemetry> &telemetry_pub,
 
     static const std::array<std::string, 3> nixl_post_status_str = {
         " Posted", " Posted and Completed", " Completed"};
-    auto duration = std::chrono::duration_cast<chrono_period_t>(std::chrono::steady_clock::now() -
-                                                                telemetry.startTime);
+    auto duration = std::chrono::duration_cast<chrono_period_us_t>(
+        std::chrono::steady_clock::now() - telemetry.startTime);
     if (stat_status == NIXL_TELEMETRY_POST) {
         telemetry.postDuration = duration;
     } else if (stat_status == NIXL_TELEMETRY_POST_AND_FINISH) {
@@ -119,7 +119,7 @@ nixlXferReqH::updateRequestStats(std::unique_ptr<nixlTelemetry> &telemetry_pub,
         telemetry_pub->addXferTime(duration, backendOp == NIXL_WRITE, telemetry.totalBytes);
     }
 
-    NIXL_TRACE << "[NIXL TELEMETRY]: From backend " << telemetry.backendType
+    NIXL_TRACE << "[NIXL TELEMETRY]: From backend " << engine->getType()
                << nixl_post_status_str[stat_status] << " Xfer with " << telemetry.descCount
                << " descriptors of total size " << telemetry.totalBytes << "B in "
                << duration.count() << "us.";
@@ -834,7 +834,6 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
 
     if (data->telemetry_) {
         handle->telemetry.totalBytes = total_bytes;
-        handle->telemetry.backendType = handle->engine->getType();
         handle->telemetry.descCount = handle->initiatorDescs->descCount();
     }
 
@@ -980,7 +979,6 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     if (data->telemetry_) {
         handle->telemetry.totalBytes = total_bytes;
-        handle->telemetry.backendType = handle->engine->getType();
         handle->telemetry.descCount = handle->initiatorDescs->descCount();
     }
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -154,10 +154,9 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &cfg
             !strcasecmp(telemetry_env_val, "yes") || !strcasecmp(telemetry_env_val, "on")) {
             telemetryEnabled = true;
             if (telemetry_env_dir != nullptr) {
-                telemetry_ = std::make_unique<nixlTelemetry>(
-                    name, std::string(telemetry_env_dir), backendEngines);
-                NIXL_DEBUG << "NIXL telemetry is enabled with output file: " << telemetry_env_dir
-                           << "/" << name;
+                std::string telemetry_file = std::string(telemetry_env_dir) + "/" + name;
+                telemetry_ = std::make_unique<nixlTelemetry>(telemetry_file, backendEngines);
+                NIXL_DEBUG << "NIXL telemetry is enabled with output file: " << telemetry_file;
             } else {
                 NIXL_DEBUG << "NIXL telemetry is enabled without an output file";
             }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -52,7 +52,8 @@
         return NIXL_ERR_MISMATCH;                    \
     } while (0)
 
-const char TELEMETRY_ENABLED_VAR[] = "NIXL_TELEMETRY_ENABLE";
+constexpr char TELEMETRY_ENABLED_VAR[] = "NIXL_TELEMETRY_ENABLE";
+constexpr char TELEMETRY_DIR_VAR[] = "NIXL_TELEMETRY_DIR";
 static const std::vector<std::vector<std::string>> illegal_plugin_combinations = {
     {"GDS", "GDS_MT"},
 };
@@ -144,12 +145,20 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &cfg
 
     memorySection = new nixlLocalSection();
     const char *telemetry_env_val = std::getenv(TELEMETRY_ENABLED_VAR);
+    const char *telemetry_env_dir = std::getenv(TELEMETRY_DIR_VAR);
 
     if (telemetry_env_val != nullptr) {
         if (!strcasecmp(telemetry_env_val, "y") || !strcasecmp(telemetry_env_val, "1") ||
             !strcasecmp(telemetry_env_val, "yes") || !strcasecmp(telemetry_env_val, "on")) {
-            telemetry_ = std::make_unique<nixlTelemetry>(name, backendEngines);
-            NIXL_DEBUG << "NIXL telemetry is enabled";
+            telemetryEnabled = true;
+            if (telemetry_env_dir != nullptr) {
+                telemetry_ = std::make_unique<nixlTelemetry>(
+                    name, std::string(telemetry_env_dir), backendEngines);
+                NIXL_DEBUG << "NIXL telemetry is enabled with output file: "
+                           << telemetry_env_dir << "/" << name;
+            } else {
+                NIXL_DEBUG << "NIXL telemetry is enabled without an output file";
+            }
         } else if (!strcasecmp(telemetry_env_val, "n") || !strcasecmp(telemetry_env_val, "0") ||
                    !strcasecmp(telemetry_env_val, "no") || !strcasecmp(telemetry_env_val, "off")) {
             NIXL_DEBUG << "NIXL telemetry is disabled";

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1247,12 +1247,12 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 nixl_status_t
 nixlAgent::createGpuXferReq(const nixlXferReqH &req_hndl, nixlGpuXferReqH *&gpu_req_hndl) const {
     if (!req_hndl.engine) {
-        NIXL_ERROR << "Invalid request handle[" << &req_hndl << "]: engine is null";
+        NIXL_ERROR_FUNC << "Invalid request handle[" << &req_hndl << "]: engine is null";
         return NIXL_ERR_INVALID_PARAM;
     }
 
     if (!req_hndl.backendHandle) {
-        NIXL_ERROR << "Invalid request handle[" << &req_hndl << "]: backendHandle is null";
+        NIXL_ERROR_FUNC << "Invalid request handle[" << &req_hndl << "]: backendHandle is null";
         return NIXL_ERR_INVALID_PARAM;
     }
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -156,8 +156,8 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &cfg
             if (telemetry_env_dir != nullptr) {
                 telemetry_ = std::make_unique<nixlTelemetry>(
                     name, std::string(telemetry_env_dir), backendEngines);
-                NIXL_DEBUG << "NIXL telemetry is enabled with output file: "
-                           << telemetry_env_dir << "/" << name;
+                NIXL_DEBUG << "NIXL telemetry is enabled with output file: " << telemetry_env_dir
+                           << "/" << name;
             } else {
                 NIXL_DEBUG << "NIXL telemetry is enabled without an output file";
             }
@@ -1201,16 +1201,17 @@ nixl_status_t
 nixlAgent::getXferTelemetry(const nixlXferReqH *req_hndl, nixl_xfer_telem_t &telemetry) const {
 
     if (!data->telemetryEnabled) {
-        NIXL_ERROR << "getXferTelemetry cannot return values when telemetry is not enabled.";
+        NIXL_ERROR_FUNC << "cannot return values when telemetry is not enabled.";
         return NIXL_ERR_NO_TELEMETRY;
     }
 
-    if (req_hndl->status < 0) return req_hndl->status;
+    if (req_hndl->status != NIXL_SUCCESS) {
+        NIXL_ERROR_FUNC << "Transfer is not complete yet";
+        return req_hndl->status;
+    }
 
-    // NIXL_SUCCESS or NIXL_IN_PROG, values are initialized
     telemetry = req_hndl->telemetry;
-
-    return req_hndl->status;
+    return NIXL_SUCCESS;
 }
 
 nixl_status_t

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -92,6 +92,8 @@ nixlEnumStrings::statusStr(const nixl_status_t &status) {
         case NIXL_ERR_REMOTE_DISCONNECT: return "NIXL_ERR_REMOTE_DISCONNECT";
         case NIXL_ERR_CANCELED:
             return "NIXL_ERR_CANCELED";
+        case NIXL_ERR_NO_TELEMETRY:
+            return "NIXL_ERR_NO_TELEMETRY";
         default:                         return "BAD_STATUS";
     }
 }

--- a/src/core/telemetry.cpp
+++ b/src/core/telemetry.cpp
@@ -34,17 +34,15 @@ namespace fs = std::filesystem;
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;
 constexpr size_t DEFAULT_TELEMETRY_BUFFER_SIZE = 4096;
 
-nixlTelemetry::nixlTelemetry(const std::string &name,
-                             const std::string &dir_path,
-                             backend_map_t &backend_map)
+nixlTelemetry::nixlTelemetry(const std::string &file_path, backend_map_t &backend_map)
     : pool_(1),
       writeTask_(pool_.get_executor(), DEFAULT_TELEMETRY_RUN_INTERVAL),
-      file_(name),
+      file_(file_path),
       backendMap_(backend_map) {
-    if (name.empty()) {
-        throw std::invalid_argument("Telemetry file name cannot be empty");
+    if (file_path.empty()) {
+        throw std::invalid_argument("Telemetry file path cannot be empty");
     }
-    initializeTelemetry(dir_path);
+    initializeTelemetry();
 }
 
 nixlTelemetry::~nixlTelemetry() {
@@ -63,12 +61,12 @@ nixlTelemetry::~nixlTelemetry() {
 }
 
 void
-nixlTelemetry::initializeTelemetry(const std::string &dir_path) {
+nixlTelemetry::initializeTelemetry() {
     auto buffer_size = std::getenv(TELEMETRY_BUFFER_SIZE_VAR) ?
         std::stoul(std::getenv(TELEMETRY_BUFFER_SIZE_VAR)) :
         DEFAULT_TELEMETRY_BUFFER_SIZE;
 
-    auto full_file_path = fs::path(dir_path) / file_;
+    auto full_file_path = fs::path(file_);
 
     if (buffer_size == 0) {
         throw std::invalid_argument("Telemetry buffer size cannot be 0");

--- a/src/core/telemetry.cpp
+++ b/src/core/telemetry.cpp
@@ -34,7 +34,9 @@ namespace fs = std::filesystem;
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;
 constexpr size_t DEFAULT_TELEMETRY_BUFFER_SIZE = 4096;
 
-nixlTelemetry::nixlTelemetry(const std::string &name, backend_map_t &backend_map)
+nixlTelemetry::nixlTelemetry(const std::string &name,
+                             const std::string &dir_path,
+                             backend_map_t &backend_map)
     : pool_(1),
       writeTask_(pool_.get_executor(), DEFAULT_TELEMETRY_RUN_INTERVAL),
       file_(name),
@@ -42,7 +44,7 @@ nixlTelemetry::nixlTelemetry(const std::string &name, backend_map_t &backend_map
     if (name.empty()) {
         throw std::invalid_argument("Telemetry file name cannot be empty");
     }
-    initializeTelemetry();
+    initializeTelemetry(dir_path);
 }
 
 nixlTelemetry::~nixlTelemetry() {
@@ -61,14 +63,12 @@ nixlTelemetry::~nixlTelemetry() {
 }
 
 void
-nixlTelemetry::initializeTelemetry() {
+nixlTelemetry::initializeTelemetry(const std::string &dir_path) {
     auto buffer_size = std::getenv(TELEMETRY_BUFFER_SIZE_VAR) ?
         std::stoul(std::getenv(TELEMETRY_BUFFER_SIZE_VAR)) :
         DEFAULT_TELEMETRY_BUFFER_SIZE;
 
-    auto folder_path = std::getenv(TELEMETRY_DIR_VAR) ? std::getenv(TELEMETRY_DIR_VAR) : "/tmp";
-
-    auto full_file_path = fs::path(folder_path) / file_;
+    auto full_file_path = fs::path(dir_path) / file_;
 
     if (buffer_size == 0) {
         throw std::invalid_argument("Telemetry buffer size cannot be 0");

--- a/src/core/telemetry.h
+++ b/src/core/telemetry.h
@@ -43,7 +43,7 @@ struct periodicTask {
 
 class nixlTelemetry {
 public:
-    nixlTelemetry(const std::string &name, const std::string &dir_path, backend_map_t &backend_map);
+    nixlTelemetry(const std::string &file_path, backend_map_t &backend_map);
 
     ~nixlTelemetry();
 
@@ -68,7 +68,7 @@ public:
 
 private:
     void
-    initializeTelemetry(const std::string &dir_path);
+    initializeTelemetry();
     void
     registerPeriodicTask(periodicTask &task);
     void

--- a/src/core/telemetry.h
+++ b/src/core/telemetry.h
@@ -43,7 +43,7 @@ struct periodicTask {
 
 class nixlTelemetry {
 public:
-    nixlTelemetry(const std::string &name, backend_map_t &backend_map);
+    nixlTelemetry(const std::string &name, const std::string &dir_path, backend_map_t &backend_map);
 
     ~nixlTelemetry();
 
@@ -68,7 +68,7 @@ public:
 
 private:
     void
-    initializeTelemetry();
+    initializeTelemetry(const std::string &dir_path);
     void
     registerPeriodicTask(periodicTask &task);
     void

--- a/src/core/telemetry_event.h
+++ b/src/core/telemetry_event.h
@@ -23,7 +23,6 @@
 #include "nixl_types.h"
 
 constexpr char TELEMETRY_BUFFER_SIZE_VAR[] = "NIXL_TELEMETRY_BUFFER_SIZE";
-constexpr char TELEMETRY_DIR_VAR[] = "NIXL_TELEMETRY_DIR";
 constexpr char TELEMETRY_RUN_INTERVAL_VAR[] = "NIXL_TELEMETRY_RUN_INTERVAL";
 
 constexpr int TELEMETRY_VERSION = 1;

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -48,13 +48,7 @@ class nixlXferReqH {
         nixl_xfer_op_t     backendOp;
         nixl_status_t      status;
 
-        // Initializing time values, as getXferTelem might be called before postXfer.
-        struct {
-            chrono_point_t startTime_ = min_chrono_time;
-            chrono_period_t postDuration_ = chrono_period_t(0);
-            chrono_period_t xferDuration_ = chrono_period_t(0);
-            size_t totalBytes_;
-        } telemetry;
+        nixl_xfer_telem_t telemetry;
 
     public:
         inline nixlXferReqH() { }

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -17,7 +17,6 @@
 #ifndef __TRANSFER_REQUEST_H_
 #define __TRANSFER_REQUEST_H_
 
-#include <chrono>
 #include <string>
 #include <unordered_map>
 #include <memory>
@@ -25,9 +24,6 @@
 #include "nixl_types.h"
 #include "backend_engine.h"
 #include "telemetry.h"
-
-using chrono_point_t = std::chrono::steady_clock::time_point;
-using std::chrono::microseconds;
 
 enum nixl_telemetry_stat_status_t {
     NIXL_TELEMETRY_POST = 0,
@@ -52,11 +48,12 @@ class nixlXferReqH {
         nixl_xfer_op_t     backendOp;
         nixl_status_t      status;
 
+        // Initializing time values, as getXferTelem might be called before postXfer.
         struct {
-            chrono_point_t startTime;
-            microseconds postDuration_ = microseconds(0);
-            microseconds xferDuration_ = microseconds(0);
-            size_t totalBytes;
+            chrono_point_t startTime_ = min_chrono_time;
+            chrono_period_t postDuration_ = chrono_period_t(0);
+            chrono_period_t xferDuration_ = chrono_period_t(0);
+            size_t totalBytes_;
         } telemetry;
 
     public:

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -126,6 +126,18 @@ protected:
         return params;
     }
 
+    void
+    addAgent(unsigned int agent_num) {
+        ports.push_back(PortAllocator::next_tcp_port());
+        agents.emplace_back(
+            std::make_unique<nixlAgent>(getAgentName(agent_num), getConfig(getPort(agent_num))));
+        nixlBackendH *backend_handle = nullptr;
+        nixl_status_t status =
+            agents.back()->createBackend(getBackendName(), getBackendParams(), backend_handle);
+        ASSERT_EQ(status, NIXL_SUCCESS);
+        EXPECT_NE(backend_handle, nullptr);
+    }
+
     void SetUp() override
     {
 #ifdef HAVE_CUDA
@@ -134,14 +146,7 @@ protected:
 
         // Create two agents
         for (size_t i = 0; i < 2; i++) {
-            ports.push_back(PortAllocator::next_tcp_port());
-            agents.emplace_back(std::make_unique<nixlAgent>(getAgentName(i),
-                                                            getConfig(getPort(i))));
-            nixlBackendH *backend_handle = nullptr;
-            nixl_status_t status = agents.back()->createBackend(
-                    getBackendName(), getBackendParams(), backend_handle);
-            ASSERT_EQ(status, NIXL_SUCCESS);
-            EXPECT_NE(backend_handle, nullptr);
+            addAgent(i);
         }
     }
 
@@ -220,10 +225,11 @@ protected:
         return result;
     }
 
-    void exchangeMDIP()
-    {
-        for (size_t i = 0; i < agents.size(); i++) {
-            for (size_t j = 0; j < agents.size(); j++) {
+    void
+    exchangeMDIP(size_t start, size_t end) {
+        // Exchange metadata for the agents in the specified range using their IP
+        for (size_t i = start; i <= end; i++) {
+            for (size_t j = start; j <= end; j++) {
                 if (i == j) {
                     continue;
                 }
@@ -236,15 +242,15 @@ protected:
         }
     }
 
-    void exchangeMD()
-    {
-        // Connect the existing agents and exchange metadata
-        for (size_t i = 0; i < agents.size(); i++) {
+    void
+    exchangeMD(size_t start, size_t end) {
+        // Exchange metadata for the agents in the specified range
+        for (size_t i = start; i <= end; i++) {
             nixl_blob_t md;
             nixl_status_t status = agents[i]->getLocalMD(md);
             ASSERT_EQ(status, NIXL_SUCCESS);
 
-            for (size_t j = 0; j < agents.size(); j++) {
+            for (size_t j = start; j <= end; j++) {
                 if (i == j)
                     continue;
                 std::string remote_agent_name;
@@ -255,11 +261,11 @@ protected:
         }
     }
 
-    void invalidateMD()
-    {
-        // Disconnect the agents and invalidate remote metadata
-        for (size_t i = 0; i < agents.size(); i++) {
-            for (size_t j = 0; j < agents.size(); j++) {
+    void
+    invalidateMD(size_t start, size_t end) {
+        // Invalidate each other's metadata for the agents in the specified range
+        for (size_t i = start; i <= end; i++) {
+            for (size_t j = start; j < end; j++) {
                 if (i == j)
                     continue;
                 nixl_status_t status = agents[j]->invalidateRemoteMD(
@@ -321,7 +327,7 @@ protected:
                        size_t num_threads) {
         const size_t total_notifs = repeat * num_threads;
 
-        exchangeMD();
+        exchangeMD(0, 1);
 
         std::vector<std::thread> threads;
         nixl_notifs_t notif_map;
@@ -344,17 +350,24 @@ protected:
         }
 
         verifyNotifs(to, from_name, total_notifs, std::move(notif_map));
-        invalidateMD();
+        invalidateMD(0, 1);
     }
 
-    void doTransfer(nixlAgent &from, const std::string &from_name,
-                    nixlAgent &to, const std::string &to_name, size_t size,
-                    size_t count, size_t repeat, size_t num_threads,
-                    nixl_mem_t src_mem_type,
-                    std::vector<MemBuffer> src_buffers,
-                    nixl_mem_t dst_mem_type,
-                    std::vector<MemBuffer> dst_buffers)
-    {
+    void
+    doTransfer(nixlAgent &from,
+               const std::string &from_name,
+               nixlAgent &to,
+               const std::string &to_name,
+               size_t size,
+               size_t count,
+               size_t repeat,
+               size_t num_threads,
+               nixl_mem_t src_mem_type,
+               std::vector<MemBuffer> src_buffers,
+               nixl_mem_t dst_mem_type,
+               std::vector<MemBuffer> dst_buffers,
+               bool test_telemetry = false,
+               nixl_status_t expected_telem_status = NIXL_SUCCESS) {
         std::mutex logger_mutex;
         std::vector<std::thread> threads;
         nixl_notifs_t notif_map;
@@ -403,6 +416,18 @@ protected:
                              << "(" << bandwidth << " GB/s)";
                 }
 
+                if (test_telemetry) {
+                    nixl_xfer_telem_t telemetry;
+                    status = from.getXferTelemetry(xfer_req, telemetry);
+                    EXPECT_EQ(status, expected_telem_status);
+                    if (status == NIXL_SUCCESS) {
+                        EXPECT_TRUE(telemetry.startTime > min_chrono_time);
+                        EXPECT_TRUE(telemetry.postDuration > chrono_period_us_t(0));
+                        EXPECT_TRUE(telemetry.xferDuration > chrono_period_us_t(0));
+                        EXPECT_TRUE(telemetry.xferDuration >= telemetry.postDuration);
+                    }
+                }
+
                 status = from.releaseXferReq(xfer_req);
                 EXPECT_EQ(status, NIXL_SUCCESS);
             });
@@ -413,7 +438,6 @@ protected:
         }
 
         verifyNotifs(to, from_name, repeat * num_threads, std::move(notif_map));
-        invalidateMD();
     }
 
     nixlAgent &getAgent(size_t idx)
@@ -461,7 +485,7 @@ TEST_P(TestTransfer, RandomSizes)
         createRegisteredMem(getAgent(0), size, count, mem_type, src_buffers);
         createRegisteredMem(getAgent(1), size, count, mem_type, dst_buffers);
 
-        exchangeMD();
+        exchangeMD(0, 1);
         doTransfer(getAgent(0),
                    getAgentName(0),
                    getAgent(1),
@@ -474,6 +498,7 @@ TEST_P(TestTransfer, RandomSizes)
                    src_buffers,
                    mem_type,
                    dst_buffers);
+        invalidateMD(0, 1);
         deregisterMem(getAgent(0), src_buffers, mem_type);
         deregisterMem(getAgent(1), dst_buffers, mem_type);
     }
@@ -484,75 +509,70 @@ TEST_P(TestTransfer, GetXferTelemetryEnabled) {
     gtest::ScopedEnv env;
     env.addVar("NIXL_TELEMETRY_ENABLE", "y");
 
-    // Setup small registered memory on both agents
+    // Create fresh agents that read the current env var and add them to the fixture
+    addAgent(2);
+    addAgent(3);
+
     constexpr size_t size = 1024;
     constexpr size_t count = 1;
-
     std::vector<MemBuffer> src_buffers, dst_buffers;
-    createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
-    createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+    createRegisteredMem(getAgent(2), size, count, DRAM_SEG, src_buffers);
+    createRegisteredMem(getAgent(3), size, count, DRAM_SEG, dst_buffers);
 
-    exchangeMD();
+    exchangeMD(2, 3);
+    doTransfer(getAgent(2),
+               getAgentName(2),
+               getAgent(3),
+               getAgentName(3),
+               size,
+               count,
+               1,
+               1,
+               DRAM_SEG,
+               src_buffers,
+               DRAM_SEG,
+               dst_buffers,
+               true,
+               NIXL_SUCCESS);
 
-    // Use the same single-transfer setup as in doTransfer but without notifications
-    nixl_opt_args_t extra_params;
-    nixlXferReqH *xfer_req = nullptr;
-    ASSERT_EQ(getAgent(0).createXferReq(NIXL_WRITE,
-                                        makeDescList<nixlBasicDesc>(src_buffers, DRAM_SEG),
-                                        makeDescList<nixlBasicDesc>(dst_buffers, DRAM_SEG),
-                                        getAgentName(1),
-                                        xfer_req,
-                                        &extra_params),
-              NIXL_SUCCESS);
-    auto status = getAgent(0).postXferReq(xfer_req);
-    ASSERT_TRUE(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
-    ASSERT_TRUE(
-        wait_until_true([&]() { return getAgent(0).getXferStatus(xfer_req) == NIXL_SUCCESS; }));
-
-    nixl_xfer_telem_t telemetry;
-    ASSERT_EQ(getAgent(0).getXferTelemetry(xfer_req, telemetry), NIXL_SUCCESS);
-    EXPECT_EQ(telemetry.descCount, count);
-    EXPECT_EQ(telemetry.totalBytes, size * count);
-
-    EXPECT_EQ(getAgent(0).releaseXferReq(xfer_req), NIXL_SUCCESS);
-    deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
-    deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
-    invalidateMD();
+    invalidateMD(2, 3);
+    deregisterMem(getAgent(2), src_buffers, DRAM_SEG);
+    deregisterMem(getAgent(3), dst_buffers, DRAM_SEG);
 }
 
 TEST_P(TestTransfer, GetXferTelemetryDisabled) {
     gtest::ScopedEnv env;
     env.addVar("NIXL_TELEMETRY_ENABLE", "n");
 
+    // Create fresh agents that read the current env var and add them to the fixture
+    addAgent(2);
+    addAgent(3);
+
     constexpr size_t size = 512;
     constexpr size_t count = 1;
     std::vector<MemBuffer> src_buffers, dst_buffers;
-    createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
-    createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+    createRegisteredMem(getAgent(2), size, count, DRAM_SEG, src_buffers);
+    createRegisteredMem(getAgent(3), size, count, DRAM_SEG, dst_buffers);
 
-    exchangeMD();
+    exchangeMD(2, 3);
+    doTransfer(getAgent(2),
+               getAgentName(2),
+               getAgent(3),
+               getAgentName(3),
+               size,
+               count,
+               1,
+               1,
+               DRAM_SEG,
+               src_buffers,
+               DRAM_SEG,
+               dst_buffers,
+               true,
+               NIXL_ERR_NO_TELEMETRY);
 
-    nixlXferReqH *xfer_req = nullptr;
-    nixl_opt_args_t extra_params;
-    ASSERT_EQ(getAgent(0).createXferReq(NIXL_WRITE,
-                                        makeDescList<nixlBasicDesc>(src_buffers, DRAM_SEG),
-                                        makeDescList<nixlBasicDesc>(dst_buffers, DRAM_SEG),
-                                        getAgentName(1),
-                                        xfer_req,
-                                        &extra_params),
-              NIXL_SUCCESS);
-    auto status = getAgent(0).postXferReq(xfer_req);
-    ASSERT_TRUE(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
-    ASSERT_TRUE(
-        wait_until_true([&]() { return getAgent(0).getXferStatus(xfer_req) == NIXL_SUCCESS; }));
-
-    nixl_xfer_telem_t telemetry;
-    EXPECT_EQ(getAgent(0).getXferTelemetry(xfer_req, telemetry), NIXL_ERR_NO_TELEMETRY);
-
-    EXPECT_EQ(getAgent(0).releaseXferReq(xfer_req), NIXL_SUCCESS);
-    deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
-    deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
-    invalidateMD();
+    invalidateMD(2, 3);
+    deregisterMem(getAgent(2), src_buffers, DRAM_SEG);
+    deregisterMem(getAgent(3), dst_buffers, DRAM_SEG);
 }
 
 TEST_P(TestTransfer, remoteMDFromSocket)
@@ -565,12 +585,13 @@ TEST_P(TestTransfer, remoteMDFromSocket)
     createRegisteredMem(getAgent(0), size, count, mem_type, src_buffers);
     createRegisteredMem(getAgent(1), size, count, mem_type, dst_buffers);
 
-    exchangeMDIP();
+    exchangeMDIP(0, 1);
     doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
                size, count, 1, 1,
                mem_type, src_buffers,
                mem_type, dst_buffers);
 
+    invalidateMD(0, 1);
     deregisterMem(getAgent(0), src_buffers, mem_type);
     deregisterMem(getAgent(1), dst_buffers, mem_type);
 }

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -554,9 +554,10 @@ TEST_P(TestTransfer, ListenerCommSize) {
     deregisterMem(getAgent(1), buffers, DRAM_SEG);
 }
 
-TEST_P(TestTransfer, GetXferTelemetryEnabled) {
+TEST_P(TestTransfer, GetXferTelemetryFile) {
     gtest::ScopedEnv env;
     env.addVar("NIXL_TELEMETRY_ENABLE", "y");
+    env.addVar("NIXL_TELEMETRY_DIR", "/tmp/");
 
     // Create fresh agents that read the current env var and add them to the fixture
     addAgent(2);
@@ -592,7 +593,7 @@ TEST_P(TestTransfer, GetXferTelemetryEnabled) {
 TEST_P(TestTransfer, GetXferTelemetryAPI) {
     // Enable telemetry without file output
     gtest::ScopedEnv env;
-    env.addVar("NIXL_TELEMETRY_ENABLE", "a");
+    env.addVar("NIXL_TELEMETRY_ENABLE", "y");
 
     // Create fresh agents that read the current env var and add them to the fixture
     addAgent(2);

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import uuid
 
 import pytest
@@ -123,6 +124,7 @@ def test_metadata_pass(two_ucx_agents):
 
     passed_name = agent2.add_remote_agent(agent1.get_agent_metadata())
     assert passed_name == agent1.name.encode()
+    utils.free_passthru(addr)
 
 
 @pytest.mark.timeout(5)
@@ -200,3 +202,50 @@ def test_incorrect_plugin_env(monkeypatch):
 
     with pytest.raises(RuntimeError):
         nixl_agent("bad env agent")
+
+
+@pytest.mark.timeout(5)
+def test_get_xfer_telemetry():
+    os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
+
+    agent1 = nixl_agent(str(uuid.uuid4()))
+    agent2 = nixl_agent(str(uuid.uuid4()))
+
+    mem_size = 128
+    addr1 = utils.malloc_passthru(mem_size)
+    addr2 = utils.malloc_passthru(mem_size)
+
+    try:
+        reg1 = agent1.get_reg_descs([(addr1, mem_size, 0, "")], mem_type="DRAM")
+        reg2 = agent2.get_reg_descs([(addr2, mem_size, 0, "")], mem_type="DRAM")
+        agent1.register_memory(reg1)
+        agent2.register_memory(reg2)
+
+        agent1.add_remote_agent(agent2.get_agent_metadata())
+        src = agent1.get_xfer_descs(
+            [(addr1, mem_size // 2, 0), (addr1 + mem_size // 2, mem_size // 2, 0)],
+            mem_type="DRAM",
+        )
+        dst = agent1.get_xfer_descs(
+            [(addr2, mem_size // 2, 0), (addr2 + mem_size // 2, mem_size // 2, 0)],
+            mem_type="DRAM",
+        )
+
+        handle = agent1.initialize_xfer("WRITE", src, dst, agent2.name)
+        st = agent1.transfer(handle)
+        assert st in ("DONE", "PROC")
+
+        while True:
+            st = agent1.check_xfer_state(handle)
+            assert st in ("DONE", "PROC")
+            if st == "DONE":
+                break
+
+        telem = agent1.get_xfer_telemetry(handle)
+        assert telem.descCount == 2
+        assert telem.totalBytes == mem_size
+
+        agent1.release_xfer_handle(handle)
+    finally:
+        utils.free_passthru(addr1)
+        utils.free_passthru(addr2)

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -204,7 +204,6 @@ def test_incorrect_plugin_env(monkeypatch):
         nixl_agent("bad env agent")
 
 
-@pytest.mark.timeout(5)
 def test_get_xfer_telemetry():
     os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
 
@@ -244,6 +243,10 @@ def test_get_xfer_telemetry():
         telem = agent1.get_xfer_telemetry(handle)
         assert telem.descCount == 2
         assert telem.totalBytes == mem_size
+        assert telem.startTime > 0
+        assert telem.postDuration > 0
+        assert telem.xferDuration > 0
+        assert telem.xferDuration >= telem.postDuration
 
         agent1.release_xfer_handle(handle)
     finally:

--- a/test/python/test_nixl_bindings.py
+++ b/test/python/test_nixl_bindings.py
@@ -150,6 +150,10 @@ def test_agent():
     telem = agent1.getXferTelemetry(handle)
     assert telem.descCount == 1
     assert telem.totalBytes == req_size
+    assert telem.startTime > 0
+    assert telem.postDuration > 0
+    assert telem.xferDuration > 0
+    assert telem.xferDuration >= telem.postDuration
 
     agent1.releaseXferReq(handle)
 

--- a/test/python/test_nixl_bindings.py
+++ b/test/python/test_nixl_bindings.py
@@ -60,6 +60,7 @@ def test_list():
 
 
 def test_agent():
+    os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
     name1 = "Agent1"
     name2 = "Agent2"
 
@@ -144,6 +145,11 @@ def test_agent():
     assert notifMap[name1][0] == noti_str.encode()
 
     logger.info("Transfer verified")
+
+    # Verify transfer telemetry
+    telem = agent1.getXferTelemetry(handle)
+    assert telem.descCount == 1
+    assert telem.totalBytes == req_size
 
     agent1.releaseXferReq(handle)
 


### PR DESCRIPTION
## What?
Add getXferTelemetry API to nixl Agent.

## Why?
Another mode of outputting telemetry, getting information per xfer_req. 
