### PR TITLE
Create host-side GPU transfer request API

### DIFF
--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -156,6 +156,15 @@ class nixlBackendEngine {
         //Backend aborts the transfer if necessary, and destructs the relevant objects
         virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) const = 0;
 
+        // Create a GPU transfer request to GPU memory for GPU transfer.
+        virtual nixl_status_t
+        createGpuXferReq(const nixlBackendReqH &req_hndl, nixlGpuXferReqH *&gpu_req_hndl) const {
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        // Release a GPU transfer request from GPU memory
+        virtual void
+        releaseGpuXferReq(nixlGpuXferReqH *gpu_req_hndl) const {}
 
         // *** Needs to be implemented if supportsRemote() is true *** //
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -312,6 +312,24 @@ class nixlAgent {
         releaseXferReq (nixlXferReqH* req_hndl) const;
 
         /**
+         * @brief  Create a GPU transfer request from a transfer request.
+         *
+         * @param  req_hndl     [in]  Transfer request obtained from makeXferReq/createXferReq
+         * @param  gpu_req_hndl [out] GPU transfer request handle
+         * @return nixl_status_t Error code if call was not successful
+         */
+        nixl_status_t
+        createGpuXferReq(const nixlXferReqH &req_hndl, nixlGpuXferReqH *&gpu_req_hndl) const;
+
+        /**
+         * @brief  Release transfer request from GPU memory
+         *
+         * @param  gpu_req_hndl  [in] GPU transfer request handle to be released
+         */
+        void
+        releaseGpuXferReq(nixlGpuXferReqH *gpu_req_hndl) const;
+
+        /**
          * @brief  Release the prepared descriptor list handle `dlist_hndl`
          *
          * @param  dlist_hndl    Prepared descriptor list handle to be released

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -78,6 +78,9 @@ class nixlAgentData {
         std::unordered_map<nixl_backend_t, nixlBackendH*> backendHandles;
         std::unordered_map<nixl_backend_t, nixl_blob_t>   connMD;
 
+        // Bookkeeping from GPU request handles to backend engines
+        std::unordered_map<nixlGpuXferReqH *, nixlBackendEngine *> gpuReqToEngine;
+
         // Local section, and Remote sections and their available common backends
         nixlLocalSection*                                        memorySection;
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1088,6 +1088,41 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 }
 
 nixl_status_t
+nixlAgent::createGpuXferReq(const nixlXferReqH &req_hndl, nixlGpuXferReqH *&gpu_req_hndl) const {
+    if (!req_hndl.engine) {
+        NIXL_ERROR << "Invalid request handle[" << &req_hndl << "]: engine is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (!req_hndl.backendHandle) {
+        NIXL_ERROR << "Invalid request handle[" << &req_hndl << "]: backendHandle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    NIXL_SHARED_LOCK_GUARD(data->lock);
+    const auto status = req_hndl.engine->createGpuXferReq(*req_hndl.backendHandle, gpu_req_hndl);
+    if (status == NIXL_SUCCESS) {
+        data->gpuReqToEngine.emplace(&gpu_req_hndl, req_hndl.engine);
+    }
+
+    return status;
+}
+
+void
+nixlAgent::releaseGpuXferReq(nixlGpuXferReqH *gpu_req_hndl) const {
+    NIXL_SHARED_LOCK_GUARD(data->lock);
+    auto it = data->gpuReqToEngine.find(gpu_req_hndl);
+    if (it == data->gpuReqToEngine.end()) {
+        NIXL_WARN << "Invalid gpu_req_hndl[" << gpu_req_hndl << "] ";
+        return;
+    }
+
+    it->second->releaseGpuXferReq(gpu_req_hndl);
+
+    data->gpuReqToEngine.erase(it);
+}
+
+nixl_status_t
 nixlAgent::releasedDlistH (nixlDlistH* dlist_hndl) const {
     NIXL_LOCK_GUARD(data->lock);
     delete dlist_hndl;

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1622,6 +1622,15 @@ nixl_status_t nixlUcxEngine::releaseReqH(nixlBackendReqH* handle) const
     return status;
 }
 
+nixl_status_t
+nixlUcxEngine::createGpuXferReq(const nixlBackendReqH &handle,
+                                nixlGpuXferReqH *&gpu_req_hndl) const {
+    return NIXL_ERR_NOT_SUPPORTED;
+}
+
+void
+nixlUcxEngine::releaseGpuXferReq(nixlGpuXferReqH *gpu_req_hndl) const {}
+
 int nixlUcxEngine::progress() {
     // TODO: add listen for connection handling if necessary
     int ret = 0;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -190,6 +190,12 @@ public:
     nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 
+    nixl_status_t
+    createGpuXferReq(const nixlBackendReqH &handle, nixlGpuXferReqH *&gpu_req_hndl) const override;
+
+    void
+    releaseGpuXferReq(nixlGpuXferReqH *gpu_req_hndl) const override;
+
     int
     progress();
 


### PR DESCRIPTION
## What?
Adds host-side API for GPU transfer request.

## Why?
To establish foundation for GPU-initiated transfers.
See also: https://github.com/ai-dynamo/nixl/pull/704

## How?
 - Added two new virtual methods to nixlBackendEngine interface:
     - `createGpuXferReq()`: Creates a GPU transfer request handle to GPU memory
     - `releaseGpuXferReq()`: Releases a GPU transfer request from GPU memory
 - Implemented public API methods in `nixlAgent` with parameter validation and thread safety
 - Added UCX backend stubs for compatibility
 - Included API documentation