### PR TITLE
Build latest gdrcopy (#712)

### DIFF
--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -137,11 +137,15 @@ RUN rm -rf /opt/hpcx/ucx
 
 RUN cd /workspace && \
     git clone --depth 1 https://github.com/NVIDIA/gdrcopy.git && \
-    cd gdrcopy/packages && \
+    cd gdrcopy && \
+    git fetch --tags --depth=1 && \
+    latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)") && \
+    git checkout "$latest_tag" && \
+    cd packages && \
     CUDA=/usr/local/cuda ./build-rpm-packages.sh && \
-    rpm -Uvh gdrcopy-kmod-2.5-1dkms.el8.noarch.rpm && \
-    rpm -Uvh gdrcopy-2.5-1.el8.$ARCH.rpm && \
-    rpm -Uvh gdrcopy-devel-2.5-1.el8.noarch.rpm
+    rpm -Uvh gdrcopy-kmod-*.el8.noarch.rpm && \
+    rpm -Uvh gdrcopy-*.el8.$ARCH.rpm && \
+    rpm -Uvh gdrcopy-devel-*.el8.noarch.rpm
 
 RUN cd /usr/local/src && \
      git clone https://github.com/openucx/ucx.git && \


### PR DESCRIPTION
Cherry-pick of #712

## What?
gdrcopy was updated from 2.5 to 2.5.1, we should use latest

## Why?
Bugfix release

## How?
Also updated the script to find the latest version