### PR TITLE
PLUGIN/MOONCAKE: Add missing deps in build script (#710)

### DIFF
--- a/src/plugins/mooncake/meson.build
+++ b/src/plugins/mooncake/meson.build
@@ -21,7 +21,7 @@ compile_flags = []
 if 'Mooncake' in static_plugins
     mooncake_backend_lib = static_library('Mooncake',
                'mooncake_backend.cpp', 'mooncake_backend.h', 'mooncake_plugin.cpp',
-               dependencies: [nixl_infra, serdes_interface, mooncake_lib, cuda_dep],
+               dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: nixl_inc_dirs,
                install: false,
                cpp_args : compile_flags,
@@ -29,7 +29,7 @@ if 'Mooncake' in static_plugins
 else
     mooncake_backend_lib = shared_library('Mooncake',
                'mooncake_backend.cpp', 'mooncake_backend.h', 'mooncake_plugin.cpp',
-               dependencies: [nixl_infra, serdes_interface, mooncake_lib, cuda_dep],
+               dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
                cpp_args : compile_flags + ['-fPIC'],


### PR DESCRIPTION
Cherry pick of #710

## What?
Fixes build for the mooncake plugin

## Why?
A library dependency was missing and compilation was failing with message:

```
[185/292] Compiling C++ object src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_backend.cpp.o
FAILED: src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_backend.cpp.o
c++ -Isrc/plugins/mooncake/libplugin_Mooncake.so.p -Isrc/plugins/mooncake -I../src/plugins/mooncake \
    -Isrc/api/cpp -I../src/api/cpp -I../src/api/cpp/backend -Isrc/infra -I../src/infra \
    -Isrc/core -I../src/core -Isrc/utils -I../src/utils \
    -I/usr/local/cuda-12.8/targets/x86_64-linux/include \
    -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror \
    -std=c++17 -O0 -g -DHAVE_ETCD -DDISABLE_GDS_BACKEND \
    '-DNIXL_USE_PLUGIN_FILE="/home/ovidium/nixl/build_release/pluginlist"' \
    -fPIC -fPIC \
    -MD -MQ src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_backend.cpp.o \
    -MF src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_backend.cpp.o.d \
    -o src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_backend.cpp.o \
    -c ../src/plugins/mooncake/mooncake_backend.cpp

In file included from ../src/plugins/mooncake/mooncake_backend.cpp:19:
../src/utils/common/nixl_log.h:21:10: fatal error: absl/log/log.h: No such file or directory
   21 | #include "absl/log/log.h"
      |          ^~~~~~~~~~~~~~~~
compilation terminated.

[186/292] Compiling C++ object src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_plugin.cpp.o
FAILED: src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_plugin.cpp.o
c++ -Isrc/plugins/mooncake/libplugin_Mooncake.so.p -Isrc/plugins/mooncake -I../src/plugins/mooncake \
    -Isrc/api/cpp -I../src/api/cpp -I../src/api/cpp/backend -Isrc/infra -I../src/infra \
    -Isrc/core -I../src/core -Isrc/utils -I../src/utils \
    -I/usr/local/cuda-12.8/targets/x86_64-linux/include \
    -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror \
    -std=c++17 -O0 -g -DHAVE_ETCD -DDISABLE_GDS_BACKEND \
    '-DNIXL_USE_PLUGIN_FILE="/home/ovidium/nixl/build_release/pluginlist"' \
    -fPIC -fPIC \
    -MD -MQ src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_plugin.cpp.o \
    -MF src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_plugin.cpp.o.d \
    -o src/plugins/mooncake/libplugin_Mooncake.so.p/mooncake_plugin.cpp.o \
    -c ../src/plugins/mooncake/mooncake_plugin.cpp

In file included from ../src/api/cpp/backend/backend_plugin.h:22,
                 from ../src/plugins/mooncake/mooncake_plugin.cpp:18:
../src/utils/common/nixl_log.h:21:10: fatal error: absl/log/log.h: No such file or directory
   21 | #include "absl/log/log.h"
      |          ^~~~~~~~~~~~~~~~
compilation terminated.

[198/292] Compiling C++ object src/plugins/ucx/libplugin_UCX.so.p/ucx_backend.cpp.o
ninja: build stopped: subcommand failed.```