### PR TITLE
BUILD: Add configurable CUDA architecture targeting with meson built-in options

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Common CUDA compute capabilities:
 - `compute_80,code=sm_80`: NVIDIA Ampere (A100, RTX 30xx)
 - `compute_86,code=sm_86`: NVIDIA Ampere (RTX 30xx consumer)
 - `compute_89,code=sm_89`: NVIDIA Ada Lovelace (RTX 40xx)
-- `compute_90,code=sm_90`: NVIDIA Hopper (H100)
+- `compute_90,code=sm_90`: NVIDIA Hopper (H100, H800, H200)
 
 ### Building Documentation
 

--- a/meson.build
+++ b/meson.build
@@ -92,22 +92,29 @@ if cuda_dep.found()
     cuda_args_option = get_option('cuda_args')
     cuda_link_args_option = get_option('cuda_link_args')
 
-    cuda_args = [
+    # Define default architectures
+    default_cuda_args = [
         '-gencode=arch=compute_80,code=sm_80',
         '-gencode=arch=compute_90,code=sm_90'
     ]
-    cuda_link_args = [
+    default_cuda_link_args = [
         '-gencode=arch=compute_80,code=sm_80',
         '-gencode=arch=compute_90,code=sm_90'
     ]
 
     # Apply defaults only if user hasn't specified custom args
     if cuda_args_option == []
+        cuda_args = default_cuda_args
         add_project_arguments(cuda_args, language: 'cuda')
+    else
+        cuda_args = []
     endif
 
     if cuda_link_args_option == []
+        cuda_link_args = default_cuda_link_args
         add_project_link_arguments(cuda_link_args, language: 'cuda')
+    else
+        cuda_link_args = []
     endif
 
     # Refer to https://mesonbuild.com/Cuda-module.html


### PR DESCRIPTION
## What?
Add support for configurable CUDA architecture targeting using Meson's built-in `cuda_args` and `cuda_link_args` options.

## Why?
Replaces hardcoded CUDA architecture flags with configurable defaults using meson's built-in CUDA argument handling for better flexibility.

## How?
- Leverage Meson's built-in `cuda_args`/`cuda_link_args` compiler options
- Apply sensible defaults (compute_80, compute_90) only when user hasn't specified custom values
- Updated README with comprehensive CUDA architecture configuration section
- Simplified code by removing custom flag handling logic

## Usage
```bash
# Uses defaults (Ampere & Hopper: compute_80, compute_90)
meson setup build

# Target specific architecture
meson setup build \
    -Dcuda_args="-gencode=arch=compute_75,code=sm_75" \
    -Dcuda_link_args="-gencode=arch=compute_75,code=sm_75"

# Target multiple architectures
meson setup build \
    -Dcuda_args="-gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80" \
    -Dcuda_link_args="-gencode=arch=compute_75,code=sm_75 -gencode=arch=compute_80,code=sm_80"
```

See `README.md` for complete documentation and additional examples.