### PR TITLE
BUILD: detect UCX GPU device API

### DIFF
--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -20,16 +20,26 @@ cpp = meson.get_compiler('cpp')
 compile_flags = []
 if cuda_dep.found()
     compile_flags = [ '-DHAVE_CUDA' ]
+    cuda = meson.get_compiler('cuda')
 
     # UCX GPU device API detection
-    if cpp.has_function('ucp_mem_list_create',
-                        prefix: '#include <ucp/api/device/ucp_host.h>',
-                        dependencies: ucx_dep)
+    have_gpu_side = cuda.compiles('''
+            #include <ucp/api/device/ucp_device_impl.h>
+            int main() { return 0; }
+        ''', dependencies : ucx_dep)
+
+    have_host_side = cpp.has_function(
+        'ucp_mem_list_create',
+        prefix: '#include <ucp/api/device/ucp_host.h>',
+        dependencies: ucx_dep)
+
+    if have_gpu_side and have_host_side
         compile_flags += ['-DHAVE_UCX_GPU_DEVICE_API']
         message('UCX GPU device API support detected and enabled')
     else
         message('UCX GPU device API support not available - GPU device API features will be disabled')
     endif
+
 endif
 
 if 'UCX' in static_plugins


### PR DESCRIPTION
## What?
Add Meson detection for UCX GPU device API.

## Why?
Ensure build enables GPU device API features only when supported.

## How?
Check for `ucp/api/ucp.cuh` and `ucp_gpu_dlist_export` in `ucp.h`,  
define `HAVE_UCX_GPU_DEVICE_API` if found, with option to disable explicitly.
