### PR TITLE
[GDS] bugfix - initialize CUfileDescr_t

### DIFF
--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -23,7 +23,7 @@ nixl_status_t gdsUtil::registerFileHandle(int fd,
                                           gdsFileHandle& gds_handle)
 {
     CUfileError_t status;
-    CUfileDescr_t descr;
+    CUfileDescr_t descr = {};
     CUfileHandle_t handle;
 
     descr.handle.fd = fd;


### PR DESCRIPTION
## What?
Zero out CUfileDescr_t before calling cuFileHandleRegister to prevent a segmentation fault
