### PR TITLE
Fix Error in barrier when testing block size above 1M

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -317,8 +317,8 @@ xferBenchConfig::loadFromFlags() {
         return -1;
     }
 
-    if (large_blk_iter_ftr == 0 || large_blk_iter_ftr > num_iter) {
-        std::cerr << "iter_factor must not be 0 and must be lower than num_iter" << std::endl;
+    if (large_blk_iter_ftr <= 0) {
+        std::cerr << "iter_factor must be greater than 0" << std::endl;
         return -1;
     }
 

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -57,7 +57,6 @@
 // TODO: This is true for CX-7, need support for other CX cards and NVLink
 #define MAXBW 50.0 // 400 Gbps or 50 GB/sec
 #define LARGE_BLOCK_SIZE (1LL * (1 << 20))
-#define MIN_WARMUP_ITERS 8
 
 #define XFERBENCH_INITIATOR_BUFFER_ELEMENT 0xbb
 #define XFERBENCH_TARGET_BUFFER_ELEMENT 0xaa

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -989,10 +989,12 @@ xferBenchNixlWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
-    ret = execTransfer(
-        agent, local_iovs, remote_iovs, xfer_op, skip, xferBenchConfig::num_threads, stats);
-    if (ret < 0) {
-        return std::variant<xferBenchStats, int>(ret);
+    if (skip > 0) {
+        ret = execTransfer(
+            agent, local_iovs, remote_iovs, xfer_op, skip, xferBenchConfig::num_threads, stats);
+        if (ret < 0) {
+            return std::variant<xferBenchStats, int>(ret);
+        }
     }
 
     // Synchronize to ensure all processes have completed the warmup (iter and polling)

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1024,8 +1024,8 @@ xferBenchNixlWorker::poll(size_t block_size) {
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {
         skip /= xferBenchConfig::large_blk_iter_ftr;
-        if (skip < MIN_WARMUP_ITERS) {
-            skip = MIN_WARMUP_ITERS;
+        if (skip < MIN_WARMUP_ITERS * xferBenchConfig::num_threads) {
+            skip = MIN_WARMUP_ITERS * xferBenchConfig::num_threads;
         }
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -986,9 +986,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {
         skip /= xferBenchConfig::large_blk_iter_ftr;
-        if (skip < MIN_WARMUP_ITERS) {
-            skip = MIN_WARMUP_ITERS;
-        }
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
@@ -1024,9 +1021,6 @@ xferBenchNixlWorker::poll(size_t block_size) {
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {
         skip /= xferBenchConfig::large_blk_iter_ftr;
-        if (skip < MIN_WARMUP_ITERS * xferBenchConfig::num_threads) {
-            skip = MIN_WARMUP_ITERS * xferBenchConfig::num_threads;
-        }
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
     total_iter = skip + num_iter;

--- a/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
@@ -182,9 +182,6 @@ xferBenchNvshmemWorker::transfer(size_t block_size,
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {
         skip /= xferBenchConfig::large_blk_iter_ftr;
-        if (skip < MIN_WARMUP_ITERS) {
-            skip = MIN_WARMUP_ITERS;
-        }
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 

--- a/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.cpp
@@ -185,11 +185,13 @@ xferBenchNvshmemWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
-    ret = execTransfer(local_trans_lists, remote_trans_lists, skip, stream, stats);
-    if (ret < 0) {
-        return std::variant<xferBenchStats, int>(ret);
+    if (skip > 0) {
+        ret = execTransfer(local_trans_lists, remote_trans_lists, skip, stream, stats);
+        if (ret < 0) {
+            return std::variant<xferBenchStats, int>(ret);
+        }
+        stats.clear();
     }
-    stats.clear();
     nvshmemx_barrier_all_on_stream(stream);
     CHECK_CUDA_ERROR(cudaStreamSynchronize(stream), "Failed to synchronize CUDA stream");
 


### PR DESCRIPTION
## What?
Fix an issue where target stuck at waiting for more data from initiator due to wrong expectation

## Why?
warm up iterations used in initiator is per thread, so target have to multiply that by thread.