### PR TITLE
Add instructions for GPU selection in nixl kvbench CTP

### DIFF
--- a/benchmark/kvbench/README.md
+++ b/benchmark/kvbench/README.md
@@ -205,11 +205,13 @@ Benchmark the performance of a continuum of traffic patterns one after the other
          0.129                2.147                    2.386              4
 ```
 
-#### CT Perftest
+#### CT Perftest {#ct-perftest}
 
 Benchmark the performance of one traffic pattern. The pattern is run in multiple iterations and then metrics are reported. Useful for optimizing specific patterns.
 
 **Reports**: CT Perftest reports total latency (time elapsed between the first rank started until the last rank finished), average time per iteration, total size sent over the network, and average bandwidth by rank.
+
+**Important note**: GPU memory is allocated with pytorch on the GPU specified by the `CUDA_VISIBLE_DEVICE` environment variable, make sure that each process sets this variable to the right device.
 
 ## Examples
 
@@ -325,7 +327,7 @@ traffic_patterns:
 **Traffic Pattern Parameters**:
 - `matrix_file`: File containing the transfer matrix (required)
 - `shards`: Number of chunks to shard the buffer into (default: 1)
-- `mem_type`: Memory type, currently supports "cuda" (default: "cuda")
+- `mem_type`: Memory type, currently supports "cuda" (default: "cuda") (Use `CUDA_VISIBLE_DEVICES` to control the GPU device)
 - `xfer_op`: Transfer operation, "READ" or "WRITE" (default: "WRITE")
 - `sleep_after_launch_sec`: Seconds to sleep before running pattern (default: 0)
 
@@ -360,6 +362,8 @@ python test/inference_workload_matgen.py generate \
 
 #### Running CTP Tests
 
+Please read the important note about setting `CUDA_VISIBLE_DEVICES` in [CT Perftest section](#ct-perftest).
+
 **Sequential CT Perftest**:
 ```bash
 # Basic usage
@@ -376,9 +380,12 @@ python main.py --debug sequential-ct-perftest ./config.yaml \
     --json-output-path ./results.json
 
 # With Slurm
-srun <params> python main.py sequential-ct-perftest ./config.yaml \
+srun <params> bash -c "
+  CUDA_VISIBLE_DEVICES=$SLURM_LOCALID
+  python main.py sequential-ct-perftest ./config.yaml \
     --verify-buffers \
     --json-output-path ./results.json
+"
 ```
 
 **CT Perftest**:

--- a/benchmark/kvbench/test/custom_traffic_perftest.py
+++ b/benchmark/kvbench/test/custom_traffic_perftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import time
 from test.traffic_pattern import TrafficPattern
 from typing import Literal, Optional, Tuple
@@ -113,6 +114,14 @@ class CTPerftest:
         self.warmup_iters = warmup_iters
 
         self.nixl_agent = nixl_agent(f"{self.my_rank}")
+
+        if (
+            not os.environ.get("CUDA_VISIBLE_DEVICES")
+            and self.traffic_pattern.mem_type == "cuda"
+        ):
+            logger.warning(
+                "Cuda buffers detected, but the env var CUDA_VISIBLE_DEVICES is not set, this will cause every process in the same host to use the same GPU device."
+            )
 
         """Initialize the buffers, one big send and recv buffer is used for all the transfers
         it has to be chunked inside each transfer to get buffers per ranks

--- a/benchmark/kvbench/test/sequential_custom_traffic_perftest.py
+++ b/benchmark/kvbench/test/sequential_custom_traffic_perftest.py
@@ -16,6 +16,7 @@
 """Sequential is different from multi in that every rank processes only one TP at a time, but they can process different ones"""
 
 import json
+import os
 import time
 from collections import defaultdict
 from itertools import chain
@@ -64,6 +65,12 @@ class SequentialCTPerftest(CTPerftest):
 
         for tp in self.traffic_patterns:
             self._check_tp_config(tp)
+        if not os.environ.get("CUDA_VISIBLE_DEVICES") and any(
+            tp.mem_type == "cuda" for tp in self.traffic_patterns
+        ):
+            logger.warning(
+                "Cuda buffers detected, but the env var CUDA_VISIBLE_DEVICES is not set, this will cause every process in the same host to use the same GPU device."
+            )
         assert "UCX" in self.nixl_agent.get_plugin_list(), "UCX plugin is not loaded"
 
         # NixlBuffer caches buffers and reuse them if they are big enough, let's initialize them once, with the largest needed size


### PR DESCRIPTION
Without `CUDA_VISIBLE_DEVICES` set by the user, the selected device is automatically the first GPU of the host, and therefore all the processes on the host use the same GPU. Thought it would be useful to add a warning and a section for it in the README.