### PR TITLE
CI: Download rustup in a more reliable way

### DIFF
--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -51,6 +51,7 @@ $SUDO rm -rf /usr/lib/cmake/grpc /usr/lib/cmake/protobuf
 
 $SUDO apt-get -qq update
 $SUDO apt-get -qq install -y curl \
+                             wget \
                              libnuma-dev \
                              numactl \
                              autotools-dev \


### PR DESCRIPTION
## What?
Download rustup with multiple retries and from static.rust-lang.org instead of sh.rustup.rs

## Why?
Many failures in CI are due to this download failing with connection timeout.

## How?
Use wget with retry mechanism as in the Dockerfiles