### PR TITLE
move the free notify msg to mooncake backend and remove the progress …

### DIFF
--- a/src/plugins/mooncake/mooncake_backend.cpp
+++ b/src/plugins/mooncake/mooncake_backend.cpp
@@ -136,6 +136,7 @@ struct nixlMooncakeBackendMD : public nixlBackendMD {
     nixlMooncakeBackendMD(bool isPrivate) : nixlBackendMD(isPrivate) {}
 
     virtual ~nixlMooncakeBackendMD() {}
+
     void *addr;
     size_t length;
     int ref_cnt;
@@ -216,6 +217,7 @@ struct nixlMooncakeBackendReqH : public nixlBackendReqH {
     nixlMooncakeBackendReqH() : nixlBackendReqH() {}
 
     virtual ~nixlMooncakeBackendReqH() {}
+
     uint64_t batch_id;
     size_t request_count;
 };
@@ -325,7 +327,7 @@ nixlMooncakeEngine::getNotifs(notif_list_t &notif_list) {
     for (int i = 0; i < size; i++) {
         notif_list.push_back(std::make_pair(notify_msgs[i].name, notify_msgs[i].msg));
     }
-    free(notify_msgs);
+    freeNotifsMsgBuf(notify_msgs, size);
     return NIXL_SUCCESS;
 }
 

--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -436,9 +436,6 @@ performTransfer(nixlBackendEngine *mooncake1,
 
         while (ret3 == NIXL_IN_PROG) {
             ret3 = mooncake1->checkXfer(handle);
-            if (progress) {
-                mooncake2->progress();
-            }
             assert(ret3 == NIXL_SUCCESS || ret3 == NIXL_IN_PROG);
         }
     }
@@ -458,9 +455,6 @@ performTransfer(nixlBackendEngine *mooncake1,
         while (ret2 == 0) {
             ret3 = mooncake2->getNotifs(target_notifs);
             ret2 = target_notifs.size();
-            if (progress) {
-                mooncake1->progress();
-            }
             assert(ret3 == NIXL_SUCCESS);
         }
 


### PR DESCRIPTION
Simple modifies.
move the free msg in function getNotifies to the mooncake inside to also free the memory inside the mooncake.

delete the "progress()" needed in the mooncake_backend_test.cpp as I saw the function is deleted by the reviewer.
