### PR TITLE
Update overlapping remote metadata in addDescList to support incremental send-recv

### DIFF
--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -381,21 +381,19 @@ nixl_status_t nixlRemoteSection::addDescList (
     for (int i=0; i<mem_elms.descCount(); ++i) {
         // TODO: Can add overlap checks (erroneous)
         int idx = target->getIndex(mem_elms[i]);
-        if (idx < 0) {
-            ret = backend->loadRemoteMD(mem_elms[i], nixl_mem, agentName, out.metadataP);
-            // In case of errors, no need to remove the previous entries
-            // Agent will delete the full object.
-            if (ret<0)
-                return ret;
-            *p = mem_elms[i]; // Copy the basic desc part
-            out.metaBlob = mem_elms[i].metaInfo;
-            target->addDesc(out);
-        } else {
-            const nixl_blob_t &prev_meta_info = (*target)[idx].metaBlob;
-            // TODO: Support metadata updates
-            if (prev_meta_info != mem_elms[i].metaInfo)
-                return NIXL_ERR_NOT_ALLOWED;
+        if (idx >= 0) {
+            // Update metadata: remove old and add new one
+            backend->unloadMD((*target)[idx].metadataP);
+            target->remDesc(idx);
         }
+
+        ret = backend->loadRemoteMD(mem_elms[i], nixl_mem, agentName, out.metadataP);
+        // In case of errors, no need to remove the previous entries
+        // Agent will delete the full object.
+        if (ret < 0) return ret;
+        *p = mem_elms[i]; // Copy the basic desc part
+        out.metaBlob = mem_elms[i].metaInfo;
+        target->addDesc(out);
     }
     return NIXL_SUCCESS;
 }


### PR DESCRIPTION
## What?
When the local agent execute `add_remote_metadata` with an updated remote metadata, unload the old metadata with a same pointer and length.

## Why?
In our use case (Encoder-Prefill Disaggregation in vLLM), the encoded multimodal tokens are not registered with the remote agent (i.e. the encode worker). For advanced routing, we tried creating new metadata using the `get_partial_agent_metadata` function and sending it to the local worker (i.e. the prefill worker).

However, this raises an error when we try to register it with the same pair of tensor pointers and lengths. Since the encoded tokens can be placed in the same pointer due to GC, we should update the metadata to include tokens of various lengths.

## Test case

Here I wrote safe communication test codes with 1000 tensors initialized in-place. This PR resolves #735.

<details>
<summary>recv.py</summary>

```python
import hashlib
import socket
import msgspec
import torch
import uuid
import time
import queue

from nixl._api import nixl_agent, nixl_agent_config
import threading
import traceback

HOST = 'localhost'
PORT = 8811


def recv_meta(recv_queue: queue.Queue):
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

        s.bind((HOST, PORT))
        s.listen()
        print(f"Server listening on {HOST}:{PORT}")

        # loop
        conn, addr = s.accept()
        with conn:
            while True:
                # Receive data length first
                data_length = int.from_bytes(conn.recv(4), byteorder='big')

                # Receive the actual data
                data = b''
                while len(data) < data_length:
                    chunk = conn.recv(data_length - len(data))
                    if not chunk:
                        break
                    data += chunk

                # Decode the agent metadata
                decoder = msgspec.msgpack.Decoder()
                agent_meta, t_ptr, t_len, t_sum = decoder.decode(data)

                recv_queue.put((agent_meta, t_ptr, t_len, t_sum))


remote_name = None


def receive_agent_meta(recv_queue: queue.Queue, agent: nixl_agent):
    global remote_name
    agent_meta, t1_ptr, t_len, t_sum = recv_queue.get()

    tensor = torch.zeros(t_len, device='cuda')

    remote_block = [(t1_ptr, tensor.numel() * tensor.element_size(), 0)]

    if agent_meta is not None:
        remote_name = agent.add_remote_agent(agent_meta)

    remote_descs = agent.get_xfer_descs(remote_block, "VRAM")
    remote_handles = agent.prep_xfer_dlist(remote_name, remote_descs)

    ptr = tensor.data_ptr()

    mem_data = [(ptr, tensor.numel() * tensor.element_size(), 0, "")]
    mem_descs = agent.get_reg_descs(mem_data, "VRAM")
    agent.register_memory(mem_descs)

    xfer_block = [(ptr, tensor.numel() * tensor.element_size(), 0)]

    xfer_descs = agent.get_xfer_descs(xfer_block, "VRAM")
    xfer_handle = agent.prep_xfer_dlist("NIXL_INIT_AGENT", xfer_descs)

    send_handle = agent.make_prepped_xfer(
        "READ",
        xfer_handle,
        [0],
        remote_handles,
        [0],
        notif_msg="notif",
    )

    agent.transfer(send_handle)

    while agent.check_xfer_state(send_handle) != "DONE":
        pass

    ts = tensor.sum().item()
    if ts != t_sum:
        print(
            f"Data mismatch! Received sum: {ts}, Expected sum: {t_sum}, length: {t_len}"
        )

    agent.release_xfer_handle(send_handle)
    agent.release_dlist_handle(remote_handles)
    agent.release_dlist_handle(xfer_handle)
    agent.deregister_memory(mem_descs)


if __name__ == "__main__":
    torch.cuda.set_device(0)

    recv_queue = queue.Queue()
    recv_thread = threading.Thread(target=recv_meta,
                                   args=(recv_queue, ),
                                   daemon=True)
    recv_thread.start()

    agent = nixl_agent(str(uuid.uuid4()), None)

    try:
        duration = 0
        for _ in range(10):
            for t in range(10):
                receive_agent_meta(recv_queue, agent)

            start_time = time.monotonic()
            for t in range(100):
                receive_agent_meta(recv_queue, agent)
            end_time = time.monotonic()

            duration += (end_time - start_time)
            time.sleep(1)

            print(f"Iteration completed, time taken: {duration}")

        print(f"Time taken: {duration}")
    except Exception as e:
        traceback.print_exc()
        print(f"Error in receive_agent_meta: {e} number at {t}")
        # The daemon thread will automatically terminate when main thread exits

```
</details>

<details>
<summary>send.py</summary>

```python
import torch
import uuid
import msgspec
import socket
import hashlib
import time
import queue
import threading
import random

from nixl._api import nixl_agent, nixl_agent_config

HOST = 'localhost'
PORT = 8811


def send_meta(send_queue: queue.Queue):
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.connect((HOST, PORT))
        while True:
            agent_meta, t_ptr, nl, t_sum = send_queue.get()

            encoder = msgspec.msgpack.Encoder()
            data = encoder.encode((agent_meta, t_ptr, nl, t_sum))

            # Send data length first
            s.send(len(data).to_bytes(4, byteorder='big'))

            # Send the actual data
            s.send(data)


def get_notif(agent: nixl_agent, notif_queue: queue.Queue):
    while True:
        for notif in agent.get_new_notifs():
            mem_descs, t = notif_queue.get()
            agent.deregister_memory(mem_descs)


def send_agent_meta(agent: nixl_agent, send_queue: queue.Queue,
                    notif_queue: queue.Queue, tensor):

    t_len = random.randint(720, 1024)
    tensor = torch.rand(t_len, device='cuda')
    t_sum = tensor.sum().item()

    data_ptr = tensor.data_ptr()
    mem_data = [(data_ptr, tensor.numel() * tensor.element_size(), 0, "")]
    mem_descs = agent.get_reg_descs(mem_data, "VRAM")
    agent.register_memory(mem_descs)

    agent_meta = agent.get_partial_agent_metadata(mem_descs, True)

    send_queue.put((agent_meta, data_ptr, t_len, t_sum))
    notif_queue.put((mem_descs, tensor))


if __name__ == "__main__":
    agent = nixl_agent(str(uuid.uuid4()), None)

    send_queue = queue.Queue()
    notif_queue = queue.Queue()
    threading.Thread(target=send_meta, args=(send_queue, ),
                     daemon=True).start()
    threading.Thread(target=get_notif, args=(agent, notif_queue),
                     daemon=True).start()

    duration = 0
    for _ in range(10):

        for t in range(10):
            send_agent_meta(agent, send_queue, notif_queue, t)

        start_time = time.monotonic()
        for t in range(100):
            send_agent_meta(agent, send_queue, notif_queue, t)
        end_time = time.monotonic()
        duration += (end_time - start_time)
        time.sleep(1)

        print(f"Time taken for sending: {duration} seconds")

    time.sleep(10)
```

</details>