### PR TITLE
Fallback to manual CUDA detection when meson detection fails

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,7 @@ project('nixl', 'CPP', version: '0.5.1',
 
 # set up some global vars for compiler, platform, configuration, etc.
 cpp = meson.get_compiler('cpp')
+fs = import('fs')
 
 dl_dep = cpp.find_library('dl', required: true)
 rt_dep = cpp.find_library('rt', required: true)

--- a/meson.build
+++ b/meson.build
@@ -64,6 +64,9 @@ if cuda_lib_path == ''
         cuda_dep = declare_dependency(
           link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
           include_directories : include_directories(cuda_inc))
+        if cuda_dep.found()
+            message('Found CUDA installation through fallback method:', cuda_home)
+        endif
     endif
 else
     message('cuda lib path ', cuda_lib_path)
@@ -95,7 +98,7 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
 else
-    error('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
+    warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
 endif
 
 # DOCA

--- a/meson.build
+++ b/meson.build
@@ -55,8 +55,8 @@ if cuda_lib_path == ''
     if not cuda_dep.found()
         # Meson is not detecting CUDA reliably on ARM, fallback to manual detection
         cuda_root = run_command('bash', '-c', 'ls -d /usr/local/cuda* 2>/dev/null | sort -V | tail -n1').stdout().strip()
-        message('CUDA root:', cuda_root)
         if cuda_root != ''
+            message('CUDA root:', cuda_root)
             cuda_lib_dirs = run_command(
                 'bash', '-c', 'ls -d ' + cuda_root + '/targets/*/lib{,/stubs} 2>/dev/null'
             ).stdout().splitlines()
@@ -68,7 +68,7 @@ if cuda_lib_path == ''
                     dependencies : [cudart, cuda],
                     include_directories : include_directories(cuda_root + '/include')
                 )
-                message('Found CUDA installation:', cuda_root)
+                message('Found CUDA installation through fallback method:', cuda_root)
             endif
         endif
     endif
@@ -102,10 +102,7 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
 else
-    # TODO: do not merge
-    detect = run_command('find', '/', '-name', 'libcuda*').stdout().strip()
-    message('CUDA libraries: ' + detect)
-    error('CUDA not found')
+    warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
 endif
 
 # DOCA

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,26 @@ cuda_stub_path = get_option('cudapath_stub')
 
 if cuda_lib_path == ''
     cuda_dep = dependency('cuda', required : false, modules : [ 'cudart', 'cuda' ])
+    if not cuda_dep.found()
+        # Meson is not detecting CUDA reliably on ARM, fallback to manual detection
+        cuda_root = run_command('bash', '-c', 'ls -d /usr/local/cuda* 2>/dev/null | sort -V | tail -n1').stdout().strip()
+        message('CUDA root:', cuda_root)
+        if cuda_root != ''
+            cuda_lib_dirs = run_command(
+                'bash', '-c', 'ls -d ' + cuda_root + '/targets/*/lib{,/stubs} 2>/dev/null'
+            ).stdout().splitlines()
+            message('CUDA libdirs:', cuda_lib_dirs)
+            cudart = cpp.find_library('cudart', dirs : cuda_lib_dirs, required : false)
+            cuda   = cpp.find_library('cuda',   dirs : cuda_lib_dirs, required : false)
+            if cudart.found() and cuda.found()
+                cuda_dep = declare_dependency(
+                    dependencies : [cudart, cuda],
+                    include_directories : include_directories(cuda_root + '/include')
+                )
+                message('Found CUDA installation:', cuda_root)
+            endif
+        endif
+    endif
 else
     message('cuda lib path ', cuda_lib_path)
     if cuda_stub_path == ''
@@ -81,6 +101,8 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
+else
+    warning('CUDA not found')
 endif
 
 # DOCA

--- a/meson.build
+++ b/meson.build
@@ -61,11 +61,13 @@ if cuda_lib_path == ''
         cuda_lib = cuda_home + '/lib64'
         cuda_inc = cuda_home + '/include'
         cuda_stub = cuda_lib + '/stubs'
-        cuda_dep = declare_dependency(
-          link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
-          include_directories : include_directories(cuda_inc))
-        if cuda_dep.found()
-            message('Found CUDA installation through fallback method:', cuda_home)
+        if fs.exists(cuda_lib) and fs.exists(cuda_inc)
+            cuda_dep = declare_dependency(
+              link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
+              include_directories : include_directories(cuda_inc))
+            if cuda_dep.found()
+                message('Found CUDA installation through fallback method:', cuda_home)
+            endif
         endif
     endif
 else

--- a/meson.build
+++ b/meson.build
@@ -53,24 +53,17 @@ cuda_stub_path = get_option('cudapath_stub')
 if cuda_lib_path == ''
     cuda_dep = dependency('cuda', required : false, modules : [ 'cudart', 'cuda' ])
     if not cuda_dep.found()
-        # Meson is not detecting CUDA reliably on ARM, fallback to manual detection
-        cuda_root = run_command('bash', '-c', 'ls -d /usr/local/cuda* 2>/dev/null | sort -V | tail -n1').stdout().strip()
-        if cuda_root != ''
-            message('CUDA root:', cuda_root)
-            cuda_lib_dirs = run_command(
-                'bash', '-c', 'ls -d ' + cuda_root + '/targets/*/lib{,/stubs} 2>/dev/null'
-            ).stdout().splitlines()
-            message('CUDA libdirs:', cuda_lib_dirs)
-            cudart = cpp.find_library('cudart', dirs : cuda_lib_dirs, required : false)
-            cuda   = cpp.find_library('cuda',   dirs : cuda_lib_dirs, required : false)
-            if cudart.found() and cuda.found()
-                cuda_dep = declare_dependency(
-                    dependencies : [cudart, cuda],
-                    include_directories : include_directories(cuda_root + '/include')
-                )
-                message('Found CUDA installation through fallback method:', cuda_root)
-            endif
+        # Meson is not detecting CUDA reliably on ARM, fallback to default
+        cuda_home = run_command('bash', '-c', 'echo $CUDA_HOME').stdout().strip()
+        if cuda_home == ''
+            cuda_home = '/usr/local/cuda'
         endif
+        cuda_lib = cuda_home + '/lib64'
+        cuda_inc = cuda_home + '/include'
+        cuda_stub = cuda_lib + '/stubs'
+        cuda_dep = declare_dependency(
+          link_args : ['-L' + cuda_lib, '-L' + cuda_stub, '-lcuda', '-lcudart'],
+          include_directories : include_directories(cuda_inc))
     endif
 else
     message('cuda lib path ', cuda_lib_path)
@@ -102,7 +95,7 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
 else
-    warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
+    error('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
 endif
 
 # DOCA

--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,10 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
 else
-    warning('CUDA not found')
+    # TODO: do not merge
+    detect = run_command('find', '/', '-name', 'libcuda*').stdout().strip()
+    message('CUDA libraries: ' + detect)
+    error('CUDA not found')
 endif
 
 # DOCA


### PR DESCRIPTION
## What?
Add manual CUDA detection as a fallback in meson build script for NIXL.

## Why?
Seeing that on lego and some other ARM hosts (but not all images), the builtin CUDA detection of meson does not find libcudart. This is due to missing pkg-config files in the base image.

Before:

```
#26 24.03 Run-time dependency CUDA (modules: cudart, cuda) found: NO (tried system)
```

After:
```
#26 24.03 Run-time dependency CUDA (modules: cudart, cuda) found: NO (tried system) <<<< THIS IS MESON
#26 24.03 WARNING: You should add the boolean check kwarg to the run_command call.
#26 24.03          It currently defaults to false,
#26 24.03          but it will default to true in meson 2.0.
#26 24.03          See also: https://github.com/mesonbuild/meson/issues/9300
#26 24.03 Message: CUDA root: /usr/local/cuda
#26 24.03 ../meson.build:62: WARNING: Project targets '>= 0.64.0' but uses feature introduced in '1.2.0': str.splitlines.
#26 24.03 Message: CUDA libdirs: ['/usr/local/cuda/targets/sbsa-linux/lib', '/usr/local/cuda/targets/sbsa-linux/lib/stubs']
#26 24.03 Library cudart found: YES
#26 24.03 Library cuda found: YES
#26 24.03 Message: Found CUDA installation: /usr/local/cuda <<<< THIS IS MANUAL FALLBACK
```

This is particularly important for the wheel packaging.