### PR TITLE
CI: avoid /build comment to trigger blossom-ci

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -3,6 +3,11 @@ name: Blossom-CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - 'release/*'
+      - main
   workflow_dispatch:
       inputs:
           platform:


### PR DESCRIPTION
We want to avoid having to add /build comment to trigger blossom CI. This will true only for branches:
- release/*
- main

## What?
Update blossom-ci workflow to avoid having to add comment in order to trigger it

## Why?
Improve usability for blossom ci

## How?
New feature was enabled in Blossom ci
