### PR TITLE
Upgrade DOCA to 3.1 in Dockerfiles

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -93,24 +93,16 @@ RUN wget --tries=3 --waitretry=5 \
     rm rustup-init* && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-# Add Mellanox repository and install packages
-RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "${ARCH}"; fi) && \
-    # Map OS names to Mellanox repository format
-    MELLANOX_OS=$(if [ "${OS}" = "ubuntu22" ]; then echo "ubuntu22.04"; elif [ "${OS}" = "ubuntu24" ]; then echo "ubuntu24.04"; else echo "${OS}"; fi) && \
-    export PKG_CONFIG_PATH="/opt/mellanox/doca/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:/opt/mellanox/dpdk/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" && \
-    curl -fsSL https://linux.mellanox.com/public/repo/doca/3.0.0/${MELLANOX_OS}/${ARCH_SUFFIX}/GPG-KEY-Mellanox.pub | \
-    gpg --dearmor | tee /usr/share/keyrings/mellanox-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/mellanox-archive-keyring.gpg] https://linux.mellanox.com/public/repo/doca/3.0.0/${MELLANOX_OS}/${ARCH_SUFFIX} ./" | \
-    tee /etc/apt/sources.list.d/mellanox.list && \
-    apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-        mlnx-dpdk mlnx-dpdk-dev \
-        doca-sdk-common doca-sdk-dma doca-sdk-dpdk-bridge \
-        doca-sdk-eth doca-sdk-flow doca-sdk-rdma doca-all
+# Add DOCA repository and install packages
+RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
+    MELLANOX_OS=$(if [ "${OS}" = "ubuntu22" ]; then echo "ubuntu2204"; elif [ "${OS}" = "ubuntu24" ]; then echo "ubuntu2404"; else echo "${OS}"; fi) && \
+    wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/doca-host_3.1.0-091000-25.07-${MELLANOX_OS}_${ARCH_SUFFIX}.deb && \
+    dpkg -i doca-host_3.1.0-091000-25.07-${MELLANOX_OS}_${ARCH_SUFFIX}.deb && \
+    apt-get update
 
 RUN if [ "$OS" = "ubuntu24" ]; then \
         apt-get install -y --no-install-recommends \
-            doca-sdk-gpunetio libdoca-sdk-gpunetio-dev; \
+            doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev; \
     fi
 
 RUN rm -rf /usr/lib/ucx

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -123,6 +123,17 @@ RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
+RUN wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/doca-host-3.1.0-091000_25.07_rhel89.${ARCH}.rpm && \
+    rpm -i doca-host-3.1.0-091000_25.07_rhel89.${ARCH}.rpm && \
+    dnf install -y libnl3-devel && \
+    cd /usr/share/doca-host-3.1.0/repo/Packages/ && \
+    rpm -ivh --nodeps doca-sdk-common-*rpm && \
+    rpm -ivh --nodeps doca-sdk-rdma-*rpm && \
+    rpm -ivh --nodeps doca-sdk-verbs-*rpm && \
+    rpm -ivh --nodeps doca-sdk-gpunetio-*rpm && \
+    # Check that gpunetio development package is installed correctly
+    pkg-config --cflags --libs doca-gpunetio
+
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 ENV CUDA_PATH=/usr/local/cuda


### PR DESCRIPTION
## What?
Upgrade DOCA from 3.0 to 3.1 in contrib and manylinux Dockerfiles

This also enables gpunetio plugin building and packaging in the python wheel

## Why?
Build was broken with CUDA 13 base image (nvcr.io/nvidia/cuda-dl-base:25.08-cuda13.0-devel-ubuntu24.04) because the base image already bundles DOCA 3.1.
