### PR TITLE
Nixlbench: Upgrade DOCA to 3.1 in nixlbench container

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -50,19 +50,17 @@ RUN apt-get update -y && \
     libgtest-dev \
     build-essential
 
-# Add Mellanox repository and install packages
-RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "${ARCH}"; fi) && \
-    export PKG_CONFIG_PATH="/opt/mellanox/doca/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:/opt/mellanox/dpdk/lib/${ARCH_SUFFIX}-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" && \
-    curl -fsSL https://linux.mellanox.com/public/repo/doca/3.0.0/ubuntu24.04/${ARCH_SUFFIX}/GPG-KEY-Mellanox.pub | \
-    gpg --dearmor | tee /usr/share/keyrings/mellanox-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/mellanox-archive-keyring.gpg] https://linux.mellanox.com/public/repo/doca/3.0.0/ubuntu24.04/${ARCH_SUFFIX} ./" | \
-    tee /etc/apt/sources.list.d/mellanox.list && \
-    DEBIAN_FRONTEND=noninteractive apt update -y && \
-    apt install -y --no-install-recommends \
-        mlnx-dpdk mlnx-dpdk-dev \
-        doca-sdk-common doca-sdk-dma doca-sdk-dpdk-bridge \
-        doca-sdk-eth doca-sdk-flow doca-sdk-rdma doca-all \
-        doca-sdk-gpunetio libdoca-sdk-gpunetio-dev
+# Add DOCA repository and install packages
+RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
+    MELLANOX_OS=$(if [ "${OS}" = "ubuntu22" ]; then echo "ubuntu2204"; elif [ "${OS}" = "ubuntu24" ]; then echo "ubuntu2404"; else echo "${OS}"; fi) && \
+    wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.1.0/host/doca-host_3.1.0-091000-25.07-${MELLANOX_OS}_${ARCH_SUFFIX}.deb && \
+    dpkg -i doca-host_3.1.0-091000-25.07-${MELLANOX_OS}_${ARCH_SUFFIX}.deb && \
+    apt-get update
+
+RUN if [ "$OS" = "ubuntu24" ]; then \
+        apt-get install -y --no-install-recommends \
+            doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev; \
+    fi
 
 # Install AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
## What?
Upgrade DOCA to 3.1.

## Why?
Fixes build with CUDA 13.0
