### PR TITLE
LISTENER: Prevent double-set of promise in etcd metadata watcher

### DIFF
--- a/src/core/nixl_listener.cpp
+++ b/src/core/nixl_listener.cpp
@@ -319,9 +319,15 @@ public:
             int64_t watch_index = response.index();
             std::promise<nixl_status_t> ret_prom;
             auto future = ret_prom.get_future();
+            std::atomic<bool> promise_set{false};
 
             // This lambda assumes lifetime only inside this method
             auto watcher_callback = [&](etcd::Response response) -> void {
+                if (promise_set.exchange(true)) {
+                    NIXL_WARN << "Ignoring subsequent watch event for key: " << metadata_key;
+                    return;
+                }
+
                 if (!response.is_ok()) {
                     NIXL_ERROR << "Watch failed for key: " << metadata_key << " : "
                                << response.error_message();


### PR DESCRIPTION
## What?
Fixes race condition in listener.

## Why?
Seeing nixl_etcd_example sometimes crash with std::future_error: Promise already satisfied

This happens when the sender makes multiple metadata changes, and depending on timing, the receiver may get more than 1 event before they have time to cancel the watcher. This is harmless, except that we set the value of a promise inside the watcher, which is only allowed to be set once.

## How?
Adds a flag to prevent handling multiple events