### PR TITLE
Implement user metadata support

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -425,6 +425,17 @@ class nixlAgent {
         nixl_status_t
         invalidateRemoteMD (const std::string &remote_agent);
 
+        /**
+         * @brief  Add local user metadata to the agent.
+         *         Overwrite if the key already exists.
+         *
+         * @param  key   Key of the user metadata
+         * @param  value Value of the user metadata
+         * @return nixl_status_t Error code if call was not successful
+         */
+        nixl_status_t
+        addLocalUserMD (const std::string &key, const std::string &value);
+
         /*** Metadata handling through direct channels (p2p socket and ETCD) ***/
         /**
          * @brief  Send your own agent metadata to a remote location.
@@ -483,6 +494,19 @@ class nixlAgent {
         nixl_status_t
         fetchRemoteMD (const std::string remote_name,
                        const nixl_opt_args_t* extra_params = nullptr);
+
+        /**
+         * @brief  Get remote user metadata from the agent.
+         *
+         * @param  remote_agent Remote agent name as string
+         * @param  key          Key of the user metadata
+         * @param  value        [out] Value of the user metadata
+         * @return nixl_status_t Error code if call was not successful
+         */
+        nixl_status_t
+        getRemoteUserMD (const std::string &remote_agent,
+                         const std::string &key,
+                         std::string &value);
 
         /**
          * @brief  Invalidate your own memory in one/all remote agent(s).

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <unordered_map>
 #include <cstdint>
+#include <optional>
 
 
 /*** Forward declarations ***/
@@ -217,6 +218,11 @@ struct nixlAgentOptionalArgs {
      * @var signal_dev_id Device ID of the signal buffer for signaling operations
      */
     uint64_t signal_dev_id = 0;
+
+    /**
+     * @var userMdKeys Used to specify the keys of the user metadata to be included in the metadata.
+     */
+    std::optional<std::vector<std::string>> userMdKeys;
 };
 
 /**

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -71,9 +71,10 @@ class nixlAgentData {
         backend_map_t                          backendEngines;
         std::array<backend_list_t, FILE_SEG+1> memToBackend;
 
-        // Bookkeping for local connection metadata and user handles per backend
+        // Bookkeeping for local connection metadata, user metadata, and backend user handles
         std::unordered_map<nixl_backend_t, nixlBackendH*> backendHandles;
         std::unordered_map<nixl_backend_t, nixl_blob_t>   connMD;
+        std::unordered_map<std::string, std::string>      userMD;
 
         // Local section, and Remote sections and their available common backends
         nixlLocalSection*                                        memorySection;
@@ -83,6 +84,9 @@ class nixlAgentData {
                            std::hash<std::string>, strEqual>     remoteBackends;
         std::unordered_map<std::string, nixlRemoteSection*,
                            std::hash<std::string>, strEqual>     remoteSections;
+        std::unordered_map<std::string,
+                           std::unordered_map<std::string, std::string>,
+                           std::hash<std::string>, strEqual>     remoteUserMD;
 
         // State/methods for listener thread
         nixlMDStreamListener               *listener;


### PR DESCRIPTION
## What?
This PR introduces support for user metadata (userMD) in Nixl.

## Why?
User metadata support enables attaching custom key–value data to agents and retrieving it across nodes. This is required to extend Nixl’s flexibility in handling agent-specific information and to support upcoming features that depend on user-defined metadata.

## How?
- Adds userMD storage to nixlAgentData for both local and remote metadata.
- Implements addLocalUserMD() to store key–value pairs locally.
- Implements getRemoteUserMD() to retrieve user metadata from remote agents.
- Extends metadata serialization so getLocalMD() includes user metadata.
- Adds filtering support (userMdKeys) to control selective user md retrieval in getLocalPartialMD().
- Provides comprehensive unit tests covering user metadata functionality.
