### PR TITLE
Nixlbench: Install torch with CUDA support (#758)

### DIFF
--- a/benchmark/kvbench/pyproject.toml
+++ b/benchmark/kvbench/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "etcd3>=0.12.0",
     "tabulate==0.9.0",
-    "torch==2.7.0",
+    "torch>=2.7.0",
     "tqdm==4.66.5",
     "numpy",
     "nixl",

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -141,6 +141,9 @@ RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
     # pybind11 pip install needed for ubuntu 22.04
     uv pip install --upgrade meson pybind11 patchelf pyYAML click tabulate
 
+RUN CUDA_SHORT_VERSION=cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .) && \
+    uv pip install torch --index https://download.pytorch.org/whl/$CUDA_SHORT_VERSION
+
 RUN rm -rf build && \
     mkdir build && \
     uv run meson setup build/ --prefix=/usr/local/nixl --buildtype=$BUILD_TYPE && \


### PR DESCRIPTION
## What?
Force installation of pytorch with CUDA support in nixlbench container image.

Also relaxed the torch version pin in kvbench, since we do not need exactly 2.7.0 and it varies depending on CUDA version.

Tested with x86-64 and aarch64 images built in CI pipeline. Both changes are needed.

## Why?
Ensure that GPU-enabled torch is selected in CI builds on ARM.

Until now, we were relying on meson to install pytorch. Selection of the variant with CUDA support worked reliably on x86_64; on ARM, it installs the CPU version.

This is a blocker for verification team, that needs torch to work out of the box with CUDA support in order to execute some of the tests in automation without any image changes.