### PR TITLE
CI: fix for blossom-ci auto trigger without comment

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -24,7 +24,7 @@ jobs:
       args: ${{ env.args }}
 
     # This job only runs for pull request comments
-    if: github.event.comment.body == '/build'
+    if: github.event.comment.body == '/build' || github.event_name == 'pull_request'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
Fix for allowing blossom ci to be triggered without a /build comment in original commit we forgot to add condition to auth stage

## What?
blossom ci trigger without /build comment

## Why?
fixup for original chnage

