### PR TITLE
Revert "CI: fix for blossom-ci auto trigger without comment (#771)"

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -24,7 +24,7 @@ jobs:
       args: ${{ env.args }}
 
     # This job only runs for pull request comments
-    if: github.event.comment.body == '/build' || github.event_name == 'pull_request'
+    if: github.event.comment.body == '/build'
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
This reverts commit 531e8038f80a89ca295049ca32a24b31b5f1d52b.

## What?
Revert previous blossom-ci avoid comment change

## Why?
This feature is broken from Blossom side and they need to fix it, to avoid check failures we need to revert back to original state

