### PR TITLE
Fix signature mismatch in xferBenchNvshmemWorker::exchangeIOV

### DIFF
--- a/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.h
+++ b/benchmark/nixlbench/src/worker/nvshmem/nvshmem_worker.h
@@ -48,7 +48,8 @@ class xferBenchNvshmemWorker: public xferBenchWorker {
         // Communication and synchronization
         int exchangeMetadata() override;
         std::vector<std::vector<xferBenchIOV>>
-        exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) override;
+        exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
+                    size_t block_size) override;
         void
         poll(size_t block_size) override;
         int


### PR DESCRIPTION
## What?
is PR fixes a build failure in nixlbench when building the NVSHMEM worker.
<img width="679" height="427" alt="image" src="https://github.com/user-attachments/assets/d2843414-6d00-4aa1-829b-cf48e0eb1796" />

## Why?
● The header previously declared exchangeIOV with a single argument, marked override.
● The source defined exchangeIOV with two arguments (const std::vector<std::vector<xferBenchIOV>>&, size_t).
● This mismatch caused a compiler error about the method not actually overriding a base class function.

## How?
🔧 Change:
The header declaration has been updated to match the definition (two arguments).

## Result:
Nixlbench-build succeeds with NVSHMEM enabled, and xferBenchNvshmemWorker now has a consistent interface.
<img width="680" height="244" alt="image" src="https://github.com/user-attachments/assets/1a61bd26-4402-4cf0-85c9-4f001bce244f" />
