### PR TITLE
CI: Add UCX version matrix and DOCA GPUNETIO support to test pipeline

### DIFF
--- a/.ci/dockerfiles/Dockerfile.gpu_test
+++ b/.ci/dockerfiles/Dockerfile.gpu_test
@@ -45,6 +45,32 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install DOCA GPUNETIO packages
+ARG DOCA_BASE=https://doca-repo-prod.nvidia.com/internal/repo/doca
+ARG DOCA_VER=3.1.0
+ARG DIST=ubuntu24.04
+ARG ARCH=x86_64
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       ca-certificates curl gnupg \
+    && curl -fsSL ${DOCA_BASE}/${DOCA_VER}/${DIST}/${ARCH}/latest/GPG-KEY-Mellanox.pub \
+       | gpg --dearmor -o /usr/share/keyrings/doca.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/doca.gpg] ${DOCA_BASE}/${DOCA_VER}/${DIST}/${ARCH}/latest/ ./" \
+       > /etc/apt/sources.list.d/doca.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+       doca-ofed-userspace \
+       doca-ofed-devel-userspace \
+       doca-sdk-gpunetio \
+       libdoca-sdk-common-dev \
+       libdoca-sdk-verbs-dev \
+       libdoca-sdk-gpunetio-dev \
+       rdma-core \
+       doca-sdk-verbs doca-sdk-common \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create group and user in one RUN command to reduce layers
 RUN if ! getent group "${_GID}" > /dev/null 2>&1; then \
         groupadd -g "${_GID}" "${_GROUP}"; \

--- a/.ci/docs/setup_nvidia_gpu_with_rdma_support_on_ubuntu.md
+++ b/.ci/docs/setup_nvidia_gpu_with_rdma_support_on_ubuntu.md
@@ -87,15 +87,22 @@ sudo modprobe nvidia_fs
 lsmod | grep nvidia_fs  # Should show loaded module
 ```
 
-### 📦 5. **Enable GDS in CUDA**
+### 📦 5. **Configure NVIDIA Module Options**
 
-GDS is bundled with CUDA ≥11.4 but requires explicit enabling:
+Configure required NVIDIA driver options:
 
 ```bash
+# Enable GPUDirect Storage
 sudo echo "options nvidia NVreg_EnableGpuDirectStorage=1" > /etc/modprobe.d/nvidia-gds.conf
+
+# Configure PeerMappingOverride for RDMA support
+sudo echo "options nvidia NVreg_RegistryDwords=\"PeerMappingOverride=1;\"" > /etc/modprobe.d/nvidia.conf
+
 sudo update-initramfs -u
 sudo reboot
 ```
+
+The `PeerMappingOverride=1` option is required for proper GPU peer-to-peer communication in RDMA environments.
 
 ### 6. **Enable Kernel Modules at Boot**
 

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -33,12 +33,15 @@ matrix:
       - nvcr.io/nvidia/pytorch:25.02-py3
     arch:
       - x86_64
+    ucx_version:
+      - master
+      - v1.19.0
 
-taskName: "${name}/${arch}/${axis_index}"
+taskName: "${name}/${arch}/${ucx_version}/${axis_index}"
 
 env:
   INSTALL_DIR: ${WORKSPACE}/nixl_install
-  UCX_VERSION: v1.19.0
+  UCX_VERSION: ${ucx_version}
   NPROC: "16"
   # Manual timeout - ci-demo doesn't handle docker exec
   TEST_TIMEOUT: 30


### PR DESCRIPTION
## What?
Integrate DOCA GPUNETIO packages into the GPU test environment and extend the test matrix with UCX version axis.

## Why?
Enable DOCA GPUNETIO functionality testing by providing the necessary packages in the test environment. 
Support parallel testing across different UCX releases.

## How?
- Integrate DOCA and GPUNETIO packages installation into `Dockerfile.gpu_test`
- Extend test matrix with `ucx_version` axis containing `master` and `v1.19.0`
- Add NVIDIA module configuration documentation