### PR TITLE
BUILD: Add configurable CUDA device debug info flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,10 @@ if cuda_dep.found()
     nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
     nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
+
+    if not get_option('cuda_enable_debug')
+        add_project_arguments('-dopt=on', language: 'cuda')
+    endif
 else
     warning('CUDA not found. UCX backend will be built without CUDA support, and some plugins will be disabled.')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,6 +24,7 @@ option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
+option('cuda_enable_debug', type: 'boolean', value: false, description: 'Enable CUDA device debug info (-G flag) for performance analysis')
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')


### PR DESCRIPTION
## What?
Add configurable CUDA device debug info flag with `cuda_enable_debug` meson option.

## Why?
Meson automatically adds the -G flag for CUDA debug builds, which significantly degrades performance. The -G flag generates device debug info and turns off optimizations unless -dopt=on is specified. 
Reference: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/ 4.2.3.3

## How?
- Add cuda_enable_debug boolean option (default: false for performance)
- Conditionally add -dopt=on only when debug is disabled to prevent automatic -G inclusion
- When enabled, allows meson to add -G flag for device debugging/profiling
