### PR TITLE
Fix build when libfabric is not installed

### DIFF
--- a/test/unit/utils/meson.build
+++ b/test/unit/utils/meson.build
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 subdir('common')
-subdir('libfabric')
+if libfabric_dep.found()
+    subdir('libfabric')
+endif
 subdir('serdes')
 subdir('stream')
 subdir('ucx')


### PR DESCRIPTION
## What?
Fix build regression.

## Why?
Missing check for libfabric dependency.
