### PR TITLE
CI: Pin GHA runner ver to fix CMake compatibility error

### DIFF
--- a/.github/workflows/aws_s3_validation.yml
+++ b/.github/workflows/aws_s3_validation.yml
@@ -10,7 +10,7 @@ jobs:
   run_aws_s3_tests:
     name: Run AWS S3 Tests
     environment: SWX_AWS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       AWS_DEFAULT_REGION: eu-central-1
       AWS_ACCESS_KEY_ID: ${{ secrets.NIXL_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
## What?
Pin GitHub Actions runner to ubuntu-24.04 in AWS S3 validation workflow.

## Why?
Fix CMake compatibility error where ubuntu-latest runner includes newer CMake that drops support for CMake < 3.5, causing builds to fail with "Compatibility with CMake < 3.5 has been removed" error.
