### PR TITLE
DEVICE/API: Add nixlGpuWriteSignal API for local signal writing

### DIFF
--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -258,7 +258,7 @@ nixlGpuReadSignal(const void *signal) {
  *
  * The signal must be initialized with the host function @ref prepGpuSignal.
  *
- * @param signal [in]  Address of the signal.
+ * @param signal [in,out]  Address of the signal.
  * @param value  [in]  Value to write to the signal.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>

--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -266,7 +266,7 @@ nixlGpuReadSignal(const void *signal) {
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ void
 nixlGpuWriteSignal(void *signal, uint64_t value) {
-    ucp_device_counter_write<static_cast<ucp_device_level_t>(level)>(signal, value);
+    ucp_device_counter_write<static_cast<ucs_device_level_t>(level)>(signal, value);
 }
 
 #endif // _NIXL_DEVICE_CUH

--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -259,7 +259,7 @@ nixlGpuReadSignal(const void *signal) {
  * The signal must be initialized with the host function @ref prepGpuSignal.
  *
  * @param signal [in,out]  Address of the signal.
- * @param value  [in]  Value to write to the signal.
+ * @param value  [in]      Value to write to the signal.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ void

--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -251,4 +251,20 @@ nixlGpuReadSignal(const void *signal) {
     return ucp_device_counter_read<static_cast<ucp_device_level_t>(level)>(signal);
 }
 
+/**
+ * @brief Write value to the local signal.
+ *
+ * This function can be used to set a signal to a specific value.
+ *
+ * The signal must be initialized with the host function @ref prepGpuSignal.
+ *
+ * @param signal [in]  Address of the signal.
+ * @param value  [in]  Value to write to the signal.
+ */
+template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
+__device__ void
+nixlGpuWriteSignal(void *signal, uint64_t value) {
+    ucp_device_counter_write<static_cast<ucp_device_level_t>(level)>(signal, value);
+}
+
 #endif // _NIXL_DEVICE_CUH


### PR DESCRIPTION
## What?
Following https://github.com/openucx/ucx/pull/10895, added `nixlGpuWriteSignal` API function to enable writing values to local GPU signals.

## Why?
Provides write capability in addition to the existing `nixlGpuReadSignal` function, enabling complete signal manipulation from GPU device code using the underlying UCX `ucp_device_counter_write` functionality.

## How?
Implemented as a templated device function following existing NIXL GPU API patterns, with support for different cooperation levels (THREAD, WARP, BLOCK, GRID) and proper UCX level conversion.