### PR TITLE
Add GDAKI test for nixlbench

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -19,6 +19,7 @@ ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
 # UCX argument is either "upstream" (default installed in base image) or "custom" (build from source)
 ARG UCX="upstream"
 ARG DEFAULT_PYTHON_VERSION="3.12"
+ARG UCX_PREFIX="/usr"
 
 # --- Stage 1: Common OS setup ---
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS os_setup_stage
@@ -97,7 +98,7 @@ RUN echo "INFO: Starting custom UCX build..." && \
     ./contrib/configure-release --with-cuda=/usr/local/cuda \
                                 $(if [ "$BUILD_TYPE" = "debug" ]; then echo "--enable-debug"; fi) \
                                 --enable-mt \
-                                --without-go && \
+                                --without-go --prefix=$UCX_PREFIX && \
     make -j${NPROC:-$(nproc)} && \
     make install && \
     cd / && \
@@ -223,7 +224,7 @@ RUN ls -ll /workspace/nixlbench
 
 RUN rm -rf build && \
     mkdir build && \
-    meson setup build -Dnixl_path=/usr/local/nixl/ -Dprefix=/usr/local/nixlbench --buildtype=$BUILD_TYPE && \
+    meson setup build -Dnixl_path=/usr/local/nixl/ -Dprefix=/usr/local/nixlbench --buildtype=$BUILD_TYPE -Ducxpath_inc=$UCX_PREFIX/include && \
     cd build && ninja && ninja install
 
 WORKDIR /workspace/nixl

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -101,6 +101,13 @@ if cuda_available
                              args: cuda_inc_path != '' ? '-I' + cuda_inc_path : [])
         cuda_fabric_available = true
     endif
+    add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
+    add_project_arguments('-rdc=true', language: 'cuda')
+
+    nvcc_flags_link = []
+    nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
+    nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
+    add_project_link_arguments(nvcc_flags_link, language: 'cuda')
 endif
 
 # OpenMP
@@ -150,6 +157,26 @@ endif
 if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
+
+have_nixl_gdaki = false
+ucxpath_inc = get_option('ucxpath_inc')
+if ucxpath_inc != ''
+    if cuda_available and add_languages('cuda', required: false)
+	nvcc = meson.get_compiler('cuda')
+        test_code = '''#include "gpu/ucx/nixl_device.cuh"
+                       int main() { return 0; }'''
+
+        if nvcc.compiles(test_code,
+                        include_directories: include_directories(nixl_inc, ucxpath_inc),
+                        dependencies: [cuda_dep],
+                        args: nvcc_flags_link)
+            have_nixl_gdaki = true
+            add_project_arguments('-DHAVE_NIXL_DEV_API', language: ['cpp', 'cuda'])
+        endif
+    endif
+endif
+
+message('Using NIXL Device API: ', have_nixl_gdaki)
 
 # Subprojects
 subdir('src/utils')

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -158,6 +158,8 @@ if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
 
+doca_gpunetio_dep = dependency('doca-gpunetio', required : false)
+
 have_nixl_gdaki = false
 ucxpath_inc = get_option('ucxpath_inc')
 if ucxpath_inc != ''
@@ -168,7 +170,7 @@ if ucxpath_inc != ''
 
         if nvcc.compiles(test_code,
                         include_directories: include_directories(nixl_inc, ucxpath_inc),
-                        dependencies: [cuda_dep],
+                        dependencies: [cuda_dep, doca_gpunetio_dep],
                         args: nvcc_flags_link)
             have_nixl_gdaki = true
             add_project_arguments('-DHAVE_NIXL_DEV_API', language: ['cpp', 'cuda'])

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -19,5 +19,6 @@ option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path
 option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD C++ Client includes')
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD C++ Client library')
 option('nixl_path', type: 'string', value: '/usr/local', description: 'Path to NiXL')
+option('ucxpath_inc', type: 'string', value: '', description: 'Path to UCX Headers installed')
 option('nvshmem_inc_path', type: 'string', value: '', description: 'Path to NVSHMEM include directory')
 option('nvshmem_lib_path', type: 'string', value: '', description: 'Path to NVSHMEM library directory')

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -131,10 +131,7 @@ const std::vector<xferBenchParamInfo> xbench_params = {
 
     // Add GDAKI options for NIXL worker
     NB_ARG_BOOL(enable_gdaki, false, "Enable GDAKI (only used with nixl worker)"),
-    NB_ARG_STRING(gdaki_gpu_device_list,
-                  "0",
-                  "Comma-separated GPU device list for GDAKI (only used with nixl worker and when "
-                  "enable_gdaki=1)"),
+
     // GDAKI kernel configuration parameters
     NB_ARG_STRING(gdaki_gpu_level,
                   "block",
@@ -443,13 +440,14 @@ xferBenchConfig::loadParams(cxxopts::ParseResult &result) {
                               << "' will fall back to 'block' coordination (enable partial "
                                  "transfers for full support)."
                               << std::endl;
+                    gdaki_gpu_level = xferBenchConfigGpuLevelBlock;
                 }
             }
 
             if (gdaki_threads_per_block < 1 ||
                 gdaki_threads_per_block > XFERBENCH_DEV_API_MAX_THREADS) {
                 std::cerr << "Invalid GDAKI threads per block: " << gdaki_threads_per_block
-                          << ". Must be between 1 and 1024" << std::endl;
+                          << ". Must be between 1 and " << XFERBENCH_DEV_API_MAX_THREADS << std::endl;
                 return -1;
             }
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -447,7 +447,8 @@ xferBenchConfig::loadParams(cxxopts::ParseResult &result) {
             if (gdaki_threads_per_block < 1 ||
                 gdaki_threads_per_block > XFERBENCH_DEV_API_MAX_THREADS) {
                 std::cerr << "Invalid GDAKI threads per block: " << gdaki_threads_per_block
-                          << ". Must be between 1 and " << XFERBENCH_DEV_API_MAX_THREADS << std::endl;
+                          << ". Must be between 1 and " << XFERBENCH_DEV_API_MAX_THREADS
+                          << std::endl;
                 return -1;
             }
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -413,25 +413,26 @@ xferBenchConfig::loadParams(cxxopts::ParseResult &result) {
 
         // Load GDAKI kernel configuration parameters
         if (enable_gdaki) {
-            gdaki_gpu_device_list = FLAGS_gdaki_gpu_device_list;
-            gdaki_threads_per_block = FLAGS_gdaki_threads_per_block;
-            gdaki_blocks_per_grid = FLAGS_gdaki_blocks_per_grid;
-            gdaki_enable_partial_transfers = FLAGS_gdaki_enable_partial_transfers;
+            gdaki_gpu_device_list = NB_ARG(gdaki_gpu_device_list);
+            gdaki_threads_per_block = NB_ARG(gdaki_threads_per_block);
+            gdaki_blocks_per_grid = NB_ARG(gdaki_blocks_per_grid);
+            gdaki_enable_partial_transfers = NB_ARG(gdaki_enable_partial_transfers);
 
             // Validate GDAKI configuration
-            if (xferBenchConfigGpuLevels.find(FLAGS_gdaki_gpu_level) ==
-                xferBenchConfigGpuLevels.end()) {
-                std::cerr << "Invalid GDAKI gpu level: " << FLAGS_gdaki_gpu_level
-                          << ". Must be: " << xferBenchConfigGpuLevelThread << ", "
-                          << xferBenchConfigGpuLevelWarp << " or " << xferBenchConfigGpuLevelBlock
-                          << std::endl;
+            if (xferBenchConfig::xferBenchConfigGpuLevels.find(NB_ARG(gdaki_gpu_level)) ==
+                xferBenchConfig::xferBenchConfigGpuLevels.end()) {
+                std::cerr << "Invalid GDAKI gpu level: " << NB_ARG(gdaki_gpu_level)
+                          << ". Must be: " << xferBenchConfig::xferBenchConfigGpuLevelThread << ", "
+                          << xferBenchConfig::xferBenchConfigGpuLevelWarp << " or "
+                          << xferBenchConfig::xferBenchConfigGpuLevelBlock << std::endl;
                 return -1;
             }
 
-            gdaki_gpu_level = FLAGS_gdaki_gpu_level;
+            gdaki_gpu_level = NB_ARG(gdaki_gpu_level);
 
             // Inform about gpu coordination level support
-            if (xferBenchConfigGpuLevelBlock != std::string_view(gdaki_gpu_level)) {
+            if (xferBenchConfig::xferBenchConfigGpuLevelBlock !=
+                std::string_view(gdaki_gpu_level)) {
                 if (gdaki_enable_partial_transfers) {
                     std::cout << "INFO: GDAKI GPU Coordination level '" << gdaki_gpu_level
                               << "' gpu coordination with partial transfers enabled." << std::endl;
@@ -440,7 +441,7 @@ xferBenchConfig::loadParams(cxxopts::ParseResult &result) {
                               << "' will fall back to 'block' coordination (enable partial "
                                  "transfers for full support)."
                               << std::endl;
-                    gdaki_gpu_level = xferBenchConfigGpuLevelBlock;
+                    gdaki_gpu_level = xferBenchConfig::xferBenchConfigGpuLevelBlock;
                 }
             }
 
@@ -458,7 +459,6 @@ xferBenchConfig::loadParams(cxxopts::ParseResult &result) {
                 return -1;
             }
         }
->>>>>>> 8f80061 (Add GDAKI test for nixlbench)
 
 #if defined(HAVE_CUDA) && !defined(HAVE_CUDA_FABRIC)
         if (enable_vmm) {

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -18,7 +18,6 @@
 #ifndef __UTILS_H
 #define __UTILS_H
 
-#include "config.h"
 #include <chrono>
 #include <cstdint>
 #include <iostream>

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -183,7 +183,7 @@ public:
     static std::string gusli_config_file;
     static uint64_t gusli_bdev_byte_offset;
     static std::string gusli_device_security;
-    tatic bool enable_gdaki;
+    static bool enable_gdaki;
     static std::string gdaki_gpu_device_list;
     static std::string gdaki_gpu_level;
     static size_t gdaki_threads_per_block;
@@ -201,16 +201,14 @@ public:
     (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
      XFERBENCH_MODE_MG == xferBenchConfig::mode)
 
-    constexpr std::string_view xferBenchConfigGpuLevelThread{"thread"};
-    constexpr std::string_view xferBenchConfigGpuLevelWarp{"warp"};
-    constexpr std::string_view xferBenchConfigGpuLevelBlock{"block"};
+    constexpr static std::string_view xferBenchConfigGpuLevelThread{"thread"};
+    constexpr static std::string_view xferBenchConfigGpuLevelWarp{"warp"};
+    constexpr static std::string_view xferBenchConfigGpuLevelBlock{"block"};
 
-    namespace {
-        const std::unordered_set<std::string_view> xferBenchConfigGpuLevels{
-            xferBenchConfigGpuLevelThread,
-            xferBenchConfigGpuLevelWarp,
-            xferBenchConfigGpuLevelBlock};
-    }
+    inline static const std::unordered_set<std::string_view> xferBenchConfigGpuLevels{
+        xferBenchConfigGpuLevelThread,
+        xferBenchConfigGpuLevelWarp,
+        xferBenchConfigGpuLevelBlock};
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -194,20 +194,22 @@ public:
 #define XFERBENCH_DEV_API_MAX_THREADS 1024
 #define XFERBENCH_DEV_API_MIN_BLOCKS_PER_GRID 1
 
-#define IS_PAIRWISE_AND_SG() (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
-                              XFERBENCH_MODE_SG == xferBenchConfig::mode)
-#define IS_PAIRWISE_AND_MG() (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
-                              XFERBENCH_MODE_MG == xferBenchConfig::mode)
+#define IS_PAIRWISE_AND_SG()                                 \
+    (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
+     XFERBENCH_MODE_SG == xferBenchConfig::mode)
+#define IS_PAIRWISE_AND_MG()                                 \
+    (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
+     XFERBENCH_MODE_MG == xferBenchConfig::mode)
 
     constexpr std::string_view xferBenchConfigGpuLevelThread{"thread"};
     constexpr std::string_view xferBenchConfigGpuLevelWarp{"warp"};
     constexpr std::string_view xferBenchConfigGpuLevelBlock{"block"};
-    
+
     namespace {
         const std::unordered_set<std::string_view> xferBenchConfigGpuLevels{
-                                                xferBenchConfigGpuLevelThread,
-                                                xferBenchConfigGpuLevelWarp,
-                                                xferBenchConfigGpuLevelBlock};
+            xferBenchConfigGpuLevelThread,
+            xferBenchConfigGpuLevelWarp,
+            xferBenchConfigGpuLevelBlock};
     }
 
     static int

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <cxxopts.hpp>
 #include <toml++/toml.hpp>
+#include <unordered_set>
 #include <utils/common/nixl_time.h>
 #include "runtime/runtime.h"
 
@@ -183,6 +184,32 @@ public:
     static std::string gusli_config_file;
     static uint64_t gusli_bdev_byte_offset;
     static std::string gusli_device_security;
+    tatic bool enable_gdaki;
+    static std::string gdaki_gpu_device_list;
+    static std::string gdaki_gpu_level;
+    static size_t gdaki_threads_per_block;
+    static size_t gdaki_blocks_per_grid;
+    static bool gdaki_enable_partial_transfers;
+
+// Device API
+#define XFERBENCH_DEV_API_MAX_THREADS 1024
+#define XFERBENCH_DEV_API_MIN_BLOCKS_PER_GRID 1
+
+#define IS_PAIRWISE_AND_SG() (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
+                              XFERBENCH_MODE_SG == xferBenchConfig::mode)
+#define IS_PAIRWISE_AND_MG() (XFERBENCH_SCHEME_PAIRWISE == xferBenchConfig::scheme && \
+                              XFERBENCH_MODE_MG == xferBenchConfig::mode)
+
+    constexpr std::string_view xferBenchConfigGpuLevelThread{"thread"};
+    constexpr std::string_view xferBenchConfigGpuLevelWarp{"warp"};
+    constexpr std::string_view xferBenchConfigGpuLevelBlock{"block"};
+    
+    namespace {
+        const std::unordered_set<std::string_view> xferBenchConfigGpuLevels{
+                                                xferBenchConfigGpuLevelThread,
+                                                xferBenchConfigGpuLevelWarp,
+                                                xferBenchConfigGpuLevelBlock};
+    }
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
@@ -1,0 +1,422 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gpu/ucx/nixl_device.cuh>
+#include "gdaki_kernels.cuh"
+
+// Helper function to get request index based on coordination level (from gtest)
+template<nixl_gpu_level_t level>
+__device__ constexpr size_t
+getRequestIndex() {
+    switch (level) {
+    case nixl_gpu_level_t::THREAD:
+        return threadIdx.x;
+    case nixl_gpu_level_t::WARP:
+        return threadIdx.x / warpSize;
+    case nixl_gpu_level_t::BLOCK:
+        return 0;
+    default:
+        return 0;
+    }
+}
+
+nixl_gpu_level_t
+stringToGpuLevel(const char *gdaki_level) {
+    if (!strcmp(gdaki_level, "WARP")) return nixl_gpu_level_t::WARP;
+    if (!strcmp(gdaki_level, "BLOCK")) return nixl_gpu_level_t::BLOCK;
+    return nixl_gpu_level_t::THREAD;
+}
+
+// GDAKI kernel for full transfers (block coordination only)
+__global__ void
+gdakiFullTransferKernel(nixlGpuXferReqH *req_handle,
+                        int num_iterations,
+                        const size_t *lens,
+                        void *const *local_addrs,
+                        const uint64_t *remote_addrs,
+                        const uint64_t signal_inc,
+                        const uint64_t remote_addr) {
+    __shared__ nixlGpuXferStatusH xfer_status;
+    nixlGpuSignal signal = {signal_inc, remote_addr};
+
+    // Execute transfers for the specified number of iterations
+    for (int i = 0; i < num_iterations; i++) {
+        // Post the GPU transfer request with signal increment of 1
+        nixl_status_t status = nixlGpuPostWriteXferReq<nixl_gpu_level_t::BLOCK>(
+            req_handle, lens, local_addrs, remote_addrs, signal, true, &xfer_status);
+        if (status != NIXL_SUCCESS) {
+            return; // Early exit on error
+        }
+
+        // Wait for transfer completion
+        do {
+            status = nixlGpuGetXferStatus<nixl_gpu_level_t::BLOCK>(xfer_status);
+        } while (status == NIXL_IN_PROG);
+
+        if (status != NIXL_SUCCESS) {
+            return; // Early exit on error
+        }
+    }
+}
+
+// GDAKI kernel for partial transfers (supports thread/warp/block coordination)
+template<nixl_gpu_level_t level>
+__global__ void
+gdakiPartialTransferKernel(nixlGpuXferReqH *req_handle,
+                           int num_iterations,
+                           const size_t count,
+                           const size_t *lens,
+                           void *const *local_addrs,
+                           const uint64_t *remote_addrs,
+                           const uint64_t signal_inc,
+                           const uint64_t remote_addr) {
+    nixlGpuXferStatusH xfer_status;
+    nixlGpuSignal signal = {signal_inc, remote_addr};
+
+    // Execute transfers for the specified number of iterations
+    for (int i = 0; i < num_iterations; i++) {
+        // Use partial transfer API which supports all coordination levels
+        nixl_status_t status = nixlGpuPostPartialWriteXferReq<level>(req_handle,
+                                                                     count,
+                                                                     nullptr,
+                                                                     lens,
+                                                                     local_addrs,
+                                                                     remote_addrs,
+                                                                     signal,
+                                                                     1,
+                                                                     true,
+                                                                     &xfer_status);
+        if (status != NIXL_SUCCESS) {
+            return; // Early exit on error
+        }
+
+        // Wait for transfer completion
+        do {
+            status = nixlGpuGetXferStatus<level>(xfer_status);
+        } while (status == NIXL_IN_PROG);
+
+        if (status != NIXL_SUCCESS) {
+            return; // Early exit on error
+        }
+    }
+}
+
+template<nixl_gpu_level_t level>
+__global__ void
+gdakiReadSignalKernel(const void *signal_addr, uint64_t *count) {
+    *count = nixlGpuReadSignal<level>(signal_addr);
+}
+
+// Host-side launcher
+nixl_status_t
+checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
+                        int num_iterations,
+                        int threads_per_block,
+                        int blocks_per_grid) {
+    // Validate parameters
+    if (num_iterations <= 0 || req_handle == nullptr) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (threads_per_block < 1 || threads_per_block > MAX_THREADS) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (blocks_per_grid < 1) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+launchDeviceKernel(nixlGpuXferReqH *req_handle,
+                   int num_iterations,
+                   const char *level,
+                   const size_t count,
+                   const size_t *lens,
+                   void *const *local_addrs,
+                   const uint64_t *remote_addrs,
+                   int threads_per_block,
+                   int blocks_per_grid,
+                   cudaStream_t stream,
+                   const uint64_t signal_inc,
+                   const uint64_t remote_addr) {
+
+    nixl_gpu_level_t gpulevel = stringToGpuLevel(level);
+    nixl_status_t ret =
+        checkDeviceKernelParams(req_handle, num_iterations, threads_per_block, blocks_per_grid);
+
+    if (ret != NIXL_SUCCESS) {
+        std::cerr << "Failed to validate kernel launch parameters" << std::endl;
+        return ret;
+    }
+
+    // Use full transfer kernel for block coordination only
+    if (gpulevel != nixl_gpu_level_t::BLOCK) {
+        std::cout << "Falling back to block coordination for full transfers" << std::endl;
+    }
+
+    // Allocate device memory for address arrays
+    void **d_local_addrs = nullptr;
+    uint64_t *d_remote_addrs = nullptr;
+    size_t *d_lens = nullptr;
+
+    cudaError_t cuda_error = cudaMalloc(&d_local_addrs, count * sizeof(void *));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for local_addrs: "
+                  << cudaGetErrorString(cuda_error) << std::endl;
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMalloc(&d_remote_addrs, count * sizeof(uint64_t));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for remote_addrs: "
+                  << cudaGetErrorString(cuda_error) << std::endl;
+        cudaFree(d_local_addrs);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMalloc(&d_lens, count * sizeof(size_t));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for lens: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Copy host arrays to device
+    cuda_error =
+        cudaMemcpy(d_local_addrs, local_addrs, count * sizeof(void *), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy local_addrs to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error =
+        cudaMemcpy(d_remote_addrs, remote_addrs, count * sizeof(uint64_t), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy remote_addrs to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMemcpy(d_lens, lens, count * sizeof(size_t), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy lens to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    gdakiFullTransferKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
+        req_handle, num_iterations, d_lens, d_local_addrs, d_remote_addrs, signal_inc, remote_addr);
+
+    // Check for launch errors
+    cudaError_t launch_error = cudaGetLastError();
+    if (launch_error != cudaSuccess) {
+        std::cerr << "Failed to launch device full transfer kernel: "
+                  << cudaGetErrorString(launch_error) << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Wait for kernel completion before freeing device memory
+    cuda_error = cudaStreamSynchronize(stream);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to synchronize stream: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+    }
+
+    // Free device memory
+    cudaFree(d_local_addrs);
+    cudaFree(d_remote_addrs);
+    cudaFree(d_lens);
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+launchDevicePartialKernel(nixlGpuXferReqH *req_handle,
+                          int num_iterations,
+                          const char *level,
+                          const size_t count,
+                          const size_t *lens,
+                          void *const *local_addrs,
+                          const uint64_t *remote_addrs,
+                          int threads_per_block,
+                          int blocks_per_grid,
+                          cudaStream_t stream,
+                          const uint64_t signal_inc,
+                          const uint64_t remote_addr) {
+
+    nixl_gpu_level_t gpulevel = stringToGpuLevel(level);
+    nixl_status_t ret =
+        checkDeviceKernelParams(req_handle, num_iterations, threads_per_block, blocks_per_grid);
+
+    if (ret != NIXL_SUCCESS) {
+        std::cerr << "Failed to validate kernel launch parameters" << std::endl;
+        return ret;
+    }
+
+    // Allocate device memory for address arrays
+    void **d_local_addrs = nullptr;
+    uint64_t *d_remote_addrs = nullptr;
+    size_t *d_lens = nullptr;
+
+    cudaError_t cuda_error = cudaMalloc(&d_local_addrs, count * sizeof(void *));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for local_addrs: "
+                  << cudaGetErrorString(cuda_error) << std::endl;
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMalloc(&d_remote_addrs, count * sizeof(uint64_t));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for remote_addrs: "
+                  << cudaGetErrorString(cuda_error) << std::endl;
+        cudaFree(d_local_addrs);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMalloc(&d_lens, count * sizeof(size_t));
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to allocate device memory for lens: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Copy host arrays to device
+    cuda_error =
+        cudaMemcpy(d_local_addrs, local_addrs, count * sizeof(void *), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy local_addrs to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error =
+        cudaMemcpy(d_remote_addrs, remote_addrs, count * sizeof(uint64_t), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy remote_addrs to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    cuda_error = cudaMemcpy(d_lens, lens, count * sizeof(size_t), cudaMemcpyHostToDevice);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to copy lens to device: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Launch partial transfer kernel based on coordination level
+    if (gpulevel == nixl_gpu_level_t::THREAD) {
+        gdakiPartialTransferKernel<nixl_gpu_level_t::THREAD>
+            <<<blocks_per_grid, threads_per_block, 0, stream>>>(req_handle,
+                                                                num_iterations,
+                                                                count,
+                                                                d_lens,
+                                                                d_local_addrs,
+                                                                d_remote_addrs,
+                                                                signal_inc,
+                                                                remote_addr);
+    } else if (gpulevel == nixl_gpu_level_t::WARP) {
+        gdakiPartialTransferKernel<nixl_gpu_level_t::WARP>
+            <<<blocks_per_grid, threads_per_block, 0, stream>>>(req_handle,
+                                                                num_iterations,
+                                                                count,
+                                                                d_lens,
+                                                                d_local_addrs,
+                                                                d_remote_addrs,
+                                                                signal_inc,
+                                                                remote_addr);
+    } else {
+        std::cerr << "Invalid GPU level selected for partial transfers: " << level << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    // Check for launch errors
+    cudaError_t launch_error = cudaGetLastError();
+    if (launch_error != cudaSuccess) {
+        std::cerr << "Failed to launch device partial transfer kernel: "
+                  << cudaGetErrorString(launch_error) << std::endl;
+        cudaFree(d_local_addrs);
+        cudaFree(d_remote_addrs);
+        cudaFree(d_lens);
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Wait for kernel completion before freeing device memory
+    cuda_error = cudaStreamSynchronize(stream);
+    if (cuda_error != cudaSuccess) {
+        std::cerr << "Failed to synchronize stream: " << cudaGetErrorString(cuda_error)
+                  << std::endl;
+    }
+
+    // Free device memory
+    cudaFree(d_local_addrs);
+    cudaFree(d_remote_addrs);
+    cudaFree(d_lens);
+
+    return NIXL_SUCCESS;
+}
+
+uint64_t
+readNixlGpuSignal(const void *signal_addr, const char *gpulevel) {
+    const nixl_gpu_level_t level = stringToGpuLevel(gpulevel);
+    uint64_t count = 0;
+    uint64_t *d_count = nullptr;
+
+    // Allocate device memory for the result
+    cudaError_t err = cudaMalloc(&d_count, sizeof(uint64_t));
+    if (err != cudaSuccess || !d_count) {
+        return 0;
+    }
+
+    // Launch kernel with single thread/block configuration
+    if (level == nixl_gpu_level_t::THREAD) {
+        gdakiReadSignalKernel<nixl_gpu_level_t::THREAD><<<1, 1>>>(signal_addr, d_count);
+    } else if (level == nixl_gpu_level_t::WARP) {
+        gdakiReadSignalKernel<nixl_gpu_level_t::WARP><<<1, 1>>>(signal_addr, d_count);
+    } else if (level == nixl_gpu_level_t::BLOCK) {
+        gdakiReadSignalKernel<nixl_gpu_level_t::BLOCK><<<1, 1>>>(signal_addr, d_count);
+    }
+
+    // Wait for kernel completion and copy result back
+    cudaDeviceSynchronize();
+    cudaMemcpy(&count, d_count, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+
+    // Free device memory
+    cudaFree(d_count);
+
+    return count;
+}

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
@@ -4,6 +4,7 @@
  */
 
 #include <gpu/ucx/nixl_device.cuh>
+#include "gdaki_levels.h"
 #include "gdaki_kernels.cuh"
 
 // Helper function to get request index based on coordination level (from gtest)
@@ -24,8 +25,12 @@ getRequestIndex() {
 
 static inline nixl_gpu_level_t
 stringToGpuLevel(std::string_view gdaki_level) {
-    if (gdaki_level == xferBenchConfigGpuLevelWarp) return nixl_gpu_level_t::WARP;
-    if (gdaki_level == xferBenchConfigGpuLevelBlock) return nixl_gpu_level_t::BLOCK;
+    if (gdaki_level == gdaki_levels::kWarp) {
+        return nixl_gpu_level_t::WARP;
+    }
+    if (gdaki_level == gdaki_levels::kBlock) {
+        return nixl_gpu_level_t::BLOCK;
+    }
     return nixl_gpu_level_t::THREAD;
 }
 

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cu
@@ -100,7 +100,6 @@ gdakiPartialTransferKernel(nixlGpuXferReqH *req_handle,
     }
 }
 
-
 template<nixl_gpu_level_t level>
 __global__ void
 gdakiReadSignalKernel(const void *signal_addr, uint64_t *count) {
@@ -125,7 +124,8 @@ checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
     }
 
     if (threads_per_block < 1 || threads_per_block > MAX_THREADS) {
-        std::cerr << "Invalid threads per block, must be between 1 and " << MAX_THREADS << std::endl;
+        std::cerr << "Invalid threads per block, must be between 1 and " << MAX_THREADS
+                  << std::endl;
         return NIXL_ERR_INVALID_PARAM;
     }
 
@@ -158,23 +158,41 @@ launchDeviceKernel(nixlGpuXferReqH *req_handle, const deviceKernelParams &params
     void **d_local_addrs_raw = nullptr;
     size_t *d_lens_raw = nullptr;
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMalloc, &d_local_addrs_raw, params.count * sizeof(void *));
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMalloc,
+                     &d_local_addrs_raw,
+                     params.count * sizeof(void *));
 
     device_ptr<void *> d_local_addrs(d_local_addrs_raw);
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMalloc, &d_lens_raw, params.count * sizeof(size_t));
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMalloc,
+                     &d_lens_raw,
+                     params.count * sizeof(size_t));
 
     device_ptr<size_t> d_lens(d_lens_raw);
 
     // Copy host arrays to device
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMemcpy, d_local_addrs.get(), params.local_addrs, params.count * sizeof(void *), cudaMemcpyHostToDevice);
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMemcpy,
+                     d_local_addrs.get(),
+                     params.local_addrs,
+                     params.count * sizeof(void *),
+                     cudaMemcpyHostToDevice);
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMemcpy, d_lens.get(), params.lens, params.count * sizeof(size_t), cudaMemcpyHostToDevice);
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMemcpy,
+                     d_lens.get(),
+                     params.lens,
+                     params.count * sizeof(size_t),
+                     cudaMemcpyHostToDevice);
 
-    gdakiFullTransferKernel
-        <<<1, params.threads_per_block>>>(req_handle,
-                                          params.num_iterations,
-                                          params.signal_inc);
+    gdakiFullTransferKernel<<<1, params.threads_per_block>>>(
+        req_handle, params.num_iterations, params.signal_inc);
     // Check for launch errors
     CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaGetLastError);
 
@@ -200,34 +218,46 @@ launchDevicePartialKernel(nixlGpuXferReqH *req_handle, const deviceKernelParams 
     void **d_local_addrs_raw = nullptr;
     size_t *d_lens_raw = nullptr;
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMalloc, &d_local_addrs_raw, params.count * sizeof(void *));
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMalloc,
+                     &d_local_addrs_raw,
+                     params.count * sizeof(void *));
 
     device_ptr<void *> d_local_addrs(d_local_addrs_raw);
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMalloc, &d_lens_raw, params.count * sizeof(size_t));
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMalloc,
+                     &d_lens_raw,
+                     params.count * sizeof(size_t));
 
     device_ptr<size_t> d_lens(d_lens_raw);
 
     // Copy host arrays to device
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMemcpy, d_local_addrs.get(), params.local_addrs, params.count * sizeof(void *), cudaMemcpyHostToDevice);
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMemcpy,
+                     d_local_addrs.get(),
+                     params.local_addrs,
+                     params.count * sizeof(void *),
+                     cudaMemcpyHostToDevice);
 
-    CUDA_CALL(return NIXL_ERR_BACKEND, UCS_LOG_LEVEL_ERROR, cudaMemcpy, d_lens.get(), params.lens, params.count * sizeof(size_t), cudaMemcpyHostToDevice);
+    CUDA_CALL(return NIXL_ERR_BACKEND,
+                     UCS_LOG_LEVEL_ERROR,
+                     cudaMemcpy,
+                     d_lens.get(),
+                     params.lens,
+                     params.count * sizeof(size_t),
+                     cudaMemcpyHostToDevice);
 
     // Launch partial transfer kernel based on coordination level
     if (gpulevel == nixl_gpu_level_t::THREAD) {
-        gdakiPartialTransferKernel<nixl_gpu_level_t::THREAD>
-            <<<1, params.threads_per_block>>>(req_handle,
-                                              params.num_iterations,
-                                              params.count,
-                                              d_lens.get(),
-                                              params.signal_inc);
+        gdakiPartialTransferKernel<nixl_gpu_level_t::THREAD><<<1, params.threads_per_block>>>(
+            req_handle, params.num_iterations, params.count, d_lens.get(), params.signal_inc);
     } else if (gpulevel == nixl_gpu_level_t::WARP) {
-        gdakiPartialTransferKernel<nixl_gpu_level_t::WARP>
-            <<<1, params.threads_per_block>>>(req_handle,
-                                              params.num_iterations,
-                                              params.count,
-                                              d_lens.get(),
-                                              params.signal_inc);
+        gdakiPartialTransferKernel<nixl_gpu_level_t::WARP><<<1, params.threads_per_block>>>(
+            req_handle, params.num_iterations, params.count, d_lens.get(), params.signal_inc);
     } else {
         std::cerr << "Invalid GPU level selected for partial transfers: " << params.level
                   << std::endl;

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
@@ -7,11 +7,11 @@
 #define GDAKI_KERNELS_CUH
 
 #include <iostream>
+#include <string_view>
+#include "utils/utils.h"
 #include <nixl_types.h>
 
 #define MAX_THREADS 1024
-
-extern "C" {
 
 nixl_status_t
 checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
@@ -19,38 +19,30 @@ checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
                         int threads_per_block,
                         int blocks_per_grid);
 
+// Common parameters for device kernel launches
+struct deviceKernelParams {
+    int num_iterations;
+    std::string_view level;
+    size_t count;
+    const size_t *lens;
+    void *const *local_addrs;
+    const uint64_t *remote_addrs;
+    int threads_per_block = 256;
+    int blocks_per_grid = 1;
+    cudaStream_t stream = 0;
+    uint64_t signal_inc = 0;
+    uint64_t remote_addr = 0;
+};
+
 // Launch Device kernel for device-side transfer execution (full transfers)
 nixl_status_t
-launchDeviceKernel(nixlGpuXferReqH *req_handle,
-                   int num_iterations,
-                   const char *level,
-                   const size_t count,
-                   const size_t *lens,
-                   void *const *local_addrs,
-                   const uint64_t *remote_addrs,
-                   int threads_per_block = 256,
-                   int blocks_per_grid = 1,
-                   cudaStream_t stream = 0,
-                   const uint64_t signal_inc = 0,
-                   const uint64_t remote_addr = 0);
+launchDeviceKernel(nixlGpuXferReqH *req_handle, const deviceKernelParams &params);
 
 // Launch Device kernel for partial transfers (supports thread/warp/block coordination)
 nixl_status_t
-launchDevicePartialKernel(nixlGpuXferReqH *req_handle,
-                          int num_iterations,
-                          const char *level,
-                          const size_t count,
-                          const size_t *lens,
-                          void *const *local_addrs,
-                          const uint64_t *remote_addrs,
-                          int threads_per_block = 256,
-                          int blocks_per_grid = 1,
-                          cudaStream_t stream = 0,
-                          const uint64_t signal_inc = 0,
-                          const uint64_t remote_addr = 0);
+launchDevicePartialKernel(nixlGpuXferReqH *req_handle, const deviceKernelParams &params);
 
 uint64_t
-readNixlGpuSignal(const void *signal_addr, const char *gpulevel);
-}
+readNixlGpuSignal(const void *signal_addr, std::string_view gpulevel);
 
 #endif // GDAKI_KERNELS_CUH

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GDAKI_KERNELS_CUH
+#define GDAKI_KERNELS_CUH
+
+#include <iostream>
+#include <nixl_types.h>
+
+#define MAX_THREADS 1024
+
+extern "C" {
+
+nixl_status_t
+checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
+                        int num_iterations,
+                        int threads_per_block,
+                        int blocks_per_grid);
+
+// Launch Device kernel for device-side transfer execution (full transfers)
+nixl_status_t
+launchDeviceKernel(nixlGpuXferReqH *req_handle,
+                   int num_iterations,
+                   const char *level,
+                   const size_t count,
+                   const size_t *lens,
+                   void *const *local_addrs,
+                   const uint64_t *remote_addrs,
+                   int threads_per_block = 256,
+                   int blocks_per_grid = 1,
+                   cudaStream_t stream = 0,
+                   const uint64_t signal_inc = 0,
+                   const uint64_t remote_addr = 0);
+
+// Launch Device kernel for partial transfers (supports thread/warp/block coordination)
+nixl_status_t
+launchDevicePartialKernel(nixlGpuXferReqH *req_handle,
+                          int num_iterations,
+                          const char *level,
+                          const size_t count,
+                          const size_t *lens,
+                          void *const *local_addrs,
+                          const uint64_t *remote_addrs,
+                          int threads_per_block = 256,
+                          int blocks_per_grid = 1,
+                          cudaStream_t stream = 0,
+                          const uint64_t signal_inc = 0,
+                          const uint64_t remote_addr = 0);
+
+uint64_t
+readNixlGpuSignal(const void *signal_addr, const char *gpulevel);
+}
+
+#endif // GDAKI_KERNELS_CUH

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
@@ -15,14 +15,14 @@
 #define MAX_THREADS 1024
 
 #ifndef CUDA_CALL
-#define CUDA_CALL(_handler, _log_level, _func, ...)                           \
-    do {                                                                      \
-        cudaError_t _cerr = _func(__VA_ARGS__);                               \
-        if (_cerr != cudaSuccess) {                                           \
-	    std::cout << #_func << " failed: " << (int)_cerr << " : "             \
-	              << cudaGetErrorString(_cerr) << std::endl;                  \
-            _handler;                                                         \
-        }                                                                     \
+#define CUDA_CALL(_handler, _log_level, _func, ...)                                                \
+    do {                                                                                           \
+        cudaError_t _cerr = _func(__VA_ARGS__);                                                    \
+        if (_cerr != cudaSuccess) {                                                                \
+            std::cout << #_func << " failed: " << (int)_cerr << " : " << cudaGetErrorString(_cerr) \
+                      << std::endl;                                                                \
+            _handler;                                                                              \
+        }                                                                                          \
     } while (0)
 #endif
 
@@ -34,13 +34,13 @@ checkDeviceKernelParams(nixlGpuXferReqH *req_handle,
 
 // RAII helpers for CUDA device allocations
 struct device_free {
-    void operator()(void *p) const noexcept {
+    void
+    operator()(void *p) const noexcept {
         if (p) cudaFree(p);
     }
 };
 
-template<class T>
-using device_ptr = std::unique_ptr<T, device_free>;
+template<class T> using device_ptr = std::unique_ptr<T, device_free>;
 
 nixl_status_t
 checkDeviceKernelParams(nixlGpuXferReqH *req_handle,

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_kernels.cuh
@@ -9,7 +9,6 @@
 #include <iostream>
 #include <string_view>
 #include <memory>
-#include "utils/utils.h"
 #include <nixl_types.h>
 
 #define MAX_THREADS 1024

--- a/benchmark/nixlbench/src/worker/nixl/gdaki_levels.h
+++ b/benchmark/nixlbench/src/worker/nixl/gdaki_levels.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GDAKI_LEVELS_H
+#define GDAKI_LEVELS_H
+
+#include <string_view>
+
+namespace gdaki_levels {
+
+inline constexpr std::string_view kThread{"thread"};
+inline constexpr std::string_view kWarp{"warp"};
+inline constexpr std::string_view kBlock{"block"};
+
+inline bool
+isValid(std::string_view level) {
+    return level == kThread || level == kWarp || level == kBlock;
+}
+
+} // namespace gdaki_levels
+
+#endif // GDAKI_LEVELS_H

--- a/benchmark/nixlbench/src/worker/nixl/meson.build
+++ b/benchmark/nixlbench/src/worker/nixl/meson.build
@@ -40,8 +40,19 @@ if cuda_available and have_nixl_gdaki
         '-o', '@OUTPUT@',
         '-I' + nixl_inc,
         '-I' + meson.current_source_dir() + '/../../..',
-        '-I' + nixl_path + '/src',
-        '-I' + nixl_path + '/src/utils',
+        '-I' + meson.current_source_dir() + '/../..',
+        '-I' + nixl_path + '/include',
+      ]
+
+      # Add UCX include path if ucxpath_inc option is provided
+      ucxpath_inc = get_option('ucxpath_inc')
+      if ucxpath_inc != ''
+          nvcc_args += [
+            '-I' + ucxpath_inc,
+            '-I' + '/opt/mellanox/doca/include']
+      endif
+
+      nvcc_args += [
         '--std=c++17',
         '-arch=sm_80',
         '--ptxas-options=-v',
@@ -50,11 +61,6 @@ if cuda_available and have_nixl_gdaki
         '-DHAVE_CUDA'
       ]
 
-      # Add UCX include path if ucxpath_inc option is provided
-      ucxpath_inc = get_option('ucxpath_inc')
-      if ucxpath_inc != ''
-        nvcc_args += ['-I' + ucxpath_inc]
-      endif
 
       # Compile CUDA kernels
       nixl_cuda_obj = custom_target('nixl_gdaki_kernels_obj',

--- a/benchmark/nixlbench/src/worker/nixl/meson.build
+++ b/benchmark/nixlbench/src/worker/nixl/meson.build
@@ -14,18 +14,65 @@
 # limitations under the License.
 
 nixl_worker_sources = [
-  'nixl_worker.cpp',
-  'nixl_worker.h',
+    'nixl_worker.cpp',
+    'nixl_worker.h',
+]
+
+nixl_worker_cuda_sources = [
+    'gdaki_kernels.cu',
 ]
 
 nixl_worker_deps = [openmp_dep, nixl_lib, nixl_build, nixl_serdes, cxxopts_dep, tomlplusplus_dep]
 if cuda_available
-  nixl_worker_deps += [cuda_dep]
+    nixl_worker_deps += [cuda_dep]
+endif
+
+# Handle CUDA compilation if available
+cuda_objects = []
+if cuda_available and have_nixl_gdaki
+    # Find nvcc compiler
+    nvcc = find_program('nvcc', required: false)
+    if nvcc.found()
+      # Build NVCC command arguments
+      nvcc_args = [
+        nvcc,
+        '-c', '@INPUT@',
+        '-o', '@OUTPUT@',
+        '-I' + nixl_inc,
+        '-I' + meson.current_source_dir() + '/../../..',
+        '-I' + nixl_path + '/src',
+        '-I' + nixl_path + '/src/utils',
+        '--std=c++17',
+        '-arch=sm_80',
+        '--ptxas-options=-v',
+        '--maxrregcount=32',
+        '--compiler-options', '-fPIC',
+        '-DHAVE_CUDA'
+      ]
+
+      # Add UCX include path if ucxpath_inc option is provided
+      ucxpath_inc = get_option('ucxpath_inc')
+      if ucxpath_inc != ''
+        nvcc_args += ['-I' + ucxpath_inc]
+      endif
+
+      # Compile CUDA kernels
+      nixl_cuda_obj = custom_target('nixl_gdaki_kernels_obj',
+        input: nixl_worker_cuda_sources,
+        output: 'gdaki_kernels.o',
+        command: nvcc_args,
+        install: false
+      )
+      cuda_objects = [nixl_cuda_obj]
+    else
+      warning('NVCC not found - CUDA kernels will not be available')
+    endif
 endif
 
 nixl_worker_lib = static_library('nixl_worker',
-  nixl_worker_sources,
-  include_directories: inc_dir,
-  dependencies: nixl_worker_deps,
-  install: true,
+    nixl_worker_sources,
+    objects: cuda_objects,
+    include_directories: inc_dir,
+    dependencies: nixl_worker_deps,
+    install: true,
 )

--- a/benchmark/nixlbench/src/worker/nixl/meson.build
+++ b/benchmark/nixlbench/src/worker/nixl/meson.build
@@ -44,6 +44,29 @@ if cuda_available and have_nixl_gdaki
         '-I' + nixl_path + '/include',
       ]
 
+      cxxopts_inc = cxxopts_dep.get_variable(pkgconfig: 'includedir',
+                                             cmake: 'CMAKE_INSTALL_INCLUDEDIR',
+                                             default_value: '')
+      if cxxopts_inc != ''
+        nvcc_args += ['-I' + cxxopts_inc]
+      endif
+      cxxopts_subproj_inc = join_paths(meson.project_source_root(),
+                                       'subprojects', 'cxxopts-3.2.0', 'include')
+      if fs.exists(cxxopts_subproj_inc)
+        nvcc_args += ['-I' + cxxopts_subproj_inc]
+      endif
+      toml_inc = tomlplusplus_dep.get_variable(pkgconfig: 'includedir',
+                                               cmake: 'CMAKE_INSTALL_INCLUDEDIR',
+                                               default_value: '')
+      if toml_inc != ''
+        nvcc_args += ['-I' + toml_inc]
+      endif
+      toml_subproj_inc = join_paths(meson.project_source_root(),
+                                    'subprojects', 'tomlplusplus-3.4.0', 'include')
+      if fs.exists(toml_subproj_inc)
+        nvcc_args += ['-I' + toml_subproj_inc]
+      endif
+
       # Add UCX include path if ucxpath_inc option is provided
       ucxpath_inc = get_option('ucxpath_inc')
       if ucxpath_inc != ''

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -358,102 +358,99 @@ xferBenchNixlWorker::cleanupSignalBuffer(std::optional<xferBenchIOV> &signal_des
 
 #define NOTIF_WIREUP_COMP "wireup_complete"
 
-int
-xferBenchNixlWorker::send_wireup_notification(const std::string &remote_name) {
-    int retry_count = 0;
-    const int max_retries = 10;
+
+bool
+xferBenchNixlWorker::sendWireupNotification(std::string_view &remote_name) {
     nixl_status_t notif_status;
     nixl_opt_args_t extra_params = {};
     extra_params.backends.push_back(backend_engine);
-    do {
-        notif_status = agent->genNotif(remote_name, NOTIF_WIREUP_COMP, &extra_params);
-        if (notif_status != NIXL_SUCCESS && retry_count < max_retries) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            retry_count++;
+    for (int retry_count = 0; retry_count < 10; retry_count++) {
+        notif_status = agent->genNotif(std::string(remote_name), NOTIF_WIREUP_COMP, &extra_params);
+        if (notif_status == NIXL_SUCCESS) {
+            return true;
         }
-    } while (notif_status != NIXL_SUCCESS && retry_count < max_retries);
-
-    if (notif_status != NIXL_SUCCESS) {
-        std::cerr << "Failed to send wireup completion notification after retries" << std::endl;
-        return -1;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    return 0;
+    std::cerr << "Failed to send wireup completion notification after retries to "
+              << remote_name << ", error: " << nixlEnumStrings::statusStr(notif_status) << std::endl;
+    return false;
 };
 
-int
-xferBenchNixlWorker::wait_for_ack(const std::string &remote_name) {
-    bool ack_received = false;
-    const int max_ack_attempts = 50;
+bool
+xferBenchNixlWorker::waitForWireupAck(std::string_view item) {
     nixl_opt_args_t extra_params = {};
     extra_params.backends.push_back(backend_engine);
 
-    for (int attempt = 0; attempt < max_ack_attempts && !ack_received; attempt++) {
-        nixl_notifs_t notifs;
-        nixl_status_t get_status = agent->getNotifs(notifs, &extra_params);
-        if (get_status >= 0 && !notifs.empty()) {
-            auto it = notifs.find(remote_name);
-            if (it != notifs.end()) {
-                for (const auto &notif : it->second) {
-                    if (notif == NOTIF_WIREUP_COMP) {
-                        ack_received = true;
-                        return 0;
-                    }
+    nixl_notifs_t notifs;
+    nixl_status_t get_status = agent->getNotifs(notifs, &extra_params);
+    if (get_status == NIXL_SUCCESS && !notifs.empty()) {
+        auto it = notifs.find(std::string(item));
+        if (it != notifs.end()) {
+            for (const auto &notif : it->second) {
+                if (notif == std::string(item)) {
+                    return true;
                 }
             }
         }
-        if (!ack_received) {
+    }
+    return false;
+}
+
+bool
+xferBenchNixlWorker::waitForAck(std::string_view &remote_name) {
+    bool ack_received = false;
+
+    for (int attempt = 0; attempt < 50 && !ack_received; attempt++) {
+        if (!waitForWireupAck(std::string_view(NOTIF_WIREUP_COMP))) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        } else {
+            return true;
         }
     }
-    if (!ack_received) {
-        std::cerr << "Timeout waiting for wireup acknowledgment from " << remote_name << std::endl;
-        return -1;
-    }
-    return 0;
+    std::cerr << "Timeout waiting for wireup acknowledgment from " << remote_name << std::endl;
+    return false;
 };
 
-int
+bool
 xferBenchNixlWorker::sendWireupMessage() {
     if (!is_gdaki_enabled) {
-        return 0;
+        return true;
     }
 
-    std::string remote_name;
+    std::string_view remote_name;
     if (isInitiator()) {
         remote_name = "target";
-        if (send_wireup_notification(remote_name) != 0) {
-            return -1;
+        if (!sendWireupNotification(remote_name)) {
+            return false;
         }
-        if (wait_for_ack(remote_name) != 0) {
-            return -1;
+        if (!waitForAck(remote_name)) {
+            return false;
         }
     } else if (isTarget()) {
         remote_name = "initiator";
-        if (wait_for_ack(remote_name) != 0) {
-            return -1;
+        if (!waitForAck(remote_name)) {
+            return false;
         }
-        if (send_wireup_notification(remote_name) != 0) {
-            return -1;
+        if (!sendWireupNotification(remote_name)) {
+            return false;
         }
     } else {
         std::cerr << "Unknown role for wireup message" << std::endl;
-        return -1;
+        return false;
     }
 
-    return 0;
+    return true;
 }
 
 void
-xferBenchNixlWorker::send_metadata(const std::string local_md, int rank) {
-    const char *send_buffer = local_md.data();
+xferBenchNixlWorker::sendMetadata(std::string_view local_md, int rank) {
     int meta_sz = local_md.size();
-
     rt->sendInt(&meta_sz, rank);
-    rt->sendChar((char *)send_buffer, meta_sz, rank);
+    rt->sendChar(const_cast<char *>(local_md.data()), meta_sz, rank);
 };
 
-int
-xferBenchNixlWorker::recv_and_load_metadata(int rank) {
+bool
+xferBenchNixlWorker::recvAndLoadMetadata(int rank) {
     int recv_meta_sz;
     rt->recvInt(&recv_meta_sz, rank);
 
@@ -465,13 +462,11 @@ xferBenchNixlWorker::recv_and_load_metadata(int rank) {
     std::string remote_agent;
     agent->loadRemoteMD(remote_metadata, remote_agent);
 
-    return remote_agent.empty() ? -1 : 0;
+    return remote_agent.empty() ? false : true;
 };
 
-int
+bool
 xferBenchNixlWorker::exchangeMetadataBidirectional() {
-    int ret = 0;
-
     // Get local metadata to send
     std::string local_metadata;
     agent->getLocalMD(local_metadata);
@@ -487,17 +482,17 @@ xferBenchNixlWorker::exchangeMetadataBidirectional() {
 
     // Phase 1: Target sends, Initiator receives
     if (isTarget()) {
-        send_metadata(local_metadata, peer_rank);
-        ret = recv_and_load_metadata(peer_rank);
-    } else { // isInitiator
-        ret = recv_and_load_metadata(peer_rank);
-
-        if (!ret) {
-            send_metadata(local_metadata, peer_rank);
+        sendMetadata(local_metadata, peer_rank);
+        if (!recvAndLoadMetadata(peer_rank)) {
+            return false;
         }
+    } else { // isInitiator
+        if (!recvAndLoadMetadata(peer_rank)) {
+            return false;
+        }
+        sendMetadata(local_metadata, peer_rank);
     }
-
-    return ret;
+    return true;
 }
 
 static bool
@@ -1145,7 +1140,9 @@ xferBenchNixlWorker::exchangeMetadata() {
 
     // Use bidirectional metadata exchange for GDAKI mode
     if (is_gdaki_enabled) {
-        ret = exchangeMetadataBidirectional();
+        if (!exchangeMetadataBidirectional()) {
+            return -1;
+        }
     } else {
         // Standard unidirectional metadata exchange for non-GDAKI mode
         if (isTarget()) {
@@ -1289,8 +1286,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     // Ensure all processes have completed the exchange with a barrier/sync
     synchronize();
     if (is_gdaki_enabled) {
-        int ret = sendWireupMessage();
-        if (ret < 0) {
+        if (!sendWireupMessage()) {
             std::cerr << "Wireup failed, aborting transfer" << std::endl;
             return std::vector<std::vector<xferBenchIOV>>();
         }
@@ -1703,7 +1699,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
 #if HAVE_NIXL_DEV_API
 void
-xferBenchNixlWorker::device_poll(size_t block_size, unsigned int skip, unsigned int num_iter) {
+xferBenchNixlWorker::devicePoll(size_t block_size, unsigned int skip, unsigned int num_iter) {
     std::string_view gpu_level = *(xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
     unsigned int total_iter = skip + num_iter;
 
@@ -1752,7 +1748,7 @@ xferBenchNixlWorker::poll(size_t block_size) {
 
     if (is_gdaki_enabled) {
 #if HAVE_NIXL_DEV_API
-        device_poll(block_size, skip, num_iter);
+        devicePoll(block_size, skip, num_iter);
 #else
         std::cerr << "Trying to run device API without supported header" << std::endl;
 #endif

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1478,8 +1478,6 @@ execDeviceTransfer(nixlAgent *agent,
         nixlXferReqH *req;
         std::string target;
 
-        uint64_t remote_addr = 0;
-
         params.notifMsg = "0xBEEF";
         params.hasNotif = true;
         target = "target";
@@ -1487,8 +1485,6 @@ execDeviceTransfer(nixlAgent *agent,
         // Set signal parameters and remove signal buffer from transfer lists for GDAKI
         if (!local_iov.empty() && !remote_iov.empty()) {
             // In GDAKI protocol: initiator signals target's buffer, target monitors its own buffer
-            const auto &signal_iov = remote_iov.back();
-            remote_addr = signal_iov.addr;
 
             // Remove signal buffer from transfer descriptor lists
             if (local_transfer_iov.size() > 0) {
@@ -1530,8 +1526,7 @@ execDeviceTransfer(nixlAgent *agent,
                                           xferBenchConfig::gdaki_threads_per_block,
                                           xferBenchConfig::gdaki_blocks_per_grid,
                                           0,
-                                          1,
-                                          remote_addr};
+                                          1};
                 CHECK_NIXL_ERROR(launchDevicePartialKernel(&gpu_req_handle, params),
                                  "launchGdakiPartialKernel failed");
             }
@@ -1547,8 +1542,7 @@ execDeviceTransfer(nixlAgent *agent,
                                           xferBenchConfig::gdaki_threads_per_block,
                                           xferBenchConfig::gdaki_blocks_per_grid,
                                           0,
-                                          1,
-                                          remote_addr};
+                                          1};
                 CHECK_NIXL_ERROR(launchDeviceKernel(&gpu_req_handle, params),
                                  "launchGdakiKernel failed");
             }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1504,12 +1504,12 @@ execDeviceTransfer(nixlAgent *agent,
         const nixlTime::us_t prepare_duration = timer.lap();
         thread_stats.prepare_duration.add(prepare_duration);
         std::string_view gpu_level =
-            *(xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
+            *(xferBenchConfig::xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
 
         // Launch appropriate GDAKI kernel based on configuration
         if (xferBenchConfig::gdaki_enable_partial_transfers &&
-            (gpu_level == xferBenchConfigGpuLevelThread ||
-             gpu_level == xferBenchConfigGpuLevelWarp)) {
+            (gpu_level == xferBenchConfig::xferBenchConfigGpuLevelThread ||
+             gpu_level == xferBenchConfig::xferBenchConfigGpuLevelWarp)) {
             // Use partial transfer kernel for thread/warp coordination
             {
                 deviceKernelParams params{num_iter,
@@ -1699,7 +1699,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
 #if HAVE_NIXL_DEV_API
 void
 xferBenchNixlWorker::devicePoll(size_t block_size, unsigned int skip, unsigned int num_iter) {
-    std::string_view gpu_level = *(xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
+    std::string_view gpu_level =
+        *(xferBenchConfig::xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
     unsigned int total_iter = skip + num_iter;
 
     // GDAKI mode: Target monitors signal buffer instead of waiting for notifications

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1520,34 +1520,38 @@ execDeviceTransfer(nixlAgent *agent,
             (gpu_level == xferBenchConfigGpuLevelThread ||
              gpu_level == xferBenchConfigGpuLevelWarp)) {
             // Use partial transfer kernel for thread/warp coordination
-            CHECK_NIXL_ERROR(launchDevicePartialKernel(&gpu_req_handle,
-                                                       num_iter,
-                                                       gpu_level.data(),
-                                                       desc_cnt,
-                                                       lengths,
-                                                       local_addrs,
-                                                       remote_addrs,
-                                                       xferBenchConfig::gdaki_threads_per_block,
-                                                       xferBenchConfig::gdaki_blocks_per_grid,
-                                                       0,
-                                                       1,
-                                                       remote_addr),
-                             "launchGdakiPartialKernel failed");
+            {
+                deviceKernelParams params{num_iter,
+                                          gpu_level,
+                                          desc_cnt,
+                                          lengths,
+                                          local_addrs,
+                                          remote_addrs,
+                                          xferBenchConfig::gdaki_threads_per_block,
+                                          xferBenchConfig::gdaki_blocks_per_grid,
+                                          0,
+                                          1,
+                                          remote_addr};
+                CHECK_NIXL_ERROR(launchDevicePartialKernel(&gpu_req_handle, params),
+                                 "launchGdakiPartialKernel failed");
+            }
         } else {
             // Use full transfer kernel (block coordination only)
-            CHECK_NIXL_ERROR(launchDeviceKernel(&gpu_req_handle,
-                                                num_iter,
-                                                gpu_level.data(),
-                                                desc_cnt,
-                                                lengths,
-                                                local_addrs,
-                                                remote_addrs,
-                                                xferBenchConfig::gdaki_threads_per_block,
-                                                xferBenchConfig::gdaki_blocks_per_grid,
-                                                0,
-                                                1,
-                                                remote_addr),
-                             "launchGdakiKernel failed");
+            {
+                deviceKernelParams params{num_iter,
+                                          gpu_level,
+                                          desc_cnt,
+                                          lengths,
+                                          local_addrs,
+                                          remote_addrs,
+                                          xferBenchConfig::gdaki_threads_per_block,
+                                          xferBenchConfig::gdaki_blocks_per_grid,
+                                          0,
+                                          1,
+                                          remote_addr};
+                CHECK_NIXL_ERROR(launchDeviceKernel(&gpu_req_handle, params),
+                                 "launchGdakiKernel failed");
+            }
         }
 
         const nixlTime::us_t post_duration = timer.lap();

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -34,13 +34,18 @@
 #include <sys/stat.h>
 #include <utils/serdes/serdes.h>
 #include <omp.h>
+#include <thread>
+#include <chrono>
+#if HAVE_NIXL_DEV_API
+#include "gdaki_kernels.cuh"
+#endif
 
 #define ROUND_UP(value, granularity) \
     ((((value) + (granularity) - 1) / (granularity)) * (granularity))
 
 #define CHECK_NIXL_ERROR(result, message)                                                       \
     do {                                                                                        \
-        if (0 != result) {                                                                      \
+        if (NIXL_SUCCESS != result) {                                                           \
             std::cerr << "NIXL: " << message << " (Error code: " << result << ")" << std::endl; \
             exit(EXIT_FAILURE);                                                                 \
         }                                                                                       \
@@ -92,6 +97,7 @@ generateGusliConfigFile(const std::vector<GusliDeviceConfig> &devices) {
 xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<std::string> devices)
     : xferBenchWorker(argc, argv) {
     seg_type = GET_SEG_TYPE(isInitiator());
+    is_gdaki_enabled = xferBenchConfig::enable_gdaki;
 
     int rank;
     std::string backend_name;
@@ -128,6 +134,10 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
 
     if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCX)) {
         backend_params["num_threads"] = std::to_string(xferBenchConfig::progress_threads);
+
+        if (is_gdaki_enabled) {
+            backend_params["gpu_devices"] = xferBenchConfig::gdaki_gpu_device_list;
+        }
 
         // No need to set device_list if all is specified
         // fallback to backend preference
@@ -311,6 +321,183 @@ iovListToNixlXferDlist(const std::vector<xferBenchIOV> &iov_list, nixl_xfer_dlis
         desc.devId = iov.devId;
         dlist.addDesc(desc);
     }
+}
+
+std::optional<xferBenchIOV>
+xferBenchNixlWorker::initSignalBuffer(int mem_dev_id, size_t sigsize) {
+    if (!is_gdaki_enabled) {
+        return std::nullopt;
+    }
+    switch (seg_type) {
+#if HAVE_CUDA
+    case VRAM_SEG:
+        return initBasicDescVram(sigsize, mem_dev_id);
+#endif
+    default:
+        std::cerr << "Unsupported signal buffer memory type: " << seg_type << std::endl;
+        return std::nullopt;
+    }
+}
+
+void
+xferBenchNixlWorker::cleanupSignalBuffer(std::optional<xferBenchIOV> &signal_desc) {
+    if (!is_gdaki_enabled) {
+        return;
+    }
+    switch (seg_type) {
+#if HAVE_CUDA
+    case VRAM_SEG:
+        cleanupBasicDescVram(signal_desc.value());
+        break;
+#endif
+    default:
+        std::cerr << "Unsupported signal buffer memory type for cleanup: " << seg_type << std::endl;
+        break;
+    }
+}
+
+#define NOTIF_WIREUP_COMP "wireup_complete"
+
+int
+xferBenchNixlWorker::send_wireup_notification(const std::string &remote_name) {
+    int retry_count = 0;
+    const int max_retries = 10;
+    nixl_status_t notif_status;
+    nixl_opt_args_t extra_params = {};
+    extra_params.backends.push_back(backend_engine);
+    do {
+        notif_status = agent->genNotif(remote_name, NOTIF_WIREUP_COMP, &extra_params);
+        if (notif_status != NIXL_SUCCESS && retry_count < max_retries) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            retry_count++;
+        }
+    } while (notif_status != NIXL_SUCCESS && retry_count < max_retries);
+
+    if (notif_status != NIXL_SUCCESS) {
+        std::cerr << "Failed to send wireup completion notification after retries" << std::endl;
+        return -1;
+    }
+    return 0;
+};
+
+int
+xferBenchNixlWorker::wait_for_ack(const std::string &remote_name) {
+    bool ack_received = false;
+    const int max_ack_attempts = 50;
+    nixl_opt_args_t extra_params = {};
+    extra_params.backends.push_back(backend_engine);
+
+    for (int attempt = 0; attempt < max_ack_attempts && !ack_received; attempt++) {
+        nixl_notifs_t notifs;
+        nixl_status_t get_status = agent->getNotifs(notifs, &extra_params);
+        if (get_status >= 0 && !notifs.empty()) {
+            auto it = notifs.find(remote_name);
+            if (it != notifs.end()) {
+                for (const auto &notif : it->second) {
+                    if (notif == NOTIF_WIREUP_COMP) {
+                        ack_received = true;
+                        return 0;
+                    }
+                }
+            }
+        }
+        if (!ack_received) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+    if (!ack_received) {
+        std::cerr << "Timeout waiting for wireup acknowledgment from " << remote_name << std::endl;
+        return -1;
+    }
+    return 0;
+};
+
+int
+xferBenchNixlWorker::sendWireupMessage() {
+    if (!is_gdaki_enabled) {
+        return 0;
+    }
+
+    std::string remote_name;
+    if (isInitiator()) {
+        remote_name = "target";
+        if (send_wireup_notification(remote_name) != 0) {
+            return -1;
+        }
+        if (wait_for_ack(remote_name) != 0) {
+            return -1;
+        }
+    } else if (isTarget()) {
+        remote_name = "initiator";
+        if (wait_for_ack(remote_name) != 0) {
+            return -1;
+        }
+        if (send_wireup_notification(remote_name) != 0) {
+            return -1;
+        }
+    } else {
+        std::cerr << "Unknown role for wireup message" << std::endl;
+        return -1;
+    }
+
+    return 0;
+}
+
+void
+xferBenchNixlWorker::send_metadata(const std::string local_md, int rank) {
+    const char *send_buffer = local_md.data();
+    int meta_sz = local_md.size();
+
+    rt->sendInt(&meta_sz, rank);
+    rt->sendChar((char *)send_buffer, meta_sz, rank);
+};
+
+int
+xferBenchNixlWorker::recv_and_load_metadata(int rank) {
+    int recv_meta_sz;
+    rt->recvInt(&recv_meta_sz, rank);
+
+    std::string recv_str;
+    recv_str.resize(recv_meta_sz, '\0');
+    rt->recvChar(recv_str.data(), recv_meta_sz, rank);
+
+    std::string remote_metadata(recv_str.data(), recv_meta_sz);
+    std::string remote_agent;
+    agent->loadRemoteMD(remote_metadata, remote_agent);
+
+    return remote_agent.empty() ? -1 : 0;
+};
+
+int
+xferBenchNixlWorker::exchangeMetadataBidirectional() {
+    int ret = 0;
+
+    // Get local metadata to send
+    std::string local_metadata;
+    agent->getLocalMD(local_metadata);
+
+    // Determine peer rank for communication
+    int peer_rank;
+    if (IS_PAIRWISE_AND_SG()) {
+        peer_rank = isTarget() ? rt->getRank() - xferBenchConfig::num_target_dev :
+                                 rt->getRank() + xferBenchConfig::num_initiator_dev;
+    } else {
+        peer_rank = isTarget() ? 0 : 1;
+    }
+
+    // Phase 1: Target sends, Initiator receives
+    if (isTarget()) {
+        send_metadata(local_metadata, peer_rank);
+        ret = recv_and_load_metadata(peer_rank);
+    } else { // isInitiator
+        ret = recv_and_load_metadata(peer_rank);
+
+        if (!ret) {
+            send_metadata(local_metadata, peer_rank);
+        }
+    }
+
+    return ret;
 }
 
 static bool
@@ -830,7 +1017,25 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
         }
 
+        // Add signal buffer for GDAKI if enabled
+        if (is_gdaki_enabled) {
+#ifdef HAVE_NIXL_DEV_API
+            size_t sigsize;
+            nixl_opt_args_t extra_params = {.backends = {backend_engine}};
+
+            CHECK_NIXL_ERROR(agent->getGpuSignalSize(sigsize, &extra_params),
+                             "getGpuSignalSize failed");
+
+            std::optional<xferBenchIOV> signal_desc = initSignalBuffer(0, sigsize);
+            if (signal_desc) {
+                iov_list.push_back(signal_desc.value());
+                signal_buffers.push_back(signal_desc.value());
+            }
+#endif
+        }
+
         nixl_reg_dlist_t desc_list(seg_type);
+
         iovListToNixlRegDlist(iov_list, desc_list);
         CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
         iov_lists.push_back(iov_list);
@@ -848,6 +1053,16 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
                     memset((void *)iov.addr, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size);
                 }
             }
+        }
+
+        if (is_gdaki_enabled && isTarget()) {
+#ifdef HAVE_NIXL_DEV_API
+            nixl_reg_dlist_t sig_list(VRAM_SEG);
+            iovListToNixlRegDlist(signal_buffers, sig_list);
+            nixl_opt_args_t extra_params = {.backends = {backend_engine}};
+
+            CHECK_NIXL_ERROR(agent->prepGpuSignal(sig_list, &extra_params), "prepGpuSignal failed");
+#endif
         }
     }
 
@@ -880,6 +1095,13 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
                 exit(EXIT_FAILURE);
             }
         }
+    }
+
+    // Clean up signal buffers for GDAKI
+    // Note: Signal buffers are already cleaned up in the main loop above since they're part of
+    // iov_lists We just need to clear the signal_buffers vector to avoid confusion
+    if (is_gdaki_enabled) {
+        signal_buffers.clear();
     }
 
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_OBJ) {
@@ -921,55 +1143,52 @@ xferBenchNixlWorker::exchangeMetadata() {
         return 0;
     }
 
-    if (isTarget()) {
-        std::string local_metadata;
-        const char *buffer;
-        int destrank;
+    // Use bidirectional metadata exchange for GDAKI mode
+    if (is_gdaki_enabled) {
+        ret = exchangeMetadataBidirectional();
+    } else {
+        // Standard unidirectional metadata exchange for non-GDAKI mode
+        if (isTarget()) {
+            std::string local_metadata;
+            const char *buffer;
+            int destrank;
 
-        agent->getLocalMD(local_metadata);
+            agent->getLocalMD(local_metadata);
 
-        buffer = local_metadata.data();
-        meta_sz = local_metadata.size();
+            buffer = local_metadata.data();
+            meta_sz = local_metadata.size();
 
-        if (IS_PAIRWISE_AND_SG()) {
-            destrank = rt->getRank() - xferBenchConfig::num_target_dev;
-            // XXX: Fix up the rank, depends on processes distributed on hosts
-            // assumes placement is adjacent ranks to same node
-        } else {
-            destrank = 0;
-        }
-        rt->sendInt(&meta_sz, destrank);
-        rt->sendChar((char *)buffer, meta_sz, destrank);
-    } else if (isInitiator()) {
-        std::string remote_agent;
-        int srcrank;
+            if (IS_PAIRWISE_AND_SG()) {
+                destrank = rt->getRank() - xferBenchConfig::num_target_dev;
+                // XXX: Fix up the rank, depends on processes distributed on hosts
+                // assumes placement is adjacent ranks to same node
+            } else {
+                destrank = 0;
+            }
+            rt->sendInt(&meta_sz, destrank);
+            rt->sendChar((char *)buffer, meta_sz, destrank);
+        } else if (isInitiator()) {
+            char *buffer;
+            std::string remote_agent;
+            int srcrank;
 
-        if (IS_PAIRWISE_AND_SG()) {
-            srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
-            // XXX: Fix up the rank, depends on processes distributed on hosts
-            // assumes placement is adjacent ranks to same node
-        } else {
-            srcrank = 1;
-        }
+            if (IS_PAIRWISE_AND_SG()) {
+                srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
+                // XXX: Fix up the rank, depends on processes distributed on hosts
+                // assumes placement is adjacent ranks to same node
+            } else {
+                srcrank = 1;
+            }
+            rt->recvInt(&meta_sz, srcrank);
+            buffer = (char *)calloc(meta_sz, sizeof(*buffer));
+            rt->recvChar((char *)buffer, meta_sz, srcrank);
 
-        ret = rt->recvInt(&meta_sz, srcrank);
-        if (ret < 0) {
-            std::cerr << "NIXL: failed to receive metadata size" << std::endl;
-            return ret;
-        }
-
-        std::string remote_metadata(meta_sz, '\0');
-        ret = rt->recvChar(remote_metadata.data(), meta_sz, srcrank);
-        if (ret < 0) {
-            std::cerr << "NIXL: failed to receive metadata" << std::endl;
-            return ret;
-        }
-
-        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent);
-        if (status != NIXL_SUCCESS) {
-            std::cerr << "NIXL: loadRemoteMD failed: " << nixlEnumStrings::statusStr(status)
-                      << std::endl;
-            return -1;
+            std::string remote_metadata(buffer, meta_sz);
+            agent->loadRemoteMD(remote_metadata, remote_agent);
+            if ("" == remote_agent) {
+                std::cerr << "NIXL: loadMetadata failed" << std::endl;
+            }
+            free(buffer);
         }
     }
 
@@ -1069,6 +1288,13 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     }
     // Ensure all processes have completed the exchange with a barrier/sync
     synchronize();
+    if (is_gdaki_enabled) {
+        int ret = sendWireupMessage();
+        if (ret < 0) {
+            std::cerr << "Wireup failed, aborting transfer" << std::endl;
+            return std::vector<std::vector<xferBenchIOV>>();
+        }
+    }
     return res;
 }
 
@@ -1188,6 +1414,173 @@ execTransferIterations(nixlAgent *agent,
     return 0;
 }
 
+#if HAVE_NIXL_DEV_API
+static int
+execDeviceTransfer(nixlAgent *agent,
+                   const std::vector<std::vector<xferBenchIOV>> &local_iovs,
+                   const std::vector<std::vector<xferBenchIOV>> &remote_iovs,
+                   const nixl_xfer_op_t op,
+                   const int num_iter,
+                   const int num_threads,
+                   xferBenchStats &stats) {
+    int ret = 0;
+    xferBenchTimer total_timer;
+
+#pragma omp parallel num_threads(num_threads)
+    {
+        xferBenchStats thread_stats;
+        thread_stats.reserve(num_iter);
+        xferBenchTimer timer;
+        const int tid = omp_get_thread_num();
+        const auto &local_iov = local_iovs[tid];
+        const auto &remote_iov = remote_iovs[tid];
+        void **local_addrs;
+        size_t *lengths;
+        uint64_t *remote_addrs;
+        unsigned int desc_cnt;
+        unsigned int idx = 0;
+
+        desc_cnt = local_iov.size();
+        local_addrs = (void **)malloc(desc_cnt * sizeof(void *));
+        remote_addrs = (uint64_t *)malloc(desc_cnt * sizeof(uint64_t));
+        lengths = (size_t *)malloc(desc_cnt * sizeof(size_t));
+
+        if (!(local_addrs != NULL && remote_addrs != NULL && lengths != NULL)) {
+            std::cout << "Failed to allocate local, remote, lengths buffers" << std::endl;
+            if (local_addrs) free(local_addrs);
+            if (remote_addrs) free(remote_addrs);
+            if (lengths) free(lengths);
+            exit(EXIT_FAILURE);
+        }
+
+#pragma omp barrier
+
+        // Skip the signal buffer
+        for (idx = 0; idx < desc_cnt - 1; idx++) {
+            const auto &li = local_iov[idx];
+            const auto &ri = remote_iov[idx];
+
+            local_addrs[idx] = reinterpret_cast<void *>(li.addr);
+            lengths[idx++] = li.len;
+            remote_addrs[idx] = static_cast<std::uint64_t>(ri.addr);
+        }
+
+        // TODO: fetch local_desc and remote_desc directly from config
+        nixl_xfer_dlist_t local_desc(GET_SEG_TYPE(true));
+        nixl_xfer_dlist_t remote_desc(GET_SEG_TYPE(false));
+
+        // Create copies of IOV lists for transfer, excluding signal buffers for GDAKI
+        std::vector<xferBenchIOV> local_transfer_iov = local_iov;
+        std::vector<xferBenchIOV> remote_transfer_iov = remote_iov;
+
+        nixl_opt_args_t params;
+        nixl_b_params_t b_params;
+        nixlXferReqH *req;
+        std::string target;
+
+        uint64_t remote_addr = 0;
+
+        params.notifMsg = "0xBEEF";
+        params.hasNotif = true;
+        target = "target";
+
+        // Set signal parameters and remove signal buffer from transfer lists for GDAKI
+        if (!local_iov.empty() && !remote_iov.empty()) {
+            // In GDAKI protocol: initiator signals target's buffer, target monitors its own buffer
+            const auto &signal_iov = remote_iov.back();
+            remote_addr = signal_iov.addr;
+
+            // Remove signal buffer from transfer descriptor lists
+            if (local_transfer_iov.size() > 0) {
+                local_transfer_iov.pop_back();
+            }
+            if (remote_transfer_iov.size() > 0) {
+                remote_transfer_iov.pop_back();
+            }
+        }
+
+        iovListToNixlXferDlist(local_transfer_iov, local_desc);
+        iovListToNixlXferDlist(remote_transfer_iov, remote_desc);
+
+        CHECK_NIXL_ERROR(agent->createXferReq(op, local_desc, remote_desc, target, req, &params),
+                         "createXferReq failed");
+
+        // Use device-side posting for GDAKI transfers
+        nixlGpuXferReqH gpu_req_handle;
+
+        CHECK_NIXL_ERROR(agent->createGpuXferReq(*req, gpu_req_handle), "createGpuXferReq failed");
+
+        const nixlTime::us_t prepare_duration = timer.lap();
+        thread_stats.prepare_duration.add(prepare_duration);
+        std::string_view gpu_level =
+            *(xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
+
+        // Launch appropriate GDAKI kernel based on configuration
+        if (xferBenchConfig::gdaki_enable_partial_transfers &&
+            (gpu_level == xferBenchConfigGpuLevelThread ||
+             gpu_level == xferBenchConfigGpuLevelWarp)) {
+            // Use partial transfer kernel for thread/warp coordination
+            CHECK_NIXL_ERROR(launchDevicePartialKernel(&gpu_req_handle,
+                                                       num_iter,
+                                                       gpu_level.data(),
+                                                       desc_cnt,
+                                                       lengths,
+                                                       local_addrs,
+                                                       remote_addrs,
+                                                       xferBenchConfig::gdaki_threads_per_block,
+                                                       xferBenchConfig::gdaki_blocks_per_grid,
+                                                       0,
+                                                       1,
+                                                       remote_addr),
+                             "launchGdakiPartialKernel failed");
+        } else {
+            // Use full transfer kernel (block coordination only)
+            CHECK_NIXL_ERROR(launchDeviceKernel(&gpu_req_handle,
+                                                num_iter,
+                                                gpu_level.data(),
+                                                desc_cnt,
+                                                lengths,
+                                                local_addrs,
+                                                remote_addrs,
+                                                xferBenchConfig::gdaki_threads_per_block,
+                                                xferBenchConfig::gdaki_blocks_per_grid,
+                                                0,
+                                                1,
+                                                remote_addr),
+                             "launchGdakiKernel failed");
+        }
+
+        const nixlTime::us_t post_duration = timer.lap();
+        thread_stats.post_duration.add(post_duration);
+
+        // Wait for kernel completion
+        cudaError_t cuda_error = cudaDeviceSynchronize();
+        if (cuda_error != cudaSuccess) {
+            std::cout << "CUDA kernel synchronization failed for device kernel: "
+                      << cudaGetErrorString(cuda_error) << std::endl;
+            ret = -1;
+        } else {
+            const nixlTime::us_t transfer_duration = timer.lap();
+            thread_stats.transfer_duration.add(transfer_duration);
+        }
+
+        // Release GPU request
+        agent->releaseGpuXferReq(gpu_req_handle);
+
+        CHECK_NIXL_ERROR(agent->releaseXferReq(req), "releaseXferReq failed");
+
+        free(local_addrs);
+        free(lengths);
+        free(remote_addrs);
+#pragma omp critical
+        { stats.add(thread_stats); }
+    }
+    const nixlTime::us_t total_duration = total_timer.lap();
+    stats.total_duration.add(total_duration);
+    return ret;
+}
+#endif /* HAVE_NIXL_DEV_API */
+
 static int
 execTransfer(nixlAgent *agent,
              const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1195,9 +1588,19 @@ execTransfer(nixlAgent *agent,
              const nixl_xfer_op_t op,
              const int num_iter,
              const int num_threads,
-             xferBenchStats &stats) {
+             xferBenchStats &stats,
+             bool is_gdaki_enabled) {
     int ret = 0;
     stats.clear();
+
+    if (is_gdaki_enabled) {
+#ifdef HAVE_NIXL_DEV_API
+        return execDeviceTransfer(agent, local_iovs, remote_iovs, op, num_iter, num_threads, stats);
+#else
+        std::cerr << "Trying to launch device kernel without header support" << std::endl;
+        return -1;
+#endif /* HAVE_NIXL_DEV_API */
+    }
 
     xferBenchTimer total_timer;
 #pragma omp parallel num_threads(num_threads)
@@ -1267,20 +1670,31 @@ xferBenchNixlWorker::transfer(size_t block_size,
     }
 
     if (skip > 0) {
-        ret = execTransfer(
-            agent, local_iovs, remote_iovs, xfer_op, skip, xferBenchConfig::num_threads, stats);
+        ret = execTransfer(agent,
+                           local_iovs,
+                           remote_iovs,
+                           xfer_op,
+                           skip,
+                           xferBenchConfig::num_threads,
+                           stats,
+                           is_gdaki_enabled);
         if (ret < 0) {
             return std::variant<xferBenchStats, int>(ret);
         }
     }
 
-    // Synchronize to ensure all processes have completed the warmup (iter and polling)
     synchronize();
 
     stats.clear();
 
-    ret = execTransfer(
-        agent, local_iovs, remote_iovs, xfer_op, num_iter, xferBenchConfig::num_threads, stats);
+    ret = execTransfer(agent,
+                       local_iovs,
+                       remote_iovs,
+                       xfer_op,
+                       num_iter,
+                       xferBenchConfig::num_threads,
+                       stats,
+                       is_gdaki_enabled);
     if (ret < 0) {
         return std::variant<xferBenchStats, int>(ret);
     }
@@ -1289,14 +1703,48 @@ xferBenchNixlWorker::transfer(size_t block_size,
     return std::variant<xferBenchStats, int>(stats);
 }
 
+#if HAVE_NIXL_DEV_API
+void
+xferBenchNixlWorker::device_poll(size_t block_size, unsigned int skip, unsigned int num_iter) {
+    std::string_view gpu_level = *(xferBenchConfigGpuLevels.find(xferBenchConfig::gdaki_gpu_level));
+    unsigned int total_iter = skip + num_iter;
+
+    // GDAKI mode: Target monitors signal buffer instead of waiting for notifications
+    // Monitor signal buffer if we have one
+    if (!signal_buffers.empty()) {
+        void *signal_addr = reinterpret_cast<void *>(signal_buffers[0].addr);
+        // Wait for warmup iterations to complete
+        uint64_t count = 0;
+        while (count < skip) {
+            count = readNixlGpuSignal(signal_addr, gpu_level.data());
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        // Synchronize after warmup (match initiator)
+        synchronize();
+
+        // Wait for all iterations to complete
+        while (count < total_iter) {
+            count = readNixlGpuSignal(signal_addr, gpu_level.data());
+            std::cout << "Got count: " << count << " while polling" << std::endl;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    } else {
+        // No signal buffer available, just synchronize at the same points as initiator
+        std::cout << "No signal buffer available, using time-based synchronization" << std::endl;
+    }
+    // Final synchronize (match initiator)
+    synchronize();
+    return;
+}
+#endif
+
 void
 xferBenchNixlWorker::poll(size_t block_size) {
-    nixl_notifs_t notifs;
-    nixl_status_t status;
-    int skip = 0, num_iter = 0, total_iter = 0;
+    unsigned int skip = 0, num_iter = 0, total_iter = 0;
 
     skip = xferBenchConfig::warmup_iter;
     num_iter = xferBenchConfig::num_iter;
+
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {
         skip /= xferBenchConfig::large_blk_iter_ftr;
@@ -1304,16 +1752,29 @@ xferBenchNixlWorker::poll(size_t block_size) {
     }
     total_iter = skip + num_iter;
 
+    if (is_gdaki_enabled) {
+#if HAVE_NIXL_DEV_API
+        device_poll(block_size, skip, num_iter);
+#else
+        std::cerr << "Trying to run device API without supported header" << std::endl;
+#endif
+        return;
+    }
+
+    // Standard polling for non-GDAKI transfers
+    nixl_notifs_t notifs;
+    nixl_status_t status;
+
     /* Ensure warmup is done*/
     do {
         status = agent->getNotifs(notifs);
-    } while (status == NIXL_SUCCESS && skip != int(notifs["initiator"].size()));
+    } while (status == NIXL_SUCCESS && skip != notifs["initiator"].size());
     synchronize();
 
     /* Polling for actual iterations*/
     do {
         status = agent->getNotifs(notifs);
-    } while (status == NIXL_SUCCESS && total_iter != int(notifs["initiator"].size()));
+    } while (status == NIXL_SUCCESS && total_iter != notifs["initiator"].size());
     synchronize();
 }
 

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -358,7 +358,6 @@ xferBenchNixlWorker::cleanupSignalBuffer(std::optional<xferBenchIOV> &signal_des
 
 #define NOTIF_WIREUP_COMP "wireup_complete"
 
-
 bool
 xferBenchNixlWorker::sendWireupNotification(std::string_view &remote_name) {
     nixl_status_t notif_status;
@@ -371,8 +370,8 @@ xferBenchNixlWorker::sendWireupNotification(std::string_view &remote_name) {
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    std::cerr << "Failed to send wireup completion notification after retries to "
-              << remote_name << ", error: " << nixlEnumStrings::statusStr(notif_status) << std::endl;
+    std::cerr << "Failed to send wireup completion notification after retries to " << remote_name
+              << ", error: " << nixlEnumStrings::statusStr(notif_status) << std::endl;
     return false;
 };
 

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -66,17 +66,19 @@ class xferBenchNixlWorker: public xferBenchWorker {
         void
         poll(size_t block_size) override;
         void
-        device_poll(size_t block_size, unsigned int skip, unsigned int num_iter);
+        devicePoll(size_t block_size, unsigned int skip, unsigned int num_iter);
         int
         synchronizeStart();
-        int
-        send_wireup_notification(const std::string &remote_name);
-        int
-        wait_for_ack(const std::string &remote_name);
+        bool
+        sendWireupNotification(std::string_view &remote_name);
+        bool
+        waitForAck(std::string_view &remote_name);
         void
-        send_metadata(std::string local_md, int rank);
-        int
-        recv_and_load_metadata(int rank);
+        sendMetadata(std::string_view local_md, int rank);
+        bool
+        recvAndLoadMetadata(int rank);
+        bool
+        waitForWireupAck(std::string_view item);
 
         // Data operations
         std::variant<xferBenchStats, int>
@@ -100,11 +102,11 @@ class xferBenchNixlWorker: public xferBenchWorker {
         cleanupSignalBuffer(std::optional<xferBenchIOV> &);
 
         // GDAKI wireup notification
-        int
+        bool
         sendWireupMessage();
 
         // GDAKI bidirectional metadata exchange
-        int
+        bool
         exchangeMetadataBidirectional();
         std::optional<xferBenchIOV>
         initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);


### PR DESCRIPTION
- Introduced GDAKI options in configuration, including GPU device list and kernel parameters.
- Implemented GDAKI kernel functions for full and partial transfers in CUDA.
- Enhanced NIXL worker to manage GDAKI signal buffers and wireup notifications.
- Updated metadata exchange to support bidirectional communication in GDAKI mode.

This commit integrates GDAKI functionality into the NIXL worker. This a rebase of PR #785 to main.
