### PR TITLE
Fix plugin directory.

### DIFF
--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -186,7 +186,7 @@ getPluginDir() {
         NIXL_ERROR << "Failed to get plugin directory from dladdr";
         return "";
     }
-    return (std::filesystem::path(info.dli_fname).parent_path() / "plugins").string();
+    return (std::filesystem::path(info.dli_fname).parent_path().parent_path() / "plugins").string();
 }
 } // namespace
 


### PR DESCRIPTION
## What?

This PR fixes a bug in the plugin directory resolution logic in `getPluginDir()`. Previously, the code attempted to locate plugins in a non-existent `core/plugins` directory. With certain build setups, this resulted in plugin loading failures, as reported when running `./examples/cpp/nixl_example`:

```shell
$ NIXL_LOG_LEVEL=DEBUG ./examples/cpp/nixl_example
I0919 19:06:48.573057   96808 nixl_agent.cpp:122] NIXL ETCD is excluded
I0919 19:06:48.573148   96808 nixl_agent.cpp:122] NIXL ETCD is excluded
I0919 19:06:48.573169   96808 nixl_plugin_manager.cpp:197] Loading plugins from file: /home/aoxy/projs/nixl/my_build/pluginlist
I0919 19:06:48.628053   96808 nixl_plugin_manager.cpp:206] Loading plugins from: /home/aoxy/projs/nixl/my_build/examples/cpp/../../src/core/plugins
E0919 19:06:48.628149   96808 nixl_plugin_manager.cpp:297] Error accessing directory("/home/aoxy/projs/nixl/my_build/examples/cpp/../../src/core/plugins"): No such file or directory
...
```

## Why?

The root cause of the bug is the logic for deriving the plugin directory path using `std::filesystem::path::parent_path`. The code snippet is:

```cpp
static std::string
getPluginDir() {
    // Environment variable takes precedence
    const char *plugin_dir = getenv("NIXL_PLUGIN_DIR");
    if (plugin_dir) {
        return plugin_dir;
    }
    // By default, use the plugin directory relative to the binary
    Dl_info info;
    int ok = dladdr(reinterpret_cast<void *>(&getPluginDir), &info);
    if (!ok) {
        NIXL_ERROR << "Failed to get plugin directory from dladdr";
        return "";
    }
    return (std::filesystem::path(info.dli_fname).parent_path() / "plugins").string();
}
```

If `info.dli_fname` is `/home/aoxy/projs/nixl/my_build/examples/cpp/../../src/core/libnixl.so`, then `std::filesystem::path(info.dli_fname).parent_path()` results in `/home/aoxy/projs/nixl/my_build/examples/cpp/../../src/core`. This means the code searches for plugins under `core/plugins`, which does not exist.

Reference on how `parent_path` works:
https://en.cppreference.com/w/cpp/filesystem/path/parent_path

```cpp
#include <filesystem>
#include <iostream>
namespace fs = std::filesystem;
 
int main()
{
    for (fs::path p : {"/var/tmp/example.txt", "/", "/var/tmp/."})
        std::cout << "The parent path of " << p
                  << " is " << p.parent_path() << '\n';
}
// Output:
// The parent path of "/var/tmp/example.txt" is "/var/tmp"
// The parent path of "/" is "/"
// The parent path of "/var/tmp/." is "/var/tmp"
```

List of the actual directory structure:

```shell
$ ls /home/jerryao/projs/nixl/my_build/examples/cpp/../../src/
api  bindings  core  infra  plugins  utils
```

The correct plugin directory should be `/home/aoxy/projs/nixl/my_build/examples/cpp/../../src/plugins`.

## How?

The fix is to use `parent_path()` twice on `info.dli_fname` before appending `"plugins"`, so that the plugin directory is set to the correct location above `core` (i.e., directly under `src`). Specifically, change

```cpp
return (std::filesystem::path(info.dli_fname).parent_path() / "plugins").string();
```

to

```cpp
return (std::filesystem::path(info.dli_fname).parent_path().parent_path() / "plugins").string();
```

This ensures the resolved path will be `/home/aoxy/projs/nixl/my_build/examples/cpp/../../src/plugins`, matching the actual project layout and fixing the loading error.
