### PR TITLE
DEVICE/API: Simplify createGpuXferReq to single-step API - WIP

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -320,14 +320,26 @@ class nixlAgent {
         releaseXferReq (nixlXferReqH* req_hndl) const;
 
         /**
-         * @brief  Create a GPU transfer request from a transfer request.
+         * @brief  Create a GPU transfer request.
          *
-         * @param  req_hndl     [in]  Transfer request obtained from makeXferReq/createXferReq
-         * @param  gpu_req_hndl [out] GPU transfer request handle
-         * @return nixl_status_t Error code if call was not successful
+         * @param  operation      [in]  Operation for transfer (e.g., NIXL_WRITE)
+         * @param  local_descs    [in]  Local descriptor list
+         * @param  remote_descs   [in]  Remote descriptor list
+         * @param  remote_agent   [in]  Remote agent name for accessing the remote data
+         * @param  gpu_req_hndl   [out] GPU transfer request handle
+         * @param  req_hndl       [out] Transfer request handle
+         * @param  extra_params   [in]  Optional extra parameters used in creating a GPU transfer
+         *                              request
+         * @return nixl_status_t  Error code if call was not successful
          */
         nixl_status_t
-        createGpuXferReq(const nixlXferReqH &req_hndl, nixlGpuXferReqH &gpu_req_hndl) const;
+        createGpuXferReq(const nixl_xfer_op_t &operation,
+                         const nixl_xfer_dlist_t &local_descs,
+                         const nixl_xfer_dlist_t &remote_descs,
+                         const std::string &remote_agent,
+                         nixlGpuXferReqH &gpu_req_hndl,
+                         nixlXferReqH *&req_hndl,
+                         const nixl_opt_args_t *extra_params = nullptr) const;
 
         /**
          * @brief  Release transfer request from GPU memory

--- a/test/gtest/device_api/single_write_test.cu
+++ b/test/gtest/device_api/single_write_test.cu
@@ -405,22 +405,19 @@ TEST_P(SingleWriteTest, BasicSingleWriteTest) {
     extra_params.notifMsg = NOTIF_MSG;
 
     nixlXferReqH *xfer_req = nullptr;
+    nixlGpuXferReqH gpu_req_hndl;
     nixl_status_t status = getAgent(SENDER_AGENT)
-                               .createXferReq(NIXL_WRITE,
-                                              makeDescList<nixlBasicDesc>(src_buffers, mem_type),
-                                              makeDescList<nixlBasicDesc>(dst_buffers, mem_type),
-                                              getAgentName(RECEIVER_AGENT),
-                                              xfer_req,
-                                              &extra_params);
+                               .createGpuXferReq(NIXL_WRITE,
+                                                 makeDescList<nixlBasicDesc>(src_buffers, mem_type),
+                                                 makeDescList<nixlBasicDesc>(dst_buffers, mem_type),
+                                                 getAgentName(RECEIVER_AGENT),
+                                                 gpu_req_hndl,
+                                                 xfer_req,
+                                                 &extra_params);
 
     ASSERT_EQ(status, NIXL_SUCCESS)
-        << "Failed to create xfer request " << nixlEnumStrings::statusStr(status);
+        << "Failed to create GPU xfer request " << nixlEnumStrings::statusStr(status);
     EXPECT_NE(xfer_req, nullptr);
-
-    nixlGpuXferReqH gpu_req_hndl;
-    status = getAgent(SENDER_AGENT).createGpuXferReq(*xfer_req, gpu_req_hndl);
-    ASSERT_EQ(status, NIXL_SUCCESS) << "Failed to create GPU xfer request";
-
     ASSERT_NE(gpu_req_hndl, nullptr) << "GPU request handle is null after createGpuXferReq";
 
     uint64_t remote_addr = static_cast<uintptr_t>(dst_buffers[0]);
@@ -507,22 +504,17 @@ TEST_P(SingleWriteTest, VariableSizeTest) {
         extra_params.notifMsg = NOTIF_MSG;
 
         nixlXferReqH *xfer_req = nullptr;
-        nixl_status_t status =
-            getAgent(SENDER_AGENT)
-                .createXferReq(NIXL_WRITE,
-                               makeDescList<nixlBasicDesc>(src_buffers, mem_type),
-                               makeDescList<nixlBasicDesc>(dst_buffers, mem_type),
-                               getAgentName(RECEIVER_AGENT),
-                               xfer_req,
-                               &extra_params);
-
-        ASSERT_EQ(status, NIXL_SUCCESS) << "Failed to create xfer request for size " << test_size;
-
         nixlGpuXferReqH gpu_req_hndl;
-        status = getAgent(SENDER_AGENT).createGpuXferReq(*xfer_req, gpu_req_hndl);
-        ASSERT_EQ(status, NIXL_SUCCESS)
-            << "Failed to create GPU xfer request for size " << test_size;
+        nixl_status_t status = getAgent(SENDER_AGENT)
+                                   .createGpuXferReq(NIXL_WRITE,
+                                                     makeDescList<nixlBasicDesc>(src_buffers, mem_type),
+                                                     makeDescList<nixlBasicDesc>(dst_buffers, mem_type),
+                                                     getAgentName(RECEIVER_AGENT),
+                                                     gpu_req_hndl,
+                                                     xfer_req,
+                                                     &extra_params);
 
+        ASSERT_EQ(status, NIXL_SUCCESS) << "Failed to create GPU xfer request for size " << test_size;
         ASSERT_NE(gpu_req_hndl, nullptr) << "GPU request handle is null after createGpuXferReq";
 
         unsigned long long *start_time_ptr = nullptr;


### PR DESCRIPTION
## What?
Replace two-step GPU transfer request creation with a single `createGpuXferReq` API that takes descriptor lists directly and returns both transfer request and GPU request handles.

## Why?
Simplify the API by reducing GPU transfer request creation from two separate function calls to a single call.

## How?
Updated `createGpuXferReq` to substitute calls to `createXferReq` + `createGpuXferReq`. Removed the old `createGpuXferReq` method and updated tests accordingly.