### PR TITLE
[Test/Example] Added backend selection option for libfabric unit tests

### DIFF
--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -86,3 +86,6 @@ else
     # This sequence ensures that we can link and load the binaries in all CI environments, even if a GPU is not present
     export LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:/usr/local/cuda/compat:/usr/local/cuda/compat/lib.real:$LD_LIBRARY_PATH
 fi
+
+# Default to false, unless TEST_LIBFABRIC is set. AWS EFA tests must set it to true.
+export TEST_LIBFABRIC=${TEST_LIBFABRIC:-false}

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -62,6 +62,7 @@ cd ${INSTALL_DIR}
 ./bin/desc_example
 ./bin/agent_example
 ./bin/nixl_example
+./bin/nixl_example LIBFABRIC
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 # Skip UCX_MO backend test on GPU worker, fails VRAM transfers

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -46,6 +46,7 @@ env
 nvidia-smi topo -m || true
 ibv_devinfo || true
 uname -a || true
+cat /sys/devices/virtual/dmi/id/product_name
 
 echo "==== Running ETCD server ===="
 etcd_port=$(get_next_tcp_port)
@@ -61,6 +62,7 @@ echo "==== Running C++ tests ===="
 cd ${INSTALL_DIR}
 ./bin/desc_example
 ./bin/agent_example
+export NIXL_LOG_LEVEL=TRACE
 ./bin/nixl_example
 ./bin/nixl_example LIBFABRIC
 ./bin/nixl_etcd_example

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -46,7 +46,7 @@ env
 nvidia-smi topo -m || true
 ibv_devinfo || true
 uname -a || true
-cat /sys/devices/virtual/dmi/id/product_name
+cat /sys/devices/virtual/dmi/id/product_name || true
 
 echo "==== Running ETCD server ===="
 etcd_port=$(get_next_tcp_port)
@@ -62,9 +62,10 @@ echo "==== Running C++ tests ===="
 cd ${INSTALL_DIR}
 ./bin/desc_example
 ./bin/agent_example
-export NIXL_LOG_LEVEL=TRACE
 ./bin/nixl_example
-./bin/nixl_example LIBFABRIC
+if $TEST_LIBFABRIC ; then
+    ./bin/nixl_example LIBFABRIC
+fi
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 # Skip UCX_MO backend test on GPU worker, fails VRAM transfers

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -46,6 +46,8 @@ pip3 install --break-system-packages pytest
 pip3 install --break-system-packages pytest-timeout
 pip3 install --break-system-packages zmq
 
+cat /sys/devices/virtual/dmi/id/product_name
+
 echo "==== Running ETCD server ===="
 etcd_port=$(get_next_tcp_port)
 etcd_peer_port=$(get_next_tcp_port)
@@ -57,6 +59,7 @@ etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_
 sleep 5
 
 echo "==== Running python tests ===="
+export NIXL_LOG_LEVEL=TRACE
 pytest -s test/python
 pytest -s test/python --backend LIBFABRIC
 python3 test/python/prep_xfer_perf.py list

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -58,6 +58,7 @@ sleep 5
 
 echo "==== Running python tests ===="
 pytest -s test/python
+pytest -s test/python --backend LIBFABRIC
 python3 test/python/prep_xfer_perf.py list
 python3 test/python/prep_xfer_perf.py array
 

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -39,6 +39,8 @@ export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 export NIXL_PREFIX=${INSTALL_DIR}
 # Raise exceptions for logging errors
 export NIXL_DEBUG_LOGGING=yes
+export FI_LOG_LEVEL=debug
+export FI_LOG_PROV=efa
 
 pip3 install --break-system-packages .
 pip3 install --break-system-packages pytest
@@ -46,6 +48,8 @@ pip3 install --break-system-packages pytest-timeout
 pip3 install --break-system-packages zmq
 
 cat /sys/devices/virtual/dmi/id/product_name
+echo "Product Name: $(cat /sys/devices/virtual/dmi/id/product_name)"
+echo "Instance ID: $(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
 
 echo "==== Running ETCD server ===="
 etcd_port=$(get_next_tcp_port)
@@ -59,7 +63,7 @@ sleep 5
 
 echo "==== Running python tests ===="
 export NIXL_LOG_LEVEL=DEBUG
-pytest -s test/python
+# pytest -s test/python
 pytest -s test/python --backend LIBFABRIC
 python3 test/python/prep_xfer_perf.py list
 python3 test/python/prep_xfer_perf.py array

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -32,10 +32,9 @@ ARCH=$(uname -m)
 [ "$ARCH" = "arm64" ] && ARCH="aarch64"
 
 export LD_LIBRARY_PATH=${INSTALL_DIR}/lib:${INSTALL_DIR}/lib/$ARCH-linux-gnu:${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins:/usr/local/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=/opt/amazon/efa/lib:$LD_LIBRARY_PATH
-export CPATH=${INSTALL_DIR}/include:/opt/amazon/efa/include:$CPATH
+export CPATH=${INSTALL_DIR}/include::$CPATH
 export PATH=${INSTALL_DIR}/bin:$PATH
-export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:/opt/amazon/efa/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 export NIXL_PREFIX=${INSTALL_DIR}
 # Raise exceptions for logging errors
@@ -59,7 +58,7 @@ etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_
 sleep 5
 
 echo "==== Running python tests ===="
-export NIXL_LOG_LEVEL=TRACE
+export NIXL_LOG_LEVEL=DEBUG
 pytest -s test/python
 pytest -s test/python --backend LIBFABRIC
 python3 test/python/prep_xfer_perf.py list

--- a/contrib/aws-efa/aws_vars.template
+++ b/contrib/aws-efa/aws_vars.template
@@ -14,6 +14,10 @@
                         "value": "${UCX_VERSION}"
                     },
                     {
+                        "name": "TEST_LIBFABRIC",
+                        "value": "true"
+                    },
+                    {
                         "name": "UCX_INSTALL_DIR",
                         "value": "/usr/local"
                     },

--- a/examples/cpp/nixl_example.cpp
+++ b/examples/cpp/nixl_example.cpp
@@ -64,10 +64,16 @@ void printParams(const nixl_b_params_t& params, const nixl_mem_list_t& mems) {
     }
 }
 
-int main()
-{
+int
+main(int argc, char **argv) {
     nixl_status_t ret1, ret2;
     std::string ret_s1, ret_s2;
+
+    // Backend name can be provided as the first CLI argument; default to "UCX"
+    std::string backend = "UCX";
+    if (argc > 1) {
+        backend = argv[1];
+    }
 
     // Example: assuming two agents running on the same machine,
     // with separate memory regions in DRAM
@@ -90,8 +96,9 @@ int main()
     for (nixl_backend_t b: plugins)
         std::cout << b << "\n";
 
-    ret1 = A1.getPluginParams("UCX", mems1, init1);
-    ret2 = A2.getPluginParams("UCX", mems2, init2);
+    std::cout << "Using backend: " << backend << "\n";
+    ret1 = A1.getPluginParams(backend, mems1, init1);
+    ret2 = A2.getPluginParams(backend, mems2, init2);
 
     assert (ret1 == NIXL_SUCCESS);
     assert (ret2 == NIXL_SUCCESS);
@@ -100,19 +107,19 @@ int main()
     printParams(init1, mems1);
     printParams(init2, mems2);
 
-    nixlBackendH* ucx1, *ucx2;
-    ret1 = A1.createBackend("UCX", init1, ucx1);
-    ret2 = A2.createBackend("UCX", init2, ucx2);
+    nixlBackendH *bknd1, *bknd2;
+    ret1 = A1.createBackend(backend, init1, bknd1);
+    ret2 = A2.createBackend(backend, init2, bknd2);
 
     nixl_opt_args_t extra_params1, extra_params2;
-    extra_params1.backends.push_back(ucx1);
-    extra_params2.backends.push_back(ucx2);
+    extra_params1.backends.push_back(bknd1);
+    extra_params2.backends.push_back(bknd2);
 
     assert (ret1 == NIXL_SUCCESS);
     assert (ret2 == NIXL_SUCCESS);
 
-    ret1 = A1.getBackendParams(ucx1, mems1, init1);
-    ret2 = A2.getBackendParams(ucx2, mems2, init2);
+    ret1 = A1.getBackendParams(bknd1, mems1, init1);
+    ret2 = A2.getBackendParams(bknd2, mems2, init2);
 
     assert (ret1 == NIXL_SUCCESS);
     assert (ret2 == NIXL_SUCCESS);
@@ -152,7 +159,6 @@ int main()
     // dlist1.print();
     // dlist2.print();
 
-    // sets the metadata field to a pointer to an object inside the ucx_class
     ret1 = A1.registerMem(dlist1, &extra_params1);
     ret2 = A2.registerMem(dlist2, &extra_params2);
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--backend",
+        action="store",
+        default="UCX",
+        help="Backend plugin name to use for tests (default: UCX)",
+    )
+
+
+@pytest.fixture(scope="session")
+def backend_name(pytestconfig):
+    return pytestconfig.getoption("--backend")


### PR DESCRIPTION
## What?
Added backend selection option to some of the tests.

Added TEST_LIBFABRIC env var to AWS EFA tests, set to true. Defaults to false in other tests (where it is unset). Prevents running libfabric tests on platforms without support.

## Why?
Now we can test new backends such as libfabric.