### PR TITLE
Add agent configuration support to Rust bindings

### DIFF
--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -57,9 +57,20 @@ nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent)
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_agent(nixl_capi_agent_t agent)
-{
-  return nixl_capi_stub_abort();
+nixl_capi_default_agent_config(nixl_capi_agent_config_t *out) {
+    return nixl_capi_stub_abort();
+}
+
+nixl_capi_status_t
+nixl_capi_create_configured_agent(const char *name,
+                                  const nixl_capi_agent_config_t *cfg,
+                                  nixl_capi_agent_t *agent) {
+    return nixl_capi_stub_abort();
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_agent(nixl_capi_agent_t agent) {
+    return nixl_capi_stub_abort();
 }
 
 nixl_capi_status_t

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -127,6 +127,23 @@ fn create_posix_backend(agent: &Agent) -> Option<(Backend, OptArgs)> {
 }
 
 #[test]
+fn create_agent_with_custom_config() {
+    // Ensure we can construct with non-default config
+    let cfg = AgentConfig {
+        enable_listen_thread: true,
+        listen_port: 0,
+        capture_telemetry: false,
+        ..Default::default()
+    };
+
+    let agent = Agent::new_configured("cfg_agent", &cfg)
+        .expect("Failed to create configured agent");
+
+    // basic sanity: can query available plugins
+    let _plugins = agent.get_available_plugins().expect("Failed to get plugins");
+}
+
+#[test]
 fn test_agent_creation() {
     let agent = Agent::new("test_agent").expect("Failed to create agent");
     drop(agent);

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -28,6 +28,19 @@
 #include <vector>
 #include <chrono>
 
+static nixl_thread_sync_t
+nixl_capi_thread_sync_to_nixl(nixl_capi_thread_sync_t sync) {
+    switch (sync) {
+    case NIXL_CAPI_THREAD_SYNC_NONE:
+        return nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE;
+    case NIXL_CAPI_THREAD_SYNC_STRICT:
+        return nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT;
+    case NIXL_CAPI_THREAD_SYNC_RW:
+        return nixl_thread_sync_t::NIXL_THREAD_SYNC_RW;
+    default:
+        return nixl_thread_sync_t::NIXL_THREAD_SYNC_DEFAULT;
+    }
+}
 
 extern "C" {
 // Internal struct definitions to match our opaque types
@@ -111,20 +124,47 @@ nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent)
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_agent(nixl_capi_agent_t agent)
-{
-  if (!agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_create_configured_agent(const char *name,
+                                  const nixl_capi_agent_config_t *cfg,
+                                  nixl_capi_agent_t *agent) {
+    if (!name || !cfg || !agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    delete agent->inner;
-    delete agent;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixlAgentConfig nixl_config(cfg->enable_prog_thread,
+                                    cfg->enable_listen_thread,
+                                    cfg->listen_port,
+                                    nixl_capi_thread_sync_to_nixl(cfg->thread_sync),
+                                    cfg->num_workers,
+                                    cfg->pthr_delay_us,
+                                    cfg->lthr_delay_us,
+                                    cfg->capture_telemetry);
+
+        auto agent_handle = new nixl_capi_agent_s;
+        agent_handle->inner = new nixlAgent(name, nixl_config);
+        *agent = agent_handle;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_agent(nixl_capi_agent_t agent) {
+    if (!agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete agent->inner;
+        delete agent;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -1824,4 +1864,4 @@ nixl_capi_query_mem(nixl_capi_agent_t agent,
     }
 }
 
-}  // extern "C"
+} // extern "C"

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -77,6 +77,26 @@ typedef struct nixl_capi_xfer_req_s* nixl_capi_xfer_req_t;
 typedef struct nixl_capi_notif_map_s* nixl_capi_notif_map_t;
 typedef struct nixl_capi_query_resp_list_s *nixl_capi_query_resp_list_t;
 
+// Thread sync enum matching nixl_thread_sync_t
+typedef enum {
+    NIXL_CAPI_THREAD_SYNC_NONE = 0,
+    NIXL_CAPI_THREAD_SYNC_STRICT = 1,
+    NIXL_CAPI_THREAD_SYNC_RW = 2,
+    NIXL_CAPI_THREAD_SYNC_DEFAULT = NIXL_CAPI_THREAD_SYNC_NONE,
+} nixl_capi_thread_sync_t;
+
+// Agent configuration struct mirroring nixlAgentConfig constructor args
+typedef struct nixl_capi_agent_config_s {
+    bool enable_prog_thread;
+    bool enable_listen_thread;
+    int listen_port;
+    nixl_capi_thread_sync_t thread_sync;
+    unsigned int num_workers;
+    uint64_t pthr_delay_us;
+    uint64_t lthr_delay_us;
+    bool capture_telemetry;
+} nixl_capi_agent_config_t;
+
 // Transfer request functions
 typedef enum {
   NIXL_CAPI_XFER_OP_READ = 0,
@@ -84,8 +104,17 @@ typedef enum {
 } nixl_capi_xfer_op_t;
 
 // Core API functions
+
+// Create an agent with a provided config
+nixl_capi_status_t
+nixl_capi_create_configured_agent(const char *name,
+                                  const nixl_capi_agent_config_t *cfg,
+                                  nixl_capi_agent_t *agent);
+
+// Create an agent with default config
 nixl_capi_status_t nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent);
 
+// Destroy an agent
 nixl_capi_status_t nixl_capi_destroy_agent(nixl_capi_agent_t agent);
 
 // Get local metadata as a byte array


### PR DESCRIPTION
## What?
Rust API:
 - Add ThreadSync and AgentConfig (with Default)
 - Add Agent::new_configured(name, &AgentConfig) alongside existing Agent::new
