### PR TITLE
Make UCX dependency optional

### DIFF
--- a/examples/cpp/meson.build
+++ b/examples/cpp/meson.build
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-nixl_example = executable('nixl_example',
-           'nixl_example.cpp',
-           dependencies: [nixl_dep, nixl_infra, nixl_common_deps, ucx_backend_dep, ucx_dep],
-           include_directories: [nixl_inc_dirs, utils_inc_dirs],
-           link_with: [serdes_lib],
-           install: true)
+if ucx_dep.found()
+    nixl_example = executable('nixl_example',
+            'nixl_example.cpp',
+            dependencies: [nixl_dep, nixl_infra, nixl_common_deps, ucx_backend_dep, ucx_dep],
+            include_directories: [nixl_inc_dirs, utils_inc_dirs],
+            link_with: [serdes_lib],
+            install: true)
+endif
 
 if etcd_dep.found()
     etcd_example = executable('nixl_etcd_example',

--- a/meson.build
+++ b/meson.build
@@ -148,7 +148,7 @@ if ucx_path != ''
       include_directories : include_directories(ucx_inc_path))
   endif
 else
-  ucx_dep = dependency('ucx', modules: ['ucx::ucs', 'ucx::ucp', 'ucx::uct'])
+  ucx_dep = dependency('ucx', modules: ['ucx::ucs', 'ucx::ucp', 'ucx::uct'], required: false)
 endif
 
 libfabric_path = get_option('libfabric_path')

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -15,8 +15,10 @@
 
 ucx_backend_inc_dirs = include_directories('./ucx')
 
-subdir('ucx')
-subdir('ucx_mo')
+if ucx_dep.found()
+    subdir('ucx')
+    subdir('ucx_mo')
+endif
 
 subdir('posix')  # Always try to build POSIX backend, it will handle its own dependencies
 subdir('obj')  # Always try to build Obj backend, it will handle its own dependencies

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -15,7 +15,9 @@
 
 subdir('common')
 subdir('serdes')
-subdir('ucx')
+if ucx_dep.found()
+    subdir('ucx')
+endif
 subdir('stream')
 subdir('file')
 

--- a/test/nixl/meson.build
+++ b/test/nixl/meson.build
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ucx_backend_dep = declare_dependency(link_with: ucx_backend_lib, include_directories: [nixl_inc_dirs, utils_inc_dirs, '../../src/plugins/ucx'])
+if ucx_dep.found()
+    ucx_backend_dep = declare_dependency(link_with: ucx_backend_lib, include_directories: [nixl_inc_dirs, utils_inc_dirs, '../../src/plugins/ucx'])
+endif
 
 desc_example = executable('desc_example',
            'desc_example.cpp',

--- a/test/unit/plugins/meson.build
+++ b/test/unit/plugins/meson.build
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-subdir('ucx')
-subdir('ucx_mo')
+if ucx_dep.found()
+    subdir('ucx')
+    subdir('ucx_mo')
+endif
 subdir('posix')
 
 

--- a/test/unit/utils/common/meson.build
+++ b/test/unit/utils/common/meson.build
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#if cuda_dep.found()
-#    cuda_dependencies = [cuda_dep]
-#    cpp_args = '-DUSE_VRAM'
-#else
-#    cuda_dependencies = []
-#    cpp_args = '-UUSE_VRAM'
-#endif
+if cuda_dep.found()
+    cuda_dependencies = [cuda_dep]
+    cpp_args = '-DUSE_VRAM'
+else
+    cuda_dependencies = []
+    cpp_args = '-UUSE_VRAM'
+endif
 
 p2p_socket = executable('p2p_test',
             'p2p_socket_test.cpp',

--- a/test/unit/utils/meson.build
+++ b/test/unit/utils/meson.build
@@ -19,4 +19,6 @@ if libfabric_dep.found()
 endif
 subdir('serdes')
 subdir('stream')
-subdir('ucx')
+if ucx_dep.found()
+    subdir('ucx')
+endif


### PR DESCRIPTION
## What?
Make UCX dependency optional

## Why?
Amazon would like to be able to build NIXL without UCX
