### PR TITLE
Fix Rust query_xfer_backend API

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -106,6 +106,15 @@ class nixlAgent {
                        const nixl_b_params_t &params,
                        nixlBackendH* &backend);
         /**
+         * @brief  Get the type of a backend
+         *
+         * @param  backend Backend handle
+         * @param  type [out] Backend type
+         * @return nixl_status_t Error code if call was not successful
+         */
+        nixl_status_t
+        getBackendType(const nixlBackendH *backend, nixl_backend_t &type) const;
+        /**
          * @brief  Register a memory/storage with NIXL. If a list of backends hints is provided
          *         (via extra_params), the registration is limited to the specified backends.
          *

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -71,8 +71,8 @@ use bindings::{
     nixl_capi_query_resp_list_size, nixl_capi_query_resp_list_has_value,
     nixl_capi_query_resp_list_get_params, nixl_capi_prep_xfer_dlist, nixl_capi_release_xfer_dlist_handle,
     nixl_capi_make_xfer_req, nixl_capi_get_local_partial_md,
-    nixl_capi_send_local_partial_md, nixl_capi_query_xfer_backend, nixl_capi_opt_args_set_ip_addr,
-    nixl_capi_opt_args_set_port
+    nixl_capi_send_local_partial_md, nixl_capi_opt_args_set_ip_addr,
+    nixl_capi_opt_args_set_port, nixl_capi_query_xfer_backend_type
 };
 
 // Re-export status codes

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -1324,10 +1324,10 @@ fn test_query_xfer_backend_success() {
             None
         ).expect("Failed to create transfer request");
         // Query which backend will be used for this transfer
-        let result: Result<Backend, NixlError> = agent1.query_xfer_backend(&xfer_req);
+        let result: Result<String, NixlError> = agent1.query_xfer_backend(&xfer_req);
         assert!(result.is_ok(), "query_xfer_backend failed with error: {:?}", result.err());
-        let backend = result.unwrap();
-        println!("Transfer will use backend: {:?}", backend);
+        let backend_name = result.unwrap();
+        println!("Transfer will use backend: {}", backend_name);
    }
 }
 #[test]

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -1508,6 +1508,32 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
 }
 
 nixl_capi_status_t
+nixl_capi_query_xfer_backend_type(nixl_capi_agent_t agent,
+                                  nixl_capi_xfer_req_t req_hndl,
+                                  void **backend_type,
+                                  size_t *backend_type_size) {
+    if (!agent || !req_hndl || !backend_type || !backend_type_size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    nixl_capi_backend_t backend_handle;
+    auto ret = nixl_capi_query_xfer_backend(agent, req_hndl, &backend_handle);
+    if (ret != NIXL_CAPI_SUCCESS) {
+        return ret;
+    }
+
+    static thread_local nixl_backend_t type;
+    auto nixl_ret = agent->inner->getBackendType(backend_handle->backend, type);
+    if (nixl_ret != NIXL_SUCCESS) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+
+    *backend_type = type.data();
+    *backend_type_size = type.size();
+    return NIXL_CAPI_SUCCESS;
+}
+
+nixl_capi_status_t
 nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req)
 {
   if (!req) {

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -243,6 +243,12 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
                              nixl_capi_xfer_req_t req_hndl,
                              nixl_capi_backend_t *backend);
 
+nixl_capi_status_t
+nixl_capi_query_xfer_backend_type(nixl_capi_agent_t agent,
+                                  nixl_capi_xfer_req_t req_hndl,
+                                  void **backend_type,
+                                  size_t *backend_type_size);
+
 nixl_capi_status_t nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req);
 
 nixl_capi_status_t nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req);

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -397,6 +397,22 @@ nixlAgent::createBackend(const nixl_backend_t &type,
 }
 
 nixl_status_t
+nixlAgent::getBackendType(const nixlBackendH *backend, nixl_backend_t &type) const {
+    if (!backend) {
+        NIXL_ERROR_FUNC << "backend handle is not provided";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    try {
+        type = backend->getType();
+        return NIXL_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_ERR_BACKEND;
+    }
+}
+
+nixl_status_t
 nixlAgent::queryMem(const nixl_reg_dlist_t &descs,
                     std::vector<nixl_query_resp_t> &resp,
                     const nixl_opt_args_t *extra_params) const {


### PR DESCRIPTION
## What?
Fix Rust query_xfer_backend API

## Why?
return a string, as rest of the API doesn't return the raw pointer

## How?
 - add `nixl_capi_query_xfer_backend_type` and use it in Rust implementation
 - add C++ `Agent::getBackendType` helper API and use it in C wrapper