### PR TITLE
CI: Enable DGX tests in CI

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -25,7 +25,7 @@ timeout_minutes: 240
 # label is defined at jenkins slave configuration, we want to run the job on a gpu agent and be able to esaly replace it without having to change this file
 runs_on_agents:
   - {nodeLabel: 'H100'}
-  # - {nodeLabel: 'DGX'}
+  - {nodeLabel: 'DGX'}
 
 matrix:
   axes:


### PR DESCRIPTION
DGX was moved out of the problematic network subnet.