### PR TITLE
Fix libfabric double-release and resource cleanup issues

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -43,6 +43,11 @@
 #define NIXL_LIBFABRIC_DATA_REQUESTS_PER_RAIL 1024 // WRITE/read operations (no buffers)
 #define NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE 8192
 
+// Retry configuration constants
+#define NIXL_LIBFABRIC_MAX_RETRIES 10
+#define NIXL_LIBFABRIC_EFA_RETRY_DELAY_US 100
+#define NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US 1000
+
 // The immediate data associated with an RDMA operation is 32 bits and is divided as follows:
 // | 4-bit MSG TYPE flag | 8-bit agent index | 16-bit XFER_ID | 4-bit SEQ_ID |
 

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -831,6 +831,7 @@ nixlLibfabricRail::processLocalSendCompletion(struct fi_cq_data_entry *comp) {
     } else {
         NIXL_ERROR << "No request found for send completion context " << comp->op_context
                    << " on rail " << rail_id;
+        return NIXL_ERR_BACKEND;
     }
 
     return NIXL_SUCCESS;
@@ -857,6 +858,7 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
     } else {
         NIXL_ERROR << "No request found for " << operation_type << " completion context "
                    << comp->op_context << " on rail " << rail_id;
+        return NIXL_ERR_BACKEND;
     }
 
     return NIXL_SUCCESS;

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -59,6 +59,13 @@ RequestPool::release(nixlLibfabricReq *req) {
 
     std::lock_guard<std::mutex> lock(pool_mutex_);
 
+    // GUARD: Check if already released
+    if (!req->in_use) {
+        NIXL_WARN << "Attempt to double-release request XFER_ID=" << req->xfer_id << " on rail "
+                  << rail_id_ << " - ignoring to prevent corruption";
+        return;
+    }
+
     NIXL_TRACE << "ReleaseReq on Rail " << rail_id_ << " releasing request XFER_ID=" << req->xfer_id
                << " pool_index=" << req->pool_index;
 
@@ -161,12 +168,16 @@ ControlRequestPool::~ControlRequestPool() {
 
 void
 ControlRequestPool::cleanup() {
+    if (buffer_chunks_.empty()) return; // Already cleaned up
+
     for (auto &chunk : buffer_chunks_) {
         if (chunk.mr) {
             fi_close(&chunk.mr->fid);
+            chunk.mr = nullptr;
         }
         if (chunk.buffer) {
             free(chunk.buffer);
+            chunk.buffer = nullptr;
         }
     }
     buffer_chunks_.clear();
@@ -826,7 +837,7 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
                                                   const char *operation_type) {
     // Find the request from context to access the completion callback
     nixlLibfabricReq *req = findRequestFromContext(comp->op_context);
-    if (req) {
+    if (req && req->in_use) { // Only process if request is still valid and in use
         // Call completion callback if it exists
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
@@ -835,6 +846,9 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
             NIXL_TRACE << "Completion callback completed for " << operation_type;
         }
         releaseRequest(req);
+    } else if (req && !req->in_use) {
+        NIXL_WARN << "Completion received for already released " << operation_type << " request "
+                  << req->xfer_id << " on rail " << rail_id << " - skipping to prevent double-free";
     } else {
         NIXL_ERROR << "No request found for " << operation_type << " completion context "
                    << comp->op_context << " on rail " << rail_id;
@@ -1019,9 +1033,9 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                << " XFER_ID: " << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr: " << dest_addr << std::dec << " context: " << &req->ctx;
 
-    // For TCP providers, implement retry mechanism for "Resource temporarily unavailable"
-    const int max_retries = (provider_name == "tcp" || provider_name == "sockets") ? 10 : 1;
-    const int retry_delay_us = 1000; // 1ms delay between retries
+    // Retry logic
+    const int max_retries = 10; // Default retry count
+    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
@@ -1037,8 +1051,8 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
             return NIXL_SUCCESS;
         }
 
-        if (ret == -FI_EAGAIN && (provider_name == "tcp" || provider_name == "sockets")) {
-            // Resource temporarily unavailable - retry for TCP providers
+        if (ret == -FI_EAGAIN) {
+            // Resource temporarily unavailable - retrying
             if (attempt < max_retries - 1) {
                 NIXL_TRACE << "fi_senddata returned EAGAIN on rail " << rail_id
                            << ", retrying (attempt " << (attempt + 1) << "/" << max_retries << ")";
@@ -1049,7 +1063,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                           << rail_id << ": " << fi_strerror(-ret);
             }
         } else {
-            // Other error or non-TCP provider - don't retry
+            // Other error - don't retry
             break;
         }
     }
@@ -1079,9 +1093,9 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                << " remote_addr: " << (void *)remote_addr << " remote_key: " << remote_key
                << " context: " << &req->ctx;
 
-    // For TCP providers, implement retry mechanism for "Resource temporarily unavailable"
-    const int max_retries = (provider_name == "tcp" || provider_name == "sockets") ? 10 : 1;
-    const int retry_delay_us = 1000; // 1ms delay between retries
+    // Retry logic
+    const int max_retries = 10; // Default retry count
+    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
@@ -1104,8 +1118,8 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
             return NIXL_SUCCESS;
         }
 
-        if (ret == -FI_EAGAIN && (provider_name == "tcp" || provider_name == "sockets")) {
-            // Resource temporarily unavailable - retry for TCP providers
+        if (ret == -FI_EAGAIN) {
+            // Resource temporarily unavailable - retrying
             if (attempt < max_retries - 1) {
                 NIXL_TRACE << "fi_writedata returned EAGAIN on rail " << rail_id
                            << ", retrying (attempt " << (attempt + 1) << "/" << max_retries << ")";
@@ -1116,7 +1130,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                           << rail_id << ": " << fi_strerror(-ret);
             }
         } else {
-            // Other error or non-TCP provider - don't retry
+            // Other error - don't retry
             break;
         }
     }
@@ -1144,9 +1158,9 @@ nixlLibfabricRail::postRead(void *local_buffer,
                << " dest_addr: " << dest_addr << " remote_addr: " << (void *)remote_addr
                << " remote_key: " << remote_key << " context: " << &req->ctx;
 
-    // For TCP providers, implement retry mechanism for "Resource temporarily unavailable"
-    const int max_retries = (provider_name == "tcp" || provider_name == "sockets") ? 10 : 1;
-    const int retry_delay_us = 1000; // 1ms delay between retries
+    // Retry logic
+    const int max_retries = 5; // Default retry count
+    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
@@ -1168,8 +1182,8 @@ nixlLibfabricRail::postRead(void *local_buffer,
             return NIXL_SUCCESS;
         }
 
-        if (ret == -FI_EAGAIN && (provider_name == "tcp" || provider_name == "sockets")) {
-            // Resource temporarily unavailable - retry for TCP providers
+        if (ret == -FI_EAGAIN) {
+            // Resource temporarily unavailable - retrying
             if (attempt < max_retries - 1) {
                 NIXL_TRACE << "fi_read returned EAGAIN on rail " << rail_id
                            << ", retrying (attempt " << (attempt + 1) << "/" << max_retries << ")";
@@ -1180,7 +1194,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
                           << rail_id << ": " << fi_strerror(-ret);
             }
         } else {
-            // Other error or non-TCP provider - don't retry
+            // Other error - don't retry
             break;
         }
     }

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1034,8 +1034,9 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                << " dest_addr: " << dest_addr << std::dec << " context: " << &req->ctx;
 
     // Retry logic
-    const int max_retries = 10; // Default retry count
-    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
+    const int max_retries = NIXL_LIBFABRIC_MAX_RETRIES;
+    const int retry_delay_us = (provider_name == "efa") ? NIXL_LIBFABRIC_EFA_RETRY_DELAY_US :
+                                                          NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US;
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
@@ -1094,8 +1095,9 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                << " context: " << &req->ctx;
 
     // Retry logic
-    const int max_retries = 10; // Default retry count
-    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
+    const int max_retries = NIXL_LIBFABRIC_MAX_RETRIES;
+    const int retry_delay_us = (provider_name == "efa") ? NIXL_LIBFABRIC_EFA_RETRY_DELAY_US :
+                                                          NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US;
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {
@@ -1159,8 +1161,9 @@ nixlLibfabricRail::postRead(void *local_buffer,
                << " remote_key: " << remote_key << " context: " << &req->ctx;
 
     // Retry logic
-    const int max_retries = 5; // Default retry count
-    const int retry_delay_us = (provider_name == "efa") ? 100 : 1000; // EFA needs shorter delay
+    const int max_retries = NIXL_LIBFABRIC_MAX_RETRIES;
+    const int retry_delay_us = (provider_name == "efa") ? NIXL_LIBFABRIC_EFA_RETRY_DELAY_US :
+                                                          NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US;
 
     int ret = -FI_EAGAIN;
     for (int attempt = 0; attempt < max_retries; ++attempt) {

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -210,7 +210,6 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                     req);
         }
         if (status != NIXL_SUCCESS) {
-            data_rails_[rail_id]->releaseRequest(req);
             return status;
         }
 
@@ -283,7 +282,6 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                         req);
             }
             if (status != NIXL_SUCCESS) {
-                data_rails_[rail_id]->releaseRequest(req);
                 return status;
             }
 
@@ -602,7 +600,6 @@ nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Failed to send control message type " << static_cast<int>(msg_type)
                    << " on control rail " << control_rail_id;
-        control_rails_[control_rail_id]->releaseRequest(req);
         return status;
     }
     return NIXL_SUCCESS;

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -210,6 +210,11 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                     req);
         }
         if (status != NIXL_SUCCESS) {
+            // Release the allocated request back to pool on failure
+            data_rails_[rail_id]->releaseRequest(req);
+            NIXL_ERROR << "Failed to submit "
+                       << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
+                       << rail_id << ", request released";
             return status;
         }
 
@@ -282,6 +287,11 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                         req);
             }
             if (status != NIXL_SUCCESS) {
+                // This request failed to submit - release it immediately
+                data_rails_[rail_id]->releaseRequest(req);
+                NIXL_ERROR << "Failed to submit "
+                           << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
+                           << rail_id << ", request released";
                 return status;
             }
 
@@ -600,6 +610,8 @@ nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Failed to send control message type " << static_cast<int>(msg_type)
                    << " on control rail " << control_rail_id;
+        // Release the pre-allocated control request back to pool on failure
+        control_rails_[control_rail_id]->releaseRequest(req);
         return status;
     }
     return NIXL_SUCCESS;


### PR DESCRIPTION
## What?

Fix libfabric backend retry failures in test_nixl_bindings.py some of the tests are failing execution with memory double free error.

## Why?

Currently fi_writedata retry logic only existis with tcp provider.
Upon inspection, we found that we need to do retries even with efa provider.
 
## How?

This PR implements retires with EFA provider and address some potential double free resources.
