### PR TITLE
Activate venv in nixlbench container

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -168,6 +168,9 @@ RUN uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION && \
     # pybind11 pip install needed for ubuntu 22.04
     uv pip install --upgrade meson pybind11 patchelf pyYAML click tabulate
 
+# Activate the virtual environment
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 RUN CUDA_SHORT_VERSION=cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .) && \
     uv pip install torch --index https://download.pytorch.org/whl/$CUDA_SHORT_VERSION
 


### PR DESCRIPTION
## What?
Activate virtual environment explicitly in nixlbench container

## Why?
Python3 should work out of the box when a shell is opened.

## Test

```
$ docker images
REPOSITORY                                                           TAG                                                                                    IMAGE ID       CREATED          SIZE
nixlbench                                                            v0.6.0.dev.bc2c2c19                                                                    755bf7ea398d   23 minutes ago   28GB

$ docker run -it 755bf7ea398d python3
                                                                                                                                                                                                                                                                                                                                                                                          ==========
== CUDA ==
==========

NVIDIA Release  (build )
CUDA Version 12.9.1.010
Container image Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
                                                                                                                                                                                                                                                                                                                                                                                          Various files include modifications (c) NVIDIA CORPORATION & AFFILIATES.  All rights reserved.

GOVERNING TERMS: The software and materials are governed by the NVIDIA Software License Agreement
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-software-license-agreement/)
and the Product-Specific Terms for NVIDIA AI Products
(found at https://www.nvidia.com/en-us/agreements/enterprise-software/product-specific-terms-for-ai-products/).
                                                                                                                                                                                                                                                                                                                                                                                          WARNING: The NVIDIA Driver was not detected.  GPU functionality will not be available.
   Use the NVIDIA Container Toolkit to start this container with GPU support; see
   https://docs.nvidia.com/datacenter/cloud-native/ .
                                                                                                                                                                                                                                                                                                                                                                                          NOTE: The SHMEM allocation limit is set to the default of 64MB.  This may be
   insufficient for CUDA.  NVIDIA recommends the use of the following flags:
   docker run --gpus all --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 ...

Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```
