### PR TITLE
Workaround for current CI instability (#835)

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -48,6 +48,7 @@ env:
   NIXL_INSTALL_DIR: /opt/nixl
   TEST_TIMEOUT: 30
   NPROC: "16"
+  UCX_TLS: "^shm"
 
 steps:
   - name: Build


### PR DESCRIPTION
Cherry-pick of #835

## What?
* Disables UCX shared memory transports
* Disables broken DGX node

## Why?
Fixes flaky issues in CI.