### PR TITLE
Fix libfabric double-release and resource cleanup issues (#839)

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -43,6 +43,11 @@
 #define NIXL_LIBFABRIC_DATA_REQUESTS_PER_RAIL 1024 // WRITE/read operations (no buffers)
 #define NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE 8192
 
+// Retry configuration constants
+#define NIXL_LIBFABRIC_MAX_RETRIES 10
+#define NIXL_LIBFABRIC_EFA_RETRY_DELAY_US 100
+#define NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US 1000
+
 // The immediate data associated with an RDMA operation is 32 bits and is divided as follows:
 // | 4-bit MSG TYPE flag | 8-bit agent index | 16-bit XFER_ID | 4-bit SEQ_ID |
 

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -210,7 +210,11 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                     req);
         }
         if (status != NIXL_SUCCESS) {
+            // Release the allocated request back to pool on failure
             data_rails_[rail_id]->releaseRequest(req);
+            NIXL_ERROR << "Failed to submit "
+                       << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
+                       << rail_id << ", request released";
             return status;
         }
 
@@ -283,7 +287,11 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(nixlLibfabricReq::OpType op_t
                                                         req);
             }
             if (status != NIXL_SUCCESS) {
+                // This request failed to submit - release it immediately
                 data_rails_[rail_id]->releaseRequest(req);
+                NIXL_ERROR << "Failed to submit "
+                           << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
+                           << rail_id << ", request released";
                 return status;
             }
 
@@ -602,6 +610,7 @@ nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Failed to send control message type " << static_cast<int>(msg_type)
                    << " on control rail " << control_rail_id;
+        // Release the pre-allocated control request back to pool on failure
         control_rails_[control_rail_id]->releaseRequest(req);
         return status;
     }


### PR DESCRIPTION
Cherry-pick of #839

## What?

Fix libfabric backend retry failures in test_nixl_bindings.py some of the tests are failing execution with memory double free error.

## Why?

Currently fi_writedata retry logic only existis with tcp provider.
Upon inspection, we found that we need to do retries even with efa provider.
 
## How?

This PR implements retires with EFA provider and address some potential double free resources.
