### PR TITLE
Add nixl-admins to code owners for .ci scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # CI/CD
 /.github/ @ai-dynamo/Devops @ai-dynamo/nixl-devops
-/.ci/ @ai-dynamo/nixl-devops
+/.ci/ @ai-dynamo/nixl-devops @ai-dynamo/nixl-admins
 CODEOWNERS @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
 
 # Legal


### PR DESCRIPTION
## What?
NIXL Admins should also be code owners for CI scripts

## Why?
Unblock approval process when devops team is unavailable
