### PR TITLE
nixlbench: Make etcd optional for storage backends

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -97,7 +97,7 @@ DEFINE_int32(gds_mt_num_threads, 1, "Number of threads used by GDS MT plugin (De
 // For example- 0:mlx5_0,mlx5_1,mlx5_2,1:mlx5_3,mlx5_4, ...
 DEFINE_string(device_list, "all", "Comma-separated device name to use for \
 		      communication (only used with nixl worker)");
-DEFINE_string(etcd_endpoints, "http://localhost:2379", "ETCD server endpoints for communication");
+DEFINE_string(etcd_endpoints, "", "ETCD server endpoints for communication (optional for storage backends)");
 
 // POSIX options - only used when backend is POSIX
 DEFINE_string (posix_api_type,
@@ -279,6 +279,13 @@ xferBenchConfig::loadFromFlags() {
     posix_api_type = FLAGS_posix_api_type;
     storage_enable_direct = FLAGS_storage_enable_direct;
 
+    // Validate ETCD configuration
+    if (!isStorageBackend() && etcd_endpoints.empty()) {
+        // For non-storage backends, set default ETCD endpoint
+        etcd_endpoints = "http://localhost:2379";
+        std::cout << "Using default ETCD endpoint for non-storage backend: " << etcd_endpoints << std::endl;
+    }
+
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {
         if (!((XFERBENCH_SEG_TYPE_VRAM == initiator_seg_type) &&
               (XFERBENCH_SEG_TYPE_VRAM == target_seg_type) &&
@@ -373,7 +380,11 @@ xferBenchConfig::printConfig() {
     printSeparator('*');
     printOption("Runtime (--runtime_type=[etcd])", runtime_type);
     if (runtime_type == XFERBENCH_RT_ETCD) {
-        printOption("ETCD Endpoint ", etcd_endpoints);
+        if (etcd_endpoints.empty()) {
+            printOption("ETCD Endpoint ", "disabled (storage backend)");
+        } else {
+            printOption("ETCD Endpoint ", etcd_endpoints);
+        }
     }
     printOption("Worker type (--worker_type=[nixl,nvshmem])", worker_type);
     if (worker_type == XFERBENCH_WORKER_NIXL) {

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -97,7 +97,9 @@ DEFINE_int32(gds_mt_num_threads, 1, "Number of threads used by GDS MT plugin (De
 // For example- 0:mlx5_0,mlx5_1,mlx5_2,1:mlx5_3,mlx5_4, ...
 DEFINE_string(device_list, "all", "Comma-separated device name to use for \
 		      communication (only used with nixl worker)");
-DEFINE_string(etcd_endpoints, "", "ETCD server endpoints for communication (optional for storage backends)");
+DEFINE_string(etcd_endpoints,
+              "",
+              "ETCD server endpoints for communication (optional for storage backends)");
 
 // POSIX options - only used when backend is POSIX
 DEFINE_string (posix_api_type,
@@ -283,7 +285,8 @@ xferBenchConfig::loadFromFlags() {
     if (!isStorageBackend() && etcd_endpoints.empty()) {
         // For non-storage backends, set default ETCD endpoint
         etcd_endpoints = "http://localhost:2379";
-        std::cout << "Using default ETCD endpoint for non-storage backend: " << etcd_endpoints << std::endl;
+        std::cout << "Using default ETCD endpoint for non-storage backend: " << etcd_endpoints
+                  << std::endl;
     }
 
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -748,6 +748,7 @@ int
 xferBenchNixlWorker::exchangeMetadata() {
     int meta_sz, ret = 0;
 
+    // Skip metadata exchange for storage backends or when ETCD is not available
     if (xferBenchConfig::isStorageBackend()) {
         return 0;
     }
@@ -1054,6 +1055,12 @@ xferBenchNixlWorker::poll(size_t block_size) {
 
 int
 xferBenchNixlWorker::synchronizeStart() {
+    // For storage backends without ETCD, no synchronization needed
+    if (xferBenchConfig::isStorageBackend() && xferBenchConfig::etcd_endpoints.empty()) {
+        std::cout << "Single instance storage backend - no synchronization needed" << std::endl;
+        return 0;
+    }
+
     if (IS_PAIRWISE_AND_SG()) {
         std::cout << "Waiting for all processes to start... (expecting " << rt->getSize()
                   << " total: " << xferBenchConfig::num_initiator_dev << " initiators and "

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -31,16 +31,41 @@ public:
 
     virtual ~xferBenchNullRT() {}
 
-    virtual int sendInt(int *buffer, int dest_rank) override { return 0; }
-    virtual int recvInt(int *buffer, int src_rank) override { return 0; }
-    virtual int broadcastInt(int *buffer, size_t count, int root_rank) override { return 0; }
-    virtual int sendChar(char *buffer, size_t count, int dest_rank) override { return 0; }
-    virtual int recvChar(char *buffer, size_t count, int src_rank) override { return 0; }
-    virtual int reduceSumDouble(double *local_value, double *global_value, int dest_rank) override {
+    virtual int
+    sendInt(int *buffer, int dest_rank) override {
+        return 0;
+    }
+
+    virtual int
+    recvInt(int *buffer, int src_rank) override {
+        return 0;
+    }
+
+    virtual int
+    broadcastInt(int *buffer, size_t count, int root_rank) override {
+        return 0;
+    }
+
+    virtual int
+    sendChar(char *buffer, size_t count, int dest_rank) override {
+        return 0;
+    }
+
+    virtual int
+    recvChar(char *buffer, size_t count, int src_rank) override {
+        return 0;
+    }
+
+    virtual int
+    reduceSumDouble(double *local_value, double *global_value, int dest_rank) override {
         *global_value = *local_value;
         return 0;
     }
-    virtual int barrier(const std::string& barrier_id) override { return 0; }
+
+    virtual int
+    barrier(const std::string &barrier_id) override {
+        return 0;
+    }
 };
 
 static xferBenchRT *createRT(int *terminate) {

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -21,7 +21,35 @@
 
 #include <unistd.h>
 
+// Null runtime for storage backends that don't need ETCD
+class xferBenchNullRT : public xferBenchRT {
+public:
+    xferBenchNullRT() {
+        setSize(1);
+        setRank(0);
+    }
+
+    virtual ~xferBenchNullRT() {}
+
+    virtual int sendInt(int *buffer, int dest_rank) override { return 0; }
+    virtual int recvInt(int *buffer, int src_rank) override { return 0; }
+    virtual int broadcastInt(int *buffer, size_t count, int root_rank) override { return 0; }
+    virtual int sendChar(char *buffer, size_t count, int dest_rank) override { return 0; }
+    virtual int recvChar(char *buffer, size_t count, int src_rank) override { return 0; }
+    virtual int reduceSumDouble(double *local_value, double *global_value, int dest_rank) override {
+        *global_value = *local_value;
+        return 0;
+    }
+    virtual int barrier(const std::string& barrier_id) override { return 0; }
+};
+
 static xferBenchRT *createRT(int *terminate) {
+    // For storage backends without ETCD endpoints, use null runtime
+    if (xferBenchConfig::isStorageBackend() && xferBenchConfig::etcd_endpoints.empty()) {
+        std::cout << "Using null runtime for storage backend without ETCD" << std::endl;
+        return new xferBenchNullRT();
+    }
+
     if (XFERBENCH_RT_ETCD == xferBenchConfig::runtime_type) {
         int total = 2;
         if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
@@ -46,6 +74,11 @@ static xferBenchRT *createRT(int *terminate) {
 }
 
 int xferBenchWorker::synchronize() {
+    // For storage backends without ETCD, no synchronization needed
+    if (xferBenchConfig::isStorageBackend() && xferBenchConfig::etcd_endpoints.empty()) {
+        return 0;
+    }
+
     if (rt->barrier("sync") != 0) {
         std::cerr << "Failed to synchronize" << std::endl;
         // assuming this is a fatal error, continue benchmarking after synchronization failure does
@@ -67,7 +100,10 @@ xferBenchWorker::xferBenchWorker(int *argc, char ***argv) {
 
     int rank = rt->getRank();
 
-    if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
+    // For storage backends without ETCD, always act as initiator
+    if (xferBenchConfig::isStorageBackend() && xferBenchConfig::etcd_endpoints.empty()) {
+        name = "initiator";
+    } else if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
         if (rank >= 0 && rank < xferBenchConfig::num_initiator_dev) {
             name = "initiator";
         } else {


### PR DESCRIPTION
## What?
Make etcd runtime optional when running storage backends for nixlbench. 

## Why?
Storage backends run in loopback mode and do not exchange metadata between instances. This makes etcd endpoints optional for storage. Nixlbench for storage backends can still be run with etcd to synchronize across multiple instances if required.

## How?
Allows simple nixlbench instances to run quickly without starting an etcd server.