### PR TITLE
Add NIXL maintainers to libfabric code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,6 @@ CODEOWNERS @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
 /benchmark @aranadive @ovidiusm @brminich
 
 # Libfabric Plugins
-/src/plugins/libfabric* @yexiang-aws @akkart-aws
-/src/utils/libfabric @yexiang-aws @akkart-aws
-/test/unit/utils/libfabric @yexiang-aws @akkart-aws
+/src/plugins/libfabric* @yexiang-aws @akkart-aws @ai-dynamo/nixl-maintainers
+/src/utils/libfabric @yexiang-aws @akkart-aws @ai-dynamo/nixl-maintainers
+/test/unit/utils/libfabric @yexiang-aws @akkart-aws @ai-dynamo/nixl-maintainers


### PR DESCRIPTION
## Why?
There should be an internal team with rights to approve changes for refactoring purposes
