### PR TITLE
libfabric: Use desc-specific target offset

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1017,7 +1017,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         int gpu_id = local[desc_idx].devId;
 
         NIXL_DEBUG << "Processing descriptor " << desc_idx << " GPU " << gpu_id
-                   << " addr: " << transfer_addr << " size: " << transfer_size;
+                   << " local_addr: " << transfer_addr << " size: " << transfer_size
+                   << " remote_addr: " << (void *)remote[desc_idx].addr;
 
         NIXL_DEBUG << "DEBUG: remote_agent='" << remote_agent << "' localAgent='" << localAgent
                    << "'";
@@ -1053,11 +1054,14 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         }
 
         // Prepare and submit transfer for remote agents
+        // Use descriptor's specific target address
+        uint64_t remote_target_addr = remote[desc_idx].addr;
+
         nixl_status_t status = rail_manager.prepareAndSubmitTransfer(
             op_type,
             transfer_addr,
             transfer_size,
-            remote_md->remote_buf_addr_,
+            remote_target_addr,
             local_md->selected_rails_,
             local_md->rail_mr_list_,
             remote_md->rail_remote_key_list_,


### PR DESCRIPTION
## What?
This fixes a bug in multi-descriptor transfers where descriptors point to different offsets within the same registered memory region.   The bug caused all descriptors to incorrectly use the base address of the registration (`remote_md->remote_buf_addr_`) instead of each descriptor's specific offset address (`remote[desc_idx].addr`).

Impact:  Block-based transfers (Iteration N would read blocks from iteration 0, etc). Also, Scatter-gather operations, Partial buffer updates.

## Why?
Without this fix, RDMA reads always target offset 0.  Should extract each descriptor's specific target address instead.

Example test case:
```
  buffer = allocate_memory(1GB)
  register_memory(buffer)

  # Pass 0: Transfer blocks 0-127
  descriptors = [
      {addr: buffer + 0*block_size, len: block_size},      # Block 0
      {addr: buffer + 1*block_size, len: block_size},      # Block 1
      ...
      {addr: buffer + 127*block_size, len: block_size}     # Block 127
  ]

  # Pass 1: Transfer blocks 128-255
  descriptors = [
      {addr: buffer + 128*block_size, len: block_size},    # Block 128  .... Bug: reads block 0
      {addr: buffer + 129*block_size, len: block_size},    # Block 129  .... Bug: reads block 1
      ...
  ]
```

## How?
After fix: Each descriptor uses `remote[desc_idx].addr` (specific target offset)