### PR TITLE
DEVICE/API: Fix segfault when releasing multiple exported batches on same endpoint

### DIFF
--- a/src/utils/ucx/ucx_utils.h
+++ b/src/utils/ucx/ucx_utils.h
@@ -28,6 +28,7 @@ extern "C"
 #include <nixl_types.h>
 #include "backend/backend_aux.h"
 #include "absl/status/statusor.h"
+#include <map>
 
 enum class nixl_ucx_mt_t {
     SINGLE,
@@ -86,6 +87,7 @@ private:
 public:
     void err_cb(ucp_ep_h ucp_ep, ucs_status_t status);
     void* exported_batch{nullptr};
+    std::map<nixlUcxReq, ucp_batch_h> exported_batches;
 
     nixl_status_t checkTxState() const {
         switch (state) {


### PR DESCRIPTION
## What?
Fix segmentation fault when releasing multiple exported batches on the same UCX endpoint.

## Why?
Single `exported_batch` variable was overwritten by subsequent exports, causing `releaseBatch()` to use wrong batch handle. This caused crashes during elastic training when removing ranks with multiple active batches.

## How?
- Replace single variable with `std::map<nixlUcxReq, ucp_batch_h>` to track multiple batch handles
- Add test `multipleExportReleaseSameEndpoint` that reproduces the bug