### PR TITLE
Fix build conflict: revert enabling tests by default in release builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -251,8 +251,8 @@ plugins_inc_dirs = include_directories('src/plugins')
 utils_inc_dirs = include_directories('src/utils')
 
 subdir('src')
-if get_option('build_tests')
-    subdir('test')
+if get_option('build_tests') and get_option('buildtype') != 'release'
+  subdir('test')
 endif
 if get_option('build_examples')
     subdir('examples')


### PR DESCRIPTION
## What?
Disable building tests in release mode. This was introduced today by #872 but broke several CI pipelines. Not clear why CI run did not catch this, possibly a conflict that was not detected.

## Why?
Release builds are failing with:

```
ninja -C build
ninja: Entering directory `build'
[236/296] Compiling C++ object test/unit/plugins/mooncake/mooncake_backend_test.p/mooncake_backend_test.cpp.o
FAILED: test/unit/plugins/mooncake/mooncake_backend_test.p/mooncake_backend_test.cpp.o
c++ -Itest/unit/plugins/mooncake/mooncake_backend_test.p -Itest/unit/plugins/mooncake -I../test/unit/plugins/mooncake -Isrc/api/cpp -I../src/api/cpp -I../src/api/cpp/backend -Isrc/infra -I../src/infra -Isrc/core -I../src/core -Isrc/utils -I../src/utils -Isrc/plugins/mooncake -I../src/plugins/mooncake -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c++17 -O3 -DHAVE_ETCD -DNDEBUG -Wno-error=maybe-uninitialized -Wno-maybe-uninitialized -pthread -UHAVE_CUDA -MD -MQ test/unit/plugins/mooncake/mooncake_backend_test.p/mooncake_backend_test.cpp.o -MF test/unit/plugins/mooncake/mooncake_backend_test.p/mooncake_backend_test.cpp.o.d -o test/unit/plugins/mooncake/mooncake_backend_test.p/mooncake_backend_test.cpp.o -c ../test/unit/plugins/mooncake/mooncake_backend_test.cpp
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void allocateWrongGPUTest(nixlBackendEngine*, int)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:301:9: error: unused variable ‘ret’ [-Werror=unused-variable]
  301 |     int ret = mooncake->registerMem(desc, VRAM_SEG, md);
      |         ^~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void allocateAndRegister(nixlBackendEngine*, int, nixl_mem_t, void*&, size_t, nixlBackendMD*&)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:323:9: error: unused variable ‘ret’ [-Werror=unused-variable]
  323 |     int ret = mooncake->registerMem(desc, mem_type, md);
      |         ^~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void loadRemote(nixlBackendEngine*, int, std::string, nixl_mem_t, void*, size_t, nixlBackendMD*&, nixlBackendMD*&)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:357:9: error: unused variable ‘ret’ [-Werror=unused-variable]
  357 |     int ret = mooncake->loadRemoteMD(info, mem_type, agent, rmd);
      |         ^~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void test_intra_agent_transfer(bool, nixlBackendEngine*, nixl_mem_t)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:496:19: error: variable ‘ret1’ set but not used [-Werror=unused-but-set-variable]
  496 |     nixl_status_t ret1;
      |                   ^~~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void test_inter_agent_transfer(bool, bool, nixlBackendEngine*, nixl_mem_t, int, nixlBackendEngine*, nixl_mem_t, int)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:619:13: error: unused variable ‘ret3_gen’ [-Werror=unused-variable]
  619 |         int ret3_gen = mooncake2->getNotifs(target_notif_gen);
      |             ^~~~~~~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:579:9: error: variable ‘ret’ set but not used [-Werror=unused-but-set-variable]
  579 |     int ret;
      |         ^~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘std::string memType2Str(nixl_mem_t)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:154:57: error: control reaches end of non-void function [-Werror=return-type]
  154 |         std::cout << "Unsupported memory type!" << std::endl;
      |                                                         ^~~~
../test/unit/plugins/mooncake/mooncake_backend_test.cpp: In function ‘void* getValidationPtr(nixl_mem_t, void*, size_t)’:
../test/unit/plugins/mooncake/mooncake_backend_test.cpp:268:57: error: control reaches end of non-void function [-Werror=return-type]
  268 |         std::cout << "Unsupported memory type!" << std::endl;
      |                                                         ^~~~
cc1plus: all warnings being treated as errors
[239/296] Compiling C++ object test/unit/plugins/gusli/nixl_gusli_test.p/nixl_gusli_test.cpp.o
FAILED: test/unit/plugins/gusli/nixl_gusli_test.p/nixl_gusli_test.cpp.o
c++ -Itest/unit/plugins/gusli/nixl_gusli_test.p -Itest/unit/plugins/gusli -I../test/unit/plugins/gusli -Isrc/api/cpp -I../src/api/cpp -I../src/api/cpp/backend -Isrc/infra -I../src/infra -Isrc/core -I../src/core -Isrc/utils -I../src/utils -Isubprojects/abseil-cpp-20240722.0 -I../subprojects/abseil-cpp-20240722.0 -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c++17 -O3 -DHAVE_ETCD -DNDEBUG -Wno-error=maybe-uninitialized -Wno-maybe-uninitialized -MD -MQ test/unit/plugins/gusli/nixl_gusli_test.p/nixl_gusli_test.cpp.o -MF test/unit/plugins/gusli/nixl_gusli_test.p/nixl_gusli_test.cpp.o.d -o test/unit/plugins/gusli/nixl_gusli_test.p/nixl_gusli_test.cpp.o -c ../test/unit/plugins/gusli/nixl_gusli_test.cpp
../test/unit/plugins/gusli/nixl_gusli_test.cpp: In member function ‘nixl_b_params_t gtest::gen_gusli_plugin_params(const nixlAgent&) const’:
../test/unit/plugins/gusli/nixl_gusli_test.cpp:215:23: error: unused variable ‘ret1’ [-Werror=unused-variable]
  215 |         nixl_status_t ret1 = agent.getPluginParams("GUSLI", mems1, params);
      |                       ^~~~
../test/unit/plugins/gusli/nixl_gusli_test.cpp: In member function ‘int gtest::run_write_read_verify()’:
../test/unit/plugins/gusli/nixl_gusli_test.cpp:424:27: error: unused variable ‘_2nd_plugin’ [-Werror=unused-variable]
  424 |             nixlBackendH *_2nd_plugin = nullptr;
      |                           ^~~~~~~~~~~
../test/unit/plugins/gusli/nixl_gusli_test.cpp:426:18: error: variable ‘init_exception_cought’ set but not used [-Werror=unused-but-set-variable]
  426 |             bool init_exception_cought = false;
      |                  ^~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
[249/296] Compiling C++ object src/bindings/python/_bindings.cpython-312-x86_64-linux-gnu.so.p/nixl_bindings.cpp.o
ninja: build stopped: subcommand failed.
```

since several tests do not build in release mode on some platforms