### PR TITLE
Libfabric: update to efa fabric

### DIFF
--- a/src/utils/libfabric/libfabric_common.cpp
+++ b/src/utils/libfabric/libfabric_common.cpp
@@ -47,7 +47,7 @@ getAvailableNetworkDevices() {
     hints->caps = FI_MSG | FI_RMA; // Basic messaging and RMA
 
     hints->caps |= FI_LOCAL_COMM | FI_REMOTE_COMM;
-    hints->mode = FI_CONTEXT | FI_CONTEXT2;
+    hints->mode = FI_CONTEXT;
     hints->ep_attr->type = FI_EP_RDM;
 
     int ret = fi_getinfo(FI_VERSION(1, 9), NULL, NULL, 0, hints, &info);

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -74,7 +74,7 @@ RequestPool::release(nixlLibfabricReq *req) const {
     req->chunk_offset = 0;
     req->chunk_size = 0;
     req->completion_callback = nullptr;
-    memset(&req->ctx, 0, sizeof(fi_context2));
+    memset(&req->ctx, 0, sizeof(fi_context));
 
     // Use pool_index instead of pointer arithmetic for deque compatibility
     size_t idx = req->pool_index;
@@ -413,7 +413,7 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
     hints->caps = 0;
     hints->caps = FI_MSG | FI_RMA;
     hints->caps |= FI_LOCAL_COMM | FI_REMOTE_COMM;
-    hints->mode = FI_CONTEXT | FI_CONTEXT2;
+    hints->mode = FI_CONTEXT;
     hints->ep_attr->type = FI_EP_RDM;
     // Configure memory registration mode based on provider capabilities
     if (provider == "tcp" || provider == "sockets") {

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -38,7 +38,7 @@ class nixlLibfabricConnection;
  *
  */
 struct nixlLibfabricReq {
-    fi_context2 ctx; ///< Libfabric context for operation tracking
+    fi_context ctx; ///< Libfabric context for operation tracking
     size_t rail_id; ///< Rail ID that owns this request
     size_t pool_index; ///< Index in the pool for deque compatibility
     uint32_t xfer_id; ///< Pre-assigned globally unique transfer ID
@@ -73,7 +73,7 @@ struct nixlLibfabricReq {
           remote_addr(0),
           local_mr(nullptr),
           remote_key(0) {
-        memset(&ctx, 0, sizeof(fi_context2));
+        memset(&ctx, 0, sizeof(fi_context));
     }
 };
 


### PR DESCRIPTION
## What?
Update from efa-direct to efa fabric by removing FI_CONTEXT2 mode

## Why?
In order to support non-GDR instances, we are going to use efa fabric which has cuda memory copy support 