### PR TITLE
DEVICE/API: Return NIXL_IN_PROG from NIXL device post APIs

### DIFF
--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -59,12 +59,13 @@ struct nixlGpuXferReqParams {
  *
  * @param status [in] UCS status code.
  *
- * @return nixl_status_t Corresponding NIXL status code.
+ * @return NIXL_IN_PROG     If the UCS status is not an error.
+ * @return NIXL_ERR_BACKEND If the UCS status is an error.
  */
 __device__ inline nixl_status_t
 nixlGpuConvertUcsStatus(ucs_status_t status) {
     if (!UCS_STATUS_IS_ERR(status)) {
-        return NIXL_SUCCESS;
+        return NIXL_IN_PROG;
     }
     printf("UCX returned error: %d\n", status);
     return NIXL_ERR_BACKEND;
@@ -83,7 +84,8 @@ nixlGpuConvertUcsStatus(ucs_status_t status) {
  * @param xfer_status   [out] Status of the transfer. If not null, use @ref
  *                            nixlGpuGetXferStatus to check for completion.
  *
- * @return nixl_status_t      Error code if call was not successful
+ * @return NIXL_IN_PROG       Transfer posted successfully.
+ * @return NIXL_ERR_BACKEND   An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ nixl_status_t
@@ -115,7 +117,8 @@ nixlGpuPostSingleWriteXferReq(nixlGpuXferReqH req_hndl,
  * @param xfer_status        [out] Status of the transfer. If not null, use @ref
  *                                 nixlGpuGetXferStatus to check for completion.
  *
- * @return nixl_status_t           Error code if call was not successful
+ * @return NIXL_IN_PROG            Transfer posted successfully.
+ * @return NIXL_ERR_BACKEND        An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ nixl_status_t
@@ -152,7 +155,8 @@ nixlGpuPostSignalXferReq(nixlGpuXferReqH req_hndl,
  * @param xfer_status        [out] Status of the transfer. If not null, use @ref
  *                                 nixlGpuGetXferStatus to check for completion.
  *
- * @return nixl_status_t           Error code if call was not successful
+ * @return NIXL_IN_PROG            Transfer posted successfully.
+ * @return NIXL_ERR_BACKEND        An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ nixl_status_t
@@ -198,7 +202,8 @@ nixlGpuPostPartialWriteXferReq(nixlGpuXferReqH req_hndl,
  * @param xfer_status        [out] Status of the transfer. If not null, use @ref
  *                                 nixlGpuGetXferStatus to check for completion.
  *
- * @return nixl_status_t           Error code if call was not successful
+ * @return NIXL_IN_PROG            Transfer posted successfully.
+ * @return NIXL_ERR_BACKEND        An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
 __device__ nixl_status_t


### PR DESCRIPTION
## What?
Change `nixlGpuConvertUcsStatus` to return `NIXL_IN_PROG` instead of `NIXL_SUCCESS` when UCS status is not an error. Update documentation for all GPU post APIs accordingly.

## Why?
UCX can return either `UCS_OK` or `UCS_INPROGRESS` for non-error cases. Checking both values would require an additional branch that degrades performance. Returning `NIXL_IN_PROG` for both cases avoids this branch while still providing the correct semantics.

## How?
Modified the return value in `nixlGpuConvertUcsStatus` and updated `@return` documentation for:
- `nixlGpuConvertUcsStatus`
- `nixlGpuPostSingleWriteXferReq`
- `nixlGpuPostSignalXferReq`
- `nixlGpuPostPartialWriteXferReq`
- `nixlGpuPostWriteXferReq`
