### PR TITLE
nixlbench: Provide remote iovs for other storage backends

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1048,7 +1048,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                         file_offset += block_size;
                         fd_idx = 0;
                     }
-               }
+                }
             }
             res.push_back(remote_iov_list);
         }


### PR DESCRIPTION
Fix the if else when creating remote iovs for storage backends

Ran on lego03:
```
root@lego03:/workspace/nixlbench/build# nixlbench --backend GDS --target_seg_type VRAM --op_type READ --filepath /data --storage_enable_direct=TRUE
WARNING: Adjusting num_iter to 1008 to allow equal distribution to 1 threads
WARNING: Adjusting warmup_iter to 112 to allow equal distribution to 1 threads
Using null runtime for storage backend without ETCD
GDS backend
GDS batch pool size: 32
GDS batch limit: 128
Single instance storage backend - no synchronization needed
Creating file: /data/nixlbench_gds_test_file_initiator_0
File /data/nixlbench_gds_test_file_initiator_0 exists, size: 8589934592
****************************************************************************************************************************************************************
NIXLBench Configuration
****************************************************************************************************************************************************************
Runtime (--runtime_type=[etcd])                             : ETCD
ETCD Endpoint                                               : disabled (storage backend)
Worker type (--worker_type=[nixl,nvshmem])                  : nixl
Backend (--backend=[UCX,UCX_MO,GDS,GDS_MT,POSIX,Mooncake,HF3FS,OBJ]): GDS
Enable pt (--enable_pt=[0,1])                               : 0
Progress threads (--progress_threads=N)                     : 0
Device list (--device_list=dev1,dev2,...)                   : all
Enable VMM (--enable_vmm=[0,1])                             : 0
GDS batch pool size (--gds_batch_pool_size=N)               : 32
GDS batch limit (--gds_batch_limit=N)                       : 128
filepath (--filepath=path)                                  : /data
Number of files (--num_files=N)                             : 1
Storage enable direct (--storage_enable_direct=[0,1])       : 1
Initiator seg type (--initiator_seg_type=[DRAM,VRAM])       : DRAM
Target seg type (--target_seg_type=[DRAM,VRAM])             : VRAM
Scheme (--scheme=[pairwise,manytoone,onetomany,tp])         : pairwise
Mode (--mode=[SG,MG])                                       : SG
Op type (--op_type=[READ,WRITE])                            : READ
Check consistency (--check_consistency=[0,1])               : 0
Total buffer size (--total_buffer_size=N)                   : 8589934592
Num initiator dev (--num_initiator_dev=N)                   : 1
Num target dev (--num_target_dev=N)                         : 1
Start block size (--start_block_size=N)                     : 4096
Max block size (--max_block_size=N)                         : 67108864
Start batch size (--start_batch_size=N)                     : 1
Max batch size (--max_batch_size=N)                         : 1
Num iter (--num_iter=N)                                     : 1008
Warmup iter (--warmup_iter=N)                               : 112
Large block iter factor (--large_blk_iter_ftr=N)            : 16
Num threads (--num_threads=N)                               : 1
----------------------------------------------------------------------------------------------------------------------------------------------------------------

Block Size (B)      Batch Size     B/W (GB/Sec)   Avg Lat. (us)  Avg Prep (us)  P99 Prep (us)  Avg Post (us)  P99 Post (us)  Avg Tx (us)    P99 Tx (us)    
----------------------------------------------------------------------------------------------------------------------------------------------------------------
4096                1              0.178218       23.0           6.0            6.0            0.0            1.0            22.9           127.0          
8192                1              0.280849       29.2           3.0            3.0            0.0            1.0            29.1           133.0          
16384               1              0.378786       43.3           3.0            3.0            0.0            1.0            43.2           147.0          
32768               1              0.461463       71.0           5.0            5.0            0.0            1.0            71.0           173.0          
65536               1              0.528035       124.1          4.0            4.0            0.0            1.0            124.1          223.0          
131072              1              0.361234       362.8          4.0            4.0            0.0            1.0            362.8          432.0          
262144              1              1.901987       137.8          4.0            4.0            0.0            1.0            137.8          225.0          
524288              1              1.086569       482.5          7.0            7.0            0.0            1.0            482.5          490.0          
1048576             1              2.176132       481.9          4.0            4.0            0.0            1.0            481.8          514.0          
2097152             1              2.875812       729.2          4.0            4.0            0.0            1.0            729.1          734.0          
4194304             1              3.897362       1076.2         4.0            4.0            0.0            1.0            1076.0         1083.0         
8388608             1              4.965912       1689.2         4.0            4.0            0.0            1.0            1689.1         1932.0         
16777216            1              6.125875       2738.7         5.0            5.0            0.0            1.0            2738.6         2816.0         
33554432            1              6.260767       5359.5         7.0            7.0            0.1            1.0            5359.2         5605.0         
67108864            1              6.405827       10476.2        6.0            6.0            0.1            1.0            10476.0        10560.0

```