### PR TITLE
updated headers (#903)

### DIFF
--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -16,16 +16,12 @@
  */
 #pragma once
 
-
-#ifdef __cplusplus
-#include <cstdbool>
-#include <cstddef>
-#include <cstdint>
-extern "C" {
-#else
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 // Status codes for our C API


### PR DESCRIPTION
Cherry pick of #903

Fixes exten C markers in Rust headers