### PR TITLE
libfabric: fix asymmetrical rails for heterogeneous node types. (#908)

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -96,9 +96,15 @@ private:
     std::shared_ptr<nixlLibfabricConnection> conn_; // Connection to remote agent
     std::vector<uint64_t> rail_remote_key_list_; // Remote access keys, one per rail
     std::vector<char *> src_ep_names_; // Source endpoint names, one per rail
+    std::vector<size_t>
+        remote_selected_endpoints_; // Remote rails selected, derived from rail_remote_key_list_.
 
 public:
     nixlLibfabricPublicMetadata() : nixlBackendMD(false) {}
+
+    void
+    derive_remote_selected_endpoints();
+
     friend class nixlLibfabricEngine;
 };
 
@@ -107,8 +113,10 @@ class nixlLibfabricConnection : public nixlBackendConnMD {
 private:
     size_t agent_index_; // Unique agent identifier in agent_names vector
     std::string remoteAgent_; // Remote agent name
-    std::vector<fi_addr_t> rail_remote_addr_list_; // Data rail libfabric addresses
-    std::vector<fi_addr_t> control_rail_remote_addr_list_; // Control rail libfabric addresses
+    std::unordered_map<size_t, std::vector<fi_addr_t>>
+        rail_remote_addr_list_; // Data rail libfabric addresses. Key: data rail id.
+    std::unordered_map<size_t, std::vector<fi_addr_t>>
+        control_rail_remote_addr_list_; // Control rail libfabric addresses. Key: control rail id.
     std::vector<char *> src_ep_names_; // Data rail endpoint names
     std::vector<char *> control_ep_names_; // Control rail endpoint names
     ConnectionState overall_state_; // Current connection state


### PR DESCRIPTION
Cherry-pick of #908

This change:
 - passes the number of rail endpoints to others via serialization,
 - added all remote endpoints for each local rails into addresses,
 - round-robin pick local rails and remote endpoints for data transfer.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
