### PR TITLE
UCX: Pin version to fix transfer issues on GB300 with CUDA 13

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -35,7 +35,7 @@ ARCH=$(uname -m)
 WHL_BASE=manylinux_2_39
 WHL_PLATFORM=${WHL_BASE}_${ARCH}
 WHL_PYTHON_VERSIONS="3.12"
-UCX_REF=${UCX_REF:-v1.19.0}
+UCX_REF=${UCX_REF:-b14d7f1ef69f7933d542fad67cabe7ecde0d39f0}
 OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 


### PR DESCRIPTION
## What?
Pin UCX version to pick up fixes for GB 300 on CUDA 13.

## Why?
VRAM-to-DRAM transfers fail with:

```
VRAM-to-DRAM READ:
[1760048752.141287] proto_reconfig.c:60   UCX  ERROR cannot find remote protocol for: ucp_context_0 inter-node cfg#2 | get(multi) into cuda/GPU0 from host
NIXL Xfer failed with status: NIXL_ERR_CANCELED

VRAM-to-DRAM WRITE:
[1760052428.331649] proto_reconfig.c:60   UCX  ERROR cannot find remote protocol for: ucp_context_0 inter-node cfg#2 | put(multi) from cuda/GPU0 to host
NIXL Xfer failed with status: NIXL_ERR_CANCELED
```

## How?
Pin to latest version that included the fix https://github.com/openucx/ucx/pull/10954. This will be picked up in the artifacts creation pipeline.