### PR TITLE
nixlbench: Fix gusli parameters (#910)

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -191,6 +191,21 @@ class xferBenchConfig {
         isStorageBackend();
 };
 
+// Shared GUSLI device config used by utils and nixl_worker
+struct GusliDeviceConfig {
+    int device_id;
+    char device_type; // 'F' for file, 'K' for kernel device, 'N' for networked server
+    std::string device_path;
+    std::string security_flags;
+};
+
+// Parser for GUSLI device list: "id:type:path,id:type:path,..."
+// security_list: comma-separated security flags; num_devices: expected device count (validation)
+std::vector<GusliDeviceConfig>
+parseGusliDeviceList(const std::string &device_list,
+                     const std::string &security_list,
+                     int num_devices);
+
 // Timer class for measuring durations at high resolution
 class xferBenchTimer {
 public:

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -35,12 +35,7 @@ struct xferFileState {
     uint64_t offset;
 };
 
-struct GusliDeviceConfig {
-    int device_id;
-    char device_type; // 'F' for file, 'K' for kernel device
-    std::string device_path;
-    std::string security_flags;
-};
+// Use shared GusliDeviceConfig and parseGusliDeviceList declared in utils.h
 
 class xferBenchNixlWorker: public xferBenchWorker {
     private:


### PR DESCRIPTION
Cherry-pick of #910

---

## What?
 - Fix GUSLI parameter handling and device selection in nixlbench.
 - Strengthen R/W consistency checks for GUSLI, especially READ behavior.
 - Refactor: move GUSLI file parsing into shared utilities.
 - Apply targeted cleanups in nixl_worker.

## Why?
 - Hardcoded device id led to incorrect device selection.
 - Consistency checks needed reliable validation for file READ/WRITE paths.
 - Centralizing parsing avoids duplication and enables reuse in consistency checks.
 - Cleanup improves maintainability and clarity around GUSLI flows.

## How?
 - Moved GUSLI file parser logic to benchmark/nixlbench/src/utils/utils.{h,cpp} and updated call sites.
 - Adjusted benchmark/nixlbench/src/worker/nixl/nixl_worker.{h,cpp} to use the new utils.
 - For READ consistency checks, pre-create the file and write data before validation.
 - Removed hardcoded dev id; corrected parameter handling for proper device selection.
 - Applied GUSLI-related fixes and general code cleanup in nixl_worker.cpp.
