### PR TITLE
nixlbench: Fix gusli parameters (#910)

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -191,6 +191,21 @@ class xferBenchConfig {
         isStorageBackend();
 };
 
+// Shared GUSLI device config used by utils and nixl_worker
+struct GusliDeviceConfig {
+    int device_id;
+    char device_type; // 'F' for file, 'K' for kernel device, 'N' for networked server
+    std::string device_path;
+    std::string security_flags;
+};
+
+// Parser for GUSLI device list: "id:type:path,id:type:path,..."
+// security_list: comma-separated security flags; num_devices: expected device count (validation)
+std::vector<GusliDeviceConfig>
+parseGusliDeviceList(const std::string &device_list,
+                     const std::string &security_list,
+                     int num_devices);
+
 // Timer class for measuring durations at high resolution
 class xferBenchTimer {
 public:

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -35,12 +35,7 @@ struct xferFileState {
     uint64_t offset;
 };
 
-struct GusliDeviceConfig {
-    int device_id;
-    char device_type; // 'F' for file, 'K' for kernel device
-    std::string device_path;
-    std::string security_flags;
-};
+// Use shared GusliDeviceConfig and parseGusliDeviceList declared in utils.h
 
 class xferBenchNixlWorker: public xferBenchWorker {
     private:


### PR DESCRIPTION
* nixlbench: Fix gusli parameters

Fix the hardcoded dev id. Fix consistency check for GUSLI R/W for file. The GUSLI file parser logic is moved to utils since utils will also use it when checking for consistency. For consistency check for READ operation, we pre-create the file and write data to it. Add a workaround for GUSLI resetting DRAM when registering memory.
