### PR TITLE
CI: Enable DGX node

### DIFF
--- a/.ci/docs/setup_nvidia_gpu_with_rdma_support_on_ubuntu.md
+++ b/.ci/docs/setup_nvidia_gpu_with_rdma_support_on_ubuntu.md
@@ -34,7 +34,10 @@ sudo reboot
 If running on nvlink hosts like DGX we should also install fabric manager
 ```bash
 sudo apt install nvidia-fabricmanager-<version> # should be same as kernel version nvidia-fabricmanager-575
+sudo systemctl enable --now nvidia-fabricmanager
 ```
+
+**Important**: On NVSwitch-enabled systems (DGX A100, H100), `nvidia-fabricmanager` must be running before GPU initialization. Without it, CUDA will fail with "system not yet initialized" errors. Ensure the service is enabled at boot.
 
 Verify with `nvidia-smi`. Driver compatibility is critical for RDMA support[^1_1][^1_3].
 

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -25,7 +25,7 @@ timeout_minutes: 240
 # label is defined at jenkins slave configuration, we want to run the job on a gpu agent and be able to esaly replace it without having to change this file
 runs_on_agents:
   - {nodeLabel: 'H100'}
-  # - {nodeLabel: 'DGX'}
+  - {nodeLabel: 'DGX'}
 
 matrix:
   axes:


### PR DESCRIPTION
## What?
Enable DGX node in CI

## Why?
MTU changes were done on the switch and the node.
Test if it resolves networking failures while fetching packages.
