### PR TITLE
adding user defined callback to peer metadata removal from etcd

### DIFF
--- a/src/api/cpp/nixl_params.h
+++ b/src/api/cpp/nixl_params.h
@@ -61,6 +61,19 @@ class nixlAgentConfig {
          */
         std::chrono::microseconds etcdWatchTimeout;
 
+
+        /**
+         * @var ETCD deletion callback
+         *      Callback function to be called when a remote agent's etcd key is deleted
+         */
+        nixl_etcd_deletion_callback_t etcd_deletion_callback;
+        /**
+         * @var ETCD deletion callback user data
+         *      User data to be passed to the deletion callback function
+         */
+        void* const etcd_deletion_callback_user_data;
+
+
         /**
          * @brief  Agent configuration constructor for enabling various features.
          * @param use_prog_thread    flag to determine use of progress thread
@@ -72,6 +85,8 @@ class nixlAgentConfig {
          * @param lthr_delay_us      Optional delay for listener thread in us
          * @param capture_telemetry  Optional flag to enable telemetry capture
          * @param etcd_watch_timeout Optional timeout for etcd watch operations in microseconds
+         * @param etcd_deletion_callback Callback function to be called when a remote agent's etcd key is deleted
+         * @param etcd_deletion_callback_user_data User data to be passed to the deletion callback function
          */
         nixlAgentConfig(const bool use_prog_thread,
                         const bool use_listen_thread = false,
@@ -82,7 +97,9 @@ class nixlAgentConfig {
                         const uint64_t lthr_delay_us = 100000,
                         const bool capture_telemetry = false,
                         const std::chrono::microseconds &etcd_watch_timeout =
-                            std::chrono::microseconds(5000000))
+                            std::chrono::microseconds(5000000),
+                        const nixl_etcd_deletion_callback_t &etcd_deletion_callback = nullptr,
+                        void* etcd_deletion_callback_user_data = nullptr)
             : useProgThread(use_prog_thread),
               useListenThread(use_listen_thread),
               listenPort(port),
@@ -90,7 +107,9 @@ class nixlAgentConfig {
               captureTelemetry(capture_telemetry),
               pthrDelay(pthr_delay_us),
               lthrDelay(lthr_delay_us),
-              etcdWatchTimeout(etcd_watch_timeout) {}
+              etcdWatchTimeout(etcd_watch_timeout),
+              etcd_deletion_callback(etcd_deletion_callback),
+              etcd_deletion_callback_user_data(etcd_deletion_callback_user_data) {}
 
         /**
          * @brief Copy constructor for nixlAgentConfig object

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <optional>
 #include <chrono>
+#include <functional>
 
 
 /*** Forward declarations ***/
@@ -278,6 +279,11 @@ struct nixlXferTelemetry {
  *        for telemetry output.
  */
 using nixl_xfer_telem_t = nixlXferTelemetry;
+
+/**
+ * @brief A typedef for a function to be called when a remote agent's etcd key is deleted
+ */
+using nixl_etcd_deletion_callback_t = std::function<nixl_status_t(const std::string &remote_agent,void* user_data)>;
 
 /**
  * @brief A define for an empty string, that indicates the descriptor list is being


### PR DESCRIPTION
## What?
Giving the user the option to define a callback for the peer's metadata removal from the ETCD.

## Why?
Current implementation has a race in resource release flow: When a peer removes its metadata from the ETCD, NIXL automatically invalidates cached MD, but the upper layers are not aware of this invalidation and will try to release requests to connections that were already invalidated.

## How?
Allowing the user to install a customized callback so he can decide what actions to do upon peer metadata removal from ETCD (releasing transfer requests, invalidating the cached MD, etc.).
