### PR TITLE
Revert: UCX: Pin version to fix transfer issues on GB300 with CUDA 13 (#934)

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -35,7 +35,7 @@ ARCH=$(uname -m)
 WHL_BASE=manylinux_2_39
 WHL_PLATFORM=${WHL_BASE}_${ARCH}
 WHL_PYTHON_VERSIONS="3.12"
-UCX_REF=${UCX_REF:-b14d7f1ef69f7933d542fad67cabe7ecde0d39f0}
+UCX_REF=${UCX_REF:-v1.19.0}
 OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 


### PR DESCRIPTION
Cherry pick of #934

## Why?
UCX build fails with CUDA 12.9.

We will bump UCX version once the issue is fixed.