### PR TITLE
Remove Libfabric dependencies from wheel (#935)

### DIFF
--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -86,7 +86,7 @@ uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
 # Bundle libraries
 uv pip install auditwheel patchelf
 
-uv run auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' $TMP_DIR/nixl-*.whl --plat $WHL_PLATFORM --wheel-dir $OUTPUT_DIR
+uv run auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' $TMP_DIR/nixl-*.whl --plat $WHL_PLATFORM --wheel-dir $OUTPUT_DIR
 
 uv run ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $OUTPUT_DIR/*.whl
 


### PR DESCRIPTION
Cherry pick of #935

## What?
Adjust wheel library filter to exclude Libfabric dependency libraries.

## Why?
Libfabric plugin was pulling its dependencies in to wheel. We recommend to manage Libfabric for using EFA through the EFA installer