### PR TITLE
Bindings: Make nixl depend on nixl-cu12

### DIFF
--- a/src/bindings/python/nixl-meta/pyproject.toml.in
+++ b/src/bindings/python/nixl-meta/pyproject.toml.in
@@ -24,7 +24,7 @@ description = "Meta package for nixl CUDA variants"
 readme = "README.md"
 requires-python = ">=3.9"
 
-dependencies = []
+dependencies = ["nixl-cu12>=@VERSION@"]
 
 [project.optional-dependencies]
 cu12 = ["nixl-cu12>=@VERSION@"]


### PR DESCRIPTION
## What?
Make `nixl-cu12` a required dependency of `nixl`.

## Why?
To improve user experience, `pip install nixl` will automatically pull `nixl-cu12` dependency, so requirements.txt / pyproject.toml do not have to change for existing users of nixl / CUDA 12.

To use nixl with CUDA 13, users still have to run `pip install nixl[cu13]` or `pip install nixl-cu13`. The CUDA 13 package has higher priority when imported when both are installed.