### PR TITLE
nixlbench: Allow compilation when etcd is not available (#953)

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -185,10 +185,6 @@ if nvshmem_available
     ]
 endif
 
-if not etcd_available
-    error('No runtime available or not found')
-endif
-
 if nvshmem_available
     # Use nvcc directly for compilation and linking
     nvcc = find_program('nvcc')

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -75,6 +75,7 @@ static xferBenchRT *createRT(int *terminate) {
         return new xferBenchNullRT();
     }
 
+#if HAVE_ETCD
     if (XFERBENCH_RT_ETCD == xferBenchConfig::runtime_type) {
         int total = 2;
         if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
@@ -93,6 +94,7 @@ static xferBenchRT *createRT(int *terminate) {
         }
         return etcd_rt;
     }
+#endif
 
     std::cerr << "Invalid runtime: " << xferBenchConfig::runtime_type << std::endl;
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Cherry-pick of #953.

The code already handled running without etcd, but now allow it to compile without etcd.