### PR TITLE
Telemetry exporter plug-in infra

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -40,6 +40,8 @@ export CPATH=${INSTALL_DIR}/include:$CPATH
 export PATH=${INSTALL_DIR}/bin:$PATH
 export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
+export NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins/telemetry/buffer
+export NIXL_TELEMETRY_EXPORTER=buffer
 
 echo "==== Show system info ===="
 env
@@ -69,7 +71,7 @@ fi
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
 mkdir -p /tmp/telemetry_test
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test ./bin/agent_example &
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH=/tmp/telemetry_test ./bin/agent_example &
 sleep 1
 ./bin/telemetry_reader /tmp/telemetry_test/Agent001 &
 telePID=$!

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -37,6 +37,8 @@ export PATH=${INSTALL_DIR}/bin:$PATH
 export PKG_CONFIG_PATH=${INSTALL_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 export NIXL_PREFIX=${INSTALL_DIR}
+export NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins/telemetry/buffer
+export NIXL_TELEMETRY_EXPORTER=buffer
 # Raise exceptions for logging errors
 export NIXL_DEBUG_LOGGING=yes
 
@@ -98,7 +100,7 @@ mkdir -p /tmp/telemetry_test
 
 python3 blocking_send_recv_example.py --mode="target" --ip=127.0.0.1 --port="$blocking_send_recv_port"&
 sleep 5
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test \
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH=/tmp/telemetry_test \
 python3 blocking_send_recv_example.py --mode="initiator" --ip=127.0.0.1 --port="$blocking_send_recv_port"
 
 python3 telemetry_reader.py --telemetry_path /tmp/telemetry_test/initiator &

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -2,15 +2,16 @@
 
 ## Overview
 
-The NIXL telemetry system provides real-time monitoring and performance tracking capabilities for NIXL applications. It collects various metrics and events during runtime and stores them in shared memory buffers that can be read by telemetry reader applications.
+The NIXL telemetry system provides real-time monitoring and performance tracking capabilities for NIXL applications. It collects various metrics and events during runtime and exports them through customizable plug-ins
 
 ## Architecture
 
 ### Telemetry Components
 
 1. **Telemetry Collection**: Built into the NIXL core library, collects events and metrics
-2. **Shared Memory Buffer**: Cyclic buffer implementation for efficient event storage
+2. **Shared Memory Buffer exporter**: Cyclic buffer exporter implementation for efficient event storage. [See Buffer Exporter README](../src/plugins/telemetry/buffer/README.md)
 3. **Telemetry Readers**: C++ and Python applications to read and display telemetry data
+4. **Prometheus exporter**: Prometheus compitable exporter. [See Prometheus Exporter README](../src/plugins/telemetry/prometheus/README.md)
 
 ### Event Structure
 
@@ -44,57 +45,10 @@ Telemetry is controlled by environment variables:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `NIXL_TELEMETRY_ENABLE` | Enable telemetry collection | Disabled |
-| `NIXL_TELEMETRY_DIR` | Directory for telemetry files | - |
 | `NIXL_TELEMETRY_BUFFER_SIZE` | Number of events in buffer | `4096` |
 | `NIXL_TELEMETRY_RUN_INTERVAL` | Flush interval (ms) | `100` |
+| `NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR` | Directory where to look for exporter plug-in | - |
+| `NIXL_TELEMETRY_EXPORTER` | Plugin {name}. Format for plugin lib is libtelemetry_exporter_{name}.so | - |
+| `NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH` | Implementation specific configuration field. (e.g external DB address, path to file) | - |
 
 - NIXL_TELEMETRY_ENABLE can be set to y/yes/on/1 to be enabled, and n/no/off/0 (or not set) to be disabled,
-- If NIXL_TELEMETRY_ENABLE is set to enabled but NIXL_TELEMETRY_DIR is not set, no telemetry file is generated and NIXL_TELEMETRY_RUN_INTERVAL is not used.
-
-## Telemetry File Format
-
-Telemetry data is stored in shared memory files with the agent name passed when creating the agent.
-
-## Using Telemetry Readers
-
-### C++ Telemetry Reader
-
-The C++ telemetry reader (`telemetry_reader.cpp`) provides a robust way to read and display telemetry events.
-
-#### Running the C++ Reader
-
-```bash
-# Read from a specific telemetry file
-./builddir/examples/cpp/telemetry_reader /tmp/agent_name
-```
-
-### Python Telemetry Reader
-
-The Python telemetry reader (`telemetry_reader.py`) provides similar functionality with additional features.
-
-#### Running the Python Reader
-
-```bash
-# Read from a specific telemetry file
-python3 examples/python/telemetry_reader.py --telemetry_path /tmp/agent_name
-```
-
-## Example Output
-
-Both readers produce similar formatted output:
-
-```
-=== NIXL Telemetry Event ===
-Timestamp: 2025-01-15 14:30:25.123456
-Category: TRANSFER
-Event: agent_tx_bytes
-Value: 1048576
-===========================
-
-=== NIXL Telemetry Event ===
-Timestamp: 2025-01-15 14:30:25.124567
-Category: MEMORY
-Event: agent_memory_registered
-Value: 4096
-===========================
-```

--- a/meson.build
+++ b/meson.build
@@ -266,6 +266,10 @@ if get_option('buildtype') == 'debug'
     add_project_arguments('-DNIXL_USE_PLUGIN_FILE="' + plugin_build_dir + '/pluginlist"',  language: 'cpp')
     plugfile = join_paths(plugin_build_dir, 'pluginlist')
     run_command('truncate', '-s 0', plugfile, check: true)
+
+    add_project_arguments('-DNIXL_USE_TELEMETRY_EXPORTER_PLUGIN_FILE="' + plugin_build_dir + '/telemetry_exporters_list"',  language: 'cpp')
+    telemetry_exporters_file = join_paths(plugin_build_dir, 'telemetry_exporters_list')
+    run_command('truncate', '-s 0', telemetry_exporters_file, check: true)
 endif
 
 nixl_inc_dirs = include_directories('src/api/cpp', 'src/api/cpp/backend', 'src/infra', 'src/core')

--- a/src/api/cpp/telemetry/telemetry_exporter.h
+++ b/src/api/cpp/telemetry/telemetry_exporter.h
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _NIXL_SRC_API_CPP_TELEMETRY_TELEMETRY_EXPORTER_H
+#define _NIXL_SRC_API_CPP_TELEMETRY_TELEMETRY_EXPORTER_H
+
+#include "nixl_types.h"
+#include "telemetry_event.h"
+
+#include <string>
+
+inline constexpr char telemetryExporterVar[] = "NIXL_TELEMETRY_EXPORTER";
+inline constexpr char telemetryExporterPluginDirVar[] = "NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR";
+inline constexpr char telemetryExporterOutputPathVar[] = "NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH";
+
+/**
+ * @struct nixlTelemetryExporterInitParams
+ * @brief Initialization parameters for telemetry exporters
+ */
+struct nixlTelemetryExporterInitParams {
+    std::string outputPath; // Output path (file path, URL, etc.)
+    std::string agentName;
+    size_t maxEventsBuffered;
+};
+
+/**
+ * @class nixlTelemetryExporter
+ * @brief Abstract base class for telemetry exporters
+ *
+ * This class defines the interface that all telemetry exporters must implement.
+ * It provides the core functionality for reading telemetry events and exporting
+ * them to various destinations.
+ */
+class nixlTelemetryExporter {
+public:
+    explicit nixlTelemetryExporter(const nixlTelemetryExporterInitParams &init_params) noexcept
+        : maxEventsBuffered_(init_params.maxEventsBuffered) {};
+    nixlTelemetryExporter(nixlTelemetryExporter &&) = delete;
+    nixlTelemetryExporter(const nixlTelemetryExporter &) = delete;
+
+    void
+    operator=(nixlTelemetryExporter &&) = delete;
+    void
+    operator=(const nixlTelemetryExporter &) = delete;
+
+    virtual ~nixlTelemetryExporter() = default;
+
+    [[nodiscard]] size_t
+    getMaxEventsBuffered() const noexcept {
+        return maxEventsBuffered_;
+    }
+
+    virtual nixl_status_t
+    exportEvent(const nixlTelemetryEvent &event) = 0;
+
+private:
+    const size_t maxEventsBuffered_;
+};
+
+#endif // _TELEMETRY_EXPORTER_H

--- a/src/api/cpp/telemetry/telemetry_plugin.h
+++ b/src/api/cpp/telemetry/telemetry_plugin.h
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _NIXL_SRC_API_CPP_TELEMETRY_TELEMETRY_PLUGIN_H
+#define _NIXL_SRC_API_CPP_TELEMETRY_TELEMETRY_PLUGIN_H
+
+#include "telemetry/telemetry_exporter.h"
+#include "common/nixl_log.h"
+
+#include <string_view>
+#include <memory>
+
+enum class nixl_telemetry_plugin_api_version : unsigned int { V1 = 1 };
+
+inline constexpr nixl_telemetry_plugin_api_version nixlTelemetryPluginApiVersionV1 =
+    nixl_telemetry_plugin_api_version::V1;
+
+// Type alias for exporter creation function
+using exporter_creator_fn_t =
+    std::unique_ptr<nixlTelemetryExporter> (*)(const nixlTelemetryExporterInitParams &init_params);
+
+class nixlTelemetryPlugin {
+public:
+    nixl_telemetry_plugin_api_version api_version;
+    exporter_creator_fn_t create_exporter;
+
+    nixlTelemetryPlugin(nixl_telemetry_plugin_api_version version,
+                        std::string_view name,
+                        std::string_view ver,
+                        exporter_creator_fn_t create) noexcept
+        : api_version(version),
+          create_exporter(create),
+          name_(name),
+          version_(ver) {}
+
+    [[nodiscard]] std::string_view
+    getName() const noexcept {
+        return name_;
+    }
+
+    [[nodiscard]] std::string_view
+    getVersion() const noexcept {
+        return version_;
+    }
+
+private:
+    std::string_view name_;
+    std::string_view version_;
+};
+
+// Macro to define exported C functions for the plugin
+#define NIXL_TELEMETRY_PLUGIN_EXPORT __attribute__((visibility("default")))
+
+// Template for creating backend plugins with minimal boilerplate
+template<typename exporterType> class nixlTelemetryPluginCreator {
+public:
+    static nixlTelemetryPlugin *
+    create(nixl_telemetry_plugin_api_version api_version,
+           std::string_view name,
+           std::string_view version) {
+        static nixlTelemetryPlugin plugin_instance(api_version, name, version, createExporter);
+
+        return &plugin_instance;
+    }
+
+private:
+    static std::unique_ptr<nixlTelemetryExporter>
+    createExporter(const nixlTelemetryExporterInitParams &init_params) {
+        try {
+            return std::make_unique<exporterType>(init_params);
+        }
+        catch (const std::exception &e) {
+            NIXL_ERROR << "Failed to create exporter: " << e.what();
+            return nullptr;
+        }
+    }
+};
+
+// Plugin must implement these functions for dynamic loading
+// Note: extern "C" is required for dynamic loading to avoid C++ name mangling
+extern "C" {
+// Initialize the plugin
+NIXL_TELEMETRY_PLUGIN_EXPORT
+nixlTelemetryPlugin *
+nixl_telemetry_plugin_init();
+
+// Cleanup the plugin
+NIXL_TELEMETRY_PLUGIN_EXPORT
+void
+nixl_telemetry_plugin_fini();
+}
+
+#endif // _NIXL_SRC_API_CPP_TELEMETRY_TELEMETRY_PLUGIN_H

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -116,6 +116,8 @@ class nixlAgentData {
         loadRemoteSections(const std::string &remote_name, nixlSerDes &sd);
         nixl_status_t
         invalidateRemoteData(const std::string &remote_name);
+        void
+        initializeTelemetry(const std::string &name, const nixlAgentConfig &cfg);
 
     public:
         nixlAgentData(const std::string &name, const nixlAgentConfig &cfg);

--- a/src/core/base_plugin_manager.cpp
+++ b/src/core/base_plugin_manager.cpp
@@ -1,0 +1,275 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "base_plugin_manager.h"
+#include "common/nixl_log.h"
+#include <dlfcn.h>
+#include <algorithm>
+
+using lock_guard = const std::lock_guard<std::mutex>;
+
+void
+dlHandleDeleter::operator()(void *handle) const noexcept {
+    if (handle) {
+        // Call cleanup function if specified
+        if (!fini_func_name.empty()) {
+            using fini_func_t = void (*)();
+            fini_func_t fini = reinterpret_cast<fini_func_t>(dlsym(handle, fini_func_name.c_str()));
+            if (fini) {
+                try {
+                    fini();
+                }
+                catch (const std::exception &e) {
+                    NIXL_WARN << "Exception in plugin cleanup (" << fini_func_name
+                              << "): " << e.what();
+                }
+                catch (...) {
+                    NIXL_WARN << "Unknown exception in plugin cleanup (" << fini_func_name << ")";
+                }
+            }
+        }
+
+        dlclose(handle);
+    }
+}
+
+basePluginHandle::basePluginHandle(std::unique_ptr<void, dlHandleDeleter> handle,
+                                   const void *plugin_interface)
+    : dlHandle_(std::move(handle)),
+      pluginInterface_(plugin_interface) {
+    assert(dlHandle_ && "DlHandleDeleter must not be null");
+    assert(pluginInterface_ && "Plugin interface must not be null");
+}
+
+basePluginManager::basePluginManager(pluginConfig config) : config_(std::move(config)) {}
+
+plugin_load_result<void>
+basePluginManager::loadPluginFromPathInternal(const std::filesystem::path &plugin_path) {
+    plugin_load_result<void> result;
+
+    dlHandleDeleter deleter(config_.finiFuncName);
+    std::unique_ptr<void, dlHandleDeleter> handle(
+        dlopen(plugin_path.c_str(), RTLD_NOW | RTLD_LOCAL), deleter);
+
+    if (!handle) {
+        result = failure_result{std::string("Failed to dlopen: ") + dlerror()};
+        NIXL_ERROR << "Failed to load plugin from " << plugin_path << ": "
+                   << std::get<failure_result>(result).message;
+        return result;
+    }
+
+    using init_func_t = void *(*)();
+    init_func_t init =
+        reinterpret_cast<init_func_t>(dlsym(handle.get(), config_.initFuncName.c_str()));
+
+    if (!init) {
+        result = failure_result{std::string("Failed to find ") + config_.initFuncName + ": " +
+                                dlerror()};
+        NIXL_ERROR << "Failed to find " << config_.initFuncName << " in " << plugin_path << ": "
+                   << std::get<failure_result>(result).message;
+        return result;
+    }
+
+    void *plugin_interface = init();
+    if (!plugin_interface) {
+        result = failure_result{"Plugin initialization returned nullptr"};
+        NIXL_ERROR << "Plugin initialization failed for " << plugin_path;
+        return result;
+    }
+
+    if (!checkApiVersion(plugin_interface)) {
+        result = failure_result{"API version mismatch"};
+        NIXL_ERROR << "Plugin API version mismatch for " << plugin_path;
+        return result;
+    }
+
+    result = success_result<void>{std::move(handle), plugin_interface};
+
+    return result;
+}
+
+std::string
+basePluginManager::extractPluginNameFromFilename(const std::string &filename) const {
+    const auto &prefix = config_.filenamePrefix;
+    const auto &suffix = config_.filenameSuffix;
+
+    const size_t min_length = prefix.size() + suffix.size() + 1; // +1 for at least 1 char name
+    if (filename.size() < min_length) {
+        return "";
+    }
+
+    if (filename.compare(0, prefix.size(), prefix) != 0) {
+        return "";
+    }
+
+    if (filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) != 0) {
+        return "";
+    }
+
+    return filename.substr(prefix.size(), filename.size() - prefix.size() - suffix.size());
+}
+
+std::filesystem::path
+basePluginManager::constructPluginPath(const std::filesystem::path &directory,
+                                       const std::string &plugin_name) const {
+
+    std::string filename = config_.filenamePrefix + plugin_name + config_.filenameSuffix;
+    return directory / filename;
+}
+
+void
+basePluginManager::discoverPluginsFromDir(const std::filesystem::path &dirpath) {
+    std::error_code ec;
+    // Use recursive iterator to find plugins in subdirectories too (for build directories)
+    std::filesystem::recursive_directory_iterator dir_iter(dirpath, ec);
+    if (ec) {
+        NIXL_ERROR << "Error accessing plugin directory(" << dirpath << "): " << ec.message();
+        return;
+    }
+
+    for (const auto &entry : dir_iter) {
+        if (!entry.is_regular_file(ec)) {
+            continue;
+        }
+
+        std::string filename = entry.path().filename().string();
+        std::string plugin_name = extractPluginNameFromFilename(filename);
+
+        if (!plugin_name.empty()) {
+            // Restore old behavior: actually load the plugin during discovery
+            auto plugin = loadPlugin(plugin_name);
+            if (plugin) {
+                NIXL_INFO << "Discovered and loaded plugin: " << plugin_name;
+            }
+        }
+    }
+}
+
+void
+basePluginManager::addPluginDirectory(const std::filesystem::path &directory) {
+    if (directory.empty()) {
+        NIXL_ERROR << "Cannot add empty plugin directory";
+        return;
+    }
+
+    if (!std::filesystem::exists(directory) || !std::filesystem::is_directory(directory)) {
+        NIXL_ERROR << "Plugin directory does not exist or is not readable: " << directory;
+        return;
+    }
+
+    {
+        lock_guard lg(lock_);
+
+        if (std::find(pluginDirs_.begin(), pluginDirs_.end(), directory) != pluginDirs_.end()) {
+            NIXL_WARN << "Plugin directory already registered: " << directory;
+            return;
+        }
+
+        pluginDirs_.insert(pluginDirs_.begin(), directory);
+    }
+
+    NIXL_INFO << "Added plugin directory: " << directory;
+
+    discoverPluginsFromDir(directory);
+}
+
+std::vector<std::filesystem::path>
+basePluginManager::getPluginDirectories() const {
+    lock_guard lg(lock_);
+    return pluginDirs_;
+}
+
+std::shared_ptr<basePluginHandle>
+basePluginManager::loadPluginInternal(const std::string &plugin_name) {
+    lock_guard lg(lock_);
+
+    // Check if the plugin is already loaded
+    auto it = loadedPlugins_.find(plugin_name);
+    if (it != loadedPlugins_.end()) {
+        return it->second;
+    }
+
+    // Try to load the plugin from all registered directories
+    for (const auto &dir : pluginDirs_) {
+        if (dir.empty()) {
+            continue;
+        }
+
+        // Construct expected plugin path in this directory
+        auto plugin_path = constructPluginPath(dir, plugin_name);
+
+        // Skip if plugin file doesn't exist in this directory
+        if (!std::filesystem::exists(plugin_path)) {
+            NIXL_DEBUG << "Plugin not found at: " << plugin_path;
+            continue;
+        }
+
+        // Load the plugin
+        auto result = loadPluginFromPathInternal(plugin_path);
+        if (std::holds_alternative<success_result<void>>(result)) {
+            auto &success = std::get<success_result<void>>(result);
+            auto plugin_handle = createPluginHandle(std::move(success.handle), success.interface);
+
+            if (plugin_handle) {
+                loadedPlugins_.emplace(plugin_name, plugin_handle);
+                NIXL_INFO << "Loaded plugin: " << plugin_name << " (version "
+                          << plugin_handle->getVersion() << ")";
+                onPluginLoaded(plugin_name, success.interface);
+                return plugin_handle;
+            }
+        }
+    }
+
+    // Failed to load the plugin
+    NIXL_ERROR << "Failed to load plugin '" << plugin_name << "' from any directory";
+    return nullptr;
+}
+
+std::shared_ptr<basePluginHandle>
+basePluginManager::getPluginInternal(const std::string &plugin_name) const {
+    lock_guard lg(lock_);
+
+    auto it = loadedPlugins_.find(plugin_name);
+    if (it != loadedPlugins_.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
+void
+basePluginManager::unloadPlugin(const std::string &plugin_name) {
+    // Check if plugin can be unloaded (e.g., not a static plugin)
+    if (!canUnloadPlugin(plugin_name)) {
+        NIXL_DEBUG << "Plugin '" << plugin_name << "' cannot be unloaded";
+        return;
+    }
+
+    lock_guard lg(lock_);
+    loadedPlugins_.erase(plugin_name);
+}
+
+std::vector<std::string>
+basePluginManager::getLoadedPluginNames() const {
+    lock_guard lg(lock_);
+
+    std::vector<std::string> names;
+    names.reserve(loadedPlugins_.size());
+    for (const auto &pair : loadedPlugins_) {
+        names.push_back(pair.first);
+    }
+    return names;
+}

--- a/src/core/base_plugin_manager.h
+++ b/src/core/base_plugin_manager.h
@@ -1,0 +1,281 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BASE_PLUGIN_MANAGER_H
+#define __BASE_PLUGIN_MANAGER_H
+
+#include "common/nixl_log.h"
+
+#include <string>
+#include <vector>
+#include <variant>
+#include <mutex>
+#include <filesystem>
+#include <memory>
+#include <functional>
+#include <map>
+
+/**
+ * Custom deleter for dlopen handles
+ */
+struct dlHandleDeleter {
+    std::string fini_func_name;
+
+    explicit dlHandleDeleter(std::string fini_name = "") : fini_func_name(std::move(fini_name)) {}
+
+    void
+    operator()(void *handle) const noexcept;
+};
+
+struct pluginConfig {
+    std::string initFuncName; // e.g., "nixl_plugin_init"
+    std::string finiFuncName; // e.g., "nixl_plugin_fini"
+    std::string filenamePrefix; // e.g., "libplugin_"
+    std::string filenameSuffix; // e.g., ".so"
+    int expectedApiVersion; // Expected API version for validation
+};
+
+template<typename pluginInterface> struct success_result {
+    std::unique_ptr<void, dlHandleDeleter> handle;
+    pluginInterface *interface;
+};
+
+struct failure_result {
+    std::string message;
+};
+
+template<typename pluginInterface>
+using plugin_load_result = std::variant<failure_result, success_result<pluginInterface>>;
+
+/**
+ * Base class for all plugin handles
+ * Provides common functionality for managing dynamic library handles
+ */
+class basePluginHandle {
+public:
+    virtual ~basePluginHandle() = default;
+
+    basePluginHandle(const basePluginHandle &) = delete;
+    basePluginHandle &
+    operator=(const basePluginHandle &) = delete;
+    basePluginHandle(basePluginHandle &&) = delete;
+    basePluginHandle &
+    operator=(basePluginHandle &&) = delete;
+
+    virtual const char *
+    getName() const = 0;
+    virtual const char *
+    getVersion() const = 0;
+
+    const void *
+    getPluginInterface() const {
+        return pluginInterface_;
+    }
+
+protected:
+    std::unique_ptr<void, dlHandleDeleter> dlHandle_;
+    const void *pluginInterface_;
+
+    basePluginHandle(std::unique_ptr<void, dlHandleDeleter> handle, const void *pluginInterface);
+};
+
+/**
+ * Base plugin manager providing common functionality for all plugin types
+ *
+ * This class implements the common plugin loading, discovery, and management
+ * logic that is shared across different plugin types (backend, telemetry, etc.)
+ */
+class basePluginManager {
+public:
+    virtual ~basePluginManager() = default;
+
+    basePluginManager(const basePluginManager &) = delete;
+    basePluginManager &
+    operator=(const basePluginManager &) = delete;
+
+    /**
+     * Discover and load all plugins from a directory
+     * Searches for files matching the configured pattern
+     */
+    void
+    discoverPluginsFromDir(const std::filesystem::path &dirpath);
+
+    /**
+     * Add a directory to search for plugins
+     * New directory is prioritized over existing ones
+     */
+    void
+    addPluginDirectory(const std::filesystem::path &directory);
+
+    /**
+     * Get all registered plugin directories
+     */
+    std::vector<std::filesystem::path>
+    getPluginDirectories() const;
+
+    /**
+     * Get plugin configuration
+     */
+    const pluginConfig &
+    getConfig() const {
+        return config_;
+    }
+
+    /**
+     * Load a specific plugin by name with automatic type casting
+     * Searches registered directories and loads the plugin if found
+     *
+     * @tparam handleType The specific plugin handle type (defaults to basePluginHandle)
+     * @param plugin_name Name of the plugin to load
+     * @return Typed plugin handle or nullptr if not found or cast fails
+     */
+    template<typename handleType = basePluginHandle>
+    std::shared_ptr<handleType>
+    loadPlugin(const std::string &plugin_name) {
+        auto base_handle = loadPluginInternal(plugin_name);
+        auto typed_handle = std::dynamic_pointer_cast<handleType>(base_handle);
+        if (!typed_handle && base_handle) {
+            NIXL_ERROR << "Failed to cast plugin '" << plugin_name << "' to requested handle type";
+        }
+
+        return typed_handle;
+    }
+
+    /**
+     * Get an already loaded plugin handle with automatic type casting
+     * Returns nullptr if plugin is not loaded
+     *
+     * @tparam handleType The specific plugin handle type (defaults to basePluginHandle)
+     * @param plugin_name Name of the plugin
+     * @return Typed plugin handle or nullptr if not loaded or cast fails
+     */
+    template<typename handleType = basePluginHandle>
+    [[nodiscard]] std::shared_ptr<handleType>
+    getPlugin(const std::string &plugin_name) const {
+        auto base_handle = getPluginInternal(plugin_name);
+        return std::dynamic_pointer_cast<handleType>(base_handle);
+    }
+
+    /**
+     * Load a plugin from a specific file path
+     * Returns typed plugin handle or nullptr if not loaded or cast fails
+     */
+    template<typename handleType = basePluginHandle>
+    std::shared_ptr<handleType>
+    loadPluginFromPath(const std::filesystem::path &plugin_path, const std::string &plugin_name) {
+        auto result = loadPluginFromPathInternal(plugin_path);
+        if (std::holds_alternative<success_result<void>>(result)) {
+            auto &success = std::get<success_result<void>>(result);
+            auto base_handle = createPluginHandle(std::move(success.handle), success.interface);
+            loadedPlugins_.emplace(plugin_name, base_handle);
+            onPluginLoaded(plugin_name, success.interface);
+
+            return std::dynamic_pointer_cast<handleType>(base_handle);
+        }
+        return nullptr;
+    }
+
+    /**
+     * Unload a plugin by name
+     * Does nothing if plugin is not loaded or cannot be unloaded
+     */
+    void
+    unloadPlugin(const std::string &plugin_name);
+
+    /**
+     * Get all loaded plugin names
+     */
+    std::vector<std::string>
+    getLoadedPluginNames() const;
+
+protected:
+    mutable std::mutex lock_;
+    std::map<std::string, std::shared_ptr<basePluginHandle>, std::less<>> loadedPlugins_;
+    explicit basePluginManager(pluginConfig config);
+
+    /**
+     * Internal non-template implementation of loadPluginFromPath
+     */
+    plugin_load_result<void>
+    loadPluginFromPathInternal(const std::filesystem::path &plugin_path);
+
+    /**
+     * Extract plugin name from filename based on configured prefix/suffix
+     * Returns empty string if filename doesn't match pattern
+     */
+    std::string
+    extractPluginNameFromFilename(const std::string &filename) const;
+
+    /**
+     * Construct full plugin path from directory and plugin name
+     */
+    std::filesystem::path
+    constructPluginPath(const std::filesystem::path &directory,
+                        const std::string &plugin_name) const;
+
+    /**
+     * Check if API version matches expected version
+     * Derived classes override to provide specific version checking logic
+     */
+    virtual bool
+    checkApiVersion(void *plugin_interface) const = 0;
+
+    /**
+     * Factory method for creating typed plugin handles
+     * Derived classes override to create their specific handle type
+     */
+    virtual std::shared_ptr<basePluginHandle>
+    createPluginHandle(std::unique_ptr<void, dlHandleDeleter> dl_handle,
+                       void *plugin_interface) = 0;
+
+    /**
+     * Check if a plugin can be unloaded
+     * Derived classes can override to prevent unloading (e.g., static plugins)
+     */
+    virtual bool
+    canUnloadPlugin(const std::string &plugin_name) const {
+        return true; // Default: allow unload
+    }
+
+    /**
+     * Called after successful plugin load - derived classes can do additional setup
+     */
+    virtual void
+    onPluginLoaded(const std::string &plugin_name, void *plugin_interface) {
+        // Default: do nothing
+        (void)plugin_name;
+        (void)plugin_interface;
+    }
+
+    /**
+     * Internal non-template implementation of loadPlugin
+     */
+    std::shared_ptr<basePluginHandle>
+    loadPluginInternal(const std::string &plugin_name);
+
+    /**
+     * Internal non-template implementation of getPlugin
+     */
+    std::shared_ptr<basePluginHandle>
+    getPluginInternal(const std::string &plugin_name) const;
+
+private:
+    std::vector<std::filesystem::path> pluginDirs_;
+    pluginConfig config_;
+};
+
+#endif // __BASE_PLUGIN_MANAGER_H

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -55,9 +55,11 @@ endif
 
 nixl_lib = library('nixl',
                    'nixl_agent.cpp',
+                   'base_plugin_manager.cpp',
                    'nixl_plugin_manager.cpp',
                    'nixl_listener.cpp',
                    'telemetry.cpp',
+                   'telemetry_plugin_manager.cpp',
                    include_directories: [ nixl_inc_dirs, utils_inc_dirs ],
                    link_args: ['-lstdc++fs'],
                    dependencies: nixl_lib_deps,

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -17,7 +17,6 @@
 
 #include "plugin_manager.h"
 #include "nixl.h"
-#include "common/nixl_log.h"
 #include <dlfcn.h>
 #include <filesystem>
 #include <dirent.h>
@@ -31,25 +30,10 @@
 using lock_guard = const std::lock_guard<std::mutex>;
 
 // pluginHandle implementation
-nixlPluginHandle::nixlPluginHandle(void* handle, nixlBackendPlugin* plugin)
-    : handle_(handle), plugin_(plugin) {
-}
-
-nixlPluginHandle::~nixlPluginHandle() {
-    if (handle_) {
-        // Call the plugin's cleanup function
-        typedef void (*fini_func_t)();
-        fini_func_t fini = (fini_func_t) dlsym(handle_, "nixl_plugin_fini");
-        if (fini) {
-            fini();
-        }
-
-        // Close the dynamic library
-        dlclose(handle_);
-        handle_ = nullptr;
-        plugin_ = nullptr;
-    }
-}
+nixlPluginHandle::nixlPluginHandle(std::unique_ptr<void, dlHandleDeleter> handle,
+                                   nixlBackendPlugin *plugin)
+    : basePluginHandle(std::move(handle), plugin),
+      plugin_(plugin) {}
 
 nixlBackendEngine* nixlPluginHandle::createEngine(const nixlBackendInitParams* init_params) const {
     if (plugin_ && plugin_->create_engine) {
@@ -115,64 +99,49 @@ std::map<nixl_backend_t, std::string> loadPluginList(const std::string& filename
     return plugins;
 }
 
-std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPluginFromPath(const std::string& plugin_path) {
-    // Open the plugin file
-    void* handle = dlopen(plugin_path.c_str(), RTLD_NOW | RTLD_LOCAL);
-    if (!handle) {
-        NIXL_INFO << "Failed to load plugin from " << plugin_path << ": " << dlerror();
-        return nullptr;
+bool
+nixlPluginManager::checkApiVersion(void *plugin_interface) const {
+    if (!plugin_interface) {
+        return false;
     }
 
-    // Get the initialization function
-    typedef nixlBackendPlugin* (*init_func_t)();
-    init_func_t init = (init_func_t) dlsym(handle, "nixl_plugin_init");
-    if (!init) {
-        NIXL_ERROR << "Failed to find nixl_plugin_init in " << plugin_path << ": " << dlerror();
-        dlclose(handle);
-        return nullptr;
-    }
-
-    // Call the initialization function
-    nixlBackendPlugin* plugin = init();
-    if (!plugin) {
-        NIXL_ERROR << "Plugin initialization failed for " << plugin_path;
-        dlclose(handle);
-        return nullptr;
-    }
-
-    // Check API version
-    if (plugin->api_version != NIXL_PLUGIN_API_VERSION) {
-        NIXL_ERROR << "Plugin API version mismatch for " << plugin_path
-                   << ": expected " << NIXL_PLUGIN_API_VERSION
-                   << ", got " << plugin->api_version;
-        dlclose(handle);
-        return nullptr;
-    }
-
-    // Create and store the plugin handle
-    auto plugin_handle = std::make_shared<const nixlPluginHandle>(handle, plugin);
-
-    return plugin_handle;
+    nixlBackendPlugin *plugin = static_cast<nixlBackendPlugin *>(plugin_interface);
+    return plugin->api_version == NIXL_PLUGIN_API_VERSION;
 }
 
-void nixlPluginManager::loadPluginsFromList(const std::string& filename) {
-    auto plugins = loadPluginList(filename);
+std::shared_ptr<basePluginHandle>
+nixlPluginManager::createPluginHandle(std::unique_ptr<void, dlHandleDeleter> dl_handle,
+                                      void *plugin_interface) {
+    auto *plugin = static_cast<nixlBackendPlugin *>(plugin_interface);
+    return std::make_shared<nixlPluginHandle>(std::move(dl_handle), plugin);
+}
 
-    lock_guard lg(lock);
+bool
+nixlPluginManager::canUnloadPlugin(const std::string &plugin_name) const {
+    // Do not unload static plugins
+    for (const auto &splugin : staticPlugins_) {
+        if (splugin.name == plugin_name) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void
+nixlPluginManager::loadPluginsFromList(const std::string &filename) {
+    auto plugins = loadPluginList(filename);
 
     for (const auto& pair : plugins) {
         const std::string& name = pair.first;
-        const std::string& path = pair.second;
+        const std::filesystem::path path = pair.second;
 
-        auto plugin_handle = loadPluginFromPath(path);
-        if (plugin_handle) {
-            loaded_plugins_[name] = plugin_handle;
-        }
+        // Load using base class - it will handle storage
+        basePluginManager::loadPluginFromPath<nixlPluginHandle>(path, name);
     }
 }
 
 namespace {
-static std::string
+static std::filesystem::path
 getPluginDir() {
     // Environment variable takes precedence
     const char *plugin_dir = getenv("NIXL_PLUGIN_DIR");
@@ -186,12 +155,17 @@ getPluginDir() {
         NIXL_ERROR << "Failed to get plugin directory from dladdr";
         return "";
     }
-    return (std::filesystem::path(info.dli_fname).parent_path() / "plugins").string();
+    return std::filesystem::path(info.dli_fname).parent_path() / "plugins";
 }
 } // namespace
 
 // PluginManager implementation
-nixlPluginManager::nixlPluginManager() {
+nixlPluginManager::nixlPluginManager()
+    : basePluginManager(pluginConfig{.initFuncName = "nixl_plugin_init",
+                                     .finiFuncName = "nixl_plugin_fini",
+                                     .filenamePrefix = "libplugin_",
+                                     .filenameSuffix = ".so",
+                                     .expectedApiVersion = NIXL_PLUGIN_API_VERSION}) {
     // Force levels right before logging
 #ifdef NIXL_USE_PLUGIN_FILE
     NIXL_DEBUG << "Loading plugins from file: " << NIXL_USE_PLUGIN_FILE;
@@ -201,11 +175,10 @@ nixlPluginManager::nixlPluginManager() {
     }
 #endif
 
-    std::string plugin_dir = getPluginDir();
+    auto plugin_dir = getPluginDir();
     if (!plugin_dir.empty()) {
-        NIXL_DEBUG << "Loading plugins from: " << plugin_dir;
-        plugin_dirs_.insert(plugin_dirs_.begin(), plugin_dir);
-        discoverPluginsFromDir(plugin_dir);
+        NIXL_DEBUG << "Loading backend plugins from: " << plugin_dir;
+        addPluginDirectory(plugin_dir);
     }
 
     registerBuiltinPlugins();
@@ -217,129 +190,6 @@ nixlPluginManager& nixlPluginManager::getInstance() {
     static nixlPluginManager instance;
 
     return instance;
-}
-
-void nixlPluginManager::addPluginDirectory(const std::string& directory) {
-    if (directory.empty()) {
-        NIXL_ERROR << "Cannot add empty plugin directory";
-        return;
-    }
-
-    // Check if directory exists
-    if (!std::filesystem::exists(directory) || !std::filesystem::is_directory(directory)) {
-        NIXL_ERROR << "Plugin directory does not exist or is not readable: " << directory;
-        return;
-    }
-
-    {
-        lock_guard lg(lock);
-
-        // Check if directory is already in the list
-        for (const auto& dir : plugin_dirs_) {
-            if (dir == directory) {
-                NIXL_WARN << "Plugin directory already registered: " << directory;
-                return;
-            }
-        }
-
-        // Prioritize the new directory by inserting it at the beginning
-        plugin_dirs_.insert(plugin_dirs_.begin(), directory);
-    }
-
-    discoverPluginsFromDir(directory);
-}
-
-std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPlugin(const std::string& plugin_name) {
-    lock_guard lg(lock);
-
-    // Check if the plugin is already loaded
-    // Static Plugins are preloaded so return handle
-    auto it = loaded_plugins_.find(plugin_name);
-    if (it != loaded_plugins_.end()) {
-        return it->second;
-    }
-
-    // Try to load the plugin from all registered directories
-    for (const auto& dir : plugin_dirs_) {
-        // Handle path joining correctly with or without trailing slash
-        std::string plugin_path;
-        if (dir.empty()) {
-            continue;
-        } else if (dir.back() == '/') {
-            plugin_path = dir + "libplugin_" + plugin_name + ".so";
-        } else {
-            plugin_path = dir + "/libplugin_" + plugin_name + ".so";
-        }
-
-        // Check if the plugin file exists before attempting to load i
-        if (!std::filesystem::exists(plugin_path)) {
-            NIXL_WARN << "Plugin file does not exist: " << plugin_path;
-            continue;
-        }
-
-        auto plugin_handle = loadPluginFromPath(plugin_path);
-        if (plugin_handle) {
-            loaded_plugins_[plugin_name] = plugin_handle;
-            return plugin_handle;
-        }
-    }
-
-    // Failed to load the plugin
-    NIXL_INFO << "Failed to load plugin '" << plugin_name << "' from any directory";
-    return nullptr;
-}
-
-void nixlPluginManager::discoverPluginsFromDir(const std::string& dirpath) {
-    std::filesystem::path dir_path(dirpath);
-    std::error_code ec;
-    std::filesystem::directory_iterator dir_iter(dir_path, ec);
-    if (ec) {
-        NIXL_ERROR << "Error accessing directory(" << dir_path << "): "
-                   << ec.message();
-        return;
-    }
-
-    for (const auto& entry : dir_iter) {
-        std::string filename = entry.path().filename().string();
-
-        if(filename.size() < 11) continue;
-        // Check if this is a plugin file
-        if (filename.substr(0, 10) == "libplugin_" &&
-            filename.substr(filename.size() - 3) == ".so") {
-
-            // Extract plugin name
-            std::string plugin_name = filename.substr(10, filename.size() - 13);
-
-            // Try to load the plugin
-            auto plugin = loadPlugin(plugin_name);
-            if (plugin) {
-                NIXL_INFO << "Discovered and loaded plugin: " << plugin_name;
-            }
-        }
-    }
-}
-
-void nixlPluginManager::unloadPlugin(const nixl_backend_t& plugin_name) {
-    // Do no unload static plugins
-    for (const auto& splugin : getStaticPlugins()) {
-        if (splugin.name == plugin_name) {
-            return;
-        }
-    }
-
-    lock_guard lg(lock);
-
-    loaded_plugins_.erase(plugin_name);
-}
-
-std::shared_ptr<const nixlPluginHandle> nixlPluginManager::getPlugin(const nixl_backend_t& plugin_name) {
-    lock_guard lg(lock);
-
-    auto it = loaded_plugins_.find(plugin_name);
-    if (it != loaded_plugins_.end()) {
-        return it->second;
-    }
-    return nullptr;
 }
 
 nixl_b_params_t nixlPluginHandle::getBackendOptions() const {
@@ -358,36 +208,30 @@ nixl_mem_list_t nixlPluginHandle::getBackendMems() const {
     return mems; // Return empty mems if not implemented
 }
 
-std::vector<nixl_backend_t> nixlPluginManager::getLoadedPluginNames() {
-    lock_guard lg(lock);
-
-    std::vector<nixl_backend_t> names;
-    for (const auto& pair : loaded_plugins_) {
-        names.push_back(pair.first);
-    }
-    return names;
-}
-
 void nixlPluginManager::registerStaticPlugin(const char* name, nixlStaticPluginCreatorFunc creator) {
-    lock_guard lg(lock);
-
     nixlStaticPluginInfo info;
     info.name = name;
     info.createFunc = creator;
-    static_plugins_.push_back(info);
+    staticPlugins_.push_back(info);
 
     //Static Plugins are considered pre-loaded
     nixlBackendPlugin* plugin = info.createFunc();
     NIXL_INFO << "Loading static plugin: " << name;
     if (plugin) {
-        // Register the loaded plugin
-        auto plugin_handle = std::make_shared<const nixlPluginHandle>(nullptr, plugin);
-        loaded_plugins_[name] = plugin_handle;
+        // Register the loaded plugin (nullptr handle for static plugins)
+        dlHandleDeleter deleter(""); // No cleanup for static plugins
+        std::unique_ptr<void, dlHandleDeleter> handle(nullptr, deleter);
+        auto plugin_handle = createPluginHandle(std::move(handle), plugin);
+
+        // Store in base class map
+        lock_guard lg(lock_);
+        loadedPlugins_.emplace(name, plugin_handle);
     }
 }
 
-const std::vector<nixlStaticPluginInfo>& nixlPluginManager::getStaticPlugins() {
-    return static_plugins_;
+const std::vector<nixlStaticPluginInfo> &
+nixlPluginManager::getStaticPlugins() const noexcept {
+    return staticPlugins_;
 }
 
 #define NIXL_REGISTER_STATIC_PLUGIN(name)                   \

--- a/src/core/telemetry.h
+++ b/src/core/telemetry.h
@@ -19,6 +19,7 @@
 
 #include "common/cyclic_buffer.h"
 #include "telemetry_event.h"
+#include "telemetry/telemetry_exporter.h"
 #include "mem_section.h"
 #include "nixl_types.h"
 
@@ -49,7 +50,7 @@ struct periodicTask {
 
 class nixlTelemetry {
 public:
-    nixlTelemetry(const std::string &file_path, backend_map_t &backend_map);
+    nixlTelemetry(const std::string &agent_name, backend_map_t &backend_map);
 
     ~nixlTelemetry();
 
@@ -74,19 +75,18 @@ public:
 
 private:
     void
-    initializeTelemetry();
+    initializeTelemetry(const std::string &agent_name);
     void
     registerPeriodicTask(periodicTask &task);
     void
     updateData(const std::string &event_name, nixl_telemetry_category_t category, uint64_t value);
     bool
-    writeEventHelper();
-    std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
+    telemetryExporterHelper();
     std::vector<nixlTelemetryEvent> events_;
+    std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::mutex mutex_;
     asio::thread_pool pool_;
     periodicTask writeTask_;
-    std::string file_;
     backend_map_t &backendMap_;
 };
 

--- a/src/core/telemetry_plugin_manager.cpp
+++ b/src/core/telemetry_plugin_manager.cpp
@@ -1,0 +1,143 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "telemetry_plugin_manager.h"
+#include <dlfcn.h>
+#include <filesystem>
+#include <cstdlib>
+#include <cassert>
+
+using lock_guard = const std::lock_guard<std::mutex>;
+
+nixlTelemetryPluginHandle::nixlTelemetryPluginHandle(std::unique_ptr<void, dlHandleDeleter> handle,
+                                                     nixlTelemetryPlugin *plugin)
+    : basePluginHandle(std::move(handle), plugin),
+      plugin_(plugin) {
+    assert(plugin_ && "Plugin interface must not be null");
+}
+
+std::unique_ptr<nixlTelemetryExporter>
+nixlTelemetryPluginHandle::createExporter(
+    const nixlTelemetryExporterInitParams &init_params) const {
+    if (plugin_ && plugin_->create_exporter) {
+        return plugin_->create_exporter(init_params);
+    }
+    return nullptr;
+}
+
+const char *
+nixlTelemetryPluginHandle::getName() const {
+    if (plugin_) {
+        auto name = plugin_->getName();
+        return !name.empty() ? name.data() : "unknown";
+    }
+    return "unknown";
+}
+
+const char *
+nixlTelemetryPluginHandle::getVersion() const {
+    if (plugin_) {
+        auto version = plugin_->getVersion();
+        return !version.empty() ? version.data() : "unknown";
+    }
+    return "unknown";
+}
+
+// Helper function to get plugin directory
+namespace {
+static std::filesystem::path
+getTelemetryPluginDir() {
+    // Environment variable takes precedence
+    const char *plugin_dir = getenv(telemetryExporterPluginDirVar);
+    if (plugin_dir) {
+        return plugin_dir;
+    }
+
+    // By default, use the telemetry_exporters subdirectory relative to the library
+    Dl_info info;
+    int ok = dladdr(reinterpret_cast<void *>(&getTelemetryPluginDir), &info);
+    if (!ok) {
+        NIXL_ERROR << "Failed to get telemetry plugin directory from dladdr";
+        return "";
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().parent_path() / "telemetry";
+}
+} // namespace
+
+// Plugin Manager implementation
+nixlTelemetryPluginManager::nixlTelemetryPluginManager()
+    : basePluginManager(
+          pluginConfig{.initFuncName = "nixl_telemetry_plugin_init",
+                       .finiFuncName = "nixl_telemetry_plugin_fini",
+                       .filenamePrefix = "libtelemetry_exporter_",
+                       .filenameSuffix = ".so",
+                       .expectedApiVersion = static_cast<int>(nixlTelemetryPluginApiVersionV1)}) {
+    std::filesystem::path plugin_dir = getTelemetryPluginDir();
+    if (!plugin_dir.empty()) {
+        NIXL_DEBUG << "Loading telemetry exporter plugins from: " << plugin_dir;
+        addPluginDirectory(plugin_dir);
+    }
+}
+
+bool
+nixlTelemetryPluginManager::checkApiVersion(void *plugin_interface) const {
+    if (!plugin_interface) {
+        return false;
+    }
+
+    nixlTelemetryPlugin *plugin = static_cast<nixlTelemetryPlugin *>(plugin_interface);
+    return plugin->api_version == nixlTelemetryPluginApiVersionV1;
+}
+
+std::shared_ptr<basePluginHandle>
+nixlTelemetryPluginManager::createPluginHandle(std::unique_ptr<void, dlHandleDeleter> dl_handle,
+                                               void *plugin_interface) {
+
+    nixlTelemetryPlugin *plugin = static_cast<nixlTelemetryPlugin *>(plugin_interface);
+    return std::make_shared<nixlTelemetryPluginHandle>(std::move(dl_handle), plugin);
+}
+
+nixlTelemetryPluginManager &
+nixlTelemetryPluginManager::getInstance() {
+    // Meyers singleton - thread-safe in C++11+
+    static nixlTelemetryPluginManager instance;
+    return instance;
+}
+
+std::unique_ptr<nixlTelemetryExporter>
+nixlTelemetryPluginManager::createExporter(std::string_view plugin_name,
+                                           const nixlTelemetryExporterInitParams &init_params) {
+    auto plugin_handle = getPlugin<nixlTelemetryPluginHandle>(std::string(plugin_name));
+    if (!plugin_handle) {
+        plugin_handle = loadPlugin<nixlTelemetryPluginHandle>(std::string(plugin_name));
+    }
+
+    if (!plugin_handle) {
+        NIXL_ERROR << "Cannot create exporter: plugin '" << plugin_name << "' not found";
+        return nullptr;
+    }
+
+    // Create the exporter instance (smart pointer handles cleanup automatically)
+    auto exporter = plugin_handle->createExporter(init_params);
+    if (!exporter) {
+        NIXL_ERROR << "Failed to create exporter instance from plugin '" << plugin_name << "'";
+        return nullptr;
+    }
+
+    NIXL_INFO << "Created telemetry exporter from plugin: " << plugin_name;
+    return exporter;
+}

--- a/src/core/telemetry_plugin_manager.h
+++ b/src/core/telemetry_plugin_manager.h
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _TELEMETRY_PLUGIN_MANAGER_H
+#define _TELEMETRY_PLUGIN_MANAGER_H
+
+#include <string>
+#include <string_view>
+#include <map>
+#include <memory>
+#include <vector>
+#include <mutex>
+#include <filesystem>
+#include "telemetry/telemetry_plugin.h"
+#include "base_plugin_manager.h"
+
+/**
+ * This class represents a telemetry exporter plugin handle used to create exporter instances.
+ * Plugin handle attributes are modified only in the constructor and destructor and remain
+ * unchanged during normal operation. This allows using it in multi-threading environments
+ * without lock protection.
+ */
+class nixlTelemetryPluginHandle : public basePluginHandle {
+private:
+    nixlTelemetryPlugin *plugin_; // Plugin interface (cached for type safety)
+
+public:
+    nixlTelemetryPluginHandle(std::unique_ptr<void, dlHandleDeleter> handle,
+                              nixlTelemetryPlugin *plugin);
+    ~nixlTelemetryPluginHandle() override = default;
+
+    [[nodiscard]] std::unique_ptr<nixlTelemetryExporter>
+    createExporter(const nixlTelemetryExporterInitParams &init_params) const;
+    const char *
+    getName() const override;
+    const char *
+    getVersion() const override;
+};
+
+/**
+ * Telemetry Exporter Plugin Manager
+ *
+ * Manages dynamic loading of telemetry exporter plugins. Unlike the backend plugin manager,
+ * this only supports dynamic plugins (no static plugins) for simplicity.
+ */
+class nixlTelemetryPluginManager : public basePluginManager {
+public:
+    // Singleton instance accessor
+    [[nodiscard]] static nixlTelemetryPluginManager &
+    getInstance();
+
+    // Delete copy constructor and assignment operator
+    nixlTelemetryPluginManager(const nixlTelemetryPluginManager &) = delete;
+    nixlTelemetryPluginManager &
+    operator=(const nixlTelemetryPluginManager &) = delete;
+
+    /**
+     * Create an exporter instance from a plugin
+     *
+     * @param plugin_name Name of the plugin to use
+     * @param init_params Initialization parameters for the exporter
+     * @return Unique pointer to created exporter or nullptr on failure
+     */
+    [[nodiscard]] std::unique_ptr<nixlTelemetryExporter>
+    createExporter(std::string_view plugin_name,
+                   const nixlTelemetryExporterInitParams &init_params);
+
+protected:
+    bool
+    checkApiVersion(void *plugin_interface) const override;
+
+    std::shared_ptr<basePluginHandle>
+    createPluginHandle(std::unique_ptr<void, dlHandleDeleter> dl_handle,
+                       void *plugin_interface) override;
+
+private:
+    // Private constructor for singleton pattern
+    nixlTelemetryPluginManager();
+};
+
+#endif // _TELEMETRY_PLUGIN_MANAGER_H

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -20,9 +20,12 @@ endif
 subdir('posix')  # Always try to build POSIX backend, it will handle its own dependencies
 subdir('obj')  # Always try to build Obj backend, it will handle its own dependencies
 
+subdir('telemetry')
+
 if libfabric_dep.found()
     subdir('libfabric')
 endif
+
 
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and cuda_dep.found()

--- a/src/plugins/telemetry/README.md
+++ b/src/plugins/telemetry/README.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL Custom Telemetry Plugin Development Guide
+
+This guide explains how to create custom telemetry exporter plugins for NIXL. Telemetry plugins allow you to export NIXL telemetry data to different monitoring systems, databases, or file formats.
+
+## Overview
+
+NIXL telemetry plugins are dynamically loaded shared libraries that export telemetry events from the NIXL agent
+
+### Built-in Event Types
+
+NIXL generates the following telemetry events:
+
+| Category | Event Name | Type | Description |
+|----------|-----------|------|-------------|
+| MEMORY | `agent_memory_registered` | Gauge | Total bytes of memory registered |
+| MEMORY | `agent_memory_deregistered` | Gauge | Total bytes of memory deregistered |
+| TRANSFER | `agent_tx_bytes` | Counter | Total bytes transmitted |
+| TRANSFER | `agent_rx_bytes` | Counter | Total bytes received |
+| TRANSFER | `agent_tx_requests_num` | Counter | Number of transmit requests |
+| TRANSFER | `agent_rx_requests_num` | Counter | Number of receive requests |
+| PERFORMANCE | `agent_xfer_time` | Gauge | Transfer time in microseconds |
+| PERFORMANCE | `agent_xfer_post_time` | Gauge | Post time in microseconds |
+| BACKEND | Backend-specific events | Counter | Dynamic events from backends |
+
+## Quick Start
+
+Here's a minimal example of a CSV file exporter plugin:
+
+### 1. Create Your Exporter Class (`csv_exporter.h`)
+
+```cpp
+#ifndef _TELEMETRY_CSV_EXPORTER_H
+#define _TELEMETRY_CSV_EXPORTER_H
+
+#include "telemetry/telemetry_exporter.h"
+#include <fstream>
+
+class nixlTelemetryCsvExporter : public nixlTelemetryExporter {
+public:
+    explicit nixlTelemetryCsvExporter(const nixlTelemetryExporterInitParams *init_params);
+    ~nixlTelemetryCsvExporter() override;
+
+    nixl_status_t exportEvent(const nixlTelemetryEvent &event) override;
+
+private:
+    std::ofstream file_;
+};
+
+#endif // _TELEMETRY_CSV_EXPORTER_H
+```
+
+### 2. Implement Your Exporter (`csv_exporter.cpp`)
+
+```cpp
+#include "csv_exporter.h"
+#include "common/nixl_log.h"
+
+nixlTelemetryCsvExporter::nixlTelemetryCsvExporter(
+    const nixlTelemetryExporterInitParams *init_params)
+    : nixlTelemetryExporter(init_params) {
+
+    file_.open(init_params->outputPath, std::ios::out | std::ios::app);
+    if (!file_.is_open()) {
+        throw std::runtime_error("Failed to open CSV file: " + init_params->outputPath);
+    }
+
+    // Write CSV header
+    file_ << "timestamp_us,category,event_name,value\n";
+    NIXL_INFO << "CSV exporter initialized: " << init_params->outputPath;
+}
+
+nixl_status_t
+nixlTelemetryCsvExporter::exportEvent(const nixlTelemetryEvent &event) {
+    if (!file_.is_open()) {
+        return NIXL_ERR_UNKNOWN;
+    }
+
+    try {
+        file_ << event.timestampUs_ << ","
+              << static_cast<int>(event.category_) << ","
+              << event.eventName_ << ","
+              << event.value_ << "\n";
+        file_.flush();
+        return NIXL_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to export event: " << e.what();
+        return NIXL_ERR_UNKNOWN;
+    }
+}
+```
+
+### 3. Create Plugin Interface (`csv_plugin.cpp`)
+
+```cpp
+#include "csv_exporter.h"
+#include "telemetry/telemetry_plugin.h"
+
+// Use the plugin creator template for minimal boilerplate
+using csv_exporter_plugin_t = nixlTelemetryPluginCreator<nixlTelemetryCsvExporter>;
+
+// Plugin initialization function - must be extern "C"
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT nixlTelemetryPlugin *
+nixl_telemetry_plugin_init() {
+    return csv_exporter_plugin_t::create(
+        NIXL_TELEMETRY_PLUGIN_API_VERSION,
+        "csv",      // Plugin name
+        "1.0.0"     // Plugin version
+    );
+}
+
+// Plugin cleanup function
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT void
+nixl_telemetry_plugin_fini() {
+    // Add any global cleanup if needed
+}
+```
+
+### 4. Build Configuration (`meson.build`)
+
+```meson
+# CSV Exporter Plugin
+csv_exporter_plugin = shared_library(
+    'libtelemetry_exporter_csv',
+    'csv_plugin.cpp',
+    'csv_exporter.cpp',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    dependencies: [nixl_infra, absl_log_dep],
+    install: true,
+    install_dir: get_option('libdir') / 'nixl' / 'telemetry_exporters',
+    name_prefix: '',
+)
+```

--- a/src/plugins/telemetry/buffer/README.md
+++ b/src/plugins/telemetry/buffer/README.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL Buffer Telemetry exporter plug-in
+
+This telemetry exporter plug-in exports NIXL telemetry events in shared memory buffers that can be read by telemetry reader applications.
+
+## Configuration
+
+To enable the Buffer plug-in, set the following environment variables:
+
+```bash
+export NIXL_TELEMETRY_ENABLE="y" # Enable NIXL telemetry
+export NIXL_TELEMETRY_EXPORTER="buffer" # Sets which plug-in to select in format libtelemetry_exporter_${NIXL_TELEMETRY_EXPORTER}.so
+export NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR="path/to/dir/with/.so/files" # Sets where to find plug-in libs
+export NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH="path/to/store/telemetry/file/" # Sets where shared memory will be located
+```
+
+## Telemetry File Format
+
+Telemetry data is stored in shared memory files with the agent name passed when creating the agent.
+
+## Using Telemetry Readers
+
+### C++ Telemetry Reader
+
+The C++ telemetry reader (`telemetry_reader.cpp`) provides a robust way to read and display telemetry events.
+
+#### Running the C++ Reader
+
+```bash
+# Read from a specific telemetry file
+./builddir/examples/cpp/telemetry_reader /tmp/agent_name
+```
+
+### Python Telemetry Reader
+
+The Python telemetry reader (`telemetry_reader.py`) provides similar functionality with additional features.
+
+#### Running the Python Reader
+
+```bash
+# Read from a specific telemetry file
+python3 examples/python/telemetry_reader.py --telemetry_path /tmp/agent_name
+```
+
+## Example Output
+
+Both readers produce similar formatted output:
+
+```
+=== NIXL Telemetry Event ===
+Timestamp: 2025-01-15 14:30:25.123456
+Category: TRANSFER
+Event: agent_tx_bytes
+Value: 1048576
+===========================
+
+=== NIXL Telemetry Event ===
+Timestamp: 2025-01-15 14:30:25.124567
+Category: MEMORY
+Event: agent_memory_registered
+Value: 4096
+===========================
+```

--- a/src/plugins/telemetry/buffer/buffer_exporter.cpp
+++ b/src/plugins/telemetry/buffer/buffer_exporter.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "buffer_exporter.h"
+#include "common/nixl_log.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <thread>
+#include <chrono>
+
+nixlTelemetryBufferExporter::nixlTelemetryBufferExporter(
+    const nixlTelemetryExporterInitParams &init_params)
+    : nixlTelemetryExporter(init_params),
+      buffer_(std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(
+          init_params.outputPath + "/" + init_params.agentName,
+          true,
+          TELEMETRY_VERSION,
+          init_params.maxEventsBuffered)) {}
+
+nixl_status_t
+nixlTelemetryBufferExporter::exportEvent(const nixlTelemetryEvent &event) {
+    if (!buffer_->push(event)) {
+        return NIXL_ERR_UNKNOWN;
+    }
+
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/telemetry/buffer/buffer_exporter.h
+++ b/src/plugins/telemetry/buffer/buffer_exporter.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _TELEMETRY_BUFFER_EXPORTER_H
+#define _TELEMETRY_BUFFER_EXPORTER_H
+
+#include "common/cyclic_buffer.h"
+#include "telemetry/telemetry_exporter.h"
+#include "telemetry_event.h"
+#include "nixl_types.h"
+
+#include <string>
+#include <fstream>
+#include <memory>
+
+/**
+ * @class nixlTelemetryBufferExporter
+ * @brief Shared memory buffer based telemetry exporter implementation
+ *
+ * This class implements the telemetry exporter interface to export
+ * telemetry events to a shared memory buffer.
+ */
+class nixlTelemetryBufferExporter : public nixlTelemetryExporter {
+public:
+    /**
+     * @brief Constructor using init params (plugin-compatible)
+     * @param init_params Initialization parameters
+     */
+    explicit nixlTelemetryBufferExporter(const nixlTelemetryExporterInitParams &init_params);
+
+    nixl_status_t
+    exportEvent(const nixlTelemetryEvent &event) override;
+
+private:
+    std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
+};
+
+#endif // _TELEMETRY_BUFFER_EXPORTER_H

--- a/src/plugins/telemetry/buffer/buffer_plugin.cpp
+++ b/src/plugins/telemetry/buffer/buffer_plugin.cpp
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "buffer_exporter.h"
+#include "telemetry/telemetry_plugin.h"
+#include "telemetry/telemetry_exporter.h"
+
+// Plugin type alias for convenience
+using buffer_exporter_plugin_t = nixlTelemetryPluginCreator<nixlTelemetryBufferExporter>;
+
+// Plugin initialization function - must be extern "C" for dynamic loading
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT nixlTelemetryPlugin *
+nixl_telemetry_plugin_init() {
+    return buffer_exporter_plugin_t::create(nixlTelemetryPluginApiVersionV1, "buffer", "1.0.0");
+}
+
+// Plugin cleanup function
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT void
+nixl_telemetry_plugin_fini() {
+    // Nothing to clean up for buffer exporter
+}

--- a/src/plugins/telemetry/buffer/meson.build
+++ b/src/plugins/telemetry/buffer/meson.build
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+buffer_exporter_plugin = shared_library(
+    'libtelemetry_exporter_buffer',
+    'buffer_plugin.cpp',
+    'buffer_exporter.cpp',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    dependencies: [nixl_infra, absl_log_dep],
+    install: true,
+    install_dir: get_option('libdir') / 'nixl' / 'telemetry_exporters',
+    name_prefix: '',
+)
+message('Building shared buffer telemetry exporter plugin')
+
+# Add to telemetry exporters list for debug builds
+if get_option('buildtype') == 'debug'
+    run_command('sh', '-c',
+                'echo "buffer=' + buffer_exporter_plugin.full_path() + '" >> ' + plugin_build_dir + '/telemetry_exporters_list',
+                check: true
+    )
+endif
+

--- a/src/plugins/telemetry/meson.build
+++ b/src/plugins/telemetry/meson.build
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+subdir('buffer')
+subdir('prometheus')

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL Prometheus Telemetry exporter plug-in
+
+This telemetry exporter plug-in exports NIXL telemetry events in Prometheus format, by_exposing an HTTP endpoint that can be scraped by Prometheus servers.
+
+## Dependencies
+
+The Prometheus exporter requires the prometheus-cpp library, which is included as a subproject:
+
+libcurl is not handled by prometheus-cpp libaray. need to install the libcurl package:
+
+```bash
+# Ubuntu/Debian
+sudo apt-get install libcurl4-openssl-dev
+# RHEL/CentOS/Fedora
+sudo dnf install libcurl-devel
+```
+
+## Configuration
+
+To enable the Prometheus plug-in, set the following environment variables:
+
+```bash
+export NIXL_TELEMETRY_ENABLE="y" # Enable NIXL telemetry
+export NIXL_TELEMETRY_EXPORTER="prometheus" # Sets which plug-in to select in format libtelemetry_exporter_${NIXL_TELEMETRY_EXPORTER}.so
+export NIXL_TELEMETRY_EXPORTER_PLUGIN_DIR="path/to/dir/with/.so/files" # Sets where to find plug-in libs
+```
+
+### Optional Configuration
+
+You can configure the HTTP bind address and port using the output path parameter:
+
+```bash
+# Default bind address is 0.0.0.0:9090
+export NIXL_TELEMETRY_EXPORTER_OUTPUT_PATH="x.x.x.x:<port num>"
+
+# The outputPath init parameter should be in format: ip_addr:port_num
+# Example configurations:
+# - Bind to all interfaces on port 9090: "0.0.0.0:9090"
+# - Bind to localhost only: "127.0.0.1:9090"
+# - Custom port: "0.0.0.0:8080"
+```
+
+### Transfer Metrics (Counters)
+- `agent_tx_bytes` - Total bytes transmitted
+- `agent_rx_bytes` - Total bytes received
+- `agent_tx_requests_num` - Number of transmit requests
+- `agent_rx_requests_num` - Number of receive requests
+
+### Performance Metrics (Gauges)
+- `agent_xfer_time` - Transfer time in microseconds
+- `agent_xfer_post_time` - Post time in microseconds
+
+### Memory Metrics (Gauges)
+- `agent_memory_registered` - Amount of memory registered
+- `agent_memory_deregistered` - Amount of memory deregistered
+
+### Backend Metrics (Dynamic Counters)
+- Backend-specific events are dynamically created as counters with category label
+

--- a/src/plugins/telemetry/prometheus/meson.build
+++ b/src/plugins/telemetry/prometheus/meson.build
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use CMake subproject directly
+cmake = import('cmake')
+prometheus_found = false
+
+# Try to get prometheus-cpp as a CMake subproject
+# Pass CMake options directly to ensure they're applied
+cmake_opts = cmake.subproject_options()
+cmake_opts.add_cmake_defines({
+    'ENABLE_PULL': 'ON',
+    'ENABLE_PUSH': 'OFF',
+    'ENABLE_COMPRESSION': 'OFF',
+    'ENABLE_TESTING': 'OFF',
+    'USE_THIRDPARTY_LIBRARIES': 'ON',
+    'BUILD_SHARED_LIBS': 'ON',
+    'CMAKE_POSITION_INDEPENDENT_CODE': 'ON',
+    'CMAKE_C_FLAGS': '-Wno-unused-but-set-variable',
+    'CMAKE_CXX_FLAGS': '-Wno-unused-but-set-variable'
+})
+
+prometheus_sub = cmake.subproject('prometheus-cpp', required: false, options: cmake_opts)
+if prometheus_sub.found()
+    # Get the CMake targets
+    prometheus_core_dep = prometheus_sub.dependency('core')
+    prometheus_pull_dep = prometheus_sub.dependency('pull')
+    prometheus_found = true
+endif
+
+if prometheus_found
+    # Prometheus Exporter Plugin
+    prometheus_exporter_plugin = shared_library(
+        'libtelemetry_exporter_prometheus',
+        'prometheus_plugin.cpp',
+        'prometheus_exporter.cpp',
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        dependencies: [nixl_infra, absl_log_dep, prometheus_core_dep, prometheus_pull_dep],
+        install: true,
+        install_dir: get_option('libdir') / 'nixl' / 'telemetry_exporters',
+        name_prefix: '',
+    )
+    message('Building Prometheus telemetry exporter plugin')
+else
+    warning('Prometheus C++ library not found. Prometheus telemetry exporter will not be built.')
+endif
+

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "prometheus_exporter.h"
+#include "common/nixl_log.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <thread>
+#include <chrono>
+
+inline const std::string prometheusExporterDefaultBindAddress = "0.0.0.0:9090";
+inline const std::string prometheusExporterTransferCategory = "NIXL_TELEMETRY_TRANSFER";
+inline const std::string prometheusExporterPerformanceCategory = "NIXL_TELEMETRY_PERFORMANCE";
+inline const std::string prometheusExporterMemoryCategory = "NIXL_TELEMETRY_MEMORY";
+inline const std::string prometheusExporterBackendCategory = "NIXL_TELEMETRY_BACKEND";
+
+nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
+    const nixlTelemetryExporterInitParams &init_params)
+    : nixlTelemetryExporter(init_params),
+      registry_(std::make_shared<prometheus::Registry>()),
+      bind_address_(prometheusExporterDefaultBindAddress) {
+
+    if (!init_params.outputPath.empty()) {
+        // Validate format: ip_addr:port_num
+        const std::string path = init_params.outputPath;
+        size_t colon_pos = path.find(':');
+
+        if (colon_pos == std::string::npos || colon_pos == 0 || colon_pos == path.length() - 1) {
+            NIXL_WARN << "Invalid bind address format '" << path
+                      << "', expected 'ip_addr:port_num'. Using default: "
+                      << prometheusExporterDefaultBindAddress;
+        } else {
+            const std::string ip_addr = path.substr(0, colon_pos);
+            const std::string port_str = path.substr(colon_pos + 1);
+
+            // Validate port is numeric
+            try {
+                const int port = std::stoi(port_str);
+                if (port < 1 || port > 65535) {
+                    NIXL_WARN << "Invalid port number " << port
+                              << ", must be between 1-65535. Using default: "
+                              << prometheusExporterDefaultBindAddress;
+                } else {
+                    bind_address_ = path;
+                }
+            }
+            catch (const std::exception &e) {
+                NIXL_WARN << "Invalid port in bind address '" << path
+                          << "', expected numeric port. Using default: "
+                          << prometheusExporterDefaultBindAddress;
+            }
+        }
+    }
+
+    try {
+        exposer_ = std::make_unique<prometheus::Exposer>(bind_address_);
+        exposer_->RegisterCollectable(registry_);
+
+        initializeMetrics();
+        NIXL_INFO << "Prometheus exporter initialized on " << bind_address_;
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to initialize Prometheus exporter: " << e.what();
+    }
+}
+
+// To make access cheaper we are creating static metrics with the labels already set
+// Events are defined in the telemetry.cpp file
+void
+nixlTelemetryPrometheusExporter::initializeMetrics() {
+    auto &tx_bytes_counter = prometheus::BuildCounter()
+                                 .Name("agent_tx_bytes")
+                                 .Help("Number of bytes sent by the agent")
+                                 .Register(*registry_);
+
+    auto &rx_bytes_counter = prometheus::BuildCounter()
+                                 .Name("agent_rx_bytes")
+                                 .Help("Number of bytes received by the agent")
+                                 .Register(*registry_);
+
+    auto &tx_requests_counter = prometheus::BuildCounter()
+                                    .Name("agent_tx_requests_num")
+                                    .Help("Number of requests sent by the agent")
+                                    .Register(*registry_);
+
+    auto &rx_requests_counter = prometheus::BuildCounter()
+                                    .Name("agent_rx_requests_num")
+                                    .Help("Number of requests received by the agent")
+                                    .Register(*registry_);
+
+    registerCounter(
+        "agent_tx_bytes", tx_bytes_counter, {{"category", prometheusExporterTransferCategory}});
+    registerCounter(
+        "agent_rx_bytes", rx_bytes_counter, {{"category", prometheusExporterTransferCategory}});
+    registerCounter("agent_tx_requests_num",
+                    tx_requests_counter,
+                    {{"category", prometheusExporterTransferCategory}});
+    registerCounter("agent_rx_requests_num",
+                    rx_requests_counter,
+                    {{"category", prometheusExporterTransferCategory}});
+
+    auto &xfer_time_gauge = prometheus::BuildGauge()
+                                .Name("agent_xfer_time")
+                                .Help("Start to Complete (per request)")
+                                .Register(*registry_);
+
+    auto &xfer_post_time_gauge = prometheus::BuildGauge()
+                                     .Name("agent_xfer_post_time")
+                                     .Help("Start to posting to Back-End (per request)")
+                                     .Register(*registry_);
+
+    auto &memory_registered_gauge = prometheus::BuildGauge()
+                                        .Name("agent_memory_registered")
+                                        .Help("Memory registered")
+                                        .Register(*registry_);
+
+    auto &memory_deregistered_gauge = prometheus::BuildGauge()
+                                          .Name("agent_memory_deregistered")
+                                          .Help("Memory deregistered")
+                                          .Register(*registry_);
+
+    registerGauge(
+        "agent_xfer_time", xfer_time_gauge, {{"category", prometheusExporterPerformanceCategory}});
+    registerGauge("agent_xfer_post_time",
+                  xfer_post_time_gauge,
+                  {{"category", prometheusExporterPerformanceCategory}});
+    registerGauge("agent_memory_registered",
+                  memory_registered_gauge,
+                  {{"category", prometheusExporterMemoryCategory}});
+    registerGauge("agent_memory_deregistered",
+                  memory_deregistered_gauge,
+                  {{"category", prometheusExporterMemoryCategory}});
+}
+
+void
+nixlTelemetryPrometheusExporter::createOrUpdateBackendEvent(const std::string &event_name,
+                                                            uint64_t value) {
+    auto it = counters_.find(event_name);
+    if (it != counters_.end()) {
+        it->second->Increment(value);
+        return;
+    }
+
+    auto &backend_counter =
+        prometheus::BuildCounter().Name(event_name).Help("Backend event").Register(*registry_);
+    counters_[event_name] = &backend_counter.Add({{"category", prometheusExporterBackendCategory}});
+    counters_[event_name]->Increment(value);
+}
+
+nixl_status_t
+nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
+    try {
+        const std::string event_name(event.eventName_);
+
+        switch (event.category_) {
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER: {
+            auto it = counters_.find(event_name);
+            if (it != counters_.end()) {
+                it->second->Increment(event.value_);
+            }
+            break;
+        }
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE:
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY: {
+            auto it = gauges_.find(event_name);
+            if (it != gauges_.end()) {
+                it->second->Set(static_cast<double>(event.value_));
+            }
+            break;
+        }
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND:
+            createOrUpdateBackendEvent(event_name, event.value_);
+            break;
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_CONNECTION:
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR:
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_SYSTEM:
+        case nixl_telemetry_category_t::NIXL_TELEMETRY_CUSTOM:
+        default:
+            break;
+        }
+
+        return NIXL_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to export telemetry event: " << e.what();
+        return NIXL_ERR_UNKNOWN;
+    }
+}

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.h
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _TELEMETRY_PROMETHEUS_EXPORTER_H
+#define _TELEMETRY_PROMETHEUS_EXPORTER_H
+
+#include "telemetry/telemetry_exporter.h"
+#include "telemetry_event.h"
+#include "nixl_types.h"
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+
+#include <prometheus/registry.h>
+#include <prometheus/exposer.h>
+#include <prometheus/counter.h>
+#include <prometheus/gauge.h>
+#include <prometheus/histogram.h>
+
+/**
+ * @class nixlTelemetryPrometheusExporter
+ * @brief Prometheus-based telemetry exporter implementation
+ *
+ * This class implements the telemetry exporter interface to export
+ * telemetry events to a Prometheus-compatible format using prometheus-cpp.
+ * It exposes metrics via an HTTP endpoint that can be scraped by Prometheus.
+ */
+class nixlTelemetryPrometheusExporter : public nixlTelemetryExporter {
+public:
+    /**
+     * @brief Constructor using init params (plugin-compatible)
+     * @param init_params Initialization parameters
+     */
+    explicit nixlTelemetryPrometheusExporter(const nixlTelemetryExporterInitParams &init_params);
+
+    nixl_status_t
+    exportEvent(const nixlTelemetryEvent &event) override;
+
+private:
+    // Prometheus components
+    std::shared_ptr<prometheus::Registry> registry_;
+    std::unique_ptr<prometheus::Exposer> exposer_;
+    std::string bind_address_;
+
+    // Maps to track created metrics by event name
+    std::unordered_map<std::string, prometheus::Counter *> counters_;
+    std::unordered_map<std::string, prometheus::Gauge *> gauges_;
+
+    // Helper methods
+    void
+    initializeMetrics();
+    void
+    createOrUpdateBackendEvent(const std::string &event_name, uint64_t value);
+
+    template<typename Family>
+    void
+    registerCounter(const std::string &name,
+                    Family &family,
+                    const std::map<std::string, std::string> &labels = {}) {
+        counters_[name] = &family.Add(labels);
+    }
+
+    template<typename Family>
+    void
+    registerGauge(const std::string &name,
+                  Family &family,
+                  const std::map<std::string, std::string> &labels = {}) {
+        gauges_[name] = &family.Add(labels);
+    }
+};
+
+#endif // _TELEMETRY_PROMETHEUS_EXPORTER_H

--- a/src/plugins/telemetry/prometheus/prometheus_plugin.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_plugin.cpp
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "prometheus_exporter.h"
+#include "telemetry/telemetry_plugin.h"
+#include "telemetry/telemetry_exporter.h"
+
+// Plugin type alias for convenience
+using prometheus_exporter_plugin_t = nixlTelemetryPluginCreator<nixlTelemetryPrometheusExporter>;
+
+// Plugin initialization function - must be extern "C" for dynamic loading
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT nixlTelemetryPlugin *
+nixl_telemetry_plugin_init() {
+    return prometheus_exporter_plugin_t::create(
+        nixlTelemetryPluginApiVersionV1, "prometheus", "1.0.0");
+}
+
+// Plugin cleanup function
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT void
+nixl_telemetry_plugin_fini() {
+    // Nothing to clean up for prometheus exporter
+}

--- a/subprojects/prometheus-cpp.wrap
+++ b/subprojects/prometheus-cpp.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/jupp0r/prometheus-cpp.git
+revision = v1.3.0
+depth = 1
+clone-recursive = true
+method = cmake

--- a/test/gtest/plugin_manager.cpp
+++ b/test/gtest/plugin_manager.cpp
@@ -50,7 +50,7 @@ protected:
     if (GetParam().type == PluginDesc::PluginType::Real)
       GTEST_SKIP();
 #endif
-    plugin_handle_ = plugin_manager_.loadPlugin(GetParam().name);
+    plugin_handle_ = plugin_manager_.loadPlugin<nixlPluginHandle>(GetParam().name);
   }
 
   void TearDown() override {
@@ -77,7 +77,7 @@ protected:
       if (plugin.type == PluginDesc::PluginType::Real)
         continue;
 #endif
-      plugin_handles_.push_back(plugin_manager_.loadPlugin(plugin.name));
+      plugin_handles_.push_back(plugin_manager_.loadPlugin<nixlPluginHandle>(plugin.name));
     }
   }
 

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -558,7 +558,6 @@ TEST_P(TestTransfer, ListenerCommSize) {
 
 TEST_P(TestTransfer, GetXferTelemetryFile) {
     env.addVar("NIXL_TELEMETRY_ENABLE", "y");
-    env.addVar("NIXL_TELEMETRY_DIR", "/tmp/");
 
     // Create fresh agents that read the current env var and add them to the fixture
     addAgent(2);

--- a/test/nixl/test_plugin.cpp
+++ b/test/nixl/test_plugin.cpp
@@ -45,7 +45,7 @@ int verify_plugin(std::string name, nixlPluginManager& plugin_manager)
     std::cout << "\nLoading " << name << " plugin..." << std::endl;
 
     // Load the plugin
-    auto plugin_ = plugin_manager.loadPlugin(name);
+    auto plugin_ = plugin_manager.loadPlugin<nixlPluginHandle>(name);
     if (!plugin_) {
         std::cerr << "Failed to load " << name << " plugin" << std::endl;
         return -1;

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -277,7 +277,6 @@ def test_get_xfer_telemetry(backend_name):
 
 def test_get_xfer_telemetry_cfg(backend_name):
     os.environ["NIXL_TELEMETRY_ENABLE"] = "m"  # invalid value not to enable
-    os.environ["NIXL_TELEMETRY_DIR"] = "/tmp/dummy"  # to be ignored
 
     agent1 = nixl_agent(
         str(uuid.uuid4()),
@@ -330,4 +329,3 @@ def test_get_xfer_telemetry_cfg(backend_name):
         utils.free_passthru(addr1)
         utils.free_passthru(addr2)
         os.environ.pop("NIXL_TELEMETRY_ENABLE")
-        os.environ.pop("NIXL_TELEMETRY_DIR")


### PR DESCRIPTION
## What?
Adds infrastructure for dynamic load of telemetry exporters
Beta implementation of prometheus  exporter

## Why?
Required capability to expose NIXL telemetry in common telemetry formats (e.g OTLP, Prometheus etc.)

## How?
Solution works as dynamically loaded user defined plugins
