### PR TITLE
Bindings: fix crash in python examples when NIXL_PLUGIN_DIR not set

### DIFF
--- a/examples/python/nixl_api_example.py
+++ b/examples/python/nixl_api_example.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     # Allocate memory and register with NIXL
 
     logger.info(
-        "Using NIXL Plugins from:\n%s",
+        "Using NIXL Plugins from: %s",
         os.environ.get("NIXL_PLUGIN_DIR", "default location"),
     )
 

--- a/examples/python/nixl_gds_example.py
+++ b/examples/python/nixl_gds_example.py
@@ -34,7 +34,10 @@ if __name__ == "__main__":
         logger.error("Please specify file path in argv")
         exit(0)
 
-    logger.info("Using NIXL Plugins from:\n%s", os.environ["NIXL_PLUGIN_DIR"])
+    logger.info(
+        "Using NIXL Plugins from: %s",
+        os.environ.get("NIXL_PLUGIN_DIR", "default location"),
+    )
 
     agent_config = nixl_agent_config(backends=[])
     nixl_agent1 = nixl_agent("GDSTester", agent_config)

--- a/examples/python/partial_md_example.py
+++ b/examples/python/partial_md_example.py
@@ -79,7 +79,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    logger.info("Using NIXL Plugins from: %s", os.environ["NIXL_PLUGIN_DIR"])
+    logger.info(
+        "Using NIXL Plugins from: %s",
+        os.environ.get("NIXL_PLUGIN_DIR", "default location"),
+    )
 
     if args.etcd:
         etcd_endpoints = os.getenv("NIXL_ETCD_ENDPOINTS", "")

--- a/examples/python/query_mem_example.py
+++ b/examples/python/query_mem_example.py
@@ -55,7 +55,10 @@ if __name__ == "__main__":
     non_existent_file = "/tmp/nixl_example_nonexistent.txt"
 
     try:
-        logger.info("Using NIXL Plugins from: %s", os.environ["NIXL_PLUGIN_DIR"])
+        logger.info(
+            "Using NIXL Plugins from: %s",
+            os.environ.get("NIXL_PLUGIN_DIR", "default location"),
+        )
 
         # Create an NIXL agent
         logger.info("Creating NIXL agent...")

--- a/test/python/prep_xfer_perf.py
+++ b/test/python/prep_xfer_perf.py
@@ -139,7 +139,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    logger.info("Using NIXL Plugins from:\n%s", os.environ["NIXL_PLUGIN_DIR"])
+    logger.info(
+        "Using NIXL Plugins from: %s",
+        os.environ.get("NIXL_PLUGIN_DIR", "default location"),
+    )
 
     # Example using nixl_agent_config
     agent = init_agent()


### PR DESCRIPTION
## What?
NIXL_PLUGIN_DIR should not be needed when running examples with nixl install through pip
