### PR TITLE
Plugin manager: use info instead of error for plugins missing external deps (#964)

### DIFF
--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPluginFromPath(co
     // Open the plugin file
     void* handle = dlopen(plugin_path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (!handle) {
-        NIXL_ERROR << "Failed to load plugin from " << plugin_path << ": " << dlerror();
+        NIXL_INFO << "Failed to load plugin from " << plugin_path << ": " << dlerror();
         return nullptr;
     }
 
@@ -285,7 +285,7 @@ std::shared_ptr<const nixlPluginHandle> nixlPluginManager::loadPlugin(const std:
     }
 
     // Failed to load the plugin
-    NIXL_ERROR << "Failed to load plugin '" << plugin_name << "' from any directory";
+    NIXL_INFO << "Failed to load plugin '" << plugin_name << "' from any directory";
     return nullptr;
 }
 


### PR DESCRIPTION
Cherry pick of #964

## What?
Python wheel does not bundle libfabric dependencies. As a result, we get log errors on non-AWS systems:

```
+ python /workspace/examples/python/nixl_api_example.py
2025-10-28 10:54:56 NIXL INFO    nixl_api_example.py:35 Using NIXL Plugins from:
default location
E1028 10:54:56.298455       1 nixl_plugin_manager.cpp:122] Failed to load plugin from /workspace/venv/lib/python3.12/site-packages/nixl_cu12/../.nixl_cu12.mesonpy.libs/plugins/libplugin_LIBFABRIC.so: /opt/amazon/efa/lib/libfabric.so.1: version `FABRIC_1.8' not found (required by /workspace/venv/lib/python3.12/site-packages/nixl_cu12/../.nixl_cu12.mesonpy.libs/plugins/libplugin_LIBFABRIC.so)
E1028 10:54:56.298478       1 nixl_plugin_manager.cpp:288] Failed to load plugin 'LIBFABRIC' from any directory
```

These logs should be INFO.