### PR TITLE
[build] make `libfabric` truly optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -188,7 +188,9 @@ else
 endif
 
 libfabric_path = get_option('libfabric_path')
-if libfabric_path != ''
+if get_option('disable_libfabric_backend')
+  libfabric_dep = disabler()
+elif libfabric_path != ''
   libfabric_lib_path = libfabric_path + '/lib'
   libfabric_inc_path = libfabric_path + '/include'
   # Check if path is absolute

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,6 +19,7 @@ option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD He
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD Libraries')
 option('disable_gds_backend', type : 'boolean', value : false, description : 'disable gds backend')
 option('disable_mooncake_backend', type : 'boolean', value : false, description : 'disable mooncake backend')
+option('disable_libfabric_backend', type : 'boolean', value : false, description : 'disable libfabric backend')
 option('install_headers', type : 'boolean', value : true, description : 'install headers')
 option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path to GDS CuFile install')
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -23,7 +23,7 @@ endif
 subdir('posix')  # Always try to build POSIX backend, it will handle its own dependencies
 subdir('obj')  # Always try to build Obj backend, it will handle its own dependencies
 
-if libfabric_dep.found()
+if libfabric_dep.found() and not get_option('disable_libfabric_backend')
     subdir('libfabric')
 endif
 

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -21,6 +21,6 @@ endif
 subdir('stream')
 subdir('file')
 
-if libfabric_dep.found()
+if libfabric_dep.found() and not get_option('disable_libfabric_backend')
     subdir('libfabric')
 endif

--- a/test/unit/utils/meson.build
+++ b/test/unit/utils/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 subdir('common')
-if libfabric_dep.found()
+if libfabric_dep.found() and not get_option('disable_libfabric_backend')
     subdir('libfabric')
 endif
 subdir('serdes')


### PR DESCRIPTION
On certain systems that already have libfabric installed, it may be undesirable to build nixl with explicit support (eg. libfabric version on the host system is too old). This allows a build-time opt out (basically bypass the current behavior of attempting to link with auto-detection), and should be backwards compatible with existing buids/CI.