### PR TITLE
Bindings: fix wheel build in verification environment (#975)

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -40,7 +40,16 @@ export NIXL_PREFIX=${INSTALL_DIR}
 # Raise exceptions for logging errors
 export NIXL_DEBUG_LOGGING=yes
 
-pip3 install --break-system-packages .
+# Set the correct wheel name based on the CUDA version
+cuda_major=$(nvcc --version | grep -oP 'release \K[0-9]+')
+case "$cuda_major" in
+    12|13) echo "CUDA $cuda_major detected" ;;
+    *) echo "Error: Unsupported CUDA version $cuda_major"; exit 1 ;;
+esac
+pip3 install --break-system-packages tomlkit
+./contrib/tomlutil.py --wheel-name "nixl-cu${cuda_major}" pyproject.toml
+# Control ninja parallelism during pip build to prevent OOM (NPROC from common.sh)
+pip3 install --break-system-packages --config-settings=compile-args="-j${NPROC}" .
 pip3 install --break-system-packages dist/nixl-*none-any.whl
 pip3 install --break-system-packages pytest
 pip3 install --break-system-packages pytest-timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 [build-system]
-requires = ["meson-python", "pybind11", "patchelf", "pyyaml", "types-PyYAML", "pytest"]
+requires = ["meson-python", "pybind11", "patchelf", "pyyaml", "types-PyYAML", "pytest", "build", "setuptools"]
 build-backend = "mesonpy"
 
 [project]


### PR DESCRIPTION
Cherry-pick of #975

## What?
.gitlab/test_python.sh fails in the verification environment (nixl container + new venv + test script)
