### PR TITLE
CI: remove Ubuntu22.04 from test matrix

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -6,7 +6,7 @@
 # Key Components:
 # - Job Configuration: Defines timeout, failure behavior, and Kubernetes resources
 # - Docker Images: Specifies the container images used for different build stages
-#   - cuda-dl-base images (25.06 for Ubuntu 24.04, 24.10 for Ubuntu 22.04) for building and testing
+#   - cuda-dl-base images (25.06 for Ubuntu 24.04) for building and testing
 #   - Podman image for container builds
 # - Matrix Axes: Defines build variations (currently x86_64 architecture)
 # - Build Steps: Sequential steps for building, testing, and container creation
@@ -35,7 +35,6 @@ kubernetes:
 
 runs_on_dockers:
   - { name: "ubuntu24.04-cuda-dl-base", url: "nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04" }
-  - { name: "ubuntu22.04-cuda-dl-base", url: "nvcr.io/nvidia/cuda-dl-base:24.10-cuda12.6-devel-ubuntu22.04" }
   - { name: "podman-v5.0.2", url: "quay.io/podman/stable:v5.0.2", category: 'tool', privileged: true }
 
 matrix:


### PR DESCRIPTION
## What?
Remove ubuntu22 from CI builds

## Why?
Justification: there is no pre built docker images (cuda-dl, pytorch etc.) that has Ubuntu22.04 with cuda newer then 12.6 and we need min cuda 12.8
