### PR TITLE
TEST/NIXL: Add timeout between getNotif calls.

### DIFF
--- a/test/nixl/nixl_test.cpp
+++ b/test/nixl/nixl_test.cpp
@@ -88,7 +88,9 @@ static void targetThread(nixlAgent &agent, nixl_opt_args_t *extra_params, int th
 
     std::cout << "Thread " << thread_id << " Wait for initiator and then send xfer descs\n";
     std::string message = serdes.exportStr();
-    while (agent.genNotif(initiator, message, extra_params) != NIXL_SUCCESS);
+    while (agent.genNotif(initiator, message, extra_params) != NIXL_SUCCESS) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
     std::cout << "Thread " << thread_id << " End Control Path metadata exchanges\n";
 
     std::cout << "Thread " << thread_id << " Start Data Path Exchanges\n";


### PR DESCRIPTION
## What?
Added timeout between `getNotif` calls.

## Why?
Test CPP step contains tons of the following messages:
```
genNotif: no specified or potential backend could send the inter-agent notifications
```
