### PR TITLE
build: remove duplicate absl_strings_dep from nixl_common_deps

### DIFF
--- a/src/utils/common/meson.build
+++ b/src/utils/common/meson.build
@@ -17,7 +17,6 @@
 absl_log_dep = abseil_proj.get_variable('absl_log_dep')
 absl_strings_dep = abseil_proj.get_variable('absl_strings_dep')
 absl_status_dep = abseil_proj.get_variable('absl_status_dep')
-absl_strings_dep = abseil_proj.get_variable('absl_strings_dep')
 absl_synchronization_dep = abseil_proj.get_variable('absl_synchronization_dep')
 
 nixl_common_inc = include_directories('.')
@@ -26,7 +25,6 @@ nixl_common_deps = [
     absl_log_dep,
     absl_strings_dep,
     absl_status_dep,
-    absl_strings_dep,
     absl_synchronization_dep,
     dependency('asio', required: true),
 ]


### PR DESCRIPTION
## What?
Removed duplicate `absl_strings_dep` dependency from the `nixl_common_deps` list in the Meson build configuration.