### PR TITLE
CI: NPROC calculation fix for unlimited Docker containers

### DIFF
--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -103,7 +103,7 @@ if [ -z "$NPROC" ]; then
             limit=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
         elif [ -f /sys/fs/cgroup/memory.max ]; then
             limit=$(cat /sys/fs/cgroup/memory.max)
-            [[ $limit == "max" ]] && limit=$((4 * 1024 * 1024 * 1024))
+            [ "$limit" = "max" ] && limit=$((4 * 1024 * 1024 * 1024))
         else
             limit=$((4 * 1024 * 1024 * 1024))
         fi


### PR DESCRIPTION
## What?
Fix NPROC handling for unlimited Docker containers running over BM.

## Why?
We encountered a case in which `/sys/fs/cgroup/memory.max` contains the string "max" instead of a number.

## How?
Set the default NPROC value if "max" was set instead of a number.
