### PR TITLE
CI: Update Podman to v5.6.2

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -16,7 +16,7 @@ kubernetes:
   requests: "{memory: 8Gi, cpu: 4000m}"
 
 runs_on_dockers:
-  - { name: "podman-v5.0.2", url: "quay.io/podman/stable:v5.0.2", privileged: true }
+  - { name: "podman-v5.6.2", url: "quay.io/podman/stable:v5.6.2", privileged: true }
 
 # Build matrix
 matrix:
@@ -57,8 +57,6 @@ steps:
   - name: Prepare
     run: |
       # Setup podman and dependencies
-      rm -f /etc/containers/storage.conf
-      podman system reset -f || true
       ln -sfT $(type -p podman) /usr/bin/docker
       yum install -y git gettext
 

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -37,7 +37,7 @@ runs_on_dockers:
   - { name: "ubuntu24.04-cuda12-dl-base", url: "nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04" }
   - { name: "ubuntu24.04-cuda13-dl-base", url: "nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04" }
   - { name: "ubuntu22.04-cuda-dl-base", url: "nvidia/cuda:13.0.1-devel-ubuntu22.04" }
-  - { name: "podman-v5.0.2", url: "quay.io/podman/stable:v5.0.2", category: 'tool', privileged: true }
+  - { name: "podman-v5.6.2", url: "quay.io/podman/stable:v5.6.2", category: 'tool', privileged: true }
 
 matrix:
   axes:
@@ -84,8 +84,6 @@ steps:
     parallel: false
     containerSelector: "{ name: 'podman.*' }"
     run: |
-      # change storage driver to improve build performance
-      rm -f /etc/containers/storage.conf ; podman system reset -f || true
       # symlink podman to docker - scripts works with docker commands
       ln -sfT $(type -p podman) /usr/bin/docker
       # install git for building container image


### PR DESCRIPTION
## What?
CI: Update Podman to v5.6.2 and remove redundant storage cleanup

## Why?
Podman v5.0.2 uses Fedora mirrors that got blocked by IT as "Adult Content". This causes build failures with SSL/checksum errors.

## How?
- Update to v5.6.2 (uses non-blocked Fedora mirrors)
- Remove obsolete `podman system reset` and `storage.conf` cleanup
