### PR TITLE
.GITLAB: CI - use a separate etcd namespace for each test script to avoid collisions

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -53,6 +53,7 @@ etcd_port=$(get_next_tcp_port)
 etcd_peer_port=$(get_next_tcp_port)
 export NIXL_ETCD_ENDPOINTS="http://127.0.0.1:${etcd_port}"
 export NIXL_ETCD_PEER_URLS="http://127.0.0.1:${etcd_peer_port}"
+export NIXL_ETCD_NAMESPACE="/nixl/cpp_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &

--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -50,6 +50,7 @@ etcd_port=$(get_next_tcp_port)
 etcd_peer_port=$(get_next_tcp_port)
 export NIXL_ETCD_ENDPOINTS="http://127.0.0.1:${etcd_port}"
 export NIXL_ETCD_PEER_URLS="http://127.0.0.1:${etcd_peer_port}"
+export NIXL_ETCD_NAMESPACE="/nixl/nixlbench_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -63,6 +63,7 @@ etcd_port=$(get_next_tcp_port)
 etcd_peer_port=$(get_next_tcp_port)
 export NIXL_ETCD_ENDPOINTS="http://127.0.0.1:${etcd_port}"
 export NIXL_ETCD_PEER_URLS="http://127.0.0.1:${etcd_peer_port}"
+export NIXL_ETCD_NAMESPACE="/nixl/python_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &


### PR DESCRIPTION
## What?
Setting a different etcd namespace for each test script execution

## Why?
To avoid namespace collisions between tests running concurrently

## How?
Using the selected etcd port as part of the namespace path
