### PR TITLE
CI: Fix deviceQuery hanging in GPU containers with InfiniBand

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -92,6 +92,7 @@ steps:
         --device=/dev/gdrdrv \
         -e EXECUTOR_NUMBER \
         -e NPROC \
+        -e CUDA_DEVICE_ORDER=PCI_BUS_ID \
         "${JOB_BASE_NAME}-${BUILD_ID}-${axis_index}"
     onfail: |
       docker rm -f "${JOB_BASE_NAME}-${BUILD_ID}-${axis_index}"


### PR DESCRIPTION
Add CUDA_DEVICE_ORDER=PCI_BUS_ID environment variable to docker run command in test-matrix.yaml to prevent deviceQuery from hanging when running in containers with GPU and Mellanox NIC attached.

The hang occurs because CUDA's default device enumeration tries to discover peer-to-peer capabilities, which can stall indefinitely with InfiniBand devices. Setting CUDA_DEVICE_ORDER=PCI_BUS_ID forces CUDA to enumerate devices by PCI bus ID instead, avoiding the problematic peer-to-peer discovery.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
