### PR TITLE
CI: Fix deviceQuery hang from MPS misconfiguration

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -71,6 +71,28 @@ steps:
       # check rdma status
       ibv_devinfo
       #ib_write_bw
+      # Ensure proper MPS configuration: MPS requires EXCLUSIVE_PROCESS compute mode
+      # If MPS is running without EXCLUSIVE_PROCESS mode, that's a misconfiguration that causes hangs
+      GPU_COUNT=$(nvidia-smi -L | wc -l)
+      if [ "$GPU_COUNT" -gt 0 ]; then
+        # Check if MPS is running
+        MPS_RUNNING=false
+        if command -v nvidia-cuda-mps-control >/dev/null 2>&1 && pgrep -f nvidia-cuda-mps-server >/dev/null 2>&1; then
+          MPS_RUNNING=true
+        fi
+
+        if [ "$MPS_RUNNING" = true ]; then
+          # MPS is running - ensure EXCLUSIVE_PROCESS mode is set (required for MPS)
+          for i in $(seq 0 $((GPU_COUNT-1))); do
+            nvidia-smi -i $i -c EXCLUSIVE_PROCESS || true
+          done
+        else
+          # MPS is not running - ensure DEFAULT mode
+          for i in $(seq 0 $((GPU_COUNT-1))); do
+            nvidia-smi -i $i -c DEFAULT || true
+          done
+        fi
+      fi
 
 
   - name: Build GPU Test Environment


### PR DESCRIPTION
## What?
Fix CI GPU tests hung during build

## Why?
Fix CI GPU tests

## How?
MPS requires EXCLUSIVE_PROCESS compute mode. When MPS was running without it, CUDA Runtime API initialization hung. Fix by ensuring EXCLUSIVE_PROCESS mode is set when MPS is running, DEFAULT mode otherwise.
