### PR TITLE
libfabric: 0 is a valid MR key

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -765,7 +765,8 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
 
     // Initialize vectors to accommodate all possible rails (for indexing consistency)
     priv->rail_mr_list_.resize(rail_manager.getNumDataRails(), nullptr);
-    priv->rail_key_list_.resize(rail_manager.getNumDataRails(), 0);
+    priv->rail_key_list_.clear();
+    priv->rail_key_list_.resize(rail_manager.getNumDataRails(), FI_KEY_NOTAVAIL);
 
 #ifdef HAVE_CUDA
     // Set CUDA context before libfabric operations for VRAM
@@ -896,10 +897,10 @@ nixlLibfabricPublicMetadata::derive_remote_selected_endpoints() {
     remote_selected_endpoints_.clear();
 
     for (size_t i = 0; i < rail_remote_key_list_.size(); ++i) {
-        if (rail_remote_key_list_[i] != 0) {
+        if (rail_remote_key_list_[i] != FI_KEY_NOTAVAIL) {
             remote_selected_endpoints_.push_back(i);
         } else {
-            NIXL_DEBUG << "Skipping remote endpoint " << i << " with key 0";
+            NIXL_DEBUG << "Skipping remote endpoint " << i << " with FI_KEY_NOTAVAIL";
         }
     }
 }

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -407,7 +407,8 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
 
     // Resize output vectors to match all rails
     mr_list_out.resize(data_rails_.size(), nullptr);
-    key_list_out.resize(data_rails_.size(), 0);
+    key_list_out.clear();
+    key_list_out.resize(data_rails_.size(), FI_KEY_NOTAVAIL);
     selected_rails_out = selected_rails; // Return which rails were selected
 
     // Register memory on each selected rail


### PR DESCRIPTION
Use FI_KEY_NOTAVAIL as placeholder for invalid MR key, not 0.

## What?
0 is a valid memory registration key that can be returned by `fi_mr_key()`. Invalid keys have value `FI_KEY_NOTAVAIL`.

## Why?
nixlLibfabricPublicMetadata::derive_remote_selected_endpoints() filters out remote endpoints with key 0, which causes valid remote endpoints to be filtered out.

## How?
