### PR TITLE
Enable libfabric backend plugin with CXI provider for Slingshot network

### DIFF
--- a/src/utils/libfabric/libfabric_common.cpp
+++ b/src/utils/libfabric/libfabric_common.cpp
@@ -50,6 +50,9 @@ getAvailableNetworkDevices() {
     hints->mode = FI_CONTEXT;
     hints->ep_attr->type = FI_EP_RDM;
 
+    // Add CXI-compatible memory registration mode
+    hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ENDPOINT | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
+
     int ret = fi_getinfo(FI_VERSION(1, 18), NULL, NULL, 0, hints, &info);
     if (ret) {
         NIXL_ERROR << "fi_getinfo failed " << fi_strerror(-ret);
@@ -85,7 +88,9 @@ getAvailableNetworkDevices() {
         }
     }
 
-    if (provider_device_map.find("efa") != provider_device_map.end()) {
+    if (provider_device_map.find("cxi") != provider_device_map.end()) {
+        return {"cxi", provider_device_map["cxi"]};
+    } else if (provider_device_map.find("efa") != provider_device_map.end()) {
         return {"efa", provider_device_map["efa"]};
     } else if (provider_device_map.find("sockets") != provider_device_map.end()) {
         return {"sockets", {provider_device_map["sockets"][0]}};

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -179,7 +179,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 
         // For TCP providers, use offset 0 instead of virtual address
         // TCP providers don't support FI_MR_VIRT_ADDR and expect offset-based addressing
-        if (data_rails_[rail_id]->provider_name == "tcp" ||
+        if (data_rails_[rail_id]->provider_name == "cxi" ||
+            data_rails_[rail_id]->provider_name == "tcp" ||
             data_rails_[rail_id]->provider_name == "sockets") {
             req->remote_addr = 0; // Use offset 0 for TCP providers
             NIXL_DEBUG << "TCP provider detected: using offset 0 instead of virtual address "
@@ -258,7 +259,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 
             // For TCP providers, use offset instead of virtual address
             // TCP providers don't support FI_MR_VIRT_ADDR and expect offset-based addressing
-            if (data_rails_[rail_id]->provider_name == "tcp" ||
+            if (data_rails_[rail_id]->provider_name == "cxi" ||
+                data_rails_[rail_id]->provider_name == "tcp" ||
                 data_rails_[rail_id]->provider_name == "sockets") {
                 req->remote_addr = chunk_offset; // Use chunk offset for TCP providers
                 NIXL_DEBUG << "TCP provider detected: using chunk offset " << chunk_offset


### PR DESCRIPTION
Enable CXI provider support in libfabric backend plugin for HPE's Slingshot network.