### PR TITLE
CI: Change k8s namespace to nbu-swx-nixl

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -11,7 +11,7 @@ timeout_minutes: 240
 # Infrastructure
 kubernetes:
   cloud: il-ipp-blossom-prod
-  namespace: swx-media
+  namespace: nbu-swx-nixl
   limits: "{memory: 16Gi, cpu: 8000m}"
   requests: "{memory: 8Gi, cpu: 4000m}"
 

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -29,7 +29,7 @@ timeout_minutes: 240
 
 kubernetes:
   cloud: il-ipp-blossom-prod
-  namespace: swx-media
+  namespace: nbu-swx-nixl
   limits: "{memory: 8Gi, cpu: 8000m}"
   requests: "{memory: 8Gi, cpu: 8000m}"
 


### PR DESCRIPTION
## What?
Update the Kubernetes namespace in the CI build matrices from `swx-media` to `nbu-swx-nixl`.

## Why?
The `swx-media` namespace is currently overutilized by other projects, causing resource constraints. 
The `nbu-swx-nixl` namespace is unused and available for exclusive use.