### PR TITLE
CI: Reduce GPU test to CUDA 13 and UCX master

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -31,12 +31,11 @@ matrix:
   axes:
     image:
       - nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04
-      # - nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04
     arch:
       - x86_64
     ucx_version:
       - master
-      # - v1.20.x
+      - v1.20.x
 
 taskName: "${name}/${arch}/ucx-${ucx_version}/${axis_index}"
 


### PR DESCRIPTION
## What?
Limit the GPU test matrix to CUDA 13 with UCX master.

## Why?
Hardware constraints combined with the NIXL tests’ fixed sleep timings create bottlenecks that significantly extend CI running time.
