### PR TITLE
Enable shared memory provider

### DIFF
--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -777,7 +777,7 @@ nixlLibfabricRail::processCompletionQueueEntry(struct fi_cq_data_entry *comp) co
         // Local read completions (fi_readdata) - use context
         return processLocalTransferCompletion(comp, "read");
 
-    } else if (flags & FI_REMOTE_WRITE) {
+    } else if (flags & FI_REMOTE_WRITE || flags & FI_REMOTE_CQ_DATA) {
         // Remote write completions (from fi_writedata) - use immediate data
         return processRemoteWriteCompletion(comp);
 


### PR DESCRIPTION
## What?

This PR enables libfabric's shared memory provider for intra-node GPU-to-GPU transfers and improves completion queue processing for remote write operations with immediate data.

__Changes include:__

1. Removed the `FI_OPT_SHARED_MEMORY_PERMITTED` disabling code that was preventing shared memory transfers
2. Added `FI_REMOTE_CQ_DATA` flag handling in completion queue entry processing

## Why?

__Shared Memory Provider Enablement:__ The previous code explicitly disabled shared memory transfers via `fi_setopt()` with `FI_OPT_SHARED_MEMORY_PERMITTED=false`. This prevented libfabric from using its shared memory provider for intra-node GPU-to-GPU communication. Since NIXL's libfabric plugin properly supports CUDA calls and HMEM interface registration, we can safely leverage libfabric's shared memory optimizations to enable efficient NVLink-based transfers between GPUs on the same node.

__Benefits:__

- Improved performance for intra-node GPU-to-GPU communication by leveraging NVLink's high-bandwidth, low-latency interconnect
- Eliminates unnecessary network transport overhead for same-node transfers
- Better utilizes available hardware capabilities

__CQ Data Flag Handling:__ The completion queue processing logic only checked for `FI_REMOTE_WRITE` flag when routing remote write completions. However, libfabric operations that include immediate data (via `fi_writedata`) may set the `FI_REMOTE_CQ_DATA` flag instead of or in addition to `FI_REMOTE_WRITE`, particularly with providers such as the SHM (shared memory) provider. This caused these completions to not be properly handled through the `processRemoteWriteCompletion` path, leading to potential compatibility issues with certain libfabric providers.

## How?

The implementation involves two key changes in `src/utils/libfabric/libfabric_rail.cpp`: First, removed the `fi_setopt()` call that disabled `FI_OPT_SHARED_MEMORY_PERMITTED` in `nixlLibfabricRail::nixlLibfabricRail()`, allowing libfabric to automatically select the shared memory provider for intra-node transfers when appropriate. Second, modified the completion queue entry processing logic in `processCompletionQueueEntry()` to check for both `FI_REMOTE_WRITE` and `FI_REMOTE_CQ_DATA` flags (changed condition from `if (flags & FI_REMOTE_WRITE)` to `if (flags & FI_REMOTE_WRITE || flags & FI_REMOTE_CQ_DATA)`), ensuring remote write completions with immediate data are properly routed through `processRemoteWriteCompletion()`. Both changes work together to enable efficient intra-node GPU communication while maintaining compatibility with libfabric's completion queue semantics.
