### PR TITLE
libfabric: Fix sockets provider deadlock by reducing CQ sread timeout

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -34,7 +34,10 @@
 
 // Libfabric configuration constants
 #define NIXL_LIBFABRIC_DEFAULT_CONTROL_RAILS 1
-#define NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS 1000
+
+// Sockets provider requires short timeout to maintain software progress during fi_cq_sread().
+// Long timeouts block in poll(), preventing message processing. EFA uses hardware completions.
+#define NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS 10
 #define NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD (128 * 1024) // 128KB
 #define LF_EP_NAME_MAX_LEN 56
 


### PR DESCRIPTION
## What?
Reduce `NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS` from 1000ms to 10ms to fix connection deadlock when using the sockets/TCP provider with libfabric backend.

## Why?
The sockets provider uses a software-based progress model that requires frequent polling to process network events. When the CM (Connection Management) thread calls `fi_cq_sread()` with a 1000ms timeout, it blocks in `poll()` for the full duration, preventing progress on pending messages. This creates a deadlock during connection establishment where both initiator and target are blocked waiting for messages that cannot be processed.

The issue manifests as connection hangs when using the sockets or TCP provider. EFA provider is unaffected because it uses hardware-assisted completion processing that doesn't require software polling.

## How?
The sockets provider's `sock_cq_sreadfrom()` function calls `ofi_rbfdwait()`, which blocks in `poll()` for the specified timeout. With a 1000ms timeout, the CM thread cannot make progress on network operations during this blocking period.

By reducing the timeout to 10ms, the CM thread wakes up frequently enough to call `sock_cq_progress()`, which processes pending network events and allows connection messages to be exchanged properly.

This change only affects the sockets/TCP provider. The EFA provider's hardware-based completion mechanism works correctly with any timeout value.
