### PR TITLE
feat(libfabric): disable unsolicited write recv for EFA RDM to reduce…

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -29,8 +29,10 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
+#include <rdma/fi_ext.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_rma.h>
+
 
 // Libfabric configuration constants
 #define NIXL_LIBFABRIC_DEFAULT_CONTROL_RAILS 1

--- a/src/utils/libfabric/meson.build
+++ b/src/utils/libfabric/meson.build
@@ -43,6 +43,20 @@ libfabric_utils_deps = [
 
 libfabric_utils_cpp_args = []
 
+# Detect optional libfabric features at compile time to enable/disable
+# functionality based on the installed libfabric version
+if libfabric_dep.found()
+    # Check for FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV (libfabric >= 2.3)
+    if cpp.has_header_symbol('rdma/fi_ext.h',
+                             'FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV',
+                             dependencies: libfabric_dep)
+        libfabric_utils_cpp_args += ['-DHAVE_FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV']
+        message('libfabric supports FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV')
+    else
+        message('libfabric does not support FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV')
+    endif
+endif
+
 # Add CUDA support if available
 if cuda_dep.found()
     libfabric_utils_deps += [cuda_dep]


### PR DESCRIPTION
__Disable unsolicited write recv for EFA RDM to reduce CQ overflow__

Add support for FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV option to disable unsolicited write receive operations on EFA RDM endpoints. This helps reduce the likelihood of completion queue overflow under high load.

Changes:

- Add fi_setopt() call to disable unsolicited write recv before endpoint enable in libfabric_rail.cpp

### What?

Adds `fi_setopt()` call to disable unsolicited write receive on EFA RDM endpoints using the `FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV` option with backward compatibility for older libfabric versions.

### Why?

Unsolicited write receive increases completion queue pressure, which can cause CQ overflow under high load with GPU-to-GPU transfers. Disabling this feature improves stability at the cost of some performance.

### How?

Calls `fi_setopt()` with `FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV=false` in the rail constructor before `fi_enable()`. The code is wrapped in `#ifdef HAVE_FI_OPT_EFA_USE_UNSOLICITED_WRITE_RECV` to ensure backward compatibility with older libfabric versions.
