### PR TITLE
CI: Switch Jenkins pipeline to svc-nixl credentials

### DIFF
--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -62,16 +62,28 @@
             // Trigger the actual build and test jobs in parallel
             parallel build: {{
                 def buildJob = 'nixl-ci-build'
-                build job: buildJob, parameters: [
+                def run = build job: buildJob, parameters: [
                     string(name: 'sha1', value: githubHelper.getMergedSHA()),
                     string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ]
+                ], propagate: false
+                def jobUrl = "${{JENKINS_URL}}blue/organizations/jenkins/${{buildJob}}/detail/${{buildJob}}/${{run.number}}/pipeline"
+                if (run.resultIsBetterOrEqualTo('SUCCESS')) {{
+                    echo "${{buildJob}} SUCCESS: ${{jobUrl}}"
+                }} else {{
+                    error("${{buildJob}} FAILED: ${{jobUrl}}")
+                }}
             }}, test: {{
                 def buildJob = 'nixl-ci-test'
-                build job: buildJob, parameters: [
+                def run = build job: buildJob, parameters: [
                     string(name: 'sha1', value: githubHelper.getMergedSHA()),
                     string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ]
+                ], propagate: false
+                def jobUrl = "${{JENKINS_URL}}blue/organizations/jenkins/${{buildJob}}/detail/${{buildJob}}/${{run.number}}/pipeline"
+                if (run.resultIsBetterOrEqualTo('SUCCESS')) {{
+                    echo "${{buildJob}} SUCCESS: ${{jobUrl}}"
+                }} else {{
+                    error("${{buildJob}} FAILED: ${{jobUrl}}")
+                }}
             }},
             failFast: false  // Continue even if some parallel jobs fail
 


### PR DESCRIPTION
## What?
Migrate the Jenkins CI pipeline credentials to use the dedicated `svc-nixl` service user.
- Update the GitHub API token credential ID from `github-token` to `svc-nixl-github-token` in the dispatcher job.
- Update the SSH key credential ID from `swx-jenkins_ssh_key` to `svc-nixl-ssh_key` in build, test, and container jobs.

## Why?
Improve security by isolating the NIXL project CI on the new dedicated Jenkins and project-specific credentials.

## How?
Modify `proj-jjb.yaml` to reference the new Jenkins credential IDs that correspond to the `svc-nixl` user configuration.