### PR TITLE
DEVICE/API/GTEST: Fix SingleWriteTest to set channel_id

### DIFF
--- a/test/gtest/device_api/single_write_test.cu
+++ b/test/gtest/device_api/single_write_test.cu
@@ -48,7 +48,7 @@ TestSingleWriteKernel(nixlGpuXferReqH req_hdnl,
 
     for (size_t i = 0; i < num_iters; ++i) {
         status = nixlGpuPostSingleWriteXferReq<level>(
-            req_hdnl, index, src_offset, remote_offset, size, is_no_delay, xfer_status_ptr);
+            req_hdnl, index, src_offset, remote_offset, size, 0, is_no_delay, xfer_status_ptr);
         if (status != NIXL_IN_PROG) {
             printf("Thread %d: nixlGpuPostSingleWriteXferReq failed iteration %lu: status=%d (0x%x)\n",
                    threadIdx.x,


### PR DESCRIPTION
## What?
Updates `SingleWriteTest` to set `channel_id` parameter in `nixlGpuPostSingleWriteXferReq`.

## Why?
Recent UCX changes (commit `1c60acc`) introduced a `channel_id` parameter. The test call site was missing this argument, causing the `is_no_delay` flag (true) to be interpreted as `channel_id` (1). This resulted in an illegal memory access on the GPU since only channel 0 is configured.

```
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from ucxDeviceApi/SingleWriteTest
[ RUN      ] ucxDeviceApi/SingleWriteTest.BasicSingleWriteTest/UCX_BLOCK
Failed to synchronize: an illegal memory access was encountered
Failed to launch kernel: an illegal memory access was encountered
../test/gtest/device_api/single_write_test.cu:441: Failure
Expected equality of these values:
  status
    Which is: -3
  NIXL_SUCCESS
    Which is: 0
Kernel launch failed with status: -3
```

## How?
Explicitly passes `0` as the `channel_id` in the `nixlGpuPostSingleWriteXferReq` call.
