### PR TITLE
API: Added a clarification for prepXfer API.

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -168,9 +168,10 @@ class nixlAgent {
          *           - For remote descriptors: it is set to the remote name, indicating
          *             that this is remote side preparation to be used for remote_side handle.
          *           - For loopback descriptors, it is set to local agent's name, indicating that
-         *             this is for a loopback (local) transfer to be uued for remote_side handle
+         *             this is for a loopback (local) transfer to be used for remote_side handle
          *         If a list of backends hints is provided (via extra_params), the preparation
-         *         is limited to the specified backends.
+         *         is limited to the specified backends. The preparation succeeds if there exists
+         *         at least one backend that can handle all elements in the descriptor list.
          *
          * @param  agent_name       Agent name as a string for preparing xfer handle
          * @param  descs            The descriptor list to be prepared for transfer requests

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -444,7 +444,7 @@ class nixl_agent:
     """
     @brief  Prepare a transfer descriptor list for data transfer.
             Later, elements from this list can be used to create a transfer request by index.
-            It should be done on the initiator agent, and for both sides of an transfer.
+            It should be done on the initiator agent, and for both sides of a transfer.
             Considering loopback, there are 3 modes for agent_name:
               - For local descriptors, it is set to NIXL_INIT_AGENT,
                 indicating that this is a local preparation to be used as local_side handle.
@@ -452,6 +452,8 @@ class nixl_agent:
                 that this is remote side preparation to be used for remote_side handle.
               - For loopback descriptors, it is set to local agent's name, indicating that
                 this is for a loopback (local) transfer to be used for remote_side handle
+            Preparation succeeds if there exists at least one backend that can handle all
+            elements in the descriptor list.
 
     @param agent_name Name of the agent. It can be "NIXL_INIT_AGENT", local agent name, or remote agent name
     @param xfer_list List of transfer descriptors, can be list of memory region tuples, tensors,


### PR DESCRIPTION
## What?
Added a clarification for prepXfer API.

## Why?
The API needed a clarification that prepXfer would succeed if at least one backend can fully handle the list, as during makeXfer it's just a mapping stage, not deciding backend per element.