### PR TITLE
feature: rust - add metadata support to descriptor reg

### DIFF
--- a/src/bindings/rust/src/descriptors/reg.rs
+++ b/src/bindings/rust/src/descriptors/reg.rs
@@ -221,9 +221,10 @@ impl<'a> RegDescList<'a> {
         let addr = unsafe { desc.as_ptr() } as usize;
         let len = desc.size();
         let dev_id = desc.device_id();
+        let metadata = desc.metadata();
 
-        // Add to list
-        self.add_desc(addr, len, dev_id);
+        // Add to list with metadata
+        self.add_desc_with_meta(addr, len, dev_id, &metadata);
         Ok(())
     }
 

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -501,6 +501,15 @@ pub trait NixlDescriptor: MemoryRegion {
 
     /// Get the device ID for this memory region
     fn device_id(&self) -> u64;
+
+    /// Get optional metadata for this descriptor.
+    ///
+    /// Metadata is used by some backends (e.g., OBJ for object storage keys).
+    /// Returns owned bytes since they're copied during registration anyway.
+    /// Default implementation returns empty vec.
+    fn metadata(&self) -> Vec<u8> {
+        Vec::new()
+    }
 }
 
 /// A trait for types that can be registered with NIXL


### PR DESCRIPTION
## What?
Enable NixlDescriptor to pass metadata through add_storage_desc() during memory registration.
- Changed NixlDescriptor::metadata() return type from &[u8] to Vec<u8>
- Updated add_storage_desc() to call desc.metadata() and pass it to add_desc_with_meta()
