### PR TITLE
chore: add @amitrad-aws as code owner for libfabric components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,6 @@ CODEOWNERS @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
 /benchmark @aranadive @ovidiusm @brminich
 
 # Libfabric Plugins
-/src/plugins/libfabric* @yexiang-aws @akkart-aws @fengjica
-/src/utils/libfabric @yexiang-aws @akkart-aws @fengjica
-/test/unit/utils/libfabric @yexiang-aws @akkart-aws @fengjica
+/src/plugins/libfabric* @amitrad-aws @yexiang-aws @akkart-aws @fengjica
+/src/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica
+/test/unit/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica


### PR DESCRIPTION
## What?
Add @amitrad-aws as a code owner for all libfabric-related paths including plugins, utilities, and unit tests. 

## Why?
This ensures proper review coverage for libfabric components alongside existing maintainers.