### PR TITLE
CI: Add BUILD_NIXL_EP param to container build job

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -51,6 +51,7 @@ pipeline_start:
     echo "ENABLE_NIXL_BUILD: ${env.ENABLE_NIXL_BUILD}"
     echo "ENABLE_NIXLBENCH_BUILD: ${env.ENABLE_NIXLBENCH_BUILD}"
     echo "BUILD_TARGET: ${params.BUILD_TARGET}"
+    echo "BUILD_NIXL_EP: ${params.BUILD_NIXL_EP}"
 
 # Build pipeline
 steps:
@@ -83,13 +84,19 @@ steps:
     run: |
       export UCX_REF="${UCX_VERSION}"
 
+      NIXL_EP_FLAG=""
+      if [[ "${BUILD_NIXL_EP}" == "true" ]]; then
+          NIXL_EP_FLAG="--build-nixl-ep"
+      fi
+
       "contrib/build-container.sh" \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_IMAGE_TAG}" \
         --tag "${LOCAL_TAG_BASE}${arch}" \
         --arch "${arch}" \
         --build-type debug \
-        --no-cache
+        --no-cache \
+        ${NIXL_EP_FLAG}
 
   - name: Add Version Info
     run: |
@@ -175,8 +182,12 @@ steps:
         echo "git clone https://github.com/openucx/ucx.git ucx-src && (cd ucx-src && git checkout ${UCX_VERSION})"
         echo "benchmark/nixlbench/contrib/build.sh --base-image ${BASE_IMAGE} --base-image-tag ${BASE_IMAGE_TAG} --tag local-test-tag --arch ${arch} --no-cache --nixl \$WORKSPACE --ucx \$WORKSPACE/ucx-src"
       else
+        NIXL_EP_FLAG=""
+        if [[ "${BUILD_NIXL_EP}" == "true" ]]; then
+            NIXL_EP_FLAG="--build-nixl-ep"
+        fi
         echo "export UCX_REF=${UCX_VERSION}"
-        echo "contrib/build-container.sh --base-image ${BASE_IMAGE} --base-image-tag ${BASE_IMAGE_TAG} --tag local-test-tag --arch ${arch} --build-type debug --no-cache"
+        echo "contrib/build-container.sh --base-image ${BASE_IMAGE} --base-image-tag ${BASE_IMAGE_TAG} --tag local-test-tag --arch ${arch} --build-type debug --no-cache ${NIXL_EP_FLAG}"
       fi
 
 pipeline_stop:
@@ -206,6 +217,7 @@ pipeline_stop:
                 <p>Base Image: <b>${params.BASE_IMAGE}:${params.BASE_IMAGE_TAG}</b></p>
                 <p>Architectures: <b>x86_64, aarch64</b></p>
                 ${params.UPDATE_LATEST ? '<p>Latest tag updated: <b>Yes</b></p>' : ''}
+                ${params.BUILD_NIXL_EP ? "<p>Build NIXL EP: <b>Yes</b></p>" : ''}
             """
         )
     }

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -282,6 +282,10 @@
             Update the latest tag for this architecture.<br/>
             When enabled, also creates: <code>&lt;base-image-tag&gt;-&lt;arch&gt;-latest</code><br/>
             Example: <code>25.10-cuda13.0-devel-ubuntu24.04-aarch64-latest</code><br/>
+      - bool:
+          name: "BUILD_NIXL_EP"
+          default: false
+          description: "Build NIXL with EP example support (pass --build-nixl-ep)"
       - string:
           name: "MAIL_TO"
           default: "25f58ae0.NVIDIA.onmicrosoft.com@amer.teams.ms"


### PR DESCRIPTION
## What?
Add `BUILD_NIXL_EP` boolean param to enable building NIXL containers with EP example support.

## Why?
NIXL v0.9.0 introduces EP example functionality that requires CI verification coverage.

## How?
Add boolean param to `proj-jjb.yaml` that passes `--build-nixl-ep` flag to `build-container.sh` when enabled.