### PR TITLE
TEST: Remove printing binary data.

### DIFF
--- a/test/nixl/agent_example.cpp
+++ b/test/nixl/agent_example.cpp
@@ -656,9 +656,6 @@ main(int argc, char **argv) {
     nixl_exit_on_failure(ret1, "Failed to get local MD", agent1);
     nixl_exit_on_failure(ret2, "Failed to get local MD", agent2);
 
-    std::cout << "Agent1's Metadata: " << meta1 << "\n";
-    std::cout << "Agent2's Metadata: " << meta2 << "\n";
-
     ret1 = A1.loadRemoteMD (meta2, ret_s1);
     ret2 = A2.loadRemoteMD (meta1, ret_s2);
     nixl_exit_on_failure(ret1, "Failed to load remote MD", agent1);


### PR DESCRIPTION
## What?
Remove printing binary data to `std::cout` in `agent_example.cpp`.

## Why?
Printing binary data to the terminal (in between normal logging) can have weird and undesirable effects and is not particularly useful.
