### PR TITLE
UCX: Check version and warn if older 1.19

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -447,8 +447,8 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     if (ucpVersion_ >= UCP_VERSION(1, 19)) {
         config.modify("MAX_COMPONENT_MDS", "32");
     } else {
-        NIXL_WARN << "UCX version is less than 1.19, CUDA support is limited, "
-                  << "including the lack of support for multi-GPU within a single process.";
+        NIXL_WARN << "UCX version " << major_version << "." << minor_version << "."
+                  << release_number << " is less than 1.19, support is limited";
     }
 
     std::string elem;


### PR DESCRIPTION
## What?
Add a warning when UCX version is older than 1.19, as it may not support all required features
