### PR TITLE
fix(rust-bindings): detect NIXL availability and fallback to stubs

### DIFF
--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -16,9 +16,18 @@
  */
 #pragma once
 
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
+// Use built-in compiler types to avoid system header dependencies
+typedef __SIZE_TYPE__ size_t;
+typedef __UINT64_TYPE__ uint64_t;
+typedef __INT64_TYPE__ int64_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+
+#ifndef __cplusplus
+typedef _Bool bool;
+#define true 1
+#define false 0
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
- Use built-in compiler types in wrapper.h instead of system headers (stdbool.h, stddef.h, stdint.h) to fix bindgen failures on systems where libclang cannot locate standard headers

- Add check_nixl_available() to detect if NIXL library is installed by checking pkg-config and common library paths for libnixl.so

- Fallback to stub API when NIXL is not found, with clear warning: "NIXL library not found, building with stub API"

This allows the Rust bindings to build successfully on systems without NIXL installed, enabling development and testing of Rust code that depends on nixl-sys without requiring the full NIXL installation.
