### PR TITLE
NIXL EP Example: Fix reset_etcd.sh

### DIFF
--- a/examples/device/ep/scripts/reset_etcd.sh
+++ b/examples/device/ep/scripts/reset_etcd.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 set +e
-pkill -9 -f etcd
+pkill -9 -x etcd
 pkill -9 -f python
 rm -rf default.etcd
 HOST_IP=$(hostname -I | awk '{print $1}')


### PR DESCRIPTION
## What?
Updated the flag for `pkill` cmdline in `examples/device/ep/scripts/reset_etcd.sh` script.

## Why?
With current cmdline `pkill -9 -f etcd` the script kills itself and never proceeds, because of the flag `-f` the name of the script is matched.
With replacement of `-f` with `-x` the exact pattern `etcd` is matched, and the script proceeds to next cmdlines in it.
