### PR TITLE
pre-commit: Run 'git clang-format' in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
         args: ["--toml", "pyproject.toml"]
         exclude: (?x)^(.*stemmer.*|.*stop_words.*|^CHANGELOG.md$|.*\.md|.*\.rs$|src/utils/serdes/serdes.h)
 
+  - repo: local
+    hooks:
+      - id: staged-clang-format
+        name: clang-format
+        entry: git clang-format
+        language: system
+        files: \.(cpp|h|hpp|cc|c|cxx|cu|cuh)$
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
## What?
This will detect code format issues in C/C++ that would have failed the CI.

## Why?
My PRs keep failing in CI because I forget to run git clang-format

## How?
I added a custom pre-commit hook that runs git clang-format. This will only format changed lines.
