### PR TITLE
posix: Format posix plugin with clang-format

### DIFF
--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -28,113 +28,127 @@
 #include "file/file_utils.h"
 
 namespace {
-    bool isValidPrepXferParams(const nixl_xfer_op_t &operation,
-                               const nixl_meta_dlist_t &local,
-                               const nixl_meta_dlist_t &remote,
-                               const std::string &remote_agent,
-                               const std::string &local_agent) {
-        if (remote_agent != local_agent) {
-            NIXL_ERROR << absl::StrFormat("Error: Remote agent must match the requesting agent (%s). Got %s",
-                                        local_agent, remote_agent);
-            return false;
-        }
-
-        if (local.getType() != DRAM_SEG) {
-            NIXL_ERROR << absl::StrFormat("Error: Local memory type must be DRAM_SEG, got %d", local.getType());
-            return false;
-        }
-
-        if (remote.getType() != FILE_SEG) {
-            NIXL_ERROR << absl::StrFormat("Error: Remote memory type must be FILE_SEG, got %d", remote.getType());
-            return false;
-        }
-
-        if (local.descCount() != remote.descCount()) {
-            NIXL_ERROR << absl::StrFormat("Error: Mismatch in descriptor counts - local: %d, remote: %d",
-                                        local.descCount(), remote.descCount());
-            return false;
-        }
-
-        return true;
+bool
+isValidPrepXferParams(const nixl_xfer_op_t &operation,
+                      const nixl_meta_dlist_t &local,
+                      const nixl_meta_dlist_t &remote,
+                      const std::string &remote_agent,
+                      const std::string &local_agent) {
+    if (remote_agent != local_agent) {
+        NIXL_ERROR << absl::StrFormat(
+            "Error: Remote agent must match the requesting agent (%s). Got %s",
+            local_agent,
+            remote_agent);
+        return false;
     }
 
-    nixlPosixBackendReqH& castPosixHandle(nixlBackendReqH* handle) {
-        if (!handle) {
-            throw nixlPosixBackendReqH::exception("received null handle", NIXL_ERR_INVALID_PARAM);
-        }
-        return dynamic_cast<nixlPosixBackendReqH&>(*handle);
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat("Error: Local memory type must be DRAM_SEG, got %d",
+                                      local.getType());
+        return false;
     }
 
-    // Stringify function for queue_t
-    inline const char* to_string(nixlPosixQueue::queue_t type) {
-        using queue_t = nixlPosixQueue::queue_t;
-        switch (type) {
-            case queue_t::AIO: return "AIO";
-            case queue_t::URING: return "URING";
-            case queue_t::POSIXAIO:
-                return "POSIXAIO";
-            case queue_t::UNSUPPORTED: return "UNSUPPORTED";
-            default: return "UNKNOWN";
-        }
+    if (remote.getType() != FILE_SEG) {
+        NIXL_ERROR << absl::StrFormat("Error: Remote memory type must be FILE_SEG, got %d",
+                                      remote.getType());
+        return false;
     }
 
-    static nixlPosixQueue::queue_t getQueueType(const nixl_b_params_t* custom_params) {
-        using queue_t = nixlPosixQueue::queue_t;
+    if (local.descCount() != remote.descCount()) {
+        NIXL_ERROR << absl::StrFormat(
+            "Error: Mismatch in descriptor counts - local: %d, remote: %d",
+            local.descCount(),
+            remote.descCount());
+        return false;
+    }
 
-        // Check for explicit backend request
-        if (custom_params) {
-            // First check if AIO is explicitly requested
-            if (custom_params->count("use_aio") > 0) {
-                const auto& value = custom_params->at("use_aio");
-                if (value == "true" || value == "1") {
-                    if (!QueueFactory::isLinuxAioAvailable()) {
-                        NIXL_ERROR << "linux_aio backend requested but not available at runtime";
-                        return queue_t::UNSUPPORTED;
-                    }
-                    return queue_t::AIO;
-                }
-            }
+    return true;
+}
 
-            // Then check if io_uring is explicitly requested
-            if (custom_params->count("use_uring") > 0) {
-                const auto& value = custom_params->at("use_uring");
-                if (value == "true" || value == "1") {
-                    if (!QueueFactory::isUringAvailable()) {
-                        NIXL_ERROR << "io_uring backend requested but not available at runtime";
-                        return queue_t::UNSUPPORTED;
-                    }
-                    return queue_t::URING;
-                }
-            }
+nixlPosixBackendReqH &
+castPosixHandle(nixlBackendReqH *handle) {
+    if (!handle) {
+        throw nixlPosixBackendReqH::exception("received null handle", NIXL_ERR_INVALID_PARAM);
+    }
+    return dynamic_cast<nixlPosixBackendReqH &>(*handle);
+}
 
-            // Then check if linux_aio is explicitly requested
-            if (custom_params->count("use_posix_aio") > 0) {
-                const auto &value = custom_params->at("use_posix_aio");
-                if (value == "true" || value == "1") {
-                    if (!QueueFactory::isPosixAioAvailable()) {
-                        NIXL_ERROR << "posix_aio backend requested but not available at runtime";
-                        return queue_t::UNSUPPORTED;
-                    }
-                    return queue_t::POSIXAIO;
-                }
-            }
-        }
-
-        if (QueueFactory::isLinuxAioAvailable()) {
-            return queue_t::AIO;
-        }
-        if (QueueFactory::isUringAvailable()) {
-            return queue_t::URING;
-        }
-        if (QueueFactory::isPosixAioAvailable()) {
-            return queue_t::POSIXAIO;
-        }
-
-        // Should never reach here. At least one of the queues should be available.
-        NIXL_ASSERT(false);
-        return queue_t::UNSUPPORTED;
+// Stringify function for queue_t
+inline const char *
+to_string(nixlPosixQueue::queue_t type) {
+    using queue_t = nixlPosixQueue::queue_t;
+    switch (type) {
+    case queue_t::AIO:
+        return "AIO";
+    case queue_t::URING:
+        return "URING";
+    case queue_t::POSIXAIO:
+        return "POSIXAIO";
+    case queue_t::UNSUPPORTED:
+        return "UNSUPPORTED";
+    default:
+        return "UNKNOWN";
     }
 }
+
+static nixlPosixQueue::queue_t
+getQueueType(const nixl_b_params_t *custom_params) {
+    using queue_t = nixlPosixQueue::queue_t;
+
+    // Check for explicit backend request
+    if (custom_params) {
+        // First check if AIO is explicitly requested
+        if (custom_params->count("use_aio") > 0) {
+            const auto &value = custom_params->at("use_aio");
+            if (value == "true" || value == "1") {
+                if (!QueueFactory::isLinuxAioAvailable()) {
+                    NIXL_ERROR << "linux_aio backend requested but not available at runtime";
+                    return queue_t::UNSUPPORTED;
+                }
+                return queue_t::AIO;
+            }
+        }
+
+        // Then check if io_uring is explicitly requested
+        if (custom_params->count("use_uring") > 0) {
+            const auto &value = custom_params->at("use_uring");
+            if (value == "true" || value == "1") {
+                if (!QueueFactory::isUringAvailable()) {
+                    NIXL_ERROR << "io_uring backend requested but not available at runtime";
+                    return queue_t::UNSUPPORTED;
+                }
+                return queue_t::URING;
+            }
+        }
+
+        // Then check if linux_aio is explicitly requested
+        if (custom_params->count("use_posix_aio") > 0) {
+            const auto &value = custom_params->at("use_posix_aio");
+            if (value == "true" || value == "1") {
+                if (!QueueFactory::isPosixAioAvailable()) {
+                    NIXL_ERROR << "posix_aio backend requested but not available at runtime";
+                    return queue_t::UNSUPPORTED;
+                }
+                return queue_t::POSIXAIO;
+            }
+        }
+    }
+
+    if (QueueFactory::isLinuxAioAvailable()) {
+        return queue_t::AIO;
+    }
+    if (QueueFactory::isUringAvailable()) {
+        return queue_t::URING;
+    }
+    if (QueueFactory::isPosixAioAvailable()) {
+        return queue_t::POSIXAIO;
+    }
+
+    // Should never reach here. At least one of the queues should be available.
+    NIXL_ASSERT(false);
+    return queue_t::UNSUPPORTED;
+}
+} // namespace
 
 // -----------------------------------------------------------------------------
 // POSIX Backend Request Handle Implementation
@@ -143,23 +157,24 @@ namespace {
 nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
                                            const nixl_meta_dlist_t &loc,
                                            const nixl_meta_dlist_t &rem,
-                                           const nixl_opt_b_args_t* args,
-                                           const nixl_b_params_t* params)
-    : operation(op)
-    , local(loc)
-    , remote(rem)
-    , opt_args(args)
-    , custom_params_(params)
-    , queue_depth_(loc.descCount())
-    , queue_type_(getQueueType(params)) {
+                                           const nixl_opt_b_args_t *args,
+                                           const nixl_b_params_t *params)
+    : operation(op),
+      local(loc),
+      remote(rem),
+      opt_args(args),
+      custom_params_(params),
+      queue_depth_(loc.descCount()),
+      queue_type_(getQueueType(params)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         throw exception(absl::StrFormat("Unsupported queue type"), NIXL_ERR_NOT_SUPPORTED);
     }
 
     if (local.descCount() == 0 || remote.descCount() == 0) {
-        throw exception(
-            absl::StrFormat("Invalid descriptor count - local: %zu, remote: %zu", local.descCount(), remote.descCount()),
-            NIXL_ERR_INVALID_PARAM);
+        throw exception(absl::StrFormat("Invalid descriptor count - local: %zu, remote: %zu",
+                                        local.descCount(),
+                                        remote.descCount()),
+                        NIXL_ERR_INVALID_PARAM);
     }
 
     nixl_status_t status = initQueues();
@@ -169,43 +184,44 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
     }
 }
 
-
-nixl_status_t nixlPosixBackendReqH::initQueues() {
+nixl_status_t
+nixlPosixBackendReqH::initQueues() {
     try {
         switch (queue_type_) {
-            case nixlPosixQueue::queue_t::AIO:
-                queue = QueueFactory::createLinuxAioQueue(queue_depth_, operation);
-                break;
-            case nixlPosixQueue::queue_t::URING:
-                queue = QueueFactory::createUringQueue(queue_depth_, operation);
-                break;
-            case nixlPosixQueue::queue_t::POSIXAIO:
-                queue = QueueFactory::createPosixAioQueue(queue_depth_, operation);
-                break;
-            default:
-                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
-                return NIXL_ERR_INVALID_PARAM;
+        case nixlPosixQueue::queue_t::AIO:
+            queue = QueueFactory::createLinuxAioQueue(queue_depth_, operation);
+            break;
+        case nixlPosixQueue::queue_t::URING:
+            queue = QueueFactory::createUringQueue(queue_depth_, operation);
+            break;
+        case nixlPosixQueue::queue_t::POSIXAIO:
+            queue = QueueFactory::createPosixAioQueue(queue_depth_, operation);
+            break;
+        default:
+            NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
+            return NIXL_ERR_INVALID_PARAM;
         }
         return NIXL_SUCCESS;
-    } catch (const nixlPosixBackendReqH::exception& e) {
+    }
+    catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << absl::StrFormat("Failed to initialize queues: %s", e.what());
         return e.code();
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception &e) {
         NIXL_ERROR << absl::StrFormat("Failed to initialize queues: %s", e.what());
         return NIXL_ERR_BACKEND;
     }
 }
 
-nixl_status_t nixlPosixBackendReqH::prepXfer() {
+nixl_status_t
+nixlPosixBackendReqH::prepXfer() {
     for (auto [local_it, remote_it] = std::make_pair(local.begin(), remote.begin());
          local_it != local.end() && remote_it != remote.end();
          ++local_it, ++remote_it) {
-        nixl_status_t status = queue->prepIO(
-            remote_it->devId,
-            reinterpret_cast<void*>(local_it->addr),
-            remote_it->len,
-            remote_it->addr
-        );
+        nixl_status_t status = queue->prepIO(remote_it->devId,
+                                             reinterpret_cast<void *>(local_it->addr),
+                                             remote_it->len,
+                                             remote_it->addr);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "Error preparing I/O operation";
@@ -216,21 +232,23 @@ nixl_status_t nixlPosixBackendReqH::prepXfer() {
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlPosixBackendReqH::checkXfer() {
+nixl_status_t
+nixlPosixBackendReqH::checkXfer() {
     return queue->checkCompleted();
 }
 
-nixl_status_t nixlPosixBackendReqH::postXfer() {
-    return queue->submit (local, remote);
+nixl_status_t
+nixlPosixBackendReqH::postXfer() {
+    return queue->submit(local, remote);
 }
 
 // -----------------------------------------------------------------------------
 // POSIX Engine Implementation
 // -----------------------------------------------------------------------------
 
-nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams* init_params)
-    : nixlBackendEngine(init_params)
-    , queue_type_(getQueueType(init_params->customParams)) {
+nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams *init_params)
+    : nixlBackendEngine(init_params),
+      queue_type_(getQueueType(init_params->customParams)) {
     if (queue_type_ == nixlPosixQueue::queue_t::UNSUPPORTED) {
         initErr = true;
         NIXL_ERROR << absl::StrFormat(
@@ -242,9 +260,10 @@ nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams* init_params)
                                  to_string(queue_type_));
 }
 
-nixl_status_t nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
-                                           const nixl_mem_t &nixl_mem,
-                                           nixlBackendMD* &out) {
+nixl_status_t
+nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
+                             const nixl_mem_t &nixl_mem,
+                             nixlBackendMD *&out) {
     auto supported_mems = getSupportedMems();
     if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) != supported_mems.end())
         return NIXL_SUCCESS;
@@ -252,16 +271,18 @@ nixl_status_t nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
     return NIXL_ERR_NOT_SUPPORTED;
 }
 
-nixl_status_t nixlPosixEngine::deregisterMem(nixlBackendMD *) {
+nixl_status_t
+nixlPosixEngine::deregisterMem(nixlBackendMD *) {
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args) const {
+nixl_status_t
+nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
+                          const nixl_meta_dlist_t &local,
+                          const nixl_meta_dlist_t &remote,
+                          const std::string &remote_agent,
+                          nixlBackendReqH *&handle,
+                          const nixl_opt_b_args_t *opt_args) const {
     if (!isValidPrepXferParams(operation, local, remote, remote_agent, localAgent)) {
         return NIXL_ERR_INVALID_PARAM;
     }
@@ -270,21 +291,22 @@ nixl_status_t nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
         // Create a params map with our backend selection
         nixl_b_params_t params;
         switch (queue_type_) {
-            case nixlPosixQueue::queue_t::AIO:
-                params["use_aio"] = "true";
-                break;
-            case nixlPosixQueue::queue_t::URING:
-                params["use_uring"] = "true";
-                break;
-            case nixlPosixQueue::queue_t::POSIXAIO:
-                params["use_posix_aio"] = "true";
-                break;
-            default:
-                NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
-                return NIXL_ERR_INVALID_PARAM;
+        case nixlPosixQueue::queue_t::AIO:
+            params["use_aio"] = "true";
+            break;
+        case nixlPosixQueue::queue_t::URING:
+            params["use_uring"] = "true";
+            break;
+        case nixlPosixQueue::queue_t::POSIXAIO:
+            params["use_posix_aio"] = "true";
+            break;
+        default:
+            NIXL_ERROR << absl::StrFormat("Invalid queue type: %s", to_string(queue_type_));
+            return NIXL_ERR_INVALID_PARAM;
         }
 
-        auto posix_handle = std::make_unique<nixlPosixBackendReqH>(operation, local, remote, opt_args, &params);
+        auto posix_handle =
+            std::make_unique<nixlPosixBackendReqH>(operation, local, remote, opt_args, &params);
         nixl_status_t status = posix_handle->prepXfer();
         if (status != NIXL_SUCCESS) {
             return status;
@@ -292,53 +314,60 @@ nixl_status_t nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
 
         handle = posix_handle.release();
         return NIXL_SUCCESS;
-    } catch (const nixlPosixBackendReqH::exception& e) {
+    }
+    catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << absl::StrFormat("Error: %s", e.what());
         return e.code();
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception &e) {
         NIXL_ERROR << absl::StrFormat("Unexpected error: %s", e.what());
         return NIXL_ERR_BACKEND;
     }
 }
 
-nixl_status_t nixlPosixEngine::postXfer(const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args) const {
+nixl_status_t
+nixlPosixEngine::postXfer(const nixl_xfer_op_t &operation,
+                          const nixl_meta_dlist_t &local,
+                          const nixl_meta_dlist_t &remote,
+                          const std::string &remote_agent,
+                          nixlBackendReqH *&handle,
+                          const nixl_opt_b_args_t *opt_args) const {
     try {
-        auto& posix_handle = castPosixHandle(handle);
+        auto &posix_handle = castPosixHandle(handle);
         nixl_status_t status = posix_handle.postXfer();
         if (status != NIXL_IN_PROG) {
             NIXL_ERROR << "Error in submitting queue";
         }
         return status;
-    } catch (const nixlPosixBackendReqH::exception& e) {
+    }
+    catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << e.what();
         return e.code();
     }
     return NIXL_ERR_BACKEND;
 }
 
-nixl_status_t nixlPosixEngine::checkXfer(nixlBackendReqH* handle) const {
+nixl_status_t
+nixlPosixEngine::checkXfer(nixlBackendReqH *handle) const {
     try {
-        auto& posix_handle = castPosixHandle(handle);
+        auto &posix_handle = castPosixHandle(handle);
         return posix_handle.checkXfer();
     }
-    catch (const nixlPosixBackendReqH::exception& e) {
+    catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << e.what();
         return e.code();
     }
     return NIXL_ERR_BACKEND;
 }
 
-nixl_status_t nixlPosixEngine::releaseReqH(nixlBackendReqH* handle) const {
+nixl_status_t
+nixlPosixEngine::releaseReqH(nixlBackendReqH *handle) const {
     try {
-        auto& posix_handle = castPosixHandle(handle);
+        auto &posix_handle = castPosixHandle(handle);
         posix_handle.~nixlPosixBackendReqH();
         return NIXL_SUCCESS;
-    } catch (const nixlPosixBackendReqH::exception& e) {
+    }
+    catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << e.what();
         return e.code();
     }

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -27,37 +27,45 @@
 
 class nixlPosixBackendReqH : public nixlBackendReqH {
 private:
-    const nixl_xfer_op_t            &operation;      // The transfer operation (read/write)
-    const nixl_meta_dlist_t         &local;          // Local memory descriptor list
-    const nixl_meta_dlist_t         &remote;         // Remote memory descriptor list
-    const nixl_opt_b_args_t         *opt_args;       // Optional backend-specific arguments
-    const nixl_b_params_t           *custom_params_; // Custom backend parameters
-    const int                       queue_depth_;    // Queue depth for async I/O
-    std::unique_ptr<nixlPosixQueue> queue;           // Async I/O queue instance
-    const nixlPosixQueue::queue_t   queue_type_;     // Type of queue used
+    const nixl_xfer_op_t &operation; // The transfer operation (read/write)
+    const nixl_meta_dlist_t &local; // Local memory descriptor list
+    const nixl_meta_dlist_t &remote; // Remote memory descriptor list
+    const nixl_opt_b_args_t *opt_args; // Optional backend-specific arguments
+    const nixl_b_params_t *custom_params_; // Custom backend parameters
+    const int queue_depth_; // Queue depth for async I/O
+    std::unique_ptr<nixlPosixQueue> queue; // Async I/O queue instance
+    const nixlPosixQueue::queue_t queue_type_; // Type of queue used
 
-    nixl_status_t initQueues();                      // Initialize async I/O queue
+    nixl_status_t
+    initQueues(); // Initialize async I/O queue
 
 public:
     nixlPosixBackendReqH(const nixl_xfer_op_t &operation,
                          const nixl_meta_dlist_t &local,
                          const nixl_meta_dlist_t &remote,
-                         const nixl_opt_b_args_t* opt_args,
-                         const nixl_b_params_t* custom_params);
+                         const nixl_opt_b_args_t *opt_args,
+                         const nixl_b_params_t *custom_params);
     ~nixlPosixBackendReqH() {};
 
-    nixl_status_t postXfer();
-    nixl_status_t prepXfer();
-    nixl_status_t checkXfer();
+    nixl_status_t
+    postXfer();
+    nixl_status_t
+    prepXfer();
+    nixl_status_t
+    checkXfer();
 
     // Exception classes
-    class exception: public std::exception {
-        private:
-            const nixl_status_t code_;
-        public:
-            exception(const std::string& msg, nixl_status_t code)
-                : std::exception(), code_(code) {}
-            nixl_status_t code() const noexcept { return code_; }
+    class exception : public std::exception {
+    private:
+        const nixl_status_t code_;
+
+    public:
+        exception(const std::string &msg, nixl_status_t code) : std::exception(), code_(code) {}
+
+        nixl_status_t
+        code() const noexcept {
+            return code_;
+        }
     };
 };
 
@@ -66,64 +74,76 @@ private:
     const nixlPosixQueue::queue_t queue_type_;
 
 public:
-    nixlPosixEngine(const nixlBackendInitParams* init_params);
+    nixlPosixEngine(const nixlBackendInitParams *init_params);
     virtual ~nixlPosixEngine() = default;
 
-    bool supportsRemote() const override {
+    bool
+    supportsRemote() const override {
         return false;
     }
 
-    bool supportsLocal() const override {
+    bool
+    supportsLocal() const override {
         return true;
     }
 
-    bool supportsNotif() const override {
+    bool
+    supportsNotif() const override {
         return false;
     }
 
-    nixl_mem_list_t getSupportedMems() const override {
+    nixl_mem_list_t
+    getSupportedMems() const override {
         return {FILE_SEG, DRAM_SEG};
     }
 
-    nixl_status_t registerMem(const nixlBlobDesc &mem,
-                              const nixl_mem_t &nixl_mem,
-                              nixlBackendMD* &out) override;
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
 
-    nixl_status_t deregisterMem(nixlBackendMD* meta) override;
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
 
-    nixl_status_t connect(const std::string &remote_agent) override {
+    nixl_status_t
+    connect(const std::string &remote_agent) override {
         return NIXL_SUCCESS;
     }
 
-    nixl_status_t disconnect(const std::string &remote_agent) override {
+    nixl_status_t
+    disconnect(const std::string &remote_agent) override {
         return NIXL_SUCCESS;
     }
 
-    nixl_status_t unloadMD(nixlBackendMD* input) override {
+    nixl_status_t
+    unloadMD(nixlBackendMD *input) override {
         return NIXL_SUCCESS;
     }
 
-    nixl_status_t prepXfer(const nixl_xfer_op_t &operation,
-                           const nixl_meta_dlist_t &local,
-                           const nixl_meta_dlist_t &remote,
-                           const std::string &remote_agent,
-                           nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t* opt_args=nullptr) const override;
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
 
-    nixl_status_t postXfer(const nixl_xfer_op_t &operation,
-                           const nixl_meta_dlist_t &local,
-                           const nixl_meta_dlist_t &remote,
-                           const std::string &remote_agent,
-                           nixlBackendReqH* &handle,
-                           const nixl_opt_b_args_t* opt_args=nullptr) const override;
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
 
-    nixl_status_t checkXfer(nixlBackendReqH* handle) const override;
-    nixl_status_t releaseReqH(nixlBackendReqH* handle) const override;
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
 
     nixl_status_t
     queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
 
-    nixl_status_t loadLocalMD(nixlBackendMD* input, nixlBackendMD* &output) override {
+    nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
         output = input;
         return NIXL_SUCCESS;
     }

--- a/src/plugins/posix/posix_queue.h
+++ b/src/plugins/posix/posix_queue.h
@@ -24,19 +24,21 @@
 
 // Abstract base class for async I/O operations
 class nixlPosixQueue {
-    public:
-        virtual ~nixlPosixQueue() = default;
-        virtual nixl_status_t
-        submit (const nixl_meta_dlist_t &local, const nixl_meta_dlist_t &remote) = 0;
-        virtual nixl_status_t checkCompleted() = 0;
-        virtual nixl_status_t prepIO(int fd, void* buf, size_t len, off_t offset) = 0;
+public:
+    virtual ~nixlPosixQueue() = default;
+    virtual nixl_status_t
+    submit(const nixl_meta_dlist_t &local, const nixl_meta_dlist_t &remote) = 0;
+    virtual nixl_status_t
+    checkCompleted() = 0;
+    virtual nixl_status_t
+    prepIO(int fd, void *buf, size_t len, off_t offset) = 0;
 
-        enum class queue_t {
-            AIO,
-            URING,
-            POSIXAIO,
-            UNSUPPORTED,
-        };
+    enum class queue_t {
+        AIO,
+        URING,
+        POSIXAIO,
+        UNSUPPORTED,
+    };
 };
 
 #endif // POSIX_QUEUE_H


### PR DESCRIPTION
## What?
Run clang-format on the POSIX plugin

## Why?
This plugin does not adhere to the current style guidelines. Let's just get it entirely reformatted in a single pass.

## How?
I ran clang-format on all of the POSIX plugin files.
