### PR TITLE
Change nixlbench to optionally call createXferReq on every I/O

### DIFF
--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -462,9 +462,10 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 
 #### Storage Backend Options (GDS, GDS_MT, POSIX, HF3FS, OBJ)
 ```
---filepath PATH            # File path for storage operations
---num_files NUM            # Number of files used by benchmark (default: 1)
---storage_enable_direct    # Enable direct I/O for storage operations
+--filepath PATH                        # File path for storage operations
+--num_files NUM                        # Number of files used by benchmark (default: 1)
+--storage_enable_direct                # Enable direct I/O for storage operations
+--recreate_xfer_req_per_iteration      # Recreate transfer request on every iteration (default: false, auto-enabled for GUSLI)
 ```
 
 #### Backend-Specific Options
@@ -690,6 +691,7 @@ GUSLI provides direct user-space access to block storage devices, supporting loc
 **Notes**:
 - Number of devices in `--device_list` must match `--num_initiator_dev` and `--num_target_dev`
 - Direct I/O is automatically enabled for GUSLI (no need to specify `--storage_enable_direct`)
+- Transfer request recreation per iteration is automatically enabled for GUSLI (can be overridden with `--recreate_xfer_req_per_iteration=false`)
 
 ### Worker Types
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -128,6 +128,10 @@ const std::vector<xferBenchParamInfo> xbench_params = {
     NB_ARG_STRING(filenames, "", "Comma-separated filenames for storage operations"),
     NB_ARG_INT32(num_files, 1, "Number of files used by benchmark"),
     NB_ARG_BOOL(storage_enable_direct, false, "Enable direct I/O for storage operations"),
+    NB_ARG_BOOL(recreate_xfer_req_per_iteration,
+                false,
+                "Recreate transfer request on every iteration (default: false, automatically set to "
+                "true for GUSLI backend unless explicitly specified)"),
 
     // GDS options - only used when backend is GDS
     NB_ARG_INT32(gds_batch_pool_size,
@@ -254,6 +258,7 @@ std::string xferBenchConfig::posix_api_type = "";
 std::string xferBenchConfig::filepath = "";
 std::string xferBenchConfig::filenames = "";
 bool xferBenchConfig::storage_enable_direct = false;
+bool xferBenchConfig::recreate_xfer_req_per_iteration = false;
 long xferBenchConfig::page_size = sysconf(_SC_PAGESIZE);
 std::string xferBenchConfig::obj_access_key = "";
 std::string xferBenchConfig::obj_secret_key = "";

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -161,6 +161,7 @@ public:
     static int num_files;
     static std::string posix_api_type;
     static bool storage_enable_direct;
+    static bool recreate_xfer_req_per_iteration;
     static int gds_batch_pool_size;
     static int gds_batch_limit;
     static int gds_mt_num_threads;


### PR DESCRIPTION
## What?
Change nixlbench to call makeXferReq on every I/O. The prepXferDlist calls are outside of the main I/O loop.

## Why?
1. We observe that all real software using NIXL calls either makeXferReq or createXferReq in the I/O path, immediately before posting the request.
2. I cannot imagine a system that wouldn't call makeXferReq on demand. Once a request is created, it's tied to all of the ranges it will be transferirng. There's no fathomable system that could know all of the exact batches it will transfer over the life of the application at start up time.

Reason 1 is insufficient for the change here because all real software I can find also busy polls in a loop after calling postXferReq and that doesn't mean we should make NIXL synchronous. Instead, it's the combination of reason 1 and reason 2 that justifies the change.

## How?
For the GUSLI path there was already logic to call createXferReq in the I/O path. I first made that always the case, rather than just for GUSLI. Then I broke createXferReq into two prepXferDlist calls up front and makeXferReq in the I/O path because that's more efficient and still realistic.
