### PR TITLE
nixl_ep: Metadata exchange via torch TCPStore

### DIFF
--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <memory>
+#include <optional>
 #include <pybind11/functional.h>
 #include <torch/python.h>
 
@@ -260,8 +261,9 @@ void Buffer::barrier() {
     ep_kernels::barrier(nixl_ctx->gpu[0],mask_buffer_ptr, sync_buffer_ptr, compute_stream);
 }
 
-void Buffer::_nixl_agents_connect(const std::vector<int>& ranks) {
+void Buffer::_nixl_agents_connect(const std::vector<int>& ranks, const std::vector<nixl_blob_t>& remote_mds) {
     EP_HOST_ASSERT(!ranks.empty());
+    EP_HOST_ASSERT(remote_mds.empty() || remote_mds.size() == ranks.size());
 
     // Assuming ranks vector does not include current rank and has only new ranks
     remote_ranks.insert(remote_ranks.end(), ranks.begin(), ranks.end());
@@ -269,11 +271,17 @@ void Buffer::_nixl_agents_connect(const std::vector<int>& ranks) {
         nixl_agent_info->remote_agent_names[remote_rank] = std::to_string(remote_rank);
     }
 
-    for (int remote_rank : ranks) {
-        nixl_status_t fetch_status = nixl_agent_info->agent->fetchRemoteMD(nixl_agent_info->remote_agent_names[remote_rank]);
-        if (fetch_status != NIXL_SUCCESS) {
-            throw std::runtime_error("Failed to fetch metadata for remote agent " + std::to_string(remote_rank) +
-                                    ", status: " + std::to_string(fetch_status));
+    for (size_t i = 0; i < ranks.size(); i++) {
+        int remote_rank = ranks[i];
+        std::string agent_name;
+
+        nixl_status_t status = !remote_mds.empty()
+            ? nixl_agent_info->agent->loadRemoteMD(remote_mds[i], agent_name)
+            : nixl_agent_info->agent->fetchRemoteMD(nixl_agent_info->remote_agent_names[remote_rank]);
+
+        if (status != NIXL_SUCCESS) {
+            throw std::runtime_error("Failed to get metadata for remote agent " + std::to_string(remote_rank) +
+                                    ", status: " + std::to_string(status));
         }
 
         // Wait for remote metadata to be available
@@ -337,18 +345,25 @@ void Buffer::_nixl_ep_barrier_buffer_clear() {
     CUDA_CHECK(cudaMemset(sync_buffer_ptr, 0, max_num_ranks * sizeof(int)));
 }
 
-void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list) {
+void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds) {
     EP_HOST_ASSERT(!remote_ranks_list.empty());
+    EP_HOST_ASSERT(!remote_mds.has_value() || remote_mds->size() == remote_ranks_list.size());
+    
     std::vector<int> new_ranks;
+    std::vector<nixl_blob_t> new_ranks_mds;
     int max_added_rank = std::max(rank, *std::max_element(remote_ranks_list.begin(), remote_ranks_list.end()));
     num_ranks = std::max(num_ranks, max_added_rank + 1);
 
-    for (int remote_rank : remote_ranks_list) {
+    for (size_t i = 0; i < remote_ranks_list.size(); i++) {
+        int remote_rank = remote_ranks_list[i];
         // Skip self and ranks we are already connected to
         if (remote_rank == rank or std::find(remote_ranks.begin(), remote_ranks.end(), remote_rank) != remote_ranks.end())
             continue;
 
         new_ranks.push_back(remote_rank);
+        if (remote_mds.has_value())
+            new_ranks_mds.push_back((*remote_mds)[i]);
+
         CUDA_CHECK(cudaMemset(mask_buffer_ptr + remote_rank, 0, sizeof(int))); // Reset mask buffer for new ranks
     }
 
@@ -357,7 +372,7 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list) {
 
     _nixl_ep_barrier_buffer_clear();
 
-    _nixl_agents_connect(new_ranks);
+    _nixl_agents_connect(new_ranks, new_ranks_mds);
 
     _nixl_agents_peer_info_gather(new_ranks);
 
@@ -659,6 +674,16 @@ void Buffer::clean_mask_buffer() {
     ep_kernels::clean_mask_buffer(mask_buffer_ptr, max_num_ranks, at::cuda::getCurrentCUDAStream());
 }
 
+std::string Buffer::get_local_metadata() const {
+    EP_HOST_ASSERT(nixl_agent_info != nullptr && nixl_agent_info->agent != nullptr);
+    nixl_blob_t metadata_blob;
+    nixl_status_t status = nixl_agent_info->agent->getLocalMD(metadata_blob);
+    if (status != NIXL_SUCCESS) {
+        throw std::runtime_error("Failed to get local metadata, status: " + std::to_string(status));
+    }
+    return metadata_blob;
+}
+
 void Buffer::_nixl_ep_gpu_ctx_update() {
     int num_local_experts = env_num_channels;
 
@@ -814,11 +839,12 @@ void Buffer::_nixl_agent_init() {
     wireup_dlist.addDesc(nixlBlobDesc((uintptr_t)(wireup_buffer_ptr), sizeof(uint64_t), get_local_device_id(), ""));
     EP_HOST_ASSERT(agent->registerMem(wireup_dlist) == NIXL_SUCCESS);
 
-    // Send local metadata
-    status = nixl_agent_info->agent->sendLocalMD();
-    if (status != NIXL_SUCCESS) {
-        throw std::runtime_error("Failed to send local metadata for agent " +
-                                nixl_agent_info->agent_name + ", status: " + std::to_string(status));
+    if (getenv("NIXL_ETCD_ENDPOINTS")) {
+        status = nixl_agent_info->agent->sendLocalMD();
+        if (status != NIXL_SUCCESS) {
+            throw std::runtime_error("Failed to send local metadata for agent " +
+                                    nixl_agent_info->agent_name + ", status: " + std::to_string(status));
+        }
     }
 }
 
@@ -1024,6 +1050,18 @@ void Buffer::_nixl_ep_p2p_ptrs_cleanup(const std::vector<int>& ranks) {
     }
 }
 
+static std::optional<std::vector<nixl_blob_t>> convert_mds(const std::optional<std::vector<pybind11::bytes>>& remote_mds) {
+    if (!remote_mds.has_value()) {
+        return std::nullopt;
+    }
+    std::vector<nixl_blob_t> md_blobs;
+    md_blobs.reserve(remote_mds->size());
+    for (const auto& md_bytes : *remote_mds) {
+        md_blobs.push_back(nixl_blob_t(md_bytes));
+    }
+    return md_blobs;
+}
+
 } // namespace nixl_ep
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -1038,7 +1076,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def(pybind11::init<int, bool, bool>())
         .def("update_memory_buffers", &nixl_ep::Buffer::update_memory_buffers)
         .def("barrier", &nixl_ep::Buffer::barrier)
-        .def("connect_ranks", &nixl_ep::Buffer::connect_ranks, py::arg("remote_ranks"))
+        .def("connect_ranks", [](nixl_ep::Buffer &buffer, const std::vector<int>& remote_ranks, const std::optional<std::vector<pybind11::bytes>>& remote_mds) {
+            buffer.connect_ranks(remote_ranks, nixl_ep::convert_mds(remote_mds));
+        }, py::arg("remote_ranks"), py::arg("remote_mds") = std::nullopt)
         .def("disconnect_ranks", &nixl_ep::Buffer::disconnect_ranks)
         .def("is_available", &nixl_ep::Buffer::is_available)
         .def("get_local_device_id", &nixl_ep::Buffer::get_local_device_id)
@@ -1050,6 +1090,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("update_mask_buffer", &nixl_ep::Buffer::update_mask_buffer)
         .def("query_mask_buffer", &nixl_ep::Buffer::query_mask_buffer)
         .def("clean_mask_buffer", &nixl_ep::Buffer::clean_mask_buffer)
-        .def("get_next_combine_buffer", &nixl_ep::Buffer::get_next_combine_buffer);
+        .def("get_next_combine_buffer", &nixl_ep::Buffer::get_next_combine_buffer)
+        .def("get_local_metadata", [](const nixl_ep::Buffer &buffer) -> pybind11::bytes {
+            std::string metadata_str = buffer.get_local_metadata();
+            return pybind11::bytes(metadata_str);
+        });
     m.def("is_sm90_compiled", nixl_ep::is_sm90_compiled);
 }

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -30,6 +30,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <torch/types.h>
+#include <optional>
 #include <tuple>
 #include <vector>
 #include <string>
@@ -144,7 +145,7 @@ private:
 
     /* Common private funcs */
     void _nixl_agent_init();
-    void _nixl_agents_connect(const std::vector<int>& ranks);
+    void _nixl_agents_connect(const std::vector<int>& ranks, const std::vector<nixl_blob_t>& remote_mds = {});
     void _nixl_agents_disconnect(const std::vector<int>& ranks);
     void _nixl_agents_peer_info_gather(std::vector<int>& ranks);
     void _nixl_agents_peer_info_cleanup(const std::vector<int>& ranks);
@@ -170,7 +171,7 @@ public:
 
     void update_memory_buffers(int num_ranks, int64_t num_rdma_bytes);
 
-    void connect_ranks(const std::vector<int>& remote_ranks_list);
+    void connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds = std::nullopt);
 
     void disconnect_ranks(const std::vector<int>& remote_ranks_list);
 
@@ -216,6 +217,8 @@ public:
     void query_mask_buffer(const torch::Tensor& mask_status);
 
     void clean_mask_buffer();
+
+    std::string get_local_metadata() const;
 };
 
 } // namespace nixl_ep

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -19,6 +19,8 @@
 # limitations under the License.
 
 import os
+from contextlib import contextmanager
+from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, List, Literal, Optional, Tuple, Union
 
 import torch
@@ -56,6 +58,7 @@ class Buffer:
         enable_shrink: bool = False,
         group: Optional[dist.ProcessGroup] = None,
         comm: Optional["mpi4py.MPI.Comm"] = None,
+        tcp_store_group: Optional[dist.TCPStore] = None,
     ) -> None:
         """
         Initialize the nixl communication buffer.
@@ -68,12 +71,14 @@ class Buffer:
             rank: the rank number.
             group: the communication group (optional).
             comm: the mpi4py.MPI.Comm communicator to use in case the group parameter is absent (optional).
+            tcp_store_group: TCPStore for metadata exchange (optional).
         """
         self.rank = rank
         self.group_size = 0  # Will be updated by `update_memory_buffers`
         self.explicitly_destroy = explicitly_destroy
         self.group = group
         self.comm = comm
+        self.tcp_store_group = tcp_store_group
         assert not (group and comm)
 
         # Configure NVLINK backend
@@ -457,6 +462,42 @@ class Buffer:
         os.environ["NIXL_EP_NUM_CHANNELS"] = str(num_experts_per_rank)
         self.runtime.update_memory_buffers(num_ranks, num_rdma_bytes)
 
+    def set_tcp_store_group(self, tcp_store_group: Optional[dist.TCPStore]) -> None:
+        """
+        Update the TCP Store group for metadata exchange.
+
+        Arguments:
+            tcp_store_group: Optional TCPStore for metadata exchange.
+        """
+        self.tcp_store_group = tcp_store_group
+
+    @contextmanager
+    def _fetch_remote_metadata_from_tcp_store(self, remote_ranks: List[int]):
+        md_key = f"NIXL_EP/{self.rank}"
+        nixl_metadata_bytes = self.runtime.get_local_metadata()
+        self.tcp_store_group.set(md_key, nixl_metadata_bytes)
+        
+        remote_md_keys = [
+            f"NIXL_EP/{rank}" for rank in remote_ranks if rank != self.rank
+        ]
+        if remote_md_keys:
+            self.tcp_store_group.wait(remote_md_keys, timedelta(seconds=30))
+        
+        remote_mds = []
+        for rank in remote_ranks:
+            if rank != self.rank:
+                remote_md_key = f"NIXL_EP/{rank}"
+                remote_md_bytes = self.tcp_store_group.get(remote_md_key)
+                remote_mds.append(remote_md_bytes)
+                print(f"Rank {self.rank}: Fetched MD from rank {rank}: {len(remote_md_bytes)} bytes")
+            else:
+                remote_mds.append(b"")
+        
+        try:
+            yield remote_mds
+        finally:
+            self.tcp_store_group.delete_key(md_key)
+
     def connect_ranks(self, remote_ranks: List[int]) -> None:
         """
         Add connections to remote ranks.
@@ -465,7 +506,11 @@ class Buffer:
             remote_ranks: List of remote rank IDs to establish connections with.
                          The current rank will be automatically filtered out.
         """
-        self.runtime.connect_ranks(remote_ranks)
+        if self.tcp_store_group is not None:
+            with self._fetch_remote_metadata_from_tcp_store(remote_ranks) as remote_mds:
+                self.runtime.connect_ranks(remote_ranks, remote_mds)
+        else:
+            self.runtime.connect_ranks(remote_ranks)
 
     def disconnect_ranks(self, remote_ranks: List[int]) -> None:
         """


### PR DESCRIPTION
Most inference engines use their own communication groups and prefer not to launch an additional ETCD server solely for nixl_ep’s connection establishment flow.

This commit adds support for exchanging metadata using an external torch.distributed.TCPStore instance (as used by vLLM).

Note that this is likely an intermediate solution.
Further discussion is needed for the broader NIXL approach, but the nixl_ep API changes are not expected to change.


