### PR TITLE
CI: Add CUDA file support to clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,4 +23,5 @@ jobs:
 
         echo "### clang format errors:"
         [ -z "$FILES" ] && echo "(no matching files)" || \
-          git diff -U0 HEAD^1 HEAD -- $FILES | clang-format-diff-19 -p1 -style=file -v
+          git diff -U0 HEAD^1 HEAD -- $FILES | \
+          clang-format-diff-19 -p1 -style=file -v -iregex ".*${FILE_PATTERN}"


### PR DESCRIPTION
## What?
Fix CI to check formatting on CUDA (.cu/.cuh) files.

## Why?
`clang-format-diff` was silently ignoring CUDA files by default, allowing unformatted code to pass CI.

## How?
Added `-iregex` flag to explicitly include .cu/.cuh extensions. Deduplicated file pattern regex.