### PR TITLE
FIX: Resolve dangling pointer in telemetry plugin getName/getVersion

### DIFF
--- a/src/api/cpp/telemetry/telemetry_plugin.h
+++ b/src/api/cpp/telemetry/telemetry_plugin.h
@@ -47,12 +47,12 @@ public:
           name_(name),
           version_(ver) {}
 
-    std::string
+    const std::string &
     getName() const noexcept {
         return name_;
     }
 
-    std::string
+    const std::string &
     getVersion() const noexcept {
         return version_;
     }

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -152,7 +152,7 @@ nixlTelemetryPluginHandle::createExporter(
 const char *
 nixlTelemetryPluginHandle::getName() const {
     if (plugin_) {
-        return plugin_->getName().data();
+        return plugin_->getName().c_str();
     }
     return "unknown";
 }
@@ -160,7 +160,7 @@ nixlTelemetryPluginHandle::getName() const {
 const char *
 nixlTelemetryPluginHandle::getVersion() const {
     if (plugin_) {
-        return plugin_->getVersion().data();
+        return plugin_->getVersion().c_str();
     }
     return "unknown";
 }


### PR DESCRIPTION
## What?
The nixlTelemetryPlugin::getName() and getVersion() methods were returning std::string by value, creating temporary objects. The nixlTelemetryPluginHandle wrapper was calling .data() on these temporaries and returning the pointer, which became dangling once the temporary was destroyed.

## Why?
This bug was caught by GCC's -Werror=return-local-addr warning in release builds with optimizations enabled, causing compilation to fail.

## How?
 The methods now return references to member strings that remain valid for the lifetime of the plugin object, eliminating the dangling pointer.
