### PR TITLE
CI: Fix Copyright workflow

### DIFF
--- a/.github/workflows/copyright-checks.yml
+++ b/.github/workflows/copyright-checks.yml
@@ -16,6 +16,8 @@ jobs:
         packages: read
       steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
         # Allowlist both variants of the mounted source directory.
       - run: git config --global --add safe.directory /__w/dynamo/dynamo
       - run: git config --global --add safe.directory /workspace


### PR DESCRIPTION
Copyright script uses the year from the git log. However, by default the github action to fetch repo in CI only uses depth 1 by default. This causes all files to link the merge commit. Set the fetch-depth attrib correctly to fetch right history for all files.

Here the Copyright check is passing in CI since its correctly getting the lastmodified year. Otherwise, it would fail for all  files.