### PR TITLE
NIXL_EP: Enable CUDA IPC NVLINK backend (#1099)

### DIFF
--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -636,10 +636,6 @@ def main():
 
     args = parser.parse_args()
 
-    # TODO_Itay: remove this once NIXL supports NVLink on multiple workers
-    assert (
-        args.nvlink_backend != "nixl"
-    ), "NIXL does not support NVLink on multiple workers yet"
     rank_server_process = None
     if not args.rank_server:
         print("Starting rank server locally", flush=True)


### PR DESCRIPTION
## What?
Enable CUDA IPC NVLINK backend for NIXL EP.

## Why?
Recent UCX bug fixes have resolved the issues that previously prevented CUDA IPC from working as NVLINK backend for NIXL EP.
Removing `UCX_TLS=^cuda_ipc` from the build script enables users of the dockerfile to use this backend. This export is no longer needed.

## How?
- Removed `UCX_TLS=^cuda_ipc` export from build script
- Removed assertion blocking `--nvlink-backend nixl` in elastic tests