### PR TITLE
Clang: Use CommentsPragmas

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,7 +38,7 @@ BreakConstructorInitializers: BeforeColon
 BreakStringLiterals: true
 ColumnLimit: 100
 # Ignore formatting for lines starting with 'SPDX'
-CommentPragmas: '^ SPDX'
+CommentPragmas: '^ *SPDX'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4


### PR DESCRIPTION
## What?
Use commentPragmas in clang

## Why?
Adding the new copyright year in the header increases the line length beyond the 100 limit. Clang formatter will wrap the line which shouldnt be done for the copyright header - it should be on one line.

## How?
Add CommentPragmas to ignore the SPDX lines.