### PR TITLE
fix: ensure useEtcd is properly initialized in all cases

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -118,6 +118,7 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &cfg
         NIXL_DEBUG << "NIXL ETCD is disabled";
     }
 #else
+    useEtcd = false;
     NIXL_DEBUG << "NIXL ETCD is excluded";
 #endif // HAVE_ETCD
     if (name.empty())


### PR DESCRIPTION
## What?
In the sglang PD disaggregation case, when using nixl as the transport backend, I observed that sglang's CPU consumption is significantly higher compared to when mooncake is used as the transport backend. Using perf, I identified the culprit as the commWorker.

## Why?
After analysis, it was determined that this issue stems from improper initialization of useEtcd in non-HAVE_ETCD conditions.

## How?
Initialization of userEtcd as false in non-HAVE_ETCD conditions.
