### PR TITLE
CI: Push images to both Artifactory repos

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -28,6 +28,7 @@ matrix:
 # Configuration
 env:
   REGISTRY_HOSTESS: "artifactory.nvidia.com"
+  REGISTRY_HOSTESS_OLD: "urm.nvidia.com"
   REGISTRY_REPO: "sw-nbu-swx-nixl-docker-local/verification"
   LOCAL_TAG_BASE: "nixl-ci:build-"
   MAIL_FROM: "jenkins@nvidia.com"
@@ -36,8 +37,12 @@ taskName: "${BUILD_TARGET}/${arch}/${axis_index}"
 
 credentials:
   - credentialsId: 'svc-nixl-new-artifactory-token'
+    # Preserve historical variable names for the primary registry push logic
     usernameVariable: 'ARTIFACTORY_USERNAME'
     passwordVariable: 'ARTIFACTORY_PASSWORD'
+  - credentialsId: 'svc-nixl-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_OLD_USERNAME'
+    passwordVariable: 'ARTIFACTORY_OLD_PASSWORD'
 
 pipeline_start:
   shell: action
@@ -149,10 +154,13 @@ steps:
       IMAGE_PROPERTIES+="BUILD_NUMBER=${BUILD_NUMBER};JOB_NAME=${JOB_NAME};BUILD_URL=${BUILD_URL};NODE_NAME=${NODE_NAME};"
       IMAGE_PROPERTIES+="BASE_IMAGE=${BASE_IMAGE};BASE_IMAGE_TAG=${BASE_IMAGE_TAG}"
 
-      # Login to Artifactory
+      [[ -n "${ARTIFACTORY_USERNAME:-}" ]] || { echo "ERROR: ARTIFACTORY_USERNAME is empty"; exit 1; }
+      [[ -n "${ARTIFACTORY_PASSWORD:-}" ]] || { echo "ERROR: ARTIFACTORY_PASSWORD is empty"; exit 1; }
+
+      # Login to new Artifactory
       echo "$ARTIFACTORY_PASSWORD" | docker login "${REGISTRY_HOSTESS}" -u "$ARTIFACTORY_USERNAME" --password-stdin
 
-      # Function to tag, push, and set properties
+      # Function to tag, push, and set properties (new Artifactory)
       tag_push_set_properties() {
         local target_tag="$1"
         echo "Creating tag: ${target_tag}"
@@ -162,21 +170,54 @@ steps:
           "${ARTIFACTORY_API}/${target_tag}?properties=${IMAGE_PROPERTIES}"
       }
 
-      # Always create standard tag
+      # Always create standard tag (new Artifactory)
       tag_push_set_properties "${TAG_NAME}"
 
-      # Check if latest tag should be updated
+      # Check if latest tag should be updated (new Artifactory)
       if [[ "${UPDATE_LATEST}" == "true" ]]; then
         tag_push_set_properties "${BASE_IMAGE_TAG}-${arch}-latest"
+      fi
+
+  - name: Push (old Artifactory)
+    credentialsId: 'svc-nixl-artifactory-token'
+    run: |
+      source version-info
+      ARTIFACTORY_REGISTRY_OLD="${REGISTRY_HOSTESS_OLD}/${REGISTRY_REPO}/${BUILD_TARGET}"
+      ARTIFACTORY_API_OLD="https://${REGISTRY_HOSTESS_OLD}/artifactory/api/storage/${REGISTRY_REPO}/${BUILD_TARGET}"
+
+      # Prepare image properties
+      IMAGE_PROPERTIES="BUILD_TARGET=${BUILD_TARGET};NIXL_VERSION=${NIXL_VERSION};UCX_VERSION=${UCX_VERSION};arch=${arch};"
+      IMAGE_PROPERTIES+="BUILD_NUMBER=${BUILD_NUMBER};JOB_NAME=${JOB_NAME};BUILD_URL=${BUILD_URL};NODE_NAME=${NODE_NAME};"
+      IMAGE_PROPERTIES+="BASE_IMAGE=${BASE_IMAGE};BASE_IMAGE_TAG=${BASE_IMAGE_TAG}"
+
+      [[ -n "${ARTIFACTORY_OLD_USERNAME:-}" ]] || { echo "ERROR: ARTIFACTORY_OLD_USERNAME is empty"; exit 1; }
+      [[ -n "${ARTIFACTORY_OLD_PASSWORD:-}" ]] || { echo "ERROR: ARTIFACTORY_OLD_PASSWORD is empty"; exit 1; }
+
+      echo "$ARTIFACTORY_OLD_PASSWORD" | docker login "${REGISTRY_HOSTESS_OLD}" -u "$ARTIFACTORY_OLD_USERNAME" --password-stdin
+
+      tag_push_set_properties_old() {
+        local target_tag="$1"
+        echo "Creating tag (old): ${target_tag}"
+        docker tag "${LOCAL_TAG_BASE}${arch}" "${ARTIFACTORY_REGISTRY_OLD}:${target_tag}"
+        docker push "${ARTIFACTORY_REGISTRY_OLD}:${target_tag}"
+        curl -H "Authorization: Bearer ${ARTIFACTORY_OLD_PASSWORD}" -X PUT \
+          "${ARTIFACTORY_API_OLD}/${target_tag}?properties=${IMAGE_PROPERTIES}"
+      }
+
+      tag_push_set_properties_old "${TAG_NAME}"
+      if [[ "${UPDATE_LATEST}" == "true" ]]; then
+        tag_push_set_properties_old "${BASE_IMAGE_TAG}-${arch}-latest"
       fi
 
   - name: Show Results
     run: |
       source version-info
       echo "Image type built: ${BUILD_TARGET} (${arch})"
-      echo "Image pushed to: ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${TAG_NAME}"
+      echo "Image pushed to (new): ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${TAG_NAME}"
+      echo "Image pushed to (old): ${REGISTRY_HOSTESS_OLD}/${REGISTRY_REPO}/${BUILD_TARGET}:${TAG_NAME}"
       if [[ "${UPDATE_LATEST}" == "true" ]]; then
-        echo "Latest tag updated: ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${BASE_IMAGE_TAG}-${arch}-latest"
+        echo "Latest tag updated (new): ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${BASE_IMAGE_TAG}-${arch}-latest"
+        echo "Latest tag updated (old): ${REGISTRY_HOSTESS_OLD}/${REGISTRY_REPO}/${BUILD_TARGET}:${BASE_IMAGE_TAG}-${arch}-latest"
       fi
 
       echo -e "\nBuild config for manual repro:"

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -228,7 +228,10 @@
       • Builds and pushes x86_64 &amp; aarch64 images with any NIXL/UCX version combination<br/>
       • Choose between <b>nixlbench</b> or <b>nixl</b> build targets<br/>
       • Optional latest tag update via <code>UPDATE_LATEST</code> parameter<br/>
-      • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ <code>verification/nixlbench/</code> or <code>verification/nixl/</code> based on target<br/>
+      • Images pushed to both registries:<br/>
+      &nbsp;&nbsp;- https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/<br/>
+      &nbsp;&nbsp;- https://urm.nvidia.com/sw-nbu-swx-nixl-docker-local/<br/>
+      &nbsp;&nbsp;Use <code>verification/nixlbench/</code> or <code>verification/nixl/</code> based on target<br/>
       • You must be part of access-artifactory-nbu-swx-nixl-users DL group in order to work with these images
       <br/>
       <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>


### PR DESCRIPTION
## What?
Push container images to both Artifactory repos (old and new).

## Why?
Clusters like Ptyche can't access the new Artifactory.

## How?
Push to both repos:
-   New: "artifactory.nvidia.com"
-   Old: "urm.nvidia.com"
