### PR TITLE
feat: 0.8.0 object patch

### DIFF
--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/obj/obj_s3_client.cpp
+++ b/src/plugins/obj/obj_s3_client.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## What?
Add environment variable support for configuring the S3 endpoint override in the OBJ plugin. The new AWS_ENDPOINT_OVERRIDE environment variable allows users to set a custom S3-compatible endpoint without needing to pass it through backend parameters.

## Why?
Currently, configuring a custom S3 endpoint (e.g., for MinIO, LocalStack, or other S3-compatible services) requires passing the endpoint_override parameter explicitly when creating the backend. This is inconsistent with how other configuration options like bucket work, which already support environment variable fallback via AWS_DEFAULT_BUCKET.

- Adding environment variable support for endpoint override:
- Allows endpoint configuration without code changes

## How?
- Added a new getEndpointOverride() helper function in obj_s3_client.cpp that follows the same pattern as getBucketName():
- First checks for endpoint_override in custom parameters
- Falls back to AWS_ENDPOINT_OVERRIDE environment variable
- Returns std::nullopt if neither is set (endpoint override is optional)
- Updated the README documentation to include the new environment variable in the configuration tables and examples