### PR TITLE
nixl_ep: Fix barrier with rank connect/disconnect

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -38,6 +38,7 @@ struct gpu_nixl_ctx {
     nixlGpuXferReqH *remote_counter_reqs; // [dest_rank]
     nixlGpuXferReqH *batch_reqs; // [dest_rank]
     int *local_barrier_buffer; // [src_rank]
+    int *local_barrier_cnt; // [dst_rank]
     nixlGpuXferReqH *remote_barrier_reqs; // [dest_rank]
     void **rdma_p2p_ptrs; // [num_ranks]
     uint64_t **counters_p2p_ptrs; // [num_ranks]
@@ -77,10 +78,6 @@ struct gpu_nixl_ctx {
 
     __device__ inline nixlGpuXferReqH remote_barrier_get(int dest_rank) {
         return remote_barrier_reqs[dest_rank];
-    }
-
-    __device__ inline int* local_barrier_buffer_get(int src_rank) {
-        return &local_barrier_buffer[src_rank];
     }
 
     __device__ inline nixlGpuXferReqH batch_get(int dest_rank) {

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -109,6 +109,7 @@ private:
     bool enable_shrink = false;
     int *mask_buffer_ptr = nullptr;
     int *sync_buffer_ptr = nullptr;
+    int *local_barrier_cnt_ptr = nullptr;
 
     // Device info and communication
     int device_id;
@@ -161,7 +162,6 @@ private:
     void _nixl_ep_counters_cleanup(const std::vector<int>& ranks_to_remove);
     void _nixl_ep_batches_cleanup(const std::vector<int>& ranks_to_remove);
     void _nixl_ep_p2p_ptrs_cleanup(const std::vector<int>& ranks_to_remove);
-    void _nixl_ep_barrier_buffer_clear(int rank);
 
 public:
     Buffer(int rank, bool explicitly_destroy, bool enable_shrink);


### PR DESCRIPTION
The previous barrier implementation assumed all
ranks participate in the same number of barriers,
using a single global counter to verify remote ranks
arrived at the barrier.

With dynamic rank addition/removal, ranks can have
different barrier counts. Therefore- switch to per-pair
barrier counters.