### PR TITLE
Apply patch for security issue in Prometheus plugin dependency (#1204)

### DIFF
--- a/.github/workflows/copyright-check.sh
+++ b/.github/workflows/copyright-check.sh
@@ -18,7 +18,7 @@ for f in $(git ls-files); do
 
   # Skip ignored top-level paths
   case "$f" in
-    *.png|*.jpg|*.jpeg|*.gif|*.ico|*.zip|*.rst|*.pyc|*.lock|*.md|*.svg|*.wrap|*.in|*.json|*.template|*.gitignore|*.python-version|*py.typed)
+    *.png|*.jpg|*.jpeg|*.gif|*.ico|*.zip|*.rst|*.pyc|*.lock|*.md|*.svg|*.wrap|*.in|*.json|*.template|*.patch|*.gitignore|*.python-version|*py.typed)
       continue
       ;;
     CODEOWNERS|*LICENSE*|Doxyfile|.clang-format|.clang-tidy|.codespellrc)

--- a/subprojects/packagefiles/fix-civetweb-security.patch
+++ b/subprojects/packagefiles/fix-civetweb-security.patch
@@ -1,0 +1,43 @@
+diff --git a/3rdparty/civetweb/src/civetweb.c b/3rdparty/civetweb/src/civetweb.c
+index bbc9aa8be..6af91f874 100644
+--- a/3rdparty/civetweb/src/civetweb.c
++++ b/3rdparty/civetweb/src/civetweb.c
+@@ -15579,7 +15579,6 @@ handle_request(struct mg_connection *conn)
+ 	/* 12. Directory uris should end with a slash */
+ 	if (file.stat.is_directory && ((uri_len = (int)strlen(ri->local_uri)) > 0)
+ 	    && (ri->local_uri[uri_len - 1] != '/')) {
+-
+ 		/* Path + server root */
+ 		size_t buflen = UTF8_PATH_MAX * 2 + 2;
+ 		char *new_path;
+@@ -15592,12 +15591,26 @@ handle_request(struct mg_connection *conn)
+ 			mg_send_http_error(conn, 500, "out or memory");
+ 		} else {
+ 			mg_get_request_link(conn, new_path, buflen - 1);
+-			strcat(new_path, "/");
++
++			size_t len = strlen(new_path);
++			if (len + 1 < buflen) {
++				new_path[len] = '/';
++				new_path[len + 1] = '\0';
++				len++;
++			}
++
+ 			if (ri->query_string) {
+-				/* Append ? and query string */
+-				strcat(new_path, "?");
+-				strcat(new_path, ri->query_string);
++				if (len + 1 < buflen) {
++					new_path[len] = '?';
++					new_path[len + 1] = '\0';
++					len++;
++				}
++
++				/* Append with size of space left for query string + null terminator */
++				size_t max_append = buflen - len - 1;
++				strncat(new_path, ri->query_string, max_append);
+ 			}
++
+ 			mg_send_http_redirect(conn, new_path, 301);
+ 			mg_free(new_path);
+ 		}

--- a/subprojects/prometheus-cpp.wrap
+++ b/subprojects/prometheus-cpp.wrap
@@ -4,3 +4,4 @@ revision = v1.3.0
 depth = 1
 clone-recursive = true
 method = cmake
+diff_files = fix-civetweb-security.patch


### PR DESCRIPTION
Cherry-pick of #1204

## What?

Fix for https://github.com/krispybyte/CVE-2025-55763

## Why?
NIXL Prometheus telemetry plugin has external dependency [prometheus-cpp](https://github.com/jupp0r/prometheus-cpp) which in turn depends on the [CivetWeb](https://github.com/civetweb/civetweb) web server used to expose the HTTP metrics API endpoint.

CivetWeb has a high severity security issue CVE-2025-55763 patched in https://github.com/civetweb/civetweb/pull/1347 on master branch and not yet published in the latest release.

## How?
Applied directly https://github.com/civetweb/civetweb/pull/1347.diff

Exclude *.patch files from copyright checks to avoid misattributing unmodified upstream open-source code fixes (Civetweb/MIT) as NVIDIA intellectual property.

## Tests

Tested on x86 with nixlbench and manual telemetry scraping:

```
export NIXL_TELEMETRY_ENABLE=y
export NIXL_TELEMETRY_EXPORTER="prometheus"
export NIXL_TELEMETRY_EXPORTER="prometheus"
export NIXL_TELEMETRY_PROMETHEUS_PORT="9999"

nixlbench --etcd-endpoints http://127.0.0.1:2379 --backend UCX --initiator_seg_type DRAM &
nixlbench --etcd-endpoints http://127.0.0.1:2379 --backend UCX --initiator_seg_type DRAM
...
---------------------------------------------------------------------------------------------------------------------------------------------------------------

Block Size (B)      Batch Size     B/W (GB/Sec)   Avg Lat. (us)  Avg Prep (us)  P99 Prep (us)  Avg Post (us)  P99 Post (us)  Avg Tx (us)    P99 Tx (us)
----------------------------------------------------------------------------------------------------------------------------------------------------------------
4096                1              0.321405       12.7           35.0           35.0           4.2            6.0            8.5            23.0
8192                1              0.333126       24.6           37.0           37.0           14.3           50.0           10.2           34.0
16384               1              0.765189       21.4           40.0           40.0           16.4           69.0           5.0            20.0
32768               1              1.588140       20.6           35.0           35.0           13.6           58.0           7.0            44.0
65536               1              4.999265       13.1           39.0           39.0           10.8           25.0           2.3            52.0
131072              1              3.518243       37.3           39.0           39.0           35.6           103.0          1.6            16.0
262144              1              5.865769       44.7           40.0           40.0           35.7           119.0          9.0            97.0
524288              1              9.894449       53.0           41.0           41.0           51.8           202.0          1.1            11.0
1048576             1              8.931366       117.4          38.0           38.0           106.3          480.0          11.1           192.0
2097152             1              8.266836       253.7          43.0           43.0           240.4          902.0          4.4            275.0
4194304             1              6.246983       671.4          39.0           39.0           657.4          2166.0         13.1           428.0
8388608             1              6.485400       1293.5         37.0           37.0           1292.3         2019.0         0.3            1.0
16777216            1              5.080315       3302.4         38.0           38.0           3301.2         4725.0         0.2            1.0
33554432            1              5.239112       6404.6         35.0           35.0           6403.2         10832.0        0.6            1.0
67108864            1              5.173186       12972.4        37.0           37.0           12971.2        18909.0        0.4            1.0
```

```
curl http://localhost:9999/metrics
# HELP exposer_transferred_bytes_total Transferred bytes to metrics services
# TYPE exposer_transferred_bytes_total counter
exposer_transferred_bytes_total 13293
# HELP exposer_scrapes_total Number of times metrics were scraped
# TYPE exposer_scrapes_total counter
exposer_scrapes_total 6
# HELP exposer_request_latencies Latencies of serving scrape requests, in microseconds
# TYPE exposer_request_latencies summary
exposer_request_latencies_count 6
exposer_request_latencies_sum 2611
exposer_request_latencies{quantile="0.5"} 349
exposer_request_latencies{quantile="0.9"} 516
exposer_request_latencies{quantile="0.99"} 516
# HELP agent_tx_bytes Number of bytes sent by the agent
# TYPE agent_tx_bytes counter
agent_tx_bytes{agent_name="initiator",category="NIXL_TELEMETRY_TRANSFER",hostname="NV-1"} 4587520
# HELP agent_rx_bytes Number of bytes received by the agent
# TYPE agent_rx_bytes counter
agent_rx_bytes{agent_name="initiator",category="NIXL_TELEMETRY_TRANSFER",hostname="NV-1"} 0
# HELP agent_tx_requests_num Number of requests sent by the agent
# TYPE agent_tx_requests_num counter
agent_tx_requests_num{agent_name="initiator",category="NIXL_TELEMETRY_TRANSFER",hostname="NV-1"} 1120
# HELP agent_rx_requests_num Number of requests received by the agent
# TYPE agent_rx_requests_num counter
agent_rx_requests_num{agent_name="initiator",category="NIXL_TELEMETRY_TRANSFER",hostname="NV-1"} 0
# HELP agent_xfer_time Start to Complete (per request)
# TYPE agent_xfer_time gauge
agent_xfer_time{agent_name="initiator",category="NIXL_TELEMETRY_PERFORMANCE",hostname="NV-1"} 10
# HELP agent_xfer_post_time Start to posting to Back-End (per request)
# TYPE agent_xfer_post_time gauge
agent_xfer_post_time{agent_name="initiator",category="NIXL_TELEMETRY_PERFORMANCE",hostname="NV-1"} 3
# HELP agent_memory_registered Memory registered
# TYPE agent_memory_registered gauge
agent_memory_registered{agent_name="initiator",category="NIXL_TELEMETRY_MEMORY",hostname="NV-1"} 8589934592
# HELP agent_memory_deregistered Memory deregistered
# TYPE agent_memory_deregistered gauge
agent_memory_deregistered{agent_name="initiator",category="NIXL_TELEMETRY_MEMORY",hostname="NV-1"} 0
```