### PR TITLE
UCX: config sane value for rcache unreleased threshold (memory leak fix)

### DIFF
--- a/src/utils/ucx/ucx_utils.cpp
+++ b/src/utils/ucx/ucx_utils.cpp
@@ -449,6 +449,7 @@ nixlUcxContext::nixlUcxContext(std::vector<std::string> devs,
     config.modify("RNDV_THRESH", "inf");
     config.modify("MAX_RMA_RAILS", "2");
     config.modify("IB_PCI_RELAXED_ORDERING", "try");
+    config.modify("RCACHE_MAX_UNRELEASED", "1024");
 
     if (ucp_version >= UCP_VERSION(1, 19)) {
         config.modify("MAX_COMPONENT_MDS", "32");


### PR DESCRIPTION
## What?
Configure UCX parameter RCACHE_MAX_UNRELEASED to finite value, overriding default value inf.

## Why?
https://github.com/vllm-project/vllm/issues/24264
Default value may cause memory leak in some setup, fixed by changing parameter value

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
