### PR TITLE
fix(libfabric): Add EFA domain validation to detect RDM init failures

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <gnu/libc-version.h>  // For glibc version detection
 #include "libfabric_backend.h"
 #include "serdes/serdes.h"
 #include "common/nixl_log.h"
@@ -294,7 +295,18 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
       rail_manager(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD),
       runtime_(FI_HMEM_SYSTEM) {
 
-    NIXL_DEBUG << "Initializing Libfabric Backend";
+    // NIXL_FORCE_DISABLE_GPU_RDMA: Environment variable to force disable GPU Direct RDMA
+    // This is a workaround for glibc incompatibility issues with EFA RDM layer
+    const char* force_disable_rdma = std::getenv("NIXL_FORCE_DISABLE_GPU_RDMA");
+    if (force_disable_rdma && std::string(force_disable_rdma) == "1") {
+        NIXL_WARN << "NIXL_FORCE_DISABLE_GPU_RDMA=1 detected, setting FI_EFA_USE_DEVICE_RDMA=0";
+        setenv("FI_EFA_USE_DEVICE_RDMA", "0", 1);
+    }
+
+    // Log glibc version at engine startup for debugging
+    NIXL_INFO << "NIXL LibfabricEngine starting, glibc version: " << gnu_get_libc_version();
+
+    NIXL_DEBUG << "Initializing Libfabric Backend with GPU Support";
 
     // Query system runtime type from rail manager (determined once at topology discovery)
     runtime_ = rail_manager.getRuntime();

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include <gnu/libc-version.h>  // For glibc version detection
+#include <gnu/libc-version.h> // For glibc version detection
 #include "libfabric_backend.h"
 #include "serdes/serdes.h"
 #include "common/nixl_log.h"
@@ -297,7 +297,7 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 
     // NIXL_FORCE_DISABLE_GPU_RDMA: Environment variable to force disable GPU Direct RDMA
     // This is a workaround for glibc incompatibility issues with EFA RDM layer
-    const char* force_disable_rdma = std::getenv("NIXL_FORCE_DISABLE_GPU_RDMA");
+    const char *force_disable_rdma = std::getenv("NIXL_FORCE_DISABLE_GPU_RDMA");
     if (force_disable_rdma && std::string(force_disable_rdma) == "1") {
         NIXL_WARN << "NIXL_FORCE_DISABLE_GPU_RDMA=1 detected, setting FI_EFA_USE_DEVICE_RDMA=0";
         setenv("FI_EFA_USE_DEVICE_RDMA", "0", 1);

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -20,7 +20,7 @@
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
 #include "libfabric_common.h"
-#include <gnu/libc-version.h>  // For glibc version detection
+#include <gnu/libc-version.h> // For glibc version detection
 
 #include <cstring>
 #include <stdexcept>
@@ -208,9 +208,9 @@ ControlRequestPool::createBufferChunk(size_t chunk_size, BufferChunk &chunk) {
         return NIXL_ERR_BACKEND;
     }
 
-    NIXL_INFO << "CreateBufferChunk on Rail " << rail_id_ << " successfully created buffer chunk:"
-              << " buffer=" << chunk.buffer << " size=" << chunk.size << " mr=" << chunk.mr
-              << " mr_key=" << fi_mr_key(chunk.mr);
+    NIXL_INFO << "CreateBufferChunk on Rail " << rail_id_
+              << " successfully created buffer chunk:" << " buffer=" << chunk.buffer
+              << " size=" << chunk.size << " mr=" << chunk.mr << " mr_key=" << fi_mr_key(chunk.mr);
 
     return NIXL_SUCCESS;
 }
@@ -280,8 +280,8 @@ ControlRequestPool::expandPool() {
         size_t buffer_offset = local_idx * NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE;
         if (buffer_offset + NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE > new_chunk.size) {
             NIXL_ERROR << " Rail " << rail_id_ << " buffer assignment out of bounds for request["
-                       << i << "]:"
-                       << " local_idx=" << local_idx << " buffer_offset=" << buffer_offset
+                       << i << "]:" << " local_idx=" << local_idx
+                       << " buffer_offset=" << buffer_offset
                        << " buffer_size=" << NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE
                        << " chunk_size=" << new_chunk.size;
             return NIXL_ERR_BACKEND;
@@ -479,7 +479,7 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
         // This catches the case where fi_domain() succeeds but RDM layer failed internally
         // (the "efa_domain_init_rdm failed. err: 28" issue that causes segfault at offset 0x18)
         {
-            const char* skip_validation = std::getenv("NIXL_SKIP_RDM_VALIDATION");
+            const char *skip_validation = std::getenv("NIXL_SKIP_RDM_VALIDATION");
             if (!skip_validation || std::string(skip_validation) != "1") {
                 // Log glibc version for debugging
                 NIXL_INFO << "Domain validation: glibc version = " << gnu_get_libc_version()
@@ -489,22 +489,24 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
                 struct fi_cq_attr test_cq_attr = {};
                 test_cq_attr.format = FI_CQ_FORMAT_DATA;
                 test_cq_attr.wait_obj = FI_WAIT_NONE;
-                test_cq_attr.size = 1;  // Minimal size for validation
+                test_cq_attr.size = 1; // Minimal size for validation
                 struct fid_cq *test_cq = nullptr;
 
                 int validate_ret = fi_cq_open(domain, &test_cq_attr, &test_cq, NULL);
                 if (validate_ret != 0) {
-                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: fi_cq_open test failed for rail " << rail_id
-                               << " with error: " << fi_strerror(-validate_ret)
+                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: fi_cq_open test failed for rail "
+                               << rail_id << " with error: " << fi_strerror(-validate_ret)
                                << " (err=" << -validate_ret << ")";
                     NIXL_ERROR << "This typically indicates EFA RDM layer failed to initialize.";
                     NIXL_ERROR << "Possible causes:";
-                    NIXL_ERROR << "  1. glibc version incompatibility (current: " << gnu_get_libc_version() << ")";
+                    NIXL_ERROR << "  1. glibc version incompatibility (current: "
+                               << gnu_get_libc_version() << ")";
                     NIXL_ERROR << "  2. EFA device resource exhaustion";
                     NIXL_ERROR << "  3. Kernel/driver compatibility issue";
                     NIXL_ERROR << "Workarounds:";
                     NIXL_ERROR << "  - Set FI_EFA_USE_DEVICE_RDMA=0 to disable GPU Direct RDMA";
-                    NIXL_ERROR << "  - Set NIXL_SKIP_RDM_VALIDATION=1 to skip this check (may crash later)";
+                    NIXL_ERROR << "  - Set NIXL_SKIP_RDM_VALIDATION=1 to skip this check (may "
+                                  "crash later)";
 
                     // Cleanup domain before throwing
                     fi_close(&domain->fid);
@@ -517,20 +519,22 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
                 }
 
                 if (test_cq == nullptr) {
-                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: test CQ is null despite success return for rail "
+                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: test CQ is null despite success "
+                                  "return for rail "
                                << rail_id;
                     fi_close(&domain->fid);
                     domain = nullptr;
-                    throw std::runtime_error(
-                        "EFA domain validation failed for rail " + std::to_string(rail_id) +
-                        ": test CQ creation returned null pointer");
+                    throw std::runtime_error("EFA domain validation failed for rail " +
+                                             std::to_string(rail_id) +
+                                             ": test CQ creation returned null pointer");
                 }
 
                 // Validation passed - close test CQ
                 fi_close(&test_cq->fid);
                 NIXL_DEBUG << "Domain validation passed for rail " << rail_id;
             } else {
-                NIXL_WARN << "Domain validation SKIPPED (NIXL_SKIP_RDM_VALIDATION=1) for rail " << rail_id;
+                NIXL_WARN << "Domain validation SKIPPED (NIXL_SKIP_RDM_VALIDATION=1) for rail "
+                          << rail_id;
             }
         }
 

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -20,6 +20,7 @@
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
 #include "libfabric_common.h"
+#include <gnu/libc-version.h>  // For glibc version detection
 
 #include <cstring>
 #include <stdexcept>
@@ -472,6 +473,65 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
         if (ret) {
             NIXL_ERROR << "fi_domain failed for rail " << rail_id << ": " << fi_strerror(-ret);
             throw std::runtime_error("fi_domain failed for rail " + std::to_string(rail_id));
+        }
+
+        // DOMAIN_VALIDATION_FIX: Validate EFA domain RDM layer is properly initialized
+        // This catches the case where fi_domain() succeeds but RDM layer failed internally
+        // (the "efa_domain_init_rdm failed. err: 28" issue that causes segfault at offset 0x18)
+        {
+            const char* skip_validation = std::getenv("NIXL_SKIP_RDM_VALIDATION");
+            if (!skip_validation || std::string(skip_validation) != "1") {
+                // Log glibc version for debugging
+                NIXL_INFO << "Domain validation: glibc version = " << gnu_get_libc_version()
+                          << ", rail " << rail_id << ", provider " << provider;
+
+                // Create a minimal test CQ to validate domain is functional
+                struct fi_cq_attr test_cq_attr = {};
+                test_cq_attr.format = FI_CQ_FORMAT_DATA;
+                test_cq_attr.wait_obj = FI_WAIT_NONE;
+                test_cq_attr.size = 1;  // Minimal size for validation
+                struct fid_cq *test_cq = nullptr;
+
+                int validate_ret = fi_cq_open(domain, &test_cq_attr, &test_cq, NULL);
+                if (validate_ret != 0) {
+                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: fi_cq_open test failed for rail " << rail_id
+                               << " with error: " << fi_strerror(-validate_ret)
+                               << " (err=" << -validate_ret << ")";
+                    NIXL_ERROR << "This typically indicates EFA RDM layer failed to initialize.";
+                    NIXL_ERROR << "Possible causes:";
+                    NIXL_ERROR << "  1. glibc version incompatibility (current: " << gnu_get_libc_version() << ")";
+                    NIXL_ERROR << "  2. EFA device resource exhaustion";
+                    NIXL_ERROR << "  3. Kernel/driver compatibility issue";
+                    NIXL_ERROR << "Workarounds:";
+                    NIXL_ERROR << "  - Set FI_EFA_USE_DEVICE_RDMA=0 to disable GPU Direct RDMA";
+                    NIXL_ERROR << "  - Set NIXL_SKIP_RDM_VALIDATION=1 to skip this check (may crash later)";
+
+                    // Cleanup domain before throwing
+                    fi_close(&domain->fid);
+                    domain = nullptr;
+
+                    throw std::runtime_error(
+                        "EFA domain validation failed for rail " + std::to_string(rail_id) +
+                        ": RDM layer may not be properly initialized. " +
+                        "Try setting FI_EFA_USE_DEVICE_RDMA=0 or use a compatible glibc version.");
+                }
+
+                if (test_cq == nullptr) {
+                    NIXL_ERROR << "DOMAIN_VALIDATION_FAILED: test CQ is null despite success return for rail "
+                               << rail_id;
+                    fi_close(&domain->fid);
+                    domain = nullptr;
+                    throw std::runtime_error(
+                        "EFA domain validation failed for rail " + std::to_string(rail_id) +
+                        ": test CQ creation returned null pointer");
+                }
+
+                // Validation passed - close test CQ
+                fi_close(&test_cq->fid);
+                NIXL_DEBUG << "Domain validation passed for rail " << rail_id;
+            } else {
+                NIXL_WARN << "Domain validation SKIPPED (NIXL_SKIP_RDM_VALIDATION=1) for rail " << rail_id;
+            }
         }
 
         // Create CQ for this rail


### PR DESCRIPTION
## Summary

Adds validation after `fi_domain()` to detect when the EFA RDM layer fails to initialize properly. This prevents cryptic segfaults on certain glibc versions by catching the issue early with clear error messages.

## Problem

On Ubuntu 24.04.3 (glibc 2.39-0ubuntu8.6), EFA's `fi_domain()` can return success even when the internal RDM layer initialization fails with `efa_domain_init_rdm err:28`. The domain appears valid but is corrupted internally. Subsequent operations (like `fi_cq_open`) crash with:

```
segfault at 18 ip 00007f... sp 00007f... error 4 in libfabric.so
```

This is extremely difficult to debug because the segfault occurs deep in libfabric with no useful stack trace.

## Solution

1. **Domain Validation**: After `fi_domain()` succeeds, create a minimal test CQ to verify the domain is actually functional
2. **Clear Error Messages**: If validation fails, log detailed troubleshooting information:
   - Current glibc version
   - Specific error codes
   - Possible causes and workarounds
3. **Environment Variables**: Add escape hatches for advanced users:
   - `NIXL_SKIP_RDM_VALIDATION=1`: Skip validation (may crash later)
   - `NIXL_FORCE_DISABLE_GPU_RDMA=1`: Force disable GPU Direct RDMA at startup

## Changes

### libfabric_rail.cpp
```cpp
// After fi_domain() succeeds, validate with test CQ
struct fi_cq_attr test_cq_attr = {};
test_cq_attr.format = FI_CQ_FORMAT_DATA;
test_cq_attr.wait_obj = FI_WAIT_NONE;
test_cq_attr.size = 1;

int validate_ret = fi_cq_open(domain, &test_cq_attr, &test_cq, NULL);
if (validate_ret != 0) {
    // Log detailed error and cleanup
    // Throw with actionable error message
}
```

### libfabric_backend.cpp
```cpp
// Check NIXL_FORCE_DISABLE_GPU_RDMA at engine startup
const char* force_disable_rdma = std::getenv("NIXL_FORCE_DISABLE_GPU_RDMA");
if (force_disable_rdma && std::string(force_disable_rdma) == "1") {
    setenv("FI_EFA_USE_DEVICE_RDMA", "0", 1);
}
```

## Testing

| Environment | glibc | Result |
|-------------|-------|--------|
| Ubuntu 24.04.3 | 2.39-0ubuntu8.6 | Validation catches issue, clear error |
| Ubuntu 22.04 | 2.35 | Validation passes, works normally |
| p5.48xlarge | 32 EFA | Multi-rail validated |

## Test Plan

- [x] Validation correctly detects corrupted domains
- [x] Clear error messages with glibc version logged
- [x] NIXL_SKIP_RDM_VALIDATION=1 bypasses check
- [x] NIXL_FORCE_DISABLE_GPU_RDMA=1 disables GPU RDMA
- [x] No performance impact on healthy systems
- [x] Works with TRT-LLM and vLLM