### PR TITLE
perf(libfabric): batch CQ reads for reduced syscall overhead

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -38,6 +38,11 @@
 // Libfabric configuration constants
 #define NIXL_LIBFABRIC_DEFAULT_CONTROL_RAILS 1
 
+// Batch CQ Reads: Read up to 16 completions per fi_cq_read() syscall
+// Based on Kalia et al. "Design Guidelines for High Performance RDMA Systems" (USENIX ATC 2016)
+// showing 83% throughput improvement from batching MMIO operations
+#define NIXL_LIBFABRIC_CQ_BATCH_SIZE 16
+
 // Sockets provider requires short timeout to maintain software progress during fi_cq_sread().
 // Long timeouts block in poll(), preventing message processing. EFA uses hardware completions.
 #define NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS 10

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -730,13 +730,14 @@ nixlLibfabricRail::setXferIdCallback(std::function<void(uint32_t)> callback) {
 // Per-Rail Completion Processing
 
 // Per-rail completion processing - handles one rail's CQ with configurable blocking behavior
+// Optimized to batch read up to NIXL_LIBFABRIC_CQ_BATCH_SIZE completions per syscall
 nixl_status_t
 nixlLibfabricRail::progressCompletionQueue(bool use_blocking) const {
-    // Completion processing
-    struct fi_cq_data_entry completion;
-    memset(&completion, 0, sizeof(completion));
+    // Batch completion processing - read up to 16 completions per syscall
+    struct fi_cq_data_entry completions[NIXL_LIBFABRIC_CQ_BATCH_SIZE];
+    memset(completions, 0, sizeof(completions));
 
-    int ret;
+    ssize_t ret;
 
     // Only protect libfabric CQ hardware operations
     {
@@ -744,10 +745,12 @@ nixlLibfabricRail::progressCompletionQueue(bool use_blocking) const {
 
         if (use_blocking && blocking_cq_sread_supported) {
             // Blocking read using fi_cq_sread (used by CM thread)
-            ret = fi_cq_sread(cq, &completion, 1, nullptr, NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS);
+            // Keep single-entry semantics for blocking to preserve timeout behavior
+            ret = fi_cq_sread(cq, completions, 1, nullptr, NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS);
         } else {
-            // Non-blocking read (used by progress thread or fallback)
-            ret = fi_cq_read(cq, &completion, 1);
+            // Non-blocking batch read (used by progress thread)
+            // Read up to NIXL_LIBFABRIC_CQ_BATCH_SIZE completions per syscall
+            ret = fi_cq_read(cq, completions, NIXL_LIBFABRIC_CQ_BATCH_SIZE);
         }
 
         if (ret < 0 && ret != -FI_EAGAIN) {
@@ -769,26 +772,34 @@ nixlLibfabricRail::progressCompletionQueue(bool use_blocking) const {
             return NIXL_ERR_BACKEND;
         }
     }
-    // CQ lock released here - completion is now local data
+    // CQ lock released here - completions are now local data
 
     if (ret == -FI_EAGAIN) {
         return NIXL_IN_PROG; // No completions available
     }
 
-    if (ret == 1) {
-        NIXL_TRACE << "Completion received on rail " << rail_id << " flags=" << std::hex
-                   << completion.flags << " data=" << completion.data
-                   << " context=" << completion.op_context << std::dec;
+    if (ret > 0) {
+        NIXL_TRACE << "Batch received " << ret << " completions on rail " << rail_id;
 
-        // Process completion using local data. Callbacks have their own thread safety
-        nixl_status_t status = processCompletionQueueEntry(&completion);
-        if (status != NIXL_SUCCESS) {
-            NIXL_ERROR << "Failed to process completion on rail " << rail_id;
-            return status;
+        // Process all completions from the batch
+        nixl_status_t overall_status = NIXL_SUCCESS;
+        for (ssize_t i = 0; i < ret; ++i) {
+            NIXL_TRACE << "Completion " << i << "/" << ret << " on rail " << rail_id
+                       << " flags=" << std::hex << completions[i].flags
+                       << " data=" << completions[i].data
+                       << " context=" << completions[i].op_context << std::dec;
+
+            // Process each completion. Continue processing even if one fails.
+            nixl_status_t status = processCompletionQueueEntry(&completions[i]);
+            if (status != NIXL_SUCCESS) {
+                NIXL_ERROR << "Failed to process completion " << i << " on rail " << rail_id;
+                overall_status = status;
+                // Continue processing remaining completions
+            }
         }
 
-        NIXL_DEBUG << "Completion processed on rail " << rail_id;
-        return NIXL_SUCCESS;
+        NIXL_DEBUG << "Batch processed " << ret << " completions on rail " << rail_id;
+        return overall_status;
     }
 
     return NIXL_ERR_BACKEND; // Unexpected case


### PR DESCRIPTION
## Summary

This PR optimizes completion queue processing by reading up to 16 completions per `fi_cq_read()` syscall instead of processing them one at a time.

### Changes

**Files Modified:**
- `src/utils/libfabric/libfabric_common.h` - Add `NIXL_LIBFABRIC_CQ_BATCH_SIZE` constant (16)
- `src/utils/libfabric/libfabric_rail.cpp` - Modify `progressCompletionQueue()` to batch reads

### Research Basis

Based on [Kalia et al. "Design Guidelines for High Performance RDMA Systems" (USENIX ATC 2016)](https://www.usenix.org/system/files/conference/atc16/atc16_paper-kalia.pdf):

> "Applications can take advantage of batching to reduce MMIO. Using multiple QPs per CPU core and batching leads to 83% improvement in per-core throughput."

### Implementation Details

```cpp
// Before: Single completion per syscall
struct fi_cq_data_entry completion;
ret = fi_cq_read(cq, &completion, 1);

// After: Batch up to 16 completions per syscall
struct fi_cq_data_entry completions[NIXL_LIBFABRIC_CQ_BATCH_SIZE];
ret = fi_cq_read(cq, completions, NIXL_LIBFABRIC_CQ_BATCH_SIZE);
for (ssize_t i = 0; i < ret; i++) {
    processCompletionQueueEntry(&completions[i]);
}
```

### Why This Helps

- Reduces syscall overhead by amortizing across multiple completions
- Improves CPU cache utilization by processing related data together  
- Particularly effective for multi-rail configurations (32-64 rails) with high completion rates
- Preserves blocking semantics for `fi_cq_sread` in connection management thread

### Design Decisions

1. **Batch size of 16**: Chosen as a balance between memory usage and batching efficiency. Can be tuned based on workload characteristics.

2. **Blocking path unchanged**: `fi_cq_sread` still reads single entries to preserve timeout semantics for the connection management thread.

3. **Continue on error**: If one completion fails to process, we continue processing the remaining completions in the batch and report the error after.

## Test Plan

- [ ] Unit tests pass
- [ ] Integration tests with EFA provider
- [ ] Benchmark comparison with baseline (results pending)