### PR TITLE
fix: prevent pkill etcd from killing other containers' processes

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -80,6 +80,7 @@ export NIXL_ETCD_NAMESPACE="/nixl/cpp_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &
+ETCD_PID=$!
 
 wait_for_etcd
 
@@ -129,4 +130,4 @@ echo "./bin/p2p_test disabled"
 echo "./bin/ucx_worker_test disabled"
 echo "${TEXT_CLEAR}"
 
-pkill etcd
+kill -9 $ETCD_PID 2>/dev/null || true

--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -54,6 +54,7 @@ export NIXL_ETCD_NAMESPACE="/nixl/nixlbench_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &
+ETCD_PID=$!
 
 wait_for_etcd
 
@@ -116,4 +117,4 @@ if $HAS_GPU ; then
     done
 fi
 
-pkill etcd
+kill -9 $ETCD_PID 2>/dev/null || true

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -80,6 +80,7 @@ export NIXL_ETCD_NAMESPACE="/nixl/python_ci/${etcd_port}"
 etcd --listen-client-urls ${NIXL_ETCD_ENDPOINTS} --advertise-client-urls ${NIXL_ETCD_ENDPOINTS} \
      --listen-peer-urls ${NIXL_ETCD_PEER_URLS} --initial-advertise-peer-urls ${NIXL_ETCD_PEER_URLS} \
      --initial-cluster default=${NIXL_ETCD_PEER_URLS} &
+ETCD_PID=$!
 
 wait_for_etcd
 
@@ -125,4 +126,4 @@ telePID=$!
 sleep 15
 kill -s INT $telePID
 
-pkill etcd
+kill -9 $ETCD_PID 2>/dev/null || true


### PR DESCRIPTION
## What?
Ensures each container only terminates its own etcd instance, allowing parallel test execution without interference.

## Why?
When running multiple test containers in parallel (e.g., SLURM enroot), `pkill etcd` would kill etcd processes across all containers, causing the second container to fail with exit code 1.

## How?
Replace `pkill etcd` with targeted process termination using captured PID.

Changes:
- Capture etcd PID immediately after backgrounding: ETCD_PID=$!
- Replace `pkill etcd` with `kill -9 $ETCD_PID 2>/dev/null || true`
- Use SIGKILL (-9) for immediate, reliable termination in test environment
- Add error suppression to prevent script failure if process already exited
