### PR TITLE
API/GPU/UCX: Device API V2. Device-side implementation.

### DIFF
--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -36,6 +36,12 @@ enum class nixl_gpu_level_t : uint64_t {
 };
 
 /**
+ * @enum  nixl_gpu_flags_t
+ * @brief An enumeration of different flags for GPU transfer requests.
+ */
+enum class nixl_gpu_flags_t : uint64_t { NO_DELAY = UCP_DEVICE_FLAG_NODELAY };
+
+/**
  * @brief Parameters for GPU transfer requests with safe type conversion.
  */
 struct nixlGpuXferReqParams {
@@ -311,7 +317,20 @@ nixlPut(const nixlMemDesc &src,
         unsigned channel_id = 0,
         unsigned flags = 0,
         nixlGpuXferStatusH *xfer_status = nullptr) {
-    return NIXL_ERR_NOT_SUPPORTED;
+    auto src_mem_list = static_cast<ucp_device_local_mem_list_handle_h>(src.mvh);
+    auto dst_mem_list = static_cast<ucp_device_remote_mem_list_handle_h>(dst.mvh);
+    ucp_device_request_t *ucp_request{xfer_status ? &xfer_status->device_request : nullptr};
+    const auto status = ucp_device_put_single<static_cast<ucs_device_level_t>(level)>(src_mem_list,
+                                                                                      src.index,
+                                                                                      src.offset,
+                                                                                      dst_mem_list,
+                                                                                      dst.index,
+                                                                                      dst.offset,
+                                                                                      size,
+                                                                                      channel_id,
+                                                                                      flags,
+                                                                                      ucp_request);
+    return nixlGpuConvertUcsStatus(status);
 }
 
 /**
@@ -336,7 +355,11 @@ nixlAtomicAdd(uint64_t value,
               unsigned channel_id = 0,
               unsigned flags = 0,
               nixlGpuXferStatusH *xfer_status = nullptr) {
-    return NIXL_ERR_NOT_SUPPORTED;
+    auto mem_list = static_cast<ucp_device_remote_mem_list_handle_h>(counter.mvh);
+    ucp_device_request_t *ucp_request{xfer_status ? &xfer_status->device_request : nullptr};
+    const auto status = ucp_device_counter_inc<static_cast<ucs_device_level_t>(level)>(
+        mem_list, counter.index, value, counter.offset, channel_id, flags, ucp_request);
+    return nixlGpuConvertUcsStatus(status);
 }
 
 /**
@@ -348,13 +371,13 @@ nixlAtomicAdd(uint64_t value,
  *
  * @param mvh    [in]  Memory view handle (remote buffers)
  * @param index  [in]  Index in the memory view
-
  * @return Pointer to the mapped memory, or nullptr if not available.
  */
-template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
-__device__ void *
+__device__ inline void *
 nixlGetPtr(nixlMemoryViewH mvh, size_t index) {
-    return nullptr;
+    auto mem_list = static_cast<ucp_device_remote_mem_list_handle_h>(mvh);
+    void *ptr;
+    return ucp_device_get_ptr(mem_list, index, &ptr) == UCS_OK ? ptr : nullptr;
 }
 
 #endif // _NIXL_DEVICE_CUH

--- a/test/gtest/device_api/single_write_test.cu
+++ b/test/gtest/device_api/single_write_test.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -93,6 +93,82 @@ TestSingleWriteKernel(nixlGpuXferReqH req_hdnl,
     }
 }
 
+struct putParams {
+    nixlMemDesc src;
+    nixlMemDesc dst;
+    size_t size;
+    unsigned channelId{0};
+    unsigned flags{static_cast<unsigned>(nixl_gpu_flags_t::NO_DELAY)};
+};
+
+template<nixl_gpu_level_t level>
+__global__ void
+putKernel(putParams put_params,
+          size_t num_iters,
+          unsigned long long *start_time,
+          unsigned long long *end_time) {
+    __shared__ nixlGpuXferStatusH xfer_statuses[MAX_THREADS];
+    nixlGpuXferStatusH xfer_status = xfer_statuses[GetReqIdx<level>()];
+
+    assert(GetReqIdx<level>() < MAX_THREADS);
+
+    if (start_time && (threadIdx.x == 0)) {
+        *start_time = GetTimeNs();
+    }
+
+    __syncthreads();
+
+    for (size_t i = 0; i < num_iters; ++i) {
+        auto status = nixlPut<level>(put_params.src,
+                                     put_params.dst,
+                                     put_params.size,
+                                     put_params.channelId,
+                                     put_params.flags,
+                                     &xfer_status);
+        if (status != NIXL_IN_PROG) {
+            printf("Thread %d: nixlPut failed iteration %zu: status=%d (0x%x)\n",
+                   threadIdx.x,
+                   i,
+                   status,
+                   static_cast<unsigned int>(status));
+            return;
+        }
+
+        status = nixlGpuGetXferStatus<level>(xfer_status);
+        if (status != NIXL_SUCCESS && status != NIXL_IN_PROG) {
+            printf("Thread %d: Failed to progress single write transfer iteration %zu: status=%d\n",
+                   threadIdx.x,
+                   i,
+                   status);
+            return;
+        }
+
+        while (status == NIXL_IN_PROG) {
+            status = nixlGpuGetXferStatus<level>(xfer_status);
+            if (status != NIXL_SUCCESS && status != NIXL_IN_PROG) {
+                printf("Thread %d: Failed to progress single write transfer iteration %zu: "
+                       "status=%d\n",
+                       threadIdx.x,
+                       i,
+                       status);
+                return;
+            }
+        }
+
+        if (status != NIXL_SUCCESS) {
+            printf("Thread %d: Transfer completion failed iteration %zu: status=%d\n",
+                   threadIdx.x,
+                   i,
+                   status);
+            return;
+        }
+    }
+
+    if (end_time && (threadIdx.x == 0)) {
+        *end_time = GetTimeNs();
+    }
+}
+
 template<nixl_gpu_level_t level>
 nixl_status_t
 LaunchSingleWriteTest(unsigned num_threads,
@@ -131,6 +207,74 @@ LaunchSingleWriteTest(unsigned num_threads,
     }
 
     return ret;
+}
+
+template<typename T> class gpuVar {
+public:
+    gpuVar() : ptr_(allocate(), &deallocate) {
+        cudaMemset(ptr_.get(), 0, sizeof(T));
+    }
+
+    T *
+    get() const {
+        return ptr_.get();
+    }
+
+    T
+    operator*() const {
+        T value;
+        cudaMemcpy(&value, ptr_.get(), sizeof(T), cudaMemcpyDeviceToHost);
+        return value;
+    }
+
+private:
+    static T *
+    allocate() {
+        T *ptr;
+        cudaMalloc(&ptr, sizeof(T));
+        return ptr;
+    }
+
+    static void
+    deallocate(T *ptr) {
+        cudaFree(ptr);
+    }
+
+    std::unique_ptr<T, void (*)(T *)> ptr_;
+};
+
+struct gpuTimer {
+    gpuVar<unsigned long long> start_;
+    gpuVar<unsigned long long> end_;
+};
+
+template<nixl_gpu_level_t level>
+nixl_status_t
+launchPutKernel(const putParams &put_params,
+                size_t num_iters,
+                gpuTimer *gpu_timer,
+                unsigned num_threads = 32) {
+    unsigned long long *start_time{nullptr};
+    unsigned long long *end_time{nullptr};
+    if (gpu_timer) {
+        start_time = gpu_timer->start_.get();
+        end_time = gpu_timer->end_.get();
+    }
+    putKernel<level><<<1, num_threads>>>(put_params, num_iters, start_time, end_time);
+
+    auto err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+        printf("Failed to synchronize: %s\n", cudaGetErrorString(err));
+        return NIXL_ERR_BACKEND;
+    }
+
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("Failed to launch kernel: %s\n", cudaGetErrorString(err));
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
 }
 
 class SingleWriteTest : public DeviceApiTestBase {
@@ -190,6 +334,18 @@ protected:
         nixlDescList<Desc> desc_list(mem_type);
         for (const auto &buffer : buffers) {
             desc_list.addDesc(Desc(buffer, buffer.getSize(), uint64_t(DEV_ID)));
+        }
+        return desc_list;
+    }
+
+    template<typename Desc>
+    nixlDescList<Desc>
+    makeDescList(const std::vector<MemBuffer> &buffers,
+                 nixl_mem_t mem_type,
+                 const std::string &agent_name) {
+        nixlDescList<Desc> desc_list(mem_type);
+        for (const auto &buffer : buffers) {
+            desc_list.addDesc(Desc(buffer, buffer.getSize(), uint64_t(DEV_ID), agent_name));
         }
         return desc_list;
     }
@@ -298,6 +454,24 @@ protected:
                 is_no_delay,
                 start_time_ptr,
                 end_time_ptr);
+        default:
+            ADD_FAILURE() << "Unknown level: " << static_cast<int>(level);
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+
+    nixl_status_t
+    dispatchLaunchPutKernel(nixl_gpu_level_t level,
+                            const putParams &put_params,
+                            size_t num_iters,
+                            gpuTimer *gpu_timer = nullptr) {
+        switch (level) {
+        case nixl_gpu_level_t::BLOCK:
+            return launchPutKernel<nixl_gpu_level_t::BLOCK>(put_params, num_iters, gpu_timer);
+        case nixl_gpu_level_t::WARP:
+            return launchPutKernel<nixl_gpu_level_t::WARP>(put_params, num_iters, gpu_timer);
+        case nixl_gpu_level_t::THREAD:
+            return launchPutKernel<nixl_gpu_level_t::THREAD>(put_params, num_iters, gpu_timer);
         default:
             ADD_FAILURE() << "Unknown level: " << static_cast<int>(level);
             return NIXL_ERR_INVALID_PARAM;
@@ -650,6 +824,181 @@ TEST_P(SingleWriteTest, MultipleWorkersTest) {
     invalidateMD();
 }
 
+TEST_P(SingleWriteTest, SingleWorkerPut) {
+    std::vector<MemBuffer> src_buffers, dst_buffers;
+    constexpr size_t size{4 * 1024};
+    constexpr size_t count{1};
+    constexpr nixl_mem_t mem_type{VRAM_SEG};
+    createRegisteredMem(getAgent(SENDER_AGENT), size, count, mem_type, src_buffers);
+    createRegisteredMem(getAgent(RECEIVER_AGENT), size, count, mem_type, dst_buffers);
+
+    auto src_data = static_cast<uint32_t *>(static_cast<void *>(src_buffers[0]));
+    cudaMemset(src_data, 0, size);
+
+    constexpr uint32_t pattern{0xDEADBEEF};
+    cudaMemcpy(src_data, &pattern, sizeof(pattern), cudaMemcpyHostToDevice);
+
+    exchangeMD(SENDER_AGENT, RECEIVER_AGENT);
+
+    nixlMemoryViewH src_mvh;
+    auto status = getAgent(SENDER_AGENT)
+                      .prepMemoryView(makeDescList<nixlBasicDesc>(src_buffers, mem_type), src_mvh);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    nixlMemoryViewH dst_mvh;
+    status = getAgent(SENDER_AGENT)
+                 .prepMemoryView(makeDescList<nixlRemoteDesc>(
+                                     dst_buffers, mem_type, getAgentName(RECEIVER_AGENT)),
+                                 dst_mvh);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    putParams put_params{{src_mvh, 0, 0}, {dst_mvh, 0, 0}, size};
+    constexpr size_t num_iters{1000};
+    gpuTimer gpu_timer;
+    status = dispatchLaunchPutKernel(GetParam(), put_params, num_iters, &gpu_timer);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    logResultsPublic(size, count, num_iters, *gpu_timer.start_, *gpu_timer.end_);
+
+    uint32_t dst_data;
+    cudaMemcpy(&dst_data,
+               static_cast<uint32_t *>(static_cast<void *>(dst_buffers[0])),
+               sizeof(uint32_t),
+               cudaMemcpyDeviceToHost);
+    EXPECT_EQ(dst_data, pattern) << "Data transfer verification failed. Expected: 0x" << std::hex
+                                 << pattern << ", Got: 0x" << dst_data;
+
+    getAgent(SENDER_AGENT).releaseMemoryView(dst_mvh);
+    getAgent(SENDER_AGENT).releaseMemoryView(src_mvh);
+    invalidateMD();
+}
+
+TEST_P(SingleWriteTest, MultipleWorkersPut) {
+    constexpr size_t size{4 * 1024};
+    constexpr nixl_mem_t mem_type{VRAM_SEG};
+
+    std::vector<std::vector<MemBuffer>> src_buffers(numWorkers);
+    std::vector<std::vector<MemBuffer>> dst_buffers(numWorkers);
+    std::vector<std::vector<uint32_t>> patterns(numWorkers);
+
+    for (size_t worker_id = 0; worker_id < numWorkers; worker_id++) {
+        createRegisteredMem(getAgent(SENDER_AGENT), size, 1, mem_type, src_buffers[worker_id]);
+        createRegisteredMem(getAgent(RECEIVER_AGENT), size, 1, mem_type, dst_buffers[worker_id]);
+
+        constexpr size_t num_elements = size / sizeof(uint32_t);
+        patterns[worker_id].resize(num_elements);
+        for (size_t i = 0; i < num_elements; i++) {
+            patterns[worker_id][i] = 0xDEAD0000 | worker_id;
+        }
+
+        cudaMemcpy(static_cast<void *>(src_buffers[worker_id][0]),
+                   patterns[worker_id].data(),
+                   size,
+                   cudaMemcpyHostToDevice);
+    }
+
+    exchangeMD(SENDER_AGENT, RECEIVER_AGENT);
+
+    std::vector<nixlMemoryViewH> src_mvhs(numWorkers);
+    std::vector<nixlMemoryViewH> dst_mvhs(numWorkers);
+    nixl_opt_args_t extra_params;
+
+    for (size_t worker_id = 0; worker_id < numWorkers; worker_id++) {
+        extra_params.customParam = "worker_id=" + std::to_string(worker_id);
+
+        auto status =
+            getAgent(SENDER_AGENT)
+                .prepMemoryView(makeDescList<nixlBasicDesc>(src_buffers[worker_id], mem_type),
+                                src_mvhs[worker_id],
+                                &extra_params);
+        ASSERT_EQ(status, NIXL_SUCCESS);
+
+        status =
+            getAgent(SENDER_AGENT)
+                .prepMemoryView(makeDescList<nixlRemoteDesc>(
+                                    dst_buffers[worker_id], mem_type, getAgentName(RECEIVER_AGENT)),
+                                dst_mvhs[worker_id],
+                                &extra_params);
+        ASSERT_EQ(status, NIXL_SUCCESS);
+    }
+
+    for (size_t worker_id = 0; worker_id < numWorkers; worker_id++) {
+        putParams put_params{{src_mvhs[worker_id], 0, 0}, {dst_mvhs[worker_id], 0, 0}, size};
+        constexpr size_t num_iters{1};
+        const auto status = dispatchLaunchPutKernel(GetParam(), put_params, num_iters);
+        ASSERT_EQ(status, NIXL_SUCCESS) << "Kernel launch failed for worker " << worker_id;
+    }
+
+    for (size_t worker_id = 0; worker_id < numWorkers; worker_id++) {
+        std::vector<uint32_t> received(size / sizeof(uint32_t));
+        cudaMemcpy(received.data(),
+                   static_cast<void *>(dst_buffers[worker_id][0]),
+                   size,
+                   cudaMemcpyDeviceToHost);
+
+        EXPECT_EQ(received, patterns[worker_id])
+            << "Worker " << worker_id << " full buffer verification failed";
+    }
+
+    Logger() << "MultipleWorkers test: " << numWorkers
+             << " workers with explicit selection verified";
+
+    for (size_t worker_id = 0; worker_id < numWorkers; worker_id++) {
+        getAgent(SENDER_AGENT).releaseMemoryView(src_mvhs[worker_id]);
+        getAgent(SENDER_AGENT).releaseMemoryView(dst_mvhs[worker_id]);
+    }
+
+    invalidateMD();
+}
+
+TEST_P(SingleWriteTest, SingleWorkerPutGap) {
+    std::vector<MemBuffer> src_buffers, dst_buffers;
+    constexpr size_t size{4 * 1024};
+    constexpr size_t count{1};
+    constexpr nixl_mem_t mem_type{VRAM_SEG};
+    createRegisteredMem(getAgent(SENDER_AGENT), size, count, mem_type, src_buffers);
+    createRegisteredMem(getAgent(RECEIVER_AGENT), size, count, mem_type, dst_buffers);
+
+    auto src_data = static_cast<uint32_t *>(static_cast<void *>(src_buffers[0]));
+    cudaMemset(src_data, 0, size);
+
+    constexpr uint32_t pattern{0xDEADBEEF};
+    cudaMemcpy(src_data, &pattern, sizeof(pattern), cudaMemcpyHostToDevice);
+
+    exchangeMD(SENDER_AGENT, RECEIVER_AGENT);
+
+    const auto local_dlist = makeDescList<nixlBasicDesc>(src_buffers, mem_type);
+    nixlMemoryViewH src_mvh;
+    auto status = getAgent(SENDER_AGENT).prepMemoryView(local_dlist, src_mvh);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    auto remote_dlist =
+        makeDescList<nixlRemoteDesc>(dst_buffers, mem_type, getAgentName(RECEIVER_AGENT));
+    remote_dlist.addDesc({{}, nixl_invalid_agent});
+    nixlMemoryViewH dst_mvh;
+    status = getAgent(SENDER_AGENT).prepMemoryView(remote_dlist, dst_mvh);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    putParams put_params{{src_mvh, 0, 0}, {dst_mvh, 0, 0}, size};
+    constexpr size_t num_iters{1000};
+    gpuTimer gpu_timer;
+    status = dispatchLaunchPutKernel(GetParam(), put_params, num_iters, &gpu_timer);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    logResultsPublic(size, count, num_iters, *gpu_timer.start_, *gpu_timer.end_);
+
+    uint32_t dst_data;
+    cudaMemcpy(&dst_data,
+               static_cast<uint32_t *>(static_cast<void *>(dst_buffers[0])),
+               sizeof(uint32_t),
+               cudaMemcpyDeviceToHost);
+    EXPECT_EQ(dst_data, pattern) << "Data transfer verification failed. Expected: 0x" << std::hex
+                                 << pattern << ", Got: 0x" << dst_data;
+
+    getAgent(SENDER_AGENT).releaseMemoryView(dst_mvh);
+    getAgent(SENDER_AGENT).releaseMemoryView(src_mvh);
+    invalidateMD();
+}
 } // namespace gtest::nixl::gpu::single_write
 
 using gtest::nixl::gpu::single_write::SingleWriteTest;


### PR DESCRIPTION
## What?
The implementation of device-side of Device API V2.

## Why?
Gives more flexibility to the users while maintaining less GPU handles.
Users create GPU transfer request handle using `nixlAgent::createGpuXferReq` in V1. Also, before calling `nixlAgent::createGpuXferReq`, `nixlAgent::createGpuXferReq` must be called.
V2 also closes the missing functionality associated with the separate creation of the source and destination memory descriptors.
