### PR TITLE
PLUGINS/UCX: Minor cleanup.

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1050,7 +1050,7 @@ nixl_status_t nixlUcxEngine::unloadMD (nixlBackendMD* input) {
 size_t
 nixlUcxEngine::getWorkerId(const nixl_opt_b_args_t *opt_args) const noexcept {
     if (opt_args) {
-        const auto worker_id = getWorkerId(*opt_args);
+        const auto worker_id = getWorkerIdFromOptArgs(*opt_args);
         if (worker_id) {
             return *worker_id;
         }
@@ -1067,7 +1067,7 @@ nixlUcxEngine::getWorkerId(const nixl_opt_b_args_t *opt_args) const noexcept {
 }
 
 std::optional<size_t>
-nixlUcxEngine::getWorkerId(const nixl_opt_b_args_t &opt_args) const noexcept {
+nixlUcxEngine::getWorkerIdFromOptArgs(const nixl_opt_b_args_t &opt_args) const noexcept {
     constexpr std::string_view worker_id_key = "worker_id=";
     size_t pos = opt_args.customParam.find(worker_id_key);
     if (pos == std::string::npos) {
@@ -1103,8 +1103,8 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    /* TODO: try to get from a pool first */
     const auto worker_id = getWorkerId(opt_args);
+    /* TODO: try to get from a pool first */
     auto *ucx_handle = new nixlUcxBackendH(getWorker(worker_id).get(), worker_id);
 
     handle = ucx_handle;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -222,7 +222,7 @@ protected:
     }
 
     [[nodiscard]] size_t
-    getWorkerId(const nixl_opt_b_args_t * = nullptr) const noexcept;
+    getWorkerId(const nixl_opt_b_args_t *opt_args = nullptr) const noexcept;
 
     virtual size_t
     getSharedWorkersSize() const {
@@ -284,8 +284,12 @@ private:
                        size_t start_idx,
                        size_t end_idx);
 
+    /**
+     * Get the worker ID from the optional arguments.
+     * Returns std::nullopt if the 'worker_id' option extraction fails.
+     */
     [[nodiscard]] std::optional<size_t>
-    getWorkerId(const nixl_opt_b_args_t &) const noexcept;
+    getWorkerIdFromOptArgs(const nixl_opt_b_args_t &opt_args) const noexcept;
 
     /* UCX data */
     std::unique_ptr<nixlUcxContext> uc;


### PR DESCRIPTION
## What?
Combined the function `getWorkerIdFromOptArgs` and checking the return value of this function into a single method.