### PR TITLE
fix:Fix role parameter validation logic error

### DIFF
--- a/test/nixl/nixl_test.cpp
+++ b/test/nixl/nixl_test.cpp
@@ -273,7 +273,7 @@ int main(int argc, char *argv[]) {
 
     std::transform(role.begin(), role.end(), role.begin(), ::tolower);
 
-    if (!role.compare(initiator) && !role.compare(target)) {
+    if (role.compare(initiator) != 0 && role.compare(target) != 0) {
             std::cerr << "Invalid role. Use 'initiator' or 'target'."
                       << "Currently "<< role <<std::endl;
             return 1;


### PR DESCRIPTION
## What?
     Resolve compilation failure caused by missing string quotes for initiator and target literals in std::string::compare() calls (corrected to "initiator" and "target").

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
