### PR TITLE
Expose C API to outside of the nixl-sys crate

### DIFF
--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -39,6 +39,25 @@ mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+/// Raw FFI bindings to the NIXL C API.
+///
+/// # Safety
+///
+/// These are unsafe functions that require careful handling:
+/// - Manual memory management (create/destroy pairs)
+/// - Thread safety is the caller's responsibility
+/// - Pointers must be valid for the duration of calls
+///
+/// Prefer using the safe wrapper types (`Agent`, `RegDescList`, etc.) when possible.
+pub mod ffi {
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    #![allow(dead_code)]
+
+    pub use super::bindings::*;
+}
+
 // Re-export types from the included bindings
 use bindings::{
     nixl_capi_create_agent, nixl_capi_create_backend, nixl_capi_create_notif_map,


### PR DESCRIPTION
## What?
Exposes the raw C API bindings via a new `pub mod ffi` module, allowing downstream crates to access the underlying NIXL C functions directly.

## Why?
Enables users to create custom agent wrappers with different locking/threading strategies for different use cases, without being constrained by the safe wrapper's `RwLock` design.

## How?
Adds a `pub mod ffi` that re-exports everything from the internal `bindings` module via `pub use super::bindings::*`.