### PR TITLE
Ofi neuron support

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -77,14 +77,14 @@ class nixlLibfabricPrivateMetadata : public nixlBackendMD {
 private:
     void *buffer_; // Local memory buffer address
     size_t length_; // Buffer length in bytes
-    int gpu_device_id_; // GPU device ID for VRAM, -1 for DRAM
+    int device_id_; // Device ID for VRAM, -1 for DRAM
     std::vector<struct fid_mr *> rail_mr_list_; // Memory registrations, one per rail
     std::vector<uint64_t> rail_key_list_; // Remote access keys, one per rail
     std::vector<char *> src_ep_names_; // Source endpoint names, one per rail
     std::vector<size_t> selected_rails_; // Rails selected based on memory topology
 
 public:
-    nixlLibfabricPrivateMetadata() : nixlBackendMD(true), gpu_device_id_(-1) {}
+    nixlLibfabricPrivateMetadata() : nixlBackendMD(true), device_id_(-1) {}
     friend class nixlLibfabricEngine;
 };
 
@@ -212,8 +212,8 @@ private:
     mutable std::mutex connection_state_mutex_;
 
 
-    // System accelerator type (set during initialization from rail_manager)
-    fi_hmem_iface system_accelerator_type_;
+    // System runtime type (set during initialization from rail_manager)
+    fi_hmem_iface runtime_;
 
     void
     cleanup();

--- a/src/plugins/libfabric/meson.build
+++ b/src/plugins/libfabric/meson.build
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-FileCopyrightText: Copyright (c) 2025 Amazon.com, Inc. and affiliates.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -279,7 +279,7 @@ public:
     registerMemory(void *buffer,
                    size_t length,
                    nixl_mem_t mem_type,
-                   int gpu_id,
+                   int device_id,
                    enum fi_hmem_iface iface,
                    struct fid_mr **mr_out,
                    uint64_t *key_out) const;

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -39,23 +39,25 @@ static const std::string NUM_RAILS_TAG{"num_rails"};
 
 nixlLibfabricRailManager::nixlLibfabricRailManager(size_t striping_threshold)
     : striping_threshold_(striping_threshold),
-      system_accelerator_type_(FI_HMEM_CUDA) {
+      runtime_(FI_HMEM_CUDA) {
     NIXL_DEBUG << "Creating rail manager with striping threshold: " << striping_threshold_
                << " bytes";
 
     // Initialize topology system
     topology = std::make_unique<nixlLibfabricTopology>();
 
-    // Determine system accelerator type once at initialization
-    if (topology->getNumNvidiaGpus() > 0) {
-        system_accelerator_type_ = FI_HMEM_CUDA;
-        NIXL_DEBUG << "System accelerator type: CUDA (" << topology->getNumNvidiaGpus() << " GPUs)";
-    } else if (topology->getNumGpus() > 0) {
-        system_accelerator_type_ = FI_HMEM_NEURON;
-        NIXL_DEBUG << "System accelerator type: NEURON (" << topology->getNumGpus() << " devices)";
+    // Determine system runtime type once at initialization
+    if (topology->getNumNvidiaAccel() > 0) {
+        runtime_ = FI_HMEM_CUDA;
+        NIXL_INFO << "System runtime: CUDA for " << topology->getNumNvidiaAccel()
+                  << " NVIDIA GPU(s)";
+    } else if (topology->getNumAwsAccel() > 0) {
+        runtime_ = FI_HMEM_NEURON;
+        NIXL_INFO << "System runtime: NEURON for " << topology->getNumAwsAccel()
+                  << " AWS Trainium device(s)";
     } else {
-        system_accelerator_type_ = FI_HMEM_SYSTEM;
-        NIXL_DEBUG << "System accelerator type: SYSTEM (no accelerators)";
+        runtime_ = FI_HMEM_SYSTEM;
+        NIXL_INFO << "System runtime: SYSTEM (no accelerators)";
     }
 
     // Get network devices from topology and create rails automatically
@@ -337,49 +339,50 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 std::vector<size_t>
 nixlLibfabricRailManager::selectRailsForMemory(void *mem_addr,
                                                nixl_mem_t mem_type,
-                                               int gpu_id,
-                                               const std::string &gpu_pci_bus_id) const {
+                                               int device_id,
+                                               const std::string &device_pci_bus_id) const {
     if (mem_type == VRAM_SEG) {
-        if (gpu_id < 0) {
-            NIXL_ERROR << "Invalid GPU ID " << gpu_id << " for VRAM memory " << mem_addr;
+        if (device_id < 0) {
+            NIXL_ERROR << "Invalid device ID " << device_id << " for VRAM memory " << mem_addr;
             return {}; // Return empty vector to indicate failure
         }
 
         // Get EFA devices for this PCI bus ID
-        std::vector<std::string> gpu_efa_devices = topology->getEfaDevicesForPci(gpu_pci_bus_id);
-        if (gpu_efa_devices.empty()) {
-            NIXL_ERROR << "No EFA devices found for PCI " << gpu_pci_bus_id;
+        std::vector<std::string> device_efa_devices =
+            topology->getEfaDevicesForPci(device_pci_bus_id);
+        if (device_efa_devices.empty()) {
+            NIXL_ERROR << "No EFA devices found for PCI " << device_pci_bus_id;
             return {}; // Return empty vector to indicate failure
         }
-        std::vector<size_t> gpu_rails;
-        for (const std::string &efa_device : gpu_efa_devices) {
+        std::vector<size_t> device_rails;
+        for (const std::string &efa_device : device_efa_devices) {
             auto it = efa_device_to_rail_map.find(efa_device);
             if (it != efa_device_to_rail_map.end()) {
                 // Bounds check: ensure rail index is valid
                 if (it->second < data_rails_.size()) {
-                    gpu_rails.push_back(it->second);
-                    NIXL_DEBUG << "VRAM memory " << mem_addr << " on GPU-PCI " << gpu_pci_bus_id
-                               << " mapped to rail " << it->second << " (EFA device=" << efa_device
-                               << ")";
+                    device_rails.push_back(it->second);
+                    NIXL_DEBUG << "VRAM memory " << mem_addr << " on device PCI "
+                               << device_pci_bus_id << " mapped to rail " << it->second
+                               << " (EFA device=" << efa_device << ")";
                 } else {
                     NIXL_WARN << "EFA device " << efa_device << " maps to rail " << it->second
                               << " but only " << data_rails_.size() << " rails available";
                 }
             } else {
                 NIXL_WARN << "EFA device " << efa_device
-                          << " not found in rail mapping for GPU-PCI " << gpu_pci_bus_id;
+                          << " not found in rail mapping for device PCI " << device_pci_bus_id;
             }
         }
 
-        if (gpu_rails.empty()) {
-            NIXL_ERROR << "No valid rail mapping found for GPU-PCI " << gpu_pci_bus_id
-                       << " (checked " << gpu_efa_devices.size() << " EFA devices)";
+        if (device_rails.empty()) {
+            NIXL_ERROR << "No valid rail mapping found for device PCI " << device_pci_bus_id
+                       << " (checked " << device_efa_devices.size() << " EFA devices)";
             return {};
         }
 
-        NIXL_DEBUG << "VRAM memory " << mem_addr << " on GPU-PCI " << gpu_pci_bus_id << " will use "
-                   << gpu_rails.size() << " rails total";
-        return gpu_rails;
+        NIXL_DEBUG << "VRAM memory " << mem_addr << " on device PCI " << device_pci_bus_id
+                   << " will use " << device_rails.size() << " rails total";
+        return device_rails;
     }
     if (mem_type == DRAM_SEG) {
         // For DRAM, use all available rails for maximum bandwidth
@@ -403,8 +406,8 @@ nixl_status_t
 nixlLibfabricRailManager::registerMemory(void *buffer,
                                          size_t length,
                                          nixl_mem_t mem_type,
-                                         int gpu_id,
-                                         const std::string &gpu_pci_bus_id,
+                                         int device_id,
+                                         const std::string &device_pci_bus_id,
                                          std::vector<struct fid_mr *> &mr_list_out,
                                          std::vector<uint64_t> &key_list_out,
                                          std::vector<size_t> &selected_rails_out) {
@@ -417,7 +420,7 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
     // For VRAM: uses PCI bus ID provided by backend to map to topology-aware rails
     // For DRAM: uses all available rails
     std::vector<size_t> selected_rails =
-        selectRailsForMemory(buffer, mem_type, gpu_id, gpu_pci_bus_id);
+        selectRailsForMemory(buffer, mem_type, device_id, device_pci_bus_id);
     if (selected_rails.empty()) {
         NIXL_ERROR << "No rails selected for memory type " << mem_type;
         return NIXL_ERR_NOT_SUPPORTED;
@@ -425,7 +428,7 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
 
     enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
     if (mem_type == VRAM_SEG) {
-        iface = topology->getMrAttrIface(gpu_id);
+        iface = topology->getMrAttrIface(device_id);
     }
 
     // Resize output vectors to match all rails
@@ -452,9 +455,9 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
 
         struct fid_mr *mr;
         uint64_t key;
-        // Pass gpu_id parameter to individual rail's registerMemory calls
-        nixl_status_t status =
-            data_rails_[rail_idx]->registerMemory(buffer, length, mem_type, gpu_id, iface, &mr, &key);
+        // Pass device_id parameter to individual rail's registerMemory calls
+        nixl_status_t status = data_rails_[rail_idx]->registerMemory(
+            buffer, length, mem_type, device_id, iface, &mr, &key);
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "Failed to register memory on rail " << rail_idx;
             // Cleanup already registered MRs
@@ -947,6 +950,6 @@ nixlLibfabricRailManager::getActiveRailCount() const {
 
 // System accelerator type getter
 fi_hmem_iface
-nixlLibfabricRailManager::getSystemAcceleratorType() const {
-    return system_accelerator_type_;
+nixlLibfabricRailManager::getRuntime() const {
+    return runtime_;
 }

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -109,8 +109,9 @@ public:
      * @param buffer Memory buffer to register
      * @param length Buffer size in bytes
      * @param mem_type Memory type (DRAM_SEG or VRAM_SEG)
-     * @param gpu_id GPU device ID (used for VRAM_SEG, ignored for DRAM_SEG)
-     * @param gpu_pci_bus_id PCI bus ID for VRAM-GPU (queried in backend layer), empty for DRAM
+     * @param device_id Device ID (used for VRAM_SEG, ignored for DRAM_SEG)
+     * @param device_pci_bus_id PCI bus ID for VRAM device (queried in backend layer), empty for
+     * DRAM
      * @param mr_list_out Memory registration handles, indexed by rail ID
      * @param key_list_out Remote access keys, indexed by rail ID
      * @param selected_rails_out List of rail IDs where memory was registered
@@ -120,8 +121,8 @@ public:
     registerMemory(void *buffer,
                    size_t length,
                    nixl_mem_t mem_type,
-                   int gpu_id,
-                   const std::string &gpu_pci_bus_id,
+                   int device_id,
+                   const std::string &device_pci_bus_id,
                    std::vector<struct fid_mr *> &mr_list_out,
                    std::vector<uint64_t> &key_list_out,
                    std::vector<size_t> &selected_rails_out);
@@ -304,17 +305,17 @@ public:
         return topology.get();
     }
 
-    /** Get the system's accelerator type.
-     * @return fi_hmem_iface type for the system's accelerator
+    /** Get the system's runtime type.
+     * @return fi_hmem_iface runtime type (CUDA, NEURON, or SYSTEM)
      */
     fi_hmem_iface
-    getSystemAcceleratorType() const;
+    getRuntime() const;
 
 private:
     size_t striping_threshold_;
 
-    // System accelerator type (determined once at initialization)
-    fi_hmem_iface system_accelerator_type_;
+    // System runtime type (determined once at initialization)
+    fi_hmem_iface runtime_;
 
     // Rail allocation
     std::vector<std::unique_ptr<nixlLibfabricRail>> data_rails_;
@@ -336,7 +337,7 @@ private:
     std::vector<size_t>
     selectRailsForMemory(void *mem_addr,
                          nixl_mem_t mem_type,
-                         int gpu_id,
+                         int device_id,
                          const std::string &pci_bus_id = "") const;
 
     // Helper functions for connection SerDes

--- a/src/utils/libfabric/libfabric_topology.h
+++ b/src/utils/libfabric/libfabric_topology.h
@@ -26,7 +26,7 @@
 /**
  * @brief Topology discovery and management for AWS instances with EFA devices
  *
- * Automatically discovers system topology using hwloc and maps GPUs to EFA devices
+ * Automatically discovers system topology using hwloc and maps accelerators to EFA devices
  * based on PCIe proximity for optimal performance. Falls back to TCP/sockets
  * when EFA devices are not available.
  */
@@ -42,8 +42,8 @@ private:
     std::string provider_name;
 
     // System information
-    int num_gpus;
-    int num_nvidia_gpus;
+    int num_aws_accel; // AWS Trainium accelerators
+    int num_nvidia_accel; // NVIDIA GPU accelerators
     int num_numa_nodes;
     int num_devices;
 
@@ -71,11 +71,11 @@ private:
     nixl_status_t
     buildPcieToLibfabricMapping();
     nixl_status_t
-    discoverGpusWithHwloc();
+    discoverAccelWithHwloc();
     nixl_status_t
     discoverEfaDevicesWithHwloc();
     nixl_status_t
-    buildGpuToEfaMapping();
+    buildAccelToEfaMapping();
     void
     cleanupHwlocTopology();
 
@@ -89,7 +89,7 @@ private:
         uint8_t function_id;
     };
 
-    struct GpuInfo {
+    struct AccelInfo {
         hwloc_obj_t hwloc_node;
         uint16_t domain_id;
         uint8_t bus_id;
@@ -99,9 +99,9 @@ private:
 
     struct NicGroup {
         std::vector<NicInfo> nics;
-        GpuInfo closest_gpu;
+        AccelInfo closest_accel;
         hwloc_obj_t common_ancestor;
-        bool has_gpu;
+        bool has_accel;
     };
 
     // NIXL topology-aware grouping algorithm methods
@@ -110,17 +110,17 @@ private:
     nixl_status_t
     buildFallbackMapping();
     nixl_status_t
-    groupNicsWithGpus(const std::vector<NicInfo> &discovered_nics,
-                      const std::vector<GpuInfo> &discovered_gpus,
-                      std::vector<NicGroup> &nic_groups);
+    groupNicsWithAccel(const std::vector<NicInfo> &discovered_nics,
+                       const std::vector<AccelInfo> &discovered_accel,
+                       std::vector<NicGroup> &nic_groups);
 
     // hwloc helper methods
     std::string
     getPcieAddressFromHwlocObj(hwloc_obj_t obj) const;
     bool
-    isNvidiaGpu(hwloc_obj_t obj) const;
+    isNvidiaAccel(hwloc_obj_t obj) const;
     bool
-    isNeuronGpu(hwloc_obj_t obj) const;
+    isNeuronAccel(hwloc_obj_t obj) const;
     bool
     isEfaDevice(hwloc_obj_t obj) const;
 
@@ -128,19 +128,19 @@ public:
     nixlLibfabricTopology(); // Automatically discovers topology
     ~nixlLibfabricTopology();
 
-    // GPU-based queries (main interface)
+    // Accelerator-based queries (main interface)
     std::vector<std::string>
     getEfaDevicesForPci(const std::string &pci_bus_id) const;
 
     // System information
     int
-    getNumGpus() const {
-        return num_gpus;
+    getNumAwsAccel() const {
+        return num_aws_accel;
     }
 
     int
-    getNumNvidiaGpus() const {
-        return num_nvidia_gpus;
+    getNumNvidiaAccel() const {
+        return num_nvidia_accel;
     }
 
     const std::vector<std::string> &
@@ -162,8 +162,9 @@ public:
     bool
     isValidDevice(const std::string &efa_device) const;
 
-    enum fi_hmem_iface getMrAttrIface(int gpu_id) const {
-        return (gpu_id < num_nvidia_gpus) ? FI_HMEM_CUDA : FI_HMEM_NEURON;
+    enum fi_hmem_iface
+    getMrAttrIface(int device_id) const {
+        return (device_id < num_nvidia_accel) ? FI_HMEM_CUDA : FI_HMEM_NEURON;
     }
 
     // Debug/info

--- a/test/unit/utils/libfabric/libfabric_topology_test.cpp
+++ b/test/unit/utils/libfabric/libfabric_topology_test.cpp
@@ -39,7 +39,7 @@ main() {
         topology.printTopologyInfo();
 
         // Test GPU-specific queries only if GPUs are detected
-        int num_gpus = topology.getNumGpus();
+        int num_gpus = topology.getNumNvidiaAccel();
         if (num_gpus > 0) {
             NIXL_INFO << "3. Testing GPU-specific queries (detected " << num_gpus << " GPUs)...";
             int test_gpus = std::min(num_gpus, 3); // Test up to 3 GPUs or all available
@@ -57,7 +57,7 @@ main() {
                          prop.pciBusID,
                          prop.pciDeviceID);
 
-                auto gpu_devices = topology.getEfaDevicesForGPUPci(pci_bus_id);
+                auto gpu_devices = topology.getEfaDevicesForPci(pci_bus_id);
 
                 std::string device_list;
                 for (const auto &device : gpu_devices) {


### PR DESCRIPTION
## What?
This PR adds AWS Neuron accelerator support to NIXL, enabling the library to work with both NVIDIA GPUs and AWS Neuron devices (INF2, TRN1, TRN2, TRN3).

## Why?
NIXL previously only supported NVIDIA GPUs. AWS Neuron accelerators are specialized ML accelerators that require different device detection and memory registration mechanisms. This PR extends NIXL to support both accelerator types.

## How?
#### Neuron Device Detection:
- Added runtime loading of libnrt.so to query Neuron device PCI addresses via nrt_get_attached_efa_bdf()
- Implemented system accelerator type detection (CUDA/NEURON/SYSTEM) at initialization
- Extended topology discovery to detect both NVIDIA (vendor 0x10de) and AWS Neuron (vendor 0x1d0f) devices
- Added Neuron device ID detection for INF2 (0x7264), TRN1 (0x7164), TRN2 (0x7364), and TRN3 (0x7564, 0x7565) families
#### Memory Registration:
- Implemented FI_HMEM_NEURON interface support in libfabric memory registration
- Added conditional CUDA context management (only for CUDA systems)
- Unified PCI-to-EFA device mapping to support both GPU and Neuron device queries
#### Build System:
- Added dl (dynamic linking) dependency for runtime libnrt.so loading