### PR TITLE
Fix aws build dependencies

### DIFF
--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,7 @@ unit_test_deps = [
     gtest_dep,
 ]
 
-aws_s3 = dependency('aws-cpp-sdk-s3', static: false, required: false)
-if aws_s3.found()
+if is_variable('obj_backend_interface')
     subdir('obj')
     unit_test_deps += [obj_unit_test_dep]
 endif

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,7 @@ obj_unit_test_dep = declare_dependency(
         '../../../../src/plugins/obj',
     ],
     dependencies: [
-        aws_s3.partial_dependency(compile_args: false, includes: true, link_args: true, links: true),
+        obj_backend_interface,
         dependency('asio', required: true),
     ],
-    link_with: obj_backend_lib,
 )


### PR DESCRIPTION
## What?
Fix aws build dependencies that caused a build error:
`test/gtest/unit/obj/meson.build:28:15: ERROR: Unknown variable "obj_backend_lib".`
The issue started from PR #1127 

## Why?
A mismatch between some meson files caused a build error to appear in my setup (probably because I was missing some of the aws dependencies)


