### PR TITLE
Add Neuron Support to nixlbench

### DIFF
--- a/benchmark/nixlbench/src/utils/meson.build
+++ b/benchmark/nixlbench/src/utils/meson.build
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 utils_sources = [
+  'neuron.cpp',
+  'neuron.h',
   'utils.cpp',
   'utils.h',
   'scope_guard.h'
@@ -23,7 +25,8 @@ utils_deps = [
   cuda_dep,
   openmp_dep,
   cxxopts_dep,
-  tomlplusplus_dep
+  tomlplusplus_dep,
+  dependency('dl', required: true)
 ]
 
 utils_lib = static_library('utils',

--- a/benchmark/nixlbench/src/utils/neuron.cpp
+++ b/benchmark/nixlbench/src/utils/neuron.cpp
@@ -1,0 +1,215 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "neuron.h"
+
+#include <dlfcn.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+void *
+dlopen_libnrt() {
+#define TRY_DLOPEN(path)                       \
+    do {                                       \
+        void *handle = dlopen(path, RTLD_NOW); \
+        if (handle) return handle;             \
+    } while (0)
+
+    static void *const libnrt_handle = []() -> void * {
+        TRY_DLOPEN("/opt/aws/neuron/lib/libnrt.so.1");
+        TRY_DLOPEN("libnrt.so.1");
+        return nullptr;
+    }();
+
+#undef TRY_DLOPEN
+
+    return libnrt_handle;
+}
+
+template<class Fn>
+Fn *
+_load_nrt_symbol(const char *fn_name, Fn *) {
+    void *libnrt_handle = dlopen_libnrt();
+    if (libnrt_handle) {
+        return reinterpret_cast<Fn *>(dlsym(libnrt_handle, fn_name));
+    }
+    return nullptr;
+}
+
+#define LOAD_NRT_SYMBOL(sym) _load_nrt_symbol(#sym, &sym)
+
+int
+nrt_init(int framework, const char *fw_version, const char *fal_version) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_init);
+    if (!fn) return -1;
+    return fn(framework, fw_version, fal_version);
+}
+
+struct nrt_tensor;
+
+int
+nrt_tensor_allocate(int tensor_placement,
+                    int vnc,
+                    size_t size,
+                    const char *name,
+                    nrt_tensor **tensor) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_tensor_allocate);
+    if (!fn) return -1;
+    return fn(tensor_placement, vnc, size, name, tensor);
+}
+
+void
+nrt_tensor_free(nrt_tensor **tensor) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_tensor_free);
+    return fn(tensor);
+}
+
+int
+nrt_tensor_read(const nrt_tensor *tensor, void *buf, size_t offset, size_t size) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_tensor_read);
+    if (!fn) return -1;
+    return fn(tensor, buf, offset, size);
+}
+
+int
+nrt_tensor_write(nrt_tensor *tensor, const void *buf, size_t offset, size_t size) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_tensor_write);
+    if (!fn) return -1;
+    return fn(tensor, buf, offset, size);
+}
+
+void *
+nrt_tensor_get_va(const nrt_tensor *tensor) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_tensor_get_va);
+    if (!fn) return nullptr;
+    return fn(tensor);
+}
+
+int
+nrt_get_visible_vnc_count(uint32_t *vnc_count) {
+    static const auto fn = LOAD_NRT_SYMBOL(nrt_get_visible_vnc_count);
+    if (!fn) return -1;
+    return fn(vnc_count);
+}
+
+struct NrtTensorDeleter {
+    void
+    operator()(nrt_tensor *tensor) const {
+        nrt_tensor_free(&tensor);
+    }
+};
+
+using NrtTensorPtr = std::unique_ptr<nrt_tensor, NrtTensorDeleter>;
+
+std::unordered_map<const void *, NrtTensorPtr> allocation_tracker;
+std::mutex allocation_tracker_mutex;
+
+nrt_tensor *
+getTensorFromVA(const void *va) {
+    std::lock_guard lock{allocation_tracker_mutex};
+
+    auto it = allocation_tracker.find(va);
+    if (it == allocation_tracker.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+} // namespace
+
+int
+neuronCoreCount() {
+    static const int core_count = []() {
+        uint32_t vnc_count;
+        if (nrt_init(1 /* framework_type=NO_FW */, "nixl_bench", "nixl_bench") == 0 &&
+            nrt_get_visible_vnc_count(&vnc_count) == 0) {
+            return static_cast<int>(vnc_count);
+        }
+        return -1;
+    }();
+
+    return core_count;
+}
+
+int
+neuronMalloc(void **addr, size_t buffer_size, int devid) {
+    nrt_tensor *tensor;
+    int status;
+
+    status = nrt_tensor_allocate(0 /* placement=device */, devid, buffer_size, nullptr, &tensor);
+    if (status != 0) return status;
+
+    NrtTensorPtr ptr{tensor};
+    *addr = nrt_tensor_get_va(tensor);
+    if (*addr == nullptr) {
+        return -1;
+    }
+
+    std::lock_guard lock{allocation_tracker_mutex};
+    allocation_tracker.emplace(*addr, std::move(ptr));
+
+    return 0;
+}
+
+int
+neuronFree(void *addr) {
+    if (!addr) return 0;
+
+    std::lock_guard lock{allocation_tracker_mutex};
+    return allocation_tracker.erase(addr) - 1;
+}
+
+int
+neuronMemcpy(void *dest, const void *src, size_t count, neuronMemcpyKind kind) {
+    nrt_tensor *tensor = getTensorFromVA(kind == neuronMemcpyHostToDevice ? dest : src);
+    if (tensor == nullptr) {
+        return -1;
+    }
+
+    if (kind == neuronMemcpyHostToDevice) {
+        return nrt_tensor_write(tensor, src, 0, count);
+    } else {
+        return nrt_tensor_read(tensor, dest, 0, count);
+    }
+}
+
+int
+neuronMemset(void *addr, int val, size_t count) {
+    nrt_tensor *tensor = getTensorFromVA(addr);
+    if (tensor == nullptr) {
+        return -1;
+    }
+
+    constexpr size_t kMaxChunkSize = 1UL << 21; // 2MB
+    std::vector<unsigned char> buf(kMaxChunkSize, static_cast<unsigned char>(val));
+    int status = 0;
+    size_t offset = 0;
+    while (offset < count && status == 0) {
+        const size_t write_len = std::min(kMaxChunkSize, count - offset);
+        status = nrt_tensor_write(tensor, buf.data(), offset, write_len);
+        offset += write_len;
+    }
+    return status;
+}

--- a/benchmark/nixlbench/src/utils/neuron.h
+++ b/benchmark/nixlbench/src/utils/neuron.h
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __NEURON_H
+#define __NEURON_H
+
+#include <iostream>
+
+/* Return the number of visible neuron cores, or -1 if neuron library
+   is not available at runtime */
+int
+neuronCoreCount();
+
+int
+neuronMalloc(void **addr, size_t buffer_size, int devid = 0);
+int
+neuronFree(void *addr);
+
+enum neuronMemcpyKind {
+    neuronMemcpyHostToDevice,
+    neuronMemcpyDeviceToHost,
+};
+
+int
+neuronMemcpy(void *dest, const void *src, size_t count, neuronMemcpyKind kind);
+int
+neuronMemset(void *addr, int val, size_t count);
+
+#define CHECK_NEURON_ERROR(result, message)                                                       \
+    do {                                                                                          \
+        if (result != 0) {                                                                        \
+            std::cerr << "NEURON: " << message << " (Error code: " << result << ")" << std::endl; \
+            exit(EXIT_FAILURE);                                                                   \
+        }                                                                                         \
+    } while (0)
+
+
+#endif

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -32,6 +32,7 @@
 #include <filesystem>
 
 #include "runtime/etcd/etcd_rt.h"
+#include "utils/neuron.h"
 #include "utils/utils.h"
 
 enum class xferBenchParamType { STRING, BOOL, UINT64, INT32 };
@@ -915,9 +916,18 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
                             exit(EXIT_FAILURE);
                         }
                         is_allocated = true;
-                        CHECK_CUDA_ERROR(
-                            cudaMemcpy(addr, (void *)iov.addr, len, cudaMemcpyDeviceToHost),
-                            "cudaMemcpy failed");
+                        // Assume no CUDA cores exist if Neuron cores are found.
+                        // There are no AWS instance types with both NVIDIA GPUs and Neuron
+                        // accelerators.
+                        if (neuronCoreCount() > 0) {
+                            CHECK_NEURON_ERROR(
+                                neuronMemcpy(addr, (void *)iov.addr, len, neuronMemcpyDeviceToHost),
+                                "nrt_tensor_read failed");
+                        } else {
+                            CHECK_CUDA_ERROR(
+                                cudaMemcpy(addr, (void *)iov.addr, len, cudaMemcpyDeviceToHost),
+                                "cudaMemcpy failed");
+                        }
 #else
                         std::cerr << "Failure in consistency check: VRAM segment type not "
                                      "supported without CUDA"
@@ -1004,9 +1014,18 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
 #if HAVE_CUDA
                     addr = calloc(1, len);
                     is_allocated = true;
-                    CHECK_CUDA_ERROR(
-                        cudaMemcpy(addr, (void *)iov.addr, len, cudaMemcpyDeviceToHost),
-                        "cudaMemcpy failed");
+                    // Assume no CUDA cores exist if Neuron cores are found.
+                    // There are no AWS instance types with both NVIDIA GPUs and Neuron
+                    // accelerators.
+                    if (neuronCoreCount() > 0) {
+                        CHECK_NEURON_ERROR(
+                            neuronMemcpy(addr, (void *)iov.addr, len, neuronMemcpyDeviceToHost),
+                            "nrt_tensor_read failed");
+                    } else {
+                        CHECK_CUDA_ERROR(
+                            cudaMemcpy(addr, (void *)iov.addr, len, cudaMemcpyDeviceToHost),
+                            "cudaMemcpy failed");
+                    }
 #else
                     std::cerr << "Failure in consistency check: VRAM segment type not supported "
                                  "without CUDA"

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <iomanip>
 #include <sstream>
+#include "utils/neuron.h"
 #include "utils/utils.h"
 #include <unistd.h>
 #include <utility>
@@ -157,9 +158,14 @@ xferBenchNixlWorker::xferBenchNixlWorker(int *argc, char ***argv, std::vector<st
             exit(EXIT_FAILURE);
         }
 
+        // We need to make sure the Neuron runtime is initialized before initializing libfabric,
+        // otherwise the FI_HMEM_NEURON backend will not be created. This issue has been fixed
+        // upstream: https://github.com/ofiwg/libfabric/pull/11804
+        int nc_count = neuronCoreCount();
+
         std::cout << "Init nixl worker, dev " << (("all" == devices[0]) ? "all" : devices[rank])
                   << " rank " << rank << ", type " << name << ", hostname " << hostname
-                  << std::endl;
+                  << ", nc_count " << nc_count << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GDS)) {
         // Using default param values for GDS backend
         std::cout << "GDS backend" << std::endl;
@@ -431,11 +437,27 @@ getVramDescCudaVmm(int devid, size_t buffer_size, uint8_t memset_value) {
 }
 
 static std::optional<xferBenchIOV>
+getVramDescNeuron(int devid, size_t buffer_size, uint8_t memset_value) {
+    void *addr;
+    CHECK_NEURON_ERROR(neuronMalloc(&addr, buffer_size, devid), "Failed to allocate nrt tensor");
+    CHECK_NEURON_ERROR(neuronMemset(addr, memset_value, buffer_size),
+                       "Failed to set device memory");
+
+    return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size, devid);
+}
+
+static std::optional<xferBenchIOV>
 getVramDesc(int devid, size_t buffer_size, bool isInit) {
-    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
     uint8_t memset_value =
         isInit ? XFERBENCH_INITIATOR_BUFFER_ELEMENT : XFERBENCH_TARGET_BUFFER_ELEMENT;
 
+    // Assume no CUDA cores exist if Neuron cores are found.
+    // There are no AWS instance types with both NVIDIA GPUs and Neuron accelerators.
+    if (neuronCoreCount() > 0) {
+        return getVramDescNeuron(devid, buffer_size, memset_value);
+    }
+
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
     if (xferBenchConfig::enable_vmm) {
         return getVramDescCudaVmm(devid, buffer_size, memset_value);
     } else {
@@ -605,8 +627,14 @@ xferBenchNixlWorker::cleanupBasicDescDram(xferBenchIOV &iov) {
 #if HAVE_CUDA
 void
 xferBenchNixlWorker::cleanupBasicDescVram(xferBenchIOV &iov) {
-    CHECK_CUDA_ERROR(cudaSetDevice(iov.devId), "Failed to set device");
+    // Assume no CUDA cores exist if Neuron cores are found.
+    // There are no AWS instance types with both NVIDIA GPUs and Neuron accelerators.
+    if (neuronCoreCount() > 0) {
+        CHECK_NEURON_ERROR(neuronFree((void *)iov.addr), "Failed to free nrt tensor");
+        return;
+    }
 
+    CHECK_CUDA_ERROR(cudaSetDevice(iov.devId), "Failed to set device");
     if (xferBenchConfig::enable_vmm) {
         CHECK_CUDA_DRIVER_ERROR(cuMemUnmap(iov.addr, iov.len), "Failed to unmap memory");
         CHECK_CUDA_DRIVER_ERROR(cuMemRelease(iov.handle), "Failed to release memory");


### PR DESCRIPTION
### What?
Adds AWS Neuron (Trainium/Inferentia) accelerator support to nixlbench for VRAM segment benchmarking.

Key changes:
- New neuron.cpp/h providing Neuron runtime API wrappers
- Dynamic loading of libnrt.so.1 via dlopen()/dlsym()
- Neuron memory operations: neuronMalloc(), neuronFree(), neuronMemcpy(), neuronMemset()
- Runtime device detection via neuronCoreCount()

### Why?
nixlbench only supported CUDA for VRAM benchmarking. This adds Neuron support while avoiding hard dependencies on libnrt.

Key benefit: We use dlopen()/dlsym() to dynamically resolve Neuron runtime symbols, so nixlbench works on systems without libnrt installed. Single binary runs on both CUDA and Neuron systems.

### How?
- Dynamic Library Loading
dlopen_libnrt() loads libnrt.so.1 at runtime (tries /opt/aws/neuron/lib/ then system path)
Template-based _load_nrt_symbol() resolves NRT functions via dlsym()
Returns nullptr if library unavailable (graceful fallback)
- Device Detection
neuronCoreCount() returns visible Neuron cores or -1 if unavailable
Initialized early in worker to ensure FI_HMEM_NEURON backend creation
Used throughout: if (devId < neuronCoreCount()) to route to Neuron vs CUDA paths
- Conditional Execution
```
// Memory allocation
if (devid < neuronCoreCount()) {
    return getVramDescNeuron(...);  // Use NRT tensors
}
// Fall through to CUDA

// Memory operations
if (iov.devId < neuronCoreCount()) {
    neuronMemcpy(...);  // Use NRT API
} else {
    cudaMemcpy(...);    // Use CUDA API
}
```
- Build Changes
Added dependency('dl') for dlopen/dlsym
No changes to CUDA dependencies (maintains compatibility)

### Related
Builds on main NIXL Neuron support which added FI_HMEM_NEURON backend and topology detection.