### PR TITLE
UTILS/UCX: Replace error/exception with WARN log message in HW detection support

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -639,7 +639,8 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
     };
     const auto status = ucp_context_query(ctx, &attr);
     if (status != UCS_OK) {
-        NIXL_ERROR << "Failed to query UCX context: " << ucs_status_string(status);
+        NIXL_WARN << "Failed to query UCX context: " << ucs_status_string(status) << ", "
+                  << "hardware support mismatch check will be skipped";
         return;
     }
 

--- a/src/utils/common/hw_info.cpp
+++ b/src/utils/common/hw_info.cpp
@@ -69,7 +69,8 @@ hwInfo::hwInfo() {
     std::error_code ec;
     std::filesystem::directory_iterator dir_iter(kPciDevicePath, ec);
     if (ec) {
-        throw std::runtime_error("Failed to scan PCI devices directory: " + ec.message());
+        NIXL_WARN << "Failed to scan PCI devices directory: " << ec.message();
+        return;
     }
 
     for (const auto &entry : dir_iter) {


### PR DESCRIPTION
## What?
Replace error/exception with WARN log message in HW detection support

## Why?
The goal of HW detection support check is to print a WARN log in case support is missing.

If the check itself fails due to any reason (e.g. permission issue), it should not error/crash or fail to create the UCX backend.
