### PR TITLE
API: Add getXferStatus overload with per-entry status codes

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -33,6 +33,10 @@ struct nixlBackendOptionalArgs {
     nixl_blob_t notifMsg;
     bool        hasNotif = false;
     nixl_blob_t customParam;
+    /** Per-entry tracking mode for this transfer. Default 0 = no per-entry events.
+     *  Set NIXL_XFER_TRACK_ERRORS to append error events, NIXL_XFER_TRACK_SUCCESSES
+     *  to also append success events. Propagated from nixlAgentOptionalArgs::trackFlags
+     *  by the agent during prepXfer/postXfer. */
     nixl_xfer_track_flags_t trackFlags = 0;
 };
 

--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -33,6 +33,7 @@ struct nixlBackendOptionalArgs {
     nixl_blob_t notifMsg;
     bool        hasNotif = false;
     nixl_blob_t customParam;
+    nixl_xfer_track_flags_t trackFlags = 0;
 };
 
 using nixl_opt_b_args_t = nixlBackendOptionalArgs;

--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -27,11 +27,10 @@
 // level direction or so.
 typedef std::vector<std::pair<std::string, std::string>> notif_list_t;
 
-
 struct nixlBackendOptionalArgs {
     // During postXfer, user might ask for a notification if supported
     nixl_blob_t notifMsg;
-    bool        hasNotif = false;
+    bool hasNotif = false;
     nixl_blob_t customParam;
     /** Per-entry tracking mode for this transfer. Default 0 = no per-entry events.
      *  Set NIXL_XFER_TRACK_ERRORS to append error events, NIXL_XFER_TRACK_SUCCESSES
@@ -42,43 +41,42 @@ struct nixlBackendOptionalArgs {
 
 using nixl_opt_b_args_t = nixlBackendOptionalArgs;
 
-
 // A base class to point to backend initialization data
 // User doesn't know about fields such as local_agent but can access it
 // after the backend is initialized by agent. If we needed to make it private
 // from the user, we should make nixlBackendEngine/nixlAgent friend classes.
 class nixlBackendInitParams {
-    public:
-        std::string       localAgent;
+public:
+    std::string localAgent;
 
-        nixl_backend_t    type;
-        nixl_b_params_t*  customParams;
+    nixl_backend_t type;
+    nixl_b_params_t *customParams;
 
-        bool              enableProgTh;
-        nixlTime::us_t    pthrDelay;
-        nixl_thread_sync_t syncMode;
-        bool enableTelemetry_;
+    bool enableProgTh;
+    nixlTime::us_t pthrDelay;
+    nixl_thread_sync_t syncMode;
+    bool enableTelemetry_;
 };
 
 // Pure virtual class to have a common pointer type
 class nixlBackendReqH {
 public:
-    nixlBackendReqH() { }
-    virtual ~nixlBackendReqH() { }
+    nixlBackendReqH() {}
+
+    virtual ~nixlBackendReqH() {}
 };
 
 // Pure virtual class to have a common pointer type for different backendMD.
 class nixlBackendMD {
-    protected:
-        bool isPrivateMD;
+protected:
+    bool isPrivateMD;
 
-    public:
-        nixlBackendMD(bool isPrivate){
-            isPrivateMD = isPrivate;
-        }
+public:
+    nixlBackendMD(bool isPrivate) {
+        isPrivateMD = isPrivate;
+    }
 
-        virtual ~nixlBackendMD(){
-        }
+    virtual ~nixlBackendMD() {}
 };
 
 // Each backend can have different connection requirement
@@ -86,38 +84,40 @@ class nixlBackendMD {
 // a connection to a remote node. Note that local information
 // is passed during the constructor and through BackendInitParams
 class nixlBackendConnMD {
-  public:
+public:
     // And some other details
     std::string dstIpAddress;
-    uint16_t    dstPort;
+    uint16_t dstPort;
 };
 
 // A pointer required to a metadata object for backends next to each BasicDesc
 class nixlMetaDesc : public nixlBasicDesc {
-  public:
-        // To be able to point to any object
-        nixlBackendMD* metadataP;
+public:
+    // To be able to point to any object
+    nixlBackendMD *metadataP;
 
-        // Reuse parent constructor without the metadata pointer
-        using nixlBasicDesc::nixlBasicDesc;
+    // Reuse parent constructor without the metadata pointer
+    using nixlBasicDesc::nixlBasicDesc;
 
-        nixlMetaDesc() : nixlBasicDesc() { metadataP = nullptr; }
+    nixlMetaDesc() : nixlBasicDesc() {
+        metadataP = nullptr;
+    }
 
-        nixlMetaDesc(uintptr_t addr, size_t len, uint64_t dev_id, nixlBackendMD *metadata)
-            : nixlBasicDesc(addr, len, dev_id),
-              metadataP(metadata) {}
+    nixlMetaDesc(uintptr_t addr, size_t len, uint64_t dev_id, nixlBackendMD *metadata)
+        : nixlBasicDesc(addr, len, dev_id),
+          metadataP(metadata) {}
 
-        // No serializer or deserializer, using parent not to expose the metadata
+    // No serializer or deserializer, using parent not to expose the metadata
 
-        inline friend bool operator==(const nixlMetaDesc &lhs, const nixlMetaDesc &rhs) {
-            return (((nixlBasicDesc)lhs == (nixlBasicDesc)rhs) &&
-                          (lhs.metadataP == rhs.metadataP));
-        }
+    inline friend bool
+    operator==(const nixlMetaDesc &lhs, const nixlMetaDesc &rhs) {
+        return (((nixlBasicDesc)lhs == (nixlBasicDesc)rhs) && (lhs.metadataP == rhs.metadataP));
+    }
 
-        inline void print(const std::string &suffix) const {
-            nixlBasicDesc::print(", Backend ptr val: " +
-                                 std::to_string((uintptr_t)metadataP) + suffix);
-        }
+    inline void
+    print(const std::string &suffix) const {
+        nixlBasicDesc::print(", Backend ptr val: " + std::to_string((uintptr_t)metadataP) + suffix);
+    }
 };
 
 struct nixlRemoteMetaDesc : public nixlMetaDesc {

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -149,6 +149,18 @@ class nixlBackendEngine {
         // Use a handle to progress backend engine and see if a transfer is completed or not
         virtual nixl_status_t checkXfer(nixlBackendReqH* handle) const = 0;
 
+        /**
+         * Optional: append new (index, status) events and return overall status.
+         * Default returns NIXL_ERR_NOT_SUPPORTED. Track mode is stored in handle from prep/post.
+         */
+        virtual nixl_status_t
+        checkXferEvents(nixlBackendReqH* handle,
+                        nixl_xfer_entry_events_t &events) const {
+            (void)handle;
+            (void)events;
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
         //Backend aborts the transfer if necessary, and destructs the relevant objects
         virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) const = 0;
 

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -154,9 +154,7 @@ class nixlBackendEngine {
          * Default returns NIXL_ERR_NOT_SUPPORTED. Track mode is stored in handle from prep/post.
          */
         virtual nixl_status_t
-        checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const {
-            (void)handle;
-            (void)events;
+        checkXferEvents(nixlBackendReqH *, nixl_xfer_entry_events_t &) const {
             return NIXL_ERR_NOT_SUPPORTED;
         }
 

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -154,8 +154,7 @@ class nixlBackendEngine {
          * Default returns NIXL_ERR_NOT_SUPPORTED. Track mode is stored in handle from prep/post.
          */
         virtual nixl_status_t
-        checkXferEvents(nixlBackendReqH* handle,
-                        nixl_xfer_entry_events_t &events) const {
+        checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const {
             (void)handle;
             (void)events;
             return NIXL_ERR_NOT_SUPPORTED;

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -31,228 +31,258 @@ constexpr size_t MAX_TELEMETRY_QUEUE_SIZE = 1000;
 
 // Base backend engine class for different backend implementations
 class nixlBackendEngine {
-    private:
-        // Members that cannot be modified by a child backend and parent bookkeep
-        nixl_backend_t  backendType;
-        nixl_b_params_t customParams;
-        std::vector<nixlTelemetryEvent> telemetryEvents_;
-        std::mutex telemetryEventsMutex_;
+private:
+    // Members that cannot be modified by a child backend and parent bookkeep
+    nixl_backend_t backendType;
+    nixl_b_params_t customParams;
+    std::vector<nixlTelemetryEvent> telemetryEvents_;
+    std::mutex telemetryEventsMutex_;
 
-    protected:
-        // Members that can be accessed by the child (localAgent cannot be modified)
-        bool              initErr = false;
-        const std::string localAgent;
-        const bool enableTelemetry_;
+protected:
+    // Members that can be accessed by the child (localAgent cannot be modified)
+    bool initErr = false;
+    const std::string localAgent;
+    const bool enableTelemetry_;
 
-        [[nodiscard]] nixl_status_t
-        setInitParam(const std::string &key, const std::string &value) {
-            if (customParams.emplace(key, value).second) {
-                return NIXL_SUCCESS;
-            }
-            return NIXL_ERR_NOT_ALLOWED;
+    [[nodiscard]] nixl_status_t
+    setInitParam(const std::string &key, const std::string &value) {
+        if (customParams.emplace(key, value).second) {
+            return NIXL_SUCCESS;
         }
+        return NIXL_ERR_NOT_ALLOWED;
+    }
 
-        [[nodiscard]] nixl_status_t getInitParam(const std::string &key, std::string &value) const {
-            const auto iter = customParams.find(key);
-            if (iter != customParams.end()) {
-                value = iter->second;
-                return NIXL_SUCCESS;
-            }
-            return NIXL_ERR_INVALID_PARAM;
+    [[nodiscard]] nixl_status_t
+    getInitParam(const std::string &key, std::string &value) const {
+        const auto iter = customParams.find(key);
+        if (iter != customParams.end()) {
+            value = iter->second;
+            return NIXL_SUCCESS;
         }
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-        void
-        addTelemetryEvent(nixl_telemetry_event_type_t event_type, uint64_t value) {
-            if (!enableTelemetry_) return;
-            if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
-            std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
-            telemetryEvents_.emplace_back(
-                nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND, event_type, value);
+    void
+    addTelemetryEvent(nixl_telemetry_event_type_t event_type, uint64_t value) {
+        if (!enableTelemetry_) {
+            return;
         }
-
-    public:
-        explicit nixlBackendEngine(const nixlBackendInitParams *init_params)
-            : backendType(init_params->type),
-              customParams(*init_params->customParams),
-              localAgent(init_params->localAgent),
-              enableTelemetry_(init_params->enableTelemetry_) {}
-
-        nixlBackendEngine(nixlBackendEngine&&) = delete;
-        nixlBackendEngine(const nixlBackendEngine&) = delete;
-
-        void operator=(nixlBackendEngine&&) = delete;
-        void operator=(const nixlBackendEngine&) = delete;
-
-        virtual ~nixlBackendEngine() = default;
-
-        std::vector<nixlTelemetryEvent>
-        getTelemetryEvents() {
-            std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
-            return std::move(telemetryEvents_);
+        if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) {
+            return;
         }
+        std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
+        telemetryEvents_.emplace_back(
+            nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND, event_type, value);
+    }
 
-        bool getInitErr() const noexcept { return initErr; }
-        const nixl_backend_t& getType() const noexcept { return backendType; }
-        const nixl_b_params_t& getCustomParams() const noexcept { return customParams; }
+public:
+    explicit nixlBackendEngine(const nixlBackendInitParams *init_params)
+        : backendType(init_params->type),
+          customParams(*init_params->customParams),
+          localAgent(init_params->localAgent),
+          enableTelemetry_(init_params->enableTelemetry_) {}
 
-        // The support function determine which methods are necessary by the child backend, and
-        // if they're called by mistake, they will return error if not implemented by backend.
+    nixlBackendEngine(nixlBackendEngine &&) = delete;
+    nixlBackendEngine(const nixlBackendEngine &) = delete;
 
-        // Determines if a backend supports remote operations
-        virtual bool supportsRemote() const = 0;
+    void
+    operator=(nixlBackendEngine &&) = delete;
+    void
+    operator=(const nixlBackendEngine &) = delete;
 
-        // Determines if a backend supports local operations
-        virtual bool supportsLocal() const = 0;
+    virtual ~nixlBackendEngine() = default;
 
-        // Determines if a backend supports sending notifications. Related methods are not
-        // pure virtual, and return errors, as parent shouldn't call if supportsNotif is false.
-        virtual bool supportsNotif() const = 0;
+    std::vector<nixlTelemetryEvent>
+    getTelemetryEvents() {
+        std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
+        return std::move(telemetryEvents_);
+    }
 
-        virtual nixl_mem_list_t getSupportedMems() const = 0;  // TODO: Return by const-reference and mark noexcept?
+    bool
+    getInitErr() const noexcept {
+        return initErr;
+    }
 
+    const nixl_backend_t &
+    getType() const noexcept {
+        return backendType;
+    }
 
-        // *** Pure virtual methods that need to be implemented by any backend *** //
+    const nixl_b_params_t &
+    getCustomParams() const noexcept {
+        return customParams;
+    }
 
-        // Register and deregister local memory
-        virtual nixl_status_t registerMem (const nixlBlobDesc &mem,
-                                           const nixl_mem_t &nixl_mem,
-                                           nixlBackendMD* &out) = 0;
-        virtual nixl_status_t deregisterMem (nixlBackendMD* meta) = 0;
+    // The support function determine which methods are necessary by the child backend, and
+    // if they're called by mistake, they will return error if not implemented by backend.
 
-        // Make connection to a remote node identified by the name into loaded conn infos
-        // Child might just return 0, if making proactive connections are not necessary.
-        // An agent might need to connect to itself for local operations.
-        virtual nixl_status_t connect(const std::string &remote_agent) = 0;
-        virtual nixl_status_t disconnect(const std::string &remote_agent) = 0;
+    // Determines if a backend supports remote operations
+    virtual bool
+    supportsRemote() const = 0;
 
-        // Remove loaded local or remote metadata for target
-        virtual nixl_status_t unloadMD (nixlBackendMD* input) = 0;
+    // Determines if a backend supports local operations
+    virtual bool
+    supportsLocal() const = 0;
 
-        // Preparing a request, which populates the async handle as desired
-        virtual nixl_status_t prepXfer (const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) const = 0;
+    // Determines if a backend supports sending notifications. Related methods are not
+    // pure virtual, and return errors, as parent shouldn't call if supportsNotif is false.
+    virtual bool
+    supportsNotif() const = 0;
 
-        // Posting a request, which completes the async handle creation and posts it
-        virtual nixl_status_t postXfer (const nixl_xfer_op_t &operation,
-                                        const nixl_meta_dlist_t &local,
-                                        const nixl_meta_dlist_t &remote,
-                                        const std::string &remote_agent,
-                                        nixlBackendReqH* &handle,
-                                        const nixl_opt_b_args_t* opt_args=nullptr
-                                       ) const = 0;
-
-        // Use a handle to progress backend engine and see if a transfer is completed or not
-        virtual nixl_status_t checkXfer(nixlBackendReqH* handle) const = 0;
-
-        /**
-         * Optional: append new (index, status) events and return overall status.
-         * Default returns NIXL_ERR_NOT_SUPPORTED. Track mode is stored in handle from prep/post.
-         */
-        virtual nixl_status_t
-        checkXferEvents(nixlBackendReqH *, nixl_xfer_entry_events_t &) const {
-            return NIXL_ERR_NOT_SUPPORTED;
-        }
-
-        //Backend aborts the transfer if necessary, and destructs the relevant objects
-        virtual nixl_status_t releaseReqH(nixlBackendReqH* handle) const = 0;
-
-        // Prepare a memory view for remote buffers
-        virtual nixl_status_t
-        prepMemView(const nixl_remote_meta_dlist_t &,
-                    nixlMemViewH &,
-                    const nixl_opt_b_args_t * = nullptr) const {
-            return NIXL_ERR_NOT_SUPPORTED;
-        }
-
-        // Prepare a memory view for local buffers
-        virtual nixl_status_t
-        prepMemView(const nixl_meta_dlist_t &,
-                    nixlMemViewH &,
-                    const nixl_opt_b_args_t * = nullptr) const {
-            return NIXL_ERR_NOT_SUPPORTED;
-        }
-
-        // Release memory view handle
-        virtual void
-        releaseMemView(nixlMemViewH) const {}
-
-        // *** Needs to be implemented if supportsRemote() is true *** //
-
-        // Gets serialized form of public metadata
-        virtual nixl_status_t getPublicData (const nixlBackendMD* meta,
-                                             std::string &str) const {
-            return NIXL_ERR_BACKEND;
-        };
-
-        // Provide the required connection info for remote nodes, should be non-empty
-        virtual nixl_status_t getConnInfo(std::string &str) const {
-            return NIXL_ERR_BACKEND;
-        }
-
-        // Deserialize from string the connection info for a remote node, if supported
-        // The generated data should be deleted in nixlBackendEngine destructor
-        virtual nixl_status_t loadRemoteConnInfo (const std::string &remote_agent,
-                                                  const std::string &remote_conn_info) {
-            return NIXL_ERR_BACKEND;
-        }
-
-        // Load remote metadata, if supported.
-        virtual nixl_status_t loadRemoteMD (const nixlBlobDesc &input,
-                                            const nixl_mem_t &nixl_mem,
-                                            const std::string &remote_agent,
-                                            nixlBackendMD* &output) {
-            return NIXL_ERR_BACKEND;
-        }
+    virtual nixl_mem_list_t
+    getSupportedMems() const = 0; // TODO: Return by const-reference and mark noexcept?
 
 
-        // *** Needs to be implemented if supportsLocal() is true *** //
+    // *** Pure virtual methods that need to be implemented by any backend *** //
 
-        // Provide the target metadata necessary for local operations, if supported
-        virtual nixl_status_t loadLocalMD (nixlBackendMD* input,
-                                           nixlBackendMD* &output) {
-            return NIXL_ERR_BACKEND;
-        }
+    // Register and deregister local memory
+    virtual nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) = 0;
+    virtual nixl_status_t
+    deregisterMem(nixlBackendMD *meta) = 0;
 
+    // Make connection to a remote node identified by the name into loaded conn infos
+    // Child might just return 0, if making proactive connections are not necessary.
+    // An agent might need to connect to itself for local operations.
+    virtual nixl_status_t
+    connect(const std::string &remote_agent) = 0;
+    virtual nixl_status_t
+    disconnect(const std::string &remote_agent) = 0;
 
-        // *** Needs to be implemented if supportsNotif() is true *** //
+    // Remove loaded local or remote metadata for target
+    virtual nixl_status_t
+    unloadMD(nixlBackendMD *input) = 0;
 
-        // Populate an empty received notif list. Elements are released within backend then.
-        virtual nixl_status_t getNotifs(notif_list_t &notif_list) { return NIXL_ERR_BACKEND; }
+    // Preparing a request, which populates the async handle as desired
+    virtual nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const = 0;
 
-        // Generates a standalone notification, not bound to a transfer.
-        virtual nixl_status_t genNotif(const std::string &remote_agent, const std::string &msg) const {
-            return NIXL_ERR_BACKEND;
-        }
+    // Posting a request, which completes the async handle creation and posts it
+    virtual nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const = 0;
 
+    // Use a handle to progress backend engine and see if a transfer is completed or not
+    virtual nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const = 0;
 
-        // *** Optional virtual methods that are good to be implemented in any backend *** //
+    /**
+     * Optional: append new (index, status) events and return overall status.
+     * Default returns NIXL_ERR_NOT_SUPPORTED. Track mode is stored in handle from prep/post.
+     */
+    virtual nixl_status_t
+    checkXferEvents(nixlBackendReqH *, nixl_xfer_entry_events_t &) const {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
 
-        // Query information about a list of memory/storage
-        virtual nixl_status_t
-        queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const {
-            // Default implementation for file backends
-            // File backends can override this to provide custom implementation
-            // For now, return not supported - for object backends
-            return NIXL_ERR_NOT_SUPPORTED;
-        }
+    // Backend aborts the transfer if necessary, and destructs the relevant objects
+    virtual nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const = 0;
 
-        // Estimate the cost (duration) of a transfer operation.
-        virtual nixl_status_t
-        estimateXferCost(const nixl_xfer_op_t &operation,
-                         const nixl_meta_dlist_t &local,
-                         const nixl_meta_dlist_t &remote,
-                         const std::string &remote_agent,
-                         nixlBackendReqH *const &handle,
-                         std::chrono::microseconds &duration,
-                         std::chrono::microseconds &err_margin,
-                         nixl_cost_t &method,
-                         const nixl_opt_args_t *extra_params = nullptr) const {
-            return NIXL_ERR_NOT_SUPPORTED;
-        }
+    // Prepare a memory view for remote buffers
+    virtual nixl_status_t
+    prepMemView(const nixl_remote_meta_dlist_t &,
+                nixlMemViewH &,
+                const nixl_opt_b_args_t * = nullptr) const {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    // Prepare a memory view for local buffers
+    virtual nixl_status_t
+    prepMemView(const nixl_meta_dlist_t &,
+                nixlMemViewH &,
+                const nixl_opt_b_args_t * = nullptr) const {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    // Release memory view handle
+    virtual void
+    releaseMemView(nixlMemViewH) const {}
+
+    // *** Needs to be implemented if supportsRemote() is true *** //
+
+    // Gets serialized form of public metadata
+    virtual nixl_status_t
+    getPublicData(const nixlBackendMD *meta, std::string &str) const {
+        return NIXL_ERR_BACKEND;
+    };
+
+    // Provide the required connection info for remote nodes, should be non-empty
+    virtual nixl_status_t
+    getConnInfo(std::string &str) const {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Deserialize from string the connection info for a remote node, if supported
+    // The generated data should be deleted in nixlBackendEngine destructor
+    virtual nixl_status_t
+    loadRemoteConnInfo(const std::string &remote_agent, const std::string &remote_conn_info) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Load remote metadata, if supported.
+    virtual nixl_status_t
+    loadRemoteMD(const nixlBlobDesc &input,
+                 const nixl_mem_t &nixl_mem,
+                 const std::string &remote_agent,
+                 nixlBackendMD *&output) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // *** Needs to be implemented if supportsLocal() is true *** //
+
+    // Provide the target metadata necessary for local operations, if supported
+    virtual nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // *** Needs to be implemented if supportsNotif() is true *** //
+
+    // Populate an empty received notif list. Elements are released within backend then.
+    virtual nixl_status_t
+    getNotifs(notif_list_t &notif_list) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Generates a standalone notification, not bound to a transfer.
+    virtual nixl_status_t
+    genNotif(const std::string &remote_agent, const std::string &msg) const {
+        return NIXL_ERR_BACKEND;
+    }
+
+    // *** Optional virtual methods that are good to be implemented in any backend *** //
+
+    // Query information about a list of memory/storage
+    virtual nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const {
+        // Default implementation for file backends
+        // File backends can override this to provide custom implementation
+        // For now, return not supported - for object backends
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    // Estimate the cost (duration) of a transfer operation.
+    virtual nixl_status_t
+    estimateXferCost(const nixl_xfer_op_t &operation,
+                     const nixl_meta_dlist_t &local,
+                     const nixl_meta_dlist_t &remote,
+                     const std::string &remote_agent,
+                     nixlBackendReqH *const &handle,
+                     std::chrono::microseconds &duration,
+                     std::chrono::microseconds &err_margin,
+                     nixl_cost_t &method,
+                     const nixl_opt_args_t *extra_params = nullptr) const {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
 };
 #endif

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -308,11 +308,11 @@ class nixlAgent {
          * @param  req_hndl      Transfer request handle after postXferReq
          * @param  events_out [out] Append-only event list (index, status).
          * @return nixl_status_t NIXL_ERR_INVALID_PARAM if xfer was created with trackFlags==0,
-         *         NIXL_ERR_IN_PROG (negative) when still in progress, NIXL_SUCCESS or error otherwise.
+         *         NIXL_IN_PROG_WITH_ERR (negative) when still in progress, NIXL_SUCCESS or error
+         * otherwise.
          */
         nixl_status_t
-        getXferStatus (nixlXferReqH* req_hndl,
-                       nixl_xfer_entry_events_t &events_out) const;
+        getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &events_out) const;
 
         /**
          * @brief  Get the telemetry data associated with `req_hndl`.

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -299,6 +299,20 @@ class nixlAgent {
         nixl_status_t
         getXferStatus (nixlXferReqH* req_hndl) const;
 
+        /**
+         * @brief  Get transfer status with per-entry (index, status) events.
+         *         Request must have been created with trackFlags != 0
+         *         (via extra_params in createXferReq/makeXferReq). Events are appended over time;
+         *         compare events_out.size() to the previous call to see new completions.
+         *
+         * @param  req_hndl      Transfer request handle after postXferReq
+         * @param  events_out [out] Append-only event list (index, status).
+         * @return nixl_status_t NIXL_ERR_INVALID_PARAM if xfer was created with trackFlags==0,
+         *         NIXL_ERR_IN_PROG (negative) when still in progress, NIXL_SUCCESS or error otherwise.
+         */
+        nixl_status_t
+        getXferStatus (nixlXferReqH* req_hndl,
+                       nixl_xfer_entry_events_t &events_out) const;
 
         /**
          * @brief  Get the telemetry data associated with `req_hndl`.

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -32,549 +32,538 @@
  * @brief nixlAgent forms the main transfer object class
  */
 class nixlAgent {
-    private:
-        /** @var  data  The members in agent class wrapped into single nixlAgentData member. */
-        const std::unique_ptr<nixlAgentData> data;
+private:
+    /** @var  data  The members in agent class wrapped into single nixlAgentData member. */
+    const std::unique_ptr<nixlAgentData> data;
 
-    public:
-        /*** Initialization and Registering Methods ***/
+public:
+    /*** Initialization and Registering Methods ***/
 
-        /**
-         * @brief Constructor for nixlAgent which gets agent name and configurations.
-         *
-         * @param name A String name assigned to the Agent to initialize the class
-         * @param cfg  Agent configuration of class type nixlAgentConfig
-         */
-        nixlAgent (const std::string &name,
-                   const nixlAgentConfig &cfg);
-        /**
-         * @brief Destructor for nixlAgent object
-         */
-        ~nixlAgent ();
+    /**
+     * @brief Constructor for nixlAgent which gets agent name and configurations.
+     *
+     * @param name A String name assigned to the Agent to initialize the class
+     * @param cfg  Agent configuration of class type nixlAgentConfig
+     */
+    nixlAgent(const std::string &name, const nixlAgentConfig &cfg);
+    /**
+     * @brief Destructor for nixlAgent object
+     */
+    ~nixlAgent();
 
-        /* It is unsafe to move nixlAgent object */
-        nixlAgent(nixlAgent&&) noexcept = delete;
-        nixlAgent &operator=(nixlAgent&&) noexcept = delete;
+    /* It is unsafe to move nixlAgent object */
+    nixlAgent(nixlAgent &&) noexcept = delete;
+    nixlAgent &
+    operator=(nixlAgent &&) noexcept = delete;
 
-        /**
-         * @brief  Discover the available supported plugins found in the plugin paths
-         *
-         * @param  plugins [out] Vector of available backend plugins
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        getAvailPlugins (std::vector<nixl_backend_t> &plugins);
+    /**
+     * @brief  Discover the available supported plugins found in the plugin paths
+     *
+     * @param  plugins [out] Vector of available backend plugins
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    getAvailPlugins(std::vector<nixl_backend_t> &plugins);
 
-        /**
-         * @brief  Get the supported memory types, and init config parameters and their
-         *         default values for a backend plugin.
-         *
-         * @param  type          Plugin backend type
-         * @param  mems [out]    List of supported memory types for nixl by the plugin
-         * @param  params [out]  List of init parameters and their values for the plugin
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        getPluginParams (const nixl_backend_t &type,
-                         nixl_mem_list_t &mems,
-                         nixl_b_params_t &params) const;
-        /**
-         * @brief  Get the backend parameters after instantiation. This will be a comprehensive
-         *         list, for instance the default values used for parameters that were not
-         *         specified during the instantiation.
-         *
-         * @param  backend       Backend type
-         * @param  mems [out]    List of supported memory types for nixl by the backend
-         * @param  params [out]  List of init parameters and their values for the backend
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        getBackendParams (const nixlBackendH* backend,
-                          nixl_mem_list_t &mems,
-                          nixl_b_params_t &params) const;
+    /**
+     * @brief  Get the supported memory types, and init config parameters and their
+     *         default values for a backend plugin.
+     *
+     * @param  type          Plugin backend type
+     * @param  mems [out]    List of supported memory types for nixl by the plugin
+     * @param  params [out]  List of init parameters and their values for the plugin
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    getPluginParams(const nixl_backend_t &type,
+                    nixl_mem_list_t &mems,
+                    nixl_b_params_t &params) const;
+    /**
+     * @brief  Get the backend parameters after instantiation. This will be a comprehensive
+     *         list, for instance the default values used for parameters that were not
+     *         specified during the instantiation.
+     *
+     * @param  backend       Backend type
+     * @param  mems [out]    List of supported memory types for nixl by the backend
+     * @param  params [out]  List of init parameters and their values for the backend
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    getBackendParams(const nixlBackendH *backend,
+                     nixl_mem_list_t &mems,
+                     nixl_b_params_t &params) const;
 
-        /**
-         * @brief  Instantiate a backend engine object based on the corresponding parameters
-         *
-         * @param  type          Backend type
-         * @param  params        Backend specific parameters
-         * @param  backend [out] Backend handle for NIXL
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        createBackend (const nixl_backend_t &type,
-                       const nixl_b_params_t &params,
-                       nixlBackendH* &backend);
-        /**
-         * @brief  Register a memory/storage with NIXL. If a list of backends hints is provided
-         *         (via extra_params), the registration is limited to the specified backends.
-         *
-         * @param  descs         Descriptor list of the buffers to be registered
-         * @param  extra_params  Optional additional parameters used in registering memory
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        registerMem (const nixl_reg_dlist_t &descs,
-                     const nixl_opt_args_t* extra_params = nullptr);
+    /**
+     * @brief  Instantiate a backend engine object based on the corresponding parameters
+     *
+     * @param  type          Backend type
+     * @param  params        Backend specific parameters
+     * @param  backend [out] Backend handle for NIXL
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    createBackend(const nixl_backend_t &type,
+                  const nixl_b_params_t &params,
+                  nixlBackendH *&backend);
+    /**
+     * @brief  Register a memory/storage with NIXL. If a list of backends hints is provided
+     *         (via extra_params), the registration is limited to the specified backends.
+     *
+     * @param  descs         Descriptor list of the buffers to be registered
+     * @param  extra_params  Optional additional parameters used in registering memory
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    registerMem(const nixl_reg_dlist_t &descs, const nixl_opt_args_t *extra_params = nullptr);
 
-        /**
-         * @brief  Deregister a memory/storage from NIXL. If a list of backends hints is provided
-         *         (via extra_params), the deregistration is limited to the specified backends.
-         *         Each descriptor in the list should match a descriptor used during registration.
-         *
-         * @param  descs         Descriptor list of the buffers to be deregistered
-         * @param  extra_params  Optional additional parameters used in deregistering memory
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        deregisterMem (const nixl_reg_dlist_t &descs,
-                       const nixl_opt_args_t* extra_params = nullptr);
+    /**
+     * @brief  Deregister a memory/storage from NIXL. If a list of backends hints is provided
+     *         (via extra_params), the deregistration is limited to the specified backends.
+     *         Each descriptor in the list should match a descriptor used during registration.
+     *
+     * @param  descs         Descriptor list of the buffers to be deregistered
+     * @param  extra_params  Optional additional parameters used in deregistering memory
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    deregisterMem(const nixl_reg_dlist_t &descs, const nixl_opt_args_t *extra_params = nullptr);
 
-        /**
-         * @brief  Query information about memory/storage with NIXL.
-         *         The backend should be specified via extra_params.
-         *
-         * @param  descs         Descriptor list of the buffers to be queried
-         * @param  resp [out]    The output information for the queried descs
-         * @param  extra_params  Additional parameters used in querying memory,
-         *                       such as indicating the backend
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        queryMem(const nixl_reg_dlist_t &descs,
-                 std::vector<nixl_query_resp_t> &resp,
-                 const nixl_opt_args_t *extra_params) const;
+    /**
+     * @brief  Query information about memory/storage with NIXL.
+     *         The backend should be specified via extra_params.
+     *
+     * @param  descs         Descriptor list of the buffers to be queried
+     * @param  resp [out]    The output information for the queried descs
+     * @param  extra_params  Additional parameters used in querying memory,
+     *                       such as indicating the backend
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs,
+             std::vector<nixl_query_resp_t> &resp,
+             const nixl_opt_args_t *extra_params) const;
 
-        /**
-         * @brief  Make connection proactively, instead of at the time of the first transfer
-         *         towards the target agent. If a list of backends hints is provided
-         *         (via extra_params), the connection is made for the specified backends.
-         *
-         * @param  remote_agent  Name of the remote agent
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        makeConnection (const std::string &remote_agent,
-                        const nixl_opt_args_t* extra_params = nullptr);
+    /**
+     * @brief  Make connection proactively, instead of at the time of the first transfer
+     *         towards the target agent. If a list of backends hints is provided
+     *         (via extra_params), the connection is made for the specified backends.
+     *
+     * @param  remote_agent  Name of the remote agent
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    makeConnection(const std::string &remote_agent, const nixl_opt_args_t *extra_params = nullptr);
 
-        /*** Transfer Request Preparation ***/
-        /**
-         * @brief  Prepare a list of descriptors for a transfer request, so later elements
-         *         from this list can be used to create a transfer request by index. It should
-         *         be done on the initiator agent, and for both sides of an transfer.
-         *         Considering loopback, there are 3 modes for agent_name:
-         *           - For local descriptors, it is set to NIXL_INIT_AGENT,
-         *             indicating that this is a local preparation to be used as local_side handle.
-         *           - For remote descriptors: it is set to the remote name, indicating
-         *             that this is remote side preparation to be used for remote_side handle.
-         *           - For loopback descriptors, it is set to local agent's name, indicating that
-         *             this is for a loopback (local) transfer to be used for remote_side handle
-         *         If a list of backends hints is provided (via extra_params), the preparation
-         *         is limited to the specified backends. The preparation succeeds if there exists
-         *         at least one backend that can handle all elements in the descriptor list.
-         *
-         * @param  agent_name       Agent name as a string for preparing xfer handle
-         * @param  descs            The descriptor list to be prepared for transfer requests
-         * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
-         * @param  extra_params     Optional additional parameters used in preparing dlist handle
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        prepXferDlist (const std::string &agent_name,
-                       const nixl_xfer_dlist_t &descs,
-                       nixlDlistH* &dlist_hndl,
-                       const nixl_opt_args_t* extra_params = nullptr) const;
-        /**
-         * @brief  Prepare a local descriptor list for transfer requests.
-         *
-         * @param  descs            The descriptor list to be prepared for transfer requests
-         * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
-         * @param  extra_params     Optional additional parameters used in preparing dlist handle
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        prepXferDlist(const nixl_xfer_dlist_t &descs,
-                      nixlDlistH *&dlist_hndl,
+    /*** Transfer Request Preparation ***/
+    /**
+     * @brief  Prepare a list of descriptors for a transfer request, so later elements
+     *         from this list can be used to create a transfer request by index. It should
+     *         be done on the initiator agent, and for both sides of an transfer.
+     *         Considering loopback, there are 3 modes for agent_name:
+     *           - For local descriptors, it is set to NIXL_INIT_AGENT,
+     *             indicating that this is a local preparation to be used as local_side handle.
+     *           - For remote descriptors: it is set to the remote name, indicating
+     *             that this is remote side preparation to be used for remote_side handle.
+     *           - For loopback descriptors, it is set to local agent's name, indicating that
+     *             this is for a loopback (local) transfer to be used for remote_side handle
+     *         If a list of backends hints is provided (via extra_params), the preparation
+     *         is limited to the specified backends. The preparation succeeds if there exists
+     *         at least one backend that can handle all elements in the descriptor list.
+     *
+     * @param  agent_name       Agent name as a string for preparing xfer handle
+     * @param  descs            The descriptor list to be prepared for transfer requests
+     * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
+     * @param  extra_params     Optional additional parameters used in preparing dlist handle
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    prepXferDlist(const std::string &agent_name,
+                  const nixl_xfer_dlist_t &descs,
+                  nixlDlistH *&dlist_hndl,
+                  const nixl_opt_args_t *extra_params = nullptr) const;
+    /**
+     * @brief  Prepare a local descriptor list for transfer requests.
+     *
+     * @param  descs            The descriptor list to be prepared for transfer requests
+     * @param  dlist_hndl [out] The prepared descriptor list handle for this transfer request
+     * @param  extra_params     Optional additional parameters used in preparing dlist handle
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    prepXferDlist(const nixl_xfer_dlist_t &descs,
+                  nixlDlistH *&dlist_hndl,
+                  const nixl_opt_args_t *extra_params = nullptr) const;
+    /**
+     * @brief  Make a transfer request `req_handl` by selecting indices from already
+     *         prepared descriptor list handles. NIXL automatically determines the backend
+     *         that can perform the transfer. If a list of backends hints is provided
+     *         (via extra_params), the selection is limited to the specified backends.
+     *         Optionally, a notification message can also be provided through extra_params.
+     *
+     * @param  operation        Operation for transfer (e.g., NIXL_WRITE)
+     * @param  local_side       Local prepared descriptor list handle
+     * @param  local_indices    Indices list to the local prepared descriptor list handle
+     * @param  remote_side      Remote (or loopback) prepared descriptor list handle
+     * @param  remote_indices   Indices list to the remote prepared descriptor list handle
+     * @param  req_handle [out] Transfer request handle output
+     * @param  extra_params     Optional additional parameters used in making a transfer request
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    makeXferReq(const nixl_xfer_op_t &operation,
+                const nixlDlistH *local_side,
+                const std::vector<int> &local_indices,
+                const nixlDlistH *remote_side,
+                const std::vector<int> &remote_indices,
+                nixlXferReqH *&req_hndl,
+                const nixl_opt_args_t *extra_params = nullptr) const;
+    /**
+     * @brief  A combined API, to create a transfer request from two descriptor lists.
+     *         NIXL will prepare each side and create a transfer handle `req_hndl`.
+     *         The below set of operations are equivalent:
+     *           1. A sequence of prepXferDlist & makeXferReq:
+     *              prepXferDlist(NIXL_INIT_AGENT, local_desc, local_desc_hndl)
+     *              prepXferDlist("Agent-remote/self", remote_desc, remote_desc_hndl)
+     *              makeXferReq(NIXL_WRITE, local_desc_hndl, list of all local indices,
+     *                          remote_desc_hndl, list of all remote_indices, req_hndl)
+     *           2. A CreateXfer:
+     *              createXferReq(NIXL_WRITE, local_desc, remote_desc,
+     *                            "Agent-remote/self", req_hndl)
+     *
+     *         If there are common descriptors across different transfer requests, using
+     *         createXfer will result in repeated computation, such as validity checks and
+     *         pre-processing done in the preparation step. If a list of backends hints is
+     *         provided (via extra_params), the selection is limited to the specified backends.
+     *         Optionally, a notification message can also be provided through extra_params.
+     *
+     * @param  operation      Operation for transfer (e.g., NIXL_WRITE)
+     * @param  local_descs    Local descriptor list
+     * @param  remote_descs   Remote (or loopback) descriptor list
+     * @param  remote_agent   Remote (or self) agent name for accessing the remote (local) data
+     * @param  req_hndl [out] Transfer request handle output
+     * @param  extra_params   Optional extra parameters used in creating a transfer request
+     * @return nixl_status_t  Error code if call was not successful
+     */
+    nixl_status_t
+    createXferReq(const nixl_xfer_op_t &operation,
+                  const nixl_xfer_dlist_t &local_descs,
+                  const nixl_xfer_dlist_t &remote_descs,
+                  const std::string &remote_agent,
+                  nixlXferReqH *&req_hndl,
+                  const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /*** Operations on prepared Transfer Request ***/
+
+    /**
+     * @brief Estimate the cost (e.g., duration) of executing a transfer request.
+     *
+     * @param req_hndl     Transfer request handle
+     * @param duration     [out] Estimated duration of the transfer
+     * @param err_margin   [out] Estimated error margin of the transfer
+     * @param method       [out] Method to compute the cost estimate
+     * @param extra_params Optional extra parameters
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    estimateXferCost(const nixlXferReqH *req_hndl,
+                     std::chrono::microseconds &duration,
+                     std::chrono::microseconds &err_margin,
+                     nixl_cost_t &method,
+                     const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /**
+     * @brief  Submit a transfer request `req_hndl` which initiates a transfer.
+     *         After this, the transfer state can be checked asynchronously till completion.
+     *         In case of small transfers that are completed within the call, return value
+     *         will be NIXL_SUCCESS. Otherwise, the output status will be NIXL_IN_PROG until
+     *         completion. Notification  message  can be preovided through the extra_params,
+     *         and can be updated per re-post.
+     *
+     * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
+     * @param  extra_params  Optional extra parameters used in posting a transfer request
+     * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
+     */
+    nixl_status_t
+    postXferReq(nixlXferReqH *req_hndl, const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /**
+     * @brief  Check the status of transfer request `req_hndl`
+     *
+     * @param  req_hndl      Transfer request handle after postXferReq
+     * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
+     */
+    nixl_status_t
+    getXferStatus(nixlXferReqH *req_hndl) const;
+
+    /**
+     * @brief  Get transfer status with per-entry (index, status) events.
+     *         Request must have been created with trackFlags != 0
+     *         (via extra_params in createXferReq/makeXferReq). Events are appended over time;
+     *         compare events_out.size() to the previous call to see new completions.
+     *
+     * @param  req_hndl      Transfer request handle after postXferReq
+     * @param  events_out [out] Append-only event list (index, status).
+     * @return nixl_status_t NIXL_ERR_INVALID_PARAM if xfer was created with trackFlags==0,
+     *         NIXL_IN_PROG_WITH_ERR (negative) when still in progress, NIXL_SUCCESS or error
+     * otherwise.
+     */
+    nixl_status_t
+    getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &events_out) const;
+
+    /**
+     * @brief  Get the telemetry data associated with `req_hndl`.
+     *
+     * @param  req_hndl        Transfer request handle obtained from makeXferReq/createXferReq
+     * @param  telemetry [out] Output telemetry information
+     * @return nixl_status_t   Error code if call was not successful
+     */
+    nixl_status_t
+    getXferTelemetry(const nixlXferReqH *req_hndl, nixl_xfer_telem_t &telemetry) const;
+
+    /**
+     * @brief  Query the backend associated with `req_hndl`. E.g., if for genNotif
+     *         the same backend as a transfer is desired.
+     *
+     * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
+     * @param  backend [out] Output backend handle chosen for the transfer request
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    queryXferBackend(const nixlXferReqH *req_hndl, nixlBackendH *&backend) const;
+
+    /**
+     * @brief  Release the transfer request `req_hndl`. If the transfer is active,
+     *         it will be canceled, or return an error if the transfer cannot be aborted.
+     *
+     * @param  req_hndl      Transfer request handle to be released
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    releaseXferReq(nixlXferReqH *req_hndl) const;
+
+    /**
+     * @brief  Prepare a memory view handle for remote buffers.
+     *
+     * Prepare a memory view handle @a mvh for the remote memory buffers described by the
+     * descriptor list @a dlist. The handle can be later used to perform a memory transfer
+     * using @ref nixlPut, @ref nixlAtomicAdd. The preparation should be done on the initiator
+     * agent. NIXL automatically determines the backend that can perform the preparation. If a
+     * list of backends hints is provided (via extra_params), the selection is limited to the
+     * specified backends.
+     *
+     * @param  dlist         [in]  Descriptor list for the remote buffers
+     * @param  mvh           [out] Memory view handle for the remote buffers
+     * @param  extra_params  [in]  Optional parameters
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    prepMemView(const nixl_remote_dlist_t &dlist,
+                nixlMemViewH &mvh,
+                const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /**
+     * @brief  Prepare a memory view handle for local buffers.
+     *
+     * Prepare a memory view handle @a mvh for the local memory buffers described by the
+     * descriptor list @a dlist. The handle can be later used to perform a memory transfer
+     * using @ref nixlPut. The preparation should be done on the initiator agent. NIXL
+     * automatically determines the backend that can perform the preparation. If a list of
+     * backends hints is provided (via extra_params), the selection is limited to the specified
+     * backends.
+     *
+     * @param  dlist         [in]  Descriptor list for the local buffers
+     * @param  mvh           [out] Memory view handle for the local buffers
+     * @param  extra_params  [in]  Optional parameters
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    prepMemView(const nixl_local_dlist_t &dlist,
+                nixlMemViewH &mvh,
+                const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /**
+     * @brief  Release a memory view handle.
+     *
+     * @param  mvh           [in] Memory view handle to be released
+     */
+    void
+    releaseMemView(nixlMemViewH mvh) const;
+
+    /**
+     * @brief  Release the prepared descriptor list handle `dlist_hndl`
+     *
+     * @param  dlist_hndl    Prepared descriptor list handle to be released
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    releasedDlistH(nixlDlistH *dlist_hndl) const;
+
+
+    /*** Notification Handling ***/
+
+    /**
+     * @brief  Add entries to the input notifications list (can be non-empty), which is a map
+     *         from agent name to a list of notification received from that agent. Elements
+     *         are released within the agent after this call. Optionally, a list of backends
+     *         can be mentioned in extra_params to only get those backends notifications.
+     *
+     * @param  notif_map     Input notifications list
+     * @param  extra_params  Optional extra parameters used in getting notifications
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    getNotifs(nixl_notifs_t &notif_map, const nixl_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Generate a notification, not bound to a transfer, e.g., for control.
+     *         Metadata of remote agent should be available before this call. The
+     *         generated notification will be received alongside other notifications
+     *         by getNotifs. Optionally, a backend can be specified for the notification
+     *         through the extra_params.
+     *
+     * @param  remote_agent  Remote agent name as string
+     * @param  msg           Notification message to be sent
+     * @param  extra_params  Optional extra parameters used in generating a standalone notif
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    genNotif(const std::string &remote_agent,
+             const nixl_blob_t &msg,
+             const nixl_opt_args_t *extra_params = nullptr) const;
+
+    /*** Metadata handling through side channel ***/
+    /**
+     * @brief  Get metadata blob for this agent, to be given to other agents.
+     *
+     * @param  str [out]     The serialized metadata blob
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    getLocalMD(nixl_blob_t &str) const;
+
+    /**
+     * @brief  Get partial metadata blob for this agent, to be given to other agents.
+     *         If `descs` is empty, only backends' connection info is included in the metadata,
+     *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
+     *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
+     *         and if `extra_params->includeConnInfo` is true, the connection info of the
+     *         backends supporting the memory type is also included.
+     *         If `extra_params->backends` is non-empty, only the descriptors supported by the
+     *         backends in the list and the backends' connection info are included in the metadata.
+     *
+     * @param  descs         [in]  Descriptor list to include in the metadata
+     * @param  str           [out] The serialized metadata blob
+     * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
+     * @return nixl_status_t       Error code if call was not successful
+     */
+    nixl_status_t
+    getLocalPartialMD(const nixl_reg_dlist_t &descs,
+                      nixl_blob_t &str,
                       const nixl_opt_args_t *extra_params = nullptr) const;
-        /**
-         * @brief  Make a transfer request `req_handl` by selecting indices from already
-         *         prepared descriptor list handles. NIXL automatically determines the backend
-         *         that can perform the transfer. If a list of backends hints is provided
-         *         (via extra_params), the selection is limited to the specified backends.
-         *         Optionally, a notification message can also be provided through extra_params.
-         *
-         * @param  operation        Operation for transfer (e.g., NIXL_WRITE)
-         * @param  local_side       Local prepared descriptor list handle
-         * @param  local_indices    Indices list to the local prepared descriptor list handle
-         * @param  remote_side      Remote (or loopback) prepared descriptor list handle
-         * @param  remote_indices   Indices list to the remote prepared descriptor list handle
-         * @param  req_handle [out] Transfer request handle output
-         * @param  extra_params     Optional additional parameters used in making a transfer request
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        makeXferReq (const nixl_xfer_op_t &operation,
-                     const nixlDlistH* local_side,
-                     const std::vector<int> &local_indices,
-                     const nixlDlistH* remote_side,
-                     const std::vector<int> &remote_indices,
-                     nixlXferReqH* &req_hndl,
-                     const nixl_opt_args_t* extra_params = nullptr) const;
-        /**
-         * @brief  A combined API, to create a transfer request from two descriptor lists.
-         *         NIXL will prepare each side and create a transfer handle `req_hndl`.
-         *         The below set of operations are equivalent:
-         *           1. A sequence of prepXferDlist & makeXferReq:
-         *              prepXferDlist(NIXL_INIT_AGENT, local_desc, local_desc_hndl)
-         *              prepXferDlist("Agent-remote/self", remote_desc, remote_desc_hndl)
-         *              makeXferReq(NIXL_WRITE, local_desc_hndl, list of all local indices,
-         *                          remote_desc_hndl, list of all remote_indices, req_hndl)
-         *           2. A CreateXfer:
-         *              createXferReq(NIXL_WRITE, local_desc, remote_desc,
-         *                            "Agent-remote/self", req_hndl)
-         *
-         *         If there are common descriptors across different transfer requests, using
-         *         createXfer will result in repeated computation, such as validity checks and
-         *         pre-processing done in the preparation step. If a list of backends hints is
-         *         provided (via extra_params), the selection is limited to the specified backends.
-         *         Optionally, a notification message can also be provided through extra_params.
-         *
-         * @param  operation      Operation for transfer (e.g., NIXL_WRITE)
-         * @param  local_descs    Local descriptor list
-         * @param  remote_descs   Remote (or loopback) descriptor list
-         * @param  remote_agent   Remote (or self) agent name for accessing the remote (local) data
-         * @param  req_hndl [out] Transfer request handle output
-         * @param  extra_params   Optional extra parameters used in creating a transfer request
-         * @return nixl_status_t  Error code if call was not successful
-         */
-        nixl_status_t
-        createXferReq (const nixl_xfer_op_t &operation,
-                       const nixl_xfer_dlist_t &local_descs,
-                       const nixl_xfer_dlist_t &remote_descs,
-                       const std::string &remote_agent,
-                       nixlXferReqH* &req_hndl,
-                       const nixl_opt_args_t* extra_params = nullptr) const;
 
-        /*** Operations on prepared Transfer Request ***/
+    /**
+     * @brief  Load other agent's metadata and unpack it internally. Now the local
+     *         agent can initiate transfers towards the remote agent.
+     *
+     * @param  remote_metadata  Serialized metadata blob to be loaded
+     * @param  agent_name [out] Agent name extracted from the loaded metadata blob
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    loadRemoteMD(const nixl_blob_t &remote_metadata, std::string &agent_name);
 
-        /**
-         * @brief Estimate the cost (e.g., duration) of executing a transfer request.
-         *
-         * @param req_hndl     Transfer request handle
-         * @param duration     [out] Estimated duration of the transfer
-         * @param err_margin   [out] Estimated error margin of the transfer
-         * @param method       [out] Method to compute the cost estimate
-         * @param extra_params Optional extra parameters
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        estimateXferCost(const nixlXferReqH* req_hndl,
-                         std::chrono::microseconds &duration,
-                         std::chrono::microseconds &err_margin,
-                         nixl_cost_t &method,
-                         const nixl_opt_args_t* extra_params = nullptr) const;
+    /**
+     * @brief  Invalidate the remote agent metadata cached locally. This will
+     *         disconnect from that agent if already connected, and no more
+     *         transfers can be initiated towards that agent.
+     *
+     * @param  remote_agent  Remote agent name to invalidate its metadata blob
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    invalidateRemoteMD(const std::string &remote_agent);
 
-        /**
-         * @brief  Submit a transfer request `req_hndl` which initiates a transfer.
-         *         After this, the transfer state can be checked asynchronously till completion.
-         *         In case of small transfers that are completed within the call, return value
-         *         will be NIXL_SUCCESS. Otherwise, the output status will be NIXL_IN_PROG until
-         *         completion. Notification  message  can be preovided through the extra_params,
-         *         and can be updated per re-post.
-         *
-         * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
-         * @param  extra_params  Optional extra parameters used in posting a transfer request
-         * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
-         */
-        nixl_status_t
-        postXferReq (nixlXferReqH* req_hndl,
-                     const nixl_opt_args_t* extra_params = nullptr) const;
+    /*** Metadata handling through direct channels (p2p socket and ETCD) ***/
+    /**
+     * @brief  Send your own agent metadata to a remote location.
+     *
+     * @param  extra_params  Only to optionally specify IP address and/or port.
+     *                       If IP is specified, this will enable peer to peer sending of your
+     * metadata. If IP unspecified, this will send your data to the metadata server. Port can be
+     * specified or defaults to default_comm_port.
+     *
+     * @return nixl_status_t Error code if call was not successful
+     */
+    nixl_status_t
+    sendLocalMD(const nixl_opt_args_t *extra_params = nullptr) const;
 
-        /**
-         * @brief  Check the status of transfer request `req_hndl`
-         *
-         * @param  req_hndl      Transfer request handle after postXferReq
-         * @return nixl_status_t NIXL_IN_PROG or error code if call was not successful
-         */
-        nixl_status_t
-        getXferStatus (nixlXferReqH* req_hndl) const;
+    /**
+     * @brief  Send partial metadata blob for this agent to peer or central metadata server
+     *         If `descs` is empty, only backends' connection info is included in the metadata,
+     *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
+     *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
+     *         and if `extra_params->includeConnInfo` is true, the connection info of the
+     *         backends supporting the memory type is also included.
+     *         If `extra_params->backends` is non-empty, only the descriptors supported by the
+     *         backends in the list and the backends' connection info are included in the metadata.
+     *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer,
+     * otherwise it will be sent to the central metadata server, if supported. If
+     * 'extra_params->port' can be set in addition to IP address, or will default to
+     * default_comm_port. The 'extra_params->metadataLabel' is required when sending to a central
+     * metadata server and ignored when sending to a peer.
+     *
+     * @param  descs         [in]  Descriptor list to include in the metadata
+     * @param  str           [out] The serialized metadata blob
+     * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
+     * @return nixl_status_t       Error code if call was not successful
+     */
+    nixl_status_t
+    sendLocalPartialMD(const nixl_reg_dlist_t &descs,
+                       const nixl_opt_args_t *extra_params = nullptr) const;
 
-        /**
-         * @brief  Get transfer status with per-entry (index, status) events.
-         *         Request must have been created with trackFlags != 0
-         *         (via extra_params in createXferReq/makeXferReq). Events are appended over time;
-         *         compare events_out.size() to the previous call to see new completions.
-         *
-         * @param  req_hndl      Transfer request handle after postXferReq
-         * @param  events_out [out] Append-only event list (index, status).
-         * @return nixl_status_t NIXL_ERR_INVALID_PARAM if xfer was created with trackFlags==0,
-         *         NIXL_IN_PROG_WITH_ERR (negative) when still in progress, NIXL_SUCCESS or error
-         * otherwise.
-         */
-        nixl_status_t
-        getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &events_out) const;
+    /**
+     * @brief  Fetch other agent's metadata from a peer or central metadata server,
+     *         then unpack it internally. When fetching from a peer, only the full metadata
+     *         is supported. When fetching from a central metadata server, the metadataLabel
+     *         can be specified to fetch partial metadata.
+     *
+     * @param  remote_name   Name of remote agent to fetch from ETCD or socket.
+     * @param  extra_params  Only to optionally specify IP address and/or port.
+     *                       If IP is specified, this will enable peer to peer fetching of metadata.
+     *                       If IP is unspecified, this will fetch from the metadata server.
+     *                       Port can be specified or defaults to default_comm_port.
+     *                       If metadataLabel is specified, it will be used as the label of the
+     * metadata to be fetched, which can be partial metadata. Otherwise, the default label of the
+     * full metadata will be used for fetching.
+     *
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    fetchRemoteMD(const std::string remote_name, const nixl_opt_args_t *extra_params = nullptr);
 
-        /**
-         * @brief  Get the telemetry data associated with `req_hndl`.
-         *
-         * @param  req_hndl        Transfer request handle obtained from makeXferReq/createXferReq
-         * @param  telemetry [out] Output telemetry information
-         * @return nixl_status_t   Error code if call was not successful
-         */
-        nixl_status_t
-        getXferTelemetry(const nixlXferReqH *req_hndl, nixl_xfer_telem_t &telemetry) const;
+    /**
+     * @brief  Invalidate your own memory in one/all remote agent(s).
+     *
+     * @param  extra_params  Only to optionally specify IP address and/or port.
+     *                       If IP is specified, this will enable peer to peer invalidation of
+     * metadata. If IP is unspecified, this will invalidate all agent's labels from the metadata
+     * server. Port can be specified or defaults to default_comm_port.
+     *
+     * @return nixl_status_t    Error code if call was not successful
+     */
+    nixl_status_t
+    invalidateLocalMD(const nixl_opt_args_t *extra_params = nullptr) const;
 
-        /**
-         * @brief  Query the backend associated with `req_hndl`. E.g., if for genNotif
-         *         the same backend as a transfer is desired.
-         *
-         * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
-         * @param  backend [out] Output backend handle chosen for the transfer request
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        queryXferBackend (const nixlXferReqH* req_hndl,
-                          nixlBackendH* &backend) const;
-
-        /**
-         * @brief  Release the transfer request `req_hndl`. If the transfer is active,
-         *         it will be canceled, or return an error if the transfer cannot be aborted.
-         *
-         * @param  req_hndl      Transfer request handle to be released
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        releaseXferReq (nixlXferReqH* req_hndl) const;
-
-        /**
-         * @brief  Prepare a memory view handle for remote buffers.
-         *
-         * Prepare a memory view handle @a mvh for the remote memory buffers described by the
-         * descriptor list @a dlist. The handle can be later used to perform a memory transfer
-         * using @ref nixlPut, @ref nixlAtomicAdd. The preparation should be done on the initiator
-         * agent. NIXL automatically determines the backend that can perform the preparation. If a
-         * list of backends hints is provided (via extra_params), the selection is limited to the
-         * specified backends.
-         *
-         * @param  dlist         [in]  Descriptor list for the remote buffers
-         * @param  mvh           [out] Memory view handle for the remote buffers
-         * @param  extra_params  [in]  Optional parameters
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        prepMemView(const nixl_remote_dlist_t &dlist,
-                    nixlMemViewH &mvh,
-                    const nixl_opt_args_t *extra_params = nullptr) const;
-
-        /**
-         * @brief  Prepare a memory view handle for local buffers.
-         *
-         * Prepare a memory view handle @a mvh for the local memory buffers described by the
-         * descriptor list @a dlist. The handle can be later used to perform a memory transfer
-         * using @ref nixlPut. The preparation should be done on the initiator agent. NIXL
-         * automatically determines the backend that can perform the preparation. If a list of
-         * backends hints is provided (via extra_params), the selection is limited to the specified
-         * backends.
-         *
-         * @param  dlist         [in]  Descriptor list for the local buffers
-         * @param  mvh           [out] Memory view handle for the local buffers
-         * @param  extra_params  [in]  Optional parameters
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        prepMemView(const nixl_local_dlist_t &dlist,
-                    nixlMemViewH &mvh,
-                    const nixl_opt_args_t *extra_params = nullptr) const;
-
-        /**
-         * @brief  Release a memory view handle.
-         *
-         * @param  mvh           [in] Memory view handle to be released
-         */
-        void
-        releaseMemView(nixlMemViewH mvh) const;
-
-        /**
-         * @brief  Release the prepared descriptor list handle `dlist_hndl`
-         *
-         * @param  dlist_hndl    Prepared descriptor list handle to be released
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        releasedDlistH (nixlDlistH* dlist_hndl) const;
-
-
-        /*** Notification Handling ***/
-
-        /**
-         * @brief  Add entries to the input notifications list (can be non-empty), which is a map
-         *         from agent name to a list of notification received from that agent. Elements
-         *         are released within the agent after this call. Optionally, a list of backends
-         *         can be mentioned in extra_params to only get those backends notifications.
-         *
-         * @param  notif_map     Input notifications list
-         * @param  extra_params  Optional extra parameters used in getting notifications
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        getNotifs (nixl_notifs_t &notif_map,
-                   const nixl_opt_args_t* extra_params = nullptr);
-
-        /**
-         * @brief  Generate a notification, not bound to a transfer, e.g., for control.
-         *         Metadata of remote agent should be available before this call. The
-         *         generated notification will be received alongside other notifications
-         *         by getNotifs. Optionally, a backend can be specified for the notification
-         *         through the extra_params.
-         *
-         * @param  remote_agent  Remote agent name as string
-         * @param  msg           Notification message to be sent
-         * @param  extra_params  Optional extra parameters used in generating a standalone notif
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        genNotif (const std::string &remote_agent,
-                  const nixl_blob_t &msg,
-                  const nixl_opt_args_t* extra_params = nullptr) const;
-
-        /*** Metadata handling through side channel ***/
-        /**
-         * @brief  Get metadata blob for this agent, to be given to other agents.
-         *
-         * @param  str [out]     The serialized metadata blob
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        getLocalMD (nixl_blob_t &str) const;
-
-        /**
-         * @brief  Get partial metadata blob for this agent, to be given to other agents.
-         *         If `descs` is empty, only backends' connection info is included in the metadata,
-         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
-         *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
-         *         and if `extra_params->includeConnInfo` is true, the connection info of the
-         *         backends supporting the memory type is also included.
-         *         If `extra_params->backends` is non-empty, only the descriptors supported by the
-         *         backends in the list and the backends' connection info are included in the metadata.
-         *
-         * @param  descs         [in]  Descriptor list to include in the metadata
-         * @param  str           [out] The serialized metadata blob
-         * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
-         * @return nixl_status_t       Error code if call was not successful
-         */
-        nixl_status_t
-        getLocalPartialMD(const nixl_reg_dlist_t &descs,
-                          nixl_blob_t &str,
-                          const nixl_opt_args_t* extra_params = nullptr) const;
-
-        /**
-         * @brief  Load other agent's metadata and unpack it internally. Now the local
-         *         agent can initiate transfers towards the remote agent.
-         *
-         * @param  remote_metadata  Serialized metadata blob to be loaded
-         * @param  agent_name [out] Agent name extracted from the loaded metadata blob
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        loadRemoteMD (const nixl_blob_t &remote_metadata,
-                      std::string &agent_name);
-
-        /**
-         * @brief  Invalidate the remote agent metadata cached locally. This will
-         *         disconnect from that agent if already connected, and no more
-         *         transfers can be initiated towards that agent.
-         *
-         * @param  remote_agent  Remote agent name to invalidate its metadata blob
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        invalidateRemoteMD (const std::string &remote_agent);
-
-        /*** Metadata handling through direct channels (p2p socket and ETCD) ***/
-        /**
-         * @brief  Send your own agent metadata to a remote location.
-         *
-         * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer sending of your metadata.
-         *                       If IP unspecified, this will send your data to the metadata server.
-         *                       Port can be specified or defaults to default_comm_port.
-         *
-         * @return nixl_status_t Error code if call was not successful
-         */
-        nixl_status_t
-        sendLocalMD (const nixl_opt_args_t* extra_params = nullptr) const;
-
-        /**
-         * @brief  Send partial metadata blob for this agent to peer or central metadata server
-         *         If `descs` is empty, only backends' connection info is included in the metadata,
-         *         regardless of the value of `extra_params->includeConnInfo` and `descs` memory type.
-         *         If `descs` is non-empty, the metadata of the descriptors in the list are included,
-         *         and if `extra_params->includeConnInfo` is true, the connection info of the
-         *         backends supporting the memory type is also included.
-         *         If `extra_params->backends` is non-empty, only the descriptors supported by the
-         *         backends in the list and the backends' connection info are included in the metadata.
-         *         If 'extra_params->ip_addr' is set, the metadata will only be sent to a single peer, otherwise
-         *         it will be sent to the central metadata server, if supported.
-         *         If 'extra_params->port' can be set in addition to IP address, or will default to default_comm_port.
-         *         The 'extra_params->metadataLabel' is required when sending to a central metadata server and
-         *         ignored when sending to a peer.
-         *
-         * @param  descs         [in]  Descriptor list to include in the metadata
-         * @param  str           [out] The serialized metadata blob
-         * @param  extra_params  [in]  Optional extra parameters used in getting partial metadata
-         * @return nixl_status_t       Error code if call was not successful
-         */
-        nixl_status_t
-        sendLocalPartialMD(const nixl_reg_dlist_t &descs,
-                           const nixl_opt_args_t* extra_params = nullptr) const;
-
-        /**
-         * @brief  Fetch other agent's metadata from a peer or central metadata server,
-         *         then unpack it internally. When fetching from a peer, only the full metadata
-         *         is supported. When fetching from a central metadata server, the metadataLabel
-         *         can be specified to fetch partial metadata.
-         *
-         * @param  remote_name   Name of remote agent to fetch from ETCD or socket.
-         * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer fetching of metadata.
-         *                       If IP is unspecified, this will fetch from the metadata server.
-         *                       Port can be specified or defaults to default_comm_port.
-         *                       If metadataLabel is specified, it will be used as the label of the metadata
-         *                       to be fetched, which can be partial metadata. Otherwise, the default label
-         *                       of the full metadata will be used for fetching.
-         *
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        fetchRemoteMD (const std::string remote_name,
-                       const nixl_opt_args_t* extra_params = nullptr);
-
-        /**
-         * @brief  Invalidate your own memory in one/all remote agent(s).
-         *
-         * @param  extra_params  Only to optionally specify IP address and/or port.
-         *                       If IP is specified, this will enable peer to peer invalidation of metadata.
-         *                       If IP is unspecified, this will invalidate all agent's labels
-         *                       from the metadata server.
-         *                       Port can be specified or defaults to default_comm_port.
-         *
-         * @return nixl_status_t    Error code if call was not successful
-         */
-        nixl_status_t
-        invalidateLocalMD (const nixl_opt_args_t* extra_params = nullptr) const;
-
-        /**
-         * @brief  Check if metadata is available for a remote agent.
-         *         For partial metadata methods are used, the descriptor list in question
-         *         can be specified; otherwise, empty `descs` can be passed.
-         *
-         * @param  str           Remote agent to check for
-         * @return nixl_status_t Error code, NOT_FOUND if metadata not found
-         */
-        nixl_status_t
-        checkRemoteMD (const std::string remote_name,
-                       const nixl_xfer_dlist_t &descs) const;
-
+    /**
+     * @brief  Check if metadata is available for a remote agent.
+     *         For partial metadata methods are used, the descriptor list in question
+     *         can be specified; otherwise, empty `descs` can be passed.
+     *
+     * @param  str           Remote agent to check for
+     * @return nixl_status_t Error code, NOT_FOUND if metadata not found
+     */
+    nixl_status_t
+    checkRemoteMD(const std::string remote_name, const nixl_xfer_dlist_t &descs) const;
 };
 
 #endif

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -67,8 +67,9 @@ enum nixl_status_t {
     NIXL_ERR_REMOTE_DISCONNECT = -10,
     NIXL_ERR_CANCELED = -11,
     NIXL_ERR_NO_TELEMETRY = -12,
-    /** In progress: use slow path / per-entry status. Kept negative so (status < 0) implies need to check. */
-    NIXL_ERR_IN_PROG = -13
+    /** In progress on the per-entry events path. Kept negative so (status < 0) implies need to
+       check. */
+    NIXL_IN_PROG_WITH_ERR = -13
 };
 
 /**
@@ -79,6 +80,7 @@ enum nixl_xfer_track_flag_t : uint32_t {
     NIXL_XFER_TRACK_ERRORS = 1u << 0,
     NIXL_XFER_TRACK_SUCCESSES = 1u << 1,
 };
+
 using nixl_xfer_track_flags_t = uint32_t;
 
 /**
@@ -87,9 +89,11 @@ using nixl_xfer_track_flags_t = uint32_t;
  *        user compares event list length to previous call to see new completions.
  */
 struct nixl_xfer_entry_event_t {
-    size_t index;        /**< Descriptor index in the transfer. */
-    nixl_status_t status; /**< NIXL_SUCCESS, error code, or NIXL_IN_PROG for that entry. */
+    size_t index; /**< Descriptor index in the transfer. */
+    nixl_status_t status; /**< NIXL_SUCCESS or an error code; never NIXL_IN_PROG (entries are only
+                             appended once complete). */
 };
+
 using nixl_xfer_entry_events_t = std::deque<nixl_xfer_entry_event_t>;
 
 /**

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -17,10 +17,12 @@
 #ifndef _NIXL_TYPES_H
 #define _NIXL_TYPES_H
 #include <vector>
+#include <deque>
 #include <string>
 #include <unordered_map>
 #include <optional>
 #include <chrono>
+#include <cstdint>
 
 
 /*** Forward declarations ***/
@@ -64,8 +66,31 @@ enum nixl_status_t {
     NIXL_ERR_NOT_SUPPORTED = -9,
     NIXL_ERR_REMOTE_DISCONNECT = -10,
     NIXL_ERR_CANCELED = -11,
-    NIXL_ERR_NO_TELEMETRY = -12
+    NIXL_ERR_NO_TELEMETRY = -12,
+    /** In progress: use slow path / per-entry status. Kept negative so (status < 0) implies need to check. */
+    NIXL_ERR_IN_PROG = -13
 };
+
+/**
+ * @brief Per-entry tracking flags (set of properties). Empty (0) = track only summarized status.
+ *        Chosen at createXferReq/makeXferReq. Extensible for future modes.
+ */
+enum nixl_xfer_track_flag_t : uint32_t {
+    NIXL_XFER_TRACK_ERRORS = 1u << 0,
+    NIXL_XFER_TRACK_SUCCESSES = 1u << 1,
+};
+using nixl_xfer_track_flags_t = uint32_t;
+
+/**
+ * @struct nixl_xfer_entry_event_t
+ * @brief One (index, status) event from checkXferEvents. Events are appended over time;
+ *        user compares event list length to previous call to see new completions.
+ */
+struct nixl_xfer_entry_event_t {
+    size_t index;        /**< Descriptor index in the transfer. */
+    nixl_status_t status; /**< NIXL_SUCCESS, error code, or NIXL_IN_PROG for that entry. */
+};
+using nixl_xfer_entry_events_t = std::deque<nixl_xfer_entry_event_t>;
 
 /**
  * @enum nixl_thread_sync_t
@@ -197,6 +222,13 @@ struct nixlAgentOptionalArgs {
      *      Deprecated. Kept for backward compatibility.
      */
     bool skipDescMerge = false;
+
+    /**
+     * @var trackFlags Per-entry tracking for this transfer (createXferReq/makeXferReq).
+     *      Empty (0): getXferStatus(req, events) returns NIXL_ERR_INVALID_PARAM.
+     *      NIXL_XFER_TRACK_ERRORS and/or NIXL_XFER_TRACK_SUCCESSES: append-only event list.
+     */
+    nixl_xfer_track_flags_t trackFlags = 0;
 
     /**
      * @var includeConnInfo legacy flag to include connection information in partial metadata.

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -32,7 +32,6 @@ class nixlBackendH;
 class nixlXferReqH;
 class nixlAgentData;
 
-
 /*** NIXL memory type, operation and status enums ***/
 
 /**
@@ -40,13 +39,13 @@ class nixlAgentData;
  * @brief  An enumeration of segment types for NIXL
  *         FILE_SEG must be last
  */
-enum nixl_mem_t {DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG};
+enum nixl_mem_t { DRAM_SEG, VRAM_SEG, BLK_SEG, OBJ_SEG, FILE_SEG };
 
 /**
  * @enum   nixl_xfer_op_t
  * @brief  An enumeration of different transfer types for NIXL
  */
-enum nixl_xfer_op_t {NIXL_READ, NIXL_WRITE};
+enum nixl_xfer_op_t { NIXL_READ, NIXL_WRITE };
 
 /**
  * @enum   nixl_status_t
@@ -80,7 +79,7 @@ enum nixl_status_t {
  *        Chosen at createXferReq/makeXferReq. Extensible for future modes.
  */
 enum nixl_xfer_track_flag_t : uint32_t {
-    NIXL_XFER_TRACK_ERRORS    = NIXL_BIT(0),
+    NIXL_XFER_TRACK_ERRORS = NIXL_BIT(0),
     NIXL_XFER_TRACK_SUCCESSES = NIXL_BIT(1),
 };
 
@@ -116,11 +115,13 @@ enum class nixl_thread_sync_t {
  *            of different enums
  */
 namespace nixlEnumStrings {
-    std::string memTypeStr(const nixl_mem_t &mem);
-    std::string xferOpStr (const nixl_xfer_op_t &op);
-    std::string statusStr (const nixl_status_t &status);
-}
-
+std::string
+memTypeStr(const nixl_mem_t &mem);
+std::string
+xferOpStr(const nixl_xfer_op_t &op);
+std::string
+statusStr(const nixl_status_t &status);
+} // namespace nixlEnumStrings
 
 /*** NIXL typedefs and defines used in the API ***/
 
@@ -192,7 +193,6 @@ enum class nixl_cost_t {
  */
 using nixl_query_resp_t = std::optional<nixl_b_params_t>;
 
-
 /**
  * @struct nixlAgentOptionalArgs
  * @brief A structure for optional argument that can be provided to relevant agent methods.
@@ -203,7 +203,7 @@ struct nixlAgentOptionalArgs {
      *      of backends to be considered. Used in registerMem / deregisterMem
      *      makeConnection / prepXferDlist / makeXferReq / createXferReq / GetNotifs / GenNotif
      */
-    std::vector<nixlBackendH*> backends;
+    std::vector<nixlBackendH *> backends;
 
     /**
      * @var notif Optional notification message used in createXferReq / makeXferReq / postXferReq.
@@ -245,13 +245,15 @@ struct nixlAgentOptionalArgs {
 
     /**
      * @var ipAddr Used to specify the IP address of a remote peer for metadata transfer.
-     *                      used in sendLocalMD, fetchRemoteMD, invalidateLocalMD, sendLocalPartialMD.
+     *                      used in sendLocalMD, fetchRemoteMD, invalidateLocalMD,
+     * sendLocalPartialMD.
      */
     std::string ipAddr;
 
     /**
      * @var port Used to specify the port of a remote peer, ipAddr must also be set
-     *                      used in sendLocalMD, fetchRemoteMD, invalidateLocalMD, sendLocalPartialMD.
+     *                      used in sendLocalMD, fetchRemoteMD, invalidateLocalMD,
+     * sendLocalPartialMD.
      */
     int port = default_comm_port;
 
@@ -261,8 +263,8 @@ struct nixlAgentOptionalArgs {
      *                    agent's key prefix, and the full key will be used to store/fetch
      *                    the metadata key-value pair from the server.
      *                    Used in fetchRemoteMD, sendLocalPartialMD.
-     *                    Note that sendLocalMD always uses default_metadata_label and ignores this parameter.
-     *                    Note that invalidateLocalMD invalidates all labels and ignores this parameter.
+     *                    Note that sendLocalMD always uses default_metadata_label and ignores this
+     * parameter. Note that invalidateLocalMD invalidates all labels and ignores this parameter.
      */
     std::string metadataLabel;
 
@@ -271,6 +273,7 @@ struct nixlAgentOptionalArgs {
      */
     nixl_blob_t customParam;
 };
+
 /**
  * @brief A typedef for a nixlAgentOptionalArgs
  *        for providing extra optional arguments

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -72,13 +72,16 @@ enum nixl_status_t {
     NIXL_IN_PROG_WITH_ERR = -13
 };
 
+/** @brief Portable single-bit mask: NIXL_BIT(0) == 1, NIXL_BIT(1) == 2, … */
+#define NIXL_BIT(n) (1u << (n))
+
 /**
  * @brief Per-entry tracking flags (set of properties). Empty (0) = track only summarized status.
  *        Chosen at createXferReq/makeXferReq. Extensible for future modes.
  */
 enum nixl_xfer_track_flag_t : uint32_t {
-    NIXL_XFER_TRACK_ERRORS = 1u << 0,
-    NIXL_XFER_TRACK_SUCCESSES = 1u << 1,
+    NIXL_XFER_TRACK_ERRORS    = NIXL_BIT(0),
+    NIXL_XFER_TRACK_SUCCESSES = NIXL_BIT(1),
 };
 
 using nixl_xfer_track_flags_t = uint32_t;

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -648,10 +648,31 @@ class nixl_agent:
         status = self.agent.getXferStatus(handle._handle)
         if status == nixlBind.NIXL_SUCCESS:
             return "DONE"
-        elif status == nixlBind.NIXL_IN_PROG or status == nixlBind.NIXL_IN_PROG_WITH_ERR:
+        elif (
+            status == nixlBind.NIXL_IN_PROG or status == nixlBind.NIXL_IN_PROG_WITH_ERR
+        ):
             return "PROC"
         else:
             return "ERR"
+
+    def get_xfer_status_with_events(
+        self,
+        handle: nixl_xfer_handle,
+        events: nixlBind.nixlXferEntryEvents,
+    ) -> int:
+        """
+        @brief Poll per-entry transfer status for requests created with track_flags.
+
+        Pass the same ``nixlXferEntryEvents`` instance on each poll to avoid per-call
+        allocations (append-only event list). Does not raise for in-progress statuses.
+
+        @param handle Transfer handle from make_prepped_xfer or initialize_xfer (must have been
+               created with non-zero track_flags).
+        @param events Container created once (e.g. ``nixlBind.nixlXferEntryEvents()``) and reused.
+        @return Raw status code (nixl_status_t), e.g. NIXL_SUCCESS, NIXL_IN_PROG,
+                NIXL_IN_PROG_WITH_ERR, or an error code.
+        """
+        return self.agent.getXferStatus(handle._handle, events)
 
     """
     @brief Get telemetry information of a transfer request.

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -648,7 +648,7 @@ class nixl_agent:
         status = self.agent.getXferStatus(handle._handle)
         if status == nixlBind.NIXL_SUCCESS:
             return "DONE"
-        elif status == nixlBind.NIXL_IN_PROG:
+        elif status == nixlBind.NIXL_IN_PROG or status == nixlBind.NIXL_IN_PROG_WITH_ERR:
             return "PROC"
         else:
             return "ERR"

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -36,12 +36,24 @@ typedef std::map<std::string, std::vector<py::bytes>> nixl_py_notifs_t;
  */
 class nixlXferEntryEvents {
 public:
-    nixl_xfer_entry_events_t &events() { return data_; }
-    const nixl_xfer_entry_events_t &events() const { return data_; }
-    size_t size() const { return data_.size(); }
-    const nixl_xfer_entry_event_t &get(size_t i) const {
-        if (i >= data_.size())
-            throw std::out_of_range("index out of range");
+    nixl_xfer_entry_events_t &
+    events() {
+        return data_;
+    }
+
+    const nixl_xfer_entry_events_t &
+    events() const {
+        return data_;
+    }
+
+    size_t
+    size() const {
+        return data_.size();
+    }
+
+    const nixl_xfer_entry_event_t &
+    get(size_t i) const {
+        if (i >= data_.size()) throw std::out_of_range("index out of range");
         return data_[i];
     }
 
@@ -113,7 +125,7 @@ void
 throw_nixl_exception(const nixl_status_t &status) {
     switch (status) {
     case NIXL_IN_PROG:
-    case NIXL_ERR_IN_PROG:
+    case NIXL_IN_PROG_WITH_ERR:
         return; // not an error (in progress)
     case NIXL_SUCCESS:
         return; // not an error
@@ -208,11 +220,10 @@ PYBIND11_MODULE(_bindings, m) {
         .value("NIXL_ERR_REMOTE_DISCONNECT", NIXL_ERR_REMOTE_DISCONNECT)
         .value("NIXL_ERR_CANCELED", NIXL_ERR_CANCELED)
         .value("NIXL_ERR_NO_TELEMETRY", NIXL_ERR_NO_TELEMETRY)
-        .value("NIXL_ERR_IN_PROG", NIXL_ERR_IN_PROG)
+        .value("NIXL_IN_PROG_WITH_ERR", NIXL_IN_PROG_WITH_ERR)
         .export_values();
 
-    m.attr("NIXL_XFER_TRACK_ERRORS") =
-        py::int_(static_cast<uint32_t>(NIXL_XFER_TRACK_ERRORS));
+    m.attr("NIXL_XFER_TRACK_ERRORS") = py::int_(static_cast<uint32_t>(NIXL_XFER_TRACK_ERRORS));
     m.attr("NIXL_XFER_TRACK_SUCCESSES") =
         py::int_(static_cast<uint32_t>(NIXL_XFER_TRACK_SUCCESSES));
 
@@ -231,34 +242,34 @@ PYBIND11_MODULE(_bindings, m) {
         .def_readonly("totalBytes", &nixl_xfer_telem_t::totalBytes)
         .def_readonly("descCount", &nixl_xfer_telem_t::descCount);
 
-    py::class_<nixlXferEntryEvents>(m, "nixlXferEntryEvents",
-                                    "Reusable container for per-entry transfer events. "
-                                    "Create once, pass to getXferStatus each poll to avoid allocation.")
+    py::class_<nixlXferEntryEvents>(
+        m,
+        "nixlXferEntryEvents",
+        "Reusable container for per-entry transfer events. "
+        "Create once, pass to getXferStatus each poll to avoid allocation.")
         .def(py::init<>())
         .def("__len__", &nixlXferEntryEvents::size)
         .def("__getitem__",
              [](const nixlXferEntryEvents &v, size_t i) {
-                 if (i >= v.size())
-                     throw py::index_error("index out of range");
+                 if (i >= v.size()) throw py::index_error("index out of range");
                  const auto &e = v.get(i);
                  return py::make_tuple(e.index, static_cast<int>(e.status));
              })
-        .def("__iter__",
-             [](const nixlXferEntryEvents &v) {
-                 py::list result;
-                 for (const auto &e : v.events())
-                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
-                 return py::iter(result);
-             },
-             py::keep_alive<0, 1>())
-        .def("to_list",
-             [](const nixlXferEntryEvents &v) {
-                 py::list result;
-                 for (const auto &e : v.events())
-                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
-                 return result;
-             },
-             "Convert to a Python list of (index, status) tuples");
+        .def(
+            "__iter__",
+            [](const nixlXferEntryEvents &v) {
+                return py::make_iterator(v.events().begin(), v.events().end());
+            },
+            py::keep_alive<0, 1>())
+        .def(
+            "to_list",
+            [](const nixlXferEntryEvents &v) {
+                py::list result;
+                for (const auto &e : v.events())
+                    result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                return result;
+            },
+            "Convert to a Python list of (index, status) tuples");
 
     py::register_exception<nixlNotPostedError>(m, "nixlNotPostedError");
     py::register_exception<nixlInvalidParamError>(m, "nixlInvalidParamError");
@@ -708,7 +719,7 @@ PYBIND11_MODULE(_bindings, m) {
             py::arg("remote_indices"),
             py::arg("notif_msg") = std::string(""),
             py::arg("backend") = std::vector<uintptr_t>({}),
-            py::arg("skip_desc_merg") = false,
+            py::arg("skip_desc_merge") = false,
             py::arg("track_flags") = 0)
         .def(
             "createXferReq",
@@ -775,34 +786,36 @@ PYBIND11_MODULE(_bindings, m) {
             py::call_guard<py::gil_scoped_release>())
         .def(
             "getXferStatus",
-            [](nixlAgent &agent, uintptr_t reqh, py::object events_obj) -> nixl_status_t {
-                if (events_obj.is_none()) {
-                    nixl_status_t ret = agent.getXferStatus((nixlXferReqH *)reqh);
-                    throw_nixl_exception(ret);
-                    return ret;
+            [](nixlAgent &agent, uintptr_t reqh) -> nixl_status_t {
+                nixl_status_t ret;
+                {
+                    py::gil_scoped_release release;
+                    ret = agent.getXferStatus((nixlXferReqH *)reqh);
                 }
-                try {
-                    nixlXferEntryEvents &events =
-                        events_obj.cast<nixlXferEntryEvents &>();
-                    nixl_status_t ret =
-                        agent.getXferStatus((nixlXferReqH *)reqh, events.events());
-                    if (ret != NIXL_SUCCESS && ret != NIXL_ERR_IN_PROG)
-                        throw_nixl_exception(ret);
-                    return ret;
-                } catch (const py::cast_error &) {
-                    throw py::type_error(
-                        "events must be None or nixl.nixlXferEntryEvents");
-                }
+                throw_nixl_exception(ret);
+                return ret;
             },
             py::arg("reqh"),
-            py::arg("events") = py::none(),
-            py::call_guard<py::gil_scoped_release>(),
             R"pbdoc(
-                Get transfer status. If events is None, returns overall status only.
-                If events is nixlXferEntryEvents, appends (index, status) events and returns status.
-                Create nixlXferEntryEvents once, pass to each poll to avoid allocation.
-                Requires trackFlags != 0 when events is provided.
-                Returns NIXL_ERR_IN_PROG when in progress, NIXL_SUCCESS when done.
+                Get aggregate transfer status. Raises an exception on error.
+                Returns NIXL_SUCCESS when complete or NIXL_IN_PROG while running.
+            )pbdoc")
+        .def(
+            "getXferStatus",
+            [](nixlAgent &agent, uintptr_t reqh, nixlXferEntryEvents &events) -> nixl_status_t {
+                py::gil_scoped_release release;
+                return agent.getXferStatus((nixlXferReqH *)reqh, events.events());
+            },
+            py::arg("reqh"),
+            py::arg("events"),
+            R"pbdoc(
+                Get transfer status with per-entry events. Never throws — always returns
+                a nixl_status_t so the caller can inspect per-entry (index, status) pairs
+                even when the overall status indicates partial failure.
+                NIXL_SUCCESS: complete, no errors.
+                NIXL_IN_PROG / NIXL_IN_PROG_WITH_ERR: still running; poll again.
+                Other negative value: transfer finished with errors; inspect events.
+                Requires trackFlags != 0.
             )pbdoc")
         .def(
             "getXferTelemetry",

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -257,10 +257,12 @@ PYBIND11_MODULE(_bindings, m) {
              })
         .def(
             "__iter__",
-            [](const nixlXferEntryEvents &v) {
-                return py::make_iterator(v.events().begin(), v.events().end());
-            },
-            py::keep_alive<0, 1>())
+            [](const nixlXferEntryEvents &v) -> py::iterator {
+                py::list result;
+                for (const auto &e : v.events())
+                    result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                return py::iter(result);
+            })
         .def(
             "to_list",
             [](const nixlXferEntryEvents &v) {
@@ -803,7 +805,7 @@ PYBIND11_MODULE(_bindings, m) {
         .def(
             "getXferStatus",
             [](nixlAgent &agent, uintptr_t reqh, nixlXferEntryEvents &events) -> nixl_status_t {
-                py::gil_scoped_release release;
+                // GIL must be held: C++ appends to events.data_ which Python may concurrently read.
                 return agent.getXferStatus((nixlXferReqH *)reqh, events.events());
             },
             py::arg("reqh"),
@@ -813,7 +815,8 @@ PYBIND11_MODULE(_bindings, m) {
                 a nixl_status_t so the caller can inspect per-entry (index, status) pairs
                 even when the overall status indicates partial failure.
                 NIXL_SUCCESS: complete, no errors.
-                NIXL_IN_PROG / NIXL_IN_PROG_WITH_ERR: still running; poll again.
+                NIXL_IN_PROG: still running, no errors observed yet; poll again.
+                NIXL_IN_PROG_WITH_ERR: still running, but at least one entry has errored; poll again.
                 Other negative value: transfer finished with errors; inspect events.
                 Requires trackFlags != 0.
             )pbdoc")

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -30,6 +30,25 @@ namespace py = pybind11;
 
 typedef std::map<std::string, std::vector<py::bytes>> nixl_py_notifs_t;
 
+/**
+ * Wrapper to hold nixl_xfer_entry_events_t for reuse across getXferStatus polling loops.
+ * Create once, pass to getXferStatus each poll to avoid per-call allocation.
+ */
+class nixlXferEntryEvents {
+public:
+    nixl_xfer_entry_events_t &events() { return data_; }
+    const nixl_xfer_entry_events_t &events() const { return data_; }
+    size_t size() const { return data_.size(); }
+    const nixl_xfer_entry_event_t &get(size_t i) const {
+        if (i >= data_.size())
+            throw std::out_of_range("index out of range");
+        return data_[i];
+    }
+
+private:
+    nixl_xfer_entry_events_t data_;
+};
+
 class nixlNotPostedError : public std::runtime_error {
 public:
     nixlNotPostedError(const char *what) : runtime_error(what) {}
@@ -94,7 +113,8 @@ void
 throw_nixl_exception(const nixl_status_t &status) {
     switch (status) {
     case NIXL_IN_PROG:
-        return; // not an error
+    case NIXL_ERR_IN_PROG:
+        return; // not an error (in progress)
     case NIXL_SUCCESS:
         return; // not an error
     case NIXL_ERR_NOT_POSTED:
@@ -185,7 +205,16 @@ PYBIND11_MODULE(_bindings, m) {
         .value("NIXL_ERR_REPOST_ACTIVE", NIXL_ERR_REPOST_ACTIVE)
         .value("NIXL_ERR_UNKNOWN", NIXL_ERR_UNKNOWN)
         .value("NIXL_ERR_NOT_SUPPORTED", NIXL_ERR_NOT_SUPPORTED)
+        .value("NIXL_ERR_REMOTE_DISCONNECT", NIXL_ERR_REMOTE_DISCONNECT)
+        .value("NIXL_ERR_CANCELED", NIXL_ERR_CANCELED)
+        .value("NIXL_ERR_NO_TELEMETRY", NIXL_ERR_NO_TELEMETRY)
+        .value("NIXL_ERR_IN_PROG", NIXL_ERR_IN_PROG)
         .export_values();
+
+    m.attr("NIXL_XFER_TRACK_ERRORS") =
+        py::int_(static_cast<uint32_t>(NIXL_XFER_TRACK_ERRORS));
+    m.attr("NIXL_XFER_TRACK_SUCCESSES") =
+        py::int_(static_cast<uint32_t>(NIXL_XFER_TRACK_SUCCESSES));
 
     py::class_<nixl_xfer_telem_t>(m, "nixlXferTelemetry")
         .def(py::init<>())
@@ -202,6 +231,34 @@ PYBIND11_MODULE(_bindings, m) {
         .def_readonly("totalBytes", &nixl_xfer_telem_t::totalBytes)
         .def_readonly("descCount", &nixl_xfer_telem_t::descCount);
 
+    py::class_<nixlXferEntryEvents>(m, "nixlXferEntryEvents",
+                                    "Reusable container for per-entry transfer events. "
+                                    "Create once, pass to getXferStatus each poll to avoid allocation.")
+        .def(py::init<>())
+        .def("__len__", &nixlXferEntryEvents::size)
+        .def("__getitem__",
+             [](const nixlXferEntryEvents &v, size_t i) {
+                 if (i >= v.size())
+                     throw py::index_error("index out of range");
+                 const auto &e = v.get(i);
+                 return py::make_tuple(e.index, static_cast<int>(e.status));
+             })
+        .def("__iter__",
+             [](const nixlXferEntryEvents &v) {
+                 py::list result;
+                 for (const auto &e : v.events())
+                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                 return py::iter(result);
+             },
+             py::keep_alive<0, 1>())
+        .def("to_list",
+             [](const nixlXferEntryEvents &v) {
+                 py::list result;
+                 for (const auto &e : v.events())
+                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                 return result;
+             },
+             "Convert to a Python list of (index, status) tuples");
 
     py::register_exception<nixlNotPostedError>(m, "nixlNotPostedError");
     py::register_exception<nixlInvalidParamError>(m, "nixlInvalidParamError");
@@ -592,7 +649,8 @@ PYBIND11_MODULE(_bindings, m) {
                py::object remote_indices,
                const std::string &notif_msg,
                const std::vector<uintptr_t> &backends,
-               bool skip_desc_merge) -> uintptr_t {
+               bool skip_desc_merge,
+               uint32_t track_flags) -> uintptr_t {
                 nixlXferReqH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
@@ -603,6 +661,7 @@ PYBIND11_MODULE(_bindings, m) {
                     extra_params.notif = notif_msg;
                 }
                 extra_params.skipDescMerge = skip_desc_merge;
+                extra_params.trackFlags = track_flags;
                 std::vector<int> local_indices_vec;
                 std::vector<int> remote_indices_vec;
 
@@ -649,7 +708,8 @@ PYBIND11_MODULE(_bindings, m) {
             py::arg("remote_indices"),
             py::arg("notif_msg") = std::string(""),
             py::arg("backend") = std::vector<uintptr_t>({}),
-            py::arg("skip_desc_merg") = false)
+            py::arg("skip_desc_merg") = false,
+            py::arg("track_flags") = 0)
         .def(
             "createXferReq",
             [](nixlAgent &agent,
@@ -658,7 +718,8 @@ PYBIND11_MODULE(_bindings, m) {
                const nixl_xfer_dlist_t &remote_descs,
                const std::string &remote_agent,
                const std::string &notif_msg,
-               const std::vector<uintptr_t> &backends) -> uintptr_t {
+               const std::vector<uintptr_t> &backends,
+               uint32_t track_flags) -> uintptr_t {
                 nixlXferReqH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
@@ -668,6 +729,7 @@ PYBIND11_MODULE(_bindings, m) {
                 if (notif_msg.size() > 0) {
                     extra_params.notif = notif_msg;
                 }
+                extra_params.trackFlags = track_flags;
                 nixl_status_t ret = agent.createXferReq(
                     operation, local_descs, remote_descs, remote_agent, handle, &extra_params);
 
@@ -680,6 +742,7 @@ PYBIND11_MODULE(_bindings, m) {
             py::arg("remote_agent"),
             py::arg("notif_msg") = std::string(""),
             py::arg("backend") = std::vector<uintptr_t>({}),
+            py::arg("track_flags") = 0,
             py::call_guard<py::gil_scoped_release>())
         .def(
             "estimateXferCost",
@@ -712,12 +775,35 @@ PYBIND11_MODULE(_bindings, m) {
             py::call_guard<py::gil_scoped_release>())
         .def(
             "getXferStatus",
-            [](nixlAgent &agent, uintptr_t reqh) -> nixl_status_t {
-                nixl_status_t ret = agent.getXferStatus((nixlXferReqH *)reqh);
-                throw_nixl_exception(ret);
-                return ret;
+            [](nixlAgent &agent, uintptr_t reqh, py::object events_obj) -> nixl_status_t {
+                if (events_obj.is_none()) {
+                    nixl_status_t ret = agent.getXferStatus((nixlXferReqH *)reqh);
+                    throw_nixl_exception(ret);
+                    return ret;
+                }
+                try {
+                    nixlXferEntryEvents &events =
+                        events_obj.cast<nixlXferEntryEvents &>();
+                    nixl_status_t ret =
+                        agent.getXferStatus((nixlXferReqH *)reqh, events.events());
+                    if (ret != NIXL_SUCCESS && ret != NIXL_ERR_IN_PROG)
+                        throw_nixl_exception(ret);
+                    return ret;
+                } catch (const py::cast_error &) {
+                    throw py::type_error(
+                        "events must be None or nixl.nixlXferEntryEvents");
+                }
             },
-            py::call_guard<py::gil_scoped_release>())
+            py::arg("reqh"),
+            py::arg("events") = py::none(),
+            py::call_guard<py::gil_scoped_release>(),
+            R"pbdoc(
+                Get transfer status. If events is None, returns overall status only.
+                If events is nixlXferEntryEvents, appends (index, status) events and returns status.
+                Create nixlXferEntryEvents once, pass to each poll to avoid allocation.
+                Requires trackFlags != 0 when events is provided.
+                Returns NIXL_ERR_IN_PROG when in progress, NIXL_SUCCESS when done.
+            )pbdoc")
         .def(
             "getXferTelemetry",
             [](nixlAgent &agent, uintptr_t reqh) -> nixl_xfer_telem_t {

--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -53,7 +53,9 @@ public:
 
     const nixl_xfer_entry_event_t &
     get(size_t i) const {
-        if (i >= data_.size()) throw std::out_of_range("index out of range");
+        if (i >= data_.size()) {
+            throw std::out_of_range("index out of range");
+        }
         return data_[i];
     }
 
@@ -251,24 +253,27 @@ PYBIND11_MODULE(_bindings, m) {
         .def("__len__", &nixlXferEntryEvents::size)
         .def("__getitem__",
              [](const nixlXferEntryEvents &v, size_t i) {
-                 if (i >= v.size()) throw py::index_error("index out of range");
+                 if (i >= v.size()) {
+                     throw py::index_error("index out of range");
+                 }
                  const auto &e = v.get(i);
                  return py::make_tuple(e.index, static_cast<int>(e.status));
              })
-        .def(
-            "__iter__",
-            [](const nixlXferEntryEvents &v) -> py::iterator {
-                py::list result;
-                for (const auto &e : v.events())
-                    result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
-                return py::iter(result);
-            })
+        .def("__iter__",
+             [](const nixlXferEntryEvents &v) -> py::iterator {
+                 py::list result;
+                 for (const auto &e : v.events()) {
+                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                 }
+                 return py::iter(result);
+             })
         .def(
             "to_list",
             [](const nixlXferEntryEvents &v) {
                 py::list result;
-                for (const auto &e : v.events())
+                for (const auto &e : v.events()) {
                     result.append(py::make_tuple(e.index, static_cast<int>(e.status)));
+                }
                 return result;
             },
             "Convert to a Python list of (index, status) tuples");
@@ -292,12 +297,14 @@ PYBIND11_MODULE(_bindings, m) {
                  static_assert(sizeof(nixlBasicDesc) == 3 * sizeof(uint64_t),
                                "nixlBasicDesc size mismatch");
                  // Check array shape and dtype
-                 if (descs.ndim() != 2 || descs.shape(1) != 3)
+                 if (descs.ndim() != 2 || descs.shape(1) != 3) {
                      throw std::invalid_argument("descs must be a Nx3 numpy array");
+                 }
                  if (!py::dtype::of<uint64_t>().equal(descs.dtype()) &&
-                     !py::dtype::of<int64_t>().equal(descs.dtype()))
+                     !py::dtype::of<int64_t>().equal(descs.dtype())) {
                      throw std::invalid_argument(
                          "descs must be a Nx3 numpy array of uint64 or int64");
+                 }
                  if (!(descs.flags() & py::array::c_style)) {
                      throw std::invalid_argument("descs must be a C-contiguous numpy array");
                  }
@@ -360,7 +367,9 @@ PYBIND11_MODULE(_bindings, m) {
              [](nixl_xfer_dlist_t &list, const py::tuple &desc) {
                  int ret = (nixl_status_t)list.getIndex(nixlBasicDesc(
                      desc[0].cast<uintptr_t>(), desc[1].cast<size_t>(), desc[2].cast<uint64_t>()));
-                 if (ret < 0) throw_nixl_exception((nixl_status_t)ret);
+                 if (ret < 0) {
+                     throw_nixl_exception((nixl_status_t)ret);
+                 }
                  return (int)ret;
              })
         .def("remDesc", &nixl_xfer_dlist_t::remDesc)
@@ -382,11 +391,13 @@ PYBIND11_MODULE(_bindings, m) {
     py::class_<nixl_reg_dlist_t>(m, "nixlRegDList")
         .def(py::init<nixl_mem_t, int>(), py::arg("type"), py::arg("init_size") = 0)
         .def(py::init([](nixl_mem_t mem, py::array descs) {
-            if (descs.ndim() != 2 || descs.shape(1) != 3)
+            if (descs.ndim() != 2 || descs.shape(1) != 3) {
                 throw std::invalid_argument("descs must be a Nx3 numpy array");
+            }
             if (!py::dtype::of<uint64_t>().equal(descs.dtype()) &&
-                !py::dtype::of<int64_t>().equal(descs.dtype()))
+                !py::dtype::of<int64_t>().equal(descs.dtype())) {
                 throw std::invalid_argument("descs must be a Nx3 numpy array of uint64 or int64");
+            }
             if (!(descs.flags() & py::array::c_style)) {
                 throw std::invalid_argument("descs must be a C-contiguous numpy array");
             }
@@ -464,7 +475,9 @@ PYBIND11_MODULE(_bindings, m) {
                                                       desc[1].cast<size_t>(),
                                                       desc[2].cast<uint64_t>(),
                                                       desc[3].cast<std::string>()));
-                 if (ret < 0) throw_nixl_exception((nixl_status_t)ret);
+                 if (ret < 0) {
+                     throw_nixl_exception((nixl_status_t)ret);
+                 }
                  return ret;
              })
         .def("trim", &nixl_reg_dlist_t::trim)
@@ -522,8 +535,9 @@ PYBIND11_MODULE(_bindings, m) {
                  nixl_mem_list_t mems;
                  std::vector<std::string> mems_vec;
                  throw_nixl_exception(agent.getPluginParams(type, mems, params));
-                 for (const auto &elm : mems)
+                 for (const auto &elm : mems) {
                      mems_vec.push_back(nixlEnumStrings::memTypeStr(elm));
+                 }
                  return std::make_pair(params, mems_vec);
              })
         .def("getBackendParams",
@@ -534,8 +548,9 @@ PYBIND11_MODULE(_bindings, m) {
                  std::vector<std::string> mems_vec;
                  throw_nixl_exception(
                      agent.getBackendParams((nixlBackendH *)backend, mems, params));
-                 for (const auto &elm : mems)
+                 for (const auto &elm : mems) {
                      mems_vec.push_back(nixlEnumStrings::memTypeStr(elm));
+                 }
                  return std::make_pair(params, mems_vec);
              })
         .def(
@@ -555,8 +570,9 @@ PYBIND11_MODULE(_bindings, m) {
                const std::vector<uintptr_t> &backends) -> nixl_status_t {
                 nixl_opt_args_t extra_params;
                 nixl_status_t ret;
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 ret = agent.registerMem(descs, &extra_params);
                 throw_nixl_exception(ret);
@@ -572,8 +588,9 @@ PYBIND11_MODULE(_bindings, m) {
                const std::vector<uintptr_t> &backends) -> nixl_status_t {
                 nixl_opt_args_t extra_params;
                 nixl_status_t ret;
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 ret = agent.deregisterMem(descs, &extra_params);
                 throw_nixl_exception(ret);
@@ -606,8 +623,9 @@ PYBIND11_MODULE(_bindings, m) {
                const std::vector<uintptr_t> &backends) {
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 nixl_status_t ret = agent.makeConnection(remote_agent, &extra_params);
                 throw_nixl_exception(ret);
@@ -623,8 +641,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixlDlistH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 throw_nixl_exception(agent.prepXferDlist(agent_name, descs, handle, &extra_params));
 
@@ -642,8 +661,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixlDlistH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 throw_nixl_exception(agent.prepXferDlist(descs, handle, &extra_params));
 
@@ -667,8 +687,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixlXferReqH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 if (notif_msg.size() > 0) {
                     extra_params.notif = notif_msg;
@@ -681,14 +702,17 @@ PYBIND11_MODULE(_bindings, m) {
                 auto init_indices_lambda = [](py::object &indices) -> std::vector<int> {
                     if (py::isinstance<py::array>(indices)) {
                         auto indices_array = indices.cast<py::array_t<uint32_t>>();
-                        if (indices_array.ndim() != 1)
+                        if (indices_array.ndim() != 1) {
                             throw std::invalid_argument("indices numpy array must be 1D");
+                        }
                         if (!py::dtype::of<uint32_t>().equal(indices_array.dtype()) &&
-                            !py::dtype::of<int32_t>().equal(indices_array.dtype()))
+                            !py::dtype::of<int32_t>().equal(indices_array.dtype())) {
                             throw std::invalid_argument(
                                 "indices numpy array must be 1D of uint32 or int32");
-                        if (!(indices_array.flags() & py::array::c_style))
+                        }
+                        if (!(indices_array.flags() & py::array::c_style)) {
                             throw std::invalid_argument("indices numpy array must be C-contiguous");
+                        }
                         // We assume that the indices array matches the nixlBasicDesc layout so we
                         // can simply memcpy
                         std::vector<int> ret(indices_array.size());
@@ -736,8 +760,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixlXferReqH *handle = nullptr;
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
                 if (notif_msg.size() > 0) {
                     extra_params.notif = notif_msg;
@@ -800,7 +825,9 @@ PYBIND11_MODULE(_bindings, m) {
             py::arg("reqh"),
             R"pbdoc(
                 Get aggregate transfer status. Raises an exception on error.
-                Returns NIXL_SUCCESS when complete or NIXL_IN_PROG while running.
+                Returns NIXL_SUCCESS when complete, NIXL_IN_PROG while running with no
+                aggregate failure yet, or NIXL_IN_PROG_WITH_ERR while running but at least
+                one entry has failed (use getXferStatus(reqh, events) for per-entry detail).
             )pbdoc")
         .def(
             "getXferStatus",
@@ -857,8 +884,9 @@ PYBIND11_MODULE(_bindings, m) {
 
                 {
                     py::gil_scoped_release release;
-                    for (uintptr_t backend : backends)
+                    for (uintptr_t backend : backends) {
                         extra_params.backends.push_back((nixlBackendH *)backend);
+                    }
 
                     nixl_status_t ret = agent.getNotifs(new_notifs, &extra_params);
 
@@ -866,8 +894,9 @@ PYBIND11_MODULE(_bindings, m) {
                 }
 
                 for (const auto &pair : new_notifs) {
-                    for (const auto &str : pair.second)
+                    for (const auto &str : pair.second) {
                         notif_map[pair.first].push_back(py::bytes(str));
+                    }
                 }
                 return notif_map;
             },
@@ -882,8 +911,9 @@ PYBIND11_MODULE(_bindings, m) {
                 nixl_opt_args_t extra_params;
                 nixl_status_t ret;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
 
 
                 ret = agent.genNotif(remote_agent, msg, &extra_params);
@@ -912,8 +942,9 @@ PYBIND11_MODULE(_bindings, m) {
 
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
                 extra_params.includeConnInfo = inc_conn_info;
 
                 throw_nixl_exception(agent.getLocalPartialMD(descs, ret_str, &extra_params));
@@ -959,8 +990,9 @@ PYBIND11_MODULE(_bindings, m) {
 
                 nixl_opt_args_t extra_params;
 
-                for (uintptr_t backend : backends)
+                for (uintptr_t backend : backends) {
                     extra_params.backends.push_back((nixlBackendH *)backend);
+                }
                 extra_params.includeConnInfo = inc_conn_info;
                 extra_params.ipAddr = ip_addr;
                 extra_params.port = port;

--- a/src/bindings/rust/build.rs
+++ b/src/bindings/rust/build.rs
@@ -223,7 +223,6 @@ fn build_stubs(cc_builder: &mut cc::Build) {
     // Get the output path for bindings
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    // Generate bindings with minimal configuration
     bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg("-std=c++17")

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -979,6 +979,35 @@ impl Agent {
         }
     }
 
+    /// Checks the status of a transfer request with per-entry events.
+    ///
+    /// The transfer must have been created with `track_flags != 0` (via OptArgs::set_track_flags).
+    /// Create `XferEntryEvents` once, pass to each poll to avoid allocation.
+    ///
+    /// # Arguments
+    /// * `req` - Transfer request handle after `post_xfer_req`
+    /// * `events` - Reusable events container (events are appended on each call)
+    pub fn get_xfer_status_with_events(
+        &self,
+        req: &XferRequest,
+        events: &XferEntryEvents,
+    ) -> Result<XferStatus, NixlError> {
+        let status = unsafe {
+            nixl_capi_get_xfer_status_with_events(
+                self.inner.write().unwrap().handle.as_ptr(),
+                req.handle(),
+                events.inner.as_ptr(),
+            )
+        };
+
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(XferStatus::Success),
+            NIXL_CAPI_IN_PROG => Ok(XferStatus::InProgress),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
     /// Queries the backend for a transfer request
     ///
     /// # Arguments

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -996,7 +996,7 @@ impl Agent {
             nixl_capi_get_xfer_status_with_events(
                 self.inner.write().unwrap().handle.as_ptr(),
                 req.handle(),
-                events.inner.as_ptr(),
+                events.as_ptr(),
             )
         };
 

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -40,6 +40,8 @@ pub struct Agent {
 pub enum XferStatus {
     Success,
     InProgress,
+    /// In progress, but at least one entry has already errored (mirrors `NIXL_IN_PROG_WITH_ERR`).
+    InProgressWithErr,
 }
 
 impl XferStatus {
@@ -1003,7 +1005,9 @@ impl Agent {
         match status {
             NIXL_CAPI_SUCCESS => Ok(XferStatus::Success),
             NIXL_CAPI_IN_PROG => Ok(XferStatus::InProgress),
+            NIXL_CAPI_IN_PROG_WITH_ERR => Ok(XferStatus::InProgressWithErr),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_SUPPORTED => Err(NixlError::NotSupported),
             _ => Err(NixlError::BackendError),
         }
     }

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -48,13 +48,17 @@ use bindings::{
     nixl_capi_destroy_params, nixl_capi_destroy_reg_dlist, nixl_capi_destroy_string_list,
     nixl_capi_destroy_xfer_dlist, nixl_capi_get_available_plugins, nixl_capi_get_backend_params,
     nixl_capi_get_local_md, nixl_capi_get_notifs, nixl_capi_get_plugin_params,
-    nixl_capi_get_xfer_status, nixl_capi_invalidate_remote_md, nixl_capi_load_remote_md,
+    nixl_capi_get_xfer_status, nixl_capi_get_xfer_status_with_events,
+    nixl_capi_xfer_entry_events_create, nixl_capi_xfer_entry_events_destroy,
+    nixl_capi_xfer_entry_events_size, nixl_capi_xfer_entry_events_get,
+    nixl_capi_invalidate_remote_md, nixl_capi_load_remote_md,
     nixl_capi_mem_list_get, nixl_capi_mem_list_is_empty, nixl_capi_mem_list_size,
     nixl_capi_mem_type_t, nixl_capi_mem_type_to_string, nixl_capi_notif_map_clear,
     nixl_capi_notif_map_get_agent_at, nixl_capi_notif_map_get_notif,
     nixl_capi_notif_map_get_notifs_size, nixl_capi_notif_map_size, nixl_capi_opt_args_add_backend,
     nixl_capi_opt_args_get_has_notif, nixl_capi_opt_args_get_notif_msg,
-    nixl_capi_opt_args_get_skip_desc_merge, nixl_capi_opt_args_set_has_notif,
+    nixl_capi_opt_args_get_skip_desc_merge, nixl_capi_opt_args_set_track_flags,
+    nixl_capi_opt_args_get_track_flags, nixl_capi_opt_args_set_has_notif,
     nixl_capi_opt_args_set_notif_msg, nixl_capi_opt_args_set_skip_desc_merge,
     nixl_capi_params_create_iterator, nixl_capi_params_destroy_iterator, nixl_capi_params_is_empty,
     nixl_capi_params_iterator_next, nixl_capi_post_xfer_req, nixl_capi_reg_dlist_add_desc,
@@ -70,6 +74,10 @@ use bindings::{
     nixl_capi_opt_args_set_port, nixl_capi_get_xfer_telemetry,
     nixl_capi_create_params, nixl_capi_params_add, nixl_capi_is_stub
 };
+
+// Per-entry tracking flags (match NIXL_CAPI_XFER_TRACK_* in wrapper.h)
+pub const XFER_TRACK_ERRORS: u32 = 1 << 0;
+pub const XFER_TRACK_SUCCESSES: u32 = 1 << 1;
 
 // Re-export status codes
 pub use bindings::{
@@ -374,6 +382,30 @@ impl OptArgs {
         let status = unsafe { nixl_capi_opt_args_set_ip_addr(self.inner.as_ptr(), c_str.as_ptr()) };
         match status {
             NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Set per-entry tracking flags for create_xfer_req/make_xfer_req.
+    /// Use NIXL_CAPI_XFER_TRACK_ERRORS and/or NIXL_CAPI_XFER_TRACK_SUCCESSES.
+    pub fn set_track_flags(&mut self, track_flags: u32) -> Result<(), NixlError> {
+        let status =
+            unsafe { nixl_capi_opt_args_set_track_flags(self.inner.as_ptr(), track_flags) };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Get per-entry tracking flags.
+    pub fn track_flags(&self) -> Result<u32, NixlError> {
+        let mut track_flags = 0u32;
+        let status =
+            unsafe { nixl_capi_opt_args_get_track_flags(self.inner.as_ptr(), &mut track_flags) };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(track_flags),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
             _ => Err(NixlError::BackendError),
         }

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -84,8 +84,10 @@ pub use bindings::{
     nixl_capi_status_t_NIXL_CAPI_ERROR_BACKEND as NIXL_CAPI_ERROR_BACKEND,
     nixl_capi_status_t_NIXL_CAPI_ERROR_INVALID_PARAM as NIXL_CAPI_ERROR_INVALID_PARAM,
     nixl_capi_status_t_NIXL_CAPI_IN_PROG as NIXL_CAPI_IN_PROG,
+    nixl_capi_status_t_NIXL_CAPI_IN_PROG_WITH_ERR as NIXL_CAPI_IN_PROG_WITH_ERR,
     nixl_capi_status_t_NIXL_CAPI_SUCCESS as NIXL_CAPI_SUCCESS,
-    nixl_capi_status_t_NIXL_CAPI_ERROR_NO_TELEMETRY as NIXL_CAPI_ERROR_NO_TELEMETRY
+    nixl_capi_status_t_NIXL_CAPI_ERROR_NO_TELEMETRY as NIXL_CAPI_ERROR_NO_TELEMETRY,
+    nixl_capi_status_t_NIXL_CAPI_ERROR_NOT_SUPPORTED as NIXL_CAPI_ERROR_NOT_SUPPORTED
 };
 
 mod agent;
@@ -125,6 +127,8 @@ pub enum NixlError {
     FailedToCreateBackend,
     #[error("Telemetry is not enabled or transfer is not complete")]
     NoTelemetry,
+    #[error("Operation not supported by this backend")]
+    NotSupported,
 }
 
 /// A safe wrapper around NIXL memory list
@@ -388,7 +392,7 @@ impl OptArgs {
     }
 
     /// Set per-entry tracking flags for create_xfer_req/make_xfer_req.
-    /// Use NIXL_CAPI_XFER_TRACK_ERRORS and/or NIXL_CAPI_XFER_TRACK_SUCCESSES.
+    /// Use [`XFER_TRACK_ERRORS`] and/or [`XFER_TRACK_SUCCESSES`].
     pub fn set_track_flags(&mut self, track_flags: u32) -> Result<(), NixlError> {
         let status =
             unsafe { nixl_capi_opt_args_set_track_flags(self.inner.as_ptr(), track_flags) };

--- a/src/bindings/rust/src/xfer.rs
+++ b/src/bindings/rust/src/xfer.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,15 +36,17 @@ impl XferEntryEvents {
         }
     }
 
-    /// Returns the number of events.
-    pub fn len(&self) -> Result<usize, NixlError> {
+    /// Returns the number of events accumulated so far.
+    pub fn len(&self) -> usize {
         let mut size = 0;
         let status = unsafe { nixl_capi_xfer_entry_events_size(self.inner.as_ptr(), &mut size) };
-        match status {
-            NIXL_CAPI_SUCCESS => Ok(size),
-            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
-            _ => Err(NixlError::BackendError),
-        }
+        assert_eq!(status, NIXL_CAPI_SUCCESS, "nixl_capi_xfer_entry_events_size failed");
+        size
+    }
+
+    /// Returns `true` if no events have been accumulated yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Returns the event at the given index as (descriptor_index, status).
@@ -71,8 +73,12 @@ impl XferEntryEvents {
         XferEntryEventsIterator {
             events: self,
             index: 0,
-            length: self.len().unwrap_or(0),
+            length: self.len(),
         }
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut bindings::nixl_capi_xfer_entry_events_s {
+        self.inner.as_ptr()
     }
 }
 
@@ -116,8 +122,10 @@ impl Iterator for XferEntryEventsIterator<'_> {
     }
 }
 
+// SAFETY: XferEntryEvents owns its heap allocation and can be moved between threads.
+// It is NOT Sync: the underlying deque is mutated by get_xfer_status_with_events
+// and has no internal synchronization. Use Mutex<XferEntryEvents> for multi-thread sharing.
 unsafe impl Send for XferEntryEvents {}
-unsafe impl Sync for XferEntryEvents {}
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/bindings/rust/src/xfer.rs
+++ b/src/bindings/rust/src/xfer.rs
@@ -15,6 +15,110 @@
 
 use super::*;
 
+/// Reusable container for per-entry transfer events.
+/// Create once, pass to `get_xfer_status_with_events` each poll to avoid allocation.
+#[derive(Debug)]
+pub struct XferEntryEvents {
+    inner: NonNull<bindings::nixl_capi_xfer_entry_events_s>,
+}
+
+impl XferEntryEvents {
+    /// Creates a new empty events container.
+    pub fn new() -> Result<Self, NixlError> {
+        let mut events = ptr::null_mut();
+        let status = unsafe { nixl_capi_xfer_entry_events_create(&mut events) };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(Self {
+                inner: NonNull::new(events).ok_or(NixlError::BackendError)?,
+            }),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Returns the number of events.
+    pub fn len(&self) -> Result<usize, NixlError> {
+        let mut size = 0;
+        let status = unsafe { nixl_capi_xfer_entry_events_size(self.inner.as_ptr(), &mut size) };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(size),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Returns the event at the given index as (descriptor_index, status).
+    pub fn get(&self, index: usize) -> Result<(usize, i32), NixlError> {
+        let mut idx_out = 0;
+        let mut status_out = 0;
+        let status = unsafe {
+            nixl_capi_xfer_entry_events_get(
+                self.inner.as_ptr(),
+                index,
+                &mut idx_out,
+                &mut status_out,
+            )
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok((idx_out, status_out)),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Returns an iterator over (index, status) events.
+    pub fn iter(&self) -> XferEntryEventsIterator<'_> {
+        XferEntryEventsIterator {
+            events: self,
+            index: 0,
+            length: self.len().unwrap_or(0),
+        }
+    }
+}
+
+impl Default for XferEntryEvents {
+    fn default() -> Self {
+        Self::new().expect("Failed to create XferEntryEvents")
+    }
+}
+
+impl Drop for XferEntryEvents {
+    fn drop(&mut self) {
+        unsafe {
+            nixl_capi_xfer_entry_events_destroy(self.inner.as_ptr());
+        }
+    }
+}
+
+/// Iterator over per-entry transfer events.
+pub struct XferEntryEventsIterator<'a> {
+    events: &'a XferEntryEvents,
+    index: usize,
+    length: usize,
+}
+
+impl Iterator for XferEntryEventsIterator<'_> {
+    type Item = Result<(usize, i32), NixlError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.length {
+            None
+        } else {
+            let result = self.events.get(self.index);
+            self.index += 1;
+            Some(result)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.length - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+unsafe impl Send for XferEntryEvents {}
+unsafe impl Sync for XferEntryEvents {}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum XferOp {

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -787,15 +787,21 @@ nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t *s
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t *idx_out, int *status_out) {
+nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events,
+                                size_t index,
+                                size_t *idx_out,
+                                int *status_out) {
     using fn_t = nixl_capi_status_t (*)(nixl_capi_xfer_entry_events_t, size_t, size_t *, int *);
     static fn_t real = (fn_t)resolve("nixl_capi_xfer_entry_events_get");
     return real(events, index, idx_out, status_out);
 }
 
 nixl_capi_status_t
-nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events) {
-    using fn_t = nixl_capi_status_t (*)(nixl_capi_agent_t, nixl_capi_xfer_req_t, nixl_capi_xfer_entry_events_t);
+nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent,
+                                      nixl_capi_xfer_req_t req_hndl,
+                                      nixl_capi_xfer_entry_events_t events) {
+    using fn_t = nixl_capi_status_t (*)(
+        nixl_capi_agent_t, nixl_capi_xfer_req_t, nixl_capi_xfer_entry_events_t);
     static fn_t real = (fn_t)resolve("nixl_capi_get_xfer_status_with_events");
     return real(agent, req_hndl, events);
 }

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -98,6 +98,7 @@ struct nixl_capi_xfer_req_s { /* empty */ };
 struct nixl_capi_notif_map_s { /* empty */ };
 struct nixl_capi_xfer_dlist_handle_s { /* empty */ };
 struct nixl_capi_query_resp_list_s { /* empty */ };
+struct nixl_capi_xfer_entry_events_s { /* empty */ };
 // clang-format on
 
 // ---- Core agent functions ----
@@ -425,6 +426,20 @@ nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool *skip_mer
 }
 
 nixl_capi_status_t
+nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, uint32_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_set_track_flags");
+    return real(args, track_flags);
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t *track_flags) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, uint32_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_track_flags");
+    return real(args, track_flags);
+}
+
+nixl_capi_status_t
 nixl_capi_opt_args_set_ip_addr(nixl_capi_opt_args_t args, const char *ip_addr) {
     using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, const char *);
     static fn_t real = (fn_t)resolve("nixl_capi_opt_args_set_ip_addr");
@@ -748,6 +763,41 @@ nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl
     using fn_t = nixl_capi_status_t (*)(nixl_capi_agent_t, nixl_capi_xfer_req_t);
     static fn_t real = (fn_t)resolve("nixl_capi_get_xfer_status");
     return real(agent, req_hndl);
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t *events) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_xfer_entry_events_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_xfer_entry_events_create");
+    return real(events);
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_xfer_entry_events_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_xfer_entry_events_destroy");
+    return real(events);
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t *size) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_xfer_entry_events_t, size_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_xfer_entry_events_size");
+    return real(events, size);
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t *idx_out, int *status_out) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_xfer_entry_events_t, size_t, size_t *, int *);
+    static fn_t real = (fn_t)resolve("nixl_capi_xfer_entry_events_get");
+    return real(events, index, idx_out, status_out);
+}
+
+nixl_capi_status_t
+nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_agent_t, nixl_capi_xfer_req_t, nixl_capi_xfer_entry_events_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_get_xfer_status_with_events");
+    return real(agent, req_hndl, events);
 }
 
 nixl_capi_status_t

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -99,6 +99,7 @@ struct nixl_capi_notif_map_s { /* empty */ };
 struct nixl_capi_xfer_dlist_handle_s { /* empty */ };
 struct nixl_capi_query_resp_list_s { /* empty */ };
 struct nixl_capi_xfer_entry_events_s { /* empty */ };
+
 // clang-format on
 
 // ---- Core agent functions ----

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -2270,3 +2270,21 @@ fn test_desc_list_serialize_with_real_storage() {
     test_serialization!(XferDescList, storage_list.iter());
     test_serialization!(RegDescList, storage_list.iter());
 }
+
+#[test]
+fn test_xfer_entry_events_and_track_flags() {
+    // Verify XferEntryEvents container and OptArgs::set_track_flags API
+    let events = XferEntryEvents::new().expect("XferEntryEvents::new");
+    assert!(events.is_empty());
+    assert_eq!(events.len(), 0);
+    assert!(events.iter().next().is_none());
+
+    let mut opt_args = OptArgs::new().expect("OptArgs::new");
+    opt_args
+        .set_track_flags(XFER_TRACK_ERRORS | XFER_TRACK_SUCCESSES)
+        .expect("set_track_flags");
+    assert_eq!(
+        opt_args.track_flags().unwrap(),
+        XFER_TRACK_ERRORS | XFER_TRACK_SUCCESSES
+    );
+}

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -2280,9 +2280,17 @@ fn test_xfer_entry_events_and_track_flags() {
     assert!(events.iter().next().is_none());
 
     let mut opt_args = OptArgs::new().expect("OptArgs::new");
+    assert_eq!(opt_args.track_flags().unwrap(), 0);
+
+    opt_args.set_track_flags(XFER_TRACK_ERRORS).expect("set_track_flags errors");
+    assert_eq!(opt_args.track_flags().unwrap(), XFER_TRACK_ERRORS);
+
+    opt_args.set_track_flags(XFER_TRACK_SUCCESSES).expect("set_track_flags successes");
+    assert_eq!(opt_args.track_flags().unwrap(), XFER_TRACK_SUCCESSES);
+
     opt_args
         .set_track_flags(XFER_TRACK_ERRORS | XFER_TRACK_SUCCESSES)
-        .expect("set_track_flags");
+        .expect("set_track_flags combined");
     assert_eq!(
         opt_args.track_flags().unwrap(),
         XFER_TRACK_ERRORS | XFER_TRACK_SUCCESSES

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -100,6 +100,10 @@ struct nixl_capi_query_resp_list_s {
     std::vector<nixl_query_resp_t> responses;
 };
 
+struct nixl_capi_xfer_entry_events_s {
+    nixl_xfer_entry_events_t events;
+};
+
 nixl_capi_status_t
 nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent)
 {
@@ -714,6 +718,36 @@ nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_mer
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
   }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags)
+{
+    if (!args) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        args->args.trackFlags = track_flags;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t* track_flags)
+{
+    if (!args || !track_flags) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        *track_flags = args->args.trackFlags;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -1554,11 +1588,91 @@ nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl
 
   try {
     nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG || ret == NIXL_ERR_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
   }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t* events)
+{
+    if (!events) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        *events = new nixl_capi_xfer_entry_events_s;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events)
+{
+    if (!events) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        delete events;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t* size)
+{
+    if (!events || !size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        *size = events->events.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t* idx_out, int* status_out)
+{
+    if (!events || !idx_out || !status_out) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        if (index >= events->events.size()) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        const auto& e = events->events[index];
+        *idx_out = e.index;
+        *status_out = static_cast<int>(e.status);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events)
+{
+    if (!agent || !req_hndl || !events) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+    try {
+        nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req, events->events);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG || ret == NIXL_ERR_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -721,8 +721,7 @@ nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_mer
 }
 
 nixl_capi_status_t
-nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags)
-{
+nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags) {
     if (!args) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -736,8 +735,7 @@ nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_fla
 }
 
 nixl_capi_status_t
-nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t* track_flags)
-{
+nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t *track_flags) {
     if (!args || !track_flags) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -1588,7 +1586,10 @@ nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl
 
   try {
     nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG || ret == NIXL_ERR_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+    if (ret == NIXL_SUCCESS) return NIXL_CAPI_SUCCESS;
+    if (ret == NIXL_IN_PROG || ret == NIXL_IN_PROG_WITH_ERR) return NIXL_CAPI_IN_PROG;
+    if (ret == NIXL_ERR_INVALID_PARAM) return NIXL_CAPI_ERROR_INVALID_PARAM;
+    return NIXL_CAPI_ERROR_BACKEND;
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1596,8 +1597,7 @@ nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t* events)
-{
+nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t *events) {
     if (!events) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -1611,8 +1611,7 @@ nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t* events)
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events)
-{
+nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events) {
     if (!events) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -1626,8 +1625,7 @@ nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events)
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t* size)
-{
+nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t *size) {
     if (!events || !size) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -1641,8 +1639,10 @@ nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t* s
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t* idx_out, int* status_out)
-{
+nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events,
+                                size_t index,
+                                size_t *idx_out,
+                                int *status_out) {
     if (!events || !idx_out || !status_out) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
@@ -1650,7 +1650,7 @@ nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t ind
         if (index >= events->events.size()) {
             return NIXL_CAPI_ERROR_INVALID_PARAM;
         }
-        const auto& e = events->events[index];
+        const auto &e = events->events[index];
         *idx_out = e.index;
         *status_out = static_cast<int>(e.status);
         return NIXL_CAPI_SUCCESS;
@@ -1661,14 +1661,18 @@ nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t ind
 }
 
 nixl_capi_status_t
-nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events)
-{
+nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent,
+                                      nixl_capi_xfer_req_t req_hndl,
+                                      nixl_capi_xfer_entry_events_t events) {
     if (!agent || !req_hndl || !events) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
     try {
         nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req, events->events);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG || ret == NIXL_ERR_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+        if (ret == NIXL_SUCCESS) return NIXL_CAPI_SUCCESS;
+        if (ret == NIXL_IN_PROG || ret == NIXL_IN_PROG_WITH_ERR) return NIXL_CAPI_IN_PROG;
+        if (ret == NIXL_ERR_INVALID_PARAM) return NIXL_CAPI_ERROR_INVALID_PARAM;
+        return NIXL_CAPI_ERROR_BACKEND;
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -44,39 +44,39 @@ nixl_capi_thread_sync_to_nixl(nixl_capi_thread_sync_t sync) {
 extern "C" {
 // Internal struct definitions to match our opaque types
 struct nixl_capi_agent_s {
-  nixlAgent* inner;
+    nixlAgent *inner;
 };
 
 struct nixl_capi_string_list_s {
-  std::vector<std::string> strings;
+    std::vector<std::string> strings;
 };
 
 struct nixl_capi_params_s {
-  nixl_b_params_t params;
+    nixl_b_params_t params;
 };
 
 struct nixl_capi_mem_list_s {
-  nixl_mem_list_t mems;
+    nixl_mem_list_t mems;
 };
 
 struct nixl_capi_backend_s {
-  nixlBackendH* backend;
+    nixlBackendH *backend;
 };
 
 struct nixl_capi_opt_args_s {
-  nixl_opt_args_t args;
+    nixl_opt_args_t args;
 };
 
 struct nixl_capi_param_iter_s {
-  nixl_b_params_t::iterator current;
-  nixl_b_params_t::iterator end;
-  std::string current_key;    // Keep string alive while iterator exists
-  std::string current_value;  // Keep string alive while iterator exists
+    nixl_b_params_t::iterator current;
+    nixl_b_params_t::iterator end;
+    std::string current_key; // Keep string alive while iterator exists
+    std::string current_value; // Keep string alive while iterator exists
 };
 
 // Internal structs for descriptor lists
 struct nixl_capi_xfer_dlist_s {
-  nixl_xfer_dlist_t* dlist;
+    nixl_xfer_dlist_t *dlist;
 };
 
 struct nixl_capi_xfer_dlist_handle_s {
@@ -84,16 +84,16 @@ struct nixl_capi_xfer_dlist_handle_s {
 };
 
 struct nixl_capi_reg_dlist_s {
-  nixl_reg_dlist_t* dlist;
+    nixl_reg_dlist_t *dlist;
 };
 
 // Internal struct for transfer request handle
 struct nixl_capi_xfer_req_s {
-  nixlXferReqH* req;
+    nixlXferReqH *req;
 };
 
 struct nixl_capi_notif_map_s {
-  nixl_notifs_t notif_map;
+    nixl_notifs_t notif_map;
 };
 
 struct nixl_capi_query_resp_list_s {
@@ -105,26 +105,25 @@ struct nixl_capi_xfer_entry_events_s {
 };
 
 nixl_capi_status_t
-nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent)
-{
-  if (!name || !agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_create_agent(const char *name, nixl_capi_agent_t *agent) {
+    if (!name || !agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-      nixlAgentConfig nixl_config;
-      nixl_config.useProgThread = true;
-      std::string agent_name = name;
-      auto inner = new nixlAgent(agent_name, nixl_config);
+    try {
+        nixlAgentConfig nixl_config;
+        nixl_config.useProgThread = true;
+        std::string agent_name = name;
+        auto inner = new nixlAgent(agent_name, nixl_config);
 
-      auto agent_handle = new nixl_capi_agent_s;
-      agent_handle->inner = inner;
-      *agent = agent_handle;
-      return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        auto agent_handle = new nixl_capi_agent_s;
+        agent_handle->inner = inner;
+        *agent = agent_handle;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -172,35 +171,34 @@ nixl_capi_destroy_agent(nixl_capi_agent_t agent) {
 }
 
 nixl_capi_status_t
-nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len)
-{
-  if (!agent || !data || !len) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    nixl_blob_t blob;
-    nixl_status_t ret = agent->inner->getLocalMD(blob);
-    if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_get_local_md(nixl_capi_agent_t agent, void **data, size_t *len) {
+    if (!agent || !data || !len) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    // Allocate memory for the blob data
-    void* blob_data = malloc(blob.size());
-    if (!blob_data) {
-      return NIXL_CAPI_ERROR_BACKEND;
+    try {
+        nixl_blob_t blob;
+        nixl_status_t ret = agent->inner->getLocalMD(blob);
+        if (ret != NIXL_SUCCESS) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        // Allocate memory for the blob data
+        void *blob_data = malloc(blob.size());
+        if (!blob_data) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        // Copy the data
+        memcpy(blob_data, blob.data(), blob.size());
+        *data = blob_data;
+        *len = blob.size();
+
+        return NIXL_CAPI_SUCCESS;
     }
-
-    // Copy the data
-    memcpy(blob_data, blob.data(), blob.size());
-    *data = blob_data;
-    *len = blob.size();
-
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -235,69 +233,66 @@ nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
 }
 
 nixl_capi_status_t
-nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name)
-{
-  if (!agent || !data || !len || !agent_name) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    // Create blob from input data - use the constructor that takes void*
-    nixl_blob_t blob;
-    blob.assign((const char*)data, len);
-    std::string name;
-
-    // Load the metadata
-    nixl_status_t ret = agent->inner->loadRemoteMD(blob, name);
-    if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void *data, size_t len, char **agent_name) {
+    if (!agent || !data || !len || !agent_name) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    // Allocate and copy the agent name
-    char* name_str = strdup(name.c_str());
-    if (!name_str) {
-      return NIXL_CAPI_ERROR_BACKEND;
-    }
-    *agent_name = name_str;
+    try {
+        // Create blob from input data - use the constructor that takes void*
+        nixl_blob_t blob;
+        blob.assign((const char *)data, len);
+        std::string name;
 
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        // Load the metadata
+        nixl_status_t ret = agent->inner->loadRemoteMD(blob, name);
+        if (ret != NIXL_SUCCESS) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        // Allocate and copy the agent name
+        char *name_str = strdup(name.c_str());
+        if (!name_str) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+        *agent_name = name_str;
+
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_invalidate_remote_md(nixl_capi_agent_t agent, const char* remote_agent)
-{
-  if (!agent || !remote_agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_invalidate_remote_md(nixl_capi_agent_t agent, const char *remote_agent) {
+    if (!agent || !remote_agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_status_t ret = agent->inner->invalidateRemoteMD(std::string(remote_agent));
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_status_t ret = agent->inner->invalidateRemoteMD(std::string(remote_agent));
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args) {
+    if (!agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
-    nixl_status_t ret = agent->inner->sendLocalMD(args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixl_status_t ret = agent->inner->sendLocalMD(args);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -318,406 +313,395 @@ nixl_capi_send_local_partial_md(nixl_capi_agent_t agent,
 }
 
 nixl_capi_status_t
-nixl_capi_fetch_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !remote_name) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_fetch_remote_md(nixl_capi_agent_t agent,
+                          const char *remote_name,
+                          nixl_capi_opt_args_t opt_args) {
+    if (!agent || !remote_name) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
-    nixl_status_t ret = agent->inner->fetchRemoteMD(std::string(remote_name), args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_invalidate_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
-    nixl_status_t ret = agent->inner->invalidateLocalMD(args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_check_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_xfer_dlist_t descs)
-{
-  if (!agent || !remote_name) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    // If descs is null, create an empty descriptor list of DRAM type
-    if (!descs) {
-        nixl_xfer_dlist_t empty_list(DRAM_SEG);
-        nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, empty_list);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-    } else {
-        nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, *descs->dlist);
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixl_status_t ret = agent->inner->fetchRemoteMD(std::string(remote_name), args);
         return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
     }
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_get_available_plugins(nixl_capi_agent_t agent, nixl_capi_string_list_t* plugins)
-{
-  if (!agent || !plugins) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    std::vector<nixl_backend_t> backend_plugins;
-    nixl_status_t ret = agent->inner->getAvailPlugins(backend_plugins);
-
-    if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_invalidate_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args) {
+    if (!agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    auto list = new nixl_capi_string_list_s;
-    list->strings = std::move(backend_plugins);
-    *plugins = list;
-
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixl_status_t ret = agent->inner->invalidateLocalMD(args);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_string_list(nixl_capi_string_list_t list)
-{
-  if (!list) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete list;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_string_list_size(nixl_capi_string_list_t list, size_t* size)
-{
-  if (!list || !size) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *size = list->strings.size();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_string_list_get(nixl_capi_string_list_t list, size_t index, const char** str)
-{
-  if (!list || !str || index >= list->strings.size()) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *str = list->strings[index].c_str();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_get_plugin_params(
-    nixl_capi_agent_t agent, const char* plugin_name, nixl_capi_mem_list_t* mems, nixl_capi_params_t* params)
-{
-  if (!agent || !plugin_name || !mems || !params) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto mem_list = new nixl_capi_mem_list_s;
-    auto param_list = new nixl_capi_params_s;
-
-    nixl_status_t ret = agent->inner->getPluginParams(plugin_name, mem_list->mems, param_list->params);
-
-    if (ret != NIXL_SUCCESS) {
-      delete mem_list;
-      delete param_list;
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_check_remote_md(nixl_capi_agent_t agent,
+                          const char *remote_name,
+                          nixl_capi_xfer_dlist_t descs) {
+    if (!agent || !remote_name) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    *mems = mem_list;
-    *params = param_list;
-
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        // If descs is null, create an empty descriptor list of DRAM type
+        if (!descs) {
+            nixl_xfer_dlist_t empty_list(DRAM_SEG);
+            nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, empty_list);
+            return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        } else {
+            nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, *descs->dlist);
+            return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        }
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_mem_list(nixl_capi_mem_list_t list)
-{
-  if (!list) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete list;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_destroy_params(nixl_capi_params_t params)
-{
-  if (!params) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete params;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_create_backend(
-    nixl_capi_agent_t agent, const char* plugin_name, nixl_capi_params_t params, nixl_capi_backend_t* backend)
-{
-  if (!agent || !plugin_name || !params || !backend) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto backend_handle = new nixl_capi_backend_s;
-    nixl_status_t ret = agent->inner->createBackend(plugin_name, params->params, backend_handle->backend);
-
-    if (ret != NIXL_SUCCESS) {
-      delete backend_handle;
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_get_available_plugins(nixl_capi_agent_t agent, nixl_capi_string_list_t *plugins) {
+    if (!agent || !plugins) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    *backend = backend_handle;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
+    try {
+        std::vector<nixl_backend_t> backend_plugins;
+        nixl_status_t ret = agent->inner->getAvailPlugins(backend_plugins);
 
-nixl_capi_status_t
-nixl_capi_destroy_backend(nixl_capi_backend_t backend)
-{
-  if (!backend) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+        if (ret != NIXL_SUCCESS) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
 
-  try {
-    delete backend;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
+        auto list = new nixl_capi_string_list_s;
+        list->strings = std::move(backend_plugins);
+        *plugins = list;
 
-nixl_capi_status_t
-nixl_capi_create_opt_args(nixl_capi_opt_args_t* args)
-{
-  if (!args) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto opt_args = new nixl_capi_opt_args_s;
-    *args = opt_args;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_destroy_opt_args(nixl_capi_opt_args_t args)
-{
-  if (!args) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete args;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nixl_capi_backend_t backend)
-{
-  if (!args || !backend) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    args->args.backends.push_back(backend->backend);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void* data, size_t len)
-{
-  if (!args || (!data && len > 0)) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    args->args.notifMsg.assign((const char*)data, len);
-    if (args->args.hasNotif || args->args.notif.has_value()) {
-        args->args.notif = args->args.notifMsg;
+        return NIXL_CAPI_SUCCESS;
     }
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t* len)
-{
-  if (!args || !data || !len) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-      const nixl_blob_t &msg =
-          args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
-      size_t msg_size = msg.size();
-      if (msg_size == 0) {
-          *data = nullptr;
-          *len = 0;
-          return NIXL_CAPI_SUCCESS;
-      }
-
-      void *msg_data = malloc(msg_size);
-      if (!msg_data) {
-          return NIXL_CAPI_ERROR_BACKEND;
-      }
-
-      memcpy(msg_data, msg.data(), msg_size);
-      *data = msg_data;
-      *len = msg_size;
-      return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif)
-{
-  if (!args) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    args->args.hasNotif = has_notif;
-    if (has_notif) {
-        args->args.notif = args->args.notifMsg;
-    } else {
-        args->args.notif.reset();
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
     }
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
 }
 
 nixl_capi_status_t
-nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif)
-{
-  if (!args || !has_notif) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_destroy_string_list(nixl_capi_string_list_t list) {
+    if (!list) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-      *has_notif = args->args.notif.has_value() || args->args.hasNotif;
-      return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        delete list;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge)
-{
-  if (!args) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_string_list_size(nixl_capi_string_list_t list, size_t *size) {
+    if (!list || !size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    args->args.skipDescMerge = skip_merge;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *size = list->strings.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_merge)
-{
-  if (!args || !skip_merge) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_string_list_get(nixl_capi_string_list_t list, size_t index, const char **str) {
+    if (!list || !str || index >= list->strings.size()) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *skip_merge = args->args.skipDescMerge;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *str = list->strings[index].c_str();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_get_plugin_params(nixl_capi_agent_t agent,
+                            const char *plugin_name,
+                            nixl_capi_mem_list_t *mems,
+                            nixl_capi_params_t *params) {
+    if (!agent || !plugin_name || !mems || !params) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto mem_list = new nixl_capi_mem_list_s;
+        auto param_list = new nixl_capi_params_s;
+
+        nixl_status_t ret =
+            agent->inner->getPluginParams(plugin_name, mem_list->mems, param_list->params);
+
+        if (ret != NIXL_SUCCESS) {
+            delete mem_list;
+            delete param_list;
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        *mems = mem_list;
+        *params = param_list;
+
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_mem_list(nixl_capi_mem_list_t list) {
+    if (!list) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete list;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_params(nixl_capi_params_t params) {
+    if (!params) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete params;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_create_backend(nixl_capi_agent_t agent,
+                         const char *plugin_name,
+                         nixl_capi_params_t params,
+                         nixl_capi_backend_t *backend) {
+    if (!agent || !plugin_name || !params || !backend) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto backend_handle = new nixl_capi_backend_s;
+        nixl_status_t ret =
+            agent->inner->createBackend(plugin_name, params->params, backend_handle->backend);
+
+        if (ret != NIXL_SUCCESS) {
+            delete backend_handle;
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        *backend = backend_handle;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_backend(nixl_capi_backend_t backend) {
+    if (!backend) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete backend;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_create_opt_args(nixl_capi_opt_args_t *args) {
+    if (!args) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto opt_args = new nixl_capi_opt_args_s;
+        *args = opt_args;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_opt_args(nixl_capi_opt_args_t args) {
+    if (!args) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete args;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nixl_capi_backend_t backend) {
+    if (!args || !backend) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        args->args.backends.push_back(backend->backend);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void *data, size_t len) {
+    if (!args || (!data && len > 0)) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        args->args.notifMsg.assign((const char *)data, len);
+        if (args->args.hasNotif || args->args.notif.has_value()) {
+            args->args.notif = args->args.notifMsg;
+        }
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void **data, size_t *len) {
+    if (!args || !data || !len) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        const nixl_blob_t &msg =
+            args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
+        size_t msg_size = msg.size();
+        if (msg_size == 0) {
+            *data = nullptr;
+            *len = 0;
+            return NIXL_CAPI_SUCCESS;
+        }
+
+        void *msg_data = malloc(msg_size);
+        if (!msg_data) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        memcpy(msg_data, msg.data(), msg_size);
+        *data = msg_data;
+        *len = msg_size;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif) {
+    if (!args) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        args->args.hasNotif = has_notif;
+        if (has_notif) {
+            args->args.notif = args->args.notifMsg;
+        } else {
+            args->args.notif.reset();
+        }
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool *has_notif) {
+    if (!args || !has_notif) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *has_notif = args->args.notif.has_value() || args->args.hasNotif;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge) {
+    if (!args) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        args->args.skipDescMerge = skip_merge;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool *skip_merge) {
+    if (!args || !skip_merge) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *skip_merge = args->args.skipDescMerge;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -805,191 +789,182 @@ nixl_capi_params_add(nixl_capi_params_t params, const char *key, const char *val
 }
 
 nixl_capi_status_t
-nixl_capi_params_is_empty(nixl_capi_params_t params, bool* is_empty)
-{
-  if (!params || !is_empty) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *is_empty = params->params.empty();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_params_create_iterator(nixl_capi_params_t params, nixl_capi_param_iter_t* iter)
-{
-  if (!params || !iter) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto param_iter = new nixl_capi_param_iter_s;
-    param_iter->current = params->params.begin();
-    param_iter->end = params->params.end();
-    *iter = param_iter;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_params_iterator_next(nixl_capi_param_iter_t iter, const char** key, const char** value, bool* has_next)
-{
-  if (!iter || !key || !value || !has_next) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    if (iter->current == iter->end) {
-      *has_next = false;
-      return NIXL_CAPI_SUCCESS;
+nixl_capi_params_is_empty(nixl_capi_params_t params, bool *is_empty) {
+    if (!params || !is_empty) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    // Store the strings in the iterator to keep them alive
-    iter->current_key = iter->current->first;
-    iter->current_value = iter->current->second;
-
-    *key = iter->current_key.c_str();
-    *value = iter->current_value.c_str();
-
-    ++iter->current;
-    *has_next = (iter->current != iter->end);
-
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *is_empty = params->params.empty();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_params_destroy_iterator(nixl_capi_param_iter_t iter)
-{
-  if (!iter) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete iter;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_mem_list_is_empty(nixl_capi_mem_list_t list, bool* is_empty)
-{
-  if (!list || !is_empty) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *is_empty = list->mems.empty();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_mem_list_size(nixl_capi_mem_list_t list, size_t* size)
-{
-  if (!list || !size) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *size = list->mems.size();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_mem_list_get(nixl_capi_mem_list_t list, size_t index, nixl_capi_mem_type_t* mem_type)
-{
-  if (!list || !mem_type || index >= list->mems.size()) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *mem_type = static_cast<nixl_capi_mem_type_t>(list->mems[index]);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_mem_type_to_string(nixl_capi_mem_type_t mem_type, const char** str)
-{
-  if (!str) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    static const char* mem_type_strings[] = {
-        "DRAM",
-        "VRAM",
-        "BLOCK",
-        "OBJECT",
-        "FILE",
-        "UNKNOWN"
-    };
-
-    if (mem_type < 0 || mem_type >= sizeof(mem_type_strings) / sizeof(mem_type_strings[0])) {
-      return NIXL_CAPI_ERROR_INVALID_PARAM;
+nixl_capi_params_create_iterator(nixl_capi_params_t params, nixl_capi_param_iter_t *iter) {
+    if (!params || !iter) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    *str = mem_type_strings[mem_type];
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        auto param_iter = new nixl_capi_param_iter_s;
+        param_iter->current = params->params.begin();
+        param_iter->end = params->params.end();
+        *iter = param_iter;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_get_backend_params(
-    nixl_capi_agent_t agent, nixl_capi_backend_t backend, nixl_capi_mem_list_t* mems, nixl_capi_params_t* params)
-{
-  if (!agent || !backend || !mems || !params) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto mem_list = new nixl_capi_mem_list_s;
-    auto param_list = new nixl_capi_params_s;
-
-    nixl_status_t ret = agent->inner->getBackendParams(backend->backend, mem_list->mems, param_list->params);
-
-    if (ret != NIXL_SUCCESS) {
-      delete mem_list;
-      delete param_list;
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_params_iterator_next(nixl_capi_param_iter_t iter,
+                               const char **key,
+                               const char **value,
+                               bool *has_next) {
+    if (!iter || !key || !value || !has_next) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    *mems = mem_list;
-    *params = param_list;
+    try {
+        if (iter->current == iter->end) {
+            *has_next = false;
+            return NIXL_CAPI_SUCCESS;
+        }
 
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        // Store the strings in the iterator to keep them alive
+        iter->current_key = iter->current->first;
+        iter->current_value = iter->current->second;
+
+        *key = iter->current_key.c_str();
+        *value = iter->current_value.c_str();
+
+        ++iter->current;
+        *has_next = (iter->current != iter->end);
+
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_params_destroy_iterator(nixl_capi_param_iter_t iter) {
+    if (!iter) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete iter;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_mem_list_is_empty(nixl_capi_mem_list_t list, bool *is_empty) {
+    if (!list || !is_empty) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *is_empty = list->mems.empty();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_mem_list_size(nixl_capi_mem_list_t list, size_t *size) {
+    if (!list || !size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *size = list->mems.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_mem_list_get(nixl_capi_mem_list_t list, size_t index, nixl_capi_mem_type_t *mem_type) {
+    if (!list || !mem_type || index >= list->mems.size()) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *mem_type = static_cast<nixl_capi_mem_type_t>(list->mems[index]);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_mem_type_to_string(nixl_capi_mem_type_t mem_type, const char **str) {
+    if (!str) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        static const char *mem_type_strings[] = {
+            "DRAM", "VRAM", "BLOCK", "OBJECT", "FILE", "UNKNOWN"};
+
+        if (mem_type < 0 || mem_type >= sizeof(mem_type_strings) / sizeof(mem_type_strings[0])) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+
+        *str = mem_type_strings[mem_type];
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_get_backend_params(nixl_capi_agent_t agent,
+                             nixl_capi_backend_t backend,
+                             nixl_capi_mem_list_t *mems,
+                             nixl_capi_params_t *params) {
+    if (!agent || !backend || !mems || !params) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto mem_list = new nixl_capi_mem_list_s;
+        auto param_list = new nixl_capi_params_s;
+
+        nixl_status_t ret =
+            agent->inner->getBackendParams(backend->backend, mem_list->mems, param_list->params);
+
+        if (ret != NIXL_SUCCESS) {
+            delete mem_list;
+            delete param_list;
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        *mems = mem_list;
+        *params = param_list;
+
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 // Transfer descriptor list functions
@@ -1011,170 +986,164 @@ nixl_capi_create_xfer_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_xfer_dlist_
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_xfer_dlist(nixl_capi_xfer_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_destroy_xfer_dlist(nixl_capi_xfer_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    delete dlist->dlist;
-    delete dlist;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        delete dlist->dlist;
+        delete dlist;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_get_type(nixl_capi_xfer_dlist_t dlist, nixl_capi_mem_type_t* mem_type)
-{
-  if (!dlist || !mem_type) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_get_type(nixl_capi_xfer_dlist_t dlist, nixl_capi_mem_type_t *mem_type) {
+    if (!dlist || !mem_type) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *mem_type = static_cast<nixl_capi_mem_type_t>(dlist->dlist->getType());
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *mem_type = static_cast<nixl_capi_mem_type_t>(dlist->dlist->getType());
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_add_desc(nixl_capi_xfer_dlist_t dlist, uintptr_t addr, size_t len, uint64_t dev_id)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_add_desc(nixl_capi_xfer_dlist_t dlist,
+                              uintptr_t addr,
+                              size_t len,
+                              uint64_t dev_id) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixlBasicDesc desc(addr, len, dev_id);
-    dlist->dlist->addDesc(desc);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixlBasicDesc desc(addr, len, dev_id);
+        dlist->dlist->addDesc(desc);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_desc_count(nixl_capi_xfer_dlist_t dlist, size_t* count)
-{
-  if (!dlist || !count) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_desc_count(nixl_capi_xfer_dlist_t dlist, size_t *count) {
+    if (!dlist || !count) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *count = dlist->dlist->descCount();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *count = dlist->dlist->descCount();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 // Deprecated: Use nixl_capi_xfer_dlist_desc_count instead
 nixl_capi_status_t
-nixl_capi_xfer_dlist_len(nixl_capi_xfer_dlist_t dlist, size_t* len)
-{
-  return nixl_capi_xfer_dlist_desc_count(dlist, len);
+nixl_capi_xfer_dlist_len(nixl_capi_xfer_dlist_t dlist, size_t *len) {
+    return nixl_capi_xfer_dlist_desc_count(dlist, len);
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_is_empty(nixl_capi_xfer_dlist_t dlist, bool* is_empty)
-{
-  if (!dlist || !is_empty) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_is_empty(nixl_capi_xfer_dlist_t dlist, bool *is_empty) {
+    if (!dlist || !is_empty) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *is_empty = dlist->dlist->isEmpty();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *is_empty = dlist->dlist->isEmpty();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_trim(nixl_capi_xfer_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_trim(nixl_capi_xfer_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->trim();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t nixl_capi_xfer_dlist_rem_desc(nixl_capi_xfer_dlist_t dlist, int index)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    dlist->dlist->remDesc(index);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->trim();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_clear(nixl_capi_xfer_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_rem_desc(nixl_capi_xfer_dlist_t dlist, int index) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->clear();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t nixl_capi_xfer_dlist_print(nixl_capi_xfer_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    dlist->dlist->print();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->remDesc(index);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_xfer_dlist_resize(nixl_capi_xfer_dlist_t dlist, size_t new_size)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_xfer_dlist_clear(nixl_capi_xfer_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->resize(new_size);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->clear();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_dlist_print(nixl_capi_xfer_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        dlist->dlist->print();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_xfer_dlist_resize(nixl_capi_xfer_dlist_t dlist, size_t new_size) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        dlist->dlist->resize(new_size);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 // Registration descriptor list functions
@@ -1196,36 +1165,34 @@ nixl_capi_create_reg_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_reg_dlist_t 
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_reg_dlist(nixl_capi_reg_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_destroy_reg_dlist(nixl_capi_reg_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    delete dlist->dlist;
-    delete dlist;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        delete dlist->dlist;
+        delete dlist;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_reg_dlist_get_type(nixl_capi_reg_dlist_t dlist, nixl_capi_mem_type_t* mem_type)
-{
-  if (!dlist || !mem_type) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_reg_dlist_get_type(nixl_capi_reg_dlist_t dlist, nixl_capi_mem_type_t *mem_type) {
+    if (!dlist || !mem_type) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *mem_type = static_cast<nixl_capi_mem_type_t>(dlist->dlist->getType());
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *mem_type = static_cast<nixl_capi_mem_type_t>(dlist->dlist->getType());
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -1259,174 +1226,175 @@ nixl_capi_reg_dlist_add_desc(nixl_capi_reg_dlist_t dlist,
 }
 
 nixl_capi_status_t
-nixl_capi_reg_dlist_desc_count(nixl_capi_reg_dlist_t dlist, size_t* count)
-{
-  if (!dlist || !count) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_reg_dlist_desc_count(nixl_capi_reg_dlist_t dlist, size_t *count) {
+    if (!dlist || !count) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *count = dlist->dlist->descCount();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *count = dlist->dlist->descCount();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_reg_dlist_is_empty(nixl_capi_reg_dlist_t dlist, bool* is_empty)
-{
-  if (!dlist || !is_empty) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_reg_dlist_is_empty(nixl_capi_reg_dlist_t dlist, bool *is_empty) {
+    if (!dlist || !is_empty) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    *is_empty = dlist->dlist->isEmpty();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t nixl_capi_reg_dlist_trim(nixl_capi_reg_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    dlist->dlist->trim();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t nixl_capi_reg_dlist_rem_desc(nixl_capi_reg_dlist_t dlist, int index)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    dlist->dlist->remDesc(index);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        *is_empty = dlist->dlist->isEmpty();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_reg_dlist_clear(nixl_capi_reg_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_reg_dlist_trim(nixl_capi_reg_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->clear();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->trim();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_reg_dlist_resize(nixl_capi_reg_dlist_t dlist, size_t new_size)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_reg_dlist_rem_desc(nixl_capi_reg_dlist_t dlist, int index) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->resize(new_size);
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->remDesc(index);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
-nixl_capi_status_t nixl_capi_reg_dlist_print(nixl_capi_reg_dlist_t dlist)
-{
-  if (!dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_status_t
+nixl_capi_reg_dlist_clear(nixl_capi_reg_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    dlist->dlist->print();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        dlist->dlist->clear();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_reg_dlist_resize(nixl_capi_reg_dlist_t dlist, size_t new_size) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        dlist->dlist->resize(new_size);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_reg_dlist_print(nixl_capi_reg_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        dlist->dlist->print();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 // Memory registration functions
 nixl_capi_status_t
-nixl_capi_register_mem(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_register_mem(nixl_capi_agent_t agent,
+                       nixl_capi_reg_dlist_t dlist,
+                       nixl_capi_opt_args_t opt_args) {
+    if (!agent || !dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
+    try {
 #ifdef NIXL_DEBUG
-    printf("** Registering memory\n");
-    printf("** Backend Count: %ld\n", opt_args ? opt_args->args.backends.size() : 0);
-    printf("** Descriptor list:\n");
-    dlist->dlist->print();
-    printf("** Registered memory\n");
+        printf("** Registering memory\n");
+        printf("** Backend Count: %ld\n", opt_args ? opt_args->args.backends.size() : 0);
+        printf("** Descriptor list:\n");
+        dlist->dlist->print();
+        printf("** Registered memory\n");
 #endif
-    nixl_status_t ret = agent->inner->registerMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        nixl_status_t ret =
+            agent->inner->registerMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_deregister_mem(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !dlist) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_deregister_mem(nixl_capi_agent_t agent,
+                         nixl_capi_reg_dlist_t dlist,
+                         nixl_capi_opt_args_t opt_args) {
+    if (!agent || !dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
+    try {
 #ifdef NIXL_DEBUG
-    printf("** Deregistering memory\n");
-    dlist->dlist->print();
-    printf("** Deregistered memory\n");
+        printf("** Deregistering memory\n");
+        dlist->dlist->print();
+        printf("** Deregistered memory\n");
 #endif
-    nixl_status_t ret = agent->inner->deregisterMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        nixl_status_t ret =
+            agent->inner->deregisterMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
-nixl_capi_status_t nixl_capi_agent_make_connection(
-    nixl_capi_agent_t agent, const char* remote_agent, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !remote_agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_status_t
+nixl_capi_agent_make_connection(nixl_capi_agent_t agent,
+                                const char *remote_agent,
+                                nixl_capi_opt_args_t opt_args) {
+    if (!agent || !remote_agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_status_t ret = agent->inner->makeConnection(std::string(remote_agent),
-                                                    opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_status_t ret = agent->inner->makeConnection(std::string(remote_agent),
+                                                         opt_args ? &opt_args->args : nullptr);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -1508,92 +1476,112 @@ nixl_capi_make_xfer_req(nixl_capi_agent_t agent,
 }
 
 nixl_capi_status_t
-nixl_capi_create_xfer_req(
-    nixl_capi_agent_t agent, nixl_capi_xfer_op_t operation, nixl_capi_xfer_dlist_t local_descs,
-    nixl_capi_xfer_dlist_t remote_descs, const char* remote_agent, nixl_capi_xfer_req_t* req_hndl,
-    nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !local_descs || !remote_descs || !remote_agent || !req_hndl) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto req = new nixl_capi_xfer_req_s;
-    nixl_status_t ret = agent->inner->createXferReq(
-        static_cast<nixl_xfer_op_t>(operation), *local_descs->dlist, *remote_descs->dlist, std::string(remote_agent),
-        req->req, opt_args ? &opt_args->args : nullptr);
-
-    if (ret != NIXL_SUCCESS) {
-      delete req;
-      return NIXL_CAPI_ERROR_BACKEND;
+nixl_capi_create_xfer_req(nixl_capi_agent_t agent,
+                          nixl_capi_xfer_op_t operation,
+                          nixl_capi_xfer_dlist_t local_descs,
+                          nixl_capi_xfer_dlist_t remote_descs,
+                          const char *remote_agent,
+                          nixl_capi_xfer_req_t *req_hndl,
+                          nixl_capi_opt_args_t opt_args) {
+    if (!agent || !local_descs || !remote_descs || !remote_agent || !req_hndl) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
 
-    *req_hndl = req;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        auto req = new nixl_capi_xfer_req_s;
+        nixl_status_t ret = agent->inner->createXferReq(static_cast<nixl_xfer_op_t>(operation),
+                                                        *local_descs->dlist,
+                                                        *remote_descs->dlist,
+                                                        std::string(remote_agent),
+                                                        req->req,
+                                                        opt_args ? &opt_args->args : nullptr);
+
+        if (ret != NIXL_SUCCESS) {
+            delete req;
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        *req_hndl = req;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_estimate_xfer_cost(
-    nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args,
-    int64_t *duration_us, int64_t *err_margin_us, nixl_capi_cost_t *method)
-{
-  if (!agent || !req_hndl || !duration_us || !err_margin_us || !method) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_estimate_xfer_cost(nixl_capi_agent_t agent,
+                             nixl_capi_xfer_req_t req_hndl,
+                             nixl_capi_opt_args_t opt_args,
+                             int64_t *duration_us,
+                             int64_t *err_margin_us,
+                             nixl_capi_cost_t *method) {
+    if (!agent || !req_hndl || !duration_us || !err_margin_us || !method) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    std::chrono::microseconds duration_us_ref;
-    std::chrono::microseconds err_margin_us_ref;
-    nixl_cost_t method_ref;
-    nixl_status_t ret = agent->inner->estimateXferCost(req_hndl->req, duration_us_ref, err_margin_us_ref, method_ref, opt_args ? &opt_args->args : nullptr);
-    *duration_us = duration_us_ref.count();
-    *err_margin_us = err_margin_us_ref.count();
-    *method = static_cast<nixl_capi_cost_t>(method_ref);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        std::chrono::microseconds duration_us_ref;
+        std::chrono::microseconds err_margin_us_ref;
+        nixl_cost_t method_ref;
+        nixl_status_t ret = agent->inner->estimateXferCost(req_hndl->req,
+                                                           duration_us_ref,
+                                                           err_margin_us_ref,
+                                                           method_ref,
+                                                           opt_args ? &opt_args->args : nullptr);
+        *duration_us = duration_us_ref.count();
+        *err_margin_us = err_margin_us_ref.count();
+        *method = static_cast<nixl_capi_cost_t>(method_ref);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_post_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !req_hndl) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_post_xfer_req(nixl_capi_agent_t agent,
+                        nixl_capi_xfer_req_t req_hndl,
+                        nixl_capi_opt_args_t opt_args) {
+    if (!agent || !req_hndl) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_status_t ret = agent->inner->postXferReq(req_hndl->req, opt_args ? &opt_args->args : nullptr);
+    try {
+        nixl_status_t ret =
+            agent->inner->postXferReq(req_hndl->req, opt_args ? &opt_args->args : nullptr);
 
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS :
+            ret == NIXL_IN_PROG    ? NIXL_CAPI_IN_PROG :
+                                     NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl)
-{
-  if (!agent || !req_hndl) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl) {
+    if (!agent || !req_hndl) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req);
-    if (ret == NIXL_SUCCESS) return NIXL_CAPI_SUCCESS;
-    if (ret == NIXL_IN_PROG || ret == NIXL_IN_PROG_WITH_ERR) return NIXL_CAPI_IN_PROG;
-    if (ret == NIXL_ERR_INVALID_PARAM) return NIXL_CAPI_ERROR_INVALID_PARAM;
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req);
+        if (ret == NIXL_SUCCESS) {
+            return NIXL_CAPI_SUCCESS;
+        }
+        if (ret == NIXL_IN_PROG || ret == NIXL_IN_PROG_WITH_ERR) {
+            return NIXL_CAPI_IN_PROG;
+        }
+        if (ret == NIXL_ERR_INVALID_PARAM) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
@@ -1669,11 +1657,21 @@ nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent,
     }
     try {
         nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req, events->events);
-        if (ret == NIXL_SUCCESS)           return NIXL_CAPI_SUCCESS;
-        if (ret == NIXL_IN_PROG)           return NIXL_CAPI_IN_PROG;
-        if (ret == NIXL_IN_PROG_WITH_ERR)  return NIXL_CAPI_IN_PROG_WITH_ERR;
-        if (ret == NIXL_ERR_INVALID_PARAM) return NIXL_CAPI_ERROR_INVALID_PARAM;
-        if (ret == NIXL_ERR_NOT_SUPPORTED) return NIXL_CAPI_ERROR_NOT_SUPPORTED;
+        if (ret == NIXL_SUCCESS) {
+            return NIXL_CAPI_SUCCESS;
+        }
+        if (ret == NIXL_IN_PROG) {
+            return NIXL_CAPI_IN_PROG;
+        }
+        if (ret == NIXL_IN_PROG_WITH_ERR) {
+            return NIXL_CAPI_IN_PROG_WITH_ERR;
+        }
+        if (ret == NIXL_ERR_INVALID_PARAM) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        if (ret == NIXL_ERR_NOT_SUPPORTED) {
+            return NIXL_CAPI_ERROR_NOT_SUPPORTED;
+        }
         return NIXL_CAPI_ERROR_BACKEND;
     }
     catch (...) {
@@ -1704,213 +1702,213 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
 }
 
 nixl_capi_status_t
-nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req)
-{
-  if (!req) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  if (req->req) {
-    return NIXL_CAPI_ERROR_INVALID_STATE;
-  }
-
-  try {
-    delete req;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req)
-{
-  if (!agent || !req || !req->req) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    nixl_status_t ret = agent->inner->releaseXferReq(req->req);
-    if (ret == NIXL_SUCCESS) {
-      req->req = nullptr;  // Prevent double-free in destroy
+nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req) {
+    if (!req) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
 
-nixl_capi_status_t
-nixl_capi_get_notifs(nixl_capi_agent_t agent, nixl_capi_notif_map_t notif_map, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !notif_map) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    nixl_status_t ret = agent->inner->getNotifs(notif_map->notif_map, opt_args ? &opt_args->args : nullptr);
-    if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+    if (req->req) {
+        return NIXL_CAPI_ERROR_INVALID_STATE;
     }
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
 
-nixl_capi_status_t
-nixl_capi_gen_notif(nixl_capi_agent_t agent, const char* remote_agent,
-                   const void* data, size_t len, nixl_capi_opt_args_t opt_args)
-{
-  if (!agent || !remote_agent) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    // Create a blob from the data
-    nixl_blob_t msg;
-    msg.assign((const char*)data, len);
-
-    // Call the C++ function with the correct signature
-    nixl_status_t ret = agent->inner->genNotif(std::string(remote_agent), msg,
-                                              opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
-  }
-  catch (...) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_create_notif_map(nixl_capi_notif_map_t* notif_map)
-{
-  if (!notif_map) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto map = new nixl_capi_notif_map_s;
-    *notif_map = map;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_destroy_notif_map(nixl_capi_notif_map_t notif_map)
-{
-  if (!notif_map) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    delete notif_map;
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_notif_map_size(nixl_capi_notif_map_t map, size_t* size)
-{
-  if (!map || !size) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    *size = map->notif_map.size();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_notif_map_get_agent_at(nixl_capi_notif_map_t map, size_t index, const char** agent_name)
-{
-  if (!map || !agent_name) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto it = map->notif_map.begin();
-    std::advance(it, index);
-    if (it == map->notif_map.end()) {
-      return NIXL_CAPI_ERROR_INVALID_PARAM;
+    try {
+        delete req;
+        return NIXL_CAPI_SUCCESS;
     }
-    *agent_name = it->first.c_str();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
-}
-
-nixl_capi_status_t
-nixl_capi_notif_map_get_notifs_size(nixl_capi_notif_map_t map, const char* agent_name, size_t* size)
-{
-  if (!map || !agent_name || !size) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto it = map->notif_map.find(agent_name);
-    if (it == map->notif_map.end()) {
-      return NIXL_CAPI_ERROR_INVALID_PARAM;
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
     }
-    *size = it->second.size();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
 }
 
 nixl_capi_status_t
-nixl_capi_notif_map_get_notif(
-    nixl_capi_notif_map_t map, const char* agent_name, size_t index, const void** data, size_t* len)
-{
-  if (!map || !agent_name || !data || !len) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
-
-  try {
-    auto it = map->notif_map.find(agent_name);
-    if (it == map->notif_map.end() || index >= it->second.size()) {
-      return NIXL_CAPI_ERROR_INVALID_PARAM;
+nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req) {
+    if (!agent || !req || !req->req) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
     }
-    const auto& notif = it->second[index];
-    *data = notif.data();
-    *len = notif.size();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+
+    try {
+        nixl_status_t ret = agent->inner->releaseXferReq(req->req);
+        if (ret == NIXL_SUCCESS) {
+            req->req = nullptr; // Prevent double-free in destroy
+        }
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 nixl_capi_status_t
-nixl_capi_notif_map_clear(nixl_capi_notif_map_t map)
-{
-  if (!map) {
-    return NIXL_CAPI_ERROR_INVALID_PARAM;
-  }
+nixl_capi_get_notifs(nixl_capi_agent_t agent,
+                     nixl_capi_notif_map_t notif_map,
+                     nixl_capi_opt_args_t opt_args) {
+    if (!agent || !notif_map) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
 
-  try {
-    map->notif_map.clear();
-    return NIXL_CAPI_SUCCESS;
-  }
-  catch (const std::exception& e) {
-    return NIXL_CAPI_ERROR_BACKEND;
-  }
+    try {
+        nixl_status_t ret =
+            agent->inner->getNotifs(notif_map->notif_map, opt_args ? &opt_args->args : nullptr);
+        if (ret != NIXL_SUCCESS) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_gen_notif(nixl_capi_agent_t agent,
+                    const char *remote_agent,
+                    const void *data,
+                    size_t len,
+                    nixl_capi_opt_args_t opt_args) {
+    if (!agent || !remote_agent) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        // Create a blob from the data
+        nixl_blob_t msg;
+        msg.assign((const char *)data, len);
+
+        // Call the C++ function with the correct signature
+        nixl_status_t ret = agent->inner->genNotif(
+            std::string(remote_agent), msg, opt_args ? &opt_args->args : nullptr);
+        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_create_notif_map(nixl_capi_notif_map_t *notif_map) {
+    if (!notif_map) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto map = new nixl_capi_notif_map_s;
+        *notif_map = map;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_notif_map(nixl_capi_notif_map_t notif_map) {
+    if (!notif_map) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete notif_map;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_notif_map_size(nixl_capi_notif_map_t map, size_t *size) {
+    if (!map || !size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        *size = map->notif_map.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_notif_map_get_agent_at(nixl_capi_notif_map_t map, size_t index, const char **agent_name) {
+    if (!map || !agent_name) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto it = map->notif_map.begin();
+        std::advance(it, index);
+        if (it == map->notif_map.end()) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        *agent_name = it->first.c_str();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_notif_map_get_notifs_size(nixl_capi_notif_map_t map,
+                                    const char *agent_name,
+                                    size_t *size) {
+    if (!map || !agent_name || !size) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto it = map->notif_map.find(agent_name);
+        if (it == map->notif_map.end()) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        *size = it->second.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_notif_map_get_notif(nixl_capi_notif_map_t map,
+                              const char *agent_name,
+                              size_t index,
+                              const void **data,
+                              size_t *len) {
+    if (!map || !agent_name || !data || !len) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto it = map->notif_map.find(agent_name);
+        if (it == map->notif_map.end() || index >= it->second.size()) {
+            return NIXL_CAPI_ERROR_INVALID_PARAM;
+        }
+        const auto &notif = it->second[index];
+        *data = notif.data();
+        *len = notif.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_notif_map_clear(nixl_capi_notif_map_t map) {
+    if (!map) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        map->notif_map.clear();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (const std::exception &e) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
 }
 
 // Query response list functions

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -1669,9 +1669,11 @@ nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent,
     }
     try {
         nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req, events->events);
-        if (ret == NIXL_SUCCESS) return NIXL_CAPI_SUCCESS;
-        if (ret == NIXL_IN_PROG || ret == NIXL_IN_PROG_WITH_ERR) return NIXL_CAPI_IN_PROG;
+        if (ret == NIXL_SUCCESS)           return NIXL_CAPI_SUCCESS;
+        if (ret == NIXL_IN_PROG)           return NIXL_CAPI_IN_PROG;
+        if (ret == NIXL_IN_PROG_WITH_ERR)  return NIXL_CAPI_IN_PROG_WITH_ERR;
         if (ret == NIXL_ERR_INVALID_PARAM) return NIXL_CAPI_ERROR_INVALID_PARAM;
+        if (ret == NIXL_ERR_NOT_SUPPORTED) return NIXL_CAPI_ERROR_NOT_SUPPORTED;
         return NIXL_CAPI_ERROR_BACKEND;
     }
     catch (...) {

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,7 +103,7 @@ typedef struct nixl_capi_agent_config_s {
 } nixl_capi_agent_config_t;
 
 // Per-entry tracking flags (match nixl_xfer_track_flag_t)
-#define NIXL_CAPI_XFER_TRACK_ERRORS   (1u << 0)
+#define NIXL_CAPI_XFER_TRACK_ERRORS (1u << 0)
 #define NIXL_CAPI_XFER_TRACK_SUCCESSES (1u << 1)
 
 // Transfer request functions
@@ -114,7 +114,7 @@ typedef enum {
 
 // Opaque handle for reusable per-entry events (avoids allocation in polling loops)
 struct nixl_capi_xfer_entry_events_s;
-typedef struct nixl_capi_xfer_entry_events_s* nixl_capi_xfer_entry_events_t;
+typedef struct nixl_capi_xfer_entry_events_s *nixl_capi_xfer_entry_events_t;
 
 // Core API functions
 
@@ -198,8 +198,10 @@ nixl_capi_status_t nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, b
 nixl_capi_status_t nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif);
 nixl_capi_status_t nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);
 nixl_capi_status_t nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_merge);
-nixl_capi_status_t nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags);
-nixl_capi_status_t nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t* track_flags);
+nixl_capi_status_t
+nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags);
+nixl_capi_status_t
+nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t *track_flags);
 nixl_capi_status_t
 nixl_capi_opt_args_set_ip_addr(nixl_capi_opt_args_t args, const char *ip_addr);
 nixl_capi_status_t
@@ -286,11 +288,21 @@ nixl_capi_status_t nixl_capi_post_xfer_req(
 
 nixl_capi_status_t nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl);
 
-nixl_capi_status_t nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t* events);
-nixl_capi_status_t nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events);
-nixl_capi_status_t nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t* size);
-nixl_capi_status_t nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t* idx_out, int* status_out);
-nixl_capi_status_t nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events);
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t *events);
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events);
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t *size);
+nixl_capi_status_t
+nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events,
+                                size_t index,
+                                size_t *idx_out,
+                                int *status_out);
+nixl_capi_status_t
+nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent,
+                                      nixl_capi_xfer_req_t req_hndl,
+                                      nixl_capi_xfer_entry_events_t events);
 
 nixl_capi_status_t
 nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -102,11 +102,19 @@ typedef struct nixl_capi_agent_config_s {
     bool capture_telemetry;
 } nixl_capi_agent_config_t;
 
+// Per-entry tracking flags (match nixl_xfer_track_flag_t)
+#define NIXL_CAPI_XFER_TRACK_ERRORS   (1u << 0)
+#define NIXL_CAPI_XFER_TRACK_SUCCESSES (1u << 1)
+
 // Transfer request functions
 typedef enum {
   NIXL_CAPI_XFER_OP_READ = 0,
   NIXL_CAPI_XFER_OP_WRITE = 1,
 } nixl_capi_xfer_op_t;
+
+// Opaque handle for reusable per-entry events (avoids allocation in polling loops)
+struct nixl_capi_xfer_entry_events_s;
+typedef struct nixl_capi_xfer_entry_events_s* nixl_capi_xfer_entry_events_t;
 
 // Core API functions
 
@@ -190,6 +198,8 @@ nixl_capi_status_t nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, b
 nixl_capi_status_t nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif);
 nixl_capi_status_t nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);
 nixl_capi_status_t nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_merge);
+nixl_capi_status_t nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags);
+nixl_capi_status_t nixl_capi_opt_args_get_track_flags(nixl_capi_opt_args_t args, uint32_t* track_flags);
 nixl_capi_status_t
 nixl_capi_opt_args_set_ip_addr(nixl_capi_opt_args_t args, const char *ip_addr);
 nixl_capi_status_t
@@ -275,6 +285,12 @@ nixl_capi_status_t nixl_capi_post_xfer_req(
     nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args);
 
 nixl_capi_status_t nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl);
+
+nixl_capi_status_t nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t* events);
+nixl_capi_status_t nixl_capi_xfer_entry_events_destroy(nixl_capi_xfer_entry_events_t events);
+nixl_capi_status_t nixl_capi_xfer_entry_events_size(nixl_capi_xfer_entry_events_t events, size_t* size);
+nixl_capi_status_t nixl_capi_xfer_entry_events_get(nixl_capi_xfer_entry_events_t events, size_t index, size_t* idx_out, int* status_out);
+nixl_capi_status_t nixl_capi_get_xfer_status_with_events(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_xfer_entry_events_t events);
 
 nixl_capi_status_t
 nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -40,12 +40,12 @@ typedef enum {
 
 // Memory types enum (matching nixl's memory types)
 typedef enum {
-  NIXL_CAPI_MEM_DRAM = 0,
-  NIXL_CAPI_MEM_VRAM = 1,
-  NIXL_CAPI_MEM_BLOCK = 2,
-  NIXL_CAPI_MEM_OBJECT = 3,
-  NIXL_CAPI_MEM_FILE = 4,
-  NIXL_CAPI_MEM_UNKNOWN = 5
+    NIXL_CAPI_MEM_DRAM = 0,
+    NIXL_CAPI_MEM_VRAM = 1,
+    NIXL_CAPI_MEM_BLOCK = 2,
+    NIXL_CAPI_MEM_OBJECT = 3,
+    NIXL_CAPI_MEM_FILE = 4,
+    NIXL_CAPI_MEM_UNKNOWN = 5
 } nixl_capi_mem_type_t;
 
 struct nixl_capi_agent_s;
@@ -71,18 +71,18 @@ struct nixl_capi_xfer_telemetry_s {
 };
 
 // Opaque handle types for C++ objects
-typedef struct nixl_capi_agent_s* nixl_capi_agent_t;
-typedef struct nixl_capi_params_s* nixl_capi_params_t;
-typedef struct nixl_capi_mem_list_s* nixl_capi_mem_list_t;
-typedef struct nixl_capi_string_list_s* nixl_capi_string_list_t;
-typedef struct nixl_capi_backend_s* nixl_capi_backend_t;
-typedef struct nixl_capi_opt_args_s* nixl_capi_opt_args_t;
-typedef struct nixl_capi_param_iter_s* nixl_capi_param_iter_t;
-typedef struct nixl_capi_xfer_dlist_s* nixl_capi_xfer_dlist_t;
+typedef struct nixl_capi_agent_s *nixl_capi_agent_t;
+typedef struct nixl_capi_params_s *nixl_capi_params_t;
+typedef struct nixl_capi_mem_list_s *nixl_capi_mem_list_t;
+typedef struct nixl_capi_string_list_s *nixl_capi_string_list_t;
+typedef struct nixl_capi_backend_s *nixl_capi_backend_t;
+typedef struct nixl_capi_opt_args_s *nixl_capi_opt_args_t;
+typedef struct nixl_capi_param_iter_s *nixl_capi_param_iter_t;
+typedef struct nixl_capi_xfer_dlist_s *nixl_capi_xfer_dlist_t;
 typedef struct nixl_capi_xfer_dlist_handle_s *nixl_capi_xfer_dlist_handle_t;
-typedef struct nixl_capi_reg_dlist_s* nixl_capi_reg_dlist_t;
-typedef struct nixl_capi_xfer_req_s* nixl_capi_xfer_req_t;
-typedef struct nixl_capi_notif_map_s* nixl_capi_notif_map_t;
+typedef struct nixl_capi_reg_dlist_s *nixl_capi_reg_dlist_t;
+typedef struct nixl_capi_xfer_req_s *nixl_capi_xfer_req_t;
+typedef struct nixl_capi_notif_map_s *nixl_capi_notif_map_t;
 typedef struct nixl_capi_query_resp_list_s *nixl_capi_query_resp_list_t;
 
 // Thread sync enum matching nixl_thread_sync_t
@@ -111,8 +111,8 @@ typedef struct nixl_capi_agent_config_s {
 
 // Transfer request functions
 typedef enum {
-  NIXL_CAPI_XFER_OP_READ = 0,
-  NIXL_CAPI_XFER_OP_WRITE = 1,
+    NIXL_CAPI_XFER_OP_READ = 0,
+    NIXL_CAPI_XFER_OP_WRITE = 1,
 } nixl_capi_xfer_op_t;
 
 // Opaque handle for reusable per-entry events (avoids allocation in polling loops)
@@ -128,13 +128,16 @@ nixl_capi_create_configured_agent(const char *name,
                                   nixl_capi_agent_t *agent);
 
 // Create an agent with default config
-nixl_capi_status_t nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent);
+nixl_capi_status_t
+nixl_capi_create_agent(const char *name, nixl_capi_agent_t *agent);
 
 // Destroy an agent
-nixl_capi_status_t nixl_capi_destroy_agent(nixl_capi_agent_t agent);
+nixl_capi_status_t
+nixl_capi_destroy_agent(nixl_capi_agent_t agent);
 
 // Get local metadata as a byte array
-nixl_capi_status_t nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len);
+nixl_capi_status_t
+nixl_capi_get_local_md(nixl_capi_agent_t agent, void **data, size_t *len);
 
 // Get local partial metadata as a byte array
 nixl_capi_status_t
@@ -145,19 +148,26 @@ nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
                                nixl_capi_opt_args_t opt_args);
 
 // Load remote metadata from a byte array
-nixl_capi_status_t nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, char** agent_name);
+nixl_capi_status_t
+nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void *data, size_t len, char **agent_name);
 
 // Invalidate remote agent metadata
-nixl_capi_status_t nixl_capi_invalidate_remote_md(nixl_capi_agent_t agent, const char* remote_agent);
+nixl_capi_status_t
+nixl_capi_invalidate_remote_md(nixl_capi_agent_t agent, const char *remote_agent);
 
 // Invalidate local metadata in etcd
-nixl_capi_status_t nixl_capi_invalidate_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_invalidate_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
 
 // Check if remote metadata is available
-nixl_capi_status_t nixl_capi_check_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_xfer_dlist_t descs);
+nixl_capi_status_t
+nixl_capi_check_remote_md(nixl_capi_agent_t agent,
+                          const char *remote_name,
+                          nixl_capi_xfer_dlist_t descs);
 
 // Send local metadata to etcd
-nixl_capi_status_t nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args);
 
 // Send local partial metadata to etcd
 nixl_capi_status_t
@@ -166,41 +176,69 @@ nixl_capi_send_local_partial_md(nixl_capi_agent_t agent,
                                 nixl_capi_opt_args_t opt_args);
 
 // Fetch remote metadata from etcd
-nixl_capi_status_t nixl_capi_fetch_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_fetch_remote_md(nixl_capi_agent_t agent,
+                          const char *remote_name,
+                          nixl_capi_opt_args_t opt_args);
 
 // Plugin and parameter functions
-nixl_capi_status_t nixl_capi_get_available_plugins(nixl_capi_agent_t agent, nixl_capi_string_list_t* plugins);
-nixl_capi_status_t nixl_capi_destroy_string_list(nixl_capi_string_list_t list);
-nixl_capi_status_t nixl_capi_string_list_size(nixl_capi_string_list_t list, size_t* size);
-nixl_capi_status_t nixl_capi_string_list_get(nixl_capi_string_list_t list, size_t index, const char** str);
+nixl_capi_status_t
+nixl_capi_get_available_plugins(nixl_capi_agent_t agent, nixl_capi_string_list_t *plugins);
+nixl_capi_status_t
+nixl_capi_destroy_string_list(nixl_capi_string_list_t list);
+nixl_capi_status_t
+nixl_capi_string_list_size(nixl_capi_string_list_t list, size_t *size);
+nixl_capi_status_t
+nixl_capi_string_list_get(nixl_capi_string_list_t list, size_t index, const char **str);
 
-nixl_capi_status_t nixl_capi_get_plugin_params(
-    nixl_capi_agent_t agent, const char* plugin_name, nixl_capi_mem_list_t* mems, nixl_capi_params_t* params);
+nixl_capi_status_t
+nixl_capi_get_plugin_params(nixl_capi_agent_t agent,
+                            const char *plugin_name,
+                            nixl_capi_mem_list_t *mems,
+                            nixl_capi_params_t *params);
 
-nixl_capi_status_t nixl_capi_destroy_mem_list(nixl_capi_mem_list_t list);
-nixl_capi_status_t nixl_capi_destroy_params(nixl_capi_params_t params);
+nixl_capi_status_t
+nixl_capi_destroy_mem_list(nixl_capi_mem_list_t list);
+nixl_capi_status_t
+nixl_capi_destroy_params(nixl_capi_params_t params);
 
 // Backend creation and management
-nixl_capi_status_t nixl_capi_create_backend(
-    nixl_capi_agent_t agent, const char* plugin_name, nixl_capi_params_t params, nixl_capi_backend_t* backend);
-nixl_capi_status_t nixl_capi_destroy_backend(nixl_capi_backend_t backend);
+nixl_capi_status_t
+nixl_capi_create_backend(nixl_capi_agent_t agent,
+                         const char *plugin_name,
+                         nixl_capi_params_t params,
+                         nixl_capi_backend_t *backend);
+nixl_capi_status_t
+nixl_capi_destroy_backend(nixl_capi_backend_t backend);
 
 // Get backend parameters after initialization
-nixl_capi_status_t nixl_capi_get_backend_params(
-    nixl_capi_agent_t agent, nixl_capi_backend_t backend, nixl_capi_mem_list_t* mems, nixl_capi_params_t* params);
+nixl_capi_status_t
+nixl_capi_get_backend_params(nixl_capi_agent_t agent,
+                             nixl_capi_backend_t backend,
+                             nixl_capi_mem_list_t *mems,
+                             nixl_capi_params_t *params);
 
 // Optional arguments management
-nixl_capi_status_t nixl_capi_create_opt_args(nixl_capi_opt_args_t* args);
-nixl_capi_status_t nixl_capi_destroy_opt_args(nixl_capi_opt_args_t args);
-nixl_capi_status_t nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nixl_capi_backend_t backend);
+nixl_capi_status_t
+nixl_capi_create_opt_args(nixl_capi_opt_args_t *args);
+nixl_capi_status_t
+nixl_capi_destroy_opt_args(nixl_capi_opt_args_t args);
+nixl_capi_status_t
+nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nixl_capi_backend_t backend);
 
 // OptArgs notification and merge control
-nixl_capi_status_t nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void* data, size_t len);
-nixl_capi_status_t nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t* len);
-nixl_capi_status_t nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif);
-nixl_capi_status_t nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif);
-nixl_capi_status_t nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);
-nixl_capi_status_t nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool* skip_merge);
+nixl_capi_status_t
+nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void *data, size_t len);
+nixl_capi_status_t
+nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void **data, size_t *len);
+nixl_capi_status_t
+nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif);
+nixl_capi_status_t
+nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool *has_notif);
+nixl_capi_status_t
+nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);
+nixl_capi_status_t
+nixl_capi_opt_args_get_skip_desc_merge(nixl_capi_opt_args_t args, bool *skip_merge);
 nixl_capi_status_t
 nixl_capi_opt_args_set_track_flags(nixl_capi_opt_args_t args, uint32_t track_flags);
 nixl_capi_status_t
@@ -215,27 +253,43 @@ nixl_capi_status_t
 nixl_capi_create_params(nixl_capi_params_t *params);
 nixl_capi_status_t
 nixl_capi_params_add(nixl_capi_params_t params, const char *key, const char *value);
-nixl_capi_status_t nixl_capi_params_is_empty(nixl_capi_params_t params, bool* is_empty);
-nixl_capi_status_t nixl_capi_params_create_iterator(nixl_capi_params_t params, nixl_capi_param_iter_t* iter);
-nixl_capi_status_t nixl_capi_params_iterator_next(
-    nixl_capi_param_iter_t iter, const char** key, const char** value, bool* has_next);
-nixl_capi_status_t nixl_capi_params_destroy_iterator(nixl_capi_param_iter_t iter);
+nixl_capi_status_t
+nixl_capi_params_is_empty(nixl_capi_params_t params, bool *is_empty);
+nixl_capi_status_t
+nixl_capi_params_create_iterator(nixl_capi_params_t params, nixl_capi_param_iter_t *iter);
+nixl_capi_status_t
+nixl_capi_params_iterator_next(nixl_capi_param_iter_t iter,
+                               const char **key,
+                               const char **value,
+                               bool *has_next);
+nixl_capi_status_t
+nixl_capi_params_destroy_iterator(nixl_capi_param_iter_t iter);
 
 // Memory list access functions
-nixl_capi_status_t nixl_capi_mem_list_is_empty(nixl_capi_mem_list_t list, bool* is_empty);
-nixl_capi_status_t nixl_capi_mem_list_size(nixl_capi_mem_list_t list, size_t* size);
-nixl_capi_status_t nixl_capi_mem_list_get(nixl_capi_mem_list_t list, size_t index, nixl_capi_mem_type_t* mem_type);
-nixl_capi_status_t nixl_capi_mem_type_to_string(nixl_capi_mem_type_t mem_type, const char** str);
+nixl_capi_status_t
+nixl_capi_mem_list_is_empty(nixl_capi_mem_list_t list, bool *is_empty);
+nixl_capi_status_t
+nixl_capi_mem_list_size(nixl_capi_mem_list_t list, size_t *size);
+nixl_capi_status_t
+nixl_capi_mem_list_get(nixl_capi_mem_list_t list, size_t index, nixl_capi_mem_type_t *mem_type);
+nixl_capi_status_t
+nixl_capi_mem_type_to_string(nixl_capi_mem_type_t mem_type, const char **str);
 
 // Memory registration functions
-nixl_capi_status_t nixl_capi_register_mem(
-    nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_register_mem(nixl_capi_agent_t agent,
+                       nixl_capi_reg_dlist_t dlist,
+                       nixl_capi_opt_args_t opt_args);
 
-nixl_capi_status_t nixl_capi_deregister_mem(
-    nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_deregister_mem(nixl_capi_agent_t agent,
+                         nixl_capi_reg_dlist_t dlist,
+                         nixl_capi_opt_args_t opt_args);
 
-nixl_capi_status_t nixl_capi_agent_make_connection(
-    nixl_capi_agent_t agent, const char* remote_agent, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_agent_make_connection(nixl_capi_agent_t agent,
+                                const char *remote_agent,
+                                nixl_capi_opt_args_t opt_args);
 
 nixl_capi_status_t
 nixl_capi_prep_xfer_dlist(nixl_capi_agent_t agent,
@@ -261,35 +315,54 @@ nixl_capi_make_xfer_req(nixl_capi_agent_t agent,
                         nixl_capi_opt_args_t opt_args);
 
 // Notification functions
-nixl_capi_status_t nixl_capi_get_notifs(
-    nixl_capi_agent_t agent, nixl_capi_notif_map_t notif_map, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_get_notifs(nixl_capi_agent_t agent,
+                     nixl_capi_notif_map_t notif_map,
+                     nixl_capi_opt_args_t opt_args);
 
-nixl_capi_status_t nixl_capi_create_notif_map(nixl_capi_notif_map_t* notif_map);
+nixl_capi_status_t
+nixl_capi_create_notif_map(nixl_capi_notif_map_t *notif_map);
 
-nixl_capi_status_t nixl_capi_destroy_notif_map(nixl_capi_notif_map_t notif_map);
+nixl_capi_status_t
+nixl_capi_destroy_notif_map(nixl_capi_notif_map_t notif_map);
 
 // Send a notification to a remote agent
-nixl_capi_status_t nixl_capi_gen_notif(nixl_capi_agent_t agent, const char* remote_agent,
-                                      const void* data, size_t len, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_gen_notif(nixl_capi_agent_t agent,
+                    const char *remote_agent,
+                    const void *data,
+                    size_t len,
+                    nixl_capi_opt_args_t opt_args);
 
 // Transfer request functions
-nixl_capi_status_t nixl_capi_create_xfer_req(
-    nixl_capi_agent_t agent, nixl_capi_xfer_op_t operation, nixl_capi_xfer_dlist_t local_descs,
-    nixl_capi_xfer_dlist_t remote_descs, const char* remote_agent, nixl_capi_xfer_req_t* req_hndl,
-    nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_create_xfer_req(nixl_capi_agent_t agent,
+                          nixl_capi_xfer_op_t operation,
+                          nixl_capi_xfer_dlist_t local_descs,
+                          nixl_capi_xfer_dlist_t remote_descs,
+                          const char *remote_agent,
+                          nixl_capi_xfer_req_t *req_hndl,
+                          nixl_capi_opt_args_t opt_args);
 
 typedef enum {
-  NIXL_CAPI_COST_ANALYTICAL_BACKEND = 0,
+    NIXL_CAPI_COST_ANALYTICAL_BACKEND = 0,
 } nixl_capi_cost_t;
 
-nixl_capi_status_t nixl_capi_estimate_xfer_cost(
-    nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args,
-    int64_t *duration_us, int64_t *err_margin_us, nixl_capi_cost_t *method);
+nixl_capi_status_t
+nixl_capi_estimate_xfer_cost(nixl_capi_agent_t agent,
+                             nixl_capi_xfer_req_t req_hndl,
+                             nixl_capi_opt_args_t opt_args,
+                             int64_t *duration_us,
+                             int64_t *err_margin_us,
+                             nixl_capi_cost_t *method);
 
-nixl_capi_status_t nixl_capi_post_xfer_req(
-    nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, nixl_capi_opt_args_t opt_args);
+nixl_capi_status_t
+nixl_capi_post_xfer_req(nixl_capi_agent_t agent,
+                        nixl_capi_xfer_req_t req_hndl,
+                        nixl_capi_opt_args_t opt_args);
 
-nixl_capi_status_t nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl);
+nixl_capi_status_t
+nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl);
 
 nixl_capi_status_t
 nixl_capi_xfer_entry_events_create(nixl_capi_xfer_entry_events_t *events);
@@ -312,30 +385,47 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
                              nixl_capi_xfer_req_t req_hndl,
                              nixl_capi_backend_t *backend);
 
-nixl_capi_status_t nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req);
+nixl_capi_status_t
+nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req);
 
-nixl_capi_status_t nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req);
+nixl_capi_status_t
+nixl_capi_destroy_xfer_req(nixl_capi_xfer_req_t req);
 
 // Descriptor list functions
 nixl_capi_status_t
 nixl_capi_create_xfer_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_xfer_dlist_t *dlist);
-nixl_capi_status_t nixl_capi_destroy_xfer_dlist(nixl_capi_xfer_dlist_t dlist);
-nixl_capi_status_t nixl_capi_xfer_dlist_get_type(nixl_capi_xfer_dlist_t dlist, nixl_capi_mem_type_t* mem_type);
-nixl_capi_status_t nixl_capi_xfer_dlist_add_desc(
-    nixl_capi_xfer_dlist_t dlist, uintptr_t addr, size_t len, uint64_t dev_id);
-nixl_capi_status_t nixl_capi_xfer_dlist_desc_count(nixl_capi_xfer_dlist_t dlist, size_t* count);
-nixl_capi_status_t nixl_capi_xfer_dlist_len(nixl_capi_xfer_dlist_t dlist, size_t* len);
-nixl_capi_status_t nixl_capi_xfer_dlist_is_empty(nixl_capi_xfer_dlist_t dlist, bool* is_empty);
-nixl_capi_status_t nixl_capi_xfer_dlist_trim(nixl_capi_xfer_dlist_t dlist);
-nixl_capi_status_t nixl_capi_xfer_dlist_rem_desc(nixl_capi_xfer_dlist_t dlist, int index);
-nixl_capi_status_t nixl_capi_xfer_dlist_clear(nixl_capi_xfer_dlist_t dlist);
-nixl_capi_status_t nixl_capi_xfer_dlist_resize(nixl_capi_xfer_dlist_t dlist, size_t new_size);
-nixl_capi_status_t nixl_capi_xfer_dlist_print(nixl_capi_xfer_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_destroy_xfer_dlist(nixl_capi_xfer_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_get_type(nixl_capi_xfer_dlist_t dlist, nixl_capi_mem_type_t *mem_type);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_add_desc(nixl_capi_xfer_dlist_t dlist,
+                              uintptr_t addr,
+                              size_t len,
+                              uint64_t dev_id);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_desc_count(nixl_capi_xfer_dlist_t dlist, size_t *count);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_len(nixl_capi_xfer_dlist_t dlist, size_t *len);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_is_empty(nixl_capi_xfer_dlist_t dlist, bool *is_empty);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_trim(nixl_capi_xfer_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_rem_desc(nixl_capi_xfer_dlist_t dlist, int index);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_clear(nixl_capi_xfer_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_resize(nixl_capi_xfer_dlist_t dlist, size_t new_size);
+nixl_capi_status_t
+nixl_capi_xfer_dlist_print(nixl_capi_xfer_dlist_t dlist);
 
 nixl_capi_status_t
 nixl_capi_create_reg_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_reg_dlist_t *dlist);
-nixl_capi_status_t nixl_capi_destroy_reg_dlist(nixl_capi_reg_dlist_t dlist);
-nixl_capi_status_t nixl_capi_reg_dlist_get_type(nixl_capi_reg_dlist_t dlist, nixl_capi_mem_type_t* mem_type);
+nixl_capi_status_t
+nixl_capi_destroy_reg_dlist(nixl_capi_reg_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_reg_dlist_get_type(nixl_capi_reg_dlist_t dlist, nixl_capi_mem_type_t *mem_type);
 nixl_capi_status_t
 nixl_capi_reg_dlist_add_desc(nixl_capi_reg_dlist_t dlist,
                              uintptr_t addr,
@@ -343,19 +433,36 @@ nixl_capi_reg_dlist_add_desc(nixl_capi_reg_dlist_t dlist,
                              uint64_t dev_id,
                              const void *metadata,
                              size_t metadata_len);
-nixl_capi_status_t nixl_capi_reg_dlist_desc_count(nixl_capi_reg_dlist_t dlist, size_t* count);
-nixl_capi_status_t nixl_capi_reg_dlist_is_empty(nixl_capi_reg_dlist_t dlist, bool* is_empty);
-nixl_capi_status_t nixl_capi_reg_dlist_trim(nixl_capi_reg_dlist_t dlist);
-nixl_capi_status_t nixl_capi_reg_dlist_rem_desc(nixl_capi_reg_dlist_t dlist, int index);
-nixl_capi_status_t nixl_capi_reg_dlist_clear(nixl_capi_reg_dlist_t dlist);
-nixl_capi_status_t nixl_capi_reg_dlist_resize(nixl_capi_reg_dlist_t dlist, size_t new_size);
-nixl_capi_status_t nixl_capi_reg_dlist_print(nixl_capi_reg_dlist_t dlist);
-nixl_capi_status_t nixl_capi_notif_map_size(nixl_capi_notif_map_t map, size_t* size);
-nixl_capi_status_t nixl_capi_notif_map_get_agent_at(nixl_capi_notif_map_t map, size_t index, const char** agent_name);
-nixl_capi_status_t nixl_capi_notif_map_get_notifs_size(nixl_capi_notif_map_t map, const char* agent_name, size_t* size);
-nixl_capi_status_t nixl_capi_notif_map_get_notif(
-    nixl_capi_notif_map_t map, const char* agent_name, size_t index, const void** data, size_t* len);
-nixl_capi_status_t nixl_capi_notif_map_clear(nixl_capi_notif_map_t map);
+nixl_capi_status_t
+nixl_capi_reg_dlist_desc_count(nixl_capi_reg_dlist_t dlist, size_t *count);
+nixl_capi_status_t
+nixl_capi_reg_dlist_is_empty(nixl_capi_reg_dlist_t dlist, bool *is_empty);
+nixl_capi_status_t
+nixl_capi_reg_dlist_trim(nixl_capi_reg_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_reg_dlist_rem_desc(nixl_capi_reg_dlist_t dlist, int index);
+nixl_capi_status_t
+nixl_capi_reg_dlist_clear(nixl_capi_reg_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_reg_dlist_resize(nixl_capi_reg_dlist_t dlist, size_t new_size);
+nixl_capi_status_t
+nixl_capi_reg_dlist_print(nixl_capi_reg_dlist_t dlist);
+nixl_capi_status_t
+nixl_capi_notif_map_size(nixl_capi_notif_map_t map, size_t *size);
+nixl_capi_status_t
+nixl_capi_notif_map_get_agent_at(nixl_capi_notif_map_t map, size_t index, const char **agent_name);
+nixl_capi_status_t
+nixl_capi_notif_map_get_notifs_size(nixl_capi_notif_map_t map,
+                                    const char *agent_name,
+                                    size_t *size);
+nixl_capi_status_t
+nixl_capi_notif_map_get_notif(nixl_capi_notif_map_t map,
+                              const char *agent_name,
+                              size_t index,
+                              const void **data,
+                              size_t *len);
+nixl_capi_status_t
+nixl_capi_notif_map_clear(nixl_capi_notif_map_t map);
 
 // Query response list functions
 nixl_capi_status_t

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -33,6 +33,9 @@ typedef enum {
     NIXL_CAPI_ERROR_EXCEPTION = -4,
     NIXL_CAPI_IN_PROG = 1,
     NIXL_CAPI_ERROR_NO_TELEMETRY = -5,
+    NIXL_CAPI_ERROR_NOT_SUPPORTED = -6,
+    /** In progress with at least one entry error; mirrors NIXL_IN_PROG_WITH_ERR. */
+    NIXL_CAPI_IN_PROG_WITH_ERR = 2,
 } nixl_capi_status_t;
 
 // Memory types enum (matching nixl's memory types)

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -53,31 +53,6 @@ nixlEngineDeleter::operator()(nixlBackendEngine *engine) const noexcept {
     // TODO: Else delete engine?
 }
 
-std::string
-nixlEnumStrings::statusStr(const nixl_status_t &status) {
-    switch (status) {
-        case NIXL_IN_PROG:               return "NIXL_IN_PROG";
-        case NIXL_SUCCESS:               return "NIXL_SUCCESS";
-        case NIXL_ERR_NOT_POSTED:        return "NIXL_ERR_NOT_POSTED";
-        case NIXL_ERR_INVALID_PARAM:     return "NIXL_ERR_INVALID_PARAM";
-        case NIXL_ERR_BACKEND:           return "NIXL_ERR_BACKEND";
-        case NIXL_ERR_NOT_FOUND:         return "NIXL_ERR_NOT_FOUND";
-        case NIXL_ERR_MISMATCH:          return "NIXL_ERR_MISMATCH";
-        case NIXL_ERR_NOT_ALLOWED:       return "NIXL_ERR_NOT_ALLOWED";
-        case NIXL_ERR_REPOST_ACTIVE:     return "NIXL_ERR_REPOST_ACTIVE";
-        case NIXL_ERR_UNKNOWN:           return "NIXL_ERR_UNKNOWN";
-        case NIXL_ERR_NOT_SUPPORTED:     return "NIXL_ERR_NOT_SUPPORTED";
-        case NIXL_ERR_REMOTE_DISCONNECT: return "NIXL_ERR_REMOTE_DISCONNECT";
-        case NIXL_ERR_CANCELED:
-            return "NIXL_ERR_CANCELED";
-        case NIXL_ERR_NO_TELEMETRY:
-            return "NIXL_ERR_NO_TELEMETRY";
-        case NIXL_IN_PROG_WITH_ERR:
-            return "NIXL_IN_PROG_WITH_ERR";
-        default:                         return "BAD_STATUS";
-    }
-}
-
 nixlXferReqH::nixlXferReqH(const std::string &remote_agent,
                            const nixl_xfer_op_t backend_op,
                            const nixl_mem_t local_type,
@@ -183,12 +158,13 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
 }
 
 /*** nixlAgent implementation ***/
-nixlAgent::nixlAgent(const std::string &name, const nixlAgentConfig &cfg) :
-    data(std::make_unique<nixlAgentData>(name, cfg))
-{
-    if(cfg.useListenThread) {
+nixlAgent::nixlAgent(const std::string &name, const nixlAgentConfig &cfg)
+    : data(std::make_unique<nixlAgentData>(name, cfg)) {
+    if (cfg.useListenThread) {
         int my_port = cfg.listenPort;
-        if(my_port == 0) my_port = default_comm_port;
+        if (my_port == 0) {
+            my_port = default_comm_port;
+        }
         data->listener = std::make_unique<nixlMDStreamListener>(my_port);
         data->listener->setupListener(); // throws on bind/listen failure
     }
@@ -208,7 +184,9 @@ nixlAgent::~nixlAgent() {
         }
 
         data->commThreadStop = true;
-        if(data->commThread.joinable()) data->commThread.join();
+        if (data->commThread.joinable()) {
+            data->commThread.join();
+        }
 
         try {
             if (data->commThreadException_) {
@@ -230,27 +208,27 @@ nixlAgent::~nixlAgent() {
 }
 
 nixl_status_t
-nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {
-    auto& plugin_manager = nixlPluginManager::getInstance();
+nixlAgent::getAvailPlugins(std::vector<nixl_backend_t> &plugins) {
+    auto &plugin_manager = nixlPluginManager::getInstance();
     plugins = plugin_manager.getAvailBackendPluginNames();
     return NIXL_SUCCESS;
 }
 
 nixl_status_t
-nixlAgent::getPluginParams (const nixl_backend_t &type,
-                            nixl_mem_list_t &mems,
-                            nixl_b_params_t &params) const {
+nixlAgent::getPluginParams(const nixl_backend_t &type,
+                           nixl_mem_list_t &mems,
+                           nixl_b_params_t &params) const {
 
     // TODO: unify to uppercase/lowercase and do ltrim/rtrim for type
 
     // First try to get options from a loaded plugin
-    auto& plugin_manager = nixlPluginManager::getInstance();
+    auto &plugin_manager = nixlPluginManager::getInstance();
     auto plugin_handle = plugin_manager.getBackendPlugin(type);
 
     if (plugin_handle) {
-      // If the plugin is already loaded, get options directly
+        // If the plugin is already loaded, get options directly
         params = plugin_handle->getBackendOptions();
-        mems   = plugin_handle->getBackendMems();
+        mems = plugin_handle->getBackendMems();
         return NIXL_SUCCESS;
     }
 
@@ -258,7 +236,7 @@ nixlAgent::getPluginParams (const nixl_backend_t &type,
     plugin_handle = plugin_manager.loadBackendPlugin(type);
     if (plugin_handle) {
         params = plugin_handle->getBackendOptions();
-        mems   = plugin_handle->getBackendMems();
+        mems = plugin_handle->getBackendMems();
 
         NIXL_LOCK_GUARD(data->lock);
 
@@ -274,16 +252,16 @@ nixlAgent::getPluginParams (const nixl_backend_t &type,
 }
 
 nixl_status_t
-nixlAgent::getBackendParams (const nixlBackendH* backend,
-                             nixl_mem_list_t &mems,
-                             nixl_b_params_t &params) const {
+nixlAgent::getBackendParams(const nixlBackendH *backend,
+                            nixl_mem_list_t &mems,
+                            nixl_b_params_t &params) const {
     if (!backend) {
         NIXL_ERROR_FUNC << "backend handle is not provided";
         return NIXL_ERR_INVALID_PARAM;
     }
 
     NIXL_LOCK_GUARD(data->lock);
-    mems   = backend->engine->getSupportedMems();
+    mems = backend->engine->getSupportedMems();
     params = backend->engine->getCustomParams();
     return NIXL_SUCCESS;
 }
@@ -309,7 +287,7 @@ nixlAgentData::warnAboutEfaHardwareMismatch() {
 nixl_status_t
 nixlAgent::createBackend(const nixl_backend_t &type,
                          const nixl_b_params_t &params,
-                         nixlBackendH* &bknd_hndl) {
+                         nixlBackendH *&bknd_hndl) {
 
     NIXL_LOCK_GUARD(data->lock);
     // Registering same type of backend is not supported, unlikely and prob error
@@ -342,7 +320,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
 
     // First, try to load the backend as a plugin
-    auto& plugin_manager = nixlPluginManager::getInstance();
+    auto &plugin_manager = nixlPluginManager::getInstance();
     auto plugin_handle = plugin_manager.loadBackendPlugin(type);
 
     if (!plugin_handle) {
@@ -431,11 +409,10 @@ nixlAgent::queryMem(const nixl_reg_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
-                       const nixl_opt_args_t* extra_params) {
+nixlAgent::registerMem(const nixl_reg_dlist_t &descs, const nixl_opt_args_t *extra_params) {
 
-    backend_list_t* backend_list;
-    unsigned int    count = 0;
+    backend_list_t *backend_list;
+    unsigned int count = 0;
 
     NIXL_LOCK_GUARD(data->lock);
 
@@ -449,14 +426,15 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
         }
     } else {
         backend_list = new backend_list_t();
-        for (auto & elm : extra_params->backends)
+        for (auto &elm : extra_params->backends) {
             backend_list->push_back(elm->engine);
+        }
     }
 
     // Best effort, if at least one succeeds NIXL_SUCCESS is returned
     // Can become more sophisticated to have a soft error case
-    for (size_t i=0; i<backend_list->size(); ++i) {
-        nixlBackendEngine* backend = (*backend_list)[i];
+    for (size_t i = 0; i < backend_list->size(); ++i) {
+        nixlBackendEngine *backend = (*backend_list)[i];
         // meta_descs use to be passed to loadLocalData
         nixl_sec_dlist_t sec_descs(descs.getType());
         nixl_status_t ret = data->localSection_.addDescList(descs, backend, sec_descs);
@@ -477,8 +455,9 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
         } // a bad_ret can be saved in an else
     }
 
-    if (extra_params && extra_params->backends.size() > 0)
+    if (extra_params && extra_params->backends.size() > 0) {
         delete backend_list;
+    }
 
     if (count > 0) {
         // sum all the sizes of the descriptors using std::accumulate
@@ -497,8 +476,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
-                         const nixl_opt_args_t* extra_params) {
+nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs, const nixl_opt_args_t *extra_params) {
 
 
     backend_set_t backend_set;
@@ -514,8 +492,9 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
         // Make a copy as we might change it in remDescList
         backend_set = *avail_backends;
     } else {
-        for (auto & elm : extra_params->backends)
+        for (auto &elm : extra_params->backends) {
             backend_set.insert(elm->engine);
+        }
     }
 
     // Doing best effort, and returning err if any
@@ -548,8 +527,7 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::makeConnection(const std::string &remote_agent,
-                          const nixl_opt_args_t* extra_params) {
+nixlAgent::makeConnection(const std::string &remote_agent, const nixl_opt_args_t *extra_params) {
     std::set<nixl_backend_t> backend_set;
     int count = 0;
 
@@ -565,16 +543,18 @@ nixlAgent::makeConnection(const std::string &remote_agent,
                             << remote_agent << "'";
             return NIXL_ERR_NOT_FOUND;
         }
-        for (auto &[r_bknd, conn_info] : data->remoteBackends_[remote_agent])
+        for (auto &[r_bknd, conn_info] : data->remoteBackends_[remote_agent]) {
             backend_set.insert(r_bknd);
+        }
     } else {
-        for (auto & elm : extra_params->backends)
+        for (auto &elm : extra_params->backends) {
             backend_set.insert(elm->engine->getType());
+        }
     }
 
     // For now trying to make all the connections, can become best effort,
     nixl_status_t ret = NIXL_SUCCESS;
-    for (auto & backend: backend_set) {
+    for (auto &backend : backend_set) {
         const auto iter = data->backendEngines_.find(backend);
         if (iter != data->backendEngines_.end()) {
             nixlBackendEngine *eng = iter->second.get();
@@ -601,10 +581,10 @@ nixlAgent::makeConnection(const std::string &remote_agent,
 }
 
 nixl_status_t
-nixlAgent::prepXferDlist (const std::string &agent_name,
-                          const nixl_xfer_dlist_t &descs,
-                          nixlDlistH* &dlist_hndl,
-                          const nixl_opt_args_t* extra_params) const {
+nixlAgent::prepXferDlist(const std::string &agent_name,
+                         const nixl_xfer_dlist_t &descs,
+                         nixlDlistH *&dlist_hndl,
+                         const nixl_opt_args_t *extra_params) const {
 
     // Using a set as order is not important to revert the operation
     backend_set_t *backend_set;
@@ -674,18 +654,18 @@ nixlAgent::prepXferDlist(const nixl_xfer_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
-                        const nixlDlistH* local_side,
-                        const std::vector<int> &local_indices,
-                        const nixlDlistH* remote_side,
-                        const std::vector<int> &remote_indices,
-                        nixlXferReqH* &req_hndl,
-                        const nixl_opt_args_t* extra_params) const {
+nixlAgent::makeXferReq(const nixl_xfer_op_t &operation,
+                       const nixlDlistH *local_side,
+                       const std::vector<int> &local_indices,
+                       const nixlDlistH *remote_side,
+                       const std::vector<int> &remote_indices,
+                       nixlXferReqH *&req_hndl,
+                       const nixl_opt_args_t *extra_params) const {
 
-    nixl_opt_b_args_t  opt_args;
-    nixl_status_t      ret;
-    int                desc_count = (int) local_indices.size();
-    nixlBackendEngine* backend    = nullptr;
+    nixl_opt_b_args_t opt_args;
+    nixl_status_t ret;
+    int desc_count = (int)local_indices.size();
+    nixlBackendEngine *backend = nullptr;
 
     req_hndl = nullptr;
 
@@ -711,7 +691,7 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
     }
 
     if (extra_params && extra_params->backends.size() > 0) {
-        for (auto & elm : extra_params->backends) {
+        for (auto &elm : extra_params->backends) {
             if ((local_side->descs.count(elm->engine) > 0) &&
                 (remote_side->descs.count(elm->engine) > 0)) {
                 backend = elm->engine;
@@ -719,15 +699,16 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
             }
         }
     } else {
-        for (auto & loc_bknd : local_side->descs) {
-            for (auto & rem_bknd : remote_side->descs) {
+        for (auto &loc_bknd : local_side->descs) {
+            for (auto &rem_bknd : remote_side->descs) {
                 if (loc_bknd.first == rem_bknd.first) {
                     backend = loc_bknd.first;
                     break;
                 }
             }
-            if (backend)
+            if (backend) {
                 break;
+            }
         }
     }
 
@@ -748,7 +729,7 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    for (int i=0; i<desc_count; ++i) {
+    for (int i = 0; i < desc_count; ++i) {
         if ((local_indices[i] >= local_descs.descCount()) || (local_indices[i] < 0)) {
             NIXL_ERROR_FUNC << "local index out of range at index " << i << " with value "
                             << local_indices[i];
@@ -790,17 +771,17 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
                                                  desc_count);
 
     if (extra_params && extra_params->skipDescMerge) {
-        for (int i=0; i<desc_count; ++i) {
+        for (int i = 0; i < desc_count; ++i) {
             handle->initiatorDescs[i] = local_descs[local_indices[i]];
             handle->targetDescs[i] = remote_descs[remote_indices[i]];
         }
     } else {
-        int i = 0, j = 0; //final list size
-        while (i<(desc_count)) {
+        int i = 0, j = 0; // final list size
+        while (i < (desc_count)) {
             nixlMetaDesc local_desc1 = local_descs[local_indices[i]];
             nixlMetaDesc remote_desc1 = remote_descs[remote_indices[i]];
 
-            if(i != (desc_count-1) ) {
+            if (i != (desc_count - 1)) {
                 const nixlMetaDesc *local_desc2 = &(local_descs[local_indices[i + 1]]);
                 const nixlMetaDesc *remote_desc2 = &(remote_descs[remote_indices[i + 1]]);
 
@@ -815,7 +796,9 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
                     remote_desc1.len += remote_desc2->len;
 
                     i++;
-                    if(i == (desc_count-1)) break;
+                    if (i == (desc_count - 1)) {
+                        break;
+                    }
 
                     local_desc2 = &(local_descs[local_indices[i + 1]]);
                     remote_desc2 = &(remote_descs[remote_indices[i + 1]]);
@@ -865,8 +848,8 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
                          const nixl_xfer_dlist_t &local_descs,
                          const nixl_xfer_dlist_t &remote_descs,
                          const std::string &remote_agent,
-                         nixlXferReqH* &req_hndl,
-                         const nixl_opt_args_t* extra_params) const {
+                         nixlXferReqH *&req_hndl,
+                         const nixl_opt_args_t *extra_params) const {
     nixl_status_t ret1, ret2;
     nixl_opt_b_args_t opt_args;
     backend_set_t backend_set;
@@ -908,18 +891,20 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             return NIXL_ERR_NOT_FOUND;
         }
 
-        for (auto & elm : *local_set)
+        for (auto &elm : *local_set) {
             if (remote_set->count(elm) != 0) {
                 backend_set.insert(elm);
             }
+        }
 
         if (backend_set.empty()) {
             NIXL_ERROR_FUNC << "no potential backend found to be able to do the transfer";
             return NIXL_ERR_NOT_FOUND;
         }
     } else {
-        for (auto & elm : extra_params->backends)
+        for (auto &elm : extra_params->backends) {
             backend_set.insert(elm->engine);
+        }
     }
 
     // TODO: when central KV is supported, add a call to fetchRemoteMD
@@ -959,8 +944,9 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             opt_args.hasNotif = true;
         }
 
-        if (extra_params->customParam.length() > 0)
+        if (extra_params->customParam.length() > 0) {
             opt_args.customParam = extra_params->customParam;
+        }
     }
 
     if (opt_args.hasNotif && (!handle->engine->supportsNotif())) {
@@ -1003,8 +989,7 @@ nixlAgent::estimateXferCost(const nixlXferReqH *req_hndl,
                             std::chrono::microseconds &duration,
                             std::chrono::microseconds &err_margin,
                             nixl_cost_t &method,
-                            const nixl_opt_args_t* extra_params) const
-{
+                            const nixl_opt_args_t *extra_params) const {
     nixl_status_t ret;
     NIXL_SHARED_LOCK_GUARD(data->lock);
 
@@ -1041,8 +1026,7 @@ nixlAgent::estimateXferCost(const nixlXferReqH *req_hndl,
 }
 
 nixl_status_t
-nixlAgent::postXferReq(nixlXferReqH *req_hndl,
-                       const nixl_opt_args_t* extra_params) const {
+nixlAgent::postXferReq(nixlXferReqH *req_hndl, const nixl_opt_args_t *extra_params) const {
     nixl_opt_b_args_t opt_args;
 
     opt_args.hasNotif = false;
@@ -1068,8 +1052,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 
     // We can't repost while a request is in progress
     if (req_hndl->status == NIXL_IN_PROG) {
-        req_hndl->status = req_hndl->engine->checkXfer(
-                                     req_hndl->backendHandle);
+        req_hndl->status = req_hndl->engine->checkXfer(req_hndl->backendHandle);
         if (req_hndl->status == NIXL_IN_PROG) {
             NIXL_ERROR_FUNC << "transfer request is still in progress and cannot be reposted";
             return NIXL_ERR_REPOST_ACTIVE;
@@ -1151,7 +1134,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 }
 
 nixl_status_t
-nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
+nixlAgent::getXferStatus(nixlXferReqH *req_hndl) const {
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
     // If the status is done, no need to recheck and no state changes.
@@ -1197,41 +1180,49 @@ nixlAgent::getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &event
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
 
-    // Skip remote-validity check when the request is already complete or errored:
-    // completed requests carry a cached result and don't need metadata anymore.
-    if (req_hndl->status == NIXL_IN_PROG &&
-        data->remoteSections_.count(req_hndl->remoteAgent) == 0) {
+    // Completed-with-error: return cached backend failure without re-querying (mirrors legacy
+    // terminal handling; avoids spurious NOT_FOUND). Still poll while SUCCESS or IN_PROG so the
+    // first checkXferEvents runs (e.g. NIXL_ERR_NOT_SUPPORTED) after synchronous completion.
+    if (req_hndl->status < 0) {
+        return req_hndl->status;
+    }
+
+    if (data->remoteSections_.count(req_hndl->remoteAgent) == 0) {
         NIXL_ERROR_FUNC << "remote agent '" << req_hndl->remoteAgent
                         << "' was invalidated during transfer";
         return NIXL_ERR_NOT_FOUND;
     }
 
-    const nixl_status_t status = req_hndl->engine->checkXferEvents(req_hndl->backendHandle, events_out);
+    const nixl_status_t status =
+        req_hndl->engine->checkXferEvents(req_hndl->backendHandle, events_out);
 
     switch (status) {
-        case NIXL_ERR_NOT_SUPPORTED:
-            return status;
-        case NIXL_ERR_REMOTE_DISCONNECT:
-            data->invalidateRemoteData(req_hndl->remoteAgent);
-            req_hndl->status = NIXL_ERR_REMOTE_DISCONNECT;
-            return NIXL_ERR_REMOTE_DISCONNECT;
-        case NIXL_IN_PROG:
-            req_hndl->status = NIXL_IN_PROG;
-            // Only signal in-progress-with-errors when at least one entry has actually errored.
-            for (const auto &ev : events_out) {
-                if (ev.status < 0) return NIXL_IN_PROG_WITH_ERR;
+    case NIXL_ERR_NOT_SUPPORTED:
+        return status;
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        data->invalidateRemoteData(req_hndl->remoteAgent);
+        req_hndl->status = NIXL_ERR_REMOTE_DISCONNECT;
+        return NIXL_ERR_REMOTE_DISCONNECT;
+    case NIXL_IN_PROG:
+        req_hndl->status = NIXL_IN_PROG;
+        // Only signal in-progress-with-errors when at least one entry has actually errored.
+        for (const auto &ev : events_out) {
+            if (ev.status < 0) {
+                return NIXL_IN_PROG_WITH_ERR;
             }
-            return NIXL_IN_PROG;
-        default:
-            break;
+        }
+        return NIXL_IN_PROG;
+    default:
+        break;
     }
 
     req_hndl->status = status;
     if (data->telemetryEnabled) {
-        if (status == NIXL_SUCCESS)
+        if (status == NIXL_SUCCESS) {
             req_hndl->updateRequestStats(data->telemetry_.get(), NIXL_TELEMETRY_FINISH);
-        else if (status < 0)
+        } else if (status < 0) {
             data->addErrorTelemetry(status);
+        }
     }
     return status;
 }
@@ -1254,8 +1245,7 @@ nixlAgent::getXferTelemetry(const nixlXferReqH *req_hndl, nixl_xfer_telem_t &tel
 }
 
 nixl_status_t
-nixlAgent::queryXferBackend(const nixlXferReqH* req_hndl,
-                            nixlBackendH* &backend) const {
+nixlAgent::queryXferBackend(const nixlXferReqH *req_hndl, nixlBackendH *&backend) const {
     NIXL_LOCK_GUARD(data->lock);
     backend = data->backendHandles_[req_hndl->engine->getType()].get();
     return NIXL_SUCCESS;
@@ -1265,15 +1255,13 @@ nixl_status_t
 nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
-    //attempt to cancel request
-    if(req_hndl->status == NIXL_IN_PROG) {
-        req_hndl->status = req_hndl->engine->checkXfer(
-                                     req_hndl->backendHandle);
+    // attempt to cancel request
+    if (req_hndl->status == NIXL_IN_PROG) {
+        req_hndl->status = req_hndl->engine->checkXfer(req_hndl->backendHandle);
 
-        if(req_hndl->status == NIXL_IN_PROG) {
+        if (req_hndl->status == NIXL_IN_PROG) {
 
-            req_hndl->status = req_hndl->engine->releaseReqH(
-                                         req_hndl->backendHandle);
+            req_hndl->status = req_hndl->engine->releaseReqH(req_hndl->backendHandle);
 
             if (req_hndl->status < 0) {
                 NIXL_ERROR_FUNC << "backend '" << req_hndl->engine->getType()
@@ -1291,18 +1279,17 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 }
 
 nixl_status_t
-nixlAgent::releasedDlistH (nixlDlistH* dlist_hndl) const {
+nixlAgent::releasedDlistH(nixlDlistH *dlist_hndl) const {
     NIXL_LOCK_GUARD(data->lock);
     delete dlist_hndl;
     return NIXL_SUCCESS;
 }
 
 nixl_status_t
-nixlAgent::getNotifs(nixl_notifs_t &notif_map,
-                     const nixl_opt_args_t* extra_params) {
-    notif_list_t    bknd_notif_list;
-    nixl_status_t   ret, bad_ret=NIXL_SUCCESS;
-    backend_list_t* backend_list;
+nixlAgent::getNotifs(nixl_notifs_t &notif_map, const nixl_opt_args_t *extra_params) {
+    notif_list_t bknd_notif_list;
+    nixl_status_t ret, bad_ret = NIXL_SUCCESS;
+    backend_list_t *backend_list;
 
     NIXL_LOCK_GUARD(data->lock);
     if (!extra_params || extra_params->backends.size() == 0) {
@@ -1313,9 +1300,11 @@ nixlAgent::getNotifs(nixl_notifs_t &notif_map,
         }
     } else {
         backend_list = new backend_list_t();
-        for (auto & elm : extra_params->backends)
-            if (elm->engine->supportsNotif())
+        for (auto &elm : extra_params->backends) {
+            if (elm->engine->supportsNotif()) {
                 backend_list->push_back(elm->engine);
+            }
+        }
 
         if (backend_list->empty()) {
             NIXL_ERROR_FUNC << "none of specified backends support notifications";
@@ -1327,28 +1316,31 @@ nixlAgent::getNotifs(nixl_notifs_t &notif_map,
     // Doing best effort, if any backend errors out we return
     // error but proceed with the rest. We can add metadata about
     // the backend to the msg, but user could put it themselves.
-    for (auto & eng: *backend_list) {
+    for (auto &eng : *backend_list) {
         bknd_notif_list.clear();
         ret = eng->getNotifs(bknd_notif_list);
         if (ret < 0) {
             NIXL_ERROR_FUNC << "backend '" << eng->getType() << "' returned error status " << ret
                             << " while getting notifications";
-            bad_ret=ret;
+            bad_ret = ret;
         }
 
-        if (bknd_notif_list.size() == 0)
+        if (bknd_notif_list.size() == 0) {
             continue;
+        }
 
-        for (auto & elm: bknd_notif_list) {
-            if (notif_map.count(elm.first) == 0)
+        for (auto &elm : bknd_notif_list) {
+            if (notif_map.count(elm.first) == 0) {
                 notif_map[elm.first] = std::vector<nixl_blob_t>();
+            }
 
             notif_map[elm.first].push_back(elm.second);
         }
     }
 
-    if (extra_params && extra_params->backends.size() > 0)
+    if (extra_params && extra_params->backends.size() > 0) {
         delete backend_list;
+    }
 
     // If any backend had an error, it was already logged
     return bad_ret;
@@ -1416,7 +1408,7 @@ nixlAgent::genNotif(const std::string &remote_agent,
 }
 
 nixl_status_t
-nixlAgent::getLocalMD (nixl_blob_t &str) const {
+nixlAgent::getLocalMD(nixl_blob_t &str) const {
     size_t conn_cnt;
     nixl_backend_t nixl_backend;
     nixl_status_t ret;
@@ -1433,22 +1425,34 @@ nixlAgent::getLocalMD (nixl_blob_t &str) const {
     nixlSerDes sd;
     ret = sd.addStr("Agent", data->name_);
     // Always returns SUCCESS, serdes class logs errors if necessary
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     ret = sd.addBuf("Conns", &conn_cnt, sizeof(conn_cnt));
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     for (auto &c : data->connMd_) {
         nixl_backend = c.first;
         ret = sd.addStr("t", nixl_backend);
-        if (ret) break;
+        if (ret) {
+            break;
+        }
         ret = sd.addStr("c", c.second);
-        if (ret) break;
+        if (ret) {
+            break;
+        }
     }
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     ret = sd.addStr("", "MemSection");
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     ret = data->localSection_.serialize(&sd);
     if (ret) {
@@ -1463,7 +1467,7 @@ nixlAgent::getLocalMD (nixl_blob_t &str) const {
 nixl_status_t
 nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
                              nixl_blob_t &str,
-                             const nixl_opt_args_t* extra_params) const {
+                             const nixl_opt_args_t *extra_params) const {
     backend_list_t tmp_list;
     backend_list_t *backend_list;
     nixl_status_t ret;
@@ -1498,7 +1502,9 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
     std::vector<typename decltype(data->connMd_)::iterator> found_iters;
     for (const auto &backend : *backend_list) {
         auto it = data->connMd_.find(backend->getType());
-        if (it == data->connMd_.end()) continue;
+        if (it == data->connMd_.end()) {
+            continue;
+        }
         found_iters.push_back(it);
         selected_engines.insert(backend);
     }
@@ -1511,24 +1517,37 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
     nixlSerDes sd;
     ret = sd.addStr("Agent", data->name_);
     // Always returns SUCCESS, serdes class logs errors if necessary
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     // Only add connection info if requested via extra_params or empty dlist
     size_t conn_cnt = ((extra_params && extra_params->includeConnInfo) || descs.descCount() == 0) ?
-                      found_iters.size() : 0;
+        found_iters.size() :
+        0;
     ret = sd.addBuf("Conns", &conn_cnt, sizeof(conn_cnt));
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     for (size_t i = 0; i < conn_cnt; i++) {
         ret = sd.addStr("t", found_iters[i]->first);
-        if (ret) break;
+        if (ret) {
+            break;
+        }
         ret = sd.addStr("c", found_iters[i]->second);
-        if (ret) break;
+        if (ret) {
+            break;
+        }
     }
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     ret = sd.addStr("", "MemSection");
-    if (ret) return NIXL_ERR_UNKNOWN;
+    if (ret) {
+        return NIXL_ERR_UNKNOWN;
+    }
 
     ret = data->localSection_.serializePartial(&sd, selected_engines, descs);
     if (ret) {
@@ -1541,8 +1560,7 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
-                         std::string &agent_name) {
+nixlAgent::loadRemoteMD(const nixl_blob_t &remote_metadata, std::string &agent_name) {
     nixlSerDes sd;
     nixl_blob_t conn_info;
     nixl_backend_t nixl_backend;
@@ -1640,17 +1658,18 @@ nixlAgent::invalidateRemoteMD(const std::string &remote_agent) {
         ret = NIXL_SUCCESS;
     }
 
-    if (ret == NIXL_ERR_NOT_FOUND)
+    if (ret == NIXL_ERR_NOT_FOUND) {
         NIXL_INFO << __FUNCTION__ << ": remote metadata for agent '" << remote_agent
                   << "' not found.";
-    else if (ret != NIXL_SUCCESS)
+    } else if (ret != NIXL_SUCCESS) {
         NIXL_ERROR_FUNC << "error invalidating remote metadata for agent '" << remote_agent
                         << "' with status " << ret;
+    }
     return ret;
 }
 
 nixl_status_t
-nixlAgent::sendLocalMD (const nixl_opt_args_t* extra_params) const {
+nixlAgent::sendLocalMD(const nixl_opt_args_t *extra_params) const {
     nixl_blob_t myMD;
     nixl_status_t ret = getLocalMD(myMD);
     if (ret < 0) {
@@ -1660,14 +1679,16 @@ nixlAgent::sendLocalMD (const nixl_opt_args_t* extra_params) const {
 
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
+        data->enqueueCommWork(
+            std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
         return NIXL_SUCCESS;
     }
 
 #if HAVE_ETCD
     // If no IP is provided, use etcd (now via thread)
     if (data->useEtcd_) {
-        data->enqueueCommWork(std::make_tuple(ETCD_SEND, default_metadata_label, 0, std::move(myMD)));
+        data->enqueueCommWork(
+            std::make_tuple(ETCD_SEND, default_metadata_label, 0, std::move(myMD)));
         return NIXL_SUCCESS;
     }
     NIXL_ERROR_FUNC << "invalid parameters to be used for either socket or ETCD";
@@ -1681,7 +1702,7 @@ nixlAgent::sendLocalMD (const nixl_opt_args_t* extra_params) const {
 
 nixl_status_t
 nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
-                              const nixl_opt_args_t* extra_params) const {
+                              const nixl_opt_args_t *extra_params) const {
     nixl_blob_t myMD;
     nixl_status_t ret = getLocalPartialMD(descs, myMD, extra_params);
     if (ret < 0) {
@@ -1691,7 +1712,8 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
 
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
+        data->enqueueCommWork(
+            std::make_tuple(SOCK_SEND, extra_params->ipAddr, extra_params->port, std::move(myMD)));
         return NIXL_SUCCESS;
     }
 
@@ -1702,7 +1724,8 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
             NIXL_ERROR_FUNC << "metadata label is required for etcd send of local partial metadata";
             return NIXL_ERR_INVALID_PARAM;
         }
-        data->enqueueCommWork(std::make_tuple(ETCD_SEND, extra_params->metadataLabel, 0, std::move(myMD)));
+        data->enqueueCommWork(
+            std::make_tuple(ETCD_SEND, extra_params->metadataLabel, 0, std::move(myMD)));
         return NIXL_SUCCESS;
     }
     NIXL_ERROR_FUNC << "invalid parameters to be used for either socket or ETCD";
@@ -1714,11 +1737,11 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
 }
 
 nixl_status_t
-nixlAgent::fetchRemoteMD (const std::string remote_name,
-                          const nixl_opt_args_t* extra_params) {
+nixlAgent::fetchRemoteMD(const std::string remote_name, const nixl_opt_args_t *extra_params) {
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_FETCH, extra_params->ipAddr, extra_params->port, ""));
+        data->enqueueCommWork(
+            std::make_tuple(SOCK_FETCH, extra_params->ipAddr, extra_params->port, ""));
         return NIXL_SUCCESS;
     }
 
@@ -1726,9 +1749,10 @@ nixlAgent::fetchRemoteMD (const std::string remote_name,
     // If no IP is provided, use etcd via thread with watch capability
     if (data->useEtcd_) {
         std::string metadata_label = extra_params && !extra_params->metadataLabel.empty() ?
-                                     extra_params->metadataLabel :
-                                     default_metadata_label;
-        data->enqueueCommWork(std::make_tuple(ETCD_FETCH, std::move(metadata_label), 0, remote_name));
+            extra_params->metadataLabel :
+            default_metadata_label;
+        data->enqueueCommWork(
+            std::make_tuple(ETCD_FETCH, std::move(metadata_label), 0, remote_name));
         return NIXL_SUCCESS;
     }
     NIXL_ERROR_FUNC << "invalid parameters to be used for either socket or ETCD";
@@ -1740,10 +1764,11 @@ nixlAgent::fetchRemoteMD (const std::string remote_name,
 }
 
 nixl_status_t
-nixlAgent::invalidateLocalMD (const nixl_opt_args_t* extra_params) const {
+nixlAgent::invalidateLocalMD(const nixl_opt_args_t *extra_params) const {
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
-        data->enqueueCommWork(std::make_tuple(SOCK_INVAL, extra_params->ipAddr, extra_params->port, ""));
+        data->enqueueCommWork(
+            std::make_tuple(SOCK_INVAL, extra_params->ipAddr, extra_params->port, ""));
         return NIXL_SUCCESS;
     }
 
@@ -1762,8 +1787,7 @@ nixlAgent::invalidateLocalMD (const nixl_opt_args_t* extra_params) const {
 }
 
 nixl_status_t
-nixlAgent::checkRemoteMD (const std::string remote_name,
-                          const nixl_xfer_dlist_t &descs) const {
+nixlAgent::checkRemoteMD(const std::string remote_name, const nixl_xfer_dlist_t &descs) const {
     NIXL_LOCK_GUARD(data->lock);
     const auto rem_sec_it = data->remoteSections_.find(remote_name);
     if (data->remoteSections_.end() == rem_sec_it) {

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -72,8 +72,8 @@ nixlEnumStrings::statusStr(const nixl_status_t &status) {
             return "NIXL_ERR_CANCELED";
         case NIXL_ERR_NO_TELEMETRY:
             return "NIXL_ERR_NO_TELEMETRY";
-        case NIXL_ERR_IN_PROG:
-            return "NIXL_ERR_IN_PROG";
+        case NIXL_IN_PROG_WITH_ERR:
+            return "NIXL_IN_PROG_WITH_ERR";
         default:                         return "BAD_STATUS";
     }
 }
@@ -963,8 +963,6 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             opt_args.customParam = extra_params->customParam;
     }
 
-    opt_args.trackFlags = handle->trackFlags;
-
     if (opt_args.hasNotif && (!handle->engine->supportsNotif())) {
         NIXL_ERROR_FUNC << "the selected backend '" << handle->engine->getType()
                         << "' does not support notifications";
@@ -1190,8 +1188,7 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
 }
 
 nixl_status_t
-nixlAgent::getXferStatus (nixlXferReqH *req_hndl,
-                          nixl_xfer_entry_events_t &events_out) const {
+nixlAgent::getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &events_out) const {
 
     if (req_hndl->trackFlags == 0) {
         NIXL_ERROR_FUNC << "getXferStatus(req, events) requires xfer created with trackFlags != 0";
@@ -1206,15 +1203,13 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl,
         return NIXL_ERR_NOT_FOUND;
     }
 
-    nixl_status_t status = req_hndl->engine->checkXferEvents(
-        req_hndl->backendHandle, events_out);
+    nixl_status_t status = req_hndl->engine->checkXferEvents(req_hndl->backendHandle, events_out);
 
-    if (status == NIXL_ERR_NOT_SUPPORTED)
-        return status;
+    if (status == NIXL_ERR_NOT_SUPPORTED) return status;
 
     if (status == NIXL_IN_PROG) {
         req_hndl->status = NIXL_IN_PROG;
-        return NIXL_ERR_IN_PROG;  /* negative so (status < 0) → slow path */
+        return NIXL_IN_PROG_WITH_ERR; /* negative so (status < 0) → slow path */
     }
 
     req_hndl->status = status;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -53,6 +53,31 @@ nixlEngineDeleter::operator()(nixlBackendEngine *engine) const noexcept {
     // TODO: Else delete engine?
 }
 
+std::string
+nixlEnumStrings::statusStr(const nixl_status_t &status) {
+    switch (status) {
+        case NIXL_IN_PROG:               return "NIXL_IN_PROG";
+        case NIXL_SUCCESS:               return "NIXL_SUCCESS";
+        case NIXL_ERR_NOT_POSTED:        return "NIXL_ERR_NOT_POSTED";
+        case NIXL_ERR_INVALID_PARAM:     return "NIXL_ERR_INVALID_PARAM";
+        case NIXL_ERR_BACKEND:           return "NIXL_ERR_BACKEND";
+        case NIXL_ERR_NOT_FOUND:         return "NIXL_ERR_NOT_FOUND";
+        case NIXL_ERR_MISMATCH:          return "NIXL_ERR_MISMATCH";
+        case NIXL_ERR_NOT_ALLOWED:       return "NIXL_ERR_NOT_ALLOWED";
+        case NIXL_ERR_REPOST_ACTIVE:     return "NIXL_ERR_REPOST_ACTIVE";
+        case NIXL_ERR_UNKNOWN:           return "NIXL_ERR_UNKNOWN";
+        case NIXL_ERR_NOT_SUPPORTED:     return "NIXL_ERR_NOT_SUPPORTED";
+        case NIXL_ERR_REMOTE_DISCONNECT: return "NIXL_ERR_REMOTE_DISCONNECT";
+        case NIXL_ERR_CANCELED:
+            return "NIXL_ERR_CANCELED";
+        case NIXL_ERR_NO_TELEMETRY:
+            return "NIXL_ERR_NO_TELEMETRY";
+        case NIXL_ERR_IN_PROG:
+            return "NIXL_ERR_IN_PROG";
+        default:                         return "BAD_STATUS";
+    }
+}
+
 nixlXferReqH::nixlXferReqH(const std::string &remote_agent,
                            const nixl_xfer_op_t backend_op,
                            const nixl_mem_t local_type,
@@ -810,6 +835,8 @@ nixlAgent::makeXferReq (const nixl_xfer_op_t &operation,
     handle->engine = backend;
     handle->notifMsg = opt_args.notifMsg;
     handle->hasNotif = opt_args.hasNotif;
+    handle->trackFlags = extra_params ? extra_params->trackFlags : 0;
+    opt_args.trackFlags = handle->trackFlags;
 
     if (data->telemetryEnabled) {
         handle->telemetry.totalBytes = total_bytes;
@@ -936,6 +963,8 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             opt_args.customParam = extra_params->customParam;
     }
 
+    opt_args.trackFlags = handle->trackFlags;
+
     if (opt_args.hasNotif && (!handle->engine->supportsNotif())) {
         NIXL_ERROR_FUNC << "the selected backend '" << handle->engine->getType()
                         << "' does not support notifications";
@@ -945,6 +974,9 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     handle->notifMsg = opt_args.notifMsg;
     handle->hasNotif = opt_args.hasNotif;
+    handle->trackFlags = extra_params ? extra_params->trackFlags : 0;
+
+    opt_args.trackFlags = handle->trackFlags;
 
     if (data->telemetryEnabled) {
         handle->telemetry.totalBytes = total_bytes;
@@ -1155,6 +1187,44 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
 
     // If the status is error when entering this method, it was already logged
     return req_hndl->status;
+}
+
+nixl_status_t
+nixlAgent::getXferStatus (nixlXferReqH *req_hndl,
+                          nixl_xfer_entry_events_t &events_out) const {
+
+    if (req_hndl->trackFlags == 0) {
+        NIXL_ERROR_FUNC << "getXferStatus(req, events) requires xfer created with trackFlags != 0";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    NIXL_SHARED_LOCK_GUARD(data->lock);
+
+    if (data->remoteSections.count(req_hndl->remoteAgent) == 0) {
+        NIXL_ERROR_FUNC << "remote agent '" << req_hndl->remoteAgent
+                        << "' was invalidated during transfer";
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    nixl_status_t status = req_hndl->engine->checkXferEvents(
+        req_hndl->backendHandle, events_out);
+
+    if (status == NIXL_ERR_NOT_SUPPORTED)
+        return status;
+
+    if (status == NIXL_IN_PROG) {
+        req_hndl->status = NIXL_IN_PROG;
+        return NIXL_ERR_IN_PROG;  /* negative so (status < 0) → slow path */
+    }
+
+    req_hndl->status = status;
+    if (data->telemetryEnabled) {
+        if (status == NIXL_SUCCESS)
+            req_hndl->updateRequestStats(data->telemetry_, NIXL_TELEMETRY_FINISH);
+        else if (status < 0)
+            data->addErrorTelemetry(status);
+    }
+    return status;
 }
 
 nixl_status_t

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1197,25 +1197,39 @@ nixlAgent::getXferStatus(nixlXferReqH *req_hndl, nixl_xfer_entry_events_t &event
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
 
-    if (data->remoteSections.count(req_hndl->remoteAgent) == 0) {
+    // Skip remote-validity check when the request is already complete or errored:
+    // completed requests carry a cached result and don't need metadata anymore.
+    if (req_hndl->status == NIXL_IN_PROG &&
+        data->remoteSections_.count(req_hndl->remoteAgent) == 0) {
         NIXL_ERROR_FUNC << "remote agent '" << req_hndl->remoteAgent
                         << "' was invalidated during transfer";
         return NIXL_ERR_NOT_FOUND;
     }
 
-    nixl_status_t status = req_hndl->engine->checkXferEvents(req_hndl->backendHandle, events_out);
+    const nixl_status_t status = req_hndl->engine->checkXferEvents(req_hndl->backendHandle, events_out);
 
-    if (status == NIXL_ERR_NOT_SUPPORTED) return status;
-
-    if (status == NIXL_IN_PROG) {
-        req_hndl->status = NIXL_IN_PROG;
-        return NIXL_IN_PROG_WITH_ERR; /* negative so (status < 0) → slow path */
+    switch (status) {
+        case NIXL_ERR_NOT_SUPPORTED:
+            return status;
+        case NIXL_ERR_REMOTE_DISCONNECT:
+            data->invalidateRemoteData(req_hndl->remoteAgent);
+            req_hndl->status = NIXL_ERR_REMOTE_DISCONNECT;
+            return NIXL_ERR_REMOTE_DISCONNECT;
+        case NIXL_IN_PROG:
+            req_hndl->status = NIXL_IN_PROG;
+            // Only signal in-progress-with-errors when at least one entry has actually errored.
+            for (const auto &ev : events_out) {
+                if (ev.status < 0) return NIXL_IN_PROG_WITH_ERR;
+            }
+            return NIXL_IN_PROG;
+        default:
+            break;
     }
 
     req_hndl->status = status;
     if (data->telemetryEnabled) {
         if (status == NIXL_SUCCESS)
-            req_hndl->updateRequestStats(data->telemetry_, NIXL_TELEMETRY_FINISH);
+            req_hndl->updateRequestStats(data->telemetry_.get(), NIXL_TELEMETRY_FINISH);
         else if (status < 0)
             data->addErrorTelemetry(status);
     }

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -54,6 +54,8 @@ statusStr(const nixl_status_t &status) {
     switch (status) {
     case NIXL_IN_PROG:
         return "NIXL_IN_PROG";
+    case NIXL_IN_PROG_WITH_ERR:
+        return "NIXL_IN_PROG_WITH_ERR";
     case NIXL_SUCCESS:
         return "NIXL_SUCCESS";
     case NIXL_ERR_NOT_POSTED:

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -38,6 +38,7 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) {
     switch (s) {
     case NIXL_SUCCESS:
     case NIXL_IN_PROG:
+    case NIXL_IN_PROG_WITH_ERR:
         NIXL_ASSERT_ALWAYS(false)
             << "nixlTelemetryEventTypeForStatus expects a negative nixl_status_t error code";
     case NIXL_ERR_NOT_POSTED:

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -74,6 +74,7 @@ private:
 
     const nixl_xfer_op_t backendOp;
     nixl_status_t status = NIXL_ERR_NOT_POSTED;
+    nixl_xfer_track_flags_t trackFlags = 0;
 
     nixl_xfer_telem_t telemetry;
 };

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Base deps for plugins that use += (e.g. OBJ when POSIX is disabled)
+plugin_deps = [nixl_infra, nixl_common_dep]
+compile_defs = []
+compile_flags = []
+
 if enabled_plugins.get('UCX')
     if not ucx_dep.found() and is_explicit_enable
         error('UCX plugin requested but UCX dependency not found')

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Base deps for plugins that use += (e.g. OBJ when POSIX is disabled)
-plugin_deps = [nixl_infra, nixl_common_dep]
 compile_defs = []
 compile_flags = []
 

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -34,7 +34,7 @@ if not is_variable('obj_utils_interface')
     subdir_done()
 endif
 
-plugin_deps += [obj_utils_interface, dependency('asio', required: true)]
+obj_plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asio', required: true)]
 
 if cuobj_dep.found()
     message('Found CUObjClient Library. Enabling S3 Accelerated engines')
@@ -48,7 +48,7 @@ if cuobj_dep.found()
         's3_accel/dell/engine_impl.cpp',
         's3_accel/dell/engine_impl.h',
     ]
-    plugin_deps += [ cuobj_dep ]
+    obj_plugin_deps += [cuobj_dep]
 else
     message ('Could not find CUObjClient Library. Skipping S3 Accelerated engines')
 endif
@@ -57,8 +57,8 @@ if 'OBJ' in static_plugins
     obj_backend_lib = static_library(
         'OBJ',
         obj_sources,
-        dependencies: plugin_deps,
-        cpp_args: compile_defs + compile_flags,
+        dependencies: obj_plugin_deps,
+        cpp_args: compile_flags,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
@@ -66,8 +66,8 @@ else
     obj_backend_lib = shared_library(
         'OBJ',
         obj_sources,
-        dependencies: plugin_deps,
-        cpp_args: compile_defs + ['-fPIC'],
+        dependencies: obj_plugin_deps,
+        cpp_args: ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -140,6 +140,12 @@ nixlObjEngine::checkXfer(nixlBackendReqH *handle) const {
 }
 
 nixl_status_t
+nixlObjEngine::checkXferEvents(nixlBackendReqH *handle,
+                               nixl_xfer_entry_events_t &events) const {
+    return impl_->checkXferEvents(handle, events);
+}
+
+nixl_status_t
 nixlObjEngine::releaseReqH(nixlBackendReqH *handle) const {
     return impl_->releaseReqH(handle);
 }

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -140,8 +140,7 @@ nixlObjEngine::checkXfer(nixlBackendReqH *handle) const {
 }
 
 nixl_status_t
-nixlObjEngine::checkXferEvents(nixlBackendReqH *handle,
-                               nixl_xfer_entry_events_t &events) const {
+nixlObjEngine::checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const {
     return impl_->checkXferEvents(handle, events);
 }
 

--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -121,12 +121,14 @@ public:
              const nixl_opt_b_args_t *opt_args) const = 0;
     virtual nixl_status_t
     checkXfer(nixlBackendReqH *handle) const = 0;
+
     virtual nixl_status_t
     checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const {
         (void)handle;
         (void)events;
         return NIXL_ERR_NOT_SUPPORTED;
     }
+
     virtual nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };
@@ -200,8 +202,7 @@ public:
     nixl_status_t
     checkXfer(nixlBackendReqH *handle) const override;
     nixl_status_t
-    checkXferEvents(nixlBackendReqH *handle,
-                    nixl_xfer_entry_events_t &events) const override;
+    checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const override;
     nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 

--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -122,6 +122,12 @@ public:
     virtual nixl_status_t
     checkXfer(nixlBackendReqH *handle) const = 0;
     virtual nixl_status_t
+    checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const {
+        (void)handle;
+        (void)events;
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+    virtual nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };
 
@@ -193,6 +199,9 @@ public:
 
     nixl_status_t
     checkXfer(nixlBackendReqH *handle) const override;
+    nixl_status_t
+    checkXferEvents(nixlBackendReqH *handle,
+                    nixl_xfer_entry_events_t &events) const override;
     nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 

--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -14,6 +14,7 @@
 #include <future>
 #include <optional>
 #include <vector>
+#include <cstdint>
 
 namespace {
 
@@ -54,27 +55,21 @@ public:
     nixlObjBackendReqH() = default;
     ~nixlObjBackendReqH() = default;
 
-    std::vector<std::future<nixl_status_t>> statusFutures_;
+    std::vector<std::shared_future<nixl_status_t>> statusFutures_;
+    nixl_xfer_track_flags_t trackFlags = 0;
+    std::vector<bool> appended_;  /* which indices already appended to events */
 
     nixl_status_t
     getOverallStatus() {
-        // Iterate front-to-back to detect failures in earlier futures even if
-        // later futures are not yet ready. This ensures we return errors as
-        // soon as they occur rather than waiting for all futures to complete.
-        auto it = statusFutures_.begin();
-        while (it != statusFutures_.end()) {
-            if (it->wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
-                auto current_status = it->get();
-                if (current_status != NIXL_SUCCESS) {
-                    statusFutures_.clear();
-                    return current_status;
-                }
-                it = statusFutures_.erase(it);
-            } else {
+        nixl_status_t first_error = NIXL_SUCCESS;
+        for (size_t i = 0; i < statusFutures_.size(); ++i) {
+            if (statusFutures_[i].wait_for(std::chrono::seconds(0)) != std::future_status::ready)
                 return NIXL_IN_PROG;
-            }
+            auto s = statusFutures_[i].get();
+            if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS)
+                first_error = s;
         }
-        return NIXL_SUCCESS;
+        return first_error;
     }
 };
 
@@ -285,6 +280,10 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
     }
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
 
+    if (opt_args)
+        req_h->trackFlags = opt_args->trackFlags;
+    req_h->appended_.resize(local.descCount(), false);
+
     for (int i = 0; i < local.descCount(); ++i) {
         const auto &local_desc = local[i];
         const auto &remote_desc = remote[i];
@@ -297,7 +296,7 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
         }
 
         auto status_promise = std::make_shared<std::promise<nixl_status_t>>();
-        req_h->statusFutures_.push_back(status_promise->get_future());
+        req_h->statusFutures_.push_back(status_promise->get_future().share());
 
         uintptr_t data_ptr = local_desc.addr;
         size_t data_len = local_desc.len;
@@ -334,6 +333,34 @@ DefaultObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
     }
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
     return req_h->getOverallStatus();
+}
+
+nixl_status_t
+DefaultObjEngineImpl::checkXferEvents(nixlBackendReqH *handle,
+                                     nixl_xfer_entry_events_t &events) const {
+    nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
+    nixl_xfer_track_flags_t flags = req_h->trackFlags;
+    if (flags == 0)
+        return NIXL_ERR_NOT_SUPPORTED;
+
+    nixl_status_t overall = NIXL_SUCCESS;
+    for (size_t i = 0; i < req_h->statusFutures_.size(); ++i) {
+        if (req_h->appended_[i])
+            continue;
+        if (req_h->statusFutures_[i].wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+            overall = NIXL_IN_PROG;
+            continue;
+        }
+        nixl_status_t s = req_h->statusFutures_[i].get();
+        if (s != NIXL_SUCCESS && overall == NIXL_SUCCESS)
+            overall = s;
+        bool include = (s != NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_ERRORS)) ||
+                      (s == NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_SUCCESSES));
+        if (include)
+            events.push_back({i, s});
+        req_h->appended_[i] = true;
+    }
+    return overall;
 }
 
 nixl_status_t

--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -30,11 +30,12 @@ isValidPrepXferParams(const nixl_xfer_op_t &operation,
         return false;
     }
 
-    if (remote_agent != local_agent)
+    if (remote_agent != local_agent) {
         NIXL_WARN << absl::StrFormat(
             "Warning: Remote agent doesn't match the requesting agent (%s). Got %s",
             local_agent,
             remote_agent);
+    }
 
     if (local.getType() != DRAM_SEG) {
         NIXL_ERROR << absl::StrFormat("Error: Local memory type must be DRAM_SEG, got %d",
@@ -67,10 +68,13 @@ public:
     getOverallStatus() {
         nixl_status_t first_error = NIXL_SUCCESS;
         for (const auto &future : statusFutures_) {
-            if (future.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+            if (future.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
                 return NIXL_IN_PROG;
+            }
             auto s = future.get();
-            if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS) first_error = s;
+            if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS) {
+                first_error = s;
+            }
         }
         return first_error;
     }
@@ -115,7 +119,9 @@ DefaultObjEngineImpl::DefaultObjEngineImpl(const nixlBackendInitParams *init_par
     // The s3_client_crt parameter is accepted for API consistency with derived
     // engine implementations (e.g., S3CrtObjEngineImpl) but is intentionally unused here.
     (void)s3_client_crt;
-    if (s3Client_) s3Client_->setExecutor(executor_);
+    if (s3Client_) {
+        s3Client_->setExecutor(executor_);
+    }
     NIXL_INFO << "Object storage backend initialized with injected S3 clients";
 }
 
@@ -128,8 +134,9 @@ DefaultObjEngineImpl::registerMem(const nixlBlobDesc &mem,
                                   const nixl_mem_t &nixl_mem,
                                   nixlBackendMD *&out) {
     nixl_mem_list_t supported_mems = {OBJ_SEG, DRAM_SEG};
-    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end())
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end()) {
         return NIXL_ERR_NOT_SUPPORTED;
+    }
 
     if (nixl_mem == OBJ_SEG) {
         std::unique_ptr<nixlObjMetadata> obj_md = std::make_unique<nixlObjMetadata>(
@@ -189,7 +196,9 @@ DefaultObjEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
                 desc.metaInfo,
                 [&resp, &has_error, i, promise = state.promise, completed = state.completed](
                     std::optional<bool> exists) {
-                    if (completed->exchange(true)) return;
+                    if (completed->exchange(true)) {
+                        return;
+                    }
                     if (!exists.has_value()) {
                         resp[i] = std::nullopt;
                         has_error.store(true, std::memory_order_relaxed);
@@ -223,8 +232,9 @@ DefaultObjEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
         // Wait for all callbacks to complete their writes to resp/has_error
         // to avoid use-after-free if a callback passed the exchange check
         // but was preempted before writing.
-        for (size_t j = 0; j < futures.size(); ++j)
+        for (size_t j = 0; j < futures.size(); ++j) {
             futures[j].wait();
+        }
         NIXL_ERROR << "Failed to query memory: " << e.what();
         return NIXL_ERR_BACKEND;
     }
@@ -262,8 +272,9 @@ DefaultObjEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
                                const std::string &local_agent,
                                nixlBackendReqH *&handle,
                                const nixl_opt_b_args_t *opt_args) const {
-    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent))
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
         return NIXL_ERR_INVALID_PARAM;
+    }
 
     auto req_h = std::make_unique<nixlObjBackendReqH>();
     handle = req_h.release();
@@ -283,9 +294,12 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
     }
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
 
-    if (opt_args) req_h->trackFlags = opt_args->trackFlags;
-    if (req_h->trackFlags)
+    if (opt_args) {
+        req_h->trackFlags = opt_args->trackFlags;
+    }
+    if (req_h->trackFlags) {
         req_h->appended_.resize(local.descCount(), false);
+    }
 
     for (int i = 0; i < local.descCount(); ++i) {
         const auto &local_desc = local[i];
@@ -317,12 +331,13 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
             status_promise->set_value(success ? NIXL_SUCCESS : NIXL_ERR_BACKEND);
         };
 
-        if (operation == NIXL_WRITE)
+        if (operation == NIXL_WRITE) {
             client->putObjectAsync(
                 obj_key_search->second, data_ptr, data_len, offset, status_callback);
-        else
+        } else {
             client->getObjectAsync(
                 obj_key_search->second, data_ptr, data_len, offset, status_callback);
+        }
     }
 
     return NIXL_IN_PROG;
@@ -341,25 +356,35 @@ DefaultObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
 nixl_status_t
 DefaultObjEngineImpl::checkXferEvents(nixlBackendReqH *handle,
                                       nixl_xfer_entry_events_t &events) const {
-    if (!handle) return NIXL_ERR_INVALID_PARAM;
+    if (!handle) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
     std::lock_guard<std::mutex> lock(req_h->eventsMutex_);
     const nixl_xfer_track_flags_t flags = req_h->trackFlags;
-    if (flags == 0) return NIXL_ERR_NOT_SUPPORTED;
+    if (flags == 0) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
 
     bool any_pending = false;
     for (size_t i = 0; i < req_h->statusFutures_.size(); ++i) {
-        if (req_h->appended_[i]) continue;
+        if (req_h->appended_[i]) {
+            continue;
+        }
         if (req_h->statusFutures_[i].wait_for(std::chrono::seconds(0)) !=
             std::future_status::ready) {
             any_pending = true;
             continue;
         }
         nixl_status_t s = req_h->statusFutures_[i].get();
-        if (s != NIXL_SUCCESS && req_h->firstError_ == NIXL_SUCCESS) req_h->firstError_ = s;
+        if (s != NIXL_SUCCESS && req_h->firstError_ == NIXL_SUCCESS) {
+            req_h->firstError_ = s;
+        }
         const bool include = (s != NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_ERRORS)) ||
             (s == NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_SUCCESSES));
-        if (include) events.push_back({i, s});
+        if (include) {
+            events.push_back({i, s});
+        }
         req_h->appended_[i] = true;
     }
     return any_pending ? NIXL_IN_PROG : req_h->firstError_;

--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <future>
+#include <mutex>
 #include <optional>
 #include <vector>
 #include <cstdint>
@@ -60,14 +61,15 @@ public:
     std::vector<bool> appended_; /* which indices already appended to events */
     nixl_status_t firstError_ =
         NIXL_SUCCESS; /* first error seen across all checkXferEvents calls */
+    mutable std::mutex eventsMutex_;
 
     nixl_status_t
     getOverallStatus() {
         nixl_status_t first_error = NIXL_SUCCESS;
-        for (size_t i = 0; i < statusFutures_.size(); ++i) {
-            if (statusFutures_[i].wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+        for (const auto &future : statusFutures_) {
+            if (future.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
                 return NIXL_IN_PROG;
-            auto s = statusFutures_[i].get();
+            auto s = future.get();
             if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS) first_error = s;
         }
         return first_error;
@@ -282,7 +284,8 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
 
     if (opt_args) req_h->trackFlags = opt_args->trackFlags;
-    req_h->appended_.resize(local.descCount(), false);
+    if (req_h->trackFlags)
+        req_h->appended_.resize(local.descCount(), false);
 
     for (int i = 0; i < local.descCount(); ++i) {
         const auto &local_desc = local[i];
@@ -338,8 +341,10 @@ DefaultObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
 nixl_status_t
 DefaultObjEngineImpl::checkXferEvents(nixlBackendReqH *handle,
                                       nixl_xfer_entry_events_t &events) const {
+    if (!handle) return NIXL_ERR_INVALID_PARAM;
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
-    nixl_xfer_track_flags_t flags = req_h->trackFlags;
+    std::lock_guard<std::mutex> lock(req_h->eventsMutex_);
+    const nixl_xfer_track_flags_t flags = req_h->trackFlags;
     if (flags == 0) return NIXL_ERR_NOT_SUPPORTED;
 
     bool any_pending = false;
@@ -352,7 +357,7 @@ DefaultObjEngineImpl::checkXferEvents(nixlBackendReqH *handle,
         }
         nixl_status_t s = req_h->statusFutures_[i].get();
         if (s != NIXL_SUCCESS && req_h->firstError_ == NIXL_SUCCESS) req_h->firstError_ = s;
-        bool include = (s != NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_ERRORS)) ||
+        const bool include = (s != NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_ERRORS)) ||
             (s == NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_SUCCESSES));
         if (include) events.push_back({i, s});
         req_h->appended_[i] = true;

--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -57,7 +57,9 @@ public:
 
     std::vector<std::shared_future<nixl_status_t>> statusFutures_;
     nixl_xfer_track_flags_t trackFlags = 0;
-    std::vector<bool> appended_;  /* which indices already appended to events */
+    std::vector<bool> appended_; /* which indices already appended to events */
+    nixl_status_t firstError_ =
+        NIXL_SUCCESS; /* first error seen across all checkXferEvents calls */
 
     nixl_status_t
     getOverallStatus() {
@@ -66,8 +68,7 @@ public:
             if (statusFutures_[i].wait_for(std::chrono::seconds(0)) != std::future_status::ready)
                 return NIXL_IN_PROG;
             auto s = statusFutures_[i].get();
-            if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS)
-                first_error = s;
+            if (s != NIXL_SUCCESS && first_error == NIXL_SUCCESS) first_error = s;
         }
         return first_error;
     }
@@ -280,8 +281,7 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
     }
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
 
-    if (opt_args)
-        req_h->trackFlags = opt_args->trackFlags;
+    if (opt_args) req_h->trackFlags = opt_args->trackFlags;
     req_h->appended_.resize(local.descCount(), false);
 
     for (int i = 0; i < local.descCount(); ++i) {
@@ -337,30 +337,27 @@ DefaultObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
 
 nixl_status_t
 DefaultObjEngineImpl::checkXferEvents(nixlBackendReqH *handle,
-                                     nixl_xfer_entry_events_t &events) const {
+                                      nixl_xfer_entry_events_t &events) const {
     nixlObjBackendReqH *req_h = static_cast<nixlObjBackendReqH *>(handle);
     nixl_xfer_track_flags_t flags = req_h->trackFlags;
-    if (flags == 0)
-        return NIXL_ERR_NOT_SUPPORTED;
+    if (flags == 0) return NIXL_ERR_NOT_SUPPORTED;
 
-    nixl_status_t overall = NIXL_SUCCESS;
+    bool any_pending = false;
     for (size_t i = 0; i < req_h->statusFutures_.size(); ++i) {
-        if (req_h->appended_[i])
-            continue;
-        if (req_h->statusFutures_[i].wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
-            overall = NIXL_IN_PROG;
+        if (req_h->appended_[i]) continue;
+        if (req_h->statusFutures_[i].wait_for(std::chrono::seconds(0)) !=
+            std::future_status::ready) {
+            any_pending = true;
             continue;
         }
         nixl_status_t s = req_h->statusFutures_[i].get();
-        if (s != NIXL_SUCCESS && overall == NIXL_SUCCESS)
-            overall = s;
+        if (s != NIXL_SUCCESS && req_h->firstError_ == NIXL_SUCCESS) req_h->firstError_ = s;
         bool include = (s != NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_ERRORS)) ||
-                      (s == NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_SUCCESSES));
-        if (include)
-            events.push_back({i, s});
+            (s == NIXL_SUCCESS && (flags & NIXL_XFER_TRACK_SUCCESSES));
+        if (include) events.push_back({i, s});
         req_h->appended_[i] = true;
     }
-    return overall;
+    return any_pending ? NIXL_IN_PROG : req_h->firstError_;
 }
 
 nixl_status_t

--- a/src/plugins/obj/s3/engine_impl.h
+++ b/src/plugins/obj/s3/engine_impl.h
@@ -45,6 +45,8 @@ public:
     nixl_status_t
     checkXfer(nixlBackendReqH *handle) const override;
     nixl_status_t
+    checkXferEvents(nixlBackendReqH *handle, nixl_xfer_entry_events_t &events) const override;
+    nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 
 protected:

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -37,6 +37,14 @@ if not aws_s3_crt.found()
     subdir_done()
 endif
 
+# plugin_deps is set by the POSIX plugin subdir; OBJ-only builds still need link deps.
+if not is_variable('plugin_deps')
+    plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asio', required: true)]
+    if cuobj_dep.found()
+        plugin_deps += [cuobj_dep]
+    endif
+endif
+
 plugins_gtest_cpp_flags = []
 plugins_gtest_cuda_deps = []
 if cuda_dep.found()

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -44,7 +44,7 @@ if cuda_dep.found()
     plugins_gtest_cuda_deps = [cuda_dep]
 endif
 
-plugins_gtest_sources = ['../main.cpp', '../common.cpp', 'obj_plugin.cpp']
+plugins_gtest_sources = ['../main.cpp', '../common.cpp', 'obj_plugin.cpp', 'test_obj_checkXferList.cpp']
 if cuobj_dep.found()
     plugins_gtest_sources += 'obj_cuobj_plugin.cpp'
 endif

--- a/test/gtest/plugins/test_obj_checkXferList.cpp
+++ b/test/gtest/plugins/test_obj_checkXferList.cpp
@@ -41,28 +41,29 @@ namespace gtest::plugins::obj::checkxferlist {
  */
 
 // Get endpoint override from environment variable for LocalStack testing
-static std::string getEndpointOverride() {
-    const char* endpoint = std::getenv("AWS_ENDPOINT_OVERRIDE");
+static std::string
+getEndpointOverride() {
+    const char *endpoint = std::getenv("AWS_ENDPOINT_OVERRIDE");
     return endpoint ? endpoint : "";
 }
 
-static nixl_b_params_t obj_params = {
-    {"crtMinLimit", "0"},
-    {"use_virtual_addressing", "false"},
-    {"scheme", "http"},
-    {"endpoint_override", getEndpointOverride()}
-};
+static nixl_b_params_t obj_params = {{"crtMinLimit", "0"},
+                                     {"use_virtual_addressing", "false"},
+                                     {"scheme", "http"},
+                                     {"endpoint_override", getEndpointOverride()}};
 static const std::string local_agent_name = "Agent1";
 static const nixlBackendInitParams obj_test_params = {.localAgent = local_agent_name,
-                                               .type = "OBJ",
-                                               .customParams = &obj_params,
-                                               .enableProgTh = false,
-                                               .pthrDelay = 0,
-                                               .syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
+                                                      .type = "OBJ",
+                                                      .customParams = &obj_params,
+                                                      .enableProgTh = false,
+                                                      .pthrDelay = 0,
+                                                      .syncMode =
+                                                          nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
 
 // Helper to check if status indicates transfer is still in progress
-static bool isInProgress(nixl_status_t status) {
-    return status == NIXL_IN_PROG || status == NIXL_ERR_IN_PROG;
+static bool
+isInProgress(nixl_status_t status) {
+    return status == NIXL_IN_PROG || status == NIXL_IN_PROG_WITH_ERR;
 }
 
 class ObjCheckXferListTest : public setupBackendTestFixture {
@@ -75,8 +76,12 @@ protected:
 // Test batch transfer with all entries succeeding
 TEST_P(ObjCheckXferListTest, BatchTransferAllSuccess) {
     const int num_buffers = 3;
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(localBackendEngine_,
+                                                localBackendEngine_,
+                                                local_agent_name,
+                                                local_agent_name,
+                                                false,
+                                                num_buffers);
 
     transfer.setLocalMem();
 
@@ -85,23 +90,21 @@ TEST_P(ObjCheckXferListTest, BatchTransferAllSuccess) {
 
     // Prepare and perform write transfer
     nixlBackendReqH *handle = nullptr;
-    auto prep_status = localBackendEngine_->prepXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto prep_status = localBackendEngine_->prepXfer(NIXL_WRITE,
+                                                     transfer.getLocalMeta(),
+                                                     transfer.getRemoteMeta(),
+                                                     local_agent_name,
+                                                     handle,
+                                                     &opt_args);
     ASSERT_EQ(prep_status, NIXL_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto status = localBackendEngine_->postXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto status = localBackendEngine_->postXfer(NIXL_WRITE,
+                                                transfer.getLocalMeta(),
+                                                transfer.getRemoteMeta(),
+                                                local_agent_name,
+                                                handle,
+                                                &opt_args);
 
     ASSERT_EQ(status, NIXL_IN_PROG);
 
@@ -133,8 +136,12 @@ TEST_P(ObjCheckXferListTest, BatchTransferAllSuccess) {
 // Test that shared_future pattern allows multiple calls
 TEST_P(ObjCheckXferListTest, SharedFutureMultipleCalls) {
     const int num_buffers = 2;
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(localBackendEngine_,
+                                                localBackendEngine_,
+                                                local_agent_name,
+                                                local_agent_name,
+                                                false,
+                                                num_buffers);
 
     transfer.setLocalMem();
 
@@ -142,23 +149,21 @@ TEST_P(ObjCheckXferListTest, SharedFutureMultipleCalls) {
     opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
 
     nixlBackendReqH *handle = nullptr;
-    auto prep_status = localBackendEngine_->prepXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto prep_status = localBackendEngine_->prepXfer(NIXL_WRITE,
+                                                     transfer.getLocalMeta(),
+                                                     transfer.getRemoteMeta(),
+                                                     local_agent_name,
+                                                     handle,
+                                                     &opt_args);
     ASSERT_EQ(prep_status, NIXL_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto status = localBackendEngine_->postXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto status = localBackendEngine_->postXfer(NIXL_WRITE,
+                                                transfer.getLocalMeta(),
+                                                transfer.getRemoteMeta(),
+                                                local_agent_name,
+                                                handle,
+                                                &opt_args);
 
     ASSERT_EQ(status, NIXL_IN_PROG);
     ASSERT_NE(handle, nullptr);
@@ -194,8 +199,12 @@ TEST_P(ObjCheckXferListTest, SharedFutureMultipleCalls) {
 // Test result caching works correctly
 TEST_P(ObjCheckXferListTest, ResultCaching) {
     const int num_buffers = 3;
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(localBackendEngine_,
+                                                localBackendEngine_,
+                                                local_agent_name,
+                                                local_agent_name,
+                                                false,
+                                                num_buffers);
 
     transfer.setLocalMem();
 
@@ -203,23 +212,21 @@ TEST_P(ObjCheckXferListTest, ResultCaching) {
     opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
 
     nixlBackendReqH *handle = nullptr;
-    auto prep_status = localBackendEngine_->prepXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto prep_status = localBackendEngine_->prepXfer(NIXL_WRITE,
+                                                     transfer.getLocalMeta(),
+                                                     transfer.getRemoteMeta(),
+                                                     local_agent_name,
+                                                     handle,
+                                                     &opt_args);
     ASSERT_EQ(prep_status, NIXL_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto status = localBackendEngine_->postXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto status = localBackendEngine_->postXfer(NIXL_WRITE,
+                                                transfer.getLocalMeta(),
+                                                transfer.getRemoteMeta(),
+                                                local_agent_name,
+                                                handle,
+                                                &opt_args);
 
     ASSERT_EQ(status, NIXL_IN_PROG);
 
@@ -254,8 +261,12 @@ TEST_P(ObjCheckXferListTest, ResultCaching) {
 // Test per-entry status collection via append-only events
 TEST_P(ObjCheckXferListTest, PerEntryStatus) {
     const int num_buffers = 4;
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(localBackendEngine_,
+                                                localBackendEngine_,
+                                                local_agent_name,
+                                                local_agent_name,
+                                                false,
+                                                num_buffers);
 
     transfer.setLocalMem();
 
@@ -263,23 +274,21 @@ TEST_P(ObjCheckXferListTest, PerEntryStatus) {
     opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
 
     nixlBackendReqH *handle = nullptr;
-    auto prep_status = localBackendEngine_->prepXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto prep_status = localBackendEngine_->prepXfer(NIXL_WRITE,
+                                                     transfer.getLocalMeta(),
+                                                     transfer.getRemoteMeta(),
+                                                     local_agent_name,
+                                                     handle,
+                                                     &opt_args);
     ASSERT_EQ(prep_status, NIXL_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto status = localBackendEngine_->postXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto status = localBackendEngine_->postXfer(NIXL_WRITE,
+                                                transfer.getLocalMeta(),
+                                                transfer.getRemoteMeta(),
+                                                local_agent_name,
+                                                handle,
+                                                &opt_args);
 
     ASSERT_EQ(status, NIXL_IN_PROG);
 
@@ -309,8 +318,12 @@ TEST_P(ObjCheckXferListTest, PerEntryStatus) {
 // Test compatibility with existing checkXfer API
 TEST_P(ObjCheckXferListTest, CheckXferCompatibility) {
     const int num_buffers = 2;
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(localBackendEngine_,
+                                                localBackendEngine_,
+                                                local_agent_name,
+                                                local_agent_name,
+                                                false,
+                                                num_buffers);
 
     transfer.setLocalMem();
 
@@ -318,23 +331,21 @@ TEST_P(ObjCheckXferListTest, CheckXferCompatibility) {
     opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
 
     nixlBackendReqH *handle = nullptr;
-    auto prep_status = localBackendEngine_->prepXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto prep_status = localBackendEngine_->prepXfer(NIXL_WRITE,
+                                                     transfer.getLocalMeta(),
+                                                     transfer.getRemoteMeta(),
+                                                     local_agent_name,
+                                                     handle,
+                                                     &opt_args);
     ASSERT_EQ(prep_status, NIXL_SUCCESS);
     ASSERT_NE(handle, nullptr);
 
-    auto status = localBackendEngine_->postXfer(
-        NIXL_WRITE,
-        transfer.getLocalMeta(),
-        transfer.getRemoteMeta(),
-        local_agent_name,
-        handle,
-        &opt_args);
+    auto status = localBackendEngine_->postXfer(NIXL_WRITE,
+                                                transfer.getLocalMeta(),
+                                                transfer.getRemoteMeta(),
+                                                local_agent_name,
+                                                handle,
+                                                &opt_args);
 
     ASSERT_EQ(status, NIXL_IN_PROG);
 
@@ -376,15 +387,15 @@ TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
     }
 
     // Register object keys - use unique keys for this test
-    std::vector<nixlBackendMD*> obj_metadata(num_buffers);
+    std::vector<nixlBackendMD *> obj_metadata(num_buffers);
     std::vector<std::string> obj_keys(num_buffers);
 
     for (int i = 0; i < num_buffers; ++i) {
         obj_keys[i] = "partial_failure_test_obj_" + std::to_string(i) + "_" +
-                      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
 
         nixlBlobDesc desc;
-        desc.addr = 0;  // offset
+        desc.addr = 0; // offset
         desc.len = buffer_size;
         desc.devId = i;
 
@@ -407,7 +418,7 @@ TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
     nixl_meta_dlist_t dst_descs(OBJ_SEG);
     for (int i = 0; i < num_buffers; ++i) {
         nixlMetaDesc desc;
-        desc.addr = 0;  // offset in object
+        desc.addr = 0; // offset in object
         desc.len = buffer_size;
         desc.devId = i;
         desc.metadataP = obj_metadata[i];
@@ -419,7 +430,7 @@ TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
     nixl_meta_dlist_t partial_src_descs(DRAM_SEG);
     nixl_meta_dlist_t partial_dst_descs(OBJ_SEG);
 
-    for (int i = 0; i < 2; ++i) {  // Only first 2
+    for (int i = 0; i < 2; ++i) { // Only first 2
         nixlMetaDesc src_desc;
         src_desc.addr = reinterpret_cast<uintptr_t>(local_buffers[i].data());
         src_desc.len = buffer_size;
@@ -500,8 +511,7 @@ TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
     // Build index->status map from events (order may vary)
     std::vector<nixl_status_t> entry_status(num_buffers, NIXL_IN_PROG);
     for (const auto &e : events) {
-        if (e.index < num_buffers)
-            entry_status[e.index] = e.status;
+        if (e.index < num_buffers) entry_status[e.index] = e.status;
     }
 
     EXPECT_EQ(entry_status[0], NIXL_SUCCESS) << "Entry 0 should have succeeded";

--- a/test/gtest/plugins/test_obj_checkXferList.cpp
+++ b/test/gtest/plugins/test_obj_checkXferList.cpp
@@ -1,0 +1,528 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <vector>
+#include <thread>
+#include <chrono>
+
+#include "plugins_common.h"
+#include "transfer_handler.h"
+#include "obj/obj_backend.h"
+#include "backend/backend_aux.h"
+
+namespace gtest::plugins::obj::checkxferlist {
+
+/**
+ * @note To run OBJ plugin tests, the following environment variables must be set:
+ *       - AWS_ACCESS_KEY_ID
+ *       - AWS_SECRET_ACCESS_KEY
+ *       - AWS_DEFAULT_REGION
+ *       - AWS_DEFAULT_BUCKET
+ *       - AWS_ENDPOINT_OVERRIDE (optional, for LocalStack testing)
+ *
+ * These variables are required for authenticating and interacting with the S3 bucket
+ * used during the tests.
+ */
+
+// Get endpoint override from environment variable for LocalStack testing
+static std::string getEndpointOverride() {
+    const char* endpoint = std::getenv("AWS_ENDPOINT_OVERRIDE");
+    return endpoint ? endpoint : "";
+}
+
+static nixl_b_params_t obj_params = {
+    {"crtMinLimit", "0"},
+    {"use_virtual_addressing", "false"},
+    {"scheme", "http"},
+    {"endpoint_override", getEndpointOverride()}
+};
+static const std::string local_agent_name = "Agent1";
+static const nixlBackendInitParams obj_test_params = {.localAgent = local_agent_name,
+                                               .type = "OBJ",
+                                               .customParams = &obj_params,
+                                               .enableProgTh = false,
+                                               .pthrDelay = 0,
+                                               .syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
+
+// Helper to check if status indicates transfer is still in progress
+static bool isInProgress(nixl_status_t status) {
+    return status == NIXL_IN_PROG || status == NIXL_ERR_IN_PROG;
+}
+
+class ObjCheckXferListTest : public setupBackendTestFixture {
+protected:
+    ObjCheckXferListTest() {
+        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+    }
+};
+
+// Test batch transfer with all entries succeeding
+TEST_P(ObjCheckXferListTest, BatchTransferAllSuccess) {
+    const int num_buffers = 3;
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+
+    transfer.setLocalMem();
+
+    nixl_opt_b_args_t opt_args;
+    opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    // Prepare and perform write transfer
+    nixlBackendReqH *handle = nullptr;
+    auto prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+    ASSERT_EQ(prep_status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    auto status = localBackendEngine_->postXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    // Poll until complete using append-only events
+    nixl_xfer_entry_events_t events;
+    nixl_status_t overall_status;
+    int max_polls = 100;
+    int poll_count = 0;
+
+    do {
+        overall_status = localBackendEngine_->checkXferEvents(handle, events);
+        if (isInProgress(overall_status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status) && poll_count < max_polls);
+
+    ASSERT_EQ(overall_status, NIXL_SUCCESS);
+    ASSERT_EQ(events.size(), static_cast<size_t>(num_buffers));
+
+    // Verify all entries succeeded
+    for (size_t i = 0; i < events.size(); ++i) {
+        EXPECT_EQ(events[i].status, NIXL_SUCCESS) << "Entry " << events[i].index << " failed";
+    }
+
+    localBackendEngine_->releaseReqH(handle);
+}
+
+// Test that shared_future pattern allows multiple calls
+TEST_P(ObjCheckXferListTest, SharedFutureMultipleCalls) {
+    const int num_buffers = 2;
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+
+    transfer.setLocalMem();
+
+    nixl_opt_b_args_t opt_args;
+    opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlBackendReqH *handle = nullptr;
+    auto prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+    ASSERT_EQ(prep_status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    auto status = localBackendEngine_->postXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+
+    ASSERT_EQ(status, NIXL_IN_PROG);
+    ASSERT_NE(handle, nullptr);
+
+    nixl_xfer_entry_events_t events1;
+    nixl_status_t overall_status;
+    int max_polls = 100;
+    int poll_count = 0;
+
+    do {
+        overall_status = localBackendEngine_->checkXferEvents(handle, events1);
+        if (isInProgress(overall_status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status) && poll_count < max_polls);
+
+    ASSERT_EQ(overall_status, NIXL_SUCCESS);
+
+    // Call checkXferEvents again - should work with shared_future (no new events)
+    nixl_xfer_entry_events_t events2;
+    auto overall_status2 = localBackendEngine_->checkXferEvents(handle, events2);
+    ASSERT_EQ(overall_status2, NIXL_SUCCESS);
+    ASSERT_EQ(events1.size(), events2.size());
+
+    // Also verify checkXfer still works
+    auto check_status = localBackendEngine_->checkXfer(handle);
+    EXPECT_EQ(check_status, NIXL_SUCCESS);
+
+    localBackendEngine_->releaseReqH(handle);
+}
+
+// Test result caching works correctly
+TEST_P(ObjCheckXferListTest, ResultCaching) {
+    const int num_buffers = 3;
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+
+    transfer.setLocalMem();
+
+    nixl_opt_b_args_t opt_args;
+    opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlBackendReqH *handle = nullptr;
+    auto prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+    ASSERT_EQ(prep_status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    auto status = localBackendEngine_->postXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    nixl_xfer_entry_events_t events;
+    nixl_status_t overall_status;
+    int max_polls = 100;
+    int poll_count = 0;
+
+    do {
+        overall_status = localBackendEngine_->checkXferEvents(handle, events);
+        if (isInProgress(overall_status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status) && poll_count < max_polls);
+
+    ASSERT_EQ(overall_status, NIXL_SUCCESS);
+    ASSERT_EQ(events.size(), static_cast<size_t>(num_buffers));
+
+    // Verify results are consistent on subsequent calls (no new events)
+    for (int call = 0; call < 5; ++call) {
+        nixl_xfer_entry_events_t cached_events;
+        auto cached_overall = localBackendEngine_->checkXferEvents(handle, cached_events);
+
+        EXPECT_EQ(cached_overall, NIXL_SUCCESS);
+        EXPECT_EQ(cached_events.size(), events.size());
+    }
+
+    localBackendEngine_->releaseReqH(handle);
+}
+
+// Test per-entry status collection via append-only events
+TEST_P(ObjCheckXferListTest, PerEntryStatus) {
+    const int num_buffers = 4;
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+
+    transfer.setLocalMem();
+
+    nixl_opt_b_args_t opt_args;
+    opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlBackendReqH *handle = nullptr;
+    auto prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+    ASSERT_EQ(prep_status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    auto status = localBackendEngine_->postXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    nixl_xfer_entry_events_t events;
+    nixl_status_t overall_status;
+    int max_polls = 100;
+    int poll_count = 0;
+
+    do {
+        overall_status = localBackendEngine_->checkXferEvents(handle, events);
+        if (isInProgress(overall_status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status) && poll_count < max_polls);
+
+    ASSERT_EQ(overall_status, NIXL_SUCCESS);
+    ASSERT_EQ(events.size(), static_cast<size_t>(num_buffers));
+
+    for (size_t i = 0; i < events.size(); ++i) {
+        EXPECT_EQ(events[i].status, NIXL_SUCCESS) << "Entry " << events[i].index << " failed";
+    }
+
+    localBackendEngine_->releaseReqH(handle);
+}
+
+// Test compatibility with existing checkXfer API
+TEST_P(ObjCheckXferListTest, CheckXferCompatibility) {
+    const int num_buffers = 2;
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, local_agent_name, local_agent_name, false, num_buffers);
+
+    transfer.setLocalMem();
+
+    nixl_opt_b_args_t opt_args;
+    opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlBackendReqH *handle = nullptr;
+    auto prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+    ASSERT_EQ(prep_status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    auto status = localBackendEngine_->postXfer(
+        NIXL_WRITE,
+        transfer.getLocalMeta(),
+        transfer.getRemoteMeta(),
+        local_agent_name,
+        handle,
+        &opt_args);
+
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    nixl_xfer_entry_events_t events;
+    nixl_status_t overall_status_events, overall_status_single;
+    int max_polls = 100;
+    int poll_count = 0;
+
+    do {
+        overall_status_events = localBackendEngine_->checkXferEvents(handle, events);
+        overall_status_single = localBackendEngine_->checkXfer(handle);
+
+        EXPECT_EQ(overall_status_events, overall_status_single);
+
+        if (isInProgress(overall_status_events)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status_events) && poll_count < max_polls);
+
+    ASSERT_EQ(overall_status_events, NIXL_SUCCESS);
+    ASSERT_EQ(overall_status_single, NIXL_SUCCESS);
+
+    localBackendEngine_->releaseReqH(handle);
+}
+
+// Test partial failures - some entries succeed, some fail
+// This test writes to some S3 objects, then attempts to read from both
+// existing and non-existing objects to verify partial failure handling
+TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
+    const int num_buffers = 4;
+    const size_t buffer_size = 64;
+
+    // Create local memory buffers
+    std::vector<std::vector<char>> local_buffers(num_buffers);
+    for (int i = 0; i < num_buffers; ++i) {
+        local_buffers[i].resize(buffer_size);
+        std::fill(local_buffers[i].begin(), local_buffers[i].end(), static_cast<char>(0x10 + i));
+    }
+
+    // Register object keys - use unique keys for this test
+    std::vector<nixlBackendMD*> obj_metadata(num_buffers);
+    std::vector<std::string> obj_keys(num_buffers);
+
+    for (int i = 0; i < num_buffers; ++i) {
+        obj_keys[i] = "partial_failure_test_obj_" + std::to_string(i) + "_" +
+                      std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+
+        nixlBlobDesc desc;
+        desc.addr = 0;  // offset
+        desc.len = buffer_size;
+        desc.devId = i;
+
+        auto status = localBackendEngine_->registerMem(desc, OBJ_SEG, obj_metadata[i]);
+        ASSERT_EQ(status, NIXL_SUCCESS) << "Failed to register object key " << i;
+    }
+
+    // Create source (DRAM) metadata for local buffers
+    nixl_meta_dlist_t src_descs(DRAM_SEG);
+    for (int i = 0; i < num_buffers; ++i) {
+        nixlMetaDesc desc;
+        desc.addr = reinterpret_cast<uintptr_t>(local_buffers[i].data());
+        desc.len = buffer_size;
+        desc.devId = i;
+        desc.metadataP = nullptr;
+        src_descs.addDesc(desc);
+    }
+
+    // Create destination (OBJ) metadata
+    nixl_meta_dlist_t dst_descs(OBJ_SEG);
+    for (int i = 0; i < num_buffers; ++i) {
+        nixlMetaDesc desc;
+        desc.addr = 0;  // offset in object
+        desc.len = buffer_size;
+        desc.devId = i;
+        desc.metadataP = obj_metadata[i];
+        dst_descs.addDesc(desc);
+    }
+
+    // Write to ONLY first 2 objects (indices 0 and 1)
+    // Objects 2 and 3 will NOT be written to
+    nixl_meta_dlist_t partial_src_descs(DRAM_SEG);
+    nixl_meta_dlist_t partial_dst_descs(OBJ_SEG);
+
+    for (int i = 0; i < 2; ++i) {  // Only first 2
+        nixlMetaDesc src_desc;
+        src_desc.addr = reinterpret_cast<uintptr_t>(local_buffers[i].data());
+        src_desc.len = buffer_size;
+        src_desc.devId = i;
+        src_desc.metadataP = nullptr;
+        partial_src_descs.addDesc(src_desc);
+
+        nixlMetaDesc dst_desc;
+        dst_desc.addr = 0;
+        dst_desc.len = buffer_size;
+        dst_desc.devId = i;
+        dst_desc.metadataP = obj_metadata[i];
+        partial_dst_descs.addDesc(dst_desc);
+    }
+
+    // Prepare and perform write to first 2 objects
+    nixlBackendReqH *write_handle = nullptr;
+    auto write_prep_status = localBackendEngine_->prepXfer(
+        NIXL_WRITE, partial_src_descs, partial_dst_descs, local_agent_name, write_handle);
+    ASSERT_EQ(write_prep_status, NIXL_SUCCESS);
+    ASSERT_NE(write_handle, nullptr);
+
+    auto write_status = localBackendEngine_->postXfer(
+        NIXL_WRITE, partial_src_descs, partial_dst_descs, local_agent_name, write_handle);
+    ASSERT_EQ(write_status, NIXL_IN_PROG);
+
+    // Wait for write to complete
+    int max_polls = 100;
+    int poll_count = 0;
+    nixl_status_t status;
+    do {
+        status = localBackendEngine_->checkXfer(write_handle);
+        if (isInProgress(status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(status) && poll_count < max_polls);
+    ASSERT_EQ(status, NIXL_SUCCESS) << "Write to first 2 objects failed";
+    localBackendEngine_->releaseReqH(write_handle);
+
+    // Clear local buffers for read verification
+    for (auto &buf : local_buffers) {
+        std::fill(buf.begin(), buf.end(), 0);
+    }
+
+    // Now try to READ from ALL 4 objects
+    // Objects 0 and 1 exist (should succeed)
+    // Objects 2 and 3 do NOT exist (should fail)
+    nixl_opt_b_args_t read_opt_args;
+    read_opt_args.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlBackendReqH *read_handle = nullptr;
+    auto read_prep_status = localBackendEngine_->prepXfer(
+        NIXL_READ, src_descs, dst_descs, local_agent_name, read_handle, &read_opt_args);
+    ASSERT_EQ(read_prep_status, NIXL_SUCCESS);
+    ASSERT_NE(read_handle, nullptr);
+
+    auto read_status = localBackendEngine_->postXfer(
+        NIXL_READ, src_descs, dst_descs, local_agent_name, read_handle, &read_opt_args);
+    ASSERT_EQ(read_status, NIXL_IN_PROG);
+
+    nixl_xfer_entry_events_t events;
+    nixl_status_t overall_status;
+    poll_count = 0;
+
+    do {
+        overall_status = localBackendEngine_->checkXferEvents(read_handle, events);
+        if (isInProgress(overall_status)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            poll_count++;
+        }
+    } while (isInProgress(overall_status) && poll_count < max_polls);
+
+    EXPECT_LT(overall_status, 0) << "Expected overall failure status";
+
+    ASSERT_EQ(events.size(), static_cast<size_t>(num_buffers));
+
+    // Build index->status map from events (order may vary)
+    std::vector<nixl_status_t> entry_status(num_buffers, NIXL_IN_PROG);
+    for (const auto &e : events) {
+        if (e.index < num_buffers)
+            entry_status[e.index] = e.status;
+    }
+
+    EXPECT_EQ(entry_status[0], NIXL_SUCCESS) << "Entry 0 should have succeeded";
+    EXPECT_EQ(entry_status[1], NIXL_SUCCESS) << "Entry 1 should have succeeded";
+    EXPECT_LT(entry_status[2], 0) << "Entry 2 should have failed (object doesn't exist)";
+    EXPECT_LT(entry_status[3], 0) << "Entry 3 should have failed (object doesn't exist)";
+
+    for (int i = 0; i < num_buffers; ++i) {
+        NIXL_INFO << "Entry " << i << " status: " << entry_status[i];
+    }
+
+    localBackendEngine_->releaseReqH(read_handle);
+
+    // Cleanup - deregister all object keys
+    for (int i = 0; i < num_buffers; ++i) {
+        localBackendEngine_->deregisterMem(obj_metadata[i]);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(ObjCheckXferListTests,
+                         ObjCheckXferListTest,
+                         testing::Values(obj_test_params));
+
+} // namespace gtest::plugins::obj::checkxferlist

--- a/test/gtest/plugins/test_obj_checkXferList.cpp
+++ b/test/gtest/plugins/test_obj_checkXferList.cpp
@@ -511,7 +511,9 @@ TEST_P(ObjCheckXferListTest, PartialFailureOnRead) {
     // Build index->status map from events (order may vary)
     std::vector<nixl_status_t> entry_status(num_buffers, NIXL_IN_PROG);
     for (const auto &e : events) {
-        if (e.index < num_buffers) entry_status[e.index] = e.status;
+        if (e.index < num_buffers) {
+            entry_status[e.index] = e.status;
+        }
     }
 
     EXPECT_EQ(entry_status[0], NIXL_SUCCESS) << "Entry 0 should have succeeded";

--- a/test/gtest/plugins/test_obj_checkXferList.cpp
+++ b/test/gtest/plugins/test_obj_checkXferList.cpp
@@ -183,11 +183,11 @@ TEST_P(ObjCheckXferListTest, SharedFutureMultipleCalls) {
 
     ASSERT_EQ(overall_status, NIXL_SUCCESS);
 
-    // Call checkXferEvents again - should work with shared_future (no new events)
-    nixl_xfer_entry_events_t events2;
-    auto overall_status2 = localBackendEngine_->checkXferEvents(handle, events2);
+    // Call checkXferEvents again with the same container — no new events should be appended.
+    size_t prev_size = events1.size();
+    auto overall_status2 = localBackendEngine_->checkXferEvents(handle, events1);
     ASSERT_EQ(overall_status2, NIXL_SUCCESS);
-    ASSERT_EQ(events1.size(), events2.size());
+    ASSERT_EQ(events1.size(), prev_size);
 
     // Also verify checkXfer still works
     auto check_status = localBackendEngine_->checkXfer(handle);
@@ -248,11 +248,11 @@ TEST_P(ObjCheckXferListTest, ResultCaching) {
 
     // Verify results are consistent on subsequent calls (no new events)
     for (int call = 0; call < 5; ++call) {
-        nixl_xfer_entry_events_t cached_events;
-        auto cached_overall = localBackendEngine_->checkXferEvents(handle, cached_events);
+        const auto prev_size = events.size();
+        auto cached_overall = localBackendEngine_->checkXferEvents(handle, events);
 
         EXPECT_EQ(cached_overall, NIXL_SUCCESS);
-        EXPECT_EQ(cached_events.size(), events.size());
+        EXPECT_EQ(events.size(), prev_size);
     }
 
     localBackendEngine_->releaseReqH(handle);
@@ -358,14 +358,14 @@ TEST_P(ObjCheckXferListTest, CheckXferCompatibility) {
         overall_status_events = localBackendEngine_->checkXferEvents(handle, events);
         overall_status_single = localBackendEngine_->checkXfer(handle);
 
-        EXPECT_EQ(overall_status_events, overall_status_single);
-
         if (isInProgress(overall_status_events)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             poll_count++;
         }
     } while (isInProgress(overall_status_events) && poll_count < max_polls);
 
+    // Compare final states only — checking on every poll is race-prone since completion
+    // can occur between the two calls.
     ASSERT_EQ(overall_status_events, NIXL_SUCCESS);
     ASSERT_EQ(overall_status_single, NIXL_SUCCESS);
 

--- a/test/gtest/plugins/transfer_handler.h
+++ b/test/gtest/plugins/transfer_handler.h
@@ -97,6 +97,16 @@ public:
             EXPECT_TRUE(srcMem_[i]->checkIncreasing(LOCAL_BUF_BYTE + i));
     }
 
+    const nixl_meta_dlist_t&
+    getLocalMeta() const {
+        return *srcDescs_;
+    }
+
+    const nixl_meta_dlist_t&
+    getRemoteMeta() const {
+        return *dstDescs_;
+    }
+
 private:
     static constexpr uint8_t LOCAL_BUF_BYTE = 0x11;
     static constexpr uint8_t XFER_BUF_BYTE = 0x22;

--- a/test/gtest/plugins/transfer_handler.h
+++ b/test/gtest/plugins/transfer_handler.h
@@ -97,12 +97,12 @@ public:
             EXPECT_TRUE(srcMem_[i]->checkIncreasing(LOCAL_BUF_BYTE + i));
     }
 
-    const nixl_meta_dlist_t&
+    const nixl_meta_dlist_t &
     getLocalMeta() const {
         return *srcDescs_;
     }
 
-    const nixl_meta_dlist_t&
+    const nixl_meta_dlist_t &
     getRemoteMeta() const {
         return *dstDescs_;
     }

--- a/test/gtest/plugins/transfer_handler.h
+++ b/test/gtest/plugins/transfer_handler.h
@@ -61,7 +61,9 @@ public:
                 std::make_unique<memoryHandler<dstMemType>>(bufferSize_, dstDevId_ + i));
         }
 
-        if (dstBackendEngine_->supportsNotif()) setupNotifs("Test");
+        if (dstBackendEngine_->supportsNotif()) {
+            setupNotifs("Test");
+        }
 
         registerMems();
         prepMems(split_buf, remote_xfer);
@@ -81,20 +83,23 @@ public:
 
     void
     setLocalMem() {
-        for (size_t i = 0; i < srcMem_.size(); i++)
+        for (size_t i = 0; i < srcMem_.size(); i++) {
             srcMem_[i]->setIncreasing(LOCAL_BUF_BYTE + i);
+        }
     }
 
     void
     resetLocalMem() {
-        for (const auto &mem : srcMem_)
+        for (const auto &mem : srcMem_) {
             mem->reset();
+        }
     }
 
     void
     checkLocalMem() {
-        for (size_t i = 0; i < srcMem_.size(); i++)
+        for (size_t i = 0; i < srcMem_.size(); i++) {
             EXPECT_TRUE(srcMem_[i]->checkIncreasing(LOCAL_BUF_BYTE + i));
+        }
     }
 
     const nixl_meta_dlist_t &

--- a/test/gtest/unit/agent/meson.build
+++ b/test/gtest/unit/agent/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@ agent_unit_test_dep = declare_dependency(
     sources: [
         '../../mocks/gmock_engine.cpp',
         'agent.cpp',
+        'test_getXferStatusList_core.cpp',
     ],
     include_directories: [nixl_inc_dirs, gtest_inc_dirs],
     dependencies: [gmock_dep, nixl_common_dep],

--- a/test/gtest/unit/agent/test_getXferStatusList_core.cpp
+++ b/test/gtest/unit/agent/test_getXferStatusList_core.cpp
@@ -27,187 +27,199 @@
 namespace gtest {
 namespace agent {
 
-static constexpr const char *local_agent_name = "LocalAgent";
-static constexpr const char *remote_agent_name = "RemoteAgent";
-static constexpr size_t bufLen = 256;
+    static constexpr const char *local_agent_name = "LocalAgent";
+    static constexpr const char *remote_agent_name = "RemoteAgent";
+    static constexpr size_t bufLen = 256;
 
-class agentHelperForXferStatus {
-protected:
-    testing::NiceMock<mocks::GMockBackendEngine> gmock_engine_;
-    std::unique_ptr<nixlAgent> agent_;
+    class agentHelperForXferStatus {
+    protected:
+        testing::NiceMock<mocks::GMockBackendEngine> gmock_engine_;
+        std::unique_ptr<nixlAgent> agent_;
 
-public:
-    agentHelperForXferStatus(const std::string &name)
-        : agent_(std::make_unique<nixlAgent>(name, nixlAgentConfig(true))) {}
+    public:
+        agentHelperForXferStatus(const std::string &name)
+            : agent_(std::make_unique<nixlAgent>(name, nixlAgentConfig(true))) {}
 
-    ~agentHelperForXferStatus() {
-        agent_.reset();
+        ~agentHelperForXferStatus() {
+            agent_.reset();
+        }
+
+        nixlAgent *
+        getAgent() const {
+            return agent_.get();
+        }
+
+        const mocks::GMockBackendEngine &
+        getGMockEngine() const {
+            return gmock_engine_;
+        }
+
+        nixl_status_t
+        createBackendWithGMock(nixl_b_params_t &params, nixlBackendH *&backend) {
+            gmock_engine_.SetToParams(params);
+            return agent_->createBackend(GetMockBackendName(), params, backend);
+        }
+
+        nixl_status_t
+        getAndLoadRemoteMd(nixlAgent *remote_agent, std::string &remote_agent_name_out) {
+            std::string remote_metadata;
+            nixl_status_t status = remote_agent->getLocalMD(remote_metadata);
+            if (status != NIXL_SUCCESS) return status;
+            return agent_->loadRemoteMD(remote_metadata, remote_agent_name_out);
+        }
+    };
+
+    class getXferStatusListTest : public ::testing::Test {
+    protected:
+        std::unique_ptr<agentHelperForXferStatus> local_agent_helper_;
+        std::unique_ptr<agentHelperForXferStatus> remote_agent_helper_;
+        nixlAgent *local_agent_;
+        nixlAgent *remote_agent_;
+
+        void
+        SetUp() override {
+            local_agent_helper_ = std::make_unique<agentHelperForXferStatus>(local_agent_name);
+            remote_agent_helper_ = std::make_unique<agentHelperForXferStatus>(remote_agent_name);
+            local_agent_ = local_agent_helper_->getAgent();
+            remote_agent_ = remote_agent_helper_->getAgent();
+        }
+
+        void
+        TearDown() override {
+            local_agent_helper_.reset();
+            remote_agent_helper_.reset();
+        }
+    };
+
+    // Test that getXferStatus with entry_status returns NOT_SUPPORTED for backends without support
+    TEST_F(getXferStatusListTest, ReturnsNotSupportedForDefaultBackend) {
+        // Create backends on BOTH agents
+        nixl_b_params_t local_params, remote_params;
+        nixlBackendH *local_backend, *remote_backend;
+        ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend),
+                  NIXL_SUCCESS);
+
+        // Register memory on both agents
+        std::vector<char> local_buf(bufLen);
+        std::vector<char> remote_buf(bufLen);
+        nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
+        nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
+
+        nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
+        local_reg_dlist.addDesc(local_desc);
+        nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
+        remote_reg_dlist.addDesc(remote_desc);
+
+        nixl_opt_args_t local_extra_params, remote_extra_params;
+        local_extra_params.backends.push_back(local_backend);
+        remote_extra_params.backends.push_back(remote_backend);
+
+        ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+
+        // Exchange metadata
+        std::string remote_agent_name_out;
+        ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out),
+                  NIXL_SUCCESS);
+
+        // Create transfer request
+        nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
+        local_xfer_dlist.addDesc(local_desc);
+        nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
+        remote_xfer_dlist.addDesc(remote_desc);
+
+        nixl_opt_args_t create_extra_params;
+        create_extra_params.backends.push_back(local_backend);
+        create_extra_params.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+        nixlXferReqH *req_hndl = nullptr;
+        ASSERT_EQ(local_agent_->createXferReq(NIXL_WRITE,
+                                              local_xfer_dlist,
+                                              remote_xfer_dlist,
+                                              remote_agent_name_out,
+                                              req_hndl,
+                                              &create_extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+
+        // Post transfer
+        ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+
+        // Try to get per-entry status - mock backend returns NOT_SUPPORTED
+        nixl_xfer_entry_events_t events;
+        nixl_status_t status = local_agent_->getXferStatus(req_hndl, events);
+
+        EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+        EXPECT_TRUE(events.empty());
+
+        // Cleanup
+        ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params),
+                  NIXL_SUCCESS);
     }
 
-    nixlAgent *getAgent() const {
-        return agent_.get();
+    // Test that standard getXferStatus still works correctly
+    TEST_F(getXferStatusListTest, StandardGetXferStatusStillWorks) {
+        // Create backends on BOTH agents
+        nixl_b_params_t local_params, remote_params;
+        nixlBackendH *local_backend, *remote_backend;
+        ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend),
+                  NIXL_SUCCESS);
+
+        // Register memory on both agents
+        std::vector<char> local_buf(bufLen);
+        std::vector<char> remote_buf(bufLen);
+        nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
+        nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
+
+        nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
+        local_reg_dlist.addDesc(local_desc);
+        nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
+        remote_reg_dlist.addDesc(remote_desc);
+
+        nixl_opt_args_t local_extra_params, remote_extra_params;
+        local_extra_params.backends.push_back(local_backend);
+        remote_extra_params.backends.push_back(remote_backend);
+
+        ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+
+        // Exchange metadata
+        std::string remote_agent_name_out;
+        ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out),
+                  NIXL_SUCCESS);
+
+        // Create transfer request
+        nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
+        local_xfer_dlist.addDesc(local_desc);
+        nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
+        remote_xfer_dlist.addDesc(remote_desc);
+
+        nixlXferReqH *req_hndl = nullptr;
+        ASSERT_EQ(
+            local_agent_->createXferReq(
+                NIXL_WRITE, local_xfer_dlist, remote_xfer_dlist, remote_agent_name_out, req_hndl),
+            NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+
+        // Post transfer
+        ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+
+        // Standard getXferStatus should work as before
+        nixl_status_t status = local_agent_->getXferStatus(req_hndl);
+        EXPECT_TRUE(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
+
+        // Cleanup
+        ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+        ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params),
+                  NIXL_SUCCESS);
     }
 
-    const mocks::GMockBackendEngine &getGMockEngine() const {
-        return gmock_engine_;
-    }
-
-    nixl_status_t createBackendWithGMock(nixl_b_params_t &params, nixlBackendH *&backend) {
-        gmock_engine_.SetToParams(params);
-        return agent_->createBackend(GetMockBackendName(), params, backend);
-    }
-
-    nixl_status_t getAndLoadRemoteMd(nixlAgent *remote_agent, std::string &remote_agent_name_out) {
-        std::string remote_metadata;
-        nixl_status_t status = remote_agent->getLocalMD(remote_metadata);
-        if (status != NIXL_SUCCESS) return status;
-        return agent_->loadRemoteMD(remote_metadata, remote_agent_name_out);
-    }
-};
-
-class getXferStatusListTest : public ::testing::Test {
-protected:
-    std::unique_ptr<agentHelperForXferStatus> local_agent_helper_;
-    std::unique_ptr<agentHelperForXferStatus> remote_agent_helper_;
-    nixlAgent *local_agent_;
-    nixlAgent *remote_agent_;
-
-    void SetUp() override {
-        local_agent_helper_ = std::make_unique<agentHelperForXferStatus>(local_agent_name);
-        remote_agent_helper_ = std::make_unique<agentHelperForXferStatus>(remote_agent_name);
-        local_agent_ = local_agent_helper_->getAgent();
-        remote_agent_ = remote_agent_helper_->getAgent();
-    }
-
-    void TearDown() override {
-        local_agent_helper_.reset();
-        remote_agent_helper_.reset();
-    }
-};
-
-// Test that getXferStatus with entry_status returns NOT_SUPPORTED for backends without support
-TEST_F(getXferStatusListTest, ReturnsNotSupportedForDefaultBackend) {
-    // Create backends on BOTH agents
-    nixl_b_params_t local_params, remote_params;
-    nixlBackendH *local_backend, *remote_backend;
-    ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend), NIXL_SUCCESS);
-
-    // Register memory on both agents
-    std::vector<char> local_buf(bufLen);
-    std::vector<char> remote_buf(bufLen);
-    nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
-    nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
-
-    nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
-    local_reg_dlist.addDesc(local_desc);
-    nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
-    remote_reg_dlist.addDesc(remote_desc);
-
-    nixl_opt_args_t local_extra_params, remote_extra_params;
-    local_extra_params.backends.push_back(local_backend);
-    remote_extra_params.backends.push_back(remote_backend);
-
-    ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
-
-    // Exchange metadata
-    std::string remote_agent_name_out;
-    ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out), NIXL_SUCCESS);
-
-    // Create transfer request
-    nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
-    local_xfer_dlist.addDesc(local_desc);
-    nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
-    remote_xfer_dlist.addDesc(remote_desc);
-
-    nixl_opt_args_t create_extra_params;
-    create_extra_params.backends.push_back(local_backend);
-    create_extra_params.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
-
-    nixlXferReqH *req_hndl = nullptr;
-    ASSERT_EQ(local_agent_->createXferReq(
-        NIXL_WRITE,
-        local_xfer_dlist,
-        remote_xfer_dlist,
-        remote_agent_name_out,
-        req_hndl,
-        &create_extra_params), NIXL_SUCCESS);
-    ASSERT_NE(req_hndl, nullptr);
-
-    // Post transfer
-    ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
-
-    // Try to get per-entry status - mock backend returns NOT_SUPPORTED
-    nixl_xfer_entry_events_t events;
-    nixl_status_t status = local_agent_->getXferStatus(req_hndl, events);
-
-    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
-    EXPECT_TRUE(events.empty());
-
-    // Cleanup
-    ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
-    ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
-}
-
-// Test that standard getXferStatus still works correctly
-TEST_F(getXferStatusListTest, StandardGetXferStatusStillWorks) {
-    // Create backends on BOTH agents
-    nixl_b_params_t local_params, remote_params;
-    nixlBackendH *local_backend, *remote_backend;
-    ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend), NIXL_SUCCESS);
-
-    // Register memory on both agents
-    std::vector<char> local_buf(bufLen);
-    std::vector<char> remote_buf(bufLen);
-    nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
-    nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
-
-    nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
-    local_reg_dlist.addDesc(local_desc);
-    nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
-    remote_reg_dlist.addDesc(remote_desc);
-
-    nixl_opt_args_t local_extra_params, remote_extra_params;
-    local_extra_params.backends.push_back(local_backend);
-    remote_extra_params.backends.push_back(remote_backend);
-
-    ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
-
-    // Exchange metadata
-    std::string remote_agent_name_out;
-    ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out), NIXL_SUCCESS);
-
-    // Create transfer request
-    nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
-    local_xfer_dlist.addDesc(local_desc);
-    nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
-    remote_xfer_dlist.addDesc(remote_desc);
-
-    nixlXferReqH *req_hndl = nullptr;
-    ASSERT_EQ(local_agent_->createXferReq(
-        NIXL_WRITE,
-        local_xfer_dlist,
-        remote_xfer_dlist,
-        remote_agent_name_out,
-        req_hndl), NIXL_SUCCESS);
-    ASSERT_NE(req_hndl, nullptr);
-
-    // Post transfer
-    ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
-
-    // Standard getXferStatus should work as before
-    nixl_status_t status = local_agent_->getXferStatus(req_hndl);
-    EXPECT_TRUE(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
-
-    // Cleanup
-    ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
-    ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
-    ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
-}
-
-}  // namespace agent
-}  // namespace gtest
+} // namespace agent
+} // namespace gtest

--- a/test/gtest/unit/agent/test_getXferStatusList_core.cpp
+++ b/test/gtest/unit/agent/test_getXferStatusList_core.cpp
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <vector>
+
+#include "common.h"
+#include "nixl.h"
+#include "nixl_types.h"
+#include "mocks/gmock_engine.h"
+
+namespace gtest {
+namespace agent {
+
+static constexpr const char *local_agent_name = "LocalAgent";
+static constexpr const char *remote_agent_name = "RemoteAgent";
+static constexpr size_t bufLen = 256;
+
+class agentHelperForXferStatus {
+protected:
+    testing::NiceMock<mocks::GMockBackendEngine> gmock_engine_;
+    std::unique_ptr<nixlAgent> agent_;
+
+public:
+    agentHelperForXferStatus(const std::string &name)
+        : agent_(std::make_unique<nixlAgent>(name, nixlAgentConfig(true))) {}
+
+    ~agentHelperForXferStatus() {
+        agent_.reset();
+    }
+
+    nixlAgent *getAgent() const {
+        return agent_.get();
+    }
+
+    const mocks::GMockBackendEngine &getGMockEngine() const {
+        return gmock_engine_;
+    }
+
+    nixl_status_t createBackendWithGMock(nixl_b_params_t &params, nixlBackendH *&backend) {
+        gmock_engine_.SetToParams(params);
+        return agent_->createBackend(GetMockBackendName(), params, backend);
+    }
+
+    nixl_status_t getAndLoadRemoteMd(nixlAgent *remote_agent, std::string &remote_agent_name_out) {
+        std::string remote_metadata;
+        nixl_status_t status = remote_agent->getLocalMD(remote_metadata);
+        if (status != NIXL_SUCCESS) return status;
+        return agent_->loadRemoteMD(remote_metadata, remote_agent_name_out);
+    }
+};
+
+class getXferStatusListTest : public ::testing::Test {
+protected:
+    std::unique_ptr<agentHelperForXferStatus> local_agent_helper_;
+    std::unique_ptr<agentHelperForXferStatus> remote_agent_helper_;
+    nixlAgent *local_agent_;
+    nixlAgent *remote_agent_;
+
+    void SetUp() override {
+        local_agent_helper_ = std::make_unique<agentHelperForXferStatus>(local_agent_name);
+        remote_agent_helper_ = std::make_unique<agentHelperForXferStatus>(remote_agent_name);
+        local_agent_ = local_agent_helper_->getAgent();
+        remote_agent_ = remote_agent_helper_->getAgent();
+    }
+
+    void TearDown() override {
+        local_agent_helper_.reset();
+        remote_agent_helper_.reset();
+    }
+};
+
+// Test that getXferStatus with entry_status returns NOT_SUPPORTED for backends without support
+TEST_F(getXferStatusListTest, ReturnsNotSupportedForDefaultBackend) {
+    // Create backends on BOTH agents
+    nixl_b_params_t local_params, remote_params;
+    nixlBackendH *local_backend, *remote_backend;
+    ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend), NIXL_SUCCESS);
+
+    // Register memory on both agents
+    std::vector<char> local_buf(bufLen);
+    std::vector<char> remote_buf(bufLen);
+    nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
+    nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
+
+    nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
+    local_reg_dlist.addDesc(local_desc);
+    nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
+    remote_reg_dlist.addDesc(remote_desc);
+
+    nixl_opt_args_t local_extra_params, remote_extra_params;
+    local_extra_params.backends.push_back(local_backend);
+    remote_extra_params.backends.push_back(remote_backend);
+
+    ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+
+    // Exchange metadata
+    std::string remote_agent_name_out;
+    ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out), NIXL_SUCCESS);
+
+    // Create transfer request
+    nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
+    local_xfer_dlist.addDesc(local_desc);
+    nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
+    remote_xfer_dlist.addDesc(remote_desc);
+
+    nixl_opt_args_t create_extra_params;
+    create_extra_params.backends.push_back(local_backend);
+    create_extra_params.trackFlags = NIXL_XFER_TRACK_ERRORS | NIXL_XFER_TRACK_SUCCESSES;
+
+    nixlXferReqH *req_hndl = nullptr;
+    ASSERT_EQ(local_agent_->createXferReq(
+        NIXL_WRITE,
+        local_xfer_dlist,
+        remote_xfer_dlist,
+        remote_agent_name_out,
+        req_hndl,
+        &create_extra_params), NIXL_SUCCESS);
+    ASSERT_NE(req_hndl, nullptr);
+
+    // Post transfer
+    ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+
+    // Try to get per-entry status - mock backend returns NOT_SUPPORTED
+    nixl_xfer_entry_events_t events;
+    nixl_status_t status = local_agent_->getXferStatus(req_hndl, events);
+
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_TRUE(events.empty());
+
+    // Cleanup
+    ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+}
+
+// Test that standard getXferStatus still works correctly
+TEST_F(getXferStatusListTest, StandardGetXferStatusStillWorks) {
+    // Create backends on BOTH agents
+    nixl_b_params_t local_params, remote_params;
+    nixlBackendH *local_backend, *remote_backend;
+    ASSERT_EQ(local_agent_helper_->createBackendWithGMock(local_params, local_backend), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_helper_->createBackendWithGMock(remote_params, remote_backend), NIXL_SUCCESS);
+
+    // Register memory on both agents
+    std::vector<char> local_buf(bufLen);
+    std::vector<char> remote_buf(bufLen);
+    nixlBlobDesc local_desc(reinterpret_cast<uintptr_t>(local_buf.data()), bufLen, 0);
+    nixlBlobDesc remote_desc(reinterpret_cast<uintptr_t>(remote_buf.data()), bufLen, 0);
+
+    nixl_reg_dlist_t local_reg_dlist(DRAM_SEG);
+    local_reg_dlist.addDesc(local_desc);
+    nixl_reg_dlist_t remote_reg_dlist(DRAM_SEG);
+    remote_reg_dlist.addDesc(remote_desc);
+
+    nixl_opt_args_t local_extra_params, remote_extra_params;
+    local_extra_params.backends.push_back(local_backend);
+    remote_extra_params.backends.push_back(remote_backend);
+
+    ASSERT_EQ(local_agent_->registerMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_->registerMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+
+    // Exchange metadata
+    std::string remote_agent_name_out;
+    ASSERT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, remote_agent_name_out), NIXL_SUCCESS);
+
+    // Create transfer request
+    nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG);
+    local_xfer_dlist.addDesc(local_desc);
+    nixl_xfer_dlist_t remote_xfer_dlist(DRAM_SEG);
+    remote_xfer_dlist.addDesc(remote_desc);
+
+    nixlXferReqH *req_hndl = nullptr;
+    ASSERT_EQ(local_agent_->createXferReq(
+        NIXL_WRITE,
+        local_xfer_dlist,
+        remote_xfer_dlist,
+        remote_agent_name_out,
+        req_hndl), NIXL_SUCCESS);
+    ASSERT_NE(req_hndl, nullptr);
+
+    // Post transfer
+    ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+
+    // Standard getXferStatus should work as before
+    nixl_status_t status = local_agent_->getXferStatus(req_hndl);
+    EXPECT_TRUE(status == NIXL_SUCCESS || status == NIXL_IN_PROG);
+
+    // Cleanup
+    ASSERT_EQ(local_agent_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    ASSERT_EQ(local_agent_->deregisterMem(local_reg_dlist, &local_extra_params), NIXL_SUCCESS);
+    ASSERT_EQ(remote_agent_->deregisterMem(remote_reg_dlist, &remote_extra_params), NIXL_SUCCESS);
+}
+
+}  // namespace agent
+}  // namespace gtest

--- a/test/gtest/unit/agent/test_getXferStatusList_core.cpp
+++ b/test/gtest/unit/agent/test_getXferStatusList_core.cpp
@@ -144,8 +144,9 @@ namespace agent {
                   NIXL_SUCCESS);
         ASSERT_NE(req_hndl, nullptr);
 
-        // Post transfer
-        ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+        // Post transfer — may return NIXL_SUCCESS (inline) or NIXL_IN_PROG (async).
+        nixl_status_t post_status = local_agent_->postXferReq(req_hndl);
+        ASSERT_TRUE(post_status == NIXL_SUCCESS || post_status == NIXL_IN_PROG);
 
         // Try to get per-entry status - mock backend returns NOT_SUPPORTED
         nixl_xfer_entry_events_t events;
@@ -207,8 +208,9 @@ namespace agent {
             NIXL_SUCCESS);
         ASSERT_NE(req_hndl, nullptr);
 
-        // Post transfer
-        ASSERT_EQ(local_agent_->postXferReq(req_hndl), NIXL_SUCCESS);
+        // Post transfer — may return NIXL_SUCCESS (inline) or NIXL_IN_PROG (async).
+        nixl_status_t post_status2 = local_agent_->postXferReq(req_hndl);
+        ASSERT_TRUE(post_status2 == NIXL_SUCCESS || post_status2 == NIXL_IN_PROG);
 
         // Standard getXferStatus should work as before
         nixl_status_t status = local_agent_->getXferStatus(req_hndl);

--- a/test/gtest/unit/agent/test_getXferStatusList_core.cpp
+++ b/test/gtest/unit/agent/test_getXferStatusList_core.cpp
@@ -64,7 +64,9 @@ namespace agent {
         getAndLoadRemoteMd(nixlAgent *remote_agent, std::string &remote_agent_name_out) {
             std::string remote_metadata;
             nixl_status_t status = remote_agent->getLocalMD(remote_metadata);
-            if (status != NIXL_SUCCESS) return status;
+            if (status != NIXL_SUCCESS) {
+                return status;
+            }
             return agent_->loadRemoteMD(remote_metadata, remote_agent_name_out);
         }
     };

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,6 @@
 subdir('nixl')
 subdir('unit')
 
-if enabled_plugins.get('UCX') and ucx_dep.found()
+if (enabled_plugins.get('UCX', false) and ucx_dep.found()) or enabled_plugins.get('OBJ', false)
     subdir('gtest')
 endif


### PR DESCRIPTION
## What?
Add per-entry status tracking for batch transfers via a new getXferStatus overload that returns individual status codes for each transfer entry.
Changes include:
New getXferStatus(nixlXferReqH*, std::vector<nixl_status_t>&) API overload in core
New NIXL_IN_PROG_WITH_ERR status indicating partial completion (some entries failed while others still in progress)
S3/Object backend implementation using shared_future pattern for checkXferList
Rust bindings: get_xfer_status_list() method and XferStatus::InProgressWithError variant
Python bindings: getXferStatusList() method returning (overall_status, entry_status_list)


## Why?
The existing getXferStatus() API only returns an overall status for batch transfers. For large batch operations, users need finer-grained visibility into which specific entries have completed, failed, or are still in progress. This enables:
Early error detection without waiting for entire batch completion
Progress tracking for long-running batch transfers
Targeted retry logic for failed entries

## How?
Core API: Added an overload that accepts a std::vector<nixl_status_t>& output parameter populated with per-entry status codes
Status codes: NIXL_IN_PROG_WITH_ERR (value 2) indicates the batch is still in progress but at least one entry has failed
S3 Backend: Uses std::shared_future to track individual async operations and report per-entry completion
Bindings: C API wrapper (nixl_capi_get_xfer_status_list) bridges to language bindings with appropriate error mapping
Fallback: Backends that don't support per-entry status return NIXL_ERR_NOT_SUPPORTED, allowing callers to fall back to regular getXferStatus()
@mkhazraee, @yosefe 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-entry transfer event tracking: append-only events list, new in-progress-with-error status, and tracking flags for errors/successes.
  * APIs and bindings: new overloads and helpers to poll per-entry events; Python and Rust expose reusable event containers, track flag constants, and transfer-creation options to enable tracking.
* **Tests**
  * New unit and integration tests covering per-entry polling, event caching, shared-promise behavior, and partial-failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->