### PR TITLE
nixl_ep: Disable fast fault detection for release builds

### DIFF
--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -100,7 +100,6 @@ nixl_ep_cuda_args = [
     '-Xcompiler', '-Wno-sign-compare',
     '-Xcompiler', '-Wno-reorder',
     '-Xcompiler', '-Wno-attributes',
-    '-DENABLE_FAST_DEBUG=1',
 ]
 
 topk_idx_bits = meson.get_external_property('topk_idx_bits', '64')
@@ -125,6 +124,12 @@ nixl_ep_override_options = []
 if get_option('buildtype') == 'debug'
     nixl_ep_override_options = ['optimization=3']
     nixl_ep_cpp_args += ['-g']
+endif
+
+enable_fast_debug = get_option('buildtype') != 'release'
+
+if enable_fast_debug
+    nixl_ep_cuda_args += ['-DENABLE_FAST_DEBUG']
 endif
 
 nixl_ep_install_rpath = join_paths(get_option('prefix'), get_option('libdir'))


### PR DESCRIPTION
When running nixl_ep with vLLM, ranks were timing out during connection because ENABLE_FAST_DEBUG was always enabled, which sets a 10-second timeout. This timeout is too short for initializing large model like DeepSeek V3.

- Remove hardcoded -DENABLE_FAST_DEBUG=1 from cuda_args
- Enable ENABLE_FAST_DEBUG only when buildtype != release