### PR TITLE
TEST: Remove printing binary data.

### DIFF
--- a/examples/cpp/nixl_example.cpp
+++ b/examples/cpp/nixl_example.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/utils/serdes/serdes_test.cpp
+++ b/test/unit/utils/serdes/serdes_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## What?
Remove more printing of binary data to `std::cout`.

## Why?
Printing binary data to the terminal (in between normal logging) can have weird and undesirable effects and is not particularly useful.

Follow-up to #1115 which only removed one example of this.