### PR TITLE
CI: Abort previous dispatcher builds for same PR

### DIFF
--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -40,7 +40,7 @@
               value: $
     description: Do NOT edit this job through the Web GUI !  # Manual edits will be overwritten
     concurrent: true    # Allow multiple builds to run simultaneously
-    sandbox: true      # Run in sandbox mode for security
+    sandbox: false
     parameters:
         - string:
             name: "VARIABLE_FROM_POST"
@@ -54,6 +54,26 @@
         // Authenticate with GitHub using stored credentials
         withCredentials([usernamePassword(credentialsId: 'svc-nixl-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {{
           githubHelper = GithubHelper.getInstance("${{GIT_PASSWORD}}", VARIABLE_FROM_POST)
+        }}
+
+        // Abort previous dispatcher runs for the same PR (mirrors UCX GitHub dispatcher logic)
+        def currentPrNumber = githubHelper.getPRNumber()?.toString()
+        if (currentPrNumber) {{
+          def slurper = new groovy.json.JsonSlurper()
+          try {{
+            Jenkins.instance.getItemByFullName(env.JOB_NAME).builds.findAll {{
+              it.isBuilding() && it.number < currentBuild.number
+            }}.each {{ b ->
+              def gd = b.getAction(hudson.model.ParametersAction)?.getParameters()?.find {{ it.name == 'VARIABLE_FROM_POST' }}?.value
+              def otherPr = gd ? slurper.parseText(gd)?.issue?.number?.toString() : null
+              if (otherPr == currentPrNumber) {{
+                echo "Aborting dispatcher #${{b.number}} for same PR #${{currentPrNumber}}"
+                b.doStop()
+              }}
+            }}
+          }} catch(Exception e) {{
+            echo "Could not abort previous dispatchers: ${{e.message}}"
+          }}
         }}
 
         def blueOceanUrl = "${{JENKINS_URL}}blue/organizations/jenkins/${{env.JOB_BASE_NAME}}/detail/${{env.JOB_BASE_NAME}}/${{env.BUILD_NUMBER}}/pipeline/"


### PR DESCRIPTION
## What?
Add “abort previous running builds for the same PR” logic to the NIXL Jenkins GitHub dispatcher job.

## Why?
Avoid wasting CI capacity by ensuring only the latest dispatcher run per PR continues.

## How?
Update the dispatcher job to scan for older running builds of the same PR number and stop them
