### PR TITLE
explicitly set useVirtualAddressing for S3CrtClient to avoid aws sdk bug

### DIFF
--- a/src/plugins/obj/s3_crt/client.cpp
+++ b/src/plugins/obj/s3_crt/client.cpp
@@ -28,6 +28,7 @@ awsS3CrtClient::awsS3CrtClient(nixl_b_params_t *custom_params,
 
     auto credentials_opt = nixl_s3_utils::createAWSCredentials(custom_params);
     bool use_virtual_addressing = nixl_s3_utils::getUseVirtualAddressing(custom_params);
+    config.useVirtualAddressing = use_virtual_addressing;
 
     if (credentials_opt.has_value())
         s3CrtClient_ = std::make_unique<Aws::S3Crt::S3CrtClient>(


### PR DESCRIPTION
## What?
Explicitly set config.useVirtualAddressing when initializing S3CrtClient
```
config.useVirtualAddressing = use_virtual_addressing;
```
because constructor of Aws::S3Crt::S3CrtClient does NOT honor the parameter use_virtual_addressing.
```
        s3CrtClient_ = std::make_unique<Aws::S3Crt::S3CrtClient>(
            config,
            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
            use_virtual_addressing);
```

## Why?
In many cases, private-deployed object storage does not support virtual host/address mode and support path style only.
```
path style: https://<endpoint>/<bucket>/<key>
virtual address: https://<bucket>.<endpoint>/<key>
```
With S3Client, constructor takes parameter `useVirtualAddressing` to initialize m_clientConfiguration then use m_clientConfiguration to initialize. 
see https://github.com/aws/aws-sdk-cpp/blob/main/generated/src/aws-cpp-sdk-s3/source/S3Client.cpp Line 249
However with S3CrtClient, constructor does not honor parameter `useVirtualAddressing`, initialize with parameter `clientConfiguration` directly
see https://github.com/aws/aws-sdk-cpp/blob/main/generated/src/aws-cpp-sdk-s3-crt/source/S3CrtClient.cpp Line 222
Therefore, we have to explictly set this config.useVirtualAddressing in nixl's s3 crt code. Otherwise, S3CrtClient won't work properly with path-style only storage

This bug is also mentioned in https://github.com/aws/aws-sdk-cpp/issues/2500

