### PR TITLE
Exclude `rc_gda` transport in hw warning tests

### DIFF
--- a/test/gtest/ucx_hw_warning_test.cpp
+++ b/test/gtest/ucx_hw_warning_test.cpp
@@ -39,7 +39,7 @@ TEST_F(UcxHardwareWarningTest, WarnWhenGpuPresentButCudaNotSupported) {
     }
 
     // Disable CUDA transport in UCX
-    envHelper_.addVar("UCX_TLS", "^cuda");
+    envHelper_.addVar("UCX_TLS", "^cuda,rc_gda");
 
     std::vector<std::string> devs;
     nixlUcxContext ctx(devs, false, 1, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, 0);
@@ -75,7 +75,7 @@ TEST_F(UcxHardwareWarningTest, WarnWhenIbPresentButRdmaNotSupported) {
     }
 
     // Disable IB transport in UCX
-    envHelper_.addVar("UCX_TLS", "^ib");
+    envHelper_.addVar("UCX_TLS", "^ib,rc_gda");
 
     std::vector<std::string> devs;
     nixlUcxContext ctx(devs, false, 1, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, 0);


### PR DESCRIPTION
## What?
Exclude `rc_gda` transport in hw warning tests as a temporary fix.

## Why?
The NIXL test `UcxHardwareWarningTest.WarnWhenIbPresentButRdmaNotSupported` failed because for example setting `UCX_TLS=^ib` did not disable InfiniBand completely because the `rc_gda` transport remained available, causing the warning not to show when expected.