### PR TITLE
feature: add rust metadata support

### DIFF
--- a/src/bindings/rust/src/descriptors/reg.rs
+++ b/src/bindings/rust/src/descriptors/reg.rs
@@ -224,9 +224,10 @@ impl<'a> RegDescList<'a> {
         let addr = unsafe { desc.as_ptr() } as usize;
         let len = desc.size();
         let dev_id = desc.device_id();
+        let metadata = desc.metadata();
 
-        // Add to list
-        self.add_desc(addr, len, dev_id);
+        // Add to list with metadata
+        self.add_desc_with_meta(addr, len, dev_id, &metadata);
         Ok(())
     }
 

--- a/src/bindings/rust/src/descriptors/reg.rs
+++ b/src/bindings/rust/src/descriptors/reg.rs
@@ -224,6 +224,45 @@ impl<'a> RegDescList<'a> {
         let addr = unsafe { desc.as_ptr() } as usize;
         let len = desc.size();
         let dev_id = desc.device_id();
+
+        // Add to list without metadata
+        self.add_desc(addr, len, dev_id);
+        Ok(())
+    }
+
+    /// Add a descriptor from a type implementing NixlDescriptor, including metadata.
+    ///
+    /// This is the metadata-aware variant of [`add_storage_desc`]. It calls
+    /// [`NixlDescriptor::metadata()`] on the descriptor and passes the result
+    /// through to the backend via [`add_desc_with_meta`].
+    ///
+    /// Use this when the backend requires metadata (e.g., OBJ backend for
+    /// object storage keys).
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - The descriptor remains valid for the lifetime of the list
+    /// - The memory region pointed to by the descriptor remains valid
+    pub fn add_storage_desc_with_metadata(
+        &mut self,
+        desc: &'a dyn NixlDescriptor,
+    ) -> Result<(), NixlError> {
+        // Validate memory type matches
+        let desc_mem_type = desc.mem_type();
+        let list_mem_type = if self.len()? > 0 {
+            self.get_type()?
+        } else {
+            desc_mem_type
+        };
+
+        if desc_mem_type != list_mem_type && list_mem_type != MemType::Unknown {
+            return Err(NixlError::InvalidParam);
+        }
+
+        // Get descriptor details
+        let addr = unsafe { desc.as_ptr() } as usize;
+        let len = desc.size();
+        let dev_id = desc.device_id();
         let metadata = desc.metadata();
 
         // Add to list with metadata

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -501,6 +501,15 @@ pub trait NixlDescriptor: MemoryRegion {
 
     /// Get the device ID for this memory region
     fn device_id(&self) -> u64;
+
+    /// Get optional metadata for this descriptor.
+    ///
+    /// Metadata is used by some backends (e.g., OBJ for object storage keys).
+    /// Returns owned bytes since they're copied during registration anyway.
+    /// Default implementation returns empty vec.
+    fn metadata(&self) -> Vec<u8> {
+        Vec::new()
+    }
 }
 
 /// A trait for types that can be registered with NIXL


### PR DESCRIPTION
## What?

Add explicit metadata-aware variants for descriptor registration:
- `RegDescList::add_storage_desc_with_metadata()` — counterpart to `add_storage_desc()`
- `Agent::register_memory_with_metadata()` — counterpart to `register_memory()`

These call `NixlDescriptor::metadata()` and pass the result through to `add_desc_with_meta()` during registration. The existing `add_storage_desc()` and `register_memory()` methods remain unchanged (no metadata).

Also keeps the `NixlDescriptor::metadata()` trait method (default returns empty vec) from the original PR.

## Why?

KVBM in [dynamo](https://github.com/ai-dynamo/dynamo) needs to pass metadata (e.g., object storage keys) into NIXL during memory registration for the OBJ backend. The current `add_storage_desc` / `register_memory` path has no way to carry metadata through to `add_desc_with_meta`.

## How?

Follows the same pattern already established at the lower level:
- `add_desc(addr, len, dev_id)` — no metadata
- `add_desc_with_meta(addr, len, dev_id, metadata)` — with metadata

Now mirrored at the higher level:
- `add_storage_desc(desc)` / `register_memory(desc, opt)` — no metadata
- `add_storage_desc_with_metadata(desc)` / `register_memory_with_metadata(desc, opt)` — calls `desc.metadata()` and forwards it

Closes: https://github.com/ai-dynamo/nixl/pull/1096