### PR TITLE
nixlbench: fix GUSLI READ consistency check failure and cleanup crash

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -123,8 +123,8 @@ static int processBatchSizes(xferBenchWorker &worker,
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
 
-            if (xferBenchConfig::check_consistency && xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
-                xferBenchUtils::checkConsistency(local_trans_lists);
+            if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
+                return EXIT_FAILURE;
             }
             if (IS_PAIRWISE_AND_SG()) {
                 // TODO: This is here just to call throughput reduction
@@ -140,15 +140,8 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return 1;
             }
 
-            if (xferBenchConfig::check_consistency) {
-                if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
-                    xferBenchUtils::checkConsistency(local_trans_lists);
-                } else if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
-                    // Only storage backends support consistency check for write on initiator
-                    if (xferBenchConfig::isStorageBackend()) {
-                        xferBenchUtils::checkConsistency(remote_trans_lists);
-                    }
-                }
+            if (!xferBenchUtils::validateTransfer(true, local_trans_lists, remote_trans_lists)) {
+                return EXIT_FAILURE;
             }
 
             xferBenchUtils::printStats(

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -814,7 +814,7 @@ parseGusliDeviceList(const std::string &device_list,
     return devices;
 }
 
-void
+bool
 xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lists) {
     int i = 0, j = 0;
     static bool gusli_devmap_init = false;
@@ -992,8 +992,34 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
     }
     if (!pass_check_consistency) {
         std::cerr << "Consistency check failed" << std::endl;
-        exit(EXIT_FAILURE);
     }
+    return pass_check_consistency;
+}
+
+bool
+xferBenchUtils::validateTransfer(bool is_initiator,
+                                 std::vector<std::vector<xferBenchIOV>> &local_lists,
+                                 std::vector<std::vector<xferBenchIOV>> &remote_lists) {
+    if (!xferBenchConfig::check_consistency) {
+        return true;
+    }
+
+    if (is_initiator) {
+        if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
+            return checkConsistency(local_lists);
+        } else if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
+            if (xferBenchConfig::isStorageBackend()) {
+                return checkConsistency(remote_lists);
+            }
+        }
+    } else {
+        // Target
+        if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
+            return checkConsistency(local_lists);
+        }
+    }
+
+    return true;
 }
 
 void

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -355,8 +355,12 @@ public:
     static bool
     rmObjS3(const std::string &name);
 
-    static void
+    static bool
     checkConsistency(std::vector<std::vector<xferBenchIOV>> &desc_lists);
+    static bool
+    validateTransfer(bool is_initiator,
+                     std::vector<std::vector<xferBenchIOV>> &local_lists,
+                     std::vector<std::vector<xferBenchIOV>> &remote_lists);
     static void
     printStatsHeader();
     static void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -89,6 +89,8 @@ class xferBenchNixlWorker: public xferBenchWorker {
         initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t dev_offset);
         void
         cleanupBasicDescBlk(xferBenchIOV &basic_desc);
+        bool
+        ensureFileHasConsistencyData(const GusliDeviceConfig &device, size_t size);
 };
 
 #endif // __NIXL_WORKER_H


### PR DESCRIPTION
Cherry pick of #1300 

## What?
Fix GUSLI READ consistency check failure and cleanup crash in nixlbench.

## Why?
Two bugs cause the reported failure:

1. File pre-population writes data at offset 0 but GUSLI reads at dev_offset (default 1MB). Additionally, if the file already exists with sufficient size, pre-population is skipped entirely, leaving stale data. This causes the consistency check to fail.

2. On consistency failure, exit() is called directly from checkConsistency(), bypassing GUSLI buffer deregistration. This triggers a ref_count assertion crash in the GUSLI library destructor (base_shm_element::~base_shm_element()).

## How?
Fix 1 - Correct file pre-population offset:
- Add ensureFileHasConsistencyData() helper that samples one page at the actual dev_offset to verify content, and only overwrites with the expected pattern (with a warning) when data differs.
- Replaces the misuse of initBasicDescFile() which was designed for file-backed storage backends, wrote at the wrong offset, and leaked file descriptors on the success path.

Fix 2 - Graceful shutdown on consistency failure:
- Change checkConsistency() from void to bool, returning the result instead of calling exit().
- Add validateTransfer() helper that centralizes the role/op-type descriptor selection logic into one place.
- Callers in processBatchSizes() now return EXIT_FAILURE on mismatch, allowing main()'s scope_guard to run deallocateMemory() and properly deregister GUSLI buffers before destruction.