### PR TITLE
CI: Adjust test timeouts for GPU pipeline

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -46,8 +46,7 @@ env:
   SLURM_GRES: gpu:2
   SLURM_MEM: 64G
   SLURM_MINCPUS: 24
-  SLURM_JOB_TIMEOUT: '01:30:00'
-  TEST_TIMEOUT: 50
+  SLURM_JOB_TIMEOUT: '02:10:00'
   STORAGE_DRIVER: overlay
   CI_IMAGE_TAG: "20260210-1"
 
@@ -121,7 +120,7 @@ steps:
 
   - name: Run CPP tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: "${TEST_TIMEOUT}"
+    timeout: 50
     parallel: false
     run: |
       set -x
@@ -132,7 +131,7 @@ steps:
 
   - name: Run Python tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: "${TEST_TIMEOUT}"
+    timeout: 10
     parallel: false
     run: |
       set -x
@@ -143,7 +142,7 @@ steps:
 
   - name: Run Rust tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: "${TEST_TIMEOUT}"
+    timeout: 10
     parallel: false
     run: |
       set -x
@@ -154,7 +153,7 @@ steps:
 
   - name: Run Nixlbench tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: "${TEST_TIMEOUT}"
+    timeout: 50
     parallel: false
     run: |
       set -x


### PR DESCRIPTION
Signed-off-by: Iaroslav Sydoruk <isydoruk@nvidia.com>

## What?
- Increase SLURM job timeout from 1:30 to 2:00 hours
- Set individual test timeouts: CPP/Nixlbench (50min), Python/Rust (10min)
- Remove TEST_TIMEOUT env variable in favor of per-test timeouts

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
