### PR TITLE
Add support setting CA bundle for Azure Blob (#1329)

### DIFF
--- a/src/plugins/azure_blob/README.md
+++ b/src/plugins/azure_blob/README.md
@@ -50,6 +50,7 @@ Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creati
 |-----------|-------------|---------|----------|
 | `account_url` | URL of Azure Storage account to use (e.g., `https://<account-name>.blob.core.windows.net`) | - | Yes* |
 | `container_name` | Name of Azure Storage container to use | - | Yes* |
+| `ca_bundle` | Path to a custom certificate bundle | - | No |
 
 
 \* If `account_url` or `container_name`  parameter is not provided, the `AZURE_STORAGE_ACCOUNT_URL` and `AZURE_STORAGE_CONTAINER_NAME` environment variables will be used as fallbacks
@@ -63,6 +64,7 @@ The following environment variables are supported for Azure Blob Storage configu
 |----------|-------------|---------|
 | `AZURE_STORAGE_ACCOUNT_URL` | URL of Azure Storage account to use | `https://<account-name>.blob.core.windows.net` |
 | `AZURE_STORAGE_CONTAINER_NAME` | Name of Azure Storage container to use | `my-container` |
+| `AZURE_CA_BUNDLE` | Path to a custom certificate bundle | `/path/to/cabundle.pem` |
 
 
 ### Configuration Priority


### PR DESCRIPTION
Cherry-pick of #1329

Support setting the ca_bundle backend parameter or setting the AZURE_CA_BUNDLE environment variable. The parameter matches parity with the OBJ/S3 CA bundle options.

While this parameter is useful in the general sense of relying on certs in non-standard locations, it also helps work around issues where libcurl is statically built on a different Linux distro than where it is run. This results in libcurl searching for cert in the wrong location (i.e., it will search for certs on /etc/pki/tls/certs/ca-bundle.crt if built on CentOS instead of /etc/ssl/certs/ca-certificates.crt where it would be if running Ubuntu). Note that this is not needed if libcurl is linked against the system libcurl.

In the future, we should consider how we can make libcurl look across the various known cert locations for Linux distros to make the plugin work as is without needing to set cert related environment variables.