### PR TITLE
libfabric: Remove delay in between post operation retries

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -51,11 +51,6 @@
 #define NIXL_LIBFABRIC_RECV_POOL_SIZE 1024 // Number of recv requests to pre-post per rail
 
 // Retry configuration constants
-#define NIXL_LIBFABRIC_MAX_RETRIES 10
-#define NIXL_LIBFABRIC_EFA_RETRY_DELAY_US 100
-#define NIXL_LIBFABRIC_DEFAULT_RETRY_DELAY_US 1000
-#define NIXL_LIBFABRIC_BASE_RETRY_DELAY_US 1000 // Base 1ms delay between retries
-#define NIXL_LIBFABRIC_MAX_RETRY_DELAY_US 100000 // Max 100ms delay between retries
 #define NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS 100 // Log every N attempts to avoid spam
 
 // The immediate data associated with an RDMA operation is 32 bits and is divided as follows:

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1057,17 +1057,12 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                            << ", retrying (attempt " << attempt << ")";
             }
 
-            // Exponential backoff with cap to avoid overwhelming the system
-            int delay_us = std::min(NIXL_LIBFABRIC_BASE_RETRY_DELAY_US * (1 + attempt / 10),
-                                    NIXL_LIBFABRIC_MAX_RETRY_DELAY_US);
-
             // Progress completion queue to drain pending completions before retry
             nixl_status_t progress_status = progressCompletionQueue();
             if (progress_status == NIXL_SUCCESS) {
                 NIXL_TRACE << "Progressed completions on rail " << rail_id << " before retry";
             }
 
-            usleep(delay_us);
             continue;
         } else {
             // Other error - don't retry, fail immediately
@@ -1136,17 +1131,12 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                            << ", retrying (attempt " << attempt << ")";
             }
 
-            // Exponential backoff with cap to avoid overwhelming the system
-            int delay_us = std::min(NIXL_LIBFABRIC_BASE_RETRY_DELAY_US * (1 + attempt / 10),
-                                    NIXL_LIBFABRIC_MAX_RETRY_DELAY_US);
-
             // Progress completion queue to drain pending completions before retry
             nixl_status_t progress_status = progressCompletionQueue();
             if (progress_status == NIXL_SUCCESS) {
                 NIXL_TRACE << "Progressed completions on rail " << rail_id << " before retry";
             }
 
-            usleep(delay_us);
             continue;
         } else {
             // Other error - don't retry, fail immediately
@@ -1213,17 +1203,12 @@ nixlLibfabricRail::postRead(void *local_buffer,
                            << ", retrying (attempt " << attempt << ")";
             }
 
-            // Exponential backoff with cap to avoid overwhelming the system
-            int delay_us = std::min(NIXL_LIBFABRIC_BASE_RETRY_DELAY_US * (1 + attempt / 10),
-                                    NIXL_LIBFABRIC_MAX_RETRY_DELAY_US);
-
             // Progress completion queue to drain pending completions before retry
             nixl_status_t progress_status = progressCompletionQueue();
             if (progress_status == NIXL_SUCCESS) {
                 NIXL_TRACE << "Progressed completions on rail " << rail_id << " before retry";
             }
 
-            usleep(delay_us);
             continue;
         } else {
             // Other error - don't retry, fail immediately


### PR DESCRIPTION
## What?
This PR removes delay in libfabric post operation retry logic for send, write, and read operations.

## Why?
The previous implementation used usleep() with exponential backoff (1ms base delay, 
capping at 100ms) when retrying operations that returned `-FI_EAGAIN`. This approach 
introduced unnecessary latency in the retry path. Since the completion queue is 
already being progressed before each retry to drain pending completions, actively 
sleeping adds no benefit and only delays recovery from transient resource exhaustion.
