### PR TITLE
CI: pin ci-demo to stable_nixl tag

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -14,7 +14,7 @@
 // This library provides functionality for interacting with GitHub
 // It is used to update the commit status and upload logs
 @Library('blossom-github-lib@master')
-@Library('github.com/Mellanox/ci-demo@master')  // External library for matrix build functionality
+@Library('github.com/Mellanox/ci-demo@stable_nixl')  // External library for matrix build functionality
 
 // Initialize the build matrix
 // The matrix class handles the parallel execution of different build configurations


### PR DESCRIPTION
## What?
Pin ci-demo library to `stable_nixl` tag instead of `master`.

## Why?
Recent changes in ci-demo `master` broke our CI pipeline.

## How?
Changed `@Library` annotation in Jenkinsfile from `ci-demo@master` to `ci-demo@stable_nixl`.