### PR TITLE
nixlbench: print P100 TX duration to detect single outliers

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -71,6 +71,7 @@ NB_ARG_STRING(scheme, XFERBENCH_SCHEME_PAIRWISE, "Scheme: pairwise, manytoone, o
 NB_ARG_STRING(mode, XFERBENCH_MODE_SG, "MODE: SG (Single GPU per proc), MG (Multi GPU per proc)");
 NB_ARG_STRING(op_type, XFERBENCH_OP_WRITE, "Op type: READ, WRITE");
 NB_ARG_BOOL(check_consistency, false, "Enable Consistency Check");
+NB_ARG_BOOL(show_extended_stats, false, "Show extended statistics (P100)");
 NB_ARG_UINT64(total_buffer_size,
               8LL * 1024 * (1 << 20),
               "Total buffer size across device for each process");
@@ -211,6 +212,7 @@ std::string xferBenchConfig::scheme = "";
 std::string xferBenchConfig::mode = "";
 std::string xferBenchConfig::op_type = "";
 bool xferBenchConfig::check_consistency = false;
+bool xferBenchConfig::show_extended_stats = false;
 size_t xferBenchConfig::total_buffer_size = 0;
 bool xferBenchConfig::recreate_xfer = false;
 int xferBenchConfig::num_initiator_dev = 0;
@@ -434,6 +436,7 @@ xferBenchConfig::loadParams(void) {
     mode = NB_ARG(mode);
     op_type = NB_ARG(op_type);
     check_consistency = NB_ARG(check_consistency);
+    show_extended_stats = NB_ARG(show_extended_stats);
     total_buffer_size = NB_ARG(total_buffer_size);
     num_initiator_dev = NB_ARG(num_initiator_dev);
     num_target_dev = NB_ARG(num_target_dev);
@@ -1069,8 +1072,11 @@ xferBenchUtils::printStatsHeader() {
                   << std::setw(15) << "Avg Post (us)"
                   << std::setw(15) << "P99 Post (us)"
                   << std::setw(15) << "Avg Tx (us)"
-                  << std::setw(15) << "P99 Tx (us)"
-                  << std::endl;
+                  << std::setw(15) << "P99 Tx (us)";
+        if (xferBenchConfig::show_extended_stats) {
+            std::cout << std::setw(15) << "P100 Tx (us)";
+        }
+        std::cout << std::endl;
         // clang-format on
     } else {
         // clang-format off
@@ -1084,8 +1090,11 @@ xferBenchUtils::printStatsHeader() {
                   << std::setw(15) << "Avg Post (us)"
                   << std::setw(15) << "P99 Post (us)"
                   << std::setw(15) << "Avg Tx (us)"
-                  << std::setw(15) << "P99 Tx (us)"
-                  << std::endl;
+                  << std::setw(15) << "P99 Tx (us)";
+        if (xferBenchConfig::show_extended_stats) {
+            std::cout << std::setw(15) << "P100 Tx (us)";
+        }
+        std::cout << std::endl;
         // clang-format on
     }
     xferBenchConfig::printSeparator('-');
@@ -1156,8 +1165,11 @@ xferBenchUtils::printStats(bool is_target,
                   << std::setw(15) << post_duration
                   << std::setw(15) << post_p99_duration
                   << std::setw(15) << transfer_duration
-                  << std::setw(15) << transfer_p99_duration
-                  << std::endl;
+                  << std::setw(15) << transfer_p99_duration;
+        if (xferBenchConfig::show_extended_stats) {
+            std::cout << std::setw(15) << stats.transfer_duration.max();
+        }
+        std::cout << std::endl;
         // clang-format on
     } else {
         // clang-format off
@@ -1172,8 +1184,11 @@ xferBenchUtils::printStats(bool is_target,
                   << std::setw(15) << post_duration
                   << std::setw(15) << post_p99_duration
                   << std::setw(15) << transfer_duration
-                  << std::setw(15) << transfer_p99_duration
-                  << std::endl;
+                  << std::setw(15) << transfer_p99_duration;
+        if (xferBenchConfig::show_extended_stats) {
+            std::cout << std::setw(15) << stats.transfer_duration.max();
+        }
+        std::cout << std::endl;
         // clang-format on
     }
 }

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -139,6 +139,7 @@ public:
     static std::string mode;
     static std::string op_type;
     static bool check_consistency;
+    static bool show_extended_stats;
     static size_t total_buffer_size;
     static bool recreate_xfer;
     static int num_initiator_dev;


### PR DESCRIPTION
## What?
Add a TX P100 column to result table

## Why?
It often occurs that P99 is lower than Average due to a single large outlier. Add P100 to clarify these cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to show extended statistics in benchmark reports. When enabled, reports include an extra P100 transfer-duration column alongside existing P99 metrics. The option is off by default and can be toggled via configuration file or command-line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->