### PR TITLE
UCX: Set gda config for relevant UCX only

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -456,7 +456,10 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
     config.modify("MAX_RMA_RAILS", "2");
     config.modify("IB_PCI_RELAXED_ORDERING", "try");
     config.modify("RCACHE_MAX_UNRELEASED", "1024");
-    config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
+
+    if (ucpVersion_ >= UCP_VERSION(1, 21)) {
+        config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
+    }
 
     if (ucpVersion_ >= UCP_VERSION(1, 19)) {
         config.modify("MAX_COMPONENT_MDS", "32");


### PR DESCRIPTION
## What?
apply `RC_GDA_NUM_CHANNELS` starting from UCX 1.21 only

## Why?
device API is not supported with earlier UCX versions
also to get rid of these warns:
`[1771585001.679746] [ip-192-168-94-81:132454:0]      ucp_worker.c:2276 UCX  WARN  invalid configurations: RC_GDA_NUM_CHANNELS=4`