### PR TITLE
libfabric: Progress control rail in PT for tcp provider

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1376,6 +1376,20 @@ nixlLibfabricEngine::genNotif(const std::string &remote_agent, const std::string
     return notifSendPriv(remote_agent, notifications, total_msg_len, 0, 0);
 }
 
+/**
+ * @brief Retrieve pending notifications from the notification queue.
+ *
+ * This function progresses completion queues (if needed) and retrieves any
+ * pending notifications. It avoids competing with the progress thread by
+ * conditionally progressing rails based on thread state:
+ *
+ * - Data rails: Progressed only if progress thread is disabled
+ * - Control rails: Progressed only if progress thread is disabled OR not handling them
+ *
+ * @param[out] notif_list List to append retrieved notifications to
+ * @return NIXL_SUCCESS if notifications retrieved, NIXL_IN_PROG if none available,
+ *         error code on failure
+ */
 nixl_status_t
 nixlLibfabricEngine::getNotifs(notif_list_t &notif_list) {
     // Progress data rails if progress thread is not enabled
@@ -1389,7 +1403,7 @@ nixlLibfabricEngine::getNotifs(notif_list_t &notif_list) {
 
     // Progress control rails only if progress thread is not handling them
     // Similar to data rails - avoid competing with progress thread
-    if (!progress_thread_enabled_ || !progress_thread_handles_control_rails_) {
+    if (!progress_thread_enabled_ || !progress_thread_handles_control_rails_.load()) {
         nixl_status_t progress_status = rail_manager.progressAllControlRails();
         if (progress_status != NIXL_SUCCESS && progress_status != NIXL_IN_PROG) {
             NIXL_ERROR << "Failed to progress control rails in getNotifs.";
@@ -1420,11 +1434,23 @@ nixlLibfabricEngine::getNotifs(notif_list_t &notif_list) {
 }
 
 /****************************************
- * Progress Thread Function (Data Rails Only)
+ * Progress Thread Function
  *****************************************/
 
-// Progress thread that continuously processes completions on data rails
-// and optionally control rails based on provider type
+/**
+ * @brief Progress thread that continuously processes completions on data rails
+ *        and optionally control rails based on provider type.
+ *
+ * This function runs in a dedicated thread to process completion queue events.
+ * It detects the libfabric provider type and conditionally progresses control
+ * rails for providers that require manual progress (e.g., TCP provider).
+ *
+ * Provider-specific behavior:
+ * - TCP provider: Progresses both data and control rails (auto-progress unreliable)
+ * - Other providers: Progresses only data rails (control rails handled elsewhere)
+ *
+ * @return NIXL_SUCCESS on clean exit, error code otherwise
+ */
 nixl_status_t
 nixlLibfabricEngine::progressThread() {
     // Check if we need to progress control rails based on provider type
@@ -1445,7 +1471,7 @@ nixlLibfabricEngine::progressThread() {
     }
 
     // Store this decision so getNotifs knows not to compete
-    progress_thread_handles_control_rails_ = progress_control_rails;
+    progress_thread_handles_control_rails_.store(progress_control_rails);
 
     NIXL_DEBUG << "PT: Thread started successfully for data rails"
                << (progress_control_rails ? " and control rails" : " only");

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -179,8 +179,8 @@ private:
     // Store user's original progress thread preference
     bool progress_thread_enabled_;
 
-    // Track if control rails are progressed in progress thread
-    bool progress_thread_handles_control_rails_;
+    // Track if control rails are progressed in progress thread (atomic for thread safety)
+    std::atomic<bool> progress_thread_handles_control_rails_;
 
     // Progress thread delay in microseconds
     std::chrono::microseconds progress_thread_delay_;


### PR DESCRIPTION
## What?
Detect TCP provider by name and manually progress control rails in the progress thread.

## Why?

The TCP provider (libfabric's xnet provider) advertises FI_PROGRESS_AUTO for both control and data progress modes, but in practice requires  manual progress on the receiver side for control messages (fi_senddata). This causes control rail operations to hang when relying solely on the provider's auto-progress mechanism.

Observed behavior:
- **TCP provider**: Control messages require manual fi_cq_read() on remote despite FI_PROGRESS_AUTO
- **Sockets provider**: Control messages work without manual progress


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Progress system now detects provider type at runtime and conditionally handles control-rail processing within the background thread, reducing unnecessary work and improving efficiency.
  * Background loop can progress both data and control paths when needed, with clearer logging for dual-path operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->