### PR TITLE
Tests/Unit: Cleanup GDS Test Flags

### DIFF
--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -83,7 +83,7 @@ void print_usage(const char* program_name) {
         << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
         << "  -h, --help              Show this help message\n"
         << "\nExample:\n"
-        << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
+        << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 128 -m 16M -t 5 -D /path/to/dir\n";
 }
 
 void printProgress(float progress) {

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -115,13 +115,6 @@ std::string generate_timestamped_filename(const std::string& base_name) {
     return base_name + std::string(timestamp);
 }
 
-void validateBuffer(void* expected, void* actual, size_t size, const char* operation) {
-    if (memcmp(expected, actual, size) != 0) {
-        std::cerr << "Data validation failed for " << operation << std::endl;
-        exit(-1);
-    }
-}
-
 // Helper function to fill buffer with repeating pattern
 void fill_test_pattern(void* buffer, size_t size) {
     char* buf = (char*)buffer;

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
     double                      total_data_gb = 0;
     bool                        use_direct = false;
     unsigned int                iterations = DEFAULT_ITERATIONS;
-    int                         parsed = 0;
+    int parsed = 0;
 
     // Parse command line options
     static struct option long_options[] = {{"dram", no_argument, 0, 'd'},

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -96,7 +96,7 @@ void printProgress(float progress) {
         else if (i == pos) std::cout << ">";
         else std::cout << " ";
     }
-    std::cout << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
+    std::cout << "] " << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
 
     // Add completion indicator
     if (progress >= 1.0) {

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -197,6 +197,7 @@ int main(int argc, char *argv[])
     double                      total_data_gb = 0;
     bool                        use_direct = false;
     unsigned int                iterations = DEFAULT_ITERATIONS;
+    int                         parsed = 0;
 
     // Parse command line options
     static struct option long_options[] = {{"dram", no_argument, 0, 'd'},
@@ -251,11 +252,12 @@ int main(int argc, char *argv[])
                 }
                 break;
             case 't':
-                iterations = atoi(optarg);
-                if (iterations <= 0) {
+                parsed = atoi(optarg);
+                if (parsed <= 0) {
                     std::cerr << "Error: Number of iterations must be positive\n";
                     return 1;
                 }
+                iterations = parsed;
                 break;
             case 'D':
                 use_direct = true;

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -157,33 +157,17 @@ cudaError_t clear_gpu_buffer(void* gpu_buffer, size_t size) {
     return cudaMemset(gpu_buffer, 0, size);
 }
 
-// Helper function to validate GPU buffer
-bool validate_gpu_buffer(void* gpu_buffer, size_t size) {
-    char* host_buffer = (char*)malloc(size);
-    char* expected_buffer = (char*)malloc(size);
-    if (!host_buffer || !expected_buffer) {
-        free(host_buffer);
-        free(expected_buffer);
-        return false;
-    }
-
+// Helper function to validate GPU buffer with pre-allocated buffers
+bool
+validate_gpu_buffer(void *gpu_buffer, size_t size, char *host_buffer, const char *expected_buffer) {
     // Copy GPU data to host
     cudaError_t err = cudaMemcpy(host_buffer, gpu_buffer, size, cudaMemcpyDeviceToHost);
     if (err != cudaSuccess) {
-        free(host_buffer);
-        free(expected_buffer);
         return false;
     }
 
-    // Create expected pattern
-    fill_test_pattern(expected_buffer, size);
-
     // Compare
-    bool match = (memcmp(host_buffer, expected_buffer, size) == 0);
-
-    free(host_buffer);
-    free(expected_buffer);
-    return match;
+    return (memcmp(host_buffer, expected_buffer, size) == 0);
 }
 
 // Helper function to format duration
@@ -614,29 +598,45 @@ int main(int argc, char *argv[])
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 5: Validating read data" << std::endl;
         std::cout << "============================================================" << std::endl;
+
+        // Pre-allocate validation buffers once for all transfers
+        char *host_buffer = use_vram ? (char *)malloc(transfer_size) : NULL;
+        char *expected_buffer = (char *)malloc(transfer_size);
+        if ((use_vram && !host_buffer) || !expected_buffer) {
+            std::cerr << "Failed to allocate validation buffers\n";
+            free(host_buffer);
+            free(expected_buffer);
+            goto cleanup;
+        }
+
+        // Generate expected pattern once
+        fill_test_pattern(expected_buffer, transfer_size);
+
         for (i = 0; i < num_transfers; i++) {
             if (use_vram) {
-                if (!validate_gpu_buffer(vram_addr[i], transfer_size)) {
+                if (!validate_gpu_buffer(
+                        vram_addr[i], transfer_size, host_buffer, expected_buffer)) {
                     std::cerr << "VRAM buffer " << i << " validation failed\n";
+                    free(host_buffer);
+                    free(expected_buffer);
                     goto cleanup;
                 }
             }
             if (use_dram) {
-                char* expected_buffer = (char*)malloc(transfer_size);
-                if (!expected_buffer) {
-                    std::cerr << "Failed to allocate validation buffer\n";
-                    goto cleanup;
-                }
-                fill_test_pattern(expected_buffer, transfer_size);
                 if (memcmp(dram_addr[i], expected_buffer, transfer_size) != 0) {
                     std::cerr << "DRAM buffer " << i << " validation failed\n";
+                    free(host_buffer);
                     free(expected_buffer);
                     goto cleanup;
                 }
-                free(expected_buffer);
             }
             printProgress(float(i + 1) / num_transfers);
         }
+
+        // Free validation buffers
+        free(host_buffer);
+        free(expected_buffer);
+
         std::cout << "\nVerification completed successfully!" << std::endl;
     }
 

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include <iostream>
+#include <memory>
 #include <string>
 #include <algorithm>
 #include <cassert>
@@ -595,42 +596,28 @@ int main(int argc, char *argv[])
         std::cout << "============================================================" << std::endl;
 
         // Pre-allocate validation buffers once for all transfers
-        char *host_buffer = use_vram ? (char *)malloc(transfer_size) : NULL;
-        char *expected_buffer = (char *)malloc(transfer_size);
-        if ((use_vram && !host_buffer) || !expected_buffer) {
-            std::cerr << "Failed to allocate validation buffers\n";
-            free(host_buffer);
-            free(expected_buffer);
-            goto cleanup;
-        }
+        auto host_buffer = use_vram ? std::make_unique<char[]>(transfer_size) : nullptr;
+        auto expected_buffer = std::make_unique<char[]>(transfer_size);
 
         // Generate expected pattern once
-        fill_test_pattern(expected_buffer, transfer_size);
+        fill_test_pattern(expected_buffer.get(), transfer_size);
 
         for (i = 0; i < num_transfers; i++) {
             if (use_vram) {
                 if (!validate_gpu_buffer(
-                        vram_addr[i], transfer_size, host_buffer, expected_buffer)) {
+                        vram_addr[i], transfer_size, host_buffer.get(), expected_buffer.get())) {
                     std::cerr << "VRAM buffer " << i << " validation failed\n";
-                    free(host_buffer);
-                    free(expected_buffer);
                     goto cleanup;
                 }
             }
             if (use_dram) {
-                if (memcmp(dram_addr[i], expected_buffer, transfer_size) != 0) {
+                if (memcmp(dram_addr[i], expected_buffer.get(), transfer_size) != 0) {
                     std::cerr << "DRAM buffer " << i << " validation failed\n";
-                    free(host_buffer);
-                    free(expected_buffer);
                     goto cleanup;
                 }
             }
             printProgress(float(i + 1) / num_transfers);
         }
-
-        // Free validation buffers
-        free(host_buffer);
-        free(expected_buffer);
 
         std::cout << "\nVerification completed successfully!" << std::endl;
     }

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -16,7 +16,9 @@
  */
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <algorithm>
 #include <cassert>
 #include <cuda_runtime.h>
@@ -44,25 +46,6 @@ static size_t PAGE_SIZE = sysconf(_SC_PAGESIZE);
 
 // Progress bar configuration
 #define PROGRESS_WIDTH 50
-
-// Helper function to parse size strings like "1K", "2M", "3G"
-size_t parse_size(const char* size_str) {
-    char* end;
-    size_t size = strtoull(size_str, &end, 10);
-    if (end == size_str) {
-        return 0;  // Invalid number
-    }
-
-    if (*end) {
-        switch (toupper(*end)) {
-            case 'K': size *= 1024; break;
-            case 'M': size *= 1024 * 1024; break;
-            case 'G': size *= 1024 * 1024 * 1024; break;
-            default: return 0;  // Invalid suffix
-        }
-    }
-    return size;
-}
 
 void print_usage(const char* program_name) {
     std::cerr
@@ -164,6 +147,42 @@ validate_gpu_buffer(void *gpu_buffer, size_t size, char *host_buffer, const char
     return (memcmp(host_buffer, expected_buffer, size) == 0);
 }
 
+// Helper function to validate numbers and suffix for K,M,G bytes
+size_t
+parsePositiveSize(const char *str, std::string_view name, bool usesSuffix) {
+    try {
+        char *end;
+        size_t value = std::strtoull(str, &end, 10);
+
+        if ((str[0] == '-') || (end == str) || (value == 0)) {
+            throw std::invalid_argument(std::string(name) + " must be a positive integer");
+        }
+
+        if (!usesSuffix) {
+            return value;
+        } else if (*end) {
+            switch (toupper(*end)) {
+            case 'K':
+                value *= 1024;
+                break;
+            case 'M':
+                value *= 1024 * 1024;
+                break;
+            case 'G':
+                value *= 1024 * 1024 * 1024;
+                break;
+            default:
+                throw std::invalid_argument("Invalid suffix for " + std::string(name));
+            }
+        }
+
+        return value;
+    }
+    catch (std::exception &e) {
+        throw std::invalid_argument(e.what());
+    }
+}
+
 // Helper function to format duration
 std::string format_duration(nixlTime::us_t us) {
     nixlTime::ms_t ms = us/1000.0;
@@ -183,22 +202,21 @@ int main(int argc, char *argv[])
     void                        **dram_addr = NULL;
     std::string                 role;
     int                         status = 0;
-    int                         i;
+    unsigned int i;
     int                         *fd = NULL;
     bool                        use_dram = false;
     bool                        use_vram = false;
     int                         opt;
     std::string                 dir_path;
     size_t                      transfer_size = DEFAULT_TRANSFER_SIZE;
-    int num_transfers = DEFAULT_NUM_TRANSFERS;
+    unsigned int num_transfers = DEFAULT_NUM_TRANSFERS;
     unsigned int                pool_size = 8;
     unsigned int                batch_limit = 128;
     size_t                      max_request_size = 16 * 1024 * 1024;
     nixlTime::us_t              total_time(0);
     double                      total_data_gb = 0;
     bool                        use_direct = false;
-    unsigned int                iterations = DEFAULT_ITERATIONS;
-    int parsed = 0;
+    unsigned int iterations = DEFAULT_ITERATIONS;
 
     // Parse command line options
     static struct option long_options[] = {{"dram", no_argument, 0, 'd'},
@@ -215,60 +233,51 @@ int main(int argc, char *argv[])
 
     while ((opt = getopt_long(argc, argv, "dvn:s:p:b:m:t:Dh", long_options, NULL)) != -1) {
         switch (opt) {
-            case 'd':
-                use_dram = true;
-                break;
-            case 'v':
-                use_vram = true;
-                break;
-            case 'n':
-                num_transfers = atoi(optarg);
-                if (num_transfers <= 0) {
-                    std::cerr << "Error: Number of transfers must be positive\n";
-                    return 1;
-                }
-                break;
-            case 's':
-                transfer_size = parse_size(optarg);
-                if (transfer_size == 0) {
-                    std::cerr << "Error: Invalid transfer size format\n";
-                    return 1;
-                }
-                break;
-            case 'p':
-                pool_size = atoi(optarg);
-                break;
-            case 'b':
-                batch_limit = atoi(optarg);
-                if (batch_limit < 1 || batch_limit > 128) {
-                    std::cerr << "Error: Batch limit must be between 1 and 128\n";
-                    return 1;
-                }
-                break;
-            case 'm':
-                max_request_size = parse_size(optarg);
-                if (max_request_size > 16*1024*1024) {
-                    std::cerr << "Error: Max request size cannot be greater than  16M\n";
-                    return 1;
-                }
-                break;
-            case 't':
-                parsed = atoi(optarg);
-                if (parsed <= 0) {
-                    std::cerr << "Error: Number of iterations must be positive\n";
-                    return 1;
-                }
-                iterations = parsed;
-                break;
-            case 'D':
-                use_direct = true;
-                break;
-            case 'h':
-                print_usage(argv[0]);
-                return 0;
-            default:
-                print_usage(argv[0]);
+        case 'd':
+            use_dram = true;
+            break;
+        case 'v':
+            use_vram = true;
+            break;
+        case 'n':
+            num_transfers =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Transfers", false));
+            break;
+        case 's':
+            transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
+            break;
+        case 'p':
+            pool_size =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "GDS Batch Pool Size", false));
+            break;
+        case 'b':
+            batch_limit =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "GDS Batch Limit", false));
+            if (batch_limit > 128) {
+                std::cerr << "Error: Batch limit must be between 1 and 128\n";
                 return 1;
+            }
+            break;
+        case 'm':
+            max_request_size = parsePositiveSize(optarg, "Max Request Size", true);
+            if (max_request_size > 16 * 1024 * 1024) {
+                std::cerr << "Error: Max request size cannot be greater than 16M\n";
+                return 1;
+            }
+            break;
+        case 't':
+            iterations =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Iterations", false));
+            break;
+        case 'D':
+            use_direct = true;
+            break;
+        case 'h':
+            print_usage(argv[0]);
+            return 0;
+        default:
+            print_usage(argv[0]);
+            return 1;
         }
     }
 
@@ -445,7 +454,7 @@ int main(int argc, char *argv[])
         nixl_reg_dlist_t src_reg(use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg(FILE_SEG);
 
-        for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
+        for (unsigned int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc(dram_buf[transfer_idx]);
             } else {
@@ -510,6 +519,7 @@ int main(int argc, char *argv[])
     std::cout << "============================================================" << std::endl;
     for (i = 0; i < num_transfers; i++) {
         if (use_vram && vram_addr[i]) {
+            cudaSetDevice(0);
             if (clear_gpu_buffer(vram_addr[i], transfer_size) != cudaSuccess) {
                 std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
                 goto cleanup;
@@ -532,7 +542,7 @@ int main(int argc, char *argv[])
         nixl_reg_dlist_t src_reg(use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg(FILE_SEG);
 
-        for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
+        for (unsigned int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc(dram_buf[transfer_idx]);
             } else {

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -231,54 +231,60 @@ int main(int argc, char *argv[])
                                            {"help", no_argument, 0, 'h'},
                                            {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "dvn:s:p:b:m:t:Dh", long_options, NULL)) != -1) {
-        switch (opt) {
-        case 'd':
-            use_dram = true;
-            break;
-        case 'v':
-            use_vram = true;
-            break;
-        case 'n':
-            num_transfers =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Transfers", false));
-            break;
-        case 's':
-            transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
-            break;
-        case 'p':
-            pool_size =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "GDS Batch Pool Size", false));
-            break;
-        case 'b':
-            batch_limit =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "GDS Batch Limit", false));
-            if (batch_limit > 128) {
-                std::cerr << "Error: Batch limit must be between 1 and 128\n";
+    try {
+        while ((opt = getopt_long(argc, argv, "dvn:s:p:b:m:t:Dh", long_options, NULL)) != -1) {
+            switch (opt) {
+            case 'd':
+                use_dram = true;
+                break;
+            case 'v':
+                use_vram = true;
+                break;
+            case 'n':
+                num_transfers = static_cast<unsigned int>(
+                    parsePositiveSize(optarg, "Number of Transfers", false));
+                break;
+            case 's':
+                transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
+                break;
+            case 'p':
+                pool_size = static_cast<unsigned int>(
+                    parsePositiveSize(optarg, "GDS Batch Pool Size", false));
+                break;
+            case 'b':
+                batch_limit =
+                    static_cast<unsigned int>(parsePositiveSize(optarg, "GDS Batch Limit", false));
+                if (batch_limit > 128) {
+                    std::cerr << "Error: Batch limit must be between 1 and 128\n";
+                    return 1;
+                }
+                break;
+            case 'm':
+                max_request_size = parsePositiveSize(optarg, "Max Request Size", true);
+                if (max_request_size > 16 * 1024 * 1024) {
+                    std::cerr << "Error: Max request size cannot be greater than 16M\n";
+                    return 1;
+                }
+                break;
+            case 't':
+                iterations = static_cast<unsigned int>(
+                    parsePositiveSize(optarg, "Number of Iterations", false));
+                break;
+            case 'D':
+                use_direct = true;
+                break;
+            case 'h':
+                print_usage(argv[0]);
+                return 0;
+            default:
+                print_usage(argv[0]);
                 return 1;
             }
-            break;
-        case 'm':
-            max_request_size = parsePositiveSize(optarg, "Max Request Size", true);
-            if (max_request_size > 16 * 1024 * 1024) {
-                std::cerr << "Error: Max request size cannot be greater than 16M\n";
-                return 1;
-            }
-            break;
-        case 't':
-            iterations =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Iterations", false));
-            break;
-        case 'D':
-            use_direct = true;
-            break;
-        case 'h':
-            print_usage(argv[0]);
-            return 0;
-        default:
-            print_usage(argv[0]);
-            return 1;
         }
+    }
+    catch (const std::invalid_argument &e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
     }
 
     // Check if directory path is provided

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -64,23 +64,26 @@ size_t parse_size(const char* size_str) {
 }
 
 void print_usage(const char* program_name) {
-    std::cerr << "Usage: " << program_name << " [options] <directory_path>\n"
-              << "Options:\n"
-              << "  -d, --dram              Use DRAM for memory operations\n"
-              << "  -v, --vram              Use VRAM for memory operations (default)\n"
-              << "  -n, --num-transfers N   Number of transfers to perform (default: " << DEFAULT_NUM_TRANSFERS << ")\n"
-              << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE << " bytes)\n"
-              << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
-              << "  -r, --no-read           Skip read test\n"
-              << "  -w, --no-write          Skip write test\n"
-              << "  -p, --pool-size SIZE    Size of batch pool (default: 8, range: 1-32)\n"
-              << "  -b, --batch-limit SIZE  Maximum requests per batch  (default: 128, Max allowed: 1-128)\n"
-              << "  -m, --max-req-size SIZE Maximum size per request (default: 16M, Max allowed: 16M)\n"
-              << "  -t, --iterations N      Number of iterations for each transfer (default: " << DEFAULT_ITERATIONS << ")\n"
-              << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
-              << "  -h, --help              Show this help message\n"
-              << "\nExample:\n"
-              << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
+    std::cerr
+        << "Usage: " << program_name << " [options] <directory_path>\n"
+        << "Options:\n"
+        << "  -d, --dram              Use DRAM for memory operations\n"
+        << "  -v, --vram              Use VRAM for memory operations (default)\n"
+        << "  -n, --num-transfers N   Number of transfers to perform (default: "
+        << DEFAULT_NUM_TRANSFERS << ")\n"
+        << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE
+        << " bytes)\n"
+        << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
+        << "  -p, --pool-size SIZE    Size of batch pool (default: 8, range: 1-32)\n"
+        << "  -b, --batch-limit SIZE  Maximum requests per batch  (default: 128, Max allowed: "
+           "1-128)\n"
+        << "  -m, --max-req-size SIZE Maximum size per request (default: 16M, Max allowed: 16M)\n"
+        << "  -t, --iterations N      Number of iterations for each transfer (default: "
+        << DEFAULT_ITERATIONS << ")\n"
+        << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
+        << "  -h, --help              Show this help message\n"
+        << "\nExample:\n"
+        << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
 }
 
 void printProgress(float progress) {
@@ -93,7 +96,7 @@ void printProgress(float progress) {
         else if (i == pos) std::cout << ">";
         else std::cout << " ";
     }
-    std::cout << "] " << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
+    std::cout << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
 
     // Add completion indicator
     if (progress >= 1.0) {
@@ -209,9 +212,7 @@ int main(int argc, char *argv[])
     int                         opt;
     std::string                 dir_path;
     size_t                      transfer_size = DEFAULT_TRANSFER_SIZE;
-    int                         num_transfers = DEFAULT_NUM_TRANSFERS;
-    bool                        skip_read = false;
-    bool                        skip_write = false;
+    int num_transfers = DEFAULT_NUM_TRANSFERS;
     unsigned int                pool_size = 8;
     unsigned int                batch_limit = 128;
     size_t                      max_request_size = 16 * 1024 * 1024;
@@ -221,23 +222,19 @@ int main(int argc, char *argv[])
     unsigned int                iterations = DEFAULT_ITERATIONS;
 
     // Parse command line options
-    static struct option long_options[] = {
-        {"dram",            no_argument,       0, 'd'},
-        {"vram",            no_argument,       0, 'v'},
-        {"num-transfers",   required_argument, 0, 'n'},
-        {"size",           required_argument, 0, 's'},
-        {"no-read",        no_argument,       0, 'r'},
-        {"no-write",       no_argument,       0, 'w'},
-        {"pool-size",      required_argument, 0, 'p'},
-        {"batch-limit",    required_argument, 0, 'b'},
-        {"max-req-size",   required_argument, 0, 'm'},
-        {"iterations",     required_argument, 0, 't'},
-        {"direct",         no_argument,       0, 'D'},
-        {"help",           no_argument,       0, 'h'},
-        {0,                0,                 0,  0}
-    };
+    static struct option long_options[] = {{"dram", no_argument, 0, 'd'},
+                                           {"vram", no_argument, 0, 'v'},
+                                           {"num-transfers", required_argument, 0, 'n'},
+                                           {"size", required_argument, 0, 's'},
+                                           {"pool-size", required_argument, 0, 'p'},
+                                           {"batch-limit", required_argument, 0, 'b'},
+                                           {"max-req-size", required_argument, 0, 'm'},
+                                           {"iterations", required_argument, 0, 't'},
+                                           {"direct", no_argument, 0, 'D'},
+                                           {"help", no_argument, 0, 'h'},
+                                           {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "dvn:s:rwp:b:m:t:Dh", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "dvn:s:p:b:m:t:Dh", long_options, NULL)) != -1) {
         switch (opt) {
             case 'd':
                 use_dram = true;
@@ -258,12 +255,6 @@ int main(int argc, char *argv[])
                     std::cerr << "Error: Invalid transfer size format\n";
                     return 1;
                 }
-                break;
-            case 'r':
-                skip_read = true;
-                break;
-            case 'w':
-                skip_write = true;
                 break;
             case 'p':
                 pool_size = atoi(optarg);
@@ -299,11 +290,6 @@ int main(int argc, char *argv[])
                 print_usage(argv[0]);
                 return 1;
         }
-    }
-
-    if (skip_read && skip_write) {
-        std::cerr << "Error: Cannot skip both read and write tests\n";
-        return 1;
     }
 
     // Check if directory path is provided
@@ -363,15 +349,6 @@ int main(int argc, char *argv[])
     std::cout << "- Max request size: " << max_request_size << " bytes" << std::endl;
     std::cout << "- Number of iterations: " << iterations << std::endl;
     std::cout << "- Use O_DIRECT: " << (use_direct ? "Yes" : "No") << std::endl;
-    std::cout << "- Operation: ";
-    if (!skip_read && !skip_write) {
-        std::cout << "Read and Write";
-    } else if (skip_read) {
-        std::cout << "Write Only";
-    } else {  // skip_write
-        std::cout << "Read Only";
-    }
-    std::cout << std::endl;
     std::cout << "============================================================\n" << std::endl;
 
     nixlAgent agent("GDSTester", cfg);
@@ -475,14 +452,9 @@ int main(int argc, char *argv[])
         }
     }
 
-    // Prepare transfer lists
-    nixl_xfer_dlist_t file_for_gds_list = file_for_gds.trim();
-    nixl_xfer_dlist_t src_list = use_dram ? dram_for_gds.trim() : vram_for_gds.trim();
-
     using namespace nixlTime;
 
-    // Perform write test if not skipped
-    if (!skip_write) {
+    {
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 2: Memory to File Transfer (Write Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
@@ -490,11 +462,9 @@ int main(int argc, char *argv[])
         us_t write_duration(0);
         nixlXferReqH* write_req = nullptr;
 
-        // Create descriptor lists for all transfers
         nixl_reg_dlist_t src_reg(use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg(FILE_SEG);
 
-        // Add all descriptors
         for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc(dram_buf[transfer_idx]);
@@ -506,20 +476,16 @@ int main(int argc, char *argv[])
         }
         std::cout << "\nAll descriptors added." << std::endl;
 
-        // Create transfer lists
         nixl_xfer_dlist_t src_list = src_reg.trim();
         nixl_xfer_dlist_t file_list = file_reg.trim();
 
-        // Create single transfer request for all transfers
-        ret = agent.createXferReq(NIXL_WRITE, src_list, file_list,
-                                "GDSTester", write_req);
+        ret = agent.createXferReq(NIXL_WRITE, src_list, file_list, "GDSTester", write_req);
         if (ret != NIXL_SUCCESS) {
             std::cerr << "Failed to create write transfer request" << std::endl;
             goto cleanup;
         }
         std::cout << "Write transfer request created." << std::endl;
 
-        // Now do the iterations
         for (unsigned int iter = 0; iter < iterations; iter++) {
             us_t iter_start = getUs();
 
@@ -529,7 +495,6 @@ int main(int argc, char *argv[])
                 goto cleanup;
             }
 
-            // Wait for completion
             while (status == NIXL_IN_PROG) {
                 status = agent.getXferStatus(write_req);
                 if (status < 0) {
@@ -560,27 +525,23 @@ int main(int argc, char *argv[])
         std::cout << "- Speed: " << gbps << " GB/s" << std::endl;
     }
 
-    // Clear buffers before read if doing both operations
-    if (!skip_read && !skip_write) {
-        std::cout << "\n============================================================" << std::endl;
-        std::cout << "PHASE 3: Clearing buffers for read test" << std::endl;
-        std::cout << "============================================================" << std::endl;
-        for (i = 0; i < num_transfers; i++) {
-            if (use_vram && vram_addr[i]) {
-                if (clear_gpu_buffer(vram_addr[i], transfer_size) != cudaSuccess) {
-                    std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
-                    goto cleanup;
-                }
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "PHASE 3: Clearing buffers for read test" << std::endl;
+    std::cout << "============================================================" << std::endl;
+    for (i = 0; i < num_transfers; i++) {
+        if (use_vram && vram_addr[i]) {
+            if (clear_gpu_buffer(vram_addr[i], transfer_size) != cudaSuccess) {
+                std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
+                goto cleanup;
             }
-            if (use_dram && dram_addr[i]) {
-                clear_buffer(dram_addr[i], transfer_size);
-            }
-            printProgress(float(i + 1) / num_transfers);
         }
+        if (use_dram && dram_addr[i]) {
+            clear_buffer(dram_addr[i], transfer_size);
+        }
+        printProgress(float(i + 1) / num_transfers);
     }
 
-    // Perform read test if not skipped
-    if (!skip_read) {
+    {
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 4: File to Memory Transfer (Read Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
@@ -588,11 +549,9 @@ int main(int argc, char *argv[])
         us_t read_duration(0);
         nixlXferReqH* read_req = nullptr;
 
-        // Create descriptor lists for all transfers
         nixl_reg_dlist_t src_reg(use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg(FILE_SEG);
 
-        // Add all descriptors
         for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc(dram_buf[transfer_idx]);
@@ -604,20 +563,16 @@ int main(int argc, char *argv[])
         }
         std::cout << "\nAll descriptors added." << std::endl;
 
-        // Create transfer lists
         nixl_xfer_dlist_t src_list = src_reg.trim();
         nixl_xfer_dlist_t file_list = file_reg.trim();
 
-        // Create single transfer request for all transfers
-        ret = agent.createXferReq(NIXL_READ, src_list, file_list,
-                                "GDSTester", read_req);
+        ret = agent.createXferReq(NIXL_READ, src_list, file_list, "GDSTester", read_req);
         if (ret != NIXL_SUCCESS) {
             std::cerr << "Failed to create read transfer request" << std::endl;
             goto cleanup;
         }
         std::cout << "Read transfer request created." << std::endl;
 
-        // Now do the iterations
         for (unsigned int iter = 0; iter < iterations; iter++) {
             us_t iter_start = getUs();
 
@@ -627,7 +582,6 @@ int main(int argc, char *argv[])
                 goto cleanup;
             }
 
-            // Wait for completion
             while (status == NIXL_IN_PROG) {
                 status = agent.getXferStatus(read_req);
                 if (status < 0) {
@@ -695,7 +649,6 @@ cleanup:
     std::cout << "Deleting test files..." << std::endl;
     for (i = 0; i < num_transfers; i++) {
         if (fd[i] > 0) {
-            // Get the filename from the file descriptor
             char proc_path[64];
             char filename[PATH_MAX];
             snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d", fd[i]);

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -127,14 +127,6 @@ generate_timestamped_filename (const std::string &base_name) {
     return base_name + std::string (timestamp);
 }
 
-void
-validateBuffer (void *expected, void *actual, size_t size, const char *operation) {
-    if (memcmp (expected, actual, size) != 0) {
-        std::cerr << "Data validation failed for " << operation << std::endl;
-        exit (-1);
-    }
-}
-
 // Helper function to fill buffer with repeating pattern
 void
 fill_test_pattern (void *buffer, size_t size) {

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -259,7 +259,7 @@ main (int argc, char *argv[]) {
             num_threads = parsed;
             break;
         case 't':
-            parsed = atoi (optarg);
+            parsed = atoi(optarg);
             if (parsed <= 0) {
                 std::cerr << "Error: Number of iterations must be positive\n";
                 return 1;
@@ -267,7 +267,7 @@ main (int argc, char *argv[]) {
             iterations = parsed;
             break;
         case 'G':
-            parsed = atoi (optarg);
+            parsed = atoi(optarg);
             if (parsed <= 0) {
                 std::cerr << "Error: Number of GPUs must be positive\n";
                 return 1;

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -232,6 +232,7 @@ main (int argc, char *argv[]) {
     std::string dir_path;
     size_t transfer_size = DEFAULT_TRANSFER_SIZE;
     int num_transfers = DEFAULT_NUM_TRANSFERS;
+    int parsed = 0;
     size_t num_threads = 0;
     nixlTime::us_t total_time (0);
     double total_data_gb = 0;
@@ -275,11 +276,12 @@ main (int argc, char *argv[]) {
             }
             break;
         case 'N':
-            num_threads = atoi (optarg);
-            if (num_threads <= 0) {
-                std::cerr << "Error: Number of iterations must be positive\n";
+            parsed = atoi(optarg);
+            if (parsed <= 0) {
+                std::cerr << "Error: Number of threads must be positive\n";
                 return 1;
             }
+            num_threads = parsed;
             break;
         case 't':
             iterations = atoi (optarg);

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -259,18 +259,20 @@ main (int argc, char *argv[]) {
             num_threads = parsed;
             break;
         case 't':
-            iterations = atoi (optarg);
-            if (iterations <= 0) {
+            parsed = atoi (optarg);
+            if (parsed <= 0) {
                 std::cerr << "Error: Number of iterations must be positive\n";
                 return 1;
             }
+            iterations = parsed;
             break;
         case 'G':
-            num_gpus = atoi (optarg);
-            if (num_gpus <= 0) {
+            parsed = atoi (optarg);
+            if (parsed <= 0) {
                 std::cerr << "Error: Number of GPUs must be positive\n";
                 return 1;
             }
+            num_gpus = parsed;
             break;
         case 'D':
             use_direct = true;

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -84,8 +84,6 @@ print_usage (const char *program_name) {
         << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE
         << " bytes)\n"
         << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
-        << "  -r, --no-read           Skip read test\n"
-        << "  -w, --no-write          Skip write test\n"
         << "  -t, --iterations N      Number of iterations for each transfer (default: "
         << DEFAULT_ITERATIONS << ")\n"
         << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
@@ -93,7 +91,7 @@ print_usage (const char *program_name) {
         << "  -N, --num-threads N     Number of CPU Threads to use (default: all CPUs detected)\n"
         << "  -h, --help              Show this help message\n"
         << "\nExample:\n"
-        << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
+        << "  " << program_name << " -d -n 100 -s 2M -t 5 -D /path/to/dir\n";
 }
 
 void
@@ -234,8 +232,6 @@ main (int argc, char *argv[]) {
     std::string dir_path;
     size_t transfer_size = DEFAULT_TRANSFER_SIZE;
     int num_transfers = DEFAULT_NUM_TRANSFERS;
-    bool skip_read = false;
-    bool skip_write = false;
     size_t num_threads = 0;
     nixlTime::us_t total_time (0);
     double total_data_gb = 0;
@@ -248,8 +244,6 @@ main (int argc, char *argv[]) {
                                            {"vram", no_argument, 0, 'v'},
                                            {"num-transfers", required_argument, 0, 'n'},
                                            {"size", required_argument, 0, 's'},
-                                           {"no-read", no_argument, 0, 'r'},
-                                           {"no-write", no_argument, 0, 'w'},
                                            {"num-gpus", required_argument, 0, 'G'},
                                            {"max-req-size", required_argument, 0, 'm'},
                                            {"num-threads", required_argument, 0, 'N'},
@@ -258,7 +252,7 @@ main (int argc, char *argv[]) {
                                            {"help", no_argument, 0, 'h'},
                                            {0, 0, 0, 0}};
 
-    while ((opt = getopt_long (argc, argv, "dvn:s:rwp:b:t:G:DhN:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "dvn:s:t:G:DhN:", long_options, NULL)) != -1) {
         switch (opt) {
         case 'd':
             use_dram = true;
@@ -279,12 +273,6 @@ main (int argc, char *argv[]) {
                 std::cerr << "Error: Invalid transfer size format\n";
                 return 1;
             }
-            break;
-        case 'r':
-            skip_read = true;
-            break;
-        case 'w':
-            skip_write = true;
             break;
         case 'N':
             num_threads = atoi (optarg);
@@ -317,11 +305,6 @@ main (int argc, char *argv[]) {
             print_usage (argv[0]);
             return 1;
         }
-    }
-
-    if (skip_read && skip_write) {
-        std::cerr << "Error: Cannot skip both read and write tests\n";
-        return 1;
     }
 
     // Check if directory path is provided
@@ -381,15 +364,6 @@ main (int argc, char *argv[]) {
     std::cout << "- Num GPUs to use: " << num_gpus << std::endl;
     std::cout << "- Number of iterations: " << iterations << std::endl;
     std::cout << "- Use O_DIRECT: " << (use_direct ? "Yes" : "No") << std::endl;
-    std::cout << "- Operation: ";
-    if (!skip_read && !skip_write) {
-        std::cout << "Read and Write";
-    } else if (skip_read) {
-        std::cout << "Write Only";
-    } else { // skip_write
-        std::cout << "Read Only";
-    }
-    std::cout << std::endl;
     std::cout << "============================================================\n" << std::endl;
 
     nixlAgent agent ("GDSMTTester", cfg);
@@ -497,14 +471,9 @@ main (int argc, char *argv[]) {
         }
     }
 
-    // Prepare transfer lists
-    nixl_xfer_dlist_t file_for_gds_mt_list = file_for_gds_mt.trim();
-    nixl_xfer_dlist_t src_list = use_dram ? dram_for_gds_mt.trim() : vram_for_gds_mt.trim();
-
     using namespace nixlTime;
 
-    // Perform write test if not skipped
-    if (!skip_write) {
+    {
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 2: Memory to File Transfer (Write Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
@@ -512,11 +481,9 @@ main (int argc, char *argv[]) {
         us_t write_duration (0);
         nixlXferReqH *write_req = nullptr;
 
-        // Create descriptor lists for all transfers
         nixl_reg_dlist_t src_reg (use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg (FILE_SEG);
 
-        // Add all descriptors
         for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc (dram_buf[transfer_idx]);
@@ -528,11 +495,9 @@ main (int argc, char *argv[]) {
         }
         std::cout << "\nAll descriptors added." << std::endl;
 
-        // Create transfer lists
         nixl_xfer_dlist_t src_list = src_reg.trim();
         nixl_xfer_dlist_t file_list = file_reg.trim();
 
-        // Create single transfer request for all transfers
         ret = agent.createXferReq (NIXL_WRITE, src_list, file_list, "GDSMTTester", write_req);
         if (ret != NIXL_SUCCESS) {
             std::cerr << "Failed to create write transfer request" << std::endl;
@@ -540,7 +505,6 @@ main (int argc, char *argv[]) {
         }
         std::cout << "Write transfer request created." << std::endl;
 
-        // Now do the iterations
         for (unsigned int iter = 0; iter < iterations; iter++) {
             us_t iter_start = getUs();
 
@@ -550,7 +514,6 @@ main (int argc, char *argv[]) {
                 goto cleanup;
             }
 
-            // Wait for completion
             while (status == NIXL_IN_PROG) {
                 status = agent.getXferStatus (write_req);
                 if (status < 0) {
@@ -582,29 +545,25 @@ main (int argc, char *argv[]) {
         std::cout << "- Speed: " << gbps << " GB/s" << std::endl;
     }
 
-    // Clear buffers before read if doing both operations
-    if (!skip_read && !skip_write) {
-        std::cout << "\n============================================================" << std::endl;
-        std::cout << "PHASE 3: Clearing buffers for read test" << std::endl;
-        std::cout << "============================================================" << std::endl;
-        for (i = 0; i < num_transfers; i++) {
-            if (use_vram && vram_addr[i]) {
-                int devId = i % num_gpus;
-                cudaSetDevice (devId);
-                if (clear_gpu_buffer (vram_addr[i], transfer_size) != cudaSuccess) {
-                    std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
-                    goto cleanup;
-                }
+    std::cout << "\n============================================================" << std::endl;
+    std::cout << "PHASE 3: Clearing buffers for read test" << std::endl;
+    std::cout << "============================================================" << std::endl;
+    for (i = 0; i < num_transfers; i++) {
+        if (use_vram && vram_addr[i]) {
+            int devId = i % num_gpus;
+            cudaSetDevice(devId);
+            if (clear_gpu_buffer(vram_addr[i], transfer_size) != cudaSuccess) {
+                std::cerr << "Failed to clear VRAM buffer " << i << std::endl;
+                goto cleanup;
             }
-            if (use_dram && dram_addr[i]) {
-                clear_buffer (dram_addr[i], transfer_size);
-            }
-            printProgress (float (i + 1) / num_transfers);
         }
+        if (use_dram && dram_addr[i]) {
+            clear_buffer(dram_addr[i], transfer_size);
+        }
+        printProgress(float(i + 1) / num_transfers);
     }
 
-    // Perform read test if not skipped
-    if (!skip_read) {
+    {
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 4: File to Memory Transfer (Read Test)" << std::endl;
         std::cout << "============================================================" << std::endl;
@@ -612,11 +571,9 @@ main (int argc, char *argv[]) {
         us_t read_duration (0);
         nixlXferReqH *read_req = nullptr;
 
-        // Create descriptor lists for all transfers
         nixl_reg_dlist_t src_reg (use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg (FILE_SEG);
 
-        // Add all descriptors
         for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc (dram_buf[transfer_idx]);
@@ -628,11 +585,9 @@ main (int argc, char *argv[]) {
         }
         std::cout << "\nAll descriptors added." << std::endl;
 
-        // Create transfer lists
         nixl_xfer_dlist_t src_list = src_reg.trim();
         nixl_xfer_dlist_t file_list = file_reg.trim();
 
-        // Create single transfer request for all transfers
         ret = agent.createXferReq (NIXL_READ, src_list, file_list, "GDSMTTester", read_req);
         if (ret != NIXL_SUCCESS) {
             std::cerr << "Failed to create read transfer request" << std::endl;
@@ -640,7 +595,6 @@ main (int argc, char *argv[]) {
         }
         std::cout << "Read transfer request created." << std::endl;
 
-        // Now do the iterations
         for (unsigned int iter = 0; iter < iterations; iter++) {
             us_t iter_start = getUs();
 
@@ -650,7 +604,6 @@ main (int argc, char *argv[]) {
                 goto cleanup;
             }
 
-            // Wait for completion
             while (status == NIXL_IN_PROG) {
                 status = agent.getXferStatus (read_req);
                 if (status < 0) {
@@ -721,7 +674,6 @@ cleanup:
     std::cout << "Deleting test files..." << std::endl;
     for (i = 0; i < num_transfers; i++) {
         if (fd[i] > 0) {
-            // Get the filename from the file descriptor
             char proc_path[64];
             char filename[PATH_MAX];
             snprintf (proc_path, sizeof (proc_path), "/proc/self/fd/%d", fd[i]);

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -232,53 +232,58 @@ main (int argc, char *argv[]) {
                                            {"num-transfers", required_argument, 0, 'n'},
                                            {"size", required_argument, 0, 's'},
                                            {"num-gpus", required_argument, 0, 'G'},
-                                           {"max-req-size", required_argument, 0, 'm'},
                                            {"num-threads", required_argument, 0, 'N'},
                                            {"iterations", required_argument, 0, 't'},
                                            {"direct", no_argument, 0, 'D'},
                                            {"help", no_argument, 0, 'h'},
                                            {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "dvn:s:t:G:DhN:", long_options, NULL)) != -1) {
-        switch (opt) {
-        case 'd':
-            use_dram = true;
-            break;
-        case 'v':
-            use_vram = true;
-            break;
-        case 'n':
-            num_transfers =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Transfers", false));
-            break;
-        case 's':
-            transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
-            if (transfer_size == 0) {
-                std::cerr << "Error: Invalid transfer size format\n";
+    try {
+        while ((opt = getopt_long(argc, argv, "dvn:s:t:G:DhN:", long_options, NULL)) != -1) {
+            switch (opt) {
+            case 'd':
+                use_dram = true;
+                break;
+            case 'v':
+                use_vram = true;
+                break;
+            case 'n':
+                num_transfers = static_cast<unsigned int>(
+                    parsePositiveSize(optarg, "Number of Transfers", false));
+                break;
+            case 's':
+                transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
+                if (transfer_size == 0) {
+                    std::cerr << "Error: Invalid transfer size format\n";
+                    return 1;
+                }
+                break;
+            case 'N':
+                num_threads = parsePositiveSize(optarg, "threads", false);
+                break;
+            case 't':
+                iterations = static_cast<unsigned int>(
+                    parsePositiveSize(optarg, "Number of iterations", false));
+                break;
+            case 'G':
+                num_gpus =
+                    static_cast<unsigned int>(parsePositiveSize(optarg, "Number of GPUs", false));
+                break;
+            case 'D':
+                use_direct = true;
+                break;
+            case 'h':
+                print_usage(argv[0]);
+                return 0;
+            default:
+                print_usage(argv[0]);
                 return 1;
             }
-            break;
-        case 'N':
-            num_threads = parsePositiveSize(optarg, "threads", false);
-            break;
-        case 't':
-            iterations =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of iterations", false));
-            break;
-        case 'G':
-            num_gpus =
-                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of GPUs", false));
-            break;
-        case 'D':
-            use_direct = true;
-            break;
-        case 'h':
-            print_usage(argv[0]);
-            return 0;
-        default:
-            print_usage(argv[0]);
-            return 1;
         }
+    }
+    catch (const std::invalid_argument &e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
     }
 
     // Check if directory path is provided

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include <iostream>
+#include <memory>
 #include <string>
 #include <algorithm>
 #include <cassert>
@@ -618,44 +619,30 @@ main (int argc, char *argv[]) {
         std::cout << "============================================================" << std::endl;
 
         // Pre-allocate validation buffers once for all transfers
-        char *host_buffer = use_vram ? (char *)malloc(transfer_size) : NULL;
-        char *expected_buffer = (char *)malloc(transfer_size);
-        if ((use_vram && !host_buffer) || !expected_buffer) {
-            std::cerr << "Failed to allocate validation buffers\n";
-            free(host_buffer);
-            free(expected_buffer);
-            goto cleanup;
-        }
+        auto host_buffer = use_vram ? std::make_unique<char[]>(transfer_size) : nullptr;
+        auto expected_buffer = std::make_unique<char[]>(transfer_size);
 
         // Generate expected pattern once
-        fill_test_pattern(expected_buffer, transfer_size);
+        fill_test_pattern(expected_buffer.get(), transfer_size);
 
         for (i = 0; i < num_transfers; i++) {
             if (use_vram) {
                 int devId = i % num_gpus;
                 cudaSetDevice (devId);
                 if (!validate_gpu_buffer(
-                        vram_addr[i], transfer_size, host_buffer, expected_buffer)) {
+                        vram_addr[i], transfer_size, host_buffer.get(), expected_buffer.get())) {
                     std::cerr << "VRAM buffer " << i << " validation failed\n";
-                    free(host_buffer);
-                    free(expected_buffer);
                     goto cleanup;
                 }
             }
             if (use_dram) {
-                if (memcmp (dram_addr[i], expected_buffer, transfer_size) != 0) {
+                if (memcmp(dram_addr[i], expected_buffer.get(), transfer_size) != 0) {
                     std::cerr << "DRAM buffer " << i << " validation failed\n";
-                    free(host_buffer);
-                    free (expected_buffer);
                     goto cleanup;
                 }
             }
             printProgress (float (i + 1) / num_transfers);
         }
-
-        // Free validation buffers
-        free(host_buffer);
-        free(expected_buffer);
 
         std::cout << "\nVerification completed successfully!" << std::endl;
     }

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -16,7 +16,9 @@
  */
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <algorithm>
 #include <cassert>
 #include <cuda_runtime.h>
@@ -45,33 +47,6 @@ static size_t PAGE_SIZE = sysconf (_SC_PAGESIZE);
 
 // Progress bar configuration
 #define PROGRESS_WIDTH 50
-
-// Helper function to parse size strings like "1K", "2M", "3G"
-size_t
-parse_size (const char *size_str) {
-    char *end;
-    size_t size = strtoull (size_str, &end, 10);
-    if (end == size_str) {
-        return 0; // Invalid number
-    }
-
-    if (*end) {
-        switch (toupper (*end)) {
-        case 'K':
-            size *= 1024;
-            break;
-        case 'M':
-            size *= 1024 * 1024;
-            break;
-        case 'G':
-            size *= 1024 * 1024 * 1024;
-            break;
-        default:
-            return 0; // Invalid suffix
-        }
-    }
-    return size;
-}
 
 void
 print_usage (const char *program_name) {
@@ -180,6 +155,42 @@ validate_gpu_buffer(void *gpu_buffer, size_t size, char *host_buffer, const char
     return (memcmp(host_buffer, expected_buffer, size) == 0);
 }
 
+// Helper function to validate numbers and suffix for K,M,G bytes
+size_t
+parsePositiveSize(const char *str, std::string_view name, bool usesSuffix) {
+    try {
+        char *end;
+        size_t value = std::strtoull(str, &end, 10);
+
+        if ((str[0] == '-') || (end == str) || (value == 0)) {
+            throw std::invalid_argument(std::string(name) + " must be a positive integer");
+        }
+
+        if (!usesSuffix) {
+            return value;
+        } else if (*end) {
+            switch (toupper(*end)) {
+            case 'K':
+                value *= 1024;
+                break;
+            case 'M':
+                value *= 1024 * 1024;
+                break;
+            case 'G':
+                value *= 1024 * 1024 * 1024;
+                break;
+            default:
+                throw std::invalid_argument("Invalid suffix for " + std::string(name));
+            }
+        }
+
+        return value;
+    }
+    catch (std::exception &e) {
+        throw std::invalid_argument(e.what());
+    }
+}
+
 // Helper function to format duration
 std::string
 format_duration (nixlTime::us_t us) {
@@ -200,15 +211,14 @@ main (int argc, char *argv[]) {
     void **dram_addr = NULL;
     std::string role;
     int status = 0;
-    int i;
+    unsigned int i;
     int *fd = NULL;
     bool use_dram = false;
     bool use_vram = false;
     int opt;
     std::string dir_path;
     size_t transfer_size = DEFAULT_TRANSFER_SIZE;
-    int num_transfers = DEFAULT_NUM_TRANSFERS;
-    int parsed = 0;
+    unsigned int num_transfers = DEFAULT_NUM_TRANSFERS;
     size_t num_threads = 0;
     nixlTime::us_t total_time (0);
     double total_data_gb = 0;
@@ -238,51 +248,35 @@ main (int argc, char *argv[]) {
             use_vram = true;
             break;
         case 'n':
-            num_transfers = atoi (optarg);
-            if (num_transfers <= 0) {
-                std::cerr << "Error: Number of transfers must be positive\n";
-                return 1;
-            }
+            num_transfers =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of Transfers", false));
             break;
         case 's':
-            transfer_size = parse_size (optarg);
+            transfer_size = parsePositiveSize(optarg, "Transfer Size", true);
             if (transfer_size == 0) {
                 std::cerr << "Error: Invalid transfer size format\n";
                 return 1;
             }
             break;
         case 'N':
-            parsed = atoi(optarg);
-            if (parsed <= 0) {
-                std::cerr << "Error: Number of threads must be positive\n";
-                return 1;
-            }
-            num_threads = parsed;
+            num_threads = parsePositiveSize(optarg, "threads", false);
             break;
         case 't':
-            parsed = atoi(optarg);
-            if (parsed <= 0) {
-                std::cerr << "Error: Number of iterations must be positive\n";
-                return 1;
-            }
-            iterations = parsed;
+            iterations =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of iterations", false));
             break;
         case 'G':
-            parsed = atoi(optarg);
-            if (parsed <= 0) {
-                std::cerr << "Error: Number of GPUs must be positive\n";
-                return 1;
-            }
-            num_gpus = parsed;
+            num_gpus =
+                static_cast<unsigned int>(parsePositiveSize(optarg, "Number of GPUs", false));
             break;
         case 'D':
             use_direct = true;
             break;
         case 'h':
-            print_usage (argv[0]);
+            print_usage(argv[0]);
             return 0;
         default:
-            print_usage (argv[0]);
+            print_usage(argv[0]);
             return 1;
         }
     }
@@ -464,7 +458,7 @@ main (int argc, char *argv[]) {
         nixl_reg_dlist_t src_reg (use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg (FILE_SEG);
 
-        for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
+        for (unsigned int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc (dram_buf[transfer_idx]);
             } else {
@@ -554,7 +548,7 @@ main (int argc, char *argv[]) {
         nixl_reg_dlist_t src_reg (use_dram ? DRAM_SEG : VRAM_SEG);
         nixl_reg_dlist_t file_reg (FILE_SEG);
 
-        for (int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
+        for (unsigned int transfer_idx = 0; transfer_idx < num_transfers; transfer_idx++) {
             if (use_dram) {
                 src_reg.addDesc (dram_buf[transfer_idx]);
             } else {

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -174,34 +174,17 @@ clear_gpu_buffer (void *gpu_buffer, size_t size) {
     return cudaMemset (gpu_buffer, 0, size);
 }
 
-// Helper function to validate GPU buffer
+// Helper function to validate GPU buffer with pre-allocated buffers
 bool
-validate_gpu_buffer (void *gpu_buffer, size_t size) {
-    char *host_buffer = (char *)malloc (size);
-    char *expected_buffer = (char *)malloc (size);
-    if (!host_buffer || !expected_buffer) {
-        free (host_buffer);
-        free (expected_buffer);
-        return false;
-    }
-
+validate_gpu_buffer(void *gpu_buffer, size_t size, char *host_buffer, const char *expected_buffer) {
     // Copy GPU data to host
     cudaError_t err = cudaMemcpy (host_buffer, gpu_buffer, size, cudaMemcpyDeviceToHost);
     if (err != cudaSuccess) {
-        free (host_buffer);
-        free (expected_buffer);
         return false;
     }
 
-    // Create expected pattern
-    fill_test_pattern (expected_buffer, size);
-
     // Compare
-    bool match = (memcmp (host_buffer, expected_buffer, size) == 0);
-
-    free (host_buffer);
-    free (expected_buffer);
-    return match;
+    return (memcmp(host_buffer, expected_buffer, size) == 0);
 }
 
 // Helper function to format duration
@@ -639,31 +622,47 @@ main (int argc, char *argv[]) {
         std::cout << "\n============================================================" << std::endl;
         std::cout << "PHASE 5: Validating read data" << std::endl;
         std::cout << "============================================================" << std::endl;
+
+        // Pre-allocate validation buffers once for all transfers
+        char *host_buffer = use_vram ? (char *)malloc(transfer_size) : NULL;
+        char *expected_buffer = (char *)malloc(transfer_size);
+        if ((use_vram && !host_buffer) || !expected_buffer) {
+            std::cerr << "Failed to allocate validation buffers\n";
+            free(host_buffer);
+            free(expected_buffer);
+            goto cleanup;
+        }
+
+        // Generate expected pattern once
+        fill_test_pattern(expected_buffer, transfer_size);
+
         for (i = 0; i < num_transfers; i++) {
             if (use_vram) {
                 int devId = i % num_gpus;
                 cudaSetDevice (devId);
-                if (!validate_gpu_buffer (vram_addr[i], transfer_size)) {
+                if (!validate_gpu_buffer(
+                        vram_addr[i], transfer_size, host_buffer, expected_buffer)) {
                     std::cerr << "VRAM buffer " << i << " validation failed\n";
+                    free(host_buffer);
+                    free(expected_buffer);
                     goto cleanup;
                 }
             }
             if (use_dram) {
-                char *expected_buffer = (char *)malloc (transfer_size);
-                if (!expected_buffer) {
-                    std::cerr << "Failed to allocate validation buffer\n";
-                    goto cleanup;
-                }
-                fill_test_pattern (expected_buffer, transfer_size);
                 if (memcmp (dram_addr[i], expected_buffer, transfer_size) != 0) {
                     std::cerr << "DRAM buffer " << i << " validation failed\n";
+                    free(host_buffer);
                     free (expected_buffer);
                     goto cleanup;
                 }
-                free (expected_buffer);
             }
             printProgress (float (i + 1) / num_transfers);
         }
+
+        // Free validation buffers
+        free(host_buffer);
+        free(expected_buffer);
+
         std::cout << "\nVerification completed successfully!" << std::endl;
     }
 


### PR DESCRIPTION
Having both skip_write and skip_read flags is a bit confusing since you would always have to perform a write before read to verify test data. This was also incorrect since with skip_write, the read operation would read garbage values from newly created but empty files.

Fix this by removing the flags and simplifying test to do write then reads. Keep the measurement part for each operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * All test phases now run by default — skip/read/write flags removed; selective disabling no longer supported.
  * Phase flow simplified and made unconditional; buffer-clearing, write, read and validation run with clearer progress reporting.
  * Validation now uses single-pass preallocation and reuses expected data for more efficient, consistent checks.

* **Chores**
  * Updated copyright year and messaging/formatting tweaks.
  * Added timestamped filename generation and streamlined validation buffer handling for efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/nixl/pull/1350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
