### PR TITLE
Handle all error message cases in metadata test

### DIFF
--- a/test/gtest/metadata_exchange.cpp
+++ b/test/gtest/metadata_exchange.cpp
@@ -395,13 +395,15 @@ TEST_F(MetadataExchangeTestFixture, SocketSendLocalAndInvalidateLocal) {
                                   " and port " + port_str);
         const LogIgnoreGuard lig3("getsockopt gave error for ip_addr: " + ip_str +
                                   " and port: " + port_str + ": No route to host");
+        const LogIgnoreGuard lig4("poll returned but socket not ready for write for ip_addr: " +
+                                  ip_str + " and port: " + port_str);
 
         ASSERT_EQ(src.agent->sendLocalMD(&send_args), NIXL_SUCCESS);
 
         std::this_thread::sleep_for(std::chrono::seconds(3)); // Must exceed timeout to catch logs.
 
-        const size_t ignored =
-            lig1.getIgnoredCount() + lig2.getIgnoredCount() + lig3.getIgnoredCount();
+        const size_t ignored = lig1.getIgnoredCount() + lig2.getIgnoredCount() +
+            lig3.getIgnoredCount() + lig4.getIgnoredCount();
         EXPECT_GE(ignored, 1);
     }
 


### PR DESCRIPTION
## What?
Fix flaky MetadataExchangeTestFixture.SocketSendLocalAndInvalidateLocal in CI

## Why?
One of the errors was not caught in the test. Sample log:

```
[2026-02-26T11:45:14.480Z] [0;33mNote: Google Test filter = MetadataExchangeTestFixture.SocketSendLocalAndInvalidateLocal
[2026-02-26T11:45:14.480Z] [m[0;32m[==========] [mRunning 1 test from 1 test suite.
[2026-02-26T11:45:14.480Z] [0;32m[----------] [mGlobal test environment set-up.
[2026-02-26T11:45:14.480Z] [0;32m[----------] [m1 test from MetadataExchangeTestFixture
[2026-02-26T11:45:14.480Z] [0;32m[ RUN      ] [mMetadataExchangeTestFixture.SocketSendLocalAndInvalidateLocal
[2026-02-26T11:45:14.480Z] E0226 13:45:10.474750 1535062 nixl_listener.cpp:81] poll returned but socket not ready for write for ip_addr: 10.10.10.10 and port: 1234
[2026-02-26T11:45:14.480Z] ATTENTION: Unexpected NIXL warning or error detected!
[2026-02-26T11:45:14.480Z] ATTENTION: Message is 'poll returned but socket not ready for write for ip_addr: 10.10.10.10 and port: 1234'
[2026-02-26T11:45:14.480Z] E0226 13:45:10.475235 1535062 nixl_listener.cpp:527] Listener thread could not connect to IP 10.10.10.10 and port 1234
[2026-02-26T11:45:14.480Z] [0;32m[       OK ] [mMetadataExchangeTestFixture.SocketSendLocalAndInvalidateLocal (6905 ms)
[2026-02-26T11:45:14.480Z] [0;32m[----------] [m1 test from MetadataExchangeTestFixture (6905 ms total)
[2026-02-26T11:45:14.480Z] 
[2026-02-26T11:45:14.480Z] [0;32m[----------] [mGlobal test environment tear-down
[2026-02-26T11:45:14.480Z] [0;32m[==========] [m1 test from 1 test suite ran. (6905 ms total)
[2026-02-26T11:45:14.480Z] [0;32m[  PASSED  ] [m1 test.
[2026-02-26T11:45:14.480Z] ATTENTION: Unexpected NIXL warning(s) and/or error(s) detected!
[2026-02-26T11:45:14.480Z] ATTENTION: Problem count is 1
[2026-02-26T11:45:14.480Z] [8/99] MetadataExchangeTestFixture.SocketSendLocalAndInvalidateLocal returned with exit code 42 (7042 ms)
```
