### PR TITLE
src/plugins/telemetry: add DTE exporter plug-in

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -334,6 +334,38 @@ if get_option('disable_gds_backend')
     add_project_arguments('-DDISABLE_GDS_BACKEND', language: 'cpp')
 endif
 
+
+enable_dte = get_option('enable_dte')
+if enable_dte
+    host_triplet = host_machine.cpu_family() + '-' + host_machine.system().to_lower() + '-gnu'
+
+    doca_path = get_option('doca_path')
+    doca_inc_path = doca_path + '/include'
+    doca_lib_path = [ doca_path + '/lib/' + host_triplet, doca_path + '/lib64']
+
+    doca_common_lib = cpp.find_library('doca_common', dirs: doca_lib_path)
+    doca_telemetry_exporter_lib = cpp.find_library('doca_telemetry_exporter', dirs: doca_lib_path)
+
+    dte_dep = declare_dependency(
+        link_args : ['-L' + doca_path + '/lib/' + host_triplet, '-L' + doca_path + '/lib64'],
+        include_directories : include_directories(doca_inc_path),
+        dependencies: [doca_common_lib, doca_telemetry_exporter_lib])
+
+    have_doca_telemetry_exporter_api = cpp.compiles('''
+        #include <doca_telemetry_exporter.h>
+        int main(void) {
+            return doca_telemetry_exporter_schema_init("test", NULL);
+        }
+        ''',
+        name: 'DOCA Telemetry Exporter API availability',
+        args : ['-DDOCA_ALLOW_EXPERIMENTAL_API'],
+        dependencies: [dte_dep])
+
+    if not have_doca_telemetry_exporter_api
+        error('DOCA Telemetry Exporter API not found, but -Denable_dte=true was requested')
+    endif
+endif
+
 # Configure NDEBUG for release builds
 if get_option('buildtype') == 'release'
     # Used by Abseil to strip DCHECK assertions and DVLOG at compile time

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,8 @@ option('disable_plugins', type: 'string', value: '', description: 'Comma-separat
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
+option('enable_dte', type: 'boolean', value: false, description: 'Enable DOCA Telemetry Exporter Plugin')
+option('doca_path', type: 'string', value: '/opt/mellanox/doca/', description: 'Path to DOCA install')
 
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')

--- a/src/plugins/telemetry/dte/README.md
+++ b/src/plugins/telemetry/dte/README.md
@@ -1,0 +1,130 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL DTE (DOCA Telemetry Exporter) Telemetry exporter plug-in
+
+This telemetry exporter plug-in exports NIXL telemetry events via the [DOCA Telemetry Exporter API](https://docs.nvidia.com/doca/sdk/doca-telemetry-exporter/index.html). Metrics can be sent to one or more destinations: a Prometheus scrape endpoint, OpenTelemetry (OTLP), IPC sockets, or file output.
+
+For more detailed information, see the [NIXL telemetry documentation](../../../../docs/telemetry.md).
+
+## Dependencies
+
+The DTE exporter requires the DOCA SDK with the Telemetry Exporter API. The plug-in is built only when explicitly enabled.
+
+Build with the DTE plug-in:
+
+```bash
+meson setup build -Denable_dte=true
+# Optionally specify DOCA install path (default: /opt/mellanox/doca/)
+meson setup build -Denable_dte=true -Ddoca_path=/path/to/doca
+```
+
+Required DOCA libraries: `doca_common`, `doca_telemetry_exporter`.
+
+## Configuration
+
+To enable the DTE plug-in, set the following environment variables:
+
+```bash
+export NIXL_TELEMETRY_ENABLE="y"   # Enable NIXL telemetry
+export NIXL_TELEMETRY_EXPORTER="dte"  # Select plug-in: libtelemetry_exporter_${NIXL_TELEMETRY_EXPORTER}.so
+```
+
+### Optional configuration
+
+#### Data root and workarounds
+
+```bash
+# Buffer data root for DOCA Telemetry Exporter
+export NIXL_TELEMETRY_DTE_DATA_ROOT="<path>"
+
+# Enable workaround for DOCA Telemetry Exporter gRPC bug (older DOCA versions).
+# Disables export manager; OTLP and Prometheus Remote Write are then unavailable.
+export NIXL_TELEMETRY_DTE_ENABLE_GRPC_BUG_WORKAROUND="y"  # or "yes", "1", "true"
+```
+
+#### Prometheus endpoint (scrape target)
+
+Expose metrics for Prometheus scraping:
+
+```bash
+export NIXL_TELEMETRY_DTE_PROMETHEUS_EP_ENABLED="y"
+
+# Optional: address (default 0.0.0.0) and port (default 9101)
+export NIXL_TELEMETRY_DTE_PROMETHEUS_EP_ADDRESS="<address>"
+export NIXL_TELEMETRY_DTE_PROMETHEUS_EP_PORT="<port_num>"
+```
+
+#### IPC destination
+
+```bash
+export NIXL_TELEMETRY_DTE_IPC_ENABLED="y"
+
+# Optional
+export NIXL_TELEMETRY_DTE_IPC_SOCKETS_DIR="<path>"
+export NIXL_TELEMETRY_DTE_IPC_RECONNECT_TIME="<ms>"
+export NIXL_TELEMETRY_DTE_IPC_RECONNECT_TRIES="<count>"
+export NIXL_TELEMETRY_DTE_IPC_SOCKET_TIMEOUT="<ms>"
+```
+
+#### File destination
+
+```bash
+export NIXL_TELEMETRY_DTE_FILE_ENABLED="y"
+
+# Optional
+export NIXL_TELEMETRY_DTE_FILE_MAX_SIZE="<bytes>"
+export NIXL_TELEMETRY_DTE_FILE_MAX_AGE="<time_in_usec>"
+```
+
+#### OpenTelemetry (OTLP) destination
+
+```bash
+export NIXL_TELEMETRY_DTE_OTLP_ENABLED="y"
+export NIXL_TELEMETRY_DTE_OTLP_ADDRESS="<host>"   # Required when OTLP is enabled
+
+# Optional: port (default 9502)
+export NIXL_TELEMETRY_DTE_OTLP_PORT="<port_num>"
+```
+
+#### Plug-in search path
+
+Same variable as for other telemetry plug-ins:
+
+```bash
+export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
+```
+
+### Metrics & Events
+
+| Event Name | Category | Counter | Gauge | Exported by DTE |
+|------------|----------|---------|-------|-----------------|
+| `agent_memory_registered` | `NIXL_TELEMETRY_MEMORY` | No | Yes | Yes |
+| `agent_memory_deregistered` | `NIXL_TELEMETRY_MEMORY` | No | Yes | Yes |
+| `agent_tx_bytes` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | Yes |
+| `agent_rx_bytes` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | Yes |
+| `agent_tx_requests_num` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | Yes |
+| `agent_rx_requests_num` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | Yes |
+| `agent_xfer_time` | `NIXL_TELEMETRY_PERFORMANCE` | No | Yes | Yes |
+| `agent_xfer_post_time` | `NIXL_TELEMETRY_PERFORMANCE` | No | Yes | Yes |
+| Backend-specific events | `NIXL_TELEMETRY_BACKEND` | Yes | - | Yes |
+| Connection / Error / System / Custom events | `NIXL_TELEMETRY_CONNECTION`, `_ERROR`, `_SYSTEM`, `_CUSTOM` | - | - | No (logged only) |
+
+- **Counter**: Instance lifetime count; increments summed from events (e.g. transfer bytes, request counts).
+- **Gauge**: Value from the last event (e.g. last memory registered, last transfer time); updated per event.
+
+Metrics are flushed automatically at a fixed interval (see plug-in implementation).

--- a/src/plugins/telemetry/dte/dte_exporter.cpp
+++ b/src/plugins/telemetry/dte/dte_exporter.cpp
@@ -1,0 +1,421 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dte_exporter.h"
+#include "common/nixl_log.h"
+#include "common/util.h"
+#include "common/configuration.h"
+#include <absl/strings/str_format.h>
+
+#include <limits.h>
+
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <string_view>
+
+// DOCA Telemetry Exporter API Documentation:
+// https://docs.nvidia.com/doca/sdk/doca-telemetry-exporter/index.html
+
+namespace {
+
+constexpr uint32_t dte_flush_interval_ms = 1000U;
+
+const char *dte_dynamic_labels[] = {"category"};
+
+constexpr const char *const dte_grpc_bug_workaround_var =
+    "NIXL_TELEMETRY_DTE_ENABLE_GRPC_BUG_WORKAROUND";
+constexpr const char *const dte_data_root_var = "NIXL_TELEMETRY_DTE_DATA_ROOT";
+constexpr const char *const dte_prometheus_ep_enabled_var =
+    "NIXL_TELEMETRY_DTE_PROMETHEUS_EP_ENABLED";
+constexpr const char *const dte_prometheus_ep_address_var =
+    "NIXL_TELEMETRY_DTE_PROMETHEUS_EP_ADDRESS";
+constexpr const char *const dte_prometheus_ep_port_var = "NIXL_TELEMETRY_DTE_PROMETHEUS_EP_PORT";
+constexpr const char *const dte_ipc_enabled_var = "NIXL_TELEMETRY_DTE_IPC_ENABLED";
+constexpr const char *const dte_ipc_sockets_dir_var = "NIXL_TELEMETRY_DTE_IPC_SOCKETS_DIR";
+constexpr const char *const dte_ipc_reconnect_time_var = "NIXL_TELEMETRY_DTE_IPC_RECONNECT_TIME";
+constexpr const char *const dte_ipc_reconnect_tries_var = "NIXL_TELEMETRY_DTE_IPC_RECONNECT_TRIES";
+constexpr const char *const dte_ipc_socket_timeout_var = "NIXL_TELEMETRY_DTE_IPC_SOCKET_TIMEOUT";
+constexpr const char *const dte_file_enabled_var = "NIXL_TELEMETRY_DTE_FILE_ENABLED";
+constexpr const char *const dte_file_max_size_var = "NIXL_TELEMETRY_DTE_FILE_MAX_SIZE";
+constexpr const char *const dte_file_max_age_var = "NIXL_TELEMETRY_DTE_FILE_MAX_AGE";
+constexpr const char *const dte_otlp_enabled_var = "NIXL_TELEMETRY_DTE_OTLP_ENABLED";
+constexpr const char *const dte_otlp_address_var = "NIXL_TELEMETRY_DTE_OTLP_ADDRESS";
+constexpr const char *const dte_otlp_port_var = "NIXL_TELEMETRY_DTE_OTLP_PORT";
+
+constexpr uint16_t dte_default_otlp_port = 9502;
+constexpr std::string_view dte_otlp_write_endpoint = "/v1/metrics";
+constexpr std::string_view dte_default_prometheus_ep_endpoint_address = "0.0.0.0";
+constexpr uint16_t dte_default_prometheus_ep_endpoint_port = 9101;
+
+// TODO: solve backward linkage issue with nixlEnumStrings::telemetryCategoryStr
+std::string
+telemetryCategoryStr(const nixl_telemetry_category_t &category) {
+    static std::array<std::string, 9> nixl_telemetry_category_str = {"NIXL_TELEMETRY_MEMORY",
+                                                                     "NIXL_TELEMETRY_TRANSFER",
+                                                                     "NIXL_TELEMETRY_CONNECTION",
+                                                                     "NIXL_TELEMETRY_BACKEND",
+                                                                     "NIXL_TELEMETRY_ERROR",
+                                                                     "NIXL_TELEMETRY_PERFORMANCE",
+                                                                     "NIXL_TELEMETRY_SYSTEM",
+                                                                     "NIXL_TELEMETRY_CUSTOM",
+                                                                     "NIXL_TELEMETRY_MAX"};
+    size_t category_int = static_cast<size_t>(category);
+    if (category_int >= nixl_telemetry_category_str.size()) return "BAD_CATEGORY";
+    return nixl_telemetry_category_str[category_int];
+}
+
+void
+getApplicationName(std::string &name) {
+    std::ifstream comm("/proc/self/comm");
+    getline(comm, name);
+}
+
+} // namespace
+
+nixlTelemetryDteExporter::nixlTelemetryDteExporter(
+    const nixlTelemetryExporterInitParams &init_params)
+    : nixlTelemetryExporter(init_params),
+      agent_name_(init_params.agentName),
+      label_set_id_(0) {
+
+    getApplicationName(application_name_);
+
+    nixl_status_t status = prepareDOCATelemetryExporter();
+    if (status != NIXL_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot prepare DOCA Telemetry Exporter: %d", status);
+        throw std::runtime_error(
+            absl::StrFormat("Cannot prepare DOCA Telemetry Exporter: %d", status));
+    }
+}
+
+nixl_status_t
+nixlTelemetryDteExporter::exportEvent(const nixlTelemetryEvent &event) {
+    const std::string event_name(event.eventName_);
+    doca_error_t res;
+    uint64_t timestamp;
+    const std::string category_name = telemetryCategoryStr(event.category_);
+    const char *dynamic_label_values[] = {category_name.c_str()};
+
+    static_assert(ARRAY_SIZE(dynamic_label_values) == ARRAY_SIZE(dte_dynamic_labels),
+                  "Dynamic label values array size mismatch");
+
+    doca_telemetry_exporter_get_timestamp(&timestamp);
+
+    switch (event.category_) {
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER: {
+        res = doca_telemetry_exporter_metrics_add_counter_increment(doca_source_.get(),
+                                                                    timestamp,
+                                                                    event_name.c_str(),
+                                                                    event.value_,
+                                                                    label_set_id_,
+                                                                    dynamic_label_values);
+        if (res != DOCA_SUCCESS) {
+            NIXL_ERROR << absl::StrFormat("Cannot add counter increment: %s",
+                                          doca_error_get_name(res));
+            return NIXL_ERR_BACKEND;
+        }
+        break;
+    }
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE:
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY: {
+        res = doca_telemetry_exporter_metrics_add_gauge_uint64(doca_source_.get(),
+                                                               timestamp,
+                                                               event_name.c_str(),
+                                                               event.value_,
+                                                               label_set_id_,
+                                                               dynamic_label_values);
+        if (res != DOCA_SUCCESS) {
+            NIXL_ERROR << absl::StrFormat("Cannot add gauge: %s", doca_error_get_name(res));
+            return NIXL_ERR_BACKEND;
+        }
+        break;
+    }
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND:
+        res = doca_telemetry_exporter_metrics_add_counter(doca_source_.get(),
+                                                          timestamp,
+                                                          event_name.c_str(),
+                                                          event.value_,
+                                                          label_set_id_,
+                                                          dynamic_label_values);
+        if (res != DOCA_SUCCESS) {
+            NIXL_ERROR << absl::StrFormat("Cannot add counter: %s", doca_error_get_name(res));
+            return NIXL_ERR_BACKEND;
+        }
+        break;
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_CONNECTION:
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR:
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_SYSTEM:
+    case nixl_telemetry_category_t::NIXL_TELEMETRY_CUSTOM:
+        NIXL_INFO << absl::StrFormat("Unsupported event category: %s", category_name.c_str());
+        break;
+    default:
+        NIXL_ERROR << absl::StrFormat("Unknown event category: %s", category_name.c_str());
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+void
+nixlTelemetryDteExporter::resetDOCAEnv() {
+    unsetenv("CLX_API_ENABLE_EXPORT_MANAGER");
+    unsetenv("CLX_OPEN_TELEMETRY_RECEIVER");
+    unsetenv("PROMETHEUS_ENDPOINT");
+}
+
+nixl_status_t
+nixlTelemetryDteExporter::setDOCAEnv(const std::string &application_name) {
+    resetDOCAEnv();
+
+    if (nixl::config::getValueDefaulted<bool>(dte_grpc_bug_workaround_var, false)) {
+        // Workaround for DOCA Telemetry Exporter API issue in older versions:
+        // The export manager (enabled by default) caused the exporter to crash.
+        // Disabling the export manager eliminates the crash but reduces DOCA Telemetry Exporter API
+        // functionality and effectively disables the OpenTelemetry (OTLP) and Prometheus Remote
+        // Write exporters.
+        setenv("CLX_API_ENABLE_EXPORT_MANAGER", "false", 1);
+    }
+
+    // Configure OTLP destination
+    if (nixl::config::getValueDefaulted<bool>(dte_otlp_enabled_var, false)) {
+        const auto otpl_address = nixl::config::getValueOptional<std::string>(dte_otlp_address_var);
+        if (!otpl_address.has_value()) {
+            NIXL_ERROR << absl::StrFormat("'%s' must be set to enable OTLP destination",
+                                          dte_otlp_address_var);
+            return NIXL_ERR_BACKEND;
+        }
+
+        const auto otpl_port =
+            nixl::config::getValueDefaulted<uint16_t>(dte_otlp_port_var, dte_default_otlp_port);
+
+        std::string receiver_url = absl::StrFormat("http://%s:%d%s",
+                                                   otpl_address.value().c_str(),
+                                                   otpl_port,
+                                                   dte_otlp_write_endpoint.data());
+
+        setenv("CLX_OPEN_TELEMETRY_RECEIVER", receiver_url.c_str(), 1);
+        setenv("CLX_OPEN_TELEMETRY_WITH_DATA_POINT_ATTRIBUTES", "true", 1);
+        setenv("CLX_OPEN_TELEMETRY_TYPE_AS_LABEL", "true", 1);
+        setenv("CLX_OPEN_TELEMETRY_SERVICE_NAME", application_name.c_str(), 1);
+        setenv("CLX_OPEN_TELEMETRY_TAG_AS_LABEL", "true", 1);
+    }
+
+    // Configure Prometheus endpoint
+    if (nixl::config::getValueDefaulted<bool>(dte_prometheus_ep_enabled_var, false)) {
+        const auto prometheus_ep_address = nixl::config::getValueDefaulted<std::string>(
+            dte_prometheus_ep_address_var, std::string(dte_default_prometheus_ep_endpoint_address));
+        const auto prometheus_ep_port = nixl::config::getValueDefaulted<uint16_t>(
+            dte_prometheus_ep_port_var, dte_default_prometheus_ep_endpoint_port);
+        std::string receiver_url =
+            absl::StrFormat("http://%s:%d", prometheus_ep_address, prometheus_ep_port);
+
+        setenv("PROMETHEUS_ENDPOINT", receiver_url.c_str(), 1);
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlTelemetryDteExporter::createDOCATelemetrySchema() {
+    doca_telemetry_exporter_schema *doca_schema_ptr;
+    doca_error_t res =
+        doca_telemetry_exporter_schema_init("nixl_telemetry_schema", &doca_schema_ptr);
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot init doca schema: %s", doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    doca_schema_.reset(doca_schema_ptr);
+
+    // Configure DOCA Telemetry Exporter buffer data root
+    const auto telemetry_data_root = nixl::config::getValueOptional<std::string>(dte_data_root_var);
+    if (telemetry_data_root.has_value()) {
+        doca_telemetry_exporter_schema_set_buf_data_root(doca_schema_.get(),
+                                                         telemetry_data_root.value().c_str());
+    }
+
+    // Configure IPC destination
+    if (nixl::config::getValueDefaulted<bool>(dte_ipc_enabled_var, false)) {
+        doca_telemetry_exporter_schema_set_ipc_enabled(doca_schema_.get());
+
+        const auto sockets_dir =
+            nixl::config::getValueOptional<std::string>(dte_ipc_sockets_dir_var);
+        if (sockets_dir.has_value()) {
+            doca_telemetry_exporter_schema_set_ipc_sockets_dir(doca_schema_.get(),
+                                                               sockets_dir.value().c_str());
+        }
+
+        const auto reconnect_time =
+            nixl::config::getValueDefaulted<uint32_t>(dte_ipc_reconnect_time_var, 0);
+        if (reconnect_time > 0) {
+            doca_telemetry_exporter_schema_set_ipc_reconnect_time(doca_schema_.get(),
+                                                                  reconnect_time);
+        }
+
+        const auto reconnect_tries =
+            nixl::config::getValueDefaulted<uint8_t>(dte_ipc_reconnect_tries_var, 0);
+        if (reconnect_tries) {
+            doca_telemetry_exporter_schema_set_ipc_reconnect_tries(doca_schema_.get(),
+                                                                   reconnect_tries);
+        }
+
+        const auto socket_timeout =
+            nixl::config::getValueDefaulted<uint32_t>(dte_ipc_socket_timeout_var, 0);
+        if (socket_timeout > 0) {
+            doca_telemetry_exporter_schema_set_ipc_socket_timeout(doca_schema_.get(),
+                                                                  socket_timeout);
+        }
+    }
+
+    // Configure file destination
+    if (nixl::config::getValueDefaulted<bool>(dte_file_enabled_var, false)) {
+        doca_telemetry_exporter_schema_set_file_write_enabled(doca_schema_.get());
+
+        const auto max_size = nixl::config::getValueDefaulted<size_t>(dte_file_max_size_var, 0);
+        if (max_size > 0) {
+            doca_telemetry_exporter_schema_set_file_write_max_size(doca_schema_.get(), max_size);
+        }
+
+        const auto max_age = nixl::config::getValueDefaulted<doca_telemetry_exporter_timestamp_t>(
+            dte_file_max_age_var, 0);
+        if (max_age > 0) {
+            doca_telemetry_exporter_schema_set_file_write_max_age(doca_schema_.get(), max_age);
+        }
+    }
+
+    res = doca_telemetry_exporter_schema_start(doca_schema_.get());
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot start doca schema: %s", doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlTelemetryDteExporter::createDOCATelemetrySource() {
+    char hostname[HOST_NAME_MAX + 1];
+    if (gethostname(hostname, sizeof(hostname)) < 0) {
+        NIXL_ERROR << absl::StrFormat("Cannot get hostname: %s", strerror(errno));
+        return NIXL_ERR_BACKEND;
+    }
+
+    doca_telemetry_exporter_source *doca_source_ptr;
+    doca_error_t res = doca_telemetry_exporter_source_create(doca_schema_.get(), &doca_source_ptr);
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot create doca source: %s", doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    doca_source_.reset(doca_source_ptr);
+
+    doca_telemetry_exporter_source_set_id(doca_source_.get(), hostname);
+    doca_telemetry_exporter_source_set_tag(doca_source_.get(), application_name_.c_str());
+
+    // Start DOCA Telemetry source
+    res = doca_telemetry_exporter_source_start(doca_source_.get());
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot start doca source: %s", doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Create metrics context - must be done AFTER starting the source
+    res = doca_telemetry_exporter_metrics_create_context(doca_source_.get());
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot create metrics context: %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    NIXL_INFO << "Metrics context created successfully";
+
+    // Set automatic flush interval - metrics will be flushed automatically every N milliseconds
+    res = doca_telemetry_exporter_metrics_set_flush_interval_ms(doca_source_.get(),
+                                                                dte_flush_interval_ms);
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Failed to set metrics flush interval: %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+    NIXL_INFO << absl::StrFormat("Automatic flush interval set to %d ms", dte_flush_interval_ms);
+
+    // Add constant labels
+    res = doca_telemetry_exporter_metrics_add_constant_label(
+        doca_source_.get(), "app_name", application_name_.c_str());
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot add constant label 'app_name': %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    res = doca_telemetry_exporter_metrics_add_constant_label(
+        doca_source_.get(), "hostname", hostname);
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot add constant label 'hostname': %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    res = doca_telemetry_exporter_metrics_add_constant_label(
+        doca_source_.get(), "agent_name", agent_name_.c_str());
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot add constant label 'agent_name': %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    // Register dynamic labels
+    res = doca_telemetry_exporter_metrics_add_label_names(
+        doca_source_.get(), dte_dynamic_labels, ARRAY_SIZE(dte_dynamic_labels), &label_set_id_);
+    if (res != DOCA_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot add dynamic label names: %s",
+                                      doca_error_get_name(res));
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlTelemetryDteExporter::prepareDOCATelemetryExporter() {
+    nixl_status_t status = setDOCAEnv(application_name_);
+    if (status != NIXL_SUCCESS) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    status = createDOCATelemetrySchema();
+    if (status != NIXL_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot create doca schema: %d", status);
+        doca_schema_.reset();
+        resetDOCAEnv();
+        return NIXL_ERR_BACKEND;
+    }
+
+    status = createDOCATelemetrySource();
+    if (status != NIXL_SUCCESS) {
+        NIXL_ERROR << absl::StrFormat("Cannot create doca source: %d", status);
+        doca_source_.reset();
+        doca_schema_.reset();
+        resetDOCAEnv();
+        return NIXL_ERR_BACKEND;
+    }
+
+    NIXL_INFO << "DOCA Telemetry Exporter prepared successfully";
+
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/telemetry/dte/dte_exporter.h
+++ b/src/plugins/telemetry/dte/dte_exporter.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TELEMETRY_DTE_DTE_EXPORTER_H
+#define NIXL_SRC_PLUGINS_TELEMETRY_DTE_DTE_EXPORTER_H
+
+#include "telemetry/telemetry_exporter.h"
+#include "telemetry_event.h"
+#include "nixl_types.h"
+#include <memory>
+
+#include <doca_telemetry_exporter.h>
+
+struct docaTelemetryExporterSourceDeleter {
+    void
+    operator()(doca_telemetry_exporter_source *p) const {
+        doca_telemetry_exporter_source_destroy(p);
+    }
+};
+
+struct docaTelemetryExporterSchemaDeleter {
+    void
+    operator()(doca_telemetry_exporter_schema *p) const {
+        doca_telemetry_exporter_schema_destroy(p);
+    }
+};
+
+using docaTelemetryExporterSource =
+    std::unique_ptr<doca_telemetry_exporter_source, docaTelemetryExporterSourceDeleter>;
+using docaTelemetryExporterSchema =
+    std::unique_ptr<doca_telemetry_exporter_schema, docaTelemetryExporterSchemaDeleter>;
+
+class nixlTelemetryDteExporter : public nixlTelemetryExporter {
+public:
+    explicit nixlTelemetryDteExporter(const nixlTelemetryExporterInitParams &init_params);
+    nixl_status_t
+    exportEvent(const nixlTelemetryEvent &event) override;
+
+protected:
+    [[nodiscard]] static nixl_status_t
+    setDOCAEnv(const std::string &application_name);
+    static void
+    resetDOCAEnv();
+    [[nodiscard]] nixl_status_t
+    createDOCATelemetrySchema();
+    [[nodiscard]] nixl_status_t
+    createDOCATelemetrySource();
+    [[nodiscard]] nixl_status_t
+    prepareDOCATelemetryExporter();
+
+private:
+    std::string application_name_;
+    const std::string agent_name_;
+    docaTelemetryExporterSchema doca_schema_;
+    docaTelemetryExporterSource doca_source_;
+    uint64_t label_set_id_;
+};
+
+#endif // NIXL_SRC_PLUGINS_TELEMETRY_DTE_DTE_EXPORTER_H

--- a/src/plugins/telemetry/dte/dte_plugin.cpp
+++ b/src/plugins/telemetry/dte/dte_plugin.cpp
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dte_exporter.h"
+#include "telemetry/telemetry_plugin.h"
+
+// Plugin type alias for convenience
+using dte_exporter_plugin_t = nixlTelemetryPluginCreator<nixlTelemetryDteExporter>;
+
+// Plugin initialization function - must be extern "C" for dynamic loading
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT nixlTelemetryPlugin *
+nixl_telemetry_plugin_init() {
+    return dte_exporter_plugin_t::create(nixlTelemetryPluginApiVersionV1, "dte", "1.0.0");
+}
+
+// Plugin cleanup function
+extern "C" NIXL_TELEMETRY_PLUGIN_EXPORT void
+nixl_telemetry_plugin_fini() {
+    // Nothing to clean up for DTE exporter
+}

--- a/src/plugins/telemetry/dte/meson.build
+++ b/src/plugins/telemetry/dte/meson.build
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if not enable_dte
+    error('DOCA Telemetry Exporter plugin requested but is disabled')
+endif
+
+# DOCA Telemetry Exporter Plugin
+dte_exporter_plugin = shared_library(
+    'libtelemetry_exporter_dte',
+    'dte_plugin.cpp',
+    'dte_exporter.cpp',
+    cpp_args: compile_defs + ['-DDOCA_ALLOW_EXPERIMENTAL_API'],
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    dependencies: [nixl_infra, absl_log_dep, dte_dep],
+    install: true,
+    install_dir: plugin_install_dir,
+    name_prefix: '',
+)

--- a/src/plugins/telemetry/meson.build
+++ b/src/plugins/telemetry/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,3 +14,6 @@
 # limitations under the License.
 
 subdir('prometheus')
+if enable_dte
+    subdir('dte')
+endif

--- a/src/utils/common/util.h
+++ b/src/utils/common/util.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,5 +20,6 @@
 #define CONCAT(a, b) CONCAT_0(a, b)
 #define CONCAT_0(a, b) a ## b
 #define UNIQUE_NAME(name) CONCAT(name, __COUNTER__)
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
 #endif /* UTIL_H */


### PR DESCRIPTION
## What?
The PR adds a telemetry exporter plug-in that sends NIXL metrics via the [DOCA Telemetry Exporter API](https://docs.nvidia.com/doca/sdk/doca-telemetry-exporter/index.html). Supports Prometheus scrape endpoint, OTLP, IPC, and file destinations. Build is optional (`-Denable_dte=true`) and depends on DOCA SDK (`doca_common`, `doca_telemetry_exporter` libs).

## Why?
The DTE (DOCA Telemetry Exporter) plug-in helps NIXL debugging, substantially increases telemetry use, and improves flexibility by supporting several export options at once (Prometheus endpoint, OTLP, IPC, file and potentially much more), so users can choose or combine backends without code changes.

## How?
The PR:
- Adds `dte_exporter` with schema/source init, event export (counters/	  gauges per category), and env-based config for data root, Prometheus EP, IPC, file, and OTLP
- Adds `dte_plugin` for dynamic loading as `libtelemetry_exporter_dte.so`
- Adds meson option `enable_dte` and `doca_path`; wire DTE into telemetry plug-in build
- Adds README with dependencies, configuration, and metrics/labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DOCA Telemetry Exporter (DTE) plugin selectable at runtime; exports counters and gauges and supports Prometheus, OTLP, IPC and file destinations.

* **Documentation**
  * Added a comprehensive DTE guide covering build enablement, runtime activation, environment variables, destination settings, and metric mappings.

* **Chores**
  * Added build options to enable DTE and specify DOCA installation path.

* **Style**
  * Added a utility macro to compute fixed-array sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->