### PR TITLE
Warn zero length buf and replace resize() by reserve()

### DIFF
--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -192,8 +192,8 @@ template <class T>
 void nixlDescList<T>::addDesc (const T &desc) {
     if (desc.len == 0) {
         NIXL_WARN << "addDesc: zero-length descriptor detected"
-                  << " (addr=0x" << std::hex << desc.addr << std::dec
-                  << ", devId=" << desc.devId << ")";
+                  << " (addr=0x" << std::hex << desc.addr << std::dec << ", devId=" << desc.devId
+                  << ")";
     }
     descs.push_back(desc);
 }

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -134,7 +134,7 @@ void nixlBlobDesc::print(const std::string &suffix) const {
 template<class T> nixlDescList<T>::nixlDescList(const nixl_mem_t &type, const int &init_size) {
     static_assert (std::is_base_of<nixlBasicDesc, T>::value);
     this->type = type;
-    this->descs.resize(init_size);
+    this->descs.reserve(init_size);
 }
 
 template <class T>
@@ -190,6 +190,11 @@ nixlDescList<T>::nixlDescList(nixlSerDes* deserializer) {
 
 template <class T>
 void nixlDescList<T>::addDesc (const T &desc) {
+    if (desc.len == 0) {
+        NIXL_WARN << "addDesc: zero-length descriptor detected"
+                  << " (addr=0x" << std::hex << desc.addr << std::dec
+                  << ", devId=" << desc.devId << ")";
+    }
     descs.push_back(desc);
 }
 

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -134,7 +134,7 @@ void nixlBlobDesc::print(const std::string &suffix) const {
 template<class T> nixlDescList<T>::nixlDescList(const nixl_mem_t &type, const int &init_size) {
     static_assert (std::is_base_of<nixlBasicDesc, T>::value);
     this->type = type;
-    this->descs.reserve(init_size);
+    this->descs.resize(init_size);
 }
 
 template <class T>


### PR DESCRIPTION
### Summary
This PR proposes two changes:
[1] Add a warning on zero-length descriptors
[2] Suggest to replace `resize` with `reserve` in `nixlDescList` constructor

### [1] Add a warning on zero-length descriptors in addDesc
Currently, `addDesc` silently accepts descriptors of zero-length tensors, which can mask bugs in the subsequent calls to `prepXferDlist`. 
This change adds a NIXL_WARN log to help debugging.

### [2] Replace resize with reserve in nixlDescList constructor
This is a suggestion, not a strict bug fix on NIXL's side -- I've run into the first issue because I was misusing the `init_size` parameter, however, I think the current behavior may be a trap that's easy to fall into.

The `nixlDescList` constructor receives `init_size` as a parameter, and calls `descs.resize(init_size)`, which creates `init_size` default-constructed descriptors with uninitialized/zeroed fields. In other words, this code:
```C++
nixl_reg_dlist_t dlist(VRAM_SEG, n);  
for (...) {
  dlist.addDesc({addr, len, dev});   
}
```
will create a list with N*2 descriptors, and not N, because the constructor will initialize N empty descriptors. 
For me the natural expectation when passing a size hint alongside an append-style API is that it works like std::vector::reserve, i.e pre-allocating capacity without creating elements.

Replacing `resize` with `reserve` aligns the behavior with this expectation. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect zero-length descriptors and emit a warning when encountered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->