### PR TITLE
Build container retention

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -16,7 +16,7 @@ kubernetes:
   requests: "{memory: 8Gi, cpu: 4000m}"
 
 runs_on_dockers:
-  - { name: "podman-v5.7.1", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+  - { name: "podman", url: "quay.io/podman/stable:v5.7.1", privileged: true }
 
 # Build matrix
 matrix:
@@ -27,12 +27,15 @@ matrix:
 
 # Configuration
 env:
-  REGISTRY_HOSTESS: "artifactory.nvidia.com"
-  REGISTRY_REPO: "sw-nbu-swx-nixl-docker-local/verification"
+  REGISTRY_HOST_NAME: "artifactory.nvidia.com"
+  REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
+  REGISTRY_REPO_PATH: "verification"
+  ARTIFACTORY_REGISTRY_URL: "${REGISTRY_HOST_NAME}/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}"
+  ARTIFACTORY_CLEANUP_AGE: "3m" # 3 months
   LOCAL_TAG_BASE: "nixl-ci:build-"
   MAIL_FROM: "jenkins@nvidia.com"
 
-taskName: "${BUILD_TARGET}/${arch}/${axis_index}"
+taskName: "${BUILD_TARGET}/${arch}"
 
 credentials:
   - credentialsId: 'svc-nixl-new-artifactory-token'
@@ -56,6 +59,7 @@ pipeline_start:
 # Build pipeline
 steps:
   - name: Prepare
+    containerSelector: "{name: 'podman'}"
     run: |
       # Setup podman and dependencies
       set -x
@@ -67,6 +71,7 @@ steps:
 
   - name: Build NIXLBench
     enable: ${ENABLE_NIXLBENCH_BUILD}
+    containerSelector: "{name: 'podman'}"
     run: |
       # Clone UCX source for nixlbench
       git clone https://github.com/openucx/ucx.git ucx-src
@@ -83,6 +88,7 @@ steps:
 
   - name: Build NIXL
     enable: ${ENABLE_NIXL_BUILD}
+    containerSelector: "{name: 'podman'}"
     run: |
       export UCX_REF="${UCX_VERSION}"
 
@@ -101,6 +107,7 @@ steps:
         ${NIXL_EP_FLAG}
 
   - name: Add Version Info
+    containerSelector: "{name: 'podman'}"
     run: |
       git config --global --add safe.directory '*'
       # Extract standardized 8-char commit hash for UCX version info:
@@ -138,11 +145,12 @@ steps:
       docker rm -f tempcontainer || true
 
   - name: Push
+    containerSelector: "{name: 'podman'}"
     credentialsId: 'svc-nixl-new-artifactory-token'
     run: |
       source version-info
-      ARTIFACTORY_REGISTRY="${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}"
-      ARTIFACTORY_API="https://${REGISTRY_HOSTESS}/artifactory/api/storage/${REGISTRY_REPO}/${BUILD_TARGET}"
+      ARTIFACTORY_REGISTRY="${ARTIFACTORY_REGISTRY_URL}/${BUILD_TARGET}"
+      ARTIFACTORY_API="https://${REGISTRY_HOST_NAME}/artifactory/api/storage/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}/${BUILD_TARGET}"
 
       # Prepare image properties
       IMAGE_PROPERTIES="BUILD_TARGET=${BUILD_TARGET};NIXL_VERSION=${NIXL_VERSION};UCX_VERSION=${UCX_VERSION};arch=${arch};"
@@ -150,7 +158,7 @@ steps:
       IMAGE_PROPERTIES+="BASE_IMAGE=${BASE_IMAGE};BASE_IMAGE_TAG=${BASE_IMAGE_TAG}"
 
       # Login to Artifactory
-      echo "$ARTIFACTORY_PASSWORD" | docker login "${REGISTRY_HOSTESS}" -u "$ARTIFACTORY_USERNAME" --password-stdin
+      echo "$ARTIFACTORY_PASSWORD" | docker login "${REGISTRY_HOST_NAME}" -u "$ARTIFACTORY_USERNAME" --password-stdin
 
       # Function to tag, push, and set properties
       tag_push_set_properties() {
@@ -174,9 +182,9 @@ steps:
     run: |
       source version-info
       echo "Image type built: ${BUILD_TARGET} (${arch})"
-      echo "Image pushed to: ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${TAG_NAME}"
+      echo "Image pushed to: ${ARTIFACTORY_REGISTRY_URL}/${BUILD_TARGET}:${TAG_NAME}"
       if [[ "${UPDATE_LATEST}" == "true" ]]; then
-        echo "Latest tag updated: ${REGISTRY_HOSTESS}/${REGISTRY_REPO}/${BUILD_TARGET}:${BASE_IMAGE_TAG}-${arch}-latest"
+        echo "Latest tag updated: ${ARTIFACTORY_REGISTRY_URL}/${BUILD_TARGET}:${BASE_IMAGE_TAG}-${arch}-latest"
       fi
 
       echo -e "\nBuild config for manual repro:"
@@ -195,6 +203,7 @@ steps:
 pipeline_stop:
   shell: action
   module: groovy
+  containerSelector: "{name: 'podman'}"
   run: |
     if (params.MAIL_TO) {
         def jobStatus = currentBuild.result ?: 'SUCCESS'
@@ -222,4 +231,7 @@ pipeline_stop:
                 ${params.BUILD_NIXL_EP ? "<p>Build NIXL EP: <b>Yes</b></p>" : ''}
             """
         )
+    }
+    withCredentials([usernamePassword(credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+      sh "yum install -y jq > /dev/null && .ci/scripts/artifactory-cleanup-by-time.sh --path ${REGISTRY_REPO_PATH}/${BUILD_TARGET} ${REGISTRY_REPO_NAME} ${ARTIFACTORY_CLEANUP_AGE}"
     }

--- a/.ci/scripts/artifactory-cleanup-by-time.sh
+++ b/.ci/scripts/artifactory-cleanup-by-time.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Artifactory cleanup by time (Docker images)
+# Deletes Docker images in a JFrog Artifactory repository that are older than a given age.
+# Only manifest.json (and list.manifest.json) are queried; image age is based on the
+# manifest's last modified date. The entire image folder is then deleted.
+#
+# Usage:
+#   export ARTIFACTORY_URL="https://your-instance.jfrog.io/artifactory"
+#   export ARTIFACTORY_USER="user"
+#   export ARTIFACTORY_TOKEN="password-or-api-key"
+#   ./artifactory-cleanup-by-time.sh [OPTIONS] REPO_KEY [AGE]
+#
+# Arguments:
+#   REPO_KEY   Repository key (e.g. sw-nbu-swx-nixl-docker-local)
+#   AGE        Age threshold: delete images whose manifest was last modified before this (default: 4w)
+#              Examples: 4w (weeks), 30d (days), 2m (months)
+#
+# Options:
+#   --dry-run       Only list images that would be deleted, do not delete
+#   --path PATH     Only consider images under this path (AQL path match)
+#
+# Environment:
+#   ARTIFACTORY_URL       Base Artifactory URL (required)
+#   ARTIFACTORY_USER      Username for API auth (required unless using token only)
+#   ARTIFACTORY_TOKEN     Password or API key (required)
+#   ARTIFACTORY_API_KEY   Alternative to ARTIFACTORY_TOKEN
+#
+# Example:
+#   ./artifactory-cleanup-by-time.sh --dry-run sw-nbu-swx-nixl-docker-local 4w
+#   ./artifactory-cleanup-by-time.sh --path "verification/nixl/" sw-nbu-swx-nixl-docker-local 4w
+
+set -e
+
+DRY_RUN=false
+PATH_FILTER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --path)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --path" >&2
+                exit 1
+            fi
+            PATH_FILTER="$2"
+            shift 2
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 [--dry-run] [--path PATH] REPO_KEY [AGE]" >&2
+    echo "  AGE default: 4w (4 weeks)" >&2
+    exit 1
+fi
+
+REPO_KEY="$1"
+AGE="${2:-4w}"
+
+# Parse age (e.g. 4w, 30d, 2m) and compute cutoff via epoch (portable)
+if [[ "$AGE" =~ ^([0-9]+)([wdm])$ ]]; then
+    NUM="${BASH_REMATCH[1]}"
+    UNIT="${BASH_REMATCH[2]}"
+else
+    echo "Invalid AGE format: $AGE (e.g. 4w, 30d, 2m)" >&2
+    exit 1
+fi
+
+NOW_EPOCH=$(date +%s)
+case "$UNIT" in
+    w) SECS_AGO=$((NUM * 7 * 24 * 3600)) ;;
+    d) SECS_AGO=$((NUM * 24 * 3600)) ;;
+    m) SECS_AGO=$((NUM * 30 * 24 * 3600)) ;;
+    *) echo "Invalid age unit: $UNIT (use w, d, or m)" >&2; exit 1 ;;
+esac
+CUTOFF_EPOCH=$((NOW_EPOCH - SECS_AGO))
+
+if date -u -d "@${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z" &>/dev/null; then
+    CUTOFF=$(date -u -d "@${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z")
+elif date -u -r "${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z" &>/dev/null; then
+    CUTOFF=$(date -u -r "${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z")
+else
+    echo "Cannot convert epoch to ISO date" >&2
+    exit 1
+fi
+
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://artifactory.nvidia.com/artifactory}"
+TOKEN="${ARTIFACTORY_TOKEN:-${ARTIFACTORY_API_KEY:?Set ARTIFACTORY_TOKEN or ARTIFACTORY_API_KEY}}"
+USER="${ARTIFACTORY_USER:-}"
+
+if [[ -n "$USER" ]]; then
+    CURL_AUTH=(-u "$USER:$TOKEN")
+else
+    CURL_AUTH=(-H "X-JFrog-Art-Api: $TOKEN")
+fi
+
+# Build AQL: only manifest files; filter by last modified date. Use $and so $or is valid.
+if [[ -n "$PATH_FILTER" ]]; then
+    PATH_MATCH="${PATH_FILTER%/}"
+    AQL='items.find({"$and":[{"repo":"'"$REPO_KEY"'"},{"path":{"$match":"'"$PATH_MATCH"'/*"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]},{"modified":{"$lt":"'"$CUTOFF"'"}}]}).include("repo","path","name")'
+else
+    AQL='items.find({"$and":[{"repo":"'"$REPO_KEY"'"},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]},{"modified":{"$lt":"'"$CUTOFF"'"}}]}).include("repo","path","name")'
+fi
+
+echo "Current time (UTC): $(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+echo "Cutoff: images with manifest last modified before $CUTOFF will be deleted (repo: $REPO_KEY)"
+if [[ -n "$PATH_FILTER" ]]; then
+    echo "Path filter: $PATH_FILTER"
+fi
+if [[ "$DRY_RUN" = true ]]; then echo "DRY RUN: no artifacts will be deleted"; fi
+
+RESPONSE=$(curl -s -w "\n%{http_code}" "${CURL_AUTH[@]}" -X POST \
+    "${ARTIFACTORY_URL}/api/search/aql" \
+    -H "Content-Type: text/plain" \
+    -d "$AQL") || { echo "AQL request failed"; exit 1; }
+
+# Split body and HTTP code (last line)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+
+if ! echo "$RESPONSE_BODY" | jq -e . >/dev/null 2>&1; then
+    echo "Artifactory response is not valid JSON (HTTP $HTTP_CODE). First 500 chars:"
+    echo "$RESPONSE_BODY" | head -c 500
+    echo ""
+    exit 1
+fi
+
+# Check for AQL errors in JSON body
+if echo "$RESPONSE_BODY" | jq -e '.errors' >/dev/null 2>&1; then
+    echo "AQL error:"
+    echo "$RESPONSE_BODY" | jq -r '.errors[]? // .'
+    exit 1
+fi
+
+RESULTS_COUNT=$(echo "$RESPONSE_BODY" | jq -r '(.results // []) | length')
+echo "AQL returned ${RESULTS_COUNT} manifest(s) matching criteria."
+
+# Each result is a manifest file; the image folder is repo/path (parent of manifest). Dedupe by folder.
+COUNT=0
+FAILED=0
+while IFS= read -r image_path; do
+    [[ -z "$image_path" ]] && continue
+    if [[ "$DRY_RUN" = true ]]; then
+        echo "  [dry-run] would delete image: $image_path"
+        COUNT=$((COUNT + 1))
+    else
+        echo "  Deleting image: $image_path"
+        if curl -sSf "${CURL_AUTH[@]}" -X DELETE "${ARTIFACTORY_URL}/${image_path}"; then
+            COUNT=$((COUNT + 1))
+        else
+            echo "  ERROR: delete failed for $image_path" >&2
+            FAILED=$((FAILED + 1))
+        fi
+    fi
+done < <(echo "$RESPONSE_BODY" | jq -r '(.results // [])[] | "\(.repo)/\(.path)"' | sort -u)
+
+if [[ "$DRY_RUN" = true ]]; then
+    echo "Done. $COUNT image(s) would be deleted."
+else
+    if [[ "$FAILED" -gt 0 ]]; then
+        echo "Done. $COUNT image(s) deleted, $FAILED failed." >&2
+        exit 1
+    fi
+    echo "Done. $COUNT image(s) deleted."
+fi


### PR DESCRIPTION
## What?
Add Artifactory cleanup script to pipeline_stop (dry-run)

## Why?
we need to make sure registry is cleaned up all the time

## How?
Running script to clean at end of build with 3M retention


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified CI container selection and registry handling, renamed registry configuration keys, and adjusted public task naming to reduce axis-specific noise.
  * Updated image push/login behavior and user-facing push/update messages to use the new registry URL format.
* **New Features**
  * Added an automated Artifactory cleanup tool to list or delete outdated image folders by age, with dry-run and path-filtering and a summary report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->