### PR TITLE
Raise error if ucx detects VRAM mem as host mem

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -589,8 +589,11 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         }
 
         if (attr.mem_type == UCS_MEMORY_TYPE_HOST) {
-            NIXL_WARN << "memory is detected as host, check that UCX is configured"
-                         " with CUDA support";
+            NIXL_ERROR << "VRAM memory is detected as host by UCX. "
+                          "UCX is likely not configured with CUDA support. "
+                          "VRAM registration cannot proceed.";
+            ucp_mem_unmap(ctx, mem.memh);
+            return -1;
         }
     }
 


### PR DESCRIPTION
### Summary
In the case where UCX is built without CUDA, `ucp_mem_map` silently succeeds on GPU pointers but misclassify them as host memory. 
Previously, `nixlUcxContext::memReg` only logged a warning in this case and returned success. 
This caused agent's `registerMem`, making the UCX backend appear fully functional for VRAM — but actual transfers would fail much later in `prepXferDlist`, `makeXferReq`, or during the transfer itself, producing confusing errors far from the root cause.

This change promotes the warning to an error and makes `memReg` fail immediately when VRAM is detected as host memory by UCX. The memory mapping is properly cleaned up (`ucp_mem_unmap`) before returning.

**Without this fix**, users with a UCX installation lacking CUDA support see the following behavior:
`registerMem(VRAM_SEG, ...)` succeeds (with only a log warning).
The backend appears available for GPU transfers.
Transfer preparation or execution fails with an unrelated error, making the root cause (missing UCX CUDA support) very hard to diagnose.

**With this fix**, `registerMem` fails immediately with a clear error message pointing to the missing UCX CUDA support, allowing callers to gracefully fall back or report the issue at the right time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced error detection and resource cleanup for GPU memory registration. The system now validates configurations more strictly and immediately terminates registration with proper resource cleanup when issues are detected, preventing continuation with problematic setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->