### PR TITLE
libfabric: Fixing unit test regression and documentation for PR 1302

### DIFF
--- a/src/plugins/libfabric/README.md
+++ b/src/plugins/libfabric/README.md
@@ -52,34 +52,59 @@ $ ninja && ninja install
 
 ## Runtime Configuration
 
-The following configuration controls the runtime behavior of the plugin:
+Following are the environment variables that control the runtime behavior of the plugin.
 
-### max_bw_per_dram_seg
+### NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG
 
-- Used to configure NUMA-aware rail selection policy for DRAM_SEG memory type registraion
-- Controls the bandwidth limit on DRAM_SEG memory type buffers
-- Specified as integer multiple of 1000^3 as common in NIC specification (e.g. 100, 200, 400, etc.)
-- If not specified then computed as the maximum possible bandwidth that would not saturate the topmost
-  PCIe brdige/switch devices of the NUMA node of the origin buffer
-- User can override during plugin creation (in code), by specifying a value (string that can be parsed as integer) for "max_bw_per_dram_seg" in the custom parameter map of the plugin.
-- User can also override with environment variable NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG
+Normally, DRAM_SEG memory type buffers should not use more bandwidth than the PCIe switches can
+sustain, as buffers travel from host (main memory) to EFA device via PCIe topology.
+
+For this reason, the plugin computes the maximum bandwidth limit that would cause the PCIe switches
+on each NUMA node **not** to be saturated. This way when DRAM_SEG memory type is used, only a
+limited number of rails is selected, such that PCIe congestion is avoided. The rail selection is
+made only from the NUMA node of the origin memory buffer. This is because NUMA nodes interconnect
+bandwidth is much smaller than the PCIe link, and it is counterproductive to stress the interconnect
+for only reduced additional network bandwidth.
+
+In case it is desired though to set a different bandwidth limit (e.g. when computed bandwidth limit
+is not suitable on some PCIe topology), the user can override this computed value through the
+environment variable NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG.
+
+To summarize:
+
+- NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG is used to configure NUMA-aware rail selection policy for
+DRAM_SEG memory type registration
+- It controls the bandwidth limit on DRAM_SEG memory type buffers
+- It should be specified as decimal Gbps (Gigabits per second), e.g. 100, 200, 400, etc.
+- If not specified, then it is computed as the maximum possible bandwidth that would not saturate
+the topmost PCIe bridge/switch devices of the NUMA node of the origin buffer
+- It can also be passed as a custom parameter during plugin/backend creation (see
+nixlAgent::createBackend()), with key "max_bw_per_dram_seg"
 - Environment variable override takes precedence over custom parameter configuration
 
 Notes:
 
-- The bandwidth limit is converted to a rail count limit. During memory registration phase of DRAM_SEG memory type, a subset of rails is selected, such that the bandwidth limit is enforced, and limited to the relevant NUMA node.
+- The bandwidth limit is converted to a rail count limit. During memory registration phase of
+DRAM_SEG memory type, a subset of rails is selected, such that the bandwidth limit is enforced
 - The subset of rails being selected is made sure not to saturate any topmost PCIe switch of the NUMA node
+- The subset of rails being selected is limited to the NUMA node of the origin buffer
 - The subset of rails being selected each time uses different rails to ensure optimal resource utilization
 - Rail selection is thread-safe
-- If user override exceeds total topmost PCIe switch capacity, then additional rails are chosen from the same NUMA node (while causing saturation of one ore more topmost PCIe switches)
-- If user override exceeds total capacity of EFA devices connected to the NUMA node, then additional rails are selected from adjacent NUMA nodes, according to NUMA distance (i.e. rails from closer nodes are selected first), while keeping the same effort to avoid saturating topmost PCIe bridges
-- If user override exceeds total capacity of all EFA devices on the machine, then all rails will be used for DRAM_SEG memory type
+- If user override exceeds total topmost PCIe switch capacity, then additional rails are chosen from
+the same NUMA node (while causing saturation of one or more topmost PCIe switches)
+- If user override exceeds total capacity of EFA devices connected to the NUMA node, then additional
+rails are selected from adjacent NUMA nodes, according to NUMA distance (i.e. rails from closer
+nodes are selected first), while keeping the same effort to avoid saturating topmost PCIe bridges
+- If user override exceeds total capacity of all EFA devices on the machine, then all rails will be
+used for DRAM_SEG memory type
+
+### Summary
 
 The following table summarizes briefly the plugin's runtime configuration:
 
 | Name | Effect | Environment Variable | Values | Examples | Notes |
 |--|--|--|--|--|--|
-| max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node |NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG | integer | 100, 200 | A multiple of 1000^3 as common in NIC specification |
+| max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node |NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG | integer | 100, 200 | Units are Gbps (Gigabits per second), auto-computed by PCIe topology, normally does not require user override |
 
 ## API Reference
 

--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -92,6 +92,9 @@
 
 #define NIXL_LIBFABRIC_CQ_BATCH_SIZE 16
 
+// Giga (decimal) constant
+constexpr inline uint64_t NIXL_LIBFABRIC_GIGA = 1000ull * 1000ull * 1000ull;
+
 /**
  * @brief Notification header for all fragments (10 bytes)
  *

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -531,7 +531,7 @@ nixlLibfabricRailManager::getDramRailLimit(const nixl_b_params_t &custom_params,
         return false;
     }
 
-    // verify a few more computed values before continuing (avoid division by zero  )
+    // verify a few more computed values before continuing (avoid division by zero)
     size_t nic_speed = topology->getAvgNicBandwidth();
     if (nic_speed == 0) {
         NIXL_WARN << "Could not deduce average EFA device line bandwidth, NUMA-aware rail "
@@ -552,7 +552,7 @@ nixlLibfabricRailManager::getDramRailLimit(const nixl_b_params_t &custom_params,
     // get bandwidth limit from configuration or environment variable, and then deduce rail count
     // limit (which is used to implement NUMA-aware rail selection policy for DRAM_SEG memory type)
     // NOTE: corresponding env var is NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG, and is specified in
-    // Gigabits per second (e.g 100, 200, etc.)
+    // decimal Gigabits per second, as multiple of 10^9 (e.g 100, 200, etc.)
     nixl_status_t res =
         LibfabricUtils::getCustomIntParam(custom_params, "max_bw_per_dram_seg", max_bw);
     if (res != NIXL_SUCCESS) {

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -88,17 +88,18 @@ public:
      *
      * - max_bw_per_dram_seg (matching environment variable NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG):
      * Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node. Specified in
-     * multiples of 1000^3 (e.g. 100, 200, etc.). If passed as key-value pair to the custom
-     * parameter map, the value should be passed as a string that can be parsed as integer (e.g.
-     * {"max_bw_per_dram_seg", "100"}). If not specified, then computed as the maximum possible
-     * bandwidth that would not saturate the topmost PCIe bridge/switch devices of the NUMA node of
-     * the origin buffer. This value (whether computed or provided by user) is converted to rail
-     * count limit and used in NUMA-aware rail selection policy for DRAM_SEG, in order to limit the
-     * number of rails used for this memory type. Rail selection is also limited to NUMA node of the
-     * origin buffer. If user override exceeds the total topmost PCIe switch capacity of the NUMA
-     * node, then rail selection spills over to additional rails on the PCI switches of the NUMA
-     * node, and subsequently to adjacent NUMA nodes if required. If user override exceeds total
-     * machine network capacity, then all rails will be used for DRAM_SEG memory type.
+     * decimal Gbps, as multiples of 10^9 (e.g. 100, 200, etc.). If passed as key-value pair to the
+     * custom parameter map, the value should be passed as a string that can be parsed as integer
+     * (e.g. {"max_bw_per_dram_seg", "100"}). If not specified, then computed as the maximum
+     * possible bandwidth that would not saturate the topmost PCIe bridge/switch devices of the NUMA
+     * node of the origin buffer. This value (whether computed or provided by user) is converted to
+     * rail count limit and used in NUMA-aware rail selection policy for DRAM_SEG, in order to limit
+     * the number of rails used for this memory type. Rail selection is also limited to NUMA node of
+     * the origin buffer. If user override exceeds the total topmost PCIe switch capacity of the
+     * NUMA node, then rail selection spills over to additional rails on the PCI switches of the
+     * NUMA node, and subsequently, if still not reaching user-specified limit, spills over to
+     * adjacent NUMA nodes if required. If user override exceeds total machine network capacity,
+     * then all rails will be used for DRAM_SEG memory type.
      */
     nixl_status_t
     init(const nixl_b_params_t &custom_params);

--- a/src/utils/libfabric/libfabric_topology.cpp
+++ b/src/utils/libfabric/libfabric_topology.cpp
@@ -577,7 +577,8 @@ nixlLibfabricTopology::buildTopologyAwareGrouping() {
             nic.libfabric_name = libfabric_name;
             nic.hwloc_node = hwloc_node;
             nic.line_speed = getPcieDevSpeed(pcie_addr);
-            // NOTE: upstream link speed is given in GB/s as float, we convert it to size_t Gbps
+            // NOTE: upstream link speed is given in decimal GB/s (i.e. multiple of 10^9) as float,
+            // so we convert it to size_t decimal Gbps
             nic.upstream_link_speed = (size_t)(hwloc_node->attr->pcidev.linkspeed * 8.0f);
             nic.numa_node_id = getPcieDevNumaNodeId(hwloc_node, pcie_addr);
             nic.domain_id = domain_id;
@@ -764,10 +765,8 @@ nixlLibfabricTopology::getPcieDevSpeed(const std::string &pcie_addr) {
     size_t speed = 0;
     std::unordered_map<std::string, size_t>::const_iterator itr = nic_speed_map.find(pcie_addr);
     if (itr != nic_speed_map.end()) {
-        // convert from bits to Giga BITS per second
-        // NOTE: device reports in multiples of 1000 and not 1024
-        const uint64_t GIGA = 1000ull * 1000ull * 1000ull;
-        speed = itr->second / GIGA;
+        // convert from bits per second to Gbps (decimal, as multiple of 10^9)
+        speed = itr->second / NIXL_LIBFABRIC_GIGA;
         NIXL_DEBUG << "Found speed for NIC at PCIe address " << pcie_addr << ": " << speed
                    << " (Gbps)";
     } else {

--- a/src/utils/libfabric/libfabric_topology.h
+++ b/src/utils/libfabric/libfabric_topology.h
@@ -90,17 +90,8 @@ private:
     struct NicInfo {
         std::string libfabric_name;
         hwloc_obj_t hwloc_node;
-        // NOTE: NIC line speed is in Gbps (as multiples of 1000^3). Since fi_getinfo() reports this
-        // value in bits per second (e.g. 100,000,000,000), this is converted to Gigabits per second
-        // (e.g. 100, 200), and compared against user config/env override, which is also specified
-        // as 100, 200, etc., in Gbps (Gigabit per second) so we can deduce number of rails from
-        // user override
-        size_t line_speed;
-        // NOTE: upstream link speed is in Gbps (as multiples of 1024^3), as reported by hwloc,
-        // originally float GB/s (e.g. 31.5077), converted to size_t Gbps (e.g. 252) - this is
-        // compared against PCIe switch link speed (also in Gbps 1024^3) to deduce number of rails
-        // from topology
-        size_t upstream_link_speed;
+        size_t line_speed; // Gbps (decimal, as multiple of 10^9, not 2^30)
+        size_t upstream_link_speed; // Gbps (decimal, as multiple of 10^9, not 2^30)
         uint16_t numa_node_id;
         uint16_t domain_id;
         uint8_t bus_id;
@@ -108,9 +99,7 @@ private:
         uint8_t function_id;
         uint16_t parent_switch_domain;
         uint8_t parent_switch_bus_id;
-        // NOTE: switch link speed is in Gbps (multiples of 1024^3), see  upstream_link_speed above
-        // for more details
-        size_t parent_switch_link_speed;
+        size_t parent_switch_link_speed; // Gbps (decimal, as multiple of 10^9, not 2^30)
     };
 
     struct AccelInfo {
@@ -277,8 +266,8 @@ public:
     }
 
     /**
-     * @brief Retrieves the average NIC bandwidth (Gbps). This is the speed as reported by
-     * fi_getinfo(), as multiples of 1000^3 (and not 1024^3).
+     * @brief Retrieves the average NIC bandwidth in Gbps (decimal, as multiple of 10^9, not 2^30).
+     * This is the speed as reported by fi_getinfo().
      */
     inline size_t
     getAvgNicBandwidth() const {
@@ -286,8 +275,8 @@ public:
     }
 
     /**
-     * @brief Retrieves the average NIC upstream link bandwidth (Gbps). This is the link speed of
-     * the PCIe device as reported by hwloc, as multiples of 1024^3.
+     * @brief Retrieves the average NIC upstream link bandwidth in Gbps (decimal, as multiple of
+     * 10^9, not 2^30). This is the link speed of the PCIe device as reported by hwloc.
      */
     inline size_t
     getAvgNicUpstreamBandwidth() const {

--- a/test/unit/utils/libfabric/libfabric_topology_test.cpp
+++ b/test/unit/utils/libfabric/libfabric_topology_test.cpp
@@ -203,9 +203,6 @@ struct NicData {
 
 typedef std::unordered_map<std::string, NicData> NicMap;
 
-// NIC speed conversion constant
-static const uint64_t GIGA = 1000ull * 1000ull * 1000ull;
-
 // testing flag env var name
 static const char *NIXL_LIBFABRIC_TESTING_ENV_VAR = "NIXL_LIBFABRIC_TESTING";
 
@@ -620,7 +617,7 @@ __wrap_fi_getinfo(uint32_t version,
             itr->nic->bus_attr->attr.pci.function_id = entry.second.func;
 
             itr->nic->link_attr = malloc_zero<fi_link_attr>();
-            itr->nic->link_attr->speed = curr_topology->nic_line_speed * GIGA;
+            itr->nic->link_attr->speed = curr_topology->nic_line_speed * NIXL_LIBFABRIC_GIGA;
 
             prev = itr;
             itr = nullptr;

--- a/test/unit/utils/libfabric/topo/g5.48xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/g5.48xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/g6.48xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/g6.48xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/p3dn.24xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/p3dn.24xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/p4d.24xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/p4d.24xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0x0000ffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0x0000ffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/p5.48xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/p5.48xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/p5en.48xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/p5en.48xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">

--- a/test/unit/utils/libfabric/topo/p6-b200.48xl-topo.xml
+++ b/test/unit/utils/libfabric/topo/p6-b200.48xl-topo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -14,7 +15,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE topology SYSTEM "hwloc2.dtd">
 <topology version="2.0">
   <object type="Machine" os_index="0" cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" complete_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" allowed_cpuset="0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff,0xffffffff" nodeset="0x00000003" complete_nodeset="0x00000003" allowed_nodeset="0x00000003" gp_index="1">


### PR DESCRIPTION
## What?
Fixing regression in unit tests due to license notice XML comment in test topo files being out of xml tag.
Fixing documentation and comments for PR 1302 (NUMA-aware rail selection for DRAM_SEG).

## Why?
Unit tests for libfabric are failing due to topology XML test file malformed (having license XML comment misplaced).
There are also some documentation additions/fixes in plugin README and comments in code.

## How?
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG (decimal Gbps); removed old per-DRAM_SEG config, clarified auto-computation from PCIe topology, NUMA-node scope, spillover behavior, unit semantics, override precedence, and thread-safety notes.
* **Chores**
  * Added decimal giga constant usage across code/tests and updated comments.
  * Consolidated XML declarations to the top of topology test files to remove duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->