### PR TITLE
nixl_worker: file_offset calculation fixed

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1138,7 +1138,9 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 }
             }
             res.push_back(remote_iov_list);
-            file_offset += block_size;
+            if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+                file_offset += block_size;
+            }
         }
     } else {
         for (const auto &local_iov : local_iovs) {


### PR DESCRIPTION
## What?
Fix `file_offset` calculation for non-GUSLI plugins.

## Why?
The regression was introduced by commit 62a5b3e.

## How?
`file_offset` calculation differs between GUSLI and POSIX plugins, so I wrapped the GUSLI-specific fix introduced by 62a5b3e in the appropriate `if`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected file offset advancement behavior for storage backends to ensure proper data placement and consistent state management across backend types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->