### PR TITLE
TEST: Fix CRT multi-buffer test timeout reporting and reduce poll spin

### DIFF
--- a/test/gtest/plugins/transfer_handler.h
+++ b/test/gtest/plugins/transfer_handler.h
@@ -103,6 +103,7 @@ private:
     static constexpr size_t NUM_ENTRIES = 4;
     static constexpr size_t ENTRY_SIZE = 16;
     static constexpr size_t BUF_SIZE = NUM_ENTRIES * ENTRY_SIZE;
+    static constexpr size_t COMP_TIMEOUT = 30;
 
     std::vector<std::unique_ptr<memoryHandler<srcMemType>>> srcMem_;
     std::vector<std::unique_ptr<memoryHandler<dstMemType>>> dstMem_;
@@ -192,12 +193,15 @@ private:
 
         NIXL_INFO << "\t\tWaiting for transfer to complete...";
 
-        auto end_time = absl::Now() + absl::Seconds(3);
+        auto end_time = absl::Now() + absl::Seconds(COMP_TIMEOUT);
 
         while (ret == NIXL_IN_PROG && absl::Now() < end_time) {
+            absl::SleepFor(absl::Milliseconds(50));
             ret = srcBackendEngine_->checkXfer(handle);
             ASSERT_TRUE(ret == NIXL_SUCCESS || ret == NIXL_IN_PROG);
         }
+
+        ASSERT_EQ(ret, NIXL_SUCCESS) << "Transfer timed out after " << COMP_TIMEOUT << " seconds";
 
         NIXL_INFO << "\nTransfer complete";
 
@@ -221,11 +225,14 @@ private:
 
         NIXL_INFO << "\t\tChecking notification flow: ";
 
-        auto end_time = absl::Now() + absl::Seconds(3);
+        auto end_time = absl::Now() + absl::Seconds(COMP_TIMEOUT);
         while (num_notifs == 0 && absl::Now() < end_time) {
+            absl::SleepFor(absl::Milliseconds(50));
             ASSERT_EQ(dstBackendEngine_->getNotifs(target_notifs), NIXL_SUCCESS);
             num_notifs = target_notifs.size();
         }
+
+        ASSERT_GT(num_notifs, 0) << "Notification timed out after " << COMP_TIMEOUT << " seconds";
 
         NIXL_INFO << "\nNotification transfer complete";
 


### PR DESCRIPTION
## What?
Fix CRT multi-buffer test (ObjCrtTests/CrtXferMultiBufsTest) timeout reporting and reduce polling spin in the transfer test harness.

## Why?
When a transfer or notification timed out, the polling loop silently fell through and the test continued — leading to a misleading data-mismatch failure deep in checkLocalMem rather than a clear timeout error. Additionally, the tight busy-loop in the polling path could starve CRT SDK background threads, making multi-buffer tests (which issue more concurrent S3 API calls) flakier than single-buffer ones.

## How?
- Added absl::SleepFor(absl::Milliseconds(50)) in both the checkXfer and getNotifs polling loops to yield CPU to CRT SDK background threads.
  - Added explicit ASSERT_EQ(ret, NIXL_SUCCESS) after the performTransfer polling loop so a timeout now fails with "Transfer timed out after 30 seconds" instead of falling through silently.
  - Added ASSERT_GT(num_notifs, 0) after the verifyNotifs polling loop for the same reason.
  - Extracted the timeout duration into a COMP_TIMEOUT constant (30 s) shared by both methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved transfer handler test reliability with configurable timeouts and refined wait mechanisms to enhance test robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->