### PR TITLE
TEST/PYTHON: Remove printing binary data.

### DIFF
--- a/test/python/test_nixl_bindings.py
+++ b/test/python/test_nixl_bindings.py
@@ -94,9 +94,6 @@ def test_agent():
     meta1 = agent1.getLocalMD()
     meta2 = agent2.getLocalMD()
 
-    logger.info("Agent1 MD: \n%s", meta1)
-    logger.info("Agent2 MD: \n%s", meta2)
-
     ret_name = agent1.loadRemoteMD(meta2)
     assert ret_name.decode(encoding="UTF-8") == name2
     ret_name = agent2.loadRemoteMD(meta1)


### PR DESCRIPTION
## What?
Remove printing of binary data to the console from a Python test.

## Why?
Printing binary data to the terminal (in between normal logging) can have weird and undesirable effects and is not particularly useful.