### PR TITLE
telemetry: lock-free double-buffer, skip-when-full

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -18,7 +18,6 @@ Custom telemetry exporter plug-ins can be created according to [src/plugins/tele
 ### Event Structure
 
 Each telemetry event contains:
-- **Timestamp**: Microsecond precision timestamp
 - **Category**: Event category for filtering and aggregation
 - **Event Name**: Descriptive name/identifier for the event
 - **Value**: Numeric value associated with the event
@@ -61,8 +60,8 @@ The **Shared Memory Buffer** plug-in, contains the data per transaction event, w
 
 ### Telemetry Details
 
-- Timestamp is done after the operation completion.
-- Current design allows silent telemetry loss.
+- Events are batched in a lock-free double buffer and periodically flushed to the exporter.
+- Under sustained overload, events may be dropped rather than blocking producers.
 - Current design does not support selective telemetry(e.g per category). All the telemetry events could be either ON or OFF.
 
 ## Enabling Telemetry
@@ -128,14 +127,12 @@ Both readers produce similar formatted output:
 
 ```
 === NIXL Telemetry Event ===
-Timestamp: 2025-01-15 14:30:25.123456
 Category: TRANSFER
 Event: agent_tx_bytes
 Value: 1048576
 ===========================
 
 === NIXL Telemetry Event ===
-Timestamp: 2025-01-15 14:30:25.124567
 Category: MEMORY
 Event: agent_memory_registered
 Value: 4096

--- a/examples/cpp/telemetry_reader.cpp
+++ b/examples/cpp/telemetry_reader.cpp
@@ -67,7 +67,8 @@ print_telemetry_event(const nixlTelemetryEvent &event) {
     std::cout << "\n=== NIXL Telemetry Event ===" << std::endl;
     std::cout << "Category: " << nixlEnumStrings::telemetryCategoryStr(event.category_)
               << std::endl;
-    std::cout << "Event name: " << event.eventName_ << std::endl;
+    std::cout << "Event name: " << nixlEnumStrings::telemetryEventNameStr(event.eventName_)
+              << std::endl;
     std::cout << "Value: " << event.value_ << std::endl;
 
     std::cout << "===========================" << std::endl;

--- a/examples/cpp/telemetry_reader.cpp
+++ b/examples/cpp/telemetry_reader.cpp
@@ -67,8 +67,7 @@ print_telemetry_event(const nixlTelemetryEvent &event) {
     std::cout << "\n=== NIXL Telemetry Event ===" << std::endl;
     std::cout << "Category: " << nixlEnumStrings::telemetryCategoryStr(event.category_)
               << std::endl;
-    std::cout << "Event name: " << nixlEnumStrings::telemetryEventNameStr(event.eventName_)
-              << std::endl;
+    std::cout << "Event name: " << event.eventName_ << std::endl;
     std::cout << "Value: " << event.value_ << std::endl;
 
     std::cout << "===========================" << std::endl;

--- a/examples/cpp/telemetry_reader.cpp
+++ b/examples/cpp/telemetry_reader.cpp
@@ -45,21 +45,6 @@ signal_handler(int signal) {
 }
 
 std::string
-format_timestamp(uint64_t timestamp_us) {
-    auto time_point =
-        std::chrono::system_clock::time_point(std::chrono::microseconds(timestamp_us));
-    auto time_t = std::chrono::system_clock::to_time_t(time_point);
-
-    std::stringstream ss;
-    ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S");
-
-    auto microseconds = timestamp_us % 1000000;
-    ss << "." << std::setfill('0') << std::setw(6) << microseconds;
-
-    return ss.str();
-}
-
-std::string
 format_bytes(uint64_t bytes) {
     const char *units[] = {"B", "KB", "MB", "GB", "TB"};
     int unit_index = 0;
@@ -80,7 +65,6 @@ print_telemetry_event(const nixlTelemetryEvent &event) {
     // Can be extended to more general ostream if needed
     // friend std::ostream &operator<<(std::ostream &os, const nixlTelemetryEvent &event)
     std::cout << "\n=== NIXL Telemetry Event ===" << std::endl;
-    std::cout << "Timestamp: " << format_timestamp(event.timestampUs_) << std::endl;
     std::cout << "Category: " << nixlEnumStrings::telemetryCategoryStr(event.category_)
               << std::endl;
     std::cout << "Event name: " << event.eventName_ << std::endl;

--- a/examples/python/telemetry_reader.py
+++ b/examples/python/telemetry_reader.py
@@ -23,7 +23,6 @@ import os
 import signal
 import sys
 import time
-from datetime import datetime
 
 # Set up logging
 logging.basicConfig(
@@ -34,8 +33,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Constants from telemetry_event.h
-TELEMETRY_VERSION = 1
-MAX_EVENT_NAME_LEN = 32
+TELEMETRY_VERSION = 2
 
 # NIXL telemetry categories
 NIXL_TELEMETRY_MEMORY = 0
@@ -47,6 +45,18 @@ NIXL_TELEMETRY_PERFORMANCE = 5
 NIXL_TELEMETRY_SYSTEM = 6
 NIXL_TELEMETRY_CUSTOM = 7
 NIXL_TELEMETRY_MAX = 8
+
+# NIXL telemetry event names (nixl_telemetry_event_name_t)
+AGENT_TX_BYTES = 0
+AGENT_RX_BYTES = 1
+AGENT_TX_REQUESTS_NUM = 2
+AGENT_RX_REQUESTS_NUM = 3
+AGENT_MEMORY_REGISTERED = 4
+AGENT_MEMORY_DEREGISTERED = 5
+AGENT_XFER_TIME = 6
+AGENT_XFER_POST_TIME = 7
+AGENT_ERROR = 8
+AGENT_BACKEND = 9
 
 # Global flag for graceful shutdown
 running = True
@@ -65,10 +75,9 @@ class NixlTelemetryEvent(ctypes.Structure):
 
     _pack_ = 1
     _fields_ = [
-        ("timestamp_us", ctypes.c_uint64),
         ("category", ctypes.c_int),
-        ("event_name", ctypes.c_char * MAX_EVENT_NAME_LEN),
-        ("_padding", ctypes.c_uint32),
+        ("event_name", ctypes.c_uint8),
+        ("_padding", ctypes.c_char * 3),
         ("value", ctypes.c_uint64),
     ]
 
@@ -197,13 +206,6 @@ class SharedRingBuffer:
             os.close(self.file_fd)
 
 
-def format_timestamp(timestamp_us):
-    """Format timestamp in microseconds to readable format"""
-    dt = datetime.fromtimestamp(timestamp_us / 1_000_000)
-    microseconds = timestamp_us % 1_000_000
-    return f"{dt.strftime('%Y-%m-%d %H:%M:%S')}.{microseconds:06d}"
-
-
 def format_bytes(bytes_val):
     """Format bytes to human readable format"""
     units = ["B", "KB", "MB", "GB", "TB"]
@@ -232,13 +234,28 @@ def get_telemetry_category_string(category):
     return category_strings.get(category, f"UNKNOWN_CATEGORY_{category}")
 
 
+def get_telemetry_event_name_string(event_name):
+    """Get string representation of telemetry event name enum"""
+    event_name_strings = {
+        AGENT_TX_BYTES: "agent_tx_bytes",
+        AGENT_RX_BYTES: "agent_rx_bytes",
+        AGENT_TX_REQUESTS_NUM: "agent_tx_requests_num",
+        AGENT_RX_REQUESTS_NUM: "agent_rx_requests_num",
+        AGENT_MEMORY_REGISTERED: "agent_memory_registered",
+        AGENT_MEMORY_DEREGISTERED: "agent_memory_deregistered",
+        AGENT_XFER_TIME: "agent_xfer_time",
+        AGENT_XFER_POST_TIME: "agent_xfer_post_time",
+        AGENT_ERROR: "agent_error",
+        AGENT_BACKEND: "agent_backend",
+    }
+    return event_name_strings.get(event_name, f"unknown_event_{event_name}")
+
+
 def print_telemetry_event(event):
     """Print telemetry event in a formatted way"""
     logger.info("\n=== NIXL Telemetry Event ===")
-    logger.info("Timestamp: %s", format_timestamp(event.timestamp_us))
 
-    # Decode event name
-    event_name = event.event_name.decode("utf-8").rstrip("\x00")
+    event_name = get_telemetry_event_name_string(event.event_name)
     category_str = get_telemetry_category_string(event.category)
 
     logger.info("Category: %s", category_str)

--- a/examples/python/telemetry_reader.py
+++ b/examples/python/telemetry_reader.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 # Constants from telemetry_event.h
 TELEMETRY_VERSION = 2
+MAX_EVENT_NAME_LEN = 32
 
 # NIXL telemetry categories
 NIXL_TELEMETRY_MEMORY = 0
@@ -45,18 +46,6 @@ NIXL_TELEMETRY_PERFORMANCE = 5
 NIXL_TELEMETRY_SYSTEM = 6
 NIXL_TELEMETRY_CUSTOM = 7
 NIXL_TELEMETRY_MAX = 8
-
-# NIXL telemetry event names (nixl_telemetry_event_name_t)
-AGENT_TX_BYTES = 0
-AGENT_RX_BYTES = 1
-AGENT_TX_REQUESTS_NUM = 2
-AGENT_RX_REQUESTS_NUM = 3
-AGENT_MEMORY_REGISTERED = 4
-AGENT_MEMORY_DEREGISTERED = 5
-AGENT_XFER_TIME = 6
-AGENT_XFER_POST_TIME = 7
-AGENT_ERROR = 8
-AGENT_BACKEND = 9
 
 # Global flag for graceful shutdown
 running = True
@@ -76,8 +65,7 @@ class NixlTelemetryEvent(ctypes.Structure):
     _pack_ = 1
     _fields_ = [
         ("category", ctypes.c_int),
-        ("event_name", ctypes.c_uint8),
-        ("_padding", ctypes.c_char * 3),
+        ("event_name", ctypes.c_char * MAX_EVENT_NAME_LEN),
         ("value", ctypes.c_uint64),
     ]
 
@@ -235,20 +223,10 @@ def get_telemetry_category_string(category):
 
 
 def get_telemetry_event_name_string(event_name):
-    """Get string representation of telemetry event name enum"""
-    event_name_strings = {
-        AGENT_TX_BYTES: "agent_tx_bytes",
-        AGENT_RX_BYTES: "agent_rx_bytes",
-        AGENT_TX_REQUESTS_NUM: "agent_tx_requests_num",
-        AGENT_RX_REQUESTS_NUM: "agent_rx_requests_num",
-        AGENT_MEMORY_REGISTERED: "agent_memory_registered",
-        AGENT_MEMORY_DEREGISTERED: "agent_memory_deregistered",
-        AGENT_XFER_TIME: "agent_xfer_time",
-        AGENT_XFER_POST_TIME: "agent_xfer_post_time",
-        AGENT_ERROR: "agent_error",
-        AGENT_BACKEND: "agent_backend",
-    }
-    return event_name_strings.get(event_name, f"unknown_event_{event_name}")
+    """Get string representation of telemetry event name"""
+    if isinstance(event_name, bytes):
+        return event_name.decode("utf-8", errors="replace").rstrip("\x00")
+    return str(event_name)
 
 
 def print_telemetry_event(event):

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -66,12 +66,8 @@ class nixlBackendEngine {
             if (!enableTelemetry_) return;
             if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
             std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
-            telemetryEvents_.emplace_back(std::chrono::duration_cast<std::chrono::microseconds>(
-                                              std::chrono::system_clock::now().time_since_epoch())
-                                              .count(),
-                                          nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND,
-                                          event_name,
-                                          value);
+            telemetryEvents_.emplace_back(
+                nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND, event_name, value);
         }
 
     public:

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -62,7 +62,7 @@ class nixlBackendEngine {
         }
 
         void
-        addTelemetryEvent(nixl_telemetry_event_name_t event_name, uint64_t value) {
+        addTelemetryEvent(const std::string &event_name, uint64_t value) {
             if (!enableTelemetry_) return;
             if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
             std::lock_guard<std::mutex> lock(telemetryEventsMutex_);

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -62,7 +62,7 @@ class nixlBackendEngine {
         }
 
         void
-        addTelemetryEvent(const std::string &event_name, uint64_t value) {
+        addTelemetryEvent(nixl_telemetry_event_name_t event_name, uint64_t value) {
             if (!enableTelemetry_) return;
             if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
             std::lock_guard<std::mutex> lock(telemetryEventsMutex_);

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -128,7 +128,7 @@ class nixlAgentData {
 
         void
         addErrorTelemetry(nixl_status_t err_status) {
-            if (telemetry_) {
+            if (telemetry_ && telemetryEnabled) {
                 telemetry_->updateErrorCount(err_status);
             }
         }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -118,8 +118,8 @@ nixlXferReqH::updateRequestStats(nixlTelemetry *telemetry_pub,
     }
 
     if (telemetry_pub && (stat_status != NIXL_TELEMETRY_POST)) {
-        telemetry_pub->addPostTime(telemetry.postDuration);
-        telemetry_pub->addXferTime(duration, backendOp == NIXL_WRITE, telemetry.totalBytes);
+        telemetry_pub->addTransferComplete(
+            telemetry.postDuration, duration, backendOp == NIXL_WRITE, telemetry.totalBytes);
     }
 
     NIXL_TRACE << "[NIXL TELEMETRY]: From backend " << engine->getType()

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -154,25 +154,25 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
 
     const auto telemetry_enabled = nixl::config::getValueOptional<bool>(TELEMETRY_ENABLED_VAR);
 
-    if (telemetry_enabled) {
-        if (*telemetry_enabled) {
-            telemetry_ = std::make_unique<nixlTelemetry>(name);
-            telemetryEnabled = telemetry_->recording;
-            if (!telemetryEnabled) {
-                NIXL_WARN << "NIXL_TELEMETRY_ENABLE is set but no telemetry exporter is configured "
-                             "(set NIXL_TELEMETRY_EXPORTER or NIXL_TELEMETRY_DIR); "
-                             "per-transfer telemetry and error export are disabled.";
-            }
-        } else if (config.captureTelemetry) {
-            telemetryEnabled = true;
+    const bool env_on = telemetry_enabled && *telemetry_enabled;
+    const bool config_wants = config.captureTelemetry;
+
+    if (env_on || config_wants) {
+        if (telemetry_enabled && !*telemetry_enabled && config_wants) {
             NIXL_WARN << "NIXL telemetry is enabled through config, "
                          "ignoring the NIXL_TELEMETRY_ENABLE environment variable";
-        } else {
-            NIXL_DEBUG << "NIXL telemetry is disabled";
         }
-    } else if (config.captureTelemetry) {
-        telemetryEnabled = true;
-        NIXL_DEBUG << "Capturing NIXL telemetry based on config (without an output file)";
+        telemetry_ = std::make_unique<nixlTelemetry>(name);
+        telemetryEnabled = telemetry_->recording;
+        if (!telemetryEnabled) {
+            NIXL_WARN << "Telemetry was requested but no exporter is configured "
+                         "(set NIXL_TELEMETRY_EXPORTER or NIXL_TELEMETRY_DIR); "
+                         "per-transfer telemetry and error export are disabled.";
+        } else if (!env_on && config_wants) {
+            NIXL_DEBUG << "Capturing NIXL telemetry based on config";
+        }
+    } else if (telemetry_enabled && !*telemetry_enabled) {
+        NIXL_DEBUG << "NIXL telemetry is disabled";
     }
 }
 
@@ -333,7 +333,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.enableProgTh = data->config_.useProgThread;
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
-    init_params.enableTelemetry_ = (data->telemetry_ != nullptr) && data->telemetryEnabled;
+    init_params.enableTelemetry_ = data->telemetryEnabled;
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -154,11 +154,11 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
 
     const auto telemetry_enabled = nixl::config::getValueOptional<bool>(TELEMETRY_ENABLED_VAR);
 
-    const bool env_on = telemetry_enabled && *telemetry_enabled;
-    const bool config_wants = config.captureTelemetry;
+    const bool telemetry_enabled_env = telemetry_enabled && *telemetry_enabled;
+    const bool telemetry_enabled_config = config.captureTelemetry;
 
-    if (env_on || config_wants) {
-        if (telemetry_enabled && !*telemetry_enabled && config_wants) {
+    if (telemetry_enabled_env || telemetry_enabled_config) {
+        if (telemetry_enabled && !*telemetry_enabled && telemetry_enabled_config) {
             NIXL_WARN << "NIXL telemetry is enabled through config, "
                          "ignoring the NIXL_TELEMETRY_ENABLE environment variable";
         }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -156,8 +156,13 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
 
     if (telemetry_enabled) {
         if (*telemetry_enabled) {
-            telemetryEnabled = true;
             telemetry_ = std::make_unique<nixlTelemetry>(name);
+            telemetryEnabled = telemetry_->recording;
+            if (!telemetryEnabled) {
+                NIXL_WARN << "NIXL_TELEMETRY_ENABLE is set but no telemetry exporter is configured "
+                             "(set NIXL_TELEMETRY_EXPORTER or NIXL_TELEMETRY_DIR); "
+                             "per-transfer telemetry and error export are disabled.";
+            }
         } else if (config.captureTelemetry) {
             telemetryEnabled = true;
             NIXL_WARN << "NIXL telemetry is enabled through config, "
@@ -328,7 +333,8 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.enableProgTh = data->config_.useProgThread;
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
-    init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
+    init_params.enableTelemetry_ =
+        (data->telemetry_ != nullptr) && data->telemetryEnabled;
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
@@ -471,7 +477,7 @@ nixlAgent::registerMem(const nixl_reg_dlist_t &descs,
 
     if (count > 0) {
         // sum all the sizes of the descriptors using std::accumulate
-        if (data->telemetry_) {
+        if (data->telemetry_ && data->telemetryEnabled) {
             uint64_t total_size = std::accumulate(
                 descs.begin(),
                 descs.end(),
@@ -514,7 +520,7 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
             bad_ret = ret;
     }
     if (bad_ret == NIXL_SUCCESS) {
-        if (data->telemetry_) {
+        if (data->telemetry_ && data->telemetryEnabled) {
             uint64_t total_size = std::accumulate(
                 descs.begin(),
                 descs.end(),

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -333,8 +333,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.enableProgTh = data->config_.useProgThread;
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
-    init_params.enableTelemetry_ =
-        (data->telemetry_ != nullptr) && data->telemetryEnabled;
+    init_params.enableTelemetry_ = (data->telemetry_ != nullptr) && data->telemetryEnabled;
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -168,7 +168,7 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
             NIXL_WARN << "Telemetry was requested but no exporter is configured "
                          "(set NIXL_TELEMETRY_EXPORTER or NIXL_TELEMETRY_DIR); "
                          "per-transfer telemetry and error export are disabled.";
-        } else if (!env_on && config_wants) {
+        } else if (!telemetry_enabled_env && telemetry_enabled_config) {
             NIXL_DEBUG << "Capturing NIXL telemetry based on config";
         }
     } else if (telemetry_enabled && !*telemetry_enabled) {

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -171,7 +171,7 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
         } else if (!telemetry_enabled_env && telemetry_enabled_config) {
             NIXL_DEBUG << "Capturing NIXL telemetry based on config";
         }
-    } else if (telemetry_enabled && !*telemetry_enabled) {
+    } else {
         NIXL_DEBUG << "NIXL telemetry is disabled";
     }
 }

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -178,7 +178,6 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-
     const size_t id = writeIdx_.fetch_add(1);
     if (id >= maxEventsBuffered_) {
         overflowed_.store(true, std::memory_order_relaxed);

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -125,7 +125,7 @@ nixlTelemetry::initializeTelemetry() {
     event_buffers_[0].resize(max_events_buffered_);
     event_buffers_[1].resize(max_events_buffered_);
     write_idx_.store(0);
-    write_buffer_index_.store(0);
+    write_buf_index_.store(0);
 
     const auto run_interval =
         nixl::config::getValueDefaulted(TELEMETRY_RUN_INTERVAL_VAR, DEFAULT_TELEMETRY_RUN_INTERVAL);
@@ -143,14 +143,14 @@ nixlTelemetry::writeEventHelper() {
         return true;
     }
     // Block producers by setting write_idx_=max so they get id>=max and skip.
+    const int w = write_buf_index_.load();
     const size_t num_events_raw = write_idx_.exchange(max_events_buffered_);
-    const int old_write = write_buffer_index_.load();
-    write_buffer_index_.store(1 - old_write);
+    write_buf_index_.store(1 - w);
     write_idx_.store(0);
     const size_t num_events = std::min(num_events_raw, max_events_buffered_);
 
     for (size_t i = 0; i < num_events; ++i) {
-        exporter_->exportEvent(event_buffers_[old_write][i]);
+        exporter_->exportEvent(event_buffers_[w][i]);
     }
 
     return true;
@@ -184,8 +184,7 @@ nixlTelemetry::updateData(const std::string &event_name,
     if (id >= max_events_buffered_) {
         return;
     }
-    const int idx = write_buffer_index_.load();
-    event_buffers_[idx][id] =
+    event_buffers_[write_buf_index_.load()][id] =
         nixlTelemetryEvent(std::chrono::duration_cast<std::chrono::microseconds>(
                                std::chrono::system_clock::now().time_since_epoch())
                                .count(),
@@ -256,15 +255,15 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
 
-    const int idx = write_buffer_index_.load();
-    event_buffers_[idx][id] =
+    auto &write = event_buffers_[write_buf_index_.load()];
+    write[id] =
         nixlTelemetryEvent(time,
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                            "agent_xfer_time",
                            xfer_time.count());
-    event_buffers_[idx][id + 1] = nixlTelemetryEvent(
+    write[id + 1] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
-    event_buffers_[idx][id + 2] = nixlTelemetryEvent(
+    write[id + 2] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -135,13 +135,12 @@ nixlTelemetry::initializeTelemetry() {
     writeTask_.interval_ = run_interval;
     writeTask_.enabled_ = true;
     registerPeriodicTask(writeTask_);
+    recording = true;
 }
 
 bool
 nixlTelemetry::writeEventHelper() {
-    if (!exporter_ || maxEventsBuffered_ == 0) {
-        return true;
-    }
+
     // Block producers by setting writeIdx_=max so they get id>=max and skip.
     const int w = writeBufIndex_.load();
     const size_t num_events_raw = writeIdx_.exchange(maxEventsBuffered_);
@@ -177,9 +176,7 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-    if (!exporter_ || maxEventsBuffered_ == 0) {
-        return;
-    }
+
     const size_t id = writeIdx_.fetch_add(1);
     if (id >= maxEventsBuffered_) {
         return;
@@ -240,9 +237,7 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
 
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    if (!exporter_ || maxEventsBuffered_ == 0) {
-        return;
-    }
+
     const size_t id = writeIdx_.fetch_add(3);
     if (id + 3 > maxEventsBuffered_) {
         return;

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -121,6 +121,12 @@ nixlTelemetry::initializeTelemetry() {
 
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;
 
+    max_events_buffered_ = buffer_size;
+    event_buffers_[0].resize(max_events_buffered_);
+    event_buffers_[1].resize(max_events_buffered_);
+    write_idx_.store(0);
+    write_buffer_index_.store(0);
+
     const auto run_interval =
         nixl::config::getValueDefaulted(TELEMETRY_RUN_INTERVAL_VAR, DEFAULT_TELEMETRY_RUN_INTERVAL);
 
@@ -133,17 +139,18 @@ nixlTelemetry::initializeTelemetry() {
 
 bool
 nixlTelemetry::writeEventHelper() {
-    std::vector<nixlTelemetryEvent> next_queue;
-    // assume next buffer will be the same size as the current one
-    next_queue.reserve(exporter_->getMaxEventsBuffered());
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        events_.swap(next_queue);
+    if (!exporter_ || max_events_buffered_ == 0) {
+        return true;
     }
+    // Block producers by setting write_idx_=max so they get id>=max and skip.
+    const size_t num_events_raw = write_idx_.exchange(max_events_buffered_);
+    const int old_write = write_buffer_index_.load();
+    write_buffer_index_.store(1 - old_write);
+    write_idx_.store(0);
+    const size_t num_events = std::min(num_events_raw, max_events_buffered_);
 
-    for (auto &event : next_queue) {
-        // if full, ignore
-        exporter_->exportEvent(event);
+    for (size_t i = 0; i < num_events; ++i) {
+        exporter_->exportEvent(event_buffers_[old_write][i]);
     }
 
     return true;
@@ -170,14 +177,21 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-    // agent can be multi-threaded
-    std::lock_guard<std::mutex> lock(mutex_);
-    events_.emplace_back(std::chrono::duration_cast<std::chrono::microseconds>(
-                             std::chrono::system_clock::now().time_since_epoch())
-                             .count(),
-                         category,
-                         event_name,
-                         value);
+    if (!exporter_ || max_events_buffered_ == 0) {
+        return;
+    }
+    const size_t id = write_idx_.fetch_add(1);
+    if (id >= max_events_buffered_) {
+        return;
+    }
+    const int idx = write_buffer_index_.load();
+    event_buffers_[idx][id] =
+        nixlTelemetryEvent(std::chrono::duration_cast<std::chrono::microseconds>(
+                               std::chrono::system_clock::now().time_since_epoch())
+                               .count(),
+                           category,
+                           event_name,
+                           value);
 }
 
 // The next 4 methods might be removed, as addXferTime covers them.
@@ -227,6 +241,14 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
 
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
+    if (!exporter_ || max_events_buffered_ == 0) {
+        return;
+    }
+    const size_t id = write_idx_.fetch_add(3);
+    if (id + 3 > max_events_buffered_) {
+        write_idx_.fetch_sub(3);
+        return;
+    }
     const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
     const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
 
@@ -234,14 +256,15 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
 
-    const std::lock_guard lock(mutex_);
-    events_.emplace_back(time,
-                         nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                         "agent_xfer_time",
-                         xfer_time.count());
-    events_.emplace_back(
+    const int idx = write_buffer_index_.load();
+    event_buffers_[idx][id] =
+        nixlTelemetryEvent(time,
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_time",
+                           xfer_time.count());
+    event_buffers_[idx][id + 1] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
-    events_.emplace_back(
+    event_buffers_[idx][id + 2] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -237,11 +237,6 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
 
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-
-    const size_t id = writeIdx_.fetch_add(3);
-    if (id + 3 > maxEventsBuffered_) {
-        return;
-    }
     const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
     const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
 
@@ -249,14 +244,28 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
 
-    auto &write = eventBuffers_[writeBufIndex_.load()];
-    write[id] = nixlTelemetryEvent(time,
-                                   nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                                   "agent_xfer_time",
-                                   xfer_time.count());
-    write[id + 1] = nixlTelemetryEvent(
+    const size_t id_xfer = writeIdx_.fetch_add(1);
+    if (id_xfer >= maxEventsBuffered_) {
+        return;
+    }
+    eventBuffers_[writeBufIndex_.load()][id_xfer] =
+        nixlTelemetryEvent(time,
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_time",
+                           xfer_time.count());
+
+    const size_t id_bytes = writeIdx_.fetch_add(1);
+    if (id_bytes >= maxEventsBuffered_) {
+        return;
+    }
+    eventBuffers_[writeBufIndex_.load()][id_bytes] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
-    write[id + 2] = nixlTelemetryEvent(
+
+    const size_t id_req = writeIdx_.fetch_add(1);
+    if (id_req >= maxEventsBuffered_) {
+        return;
+    }
+    eventBuffers_[writeBufIndex_.load()][id_req] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -90,11 +90,10 @@ getExporterName() {
 void
 fillTelemetryEventSlot(nixlTelemetryEvent &slot,
                        nixl_telemetry_category_t category,
-                       const char *event_name,
+                       nixl_telemetry_event_name_t event_name,
                        uint64_t value) noexcept {
     slot.category_ = category;
-    strncpy(slot.eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
-    slot.eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
+    slot.eventName_ = event_name;
     slot.value_ = value;
 }
 
@@ -184,7 +183,7 @@ nixlTelemetry::registerPeriodicTask(periodicTask &task) {
 }
 
 void
-nixlTelemetry::updateData(const char *event_name,
+nixlTelemetry::updateData(nixl_telemetry_event_name_t event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
 
@@ -199,45 +198,49 @@ nixlTelemetry::updateData(const char *event_name,
 // The next 4 methods might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::updateTxBytes(uint64_t tx_bytes) {
-    updateData("agent_tx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, tx_bytes);
+    updateData(nixl_telemetry_event_name_t::AGENT_TX_BYTES,
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+               tx_bytes);
 }
 
 void
 nixlTelemetry::updateRxBytes(uint64_t rx_bytes) {
-    updateData("agent_rx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, rx_bytes);
+    updateData(nixl_telemetry_event_name_t::AGENT_RX_BYTES,
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+               rx_bytes);
 }
 
 void
 nixlTelemetry::updateTxRequestsNum(uint32_t tx_requests_num) {
-    updateData("agent_tx_requests_num",
+    updateData(nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM,
                nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                tx_requests_num);
 }
 
 void
 nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
-    updateData("agent_rx_requests_num",
+    updateData(nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM,
                nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                rx_requests_num);
 }
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData(nixlEnumStrings::statusStr(error_type).c_str(),
+    updateData(nixl_telemetry_event_name_t::AGENT_ERROR,
                nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
-               1);
+               static_cast<uint64_t>(error_type));
 }
 
 void
 nixlTelemetry::updateMemoryRegistered(uint64_t memory_registered) {
-    updateData("agent_memory_registered",
+    updateData(nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED,
                nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_registered);
 }
 
 void
 nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
-    updateData("agent_memory_deregistered",
+    updateData(nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED,
                nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_deregistered);
 }
@@ -245,8 +248,10 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
 // addXferTime and addPostTime might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
-    const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
+    const auto bytes_name = is_write ? nixl_telemetry_event_name_t::AGENT_TX_BYTES :
+                                       nixl_telemetry_event_name_t::AGENT_RX_BYTES;
+    const auto requests_name = is_write ? nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM :
+                                          nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM;
 
     const size_t id_xfer = writeIdx_.fetch_add(1);
     if (id_xfer >= maxEventsBuffered_) {
@@ -254,7 +259,7 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
     }
     fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_xfer],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_time",
+                           nixl_telemetry_event_name_t::AGENT_XFER_TIME,
                            static_cast<uint64_t>(xfer_time.count()));
 
     const size_t id_bytes = writeIdx_.fetch_add(1);
@@ -278,7 +283,7 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
 
 void
 nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
-    updateData("agent_xfer_post_time",
+    updateData(nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME,
                nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                post_time.count());
 }
@@ -298,19 +303,21 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
 
     fillTelemetryEventSlot(arr[id],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_post_time",
+                           nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME,
                            static_cast<uint64_t>(post_time.count()));
     fillTelemetryEventSlot(arr[id + 1],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_time",
+                           nixl_telemetry_event_name_t::AGENT_XFER_TIME,
                            static_cast<uint64_t>(xfer_time.count()));
     fillTelemetryEventSlot(arr[id + 2],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? "agent_tx_bytes" : "agent_rx_bytes",
+                           is_write ? nixl_telemetry_event_name_t::AGENT_TX_BYTES :
+                                      nixl_telemetry_event_name_t::AGENT_RX_BYTES,
                            bytes);
     fillTelemetryEventSlot(arr[id + 3],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? "agent_tx_requests_num" : "agent_rx_requests_num",
+                           is_write ? nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM :
+                                      nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM,
                            1);
 }
 
@@ -329,3 +336,4 @@ nixlEnumStrings::telemetryCategoryStr(const nixl_telemetry_category_t &category)
     if (category_int >= nixl_telemetry_category_str.size()) return "BAD_CATEGORY";
     return nixl_telemetry_category_str[category_int];
 }
+

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -262,14 +262,10 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                            nixl_telemetry_event_name_t::AGENT_XFER_TIME,
                            static_cast<uint64_t>(xfer_time.count()));
-    fillTelemetryEventSlot(arr[id_base + 1],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           bytes_name,
-                           bytes);
-    fillTelemetryEventSlot(arr[id_base + 2],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           requests_name,
-                           1);
+    fillTelemetryEventSlot(
+        arr[id_base + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
+    fillTelemetryEventSlot(
+        arr[id_base + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
 }
 
 void

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -60,9 +60,8 @@ nixlTelemetry::~nixlTelemetry() {
         // continue anyway since it's not critical
     }
 
-    if (buffer_) {
+    if (eventBuffers_[0]) {
         writeEventHelper();
-        buffer_.reset();
     }
 }
 
@@ -124,8 +123,7 @@ nixlTelemetry::initializeTelemetry() {
     eventBufferSize_ = buffer_size;
     eventBuffers_[0] = std::make_unique<nixlTelemetryEvent[]>(eventBufferSize_);
     eventBuffers_[1] = std::make_unique<nixlTelemetryEvent[]>(eventBufferSize_);
-    writeIndex_.store(0);
-    writeBufferIndex_.store(0);
+    writeState_.store(0);
 
     const auto run_interval =
         nixl::config::getValueDefaulted(TELEMETRY_RUN_INTERVAL_VAR, DEFAULT_TELEMETRY_RUN_INTERVAL);
@@ -140,20 +138,23 @@ nixlTelemetry::initializeTelemetry() {
 
 bool
 nixlTelemetry::writeEventHelper() {
-    // Disable new writes: setting writeIndex_=max causes them to see id>=max and skip.
-    const size_t num_events_raw = writeIndex_.exchange(eventBufferSize_);
-    const unsigned w = writeBufferIndex_.fetch_xor(1);
-    writeIndex_.store(0);
-    const size_t num_events = std::min(num_events_raw, eventBufferSize_);
+    // Single exchange: swap to the other buffer and reset index to 0.
+    const size_t old = writeState_.exchange(nextBufBit_);
+    const unsigned buf = (old & BUF_BIT) ? 1 : 0;
+    const size_t numRaw = old & IDX_MASK;
+    const size_t numEvents = std::min(numRaw, eventBufferSize_);
 
-    if (num_events_raw > eventBufferSize_) {
+    if (numRaw > eventBufferSize_) {
         NIXL_WARN << "Telemetry events were dropped due to buffer overflow";
     }
 
-    for (size_t i = 0; i < num_events; ++i) {
-        exporter_->exportEvent(eventBuffers_[w][i]);
+    for (size_t i = 0; i < numEvents; ++i) {
+        if (eventBuffers_[buf][i].eventName_[0] == '\0') continue;
+        exporter_->exportEvent(eventBuffers_[buf][i]);
+        eventBuffers_[buf][i].eventName_[0] = '\0';
     }
 
+    nextBufBit_ ^= BUF_BIT;
     return true;
 }
 
@@ -178,13 +179,12 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-    const size_t id = writeIndex_.fetch_add(1);
-    if (id >= eventBufferSize_) {
-        return;
-    }
+    const size_t old = writeState_.fetch_add(1);
+    const unsigned buf = (old & BUF_BIT) ? 1 : 0;
+    const size_t id = old & IDX_MASK;
+    if (id >= eventBufferSize_) return;
 
-    eventBuffers_[writeBufferIndex_.load()][id] =
-        nixlTelemetryEvent(category, event_name.c_str(), value);
+    eventBuffers_[buf][id] = nixlTelemetryEvent(category, event_name.c_str(), value);
 }
 
 // The next 4 methods might be removed, as addTransferComplete covers them.
@@ -238,14 +238,12 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
                                    std::chrono::microseconds xfer_time,
                                    bool is_write,
                                    uint64_t bytes) {
-    const size_t id = writeIndex_.fetch_add(4);
-    if (id + 4 > eventBufferSize_) {
-        return;
-    }
+    const size_t old = writeState_.fetch_add(4);
+    const unsigned buf = (old & BUF_BIT) ? 1 : 0;
+    const size_t id = old & IDX_MASK;
+    if (id + 4 > eventBufferSize_) return;
 
-    const unsigned buf = writeBufferIndex_.load(std::memory_order_acquire);
     auto &arr = eventBuffers_[buf];
-
     arr[id] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                                  "agent_xfer_post_time",
                                  static_cast<uint64_t>(post_time.count()));

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -87,6 +87,19 @@ getExporterName() {
     return defaultTelemetryPlugin;
 }
 
+void
+fillTelemetryEventSlot(nixlTelemetryEvent &slot,
+                       uint64_t timestamp_us,
+                       nixl_telemetry_category_t category,
+                       const char *event_name,
+                       uint64_t value) noexcept {
+    slot.timestampUs_ = timestamp_us;
+    slot.category_ = category;
+    strncpy(slot.eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
+    slot.eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
+    slot.value_ = value;
+}
+
 } // namespace
 
 void
@@ -173,7 +186,7 @@ nixlTelemetry::registerPeriodicTask(periodicTask &task) {
 }
 
 void
-nixlTelemetry::updateData(const std::string &event_name,
+nixlTelemetry::updateData(const char *event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
 
@@ -181,8 +194,9 @@ nixlTelemetry::updateData(const std::string &event_name,
     if (id >= maxEventsBuffered_) {
         return;
     }
-    eventBuffers_[writeBufIndex_.load()][id] =
-        nixlTelemetryEvent(std::chrono::duration_cast<std::chrono::microseconds>(
+
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id],
+                           std::chrono::duration_cast<std::chrono::microseconds>(
                                std::chrono::system_clock::now().time_since_epoch())
                                .count(),
                            category,
@@ -217,8 +231,9 @@ nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData(
-        nixlEnumStrings::statusStr(error_type), nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
+    updateData(nixlEnumStrings::statusStr(error_type).c_str(),
+               nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
+               1);
 }
 
 void
@@ -248,25 +263,31 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
     if (id_xfer >= maxEventsBuffered_) {
         return;
     }
-    eventBuffers_[writeBufIndex_.load()][id_xfer] =
-        nixlTelemetryEvent(time,
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_xfer],
+                           time,
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                            "agent_xfer_time",
-                           xfer_time.count());
+                           static_cast<uint64_t>(xfer_time.count()));
 
     const size_t id_bytes = writeIdx_.fetch_add(1);
     if (id_bytes >= maxEventsBuffered_) {
         return;
     }
-    eventBuffers_[writeBufIndex_.load()][id_bytes] = nixlTelemetryEvent(
-        time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_bytes],
+                           time,
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           bytes_name,
+                           bytes);
 
     const size_t id_req = writeIdx_.fetch_add(1);
     if (id_req >= maxEventsBuffered_) {
         return;
     }
-    eventBuffers_[writeBufIndex_.load()][id_req] = nixlTelemetryEvent(
-        time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_req],
+                           time,
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           requests_name,
+                           1);
 }
 
 void

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -89,11 +89,9 @@ getExporterName() {
 
 void
 fillTelemetryEventSlot(nixlTelemetryEvent &slot,
-                       uint64_t timestamp_us,
                        nixl_telemetry_category_t category,
                        const char *event_name,
                        uint64_t value) noexcept {
-    slot.timestampUs_ = timestamp_us;
     slot.category_ = category;
     strncpy(slot.eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
     slot.eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
@@ -195,16 +193,10 @@ nixlTelemetry::updateData(const char *event_name,
         return;
     }
 
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id],
-                           std::chrono::duration_cast<std::chrono::microseconds>(
-                               std::chrono::system_clock::now().time_since_epoch())
-                               .count(),
-                           category,
-                           event_name,
-                           value);
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id], category, event_name, value);
 }
 
-// The next 4 methods might be removed, as addXferTime covers them.
+// The next 4 methods might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::updateTxBytes(uint64_t tx_bytes) {
     updateData("agent_tx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, tx_bytes);
@@ -250,21 +242,17 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
                memory_deregistered);
 }
 
+// addXferTime and addPostTime might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
     const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
     const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
-
-    const auto time = std::chrono::duration_cast<std::chrono::microseconds>(
-                          std::chrono::system_clock::now().time_since_epoch())
-                          .count();
 
     const size_t id_xfer = writeIdx_.fetch_add(1);
     if (id_xfer >= maxEventsBuffered_) {
         return;
     }
     fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_xfer],
-                           time,
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                            "agent_xfer_time",
                            static_cast<uint64_t>(xfer_time.count()));
@@ -274,7 +262,6 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
         return;
     }
     fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_bytes],
-                           time,
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                            bytes_name,
                            bytes);
@@ -284,7 +271,6 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
         return;
     }
     fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_req],
-                           time,
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                            requests_name,
                            1);
@@ -295,6 +281,37 @@ nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
     updateData("agent_xfer_post_time",
                nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                post_time.count());
+}
+
+void
+nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
+                                   std::chrono::microseconds xfer_time,
+                                   bool is_write,
+                                   uint64_t bytes) {
+    const size_t id = writeIdx_.fetch_add(4);
+    if (id + 4 > maxEventsBuffered_) {
+        return;
+    }
+
+    const int buf = writeBufIndex_.load(std::memory_order_acquire);
+    auto &arr = eventBuffers_[buf];
+
+    fillTelemetryEventSlot(arr[id],
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_post_time",
+                           static_cast<uint64_t>(post_time.count()));
+    fillTelemetryEventSlot(arr[id + 1],
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_time",
+                           static_cast<uint64_t>(xfer_time.count()));
+    fillTelemetryEventSlot(arr[id + 2],
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           is_write ? "agent_tx_bytes" : "agent_rx_bytes",
+                           bytes);
+    fillTelemetryEventSlot(arr[id + 3],
+                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           is_write ? "agent_tx_requests_num" : "agent_rx_requests_num",
+                           1);
 }
 
 std::string

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -253,29 +253,20 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
     const auto requests_name = is_write ? nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM :
                                           nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM;
 
-    const size_t id_xfer = writeIdx_.fetch_add(1);
-    if (id_xfer >= maxEventsBuffered_) {
+    const size_t id_base = writeIdx_.fetch_add(3);
+    if (id_base + 2 >= maxEventsBuffered_) {
         return;
     }
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_xfer],
+    auto *arr = eventBuffers_[writeBufIndex_.load()];
+    fillTelemetryEventSlot(arr[id_base],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                            nixl_telemetry_event_name_t::AGENT_XFER_TIME,
                            static_cast<uint64_t>(xfer_time.count()));
-
-    const size_t id_bytes = writeIdx_.fetch_add(1);
-    if (id_bytes >= maxEventsBuffered_) {
-        return;
-    }
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_bytes],
+    fillTelemetryEventSlot(arr[id_base + 1],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                            bytes_name,
                            bytes);
-
-    const size_t id_req = writeIdx_.fetch_add(1);
-    if (id_req >= maxEventsBuffered_) {
-        return;
-    }
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id_req],
+    fillTelemetryEventSlot(arr[id_base + 2],
                            nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                            requests_name,
                            1);

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -121,11 +121,11 @@ nixlTelemetry::initializeTelemetry() {
 
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;
 
-    maxEventsBuffered_ = buffer_size;
-    eventBuffers_[0] = std::make_unique<nixlTelemetryEvent[]>(maxEventsBuffered_);
-    eventBuffers_[1] = std::make_unique<nixlTelemetryEvent[]>(maxEventsBuffered_);
-    writeIdx_.store(0);
-    writeBufIndex_.store(0);
+    eventBufferSize_ = buffer_size;
+    eventBuffers_[0] = std::make_unique<nixlTelemetryEvent[]>(eventBufferSize_);
+    eventBuffers_[1] = std::make_unique<nixlTelemetryEvent[]>(eventBufferSize_);
+    writeIndex_.store(0);
+    writeBufferIndex_.store(0);
 
     const auto run_interval =
         nixl::config::getValueDefaulted(TELEMETRY_RUN_INTERVAL_VAR, DEFAULT_TELEMETRY_RUN_INTERVAL);
@@ -140,13 +140,13 @@ nixlTelemetry::initializeTelemetry() {
 
 bool
 nixlTelemetry::writeEventHelper() {
-    // Block producers by setting writeIdx_=max so they get id>=max and skip.
-    const size_t num_events_raw = writeIdx_.exchange(maxEventsBuffered_);
-    const int w = writeBufIndex_.fetch_xor(1);
-    writeIdx_.store(0);
-    const size_t num_events = std::min(num_events_raw, maxEventsBuffered_);
+    // Disable new writes: setting writeIndex_=max causes them to see id>=max and skip.
+    const size_t num_events_raw = writeIndex_.exchange(eventBufferSize_);
+    const unsigned w = writeBufferIndex_.fetch_xor(1);
+    writeIndex_.store(0);
+    const size_t num_events = std::min(num_events_raw, eventBufferSize_);
 
-    if (overflowed_.exchange(false, std::memory_order_relaxed)) {
+    if (num_events_raw > eventBufferSize_) {
         NIXL_WARN << "Telemetry events were dropped due to buffer overflow";
     }
 
@@ -178,13 +178,12 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-    const size_t id = writeIdx_.fetch_add(1);
-    if (id >= maxEventsBuffered_) {
-        overflowed_.store(true, std::memory_order_relaxed);
+    const size_t id = writeIndex_.fetch_add(1);
+    if (id >= eventBufferSize_) {
         return;
     }
 
-    eventBuffers_[writeBufIndex_.load()][id] =
+    eventBuffers_[writeBufferIndex_.load()][id] =
         nixlTelemetryEvent(category, event_name.c_str(), value);
 }
 
@@ -239,13 +238,12 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
                                    std::chrono::microseconds xfer_time,
                                    bool is_write,
                                    uint64_t bytes) {
-    const size_t id = writeIdx_.fetch_add(4);
-    if (id + 4 > maxEventsBuffered_) {
-        overflowed_.store(true, std::memory_order_relaxed);
+    const size_t id = writeIndex_.fetch_add(4);
+    if (id + 4 > eventBufferSize_) {
         return;
     }
 
-    const int buf = writeBufIndex_.load(std::memory_order_acquire);
+    const unsigned buf = writeBufferIndex_.load(std::memory_order_acquire);
     auto &arr = eventBuffers_[buf];
 
     arr[id] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -90,10 +90,11 @@ getExporterName() {
 void
 fillTelemetryEventSlot(nixlTelemetryEvent &slot,
                        nixl_telemetry_category_t category,
-                       nixl_telemetry_event_name_t event_name,
+                       const char *event_name,
                        uint64_t value) noexcept {
     slot.category_ = category;
-    slot.eventName_ = event_name;
+    strncpy(slot.eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
+    slot.eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
     slot.value_ = value;
 }
 
@@ -183,7 +184,7 @@ nixlTelemetry::registerPeriodicTask(periodicTask &task) {
 }
 
 void
-nixlTelemetry::updateData(nixl_telemetry_event_name_t event_name,
+nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
 
@@ -192,86 +193,73 @@ nixlTelemetry::updateData(nixl_telemetry_event_name_t event_name,
         return;
     }
 
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id], category, event_name, value);
+    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id], category, event_name.c_str(),
+                           value);
 }
 
 // The next 4 methods might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::updateTxBytes(uint64_t tx_bytes) {
-    updateData(nixl_telemetry_event_name_t::AGENT_TX_BYTES,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-               tx_bytes);
+    updateData("agent_tx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, tx_bytes);
 }
 
 void
 nixlTelemetry::updateRxBytes(uint64_t rx_bytes) {
-    updateData(nixl_telemetry_event_name_t::AGENT_RX_BYTES,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-               rx_bytes);
+    updateData("agent_rx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, rx_bytes);
 }
 
 void
 nixlTelemetry::updateTxRequestsNum(uint32_t tx_requests_num) {
-    updateData(nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+    updateData("agent_tx_requests_num", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                tx_requests_num);
 }
 
 void
 nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
-    updateData(nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+    updateData("agent_rx_requests_num", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                rx_requests_num);
 }
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData(nixl_telemetry_event_name_t::AGENT_ERROR,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
+    updateData("agent_error", nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
                static_cast<uint64_t>(error_type));
 }
 
 void
 nixlTelemetry::updateMemoryRegistered(uint64_t memory_registered) {
-    updateData(nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
+    updateData("agent_memory_registered", nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_registered);
 }
 
 void
 nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
-    updateData(nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
+    updateData("agent_memory_deregistered", nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_deregistered);
 }
 
 // addXferTime and addPostTime might be removed, as addTransferComplete covers them.
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    const auto bytes_name = is_write ? nixl_telemetry_event_name_t::AGENT_TX_BYTES :
-                                       nixl_telemetry_event_name_t::AGENT_RX_BYTES;
-    const auto requests_name = is_write ? nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM :
-                                          nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM;
+    const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
+    const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
 
     const size_t id_base = writeIdx_.fetch_add(3);
     if (id_base + 2 >= maxEventsBuffered_) {
         return;
     }
-    auto *arr = eventBuffers_[writeBufIndex_.load()];
-    fillTelemetryEventSlot(arr[id_base],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           nixl_telemetry_event_name_t::AGENT_XFER_TIME,
-                           static_cast<uint64_t>(xfer_time.count()));
-    fillTelemetryEventSlot(
-        arr[id_base + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
-    fillTelemetryEventSlot(
-        arr[id_base + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
+    auto &arr = eventBuffers_[writeBufIndex_.load()];
+    fillTelemetryEventSlot(arr[id_base], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
+    fillTelemetryEventSlot(arr[id_base + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           bytes_name, bytes);
+    fillTelemetryEventSlot(arr[id_base + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           requests_name, 1);
 }
 
 void
 nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
-    updateData(nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+    updateData("agent_xfer_post_time", nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                post_time.count());
 }
 
@@ -288,24 +276,14 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
     const int buf = writeBufIndex_.load(std::memory_order_acquire);
     auto &arr = eventBuffers_[buf];
 
-    fillTelemetryEventSlot(arr[id],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME,
-                           static_cast<uint64_t>(post_time.count()));
-    fillTelemetryEventSlot(arr[id + 1],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           nixl_telemetry_event_name_t::AGENT_XFER_TIME,
-                           static_cast<uint64_t>(xfer_time.count()));
-    fillTelemetryEventSlot(arr[id + 2],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? nixl_telemetry_event_name_t::AGENT_TX_BYTES :
-                                      nixl_telemetry_event_name_t::AGENT_RX_BYTES,
-                           bytes);
-    fillTelemetryEventSlot(arr[id + 3],
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM :
-                                      nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM,
-                           1);
+    fillTelemetryEventSlot(arr[id], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_post_time", static_cast<uint64_t>(post_time.count()));
+    fillTelemetryEventSlot(arr[id + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                           "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
+    fillTelemetryEventSlot(arr[id + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           is_write ? "agent_tx_bytes" : "agent_rx_bytes", bytes);
+    fillTelemetryEventSlot(arr[id + 3], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                           is_write ? "agent_tx_requests_num" : "agent_rx_requests_num", 1);
 }
 
 std::string

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -336,4 +336,3 @@ nixlEnumStrings::telemetryCategoryStr(const nixl_telemetry_category_t &category)
     if (category_int >= nixl_telemetry_category_str.size()) return "BAD_CATEGORY";
     return nixl_telemetry_category_str[category_int];
 }
-

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -121,11 +121,11 @@ nixlTelemetry::initializeTelemetry() {
 
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;
 
-    max_events_buffered_ = buffer_size;
-    event_buffers_[0].resize(max_events_buffered_);
-    event_buffers_[1].resize(max_events_buffered_);
-    write_idx_.store(0);
-    write_buf_index_.store(0);
+    maxEventsBuffered_ = buffer_size;
+    eventBuffers_[0].resize(maxEventsBuffered_);
+    eventBuffers_[1].resize(maxEventsBuffered_);
+    writeIdx_.store(0);
+    writeBufIndex_.store(0);
 
     const auto run_interval =
         nixl::config::getValueDefaulted(TELEMETRY_RUN_INTERVAL_VAR, DEFAULT_TELEMETRY_RUN_INTERVAL);
@@ -139,18 +139,18 @@ nixlTelemetry::initializeTelemetry() {
 
 bool
 nixlTelemetry::writeEventHelper() {
-    if (!exporter_ || max_events_buffered_ == 0) {
+    if (!exporter_ || maxEventsBuffered_ == 0) {
         return true;
     }
-    // Block producers by setting write_idx_=max so they get id>=max and skip.
-    const int w = write_buf_index_.load();
-    const size_t num_events_raw = write_idx_.exchange(max_events_buffered_);
-    write_buf_index_.store(1 - w);
-    write_idx_.store(0);
-    const size_t num_events = std::min(num_events_raw, max_events_buffered_);
+    // Block producers by setting writeIdx_=max so they get id>=max and skip.
+    const int w = writeBufIndex_.load();
+    const size_t num_events_raw = writeIdx_.exchange(maxEventsBuffered_);
+    writeBufIndex_.store(1 - w);
+    writeIdx_.store(0);
+    const size_t num_events = std::min(num_events_raw, maxEventsBuffered_);
 
     for (size_t i = 0; i < num_events; ++i) {
-        exporter_->exportEvent(event_buffers_[w][i]);
+        exporter_->exportEvent(eventBuffers_[w][i]);
     }
 
     return true;
@@ -177,14 +177,14 @@ void
 nixlTelemetry::updateData(const std::string &event_name,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
-    if (!exporter_ || max_events_buffered_ == 0) {
+    if (!exporter_ || maxEventsBuffered_ == 0) {
         return;
     }
-    const size_t id = write_idx_.fetch_add(1);
-    if (id >= max_events_buffered_) {
+    const size_t id = writeIdx_.fetch_add(1);
+    if (id >= maxEventsBuffered_) {
         return;
     }
-    event_buffers_[write_buf_index_.load()][id] =
+    eventBuffers_[writeBufIndex_.load()][id] =
         nixlTelemetryEvent(std::chrono::duration_cast<std::chrono::microseconds>(
                                std::chrono::system_clock::now().time_since_epoch())
                                .count(),
@@ -240,12 +240,11 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
 
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    if (!exporter_ || max_events_buffered_ == 0) {
+    if (!exporter_ || maxEventsBuffered_ == 0) {
         return;
     }
-    const size_t id = write_idx_.fetch_add(3);
-    if (id + 3 > max_events_buffered_) {
-        write_idx_.fetch_sub(3);
+    const size_t id = writeIdx_.fetch_add(3);
+    if (id + 3 > maxEventsBuffered_) {
         return;
     }
     const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
@@ -255,12 +254,11 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                           std::chrono::system_clock::now().time_since_epoch())
                           .count();
 
-    auto &write = event_buffers_[write_buf_index_.load()];
-    write[id] =
-        nixlTelemetryEvent(time,
-                           nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_time",
-                           xfer_time.count());
+    auto &write = eventBuffers_[writeBufIndex_.load()];
+    write[id] = nixlTelemetryEvent(time,
+                                   nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                                   "agent_xfer_time",
+                                   xfer_time.count());
     write[id + 1] = nixlTelemetryEvent(
         time, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
     write[id + 2] = nixlTelemetryEvent(

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -140,7 +140,6 @@ nixlTelemetry::initializeTelemetry() {
 
 bool
 nixlTelemetry::writeEventHelper() {
-
     // Block producers by setting writeIdx_=max so they get id>=max and skip.
     const size_t num_events_raw = writeIdx_.exchange(maxEventsBuffered_);
     const int w = writeBufIndex_.fetch_xor(1);

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -203,31 +203,36 @@ nixlTelemetry::updateRxBytes(uint64_t rx_bytes) {
 
 void
 nixlTelemetry::updateTxRequestsNum(uint32_t tx_requests_num) {
-    updateData("agent_tx_requests_num", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+    updateData("agent_tx_requests_num",
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                tx_requests_num);
 }
 
 void
 nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
-    updateData("agent_rx_requests_num", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+    updateData("agent_rx_requests_num",
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                rx_requests_num);
 }
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData("agent_error", nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
+    updateData("agent_error",
+               nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
                static_cast<uint64_t>(error_type));
 }
 
 void
 nixlTelemetry::updateMemoryRegistered(uint64_t memory_registered) {
-    updateData("agent_memory_registered", nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
+    updateData("agent_memory_registered",
+               nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_registered);
 }
 
 void
 nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
-    updateData("agent_memory_deregistered", nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
+    updateData("agent_memory_deregistered",
+               nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_deregistered);
 }
 
@@ -246,11 +251,14 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
     auto &arr = eventBuffers_[buf];
 
     arr[id] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                                "agent_xfer_post_time", static_cast<uint64_t>(post_time.count()));
+                                 "agent_xfer_post_time",
+                                 static_cast<uint64_t>(post_time.count()));
     arr[id + 1] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                                     "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
+                                     "agent_xfer_time",
+                                     static_cast<uint64_t>(xfer_time.count()));
     arr[id + 2] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                                     is_write ? "agent_tx_bytes" : "agent_rx_bytes", bytes);
+                                     is_write ? "agent_tx_bytes" : "agent_rx_bytes",
+                                     bytes);
     arr[id + 3] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                                      is_write ? "agent_tx_requests_num" : "agent_rx_requests_num",
                                      1);

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -87,17 +87,6 @@ getExporterName() {
     return defaultTelemetryPlugin;
 }
 
-void
-fillTelemetryEventSlot(nixlTelemetryEvent &slot,
-                       nixl_telemetry_category_t category,
-                       const char *event_name,
-                       uint64_t value) noexcept {
-    slot.category_ = category;
-    strncpy(slot.eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
-    slot.eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
-    slot.value_ = value;
-}
-
 } // namespace
 
 void
@@ -133,8 +122,8 @@ nixlTelemetry::initializeTelemetry() {
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;
 
     maxEventsBuffered_ = buffer_size;
-    eventBuffers_[0].resize(maxEventsBuffered_);
-    eventBuffers_[1].resize(maxEventsBuffered_);
+    eventBuffers_[0] = std::make_unique<nixlTelemetryEvent[]>(maxEventsBuffered_);
+    eventBuffers_[1] = std::make_unique<nixlTelemetryEvent[]>(maxEventsBuffered_);
     writeIdx_.store(0);
     writeBufIndex_.store(0);
 
@@ -153,11 +142,14 @@ bool
 nixlTelemetry::writeEventHelper() {
 
     // Block producers by setting writeIdx_=max so they get id>=max and skip.
-    const int w = writeBufIndex_.load();
     const size_t num_events_raw = writeIdx_.exchange(maxEventsBuffered_);
-    writeBufIndex_.store(1 - w);
+    const int w = writeBufIndex_.fetch_xor(1);
     writeIdx_.store(0);
     const size_t num_events = std::min(num_events_raw, maxEventsBuffered_);
+
+    if (overflowed_.exchange(false, std::memory_order_relaxed)) {
+        NIXL_WARN << "Telemetry events were dropped due to buffer overflow";
+    }
 
     for (size_t i = 0; i < num_events; ++i) {
         exporter_->exportEvent(eventBuffers_[w][i]);
@@ -190,11 +182,12 @@ nixlTelemetry::updateData(const std::string &event_name,
 
     const size_t id = writeIdx_.fetch_add(1);
     if (id >= maxEventsBuffered_) {
+        overflowed_.store(true, std::memory_order_relaxed);
         return;
     }
 
-    fillTelemetryEventSlot(eventBuffers_[writeBufIndex_.load()][id], category, event_name.c_str(),
-                           value);
+    eventBuffers_[writeBufIndex_.load()][id] =
+        nixlTelemetryEvent(category, event_name.c_str(), value);
 }
 
 // The next 4 methods might be removed, as addTransferComplete covers them.
@@ -238,31 +231,6 @@ nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
                memory_deregistered);
 }
 
-// addXferTime and addPostTime might be removed, as addTransferComplete covers them.
-void
-nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
-    const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
-
-    const size_t id_base = writeIdx_.fetch_add(3);
-    if (id_base + 2 >= maxEventsBuffered_) {
-        return;
-    }
-    auto &arr = eventBuffers_[writeBufIndex_.load()];
-    fillTelemetryEventSlot(arr[id_base], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
-    fillTelemetryEventSlot(arr[id_base + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           bytes_name, bytes);
-    fillTelemetryEventSlot(arr[id_base + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           requests_name, 1);
-}
-
-void
-nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
-    updateData("agent_xfer_post_time", nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-               post_time.count());
-}
-
 void
 nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
                                    std::chrono::microseconds xfer_time,
@@ -270,20 +238,22 @@ nixlTelemetry::addTransferComplete(std::chrono::microseconds post_time,
                                    uint64_t bytes) {
     const size_t id = writeIdx_.fetch_add(4);
     if (id + 4 > maxEventsBuffered_) {
+        overflowed_.store(true, std::memory_order_relaxed);
         return;
     }
 
     const int buf = writeBufIndex_.load(std::memory_order_acquire);
     auto &arr = eventBuffers_[buf];
 
-    fillTelemetryEventSlot(arr[id], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_post_time", static_cast<uint64_t>(post_time.count()));
-    fillTelemetryEventSlot(arr[id + 1], nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                           "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
-    fillTelemetryEventSlot(arr[id + 2], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? "agent_tx_bytes" : "agent_rx_bytes", bytes);
-    fillTelemetryEventSlot(arr[id + 3], nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                           is_write ? "agent_tx_requests_num" : "agent_rx_requests_num", 1);
+    arr[id] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                                "agent_xfer_post_time", static_cast<uint64_t>(post_time.count()));
+    arr[id + 1] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
+                                     "agent_xfer_time", static_cast<uint64_t>(xfer_time.count()));
+    arr[id + 2] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                                     is_write ? "agent_tx_bytes" : "agent_rx_bytes", bytes);
+    arr[id + 3] = nixlTelemetryEvent(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                                     is_write ? "agent_tx_requests_num" : "agent_rx_requests_num",
+                                     1);
 }
 
 std::string

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -80,7 +80,7 @@ private:
     void
     registerPeriodicTask(periodicTask &task);
     void
-    updateData(const std::string &event_name, nixl_telemetry_category_t category, uint64_t value);
+    updateData(const char *event_name, nixl_telemetry_category_t category, uint64_t value);
     bool
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -71,6 +71,11 @@ public:
     addXferTime(std::chrono::microseconds transaction_time, bool is_write, uint64_t bytes);
     void
     addPostTime(std::chrono::microseconds post_time);
+    void
+    addTransferComplete(std::chrono::microseconds post_time,
+                        std::chrono::microseconds xfer_time,
+                        bool is_write,
+                        uint64_t bytes);
 
     bool recording{false};
 

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -85,9 +85,7 @@ private:
     void
     registerPeriodicTask(periodicTask &task);
     void
-    updateData(nixl_telemetry_event_name_t event_name,
-               nixl_telemetry_category_t category,
-               uint64_t value);
+    updateData(const std::string &event_name, nixl_telemetry_category_t category, uint64_t value);
     bool
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -25,7 +25,6 @@
 
 #include <string>
 #include <vector>
-#include <mutex>
 #include <memory>
 #include <chrono>
 #include <functional>
@@ -84,8 +83,11 @@ private:
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    std::vector<nixlTelemetryEvent> events_;
-    std::mutex mutex_;
+    // Lock-free double buffer: producers write to event_buffers_[write_buffer_index_]
+    std::vector<nixlTelemetryEvent> event_buffers_[2];
+    size_t max_events_buffered_{0};
+    std::atomic<size_t> write_idx_{0};
+    std::atomic<int> write_buffer_index_{0}; // 0 or 1
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -24,7 +24,6 @@
 #include "nixl_types.h"
 
 #include <string>
-#include <vector>
 #include <memory>
 #include <chrono>
 #include <functional>
@@ -68,10 +67,6 @@ public:
     void
     updateMemoryDeregistered(uint64_t memory_deregistered);
     void
-    addXferTime(std::chrono::microseconds transaction_time, bool is_write, uint64_t bytes);
-    void
-    addPostTime(std::chrono::microseconds post_time);
-    void
     addTransferComplete(std::chrono::microseconds post_time,
                         std::chrono::microseconds xfer_time,
                         bool is_write,
@@ -90,12 +85,13 @@ private:
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    // Double buffer: writeBufIndex_ is 0|1 — same role as colleague's write* -> arr. Swap = one
-    // store.
-    std::vector<nixlTelemetryEvent> eventBuffers_[2];
+    // Lock-free double buffer: producers write to eventBuffers_[writeBufIndex_],
+    // consumer swaps writeBufIndex_ and drains the inactive buffer.
+    std::unique_ptr<nixlTelemetryEvent[]> eventBuffers_[2];
     size_t maxEventsBuffered_{0};
     std::atomic<size_t> writeIdx_{0};
     std::atomic<int> writeBufIndex_{0};
+    std::atomic<bool> overflowed_{false};
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -85,13 +85,12 @@ private:
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    // Lock-free double buffer: producers write to eventBuffers_[writeBufIndex_],
-    // consumer swaps writeBufIndex_ and drains the inactive buffer.
+    // Lock-free double buffer: producers write to eventBuffers_[writeBufferIndex_],
+    // consumer swaps writeBufferIndex_ and drains the inactive buffer.
     std::unique_ptr<nixlTelemetryEvent[]> eventBuffers_[2];
-    size_t maxEventsBuffered_{0};
-    std::atomic<size_t> writeIdx_{0};
-    std::atomic<int> writeBufIndex_{0};
-    std::atomic<bool> overflowed_{false};
+    size_t eventBufferSize_{0};
+    std::atomic<size_t> writeIndex_{0};
+    std::atomic<unsigned> writeBufferIndex_{0};
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -83,11 +83,11 @@ private:
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    // Lock-free double buffer: producers write to event_buffers_[write_buffer_index_]
+    // Double buffer: write_buf_index_ is 0|1 — same role as colleague's write* -> arr. Swap = one store.
     std::vector<nixlTelemetryEvent> event_buffers_[2];
     size_t max_events_buffered_{0};
     std::atomic<size_t> write_idx_{0};
-    std::atomic<int> write_buffer_index_{0}; // 0 or 1
+    std::atomic<int> write_buf_index_{0};
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -17,10 +17,8 @@
 #ifndef NIXL_SRC_CORE_TELEMETRY_TELEMETRY_H
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_H
 
-#include "common/cyclic_buffer.h"
 #include "telemetry/telemetry_exporter.h"
 #include "telemetry_event.h"
-#include "mem_section.h"
 #include "nixl_types.h"
 
 #include <string>
@@ -84,13 +82,15 @@ private:
     bool
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
-    std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    // Lock-free double buffer: producers write to eventBuffers_[writeBufferIndex_],
-    // consumer swaps writeBufferIndex_ and drains the inactive buffer.
+    // Lock-free double buffer.  writeState_ packs the buffer selector
+    // (bit 63) and write index (bits 0-62) into one atomic so that
+    // producers obtain both from a single fetch_add — no buf/index race.
+    static constexpr size_t BUF_BIT = size_t(1) << 63;
+    static constexpr size_t IDX_MASK = BUF_BIT - 1;
     std::unique_ptr<nixlTelemetryEvent[]> eventBuffers_[2];
     size_t eventBufferSize_{0};
-    std::atomic<size_t> writeIndex_{0};
-    std::atomic<unsigned> writeBufferIndex_{0};
+    std::atomic<size_t> writeState_{0};
+    size_t nextBufBit_{BUF_BIT};
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -72,6 +72,8 @@ public:
     void
     addPostTime(std::chrono::microseconds post_time);
 
+    bool recording{false};
+
 private:
     void
     initializeTelemetry();

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -85,7 +85,9 @@ private:
     void
     registerPeriodicTask(periodicTask &task);
     void
-    updateData(const char *event_name, nixl_telemetry_category_t category, uint64_t value);
+    updateData(nixl_telemetry_event_name_t event_name,
+               nixl_telemetry_category_t category,
+               uint64_t value);
     bool
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -83,11 +83,12 @@ private:
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
-    // Double buffer: write_buf_index_ is 0|1 — same role as colleague's write* -> arr. Swap = one store.
-    std::vector<nixlTelemetryEvent> event_buffers_[2];
-    size_t max_events_buffered_{0};
-    std::atomic<size_t> write_idx_{0};
-    std::atomic<int> write_buf_index_{0};
+    // Double buffer: writeBufIndex_ is 0|1 — same role as colleague's write* -> arr. Swap = one
+    // store.
+    std::vector<nixlTelemetryEvent> eventBuffers_[2];
+    size_t maxEventsBuffered_{0};
+    std::atomic<size_t> writeIdx_{0};
+    std::atomic<int> writeBufIndex_{0};
     asio::thread_pool pool_;
     periodicTask writeTask_;
     std::string agentName_;

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -55,29 +55,25 @@ telemetryCategoryStr(const nixl_telemetry_category_t &category);
  * @brief A structure to hold individual telemetry event data for cyclic buffer storage
  */
 struct nixlTelemetryEvent {
-    uint64_t timestampUs_;
     nixl_telemetry_category_t category_; // Main event category for filtering
     char eventName_[MAX_EVENT_NAME_LEN]; // Detailed event name/identifier
     uint64_t value_; // Numeric value associated with the event
 
     nixlTelemetryEvent() noexcept = default;
 
-    nixlTelemetryEvent(uint64_t timestamp_us,
-                       nixl_telemetry_category_t category,
+    nixlTelemetryEvent(nixl_telemetry_category_t category,
                        const char *event_name,
                        uint64_t value) noexcept
-        : timestampUs_(timestamp_us),
-          category_(category),
+        : category_(category),
           value_(value) {
         strncpy(eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
         eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
     }
 
-    nixlTelemetryEvent(uint64_t timestamp_us,
-                       nixl_telemetry_category_t category,
+    nixlTelemetryEvent(nixl_telemetry_category_t category,
                        const std::string &event_name,
                        uint64_t value) noexcept
-        : nixlTelemetryEvent(timestamp_us, category, event_name.c_str(), value) {}
+        : nixlTelemetryEvent(category, event_name.c_str(), value) {}
 };
 
 #endif

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -18,6 +18,7 @@
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
 #include <cstdint>
+#include <cstring>
 
 #include <string>
 
@@ -27,6 +28,7 @@ constexpr char TELEMETRY_BUFFER_SIZE_VAR[] = "NIXL_TELEMETRY_BUFFER_SIZE";
 constexpr char TELEMETRY_RUN_INTERVAL_VAR[] = "NIXL_TELEMETRY_RUN_INTERVAL";
 
 constexpr inline int TELEMETRY_VERSION = 2;
+constexpr inline size_t MAX_EVENT_NAME_LEN = 32;
 
 /**
  * @enum nixl_telemetry_category_t
@@ -43,54 +45,9 @@ enum class nixl_telemetry_category_t {
     NIXL_TELEMETRY_CUSTOM = 7, // Custom/user-defined events
 };
 
-/**
- * @enum nixl_telemetry_event_name_t
- * @brief Enumerates all known telemetry event names, avoiding per-event string copies.
- */
-enum class nixl_telemetry_event_name_t : uint8_t {
-    AGENT_TX_BYTES = 0,
-    AGENT_RX_BYTES = 1,
-    AGENT_TX_REQUESTS_NUM = 2,
-    AGENT_RX_REQUESTS_NUM = 3,
-    AGENT_MEMORY_REGISTERED = 4,
-    AGENT_MEMORY_DEREGISTERED = 5,
-    AGENT_XFER_TIME = 6,
-    AGENT_XFER_POST_TIME = 7,
-    AGENT_ERROR = 8,
-    AGENT_BACKEND = 9,
-};
-
 namespace nixlEnumStrings {
 std::string
 telemetryCategoryStr(const nixl_telemetry_category_t &category);
-
-inline std::string
-telemetryEventNameStr(nixl_telemetry_event_name_t name) {
-    switch (name) {
-    case nixl_telemetry_event_name_t::AGENT_TX_BYTES:
-        return "agent_tx_bytes";
-    case nixl_telemetry_event_name_t::AGENT_RX_BYTES:
-        return "agent_rx_bytes";
-    case nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM:
-        return "agent_tx_requests_num";
-    case nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM:
-        return "agent_rx_requests_num";
-    case nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED:
-        return "agent_memory_registered";
-    case nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED:
-        return "agent_memory_deregistered";
-    case nixl_telemetry_event_name_t::AGENT_XFER_TIME:
-        return "agent_xfer_time";
-    case nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME:
-        return "agent_xfer_post_time";
-    case nixl_telemetry_event_name_t::AGENT_ERROR:
-        return "agent_error";
-    case nixl_telemetry_event_name_t::AGENT_BACKEND:
-        return "agent_backend";
-    default:
-        return "unknown_event";
-    }
-}
 }
 
 /**
@@ -99,17 +56,24 @@ telemetryEventNameStr(nixl_telemetry_event_name_t name) {
  */
 struct nixlTelemetryEvent {
     nixl_telemetry_category_t category_; // Main event category for filtering
-    nixl_telemetry_event_name_t eventName_; // Detailed event name/identifier
+    char eventName_[MAX_EVENT_NAME_LEN]; // Detailed event name/identifier
     uint64_t value_; // Numeric value associated with the event
 
     nixlTelemetryEvent() noexcept = default;
 
     nixlTelemetryEvent(nixl_telemetry_category_t category,
-                       nixl_telemetry_event_name_t event_name,
+                       const char *event_name,
                        uint64_t value) noexcept
         : category_(category),
-          eventName_(event_name),
-          value_(value) {}
+          value_(value) {
+        strncpy(eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
+        eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
+    }
+
+    nixlTelemetryEvent(nixl_telemetry_category_t category,
+                       const std::string &event_name,
+                       uint64_t value) noexcept
+        : nixlTelemetryEvent(category, event_name.c_str(), value) {}
 };
 
 #endif

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -18,7 +18,6 @@
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
 #include <cstdint>
-#include <cstring>
 
 #include <string>
 
@@ -27,8 +26,7 @@
 constexpr char TELEMETRY_BUFFER_SIZE_VAR[] = "NIXL_TELEMETRY_BUFFER_SIZE";
 constexpr char TELEMETRY_RUN_INTERVAL_VAR[] = "NIXL_TELEMETRY_RUN_INTERVAL";
 
-constexpr inline int TELEMETRY_VERSION = 1;
-constexpr inline size_t MAX_EVENT_NAME_LEN = 32;
+constexpr inline int TELEMETRY_VERSION = 2;
 
 /**
  * @enum nixl_telemetry_category_t
@@ -45,9 +43,43 @@ enum class nixl_telemetry_category_t {
     NIXL_TELEMETRY_CUSTOM = 7, // Custom/user-defined events
 };
 
+/**
+ * @enum nixl_telemetry_event_name_t
+ * @brief Enumerates all known telemetry event names, avoiding per-event string copies.
+ */
+enum class nixl_telemetry_event_name_t : uint8_t {
+    AGENT_TX_BYTES = 0,
+    AGENT_RX_BYTES = 1,
+    AGENT_TX_REQUESTS_NUM = 2,
+    AGENT_RX_REQUESTS_NUM = 3,
+    AGENT_MEMORY_REGISTERED = 4,
+    AGENT_MEMORY_DEREGISTERED = 5,
+    AGENT_XFER_TIME = 6,
+    AGENT_XFER_POST_TIME = 7,
+    AGENT_ERROR = 8,
+    AGENT_BACKEND = 9,
+};
+
 namespace nixlEnumStrings {
 std::string
 telemetryCategoryStr(const nixl_telemetry_category_t &category);
+
+inline std::string
+telemetryEventNameStr(nixl_telemetry_event_name_t name) {
+    switch (name) {
+    case nixl_telemetry_event_name_t::AGENT_TX_BYTES:            return "agent_tx_bytes";
+    case nixl_telemetry_event_name_t::AGENT_RX_BYTES:            return "agent_rx_bytes";
+    case nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM:     return "agent_tx_requests_num";
+    case nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM:     return "agent_rx_requests_num";
+    case nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED:   return "agent_memory_registered";
+    case nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED: return "agent_memory_deregistered";
+    case nixl_telemetry_event_name_t::AGENT_XFER_TIME:           return "agent_xfer_time";
+    case nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME:      return "agent_xfer_post_time";
+    case nixl_telemetry_event_name_t::AGENT_ERROR:               return "agent_error";
+    case nixl_telemetry_event_name_t::AGENT_BACKEND:             return "agent_backend";
+    default:                                                      return "unknown_event";
+    }
+}
 }
 
 /**
@@ -56,24 +88,17 @@ telemetryCategoryStr(const nixl_telemetry_category_t &category);
  */
 struct nixlTelemetryEvent {
     nixl_telemetry_category_t category_; // Main event category for filtering
-    char eventName_[MAX_EVENT_NAME_LEN]; // Detailed event name/identifier
+    nixl_telemetry_event_name_t eventName_; // Detailed event name/identifier
     uint64_t value_; // Numeric value associated with the event
 
     nixlTelemetryEvent() noexcept = default;
 
     nixlTelemetryEvent(nixl_telemetry_category_t category,
-                       const char *event_name,
+                       nixl_telemetry_event_name_t event_name,
                        uint64_t value) noexcept
         : category_(category),
-          value_(value) {
-        strncpy(eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
-        eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
-    }
-
-    nixlTelemetryEvent(nixl_telemetry_category_t category,
-                       const std::string &event_name,
-                       uint64_t value) noexcept
-        : nixlTelemetryEvent(category, event_name.c_str(), value) {}
+          eventName_(event_name),
+          value_(value) {}
 };
 
 #endif

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -67,17 +67,28 @@ telemetryCategoryStr(const nixl_telemetry_category_t &category);
 inline std::string
 telemetryEventNameStr(nixl_telemetry_event_name_t name) {
     switch (name) {
-    case nixl_telemetry_event_name_t::AGENT_TX_BYTES:            return "agent_tx_bytes";
-    case nixl_telemetry_event_name_t::AGENT_RX_BYTES:            return "agent_rx_bytes";
-    case nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM:     return "agent_tx_requests_num";
-    case nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM:     return "agent_rx_requests_num";
-    case nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED:   return "agent_memory_registered";
-    case nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED: return "agent_memory_deregistered";
-    case nixl_telemetry_event_name_t::AGENT_XFER_TIME:           return "agent_xfer_time";
-    case nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME:      return "agent_xfer_post_time";
-    case nixl_telemetry_event_name_t::AGENT_ERROR:               return "agent_error";
-    case nixl_telemetry_event_name_t::AGENT_BACKEND:             return "agent_backend";
-    default:                                                      return "unknown_event";
+    case nixl_telemetry_event_name_t::AGENT_TX_BYTES:
+        return "agent_tx_bytes";
+    case nixl_telemetry_event_name_t::AGENT_RX_BYTES:
+        return "agent_rx_bytes";
+    case nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM:
+        return "agent_tx_requests_num";
+    case nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM:
+        return "agent_rx_requests_num";
+    case nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED:
+        return "agent_memory_registered";
+    case nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED:
+        return "agent_memory_deregistered";
+    case nixl_telemetry_event_name_t::AGENT_XFER_TIME:
+        return "agent_xfer_time";
+    case nixl_telemetry_event_name_t::AGENT_XFER_POST_TIME:
+        return "agent_xfer_post_time";
+    case nixl_telemetry_event_name_t::AGENT_ERROR:
+        return "agent_error";
+    case nixl_telemetry_event_name_t::AGENT_BACKEND:
+        return "agent_backend";
+    default:
+        return "unknown_event";
     }
 }
 }

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -124,7 +124,7 @@ nixlTelemetryPrometheusExporter::registerGauge(const std::string &name,
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
-        const std::string event_name = nixlEnumStrings::telemetryEventNameStr(event.eventName_);
+        const std::string event_name(event.eventName_);
 
         switch (event.category_) {
         case nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER:

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -124,7 +124,7 @@ nixlTelemetryPrometheusExporter::registerGauge(const std::string &name,
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
-        const std::string event_name(event.eventName_);
+        const std::string event_name = nixlEnumStrings::telemetryEventNameStr(event.eventName_);
 
         switch (event.category_) {
         case nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER:

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -151,46 +151,46 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_EQ(buffer->full(), false);
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM);
+    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM);
+    EXPECT_STREQ(event.eventName_, "agent_rx_requests_num");
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_ERROR);
+    EXPECT_STREQ(event.eventName_, "agent_error");
     EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED);
+    EXPECT_STREQ(event.eventName_, "agent_memory_registered");
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED);
+    EXPECT_STREQ(event.eventName_, "agent_memory_deregistered");
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_XFER_TIME);
+    EXPECT_STREQ(event.eventName_, "agent_xfer_time");
     EXPECT_EQ(event.value_, 100);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
     EXPECT_EQ(event.value_, 2000);
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM);
+    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
     EXPECT_EQ(event.value_, 1);
     envHelper_.popVar();
 }
 
 TEST_F(telemetryTest, TelemetryEventStructure) {
     nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                              nixl_telemetry_event_name_t::AGENT_TX_BYTES,
+                              "agent_tx_bytes",
                               42);
 
     EXPECT_EQ(event1.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
     EXPECT_EQ(event1.value_, 42);
-    EXPECT_EQ(event1.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
+    EXPECT_STREQ(event1.eventName_, "agent_tx_bytes");
 }
 
 TEST_F(telemetryTest, ShortRunInterval) {
@@ -315,11 +315,11 @@ TEST_F(telemetryTest, TelemetryAgentEventsOne) {
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     envHelper_.popVar();
@@ -346,11 +346,11 @@ TEST_F(telemetryTest, TelemetryAgentEventsTwo) {
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
+    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_ERROR);
+    EXPECT_STREQ(event.eventName_, "agent_error");
     EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR);
 

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -138,13 +138,14 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_NO_THROW(telemetry.updateErrorCount(nixl_status_t::NIXL_ERR_BACKEND));
     EXPECT_NO_THROW(telemetry.updateMemoryRegistered(1024));
     EXPECT_NO_THROW(telemetry.updateMemoryDeregistered(1024));
-    EXPECT_NO_THROW(telemetry.addXferTime(std::chrono::microseconds(100), true, 2000));
+    EXPECT_NO_THROW(telemetry.addTransferComplete(std::chrono::microseconds(50),
+                                                  std::chrono::microseconds(100), true, 2000));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     auto path = testDir_.string() + "/" + testFile_;
     auto buffer =
         std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(path, false, TELEMETRY_VERSION);
-    EXPECT_EQ(buffer->size(), 10);
+    EXPECT_EQ(buffer->size(), 11);
     EXPECT_EQ(buffer->version(), TELEMETRY_VERSION);
     EXPECT_EQ(buffer->capacity(), capacity_);
     EXPECT_EQ(buffer->empty(), false);
@@ -171,6 +172,9 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     buffer->pop(event);
     EXPECT_STREQ(event.eventName_, "agent_memory_deregistered");
     EXPECT_EQ(event.value_, 1024);
+    buffer->pop(event);
+    EXPECT_STREQ(event.eventName_, "agent_xfer_post_time");
+    EXPECT_EQ(event.value_, 50);
     buffer->pop(event);
     EXPECT_STREQ(event.eventName_, "agent_xfer_time");
     EXPECT_EQ(event.value_, 100);

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -151,45 +151,46 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_EQ(buffer->full(), false);
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_BYTES);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_requests_num");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_,
-                 nixlEnumStrings::statusStr(nixl_status_t::NIXL_ERR_BACKEND).c_str());
-    EXPECT_EQ(event.value_, 1);
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_ERROR);
+    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_memory_registered");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_MEMORY_REGISTERED);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_memory_deregistered");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_MEMORY_DEREGISTERED);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_xfer_time");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_XFER_TIME);
     EXPECT_EQ(event.value_, 100);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.value_, 2000);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     envHelper_.popVar();
 }
 
 TEST_F(telemetryTest, TelemetryEventStructure) {
-    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, "test_event", 42);
+    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                              nixl_telemetry_event_name_t::AGENT_TX_BYTES,
+                              42);
 
     EXPECT_EQ(event1.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
     EXPECT_EQ(event1.value_, 42);
-    EXPECT_STREQ(event1.eventName_, "test_event");
+    EXPECT_EQ(event1.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
 }
 
 TEST_F(telemetryTest, ShortRunInterval) {
@@ -314,11 +315,11 @@ TEST_F(telemetryTest, TelemetryAgentEventsOne) {
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_RX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     envHelper_.popVar();
@@ -336,21 +337,21 @@ TEST_F(telemetryTest, TelemetryAgentEventsTwo) {
     // Wait for the telemetry to be written
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    // Verify that both agent and backend events are written
+    // Verify that only agent events are written (no backend events)
     auto path = testDir_.string() + "/" + testFile_;
     auto buffer =
         std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(path, false, TELEMETRY_VERSION);
 
-    EXPECT_EQ(buffer->size(), 2); // 2 agent events
+    EXPECT_EQ(buffer->size(), 2);
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_,
-                 nixlEnumStrings::statusStr(nixl_status_t::NIXL_ERR_BACKEND).c_str());
+    EXPECT_EQ(event.eventName_, nixl_telemetry_event_name_t::AGENT_ERROR);
+    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR);
 
     envHelper_.popVar();

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -185,10 +185,8 @@ TEST_F(telemetryTest, TransferBytesTracking) {
 }
 
 TEST_F(telemetryTest, TelemetryEventStructure) {
-    nixlTelemetryEvent event1(
-        1234567890, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, "test_event", 42);
+    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, "test_event", 42);
 
-    EXPECT_EQ(event1.timestampUs_, 1234567890);
     EXPECT_EQ(event1.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
     EXPECT_EQ(event1.value_, 42);
     EXPECT_STREQ(event1.eventName_, "test_event");

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -138,8 +138,8 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_NO_THROW(telemetry.updateErrorCount(nixl_status_t::NIXL_ERR_BACKEND));
     EXPECT_NO_THROW(telemetry.updateMemoryRegistered(1024));
     EXPECT_NO_THROW(telemetry.updateMemoryDeregistered(1024));
-    EXPECT_NO_THROW(telemetry.addTransferComplete(std::chrono::microseconds(50),
-                                                  std::chrono::microseconds(100), true, 2000));
+    EXPECT_NO_THROW(telemetry.addTransferComplete(
+        std::chrono::microseconds(50), std::chrono::microseconds(100), true, 2000));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     auto path = testDir_.string() + "/" + testFile_;
@@ -188,9 +188,8 @@ TEST_F(telemetryTest, TransferBytesTracking) {
 }
 
 TEST_F(telemetryTest, TelemetryEventStructure) {
-    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
-                              "agent_tx_bytes",
-                              42);
+    nixlTelemetryEvent event1(
+        nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, "agent_tx_bytes", 42);
 
     EXPECT_EQ(event1.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
     EXPECT_EQ(event1.value_, 42);


### PR DESCRIPTION
Replaces the previous mutex-protected single event queue with a **lock-free double buffer** for telemetry events. One buffer is written by producers (agent threads calling `updateData` / `addXferTime`); the periodic write task drains the other buffer and exports events. When the active buffer reaches capacity it is marked full; producers skip appending until the next drain (no blocking, no mutex).


- **Lower latency on the hot path:** Telemetry is in the data path; a mutex in `updateData`/`addXferTime` can add contention and tail latency under load.
- **Avoid blocking producers:** Under heavy load, if the consumer is slow, the old design could block all producers. This design keeps producers non-blocking: they either append or skip.

Trade-off: under sustained overload, some events are dropped instead of backing up and blocking.

- **Two fixed buffers** (`event_buffers_[2]`): at any time, producers write to the buffer indexed by `write_buffer_index_`; the write task drains the other buffer.
- **Lock-free coordination:** `write_buffer_index_`, `write_idx_`, and `full_` are atomics. Producers use `fetch_add` on `write_idx_` to reserve a slot; if the buffer is already full they return without blocking.
- **Drain step:** In `writeEventHelper()`, the consumer sets `full_` (blocking new writes to the current buffer), swaps the active buffer with `write_buffer_index_`, resets `write_idx_` for the new buffer, drains the old buffer to the exporter, then (conceptually) allows writes again to the new buffer.
- **Skip-when-full:** In `updateData`/`addXferTime`, if `full_.load()` is true or the reserved index is past the buffer size, the call returns immediately and the event is dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Telemetry redesigned for lower contention and higher throughput using lock-free double-buffering and batched writes.

* **New Features**
  * Added a consolidated “transfer complete” telemetry event API and a public recording flag to control telemetry state.

* **Bug Fixes / Behavior**
  * Telemetry is only active when an exporter is configured; bookkeeping and per-transfer reporting are gated and will warn when disabled.

* **Behavior Change**
  * Per-event timestamps removed from telemetry events and reader output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->