### PR TITLE
libfabric: fix logging when it retries

### DIFF
--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -709,6 +709,28 @@ nixlLibfabricRail::setXferIdCallback(std::function<void(uint32_t)> callback) {
     xferIdCallback = callback;
 }
 
+
+namespace {
+
+// Helper function to handle exponential backoff logging for retry operations
+inline void
+logRetryAttempt(unsigned int attempt,
+                unsigned int &log_threshold,
+                const char *operation_name,
+                uint16_t rail_id) {
+    if (attempt == log_threshold ||
+        (attempt > INT_MAX / 2 && attempt % NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS == 0)) {
+        NIXL_INFO << operation_name << " still retrying EAGAIN on rail " << rail_id << " after "
+                  << attempt << " attempts";
+        if (log_threshold <= INT_MAX / 2) {
+            log_threshold *= 2;
+        }
+    }
+}
+
+}  // namespace
+
+
 // Per-rail completion processing - handles one rail's CQ with configurable blocking behavior
 nixl_status_t
 nixlLibfabricRail::progressCompletionQueue() const {
@@ -1038,7 +1060,8 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
 
     // Retry indefinitely until senddata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
-    int attempt = 0;
+    unsigned int attempt = 0;
+    unsigned int log_threshold = NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS;
 
     while (true) {
         // Libfabric fi_senddata call
@@ -1065,14 +1088,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
             // Resource temporarily unavailable - retry indefinitely for all providers
             attempt++;
 
-            // Log every N attempts to avoid log spam
-            if (attempt % NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS == 0) {
-                NIXL_INFO << "fi_senddata still retrying EAGAIN on rail " << rail_id << " after "
-                          << attempt << " attempts";
-            } else {
-                NIXL_TRACE << "fi_senddata returned EAGAIN on rail " << rail_id
-                           << ", retrying (attempt " << attempt << ")";
-            }
+            logRetryAttempt(attempt, log_threshold, "fi_senddata", rail_id);
 
             // Progress completion queue to drain pending completions before retry
             if (!progress_thread_enabled_) {
@@ -1120,7 +1136,8 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
 
     // Retry indefinitely until writedata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
-    int attempt = 0;
+    unsigned int attempt = 0;
+    unsigned int log_threshold = NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS;
 
     while (true) {
         // Libfabric fi_writedata call
@@ -1149,14 +1166,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
             // Resource temporarily unavailable - retry indefinitely for all providers
             attempt++;
 
-            // Log every N attempts to avoid log spam
-            if (attempt % NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS == 0) {
-                NIXL_INFO << "fi_writedata still retrying EAGAIN on rail " << rail_id << " after "
-                          << attempt << " attempts";
-            } else {
-                NIXL_TRACE << "fi_writedata returned EAGAIN on rail " << rail_id
-                           << ", retrying (attempt " << attempt << ")";
-            }
+            logRetryAttempt(attempt, log_threshold, "fi_writedata", rail_id);
 
             // Progress completion queue to drain pending completions before retry
             if (!progress_thread_enabled_) {
@@ -1203,7 +1213,8 @@ nixlLibfabricRail::postRead(void *local_buffer,
 
     // Retry indefinitely until readdata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
-    int attempt = 0;
+    unsigned int attempt = 0;
+    unsigned int log_threshold = NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS;
 
     while (true) {
         // Libfabric fi_read call
@@ -1231,14 +1242,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
             // Resource temporarily unavailable - retry indefinitely for all providers
             attempt++;
 
-            // Log every N attempts to avoid log spam
-            if (attempt % NIXL_LIBFABRIC_LOG_INTERVAL_ATTEMPTS == 0) {
-                NIXL_INFO << "fi_read still retrying EAGAIN on rail " << rail_id << " after "
-                          << attempt << " attempts";
-            } else {
-                NIXL_TRACE << "fi_read returned EAGAIN on rail " << rail_id
-                           << ", retrying (attempt " << attempt << ")";
-            }
+            logRetryAttempt(attempt, log_threshold, "fi_read", rail_id);
 
             // Progress completion queue to drain pending completions before retry
             if (!progress_thread_enabled_) {


### PR DESCRIPTION
Today when retries happen, at 1 per 100 attempts, it floods the log. This change makes exponentially backoff logging until INT_MAX / 2,  and then logging at regular interval because that's already bad enough to indicate a bigger issue.

## What?
Busy retrying at initialization can take 1 - 2 seconds on some platforms. It floods the log when that's done at 1 per 100 attempts. E.g.
I0317 18:48:10.397101  162355 libfabric_rail.cpp:1202] fi_read still retrying EAGAIN on rail 0 after 100 attempts
...
I0317 18:48:12.180008  162355 libfabric_rail.cpp:1202] fi_read still retrying EAGAIN on rail 0 after 6553600 attempts

## Why?
Makes one hard to scroll in logs.

## How?
Logging only at iterations of power of (100 *) 2 until INT_MAX /2 (over 2 billion). If it's still retrying after that point, just let it be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor & Optimization**
  * Reduced logging verbosity during prolonged retry loops to minimize log spam and surface more actionable messages.
  * Centralized and standardized retry logging with an exponential backoff so entries appear less frequently and at predictable intervals.
  * Adjusted retry counter handling for more consistent and robust retry behavior, improving observability and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->