### PR TITLE
Add Dell ObjectScale accelerated engine support to plugin_gtest for OBJ plugin.

### DIFF
--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __MEMORY_HANDLER_H
-#define __MEMORY_HANDLER_H
+#ifndef NIXL_TEST_GTEST_PLUGINS_MEMORY_HANDLER_H
+#define NIXL_TEST_GTEST_PLUGINS_MEMORY_HANDLER_H
 
 #include <absl/strings/str_format.h>
 #include "backend/backend_aux.h"
@@ -258,4 +258,4 @@ private:
 #endif // HAVE_CUDA
 
 } // namespace gtest::plugins
-#endif // __MEMORY_HANDLER_H
+#endif // NIXL_TEST_GTEST_PLUGINS_MEMORY_HANDLER_H

--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -18,6 +18,7 @@
 #define NIXL_TEST_GTEST_PLUGINS_MEMORY_HANDLER_H
 
 #include <absl/strings/str_format.h>
+#include <stdexcept>
 #include "backend/backend_aux.h"
 #include "backend_engine.h"
 #include "common/nixl_log.h"

--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -142,14 +142,30 @@ private:
 template<> class memoryHandler<VRAM_SEG> {
 public:
     memoryHandler(size_t len, int dev_id) : buf_(nullptr), len_(len), devId_(dev_id), md_(nullptr) {
-        cudaSetDevice(dev_id);
-        cudaMalloc(&buf_, len_);
+        cudaError_t err = cudaSetDevice(dev_id);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaSetDevice(" << dev_id << ") failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaSetDevice failed");
+        }
+        err = cudaMalloc(&buf_, len_);
+        if (err != cudaSuccess) {
+            buf_ = nullptr;
+            NIXL_ERROR << "cudaMalloc(" << len_ << ") failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaMalloc failed");
+        }
     }
 
     ~memoryHandler() {
         if (buf_) {
-            cudaSetDevice(devId_);
-            cudaFree(buf_);
+            cudaError_t err = cudaSetDevice(devId_);
+            if (err != cudaSuccess) {
+                NIXL_ERROR << "cudaSetDevice(" << devId_
+                           << ") failed in destructor: " << cudaGetErrorString(err);
+            }
+            err = cudaFree(buf_);
+            if (err != cudaSuccess) {
+                NIXL_ERROR << "cudaFree failed: " << cudaGetErrorString(err);
+            }
         }
     }
 
@@ -158,15 +174,31 @@ public:
         std::vector<uint8_t> host(len_);
         for (auto &entry : host)
             entry = start_byte++;
-        cudaSetDevice(devId_);
-        cudaMemcpy(buf_, host.data(), len_, cudaMemcpyHostToDevice);
+        cudaError_t err = cudaSetDevice(devId_);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaSetDevice(" << devId_ << ") failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaSetDevice failed");
+        }
+        err = cudaMemcpy(buf_, host.data(), len_, cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaMemcpy H2D failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaMemcpy failed");
+        }
     }
 
     bool
     checkIncreasing(uint8_t start_byte) {
         std::vector<uint8_t> host(len_);
-        cudaSetDevice(devId_);
-        cudaMemcpy(host.data(), buf_, len_, cudaMemcpyDeviceToHost);
+        cudaError_t err = cudaSetDevice(devId_);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaSetDevice(" << devId_ << ") failed: " << cudaGetErrorString(err);
+            return false;
+        }
+        err = cudaMemcpy(host.data(), buf_, len_, cudaMemcpyDeviceToHost);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaMemcpy D2H failed: " << cudaGetErrorString(err);
+            return false;
+        }
         for (auto &entry : host) {
             uint8_t expected_byte = start_byte++;
             if (entry != expected_byte) {
@@ -180,8 +212,16 @@ public:
 
     void
     reset() {
-        cudaSetDevice(devId_);
-        cudaMemset(buf_, 0x00, len_);
+        cudaError_t err = cudaSetDevice(devId_);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaSetDevice(" << devId_ << ") failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaSetDevice failed");
+        }
+        err = cudaMemset(buf_, 0x00, len_);
+        if (err != cudaSuccess) {
+            NIXL_ERROR << "cudaMemset failed: " << cudaGetErrorString(err);
+            throw std::runtime_error("cudaMemset failed");
+        }
     }
 
     void

--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,10 @@
 #include "backend_engine.h"
 #include "common/nixl_log.h"
 #include "nixl.h"
+
+#ifdef HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
 
 namespace gtest::plugins {
 
@@ -126,6 +130,92 @@ private:
     int devId_;
     nixlBackendMD *md_;
 };
+
+#ifdef HAVE_CUDA
+/**
+ * @brief Memory handler specialization for GPU (VRAM) memory segments.
+ *
+ * Manages CUDA device memory allocation and transfers. Uses host-side staging
+ * buffers for data initialization (setIncreasing) and verification (checkIncreasing),
+ * copying between host and device via cudaMemcpy.
+ */
+template<> class memoryHandler<VRAM_SEG> {
+public:
+    memoryHandler(size_t len, int dev_id) : buf_(nullptr), len_(len), devId_(dev_id), md_(nullptr) {
+        cudaSetDevice(dev_id);
+        cudaMalloc(&buf_, len_);
+    }
+
+    ~memoryHandler() {
+        if (buf_) {
+            cudaSetDevice(devId_);
+            cudaFree(buf_);
+        }
+    }
+
+    void
+    setIncreasing(uint8_t start_byte) {
+        std::vector<uint8_t> host(len_);
+        for (auto &entry : host)
+            entry = start_byte++;
+        cudaSetDevice(devId_);
+        cudaMemcpy(buf_, host.data(), len_, cudaMemcpyHostToDevice);
+    }
+
+    bool
+    checkIncreasing(uint8_t start_byte) {
+        std::vector<uint8_t> host(len_);
+        cudaSetDevice(devId_);
+        cudaMemcpy(host.data(), buf_, len_, cudaMemcpyDeviceToHost);
+        for (auto &entry : host) {
+            uint8_t expected_byte = start_byte++;
+            if (entry != expected_byte) {
+                NIXL_ERROR << "Verification failed! local: " << entry
+                           << ", expected: " << expected_byte;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void
+    reset() {
+        cudaSetDevice(devId_);
+        cudaMemset(buf_, 0x00, len_);
+    }
+
+    void
+    populateBlobDesc(nixlBlobDesc *desc, int buf_index = 0) {
+        desc->addr = reinterpret_cast<uintptr_t>(buf_);
+        desc->len = len_;
+        desc->devId = devId_;
+    }
+
+    void
+    populateMetaDesc(nixlMetaDesc *desc, int entry_index, size_t entry_size) {
+        desc->addr = reinterpret_cast<uintptr_t>(buf_) + entry_index * entry_size;
+        desc->len = entry_size;
+        desc->devId = devId_;
+        desc->metadataP = md_;
+    }
+
+    void
+    setMD(nixlBackendMD *md) {
+        md_ = md;
+    }
+
+    nixlBackendMD *
+    getMD() {
+        return md_;
+    }
+
+private:
+    void *buf_;
+    size_t len_;
+    int devId_;
+    nixlBackendMD *md_;
+};
+#endif // HAVE_CUDA
 
 } // namespace gtest::plugins
 #endif // __MEMORY_HANDLER_H

--- a/test/gtest/plugins/memory_handler.h
+++ b/test/gtest/plugins/memory_handler.h
@@ -170,6 +170,10 @@ public:
         }
     }
 
+    memoryHandler(const memoryHandler &) = delete;
+    memoryHandler &
+    operator=(const memoryHandler &) = delete;
+
     void
     setIncreasing(uint8_t start_byte) {
         std::vector<uint8_t> host(len_);

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -44,8 +44,13 @@ if cuda_dep.found()
     plugins_gtest_cuda_deps = [cuda_dep]
 endif
 
+plugins_gtest_sources = ['../main.cpp', '../common.cpp', 'obj_plugin.cpp']
+if cuobj_dep.found()
+    plugins_gtest_sources += 'obj_cuobj_plugin.cpp'
+endif
+
 plugins_test_exe = executable('plugins_gtest',
-    sources : ['../main.cpp', '../common.cpp', 'obj_plugin.cpp'],
+    sources : plugins_gtest_sources,
     include_directories: [nixl_inc_dirs, utils_inc_dirs, plugins_inc_dirs, '.'],
     cpp_args : plugins_gtest_cpp_flags,
     dependencies : [nixl_dep, gtest_dep, absl_strings_dep, absl_time_dep, plugin_deps,

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -37,11 +37,19 @@ if not aws_s3_crt.found()
     subdir_done()
 endif
 
+plugins_gtest_cpp_flags = []
+plugins_gtest_cuda_deps = []
+if cuda_dep.found()
+    plugins_gtest_cpp_flags += '-DHAVE_CUDA'
+    plugins_gtest_cuda_deps = [cuda_dep]
+endif
+
 plugins_test_exe = executable('plugins_gtest',
     sources : ['../main.cpp', '../common.cpp', 'obj_plugin.cpp'],
     include_directories: [nixl_inc_dirs, utils_inc_dirs, plugins_inc_dirs, '.'],
+    cpp_args : plugins_gtest_cpp_flags,
     dependencies : [nixl_dep, gtest_dep, absl_strings_dep, absl_time_dep, plugin_deps,
-                    obj_backend_interface],
+                    obj_backend_interface] + plugins_gtest_cuda_deps,
     link_with: [nixl_build_lib],
     install : true
 )

--- a/test/gtest/plugins/obj_cuobj_plugin.cpp
+++ b/test/gtest/plugins/obj_cuobj_plugin.cpp
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined HAVE_CUOBJ_CLIENT
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+#include "plugins_common.h"
+#include "transfer_handler.h"
+#include "obj/obj_backend.h"
+
+namespace gtest::plugins::obj {
+
+nixl_b_params_t obj_accel_params = {{"accelerated", "true"}};
+nixl_b_params_t obj_dell_params = {{"accelerated", "true"},
+                                   {"type", "dell"},
+                                   {"req_checksum", "required"},
+                                   {"scheme", "http"}};
+const std::string accel_agent_name = "Agent3-Accel";
+const std::string dell_agent_name = "Agent4-Dell";
+
+const nixlBackendInitParams obj_accel_test_params = {.localAgent = accel_agent_name,
+                                                     .type = "OBJ",
+                                                     .customParams = &obj_accel_params,
+                                                     .enableProgTh = false,
+                                                     .pthrDelay = 0,
+                                                     .syncMode =
+                                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
+
+const nixlBackendInitParams obj_dell_test_params = {.localAgent = dell_agent_name,
+                                                    .type = "OBJ",
+                                                    .customParams = &obj_dell_params,
+                                                    .enableProgTh = false,
+                                                    .pthrDelay = 0,
+                                                    .syncMode =
+                                                        nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
+
+// Separate test suite for S3 Accelerated client with accelerated=true
+// Note: These tests require the cuobjclient library to be available at compile time
+class setupObjAccelTestFixture : public setupBackendTestFixture {
+protected:
+    setupObjAccelTestFixture() {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (endpoint && endpoint[0] != '\0') {
+            obj_accel_params["endpoint_override"] = endpoint;
+            obj_accel_params["req_checksum"] = "required";
+        }
+        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+    }
+};
+
+TEST_P(setupObjAccelTestFixture, AccelXferTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 1);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjAccelTestFixture, AccelXferMultiBufsTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjAccelTestFixture, AccelQueryMemTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+
+    nixl_reg_dlist_t descs(OBJ_SEG);
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-0"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-1"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-nonexistent"));
+    std::vector<nixl_query_resp_t> resp;
+    localBackendEngine_->queryMem(descs, resp);
+
+    EXPECT_EQ(resp.size(), 3);
+    EXPECT_EQ(resp[0].has_value(), true);
+    EXPECT_EQ(resp[1].has_value(), true);
+    EXPECT_EQ(resp[2].has_value(), false);
+}
+
+INSTANTIATE_TEST_SUITE_P(ObjAccelTests,
+                         setupObjAccelTestFixture,
+                         testing::Values(obj_accel_test_params));
+
+/**
+ * @brief Test fixture for Dell ObjectScale S3 over RDMA engine.
+ *
+ * Reads the NIXL_OBJ_ENDPOINT_OVERRIDE environment variable to configure
+ * the Dell ObjectScale endpoint. Tests are skipped if the variable is not set.
+ * Requires cuobjclient library (HAVE_CUOBJ_CLIENT).
+ */
+class setupObjDellTestFixture : public setupBackendTestFixture {
+protected:
+    setupObjDellTestFixture() {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (endpoint && endpoint[0] != '\0') {
+            obj_dell_params["endpoint_override"] = endpoint;
+            localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+        }
+    }
+
+    void
+    SetUp() override {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (!endpoint || endpoint[0] == '\0') {
+            GTEST_SKIP() << "NIXL_OBJ_ENDPOINT_OVERRIDE not set, skipping Dell tests";
+        }
+        setupBackendTestFixture::SetUp();
+    }
+};
+
+TEST_P(setupObjDellTestFixture, DellXferTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjDellTestFixture, DellXferMultiBufsTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjDellTestFixture, DellQueryMemTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+
+    nixl_reg_dlist_t descs(OBJ_SEG);
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-0"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-1"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-nonexistent"));
+    std::vector<nixl_query_resp_t> resp;
+    localBackendEngine_->queryMem(descs, resp);
+
+    EXPECT_EQ(resp.size(), 3);
+    EXPECT_EQ(resp[0].has_value(), true);
+    EXPECT_EQ(resp[1].has_value(), true);
+    EXPECT_EQ(resp[2].has_value(), false);
+}
+
+#ifdef HAVE_CUDA
+// GPU memory (VRAM_SEG) transfer test for Dell ObjectScale RDMA engine.
+// Exercises the VRAM-specific code paths: cuMemObjGetDescriptor/PutDescriptor for
+// RDMA descriptor registration, and putObjectRdmaAsync/getObjectRdmaAsync for
+// GPU-direct RDMA transfers.
+TEST_P(setupObjDellTestFixture, DellVramXferTest) {
+    transferHandler<VRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+#endif // HAVE_CUDA
+
+INSTANTIATE_TEST_SUITE_P(ObjDellTests,
+                         setupObjDellTestFixture,
+                         testing::Values(obj_dell_test_params));
+
+} // namespace gtest::plugins::obj
+
+#endif // HAVE_CUOBJ_CLIENT

--- a/test/gtest/plugins/obj_cuobj_plugin.cpp
+++ b/test/gtest/plugins/obj_cuobj_plugin.cpp
@@ -24,6 +24,10 @@
 #include "transfer_handler.h"
 #include "obj/obj_backend.h"
 
+#ifdef HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 namespace gtest::plugins::obj {
 
 nixl_b_params_t obj_accel_params = {{"accelerated", "true"}};
@@ -54,13 +58,18 @@ const nixlBackendInitParams obj_dell_test_params = {.localAgent = dell_agent_nam
 // Note: These tests require the cuobjclient library to be available at compile time
 class setupObjAccelTestFixture : public setupBackendTestFixture {
 protected:
+    nixl_b_params_t localParams_;
+
     setupObjAccelTestFixture() {
+        localParams_ = *GetParam().customParams;
         const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
         if (endpoint && endpoint[0] != '\0') {
-            obj_accel_params["endpoint_override"] = endpoint;
-            obj_accel_params["req_checksum"] = "required";
+            localParams_["endpoint_override"] = endpoint;
+            localParams_["req_checksum"] = "required";
         }
-        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+        nixlBackendInitParams initParams = GetParam();
+        initParams.customParams = &localParams_;
+        localBackendEngine_ = std::make_shared<nixlObjEngine>(&initParams);
     }
 };
 
@@ -116,11 +125,16 @@ INSTANTIATE_TEST_SUITE_P(ObjAccelTests,
  */
 class setupObjDellTestFixture : public setupBackendTestFixture {
 protected:
+    nixl_b_params_t localParams_;
+
     setupObjDellTestFixture() {
+        localParams_ = *GetParam().customParams;
         const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
         if (endpoint && endpoint[0] != '\0') {
-            obj_dell_params["endpoint_override"] = endpoint;
-            localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+            localParams_["endpoint_override"] = endpoint;
+            nixlBackendInitParams initParams = GetParam();
+            initParams.customParams = &localParams_;
+            localBackendEngine_ = std::make_shared<nixlObjEngine>(&initParams);
         }
     }
 
@@ -179,6 +193,11 @@ TEST_P(setupObjDellTestFixture, DellQueryMemTest) {
 // RDMA descriptor registration, and putObjectRdmaAsync/getObjectRdmaAsync for
 // GPU-direct RDMA transfers.
 TEST_P(setupObjDellTestFixture, DellVramXferTest) {
+    int device_count = 0;
+    cudaError_t err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "No CUDA devices available, skipping VRAM test";
+    }
     transferHandler<VRAM_SEG, OBJ_SEG> transfer(
         localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
     transfer.setLocalMem();

--- a/test/gtest/plugins/obj_plugin.cpp
+++ b/test/gtest/plugins/obj_plugin.cpp
@@ -33,34 +33,31 @@ namespace gtest::plugins::obj {
  * These variables are required for authenticating and interacting with the S3 bucket
  * used during the tests.
  *
- * For Dell ObjectScale tests, the following additional environment variable is required:
- *       - NIXL_OBJ_ENDPOINT_OVERRIDE  (e.g. http://100.68.213.151:9020)
- *
  * Test suites:
  * - ObjTests: Standard S3 client tests (crtMinLimit = 0)
  * - ObjCrtTests: S3 CRT client tests (crtMinLimit = 5 MiB, buffer = 10 MiB)
  *                crtMinLimit is set to the S3 minimum part size (5 MiB) so that
  *                partSize is not clamped and MPU is exercised with multiple parts.
  * - ObjAccelTests: S3 Accelerated client tests (accelerated = true)
- *                  Note: Only compiled if HAVE_CUOBJ_CLIENT is defined
+ *                  Note: Defined in obj_cuobj_plugin.cpp, only compiled if
+ *                  HAVE_CUOBJ_CLIENT is defined
  * - ObjDellTests: Dell ObjectScale S3 over RDMA tests
  *                 (accelerated = true, type = dell, req_checksum = required, scheme = http)
- *                 Note: Only compiled if HAVE_CUOBJ_CLIENT is defined.
+ *                 Note: Defined in obj_cuobj_plugin.cpp, only compiled if
+ *                 HAVE_CUOBJ_CLIENT is defined.
  *                 Skipped at runtime if NIXL_OBJ_ENDPOINT_OVERRIDE is not set.
  *                 Includes DellVramXferTest (GPU memory) if HAVE_CUDA is also defined.
+ *
+ * Environment:
+ *       - NIXL_OBJ_ENDPOINT_OVERRIDE  (e.g. http://100.68.213.151:9020)
+ *         Optional for all test suites. When set, overrides the S3 endpoint for
+ *         Standard, CRT, Accel, and Dell tests alike.
  */
 
 nixl_b_params_t obj_params = {{"crtMinLimit", "0"}};
 nixl_b_params_t obj_crt_params = {{"crtMinLimit", "5242880"}}; // 5 MiB: S3 minimum part size
-nixl_b_params_t obj_accel_params = {{"accelerated", "true"}};
-nixl_b_params_t obj_dell_params = {{"accelerated", "true"},
-                                   {"type", "dell"},
-                                   {"req_checksum", "required"},
-                                   {"scheme", "http"}};
 const std::string local_agent_name = "Agent1";
 const std::string crt_agent_name = "Agent2-CRT";
-const std::string accel_agent_name = "Agent3-Accel";
-const std::string dell_agent_name = "Agent4-Dell";
 const nixlBackendInitParams obj_test_params = {.localAgent = local_agent_name,
                                                .type = "OBJ",
                                                .customParams = &obj_params,
@@ -76,25 +73,14 @@ const nixlBackendInitParams obj_crt_test_params = {.localAgent = crt_agent_name,
                                                    .syncMode =
                                                        nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
 
-const nixlBackendInitParams obj_accel_test_params = {.localAgent = accel_agent_name,
-                                                     .type = "OBJ",
-                                                     .customParams = &obj_accel_params,
-                                                     .enableProgTh = false,
-                                                     .pthrDelay = 0,
-                                                     .syncMode =
-                                                         nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
-
-const nixlBackendInitParams obj_dell_test_params = {.localAgent = dell_agent_name,
-                                                    .type = "OBJ",
-                                                    .customParams = &obj_dell_params,
-                                                    .enableProgTh = false,
-                                                    .pthrDelay = 0,
-                                                    .syncMode =
-                                                        nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
-
 class setupObjTestFixture : public setupBackendTestFixture {
 protected:
     setupObjTestFixture() {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (endpoint && endpoint[0] != '\0') {
+            obj_params["endpoint_override"] = endpoint;
+            obj_params["req_checksum"] = "required";
+        }
         localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
     }
 };
@@ -144,6 +130,10 @@ INSTANTIATE_TEST_SUITE_P(ObjTests, setupObjTestFixture, testing::Values(obj_test
 class setupObjCrtTestFixture : public setupBackendTestFixture {
 protected:
     setupObjCrtTestFixture() {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (endpoint && endpoint[0] != '\0') {
+            obj_crt_params["endpoint_override"] = endpoint;
+        }
         localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
     }
 };
@@ -206,146 +196,5 @@ TEST_P(setupObjCrtTestFixture, CrtQueryMemTest) {
 }
 
 INSTANTIATE_TEST_SUITE_P(ObjCrtTests, setupObjCrtTestFixture, testing::Values(obj_crt_test_params));
-
-#if defined HAVE_CUOBJ_CLIENT
-// Separate test suite for S3 Accelerated client with accelerated=true
-// Note: These tests require the cuobjclient library to be available at compile time
-class setupObjAccelTestFixture : public setupBackendTestFixture {
-protected:
-    setupObjAccelTestFixture() {
-        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
-    }
-};
-
-TEST_P(setupObjAccelTestFixture, AccelXferTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 1);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
-    transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
-}
-
-TEST_P(setupObjAccelTestFixture, AccelXferMultiBufsTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 3);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
-    transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
-}
-
-TEST_P(setupObjAccelTestFixture, AccelQueryMemTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, accel_agent_name, accel_agent_name, false, 3);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-
-    nixl_reg_dlist_t descs(OBJ_SEG);
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-0"));
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-1"));
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-nonexistent"));
-    std::vector<nixl_query_resp_t> resp;
-    localBackendEngine_->queryMem(descs, resp);
-
-    EXPECT_EQ(resp.size(), 3);
-    EXPECT_EQ(resp[0].has_value(), true);
-    EXPECT_EQ(resp[1].has_value(), true);
-    EXPECT_EQ(resp[2].has_value(), false);
-}
-
-INSTANTIATE_TEST_SUITE_P(ObjAccelTests,
-                         setupObjAccelTestFixture,
-                         testing::Values(obj_accel_test_params));
-
-/**
- * @brief Test fixture for Dell ObjectScale S3 over RDMA engine.
- *
- * Reads the NIXL_OBJ_ENDPOINT_OVERRIDE environment variable to configure
- * the Dell ObjectScale endpoint. Tests are skipped if the variable is not set.
- * Requires cuobjclient library (HAVE_CUOBJ_CLIENT).
- */
-class setupObjDellTestFixture : public setupBackendTestFixture {
-protected:
-    setupObjDellTestFixture() {
-        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
-        if (endpoint && endpoint[0] != '\0') {
-            obj_dell_params["endpoint_override"] = endpoint;
-            localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
-        }
-    }
-
-    void
-    SetUp() override {
-        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
-        if (!endpoint || endpoint[0] == '\0') {
-            GTEST_SKIP() << "NIXL_OBJ_ENDPOINT_OVERRIDE not set, skipping Dell tests";
-        }
-        setupBackendTestFixture::SetUp();
-    }
-};
-
-TEST_P(setupObjDellTestFixture, DellXferTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
-    transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
-}
-
-TEST_P(setupObjDellTestFixture, DellXferMultiBufsTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
-    transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
-}
-
-TEST_P(setupObjDellTestFixture, DellQueryMemTest) {
-    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-
-    nixl_reg_dlist_t descs(OBJ_SEG);
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-0"));
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-1"));
-    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-nonexistent"));
-    std::vector<nixl_query_resp_t> resp;
-    localBackendEngine_->queryMem(descs, resp);
-
-    EXPECT_EQ(resp.size(), 3);
-    EXPECT_EQ(resp[0].has_value(), true);
-    EXPECT_EQ(resp[1].has_value(), true);
-    EXPECT_EQ(resp[2].has_value(), false);
-}
-
-#ifdef HAVE_CUDA
-// GPU memory (VRAM_SEG) transfer test for Dell ObjectScale RDMA engine.
-// Exercises the VRAM-specific code paths: cuMemObjGetDescriptor/PutDescriptor for
-// RDMA descriptor registration, and putObjectRdmaAsync/getObjectRdmaAsync for
-// GPU-direct RDMA transfers.
-TEST_P(setupObjDellTestFixture, DellVramXferTest) {
-    transferHandler<VRAM_SEG, OBJ_SEG> transfer(
-        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
-    transfer.setLocalMem();
-    transfer.testTransfer(NIXL_WRITE);
-    transfer.resetLocalMem();
-    transfer.testTransfer(NIXL_READ);
-    transfer.checkLocalMem();
-}
-#endif // HAVE_CUDA
-
-INSTANTIATE_TEST_SUITE_P(ObjDellTests,
-                         setupObjDellTestFixture,
-                         testing::Values(obj_dell_test_params));
-
-#endif // HAVE_CUOBJ_CLIENT
 
 } // namespace gtest::plugins::obj

--- a/test/gtest/plugins/obj_plugin.cpp
+++ b/test/gtest/plugins/obj_plugin.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <cstdlib>
 
 #include "plugins_common.h"
 #include "transfer_handler.h"
@@ -32,6 +33,9 @@ namespace gtest::plugins::obj {
  * These variables are required for authenticating and interacting with the S3 bucket
  * used during the tests.
  *
+ * For Dell ObjectScale tests, the following additional environment variable is required:
+ *       - NIXL_OBJ_ENDPOINT_OVERRIDE  (e.g. http://100.68.213.151:9020)
+ *
  * Test suites:
  * - ObjTests: Standard S3 client tests (crtMinLimit = 0)
  * - ObjCrtTests: S3 CRT client tests (crtMinLimit = 5 MiB, buffer = 10 MiB)
@@ -39,14 +43,24 @@ namespace gtest::plugins::obj {
  *                partSize is not clamped and MPU is exercised with multiple parts.
  * - ObjAccelTests: S3 Accelerated client tests (accelerated = true)
  *                  Note: Only compiled if HAVE_CUOBJ_CLIENT is defined
+ * - ObjDellTests: Dell ObjectScale S3 over RDMA tests
+ *                 (accelerated = true, type = dell, req_checksum = required, scheme = http)
+ *                 Note: Only compiled if HAVE_CUOBJ_CLIENT is defined.
+ *                 Skipped at runtime if NIXL_OBJ_ENDPOINT_OVERRIDE is not set.
+ *                 Includes DellVramXferTest (GPU memory) if HAVE_CUDA is also defined.
  */
 
 nixl_b_params_t obj_params = {{"crtMinLimit", "0"}};
 nixl_b_params_t obj_crt_params = {{"crtMinLimit", "5242880"}}; // 5 MiB: S3 minimum part size
 nixl_b_params_t obj_accel_params = {{"accelerated", "true"}};
+nixl_b_params_t obj_dell_params = {{"accelerated", "true"},
+                                   {"type", "dell"},
+                                   {"req_checksum", "required"},
+                                   {"scheme", "http"}};
 const std::string local_agent_name = "Agent1";
 const std::string crt_agent_name = "Agent2-CRT";
 const std::string accel_agent_name = "Agent3-Accel";
+const std::string dell_agent_name = "Agent4-Dell";
 const nixlBackendInitParams obj_test_params = {.localAgent = local_agent_name,
                                                .type = "OBJ",
                                                .customParams = &obj_params,
@@ -69,6 +83,14 @@ const nixlBackendInitParams obj_accel_test_params = {.localAgent = accel_agent_n
                                                      .pthrDelay = 0,
                                                      .syncMode =
                                                          nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
+
+const nixlBackendInitParams obj_dell_test_params = {.localAgent = dell_agent_name,
+                                                    .type = "OBJ",
+                                                    .customParams = &obj_dell_params,
+                                                    .enableProgTh = false,
+                                                    .pthrDelay = 0,
+                                                    .syncMode =
+                                                        nixl_thread_sync_t::NIXL_THREAD_SYNC_RW};
 
 class setupObjTestFixture : public setupBackendTestFixture {
 protected:
@@ -115,7 +137,6 @@ TEST_P(setupObjTestFixture, queryMemTest) {
     EXPECT_EQ(resp[1].has_value(), true);
     EXPECT_EQ(resp[2].has_value(), false);
 }
-
 
 INSTANTIATE_TEST_SUITE_P(ObjTests, setupObjTestFixture, testing::Values(obj_test_params));
 
@@ -238,6 +259,93 @@ TEST_P(setupObjAccelTestFixture, AccelQueryMemTest) {
 INSTANTIATE_TEST_SUITE_P(ObjAccelTests,
                          setupObjAccelTestFixture,
                          testing::Values(obj_accel_test_params));
+
+/**
+ * @brief Test fixture for Dell ObjectScale S3 over RDMA engine.
+ *
+ * Reads the NIXL_OBJ_ENDPOINT_OVERRIDE environment variable to configure
+ * the Dell ObjectScale endpoint. Tests are skipped if the variable is not set.
+ * Requires cuobjclient library (HAVE_CUOBJ_CLIENT).
+ */
+class setupObjDellTestFixture : public setupBackendTestFixture {
+protected:
+    setupObjDellTestFixture() {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (endpoint && endpoint[0] != '\0') {
+            obj_dell_params["endpoint_override"] = endpoint;
+            localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+        }
+    }
+
+    void
+    SetUp() override {
+        const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
+        if (!endpoint || endpoint[0] == '\0') {
+            GTEST_SKIP() << "NIXL_OBJ_ENDPOINT_OVERRIDE not set, skipping Dell tests";
+        }
+        setupBackendTestFixture::SetUp();
+    }
+};
+
+TEST_P(setupObjDellTestFixture, DellXferTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjDellTestFixture, DellXferMultiBufsTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+
+TEST_P(setupObjDellTestFixture, DellQueryMemTest) {
+    transferHandler<DRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 3);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+
+    nixl_reg_dlist_t descs(OBJ_SEG);
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-0"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-1"));
+    descs.addDesc(nixlBlobDesc(nixlBasicDesc(), "test-obj-key-nonexistent"));
+    std::vector<nixl_query_resp_t> resp;
+    localBackendEngine_->queryMem(descs, resp);
+
+    EXPECT_EQ(resp.size(), 3);
+    EXPECT_EQ(resp[0].has_value(), true);
+    EXPECT_EQ(resp[1].has_value(), true);
+    EXPECT_EQ(resp[2].has_value(), false);
+}
+
+#ifdef HAVE_CUDA
+// GPU memory (VRAM_SEG) transfer test for Dell ObjectScale RDMA engine.
+// Exercises the VRAM-specific code paths: cuMemObjGetDescriptor/PutDescriptor for
+// RDMA descriptor registration, and putObjectRdmaAsync/getObjectRdmaAsync for
+// GPU-direct RDMA transfers.
+TEST_P(setupObjDellTestFixture, DellVramXferTest) {
+    transferHandler<VRAM_SEG, OBJ_SEG> transfer(
+        localBackendEngine_, localBackendEngine_, dell_agent_name, dell_agent_name, false, 1);
+    transfer.setLocalMem();
+    transfer.testTransfer(NIXL_WRITE);
+    transfer.resetLocalMem();
+    transfer.testTransfer(NIXL_READ);
+    transfer.checkLocalMem();
+}
+#endif // HAVE_CUDA
+
+INSTANTIATE_TEST_SUITE_P(ObjDellTests,
+                         setupObjDellTestFixture,
+                         testing::Values(obj_dell_test_params));
+
 #endif // HAVE_CUOBJ_CLIENT
 
 } // namespace gtest::plugins::obj

--- a/test/gtest/plugins/obj_plugin.cpp
+++ b/test/gtest/plugins/obj_plugin.cpp
@@ -75,13 +75,18 @@ const nixlBackendInitParams obj_crt_test_params = {.localAgent = crt_agent_name,
 
 class setupObjTestFixture : public setupBackendTestFixture {
 protected:
+    nixl_b_params_t localParams_;
+
     setupObjTestFixture() {
+        localParams_ = *GetParam().customParams;
         const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
         if (endpoint && endpoint[0] != '\0') {
-            obj_params["endpoint_override"] = endpoint;
-            obj_params["req_checksum"] = "required";
+            localParams_["endpoint_override"] = endpoint;
+            localParams_["req_checksum"] = "required";
         }
-        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+        nixlBackendInitParams initParams = GetParam();
+        initParams.customParams = &localParams_;
+        localBackendEngine_ = std::make_shared<nixlObjEngine>(&initParams);
     }
 };
 
@@ -129,12 +134,18 @@ INSTANTIATE_TEST_SUITE_P(ObjTests, setupObjTestFixture, testing::Values(obj_test
 // Separate test suite for S3 CRT client with crtMinLimit enabled
 class setupObjCrtTestFixture : public setupBackendTestFixture {
 protected:
+    nixl_b_params_t localParams_;
+
     setupObjCrtTestFixture() {
+        localParams_ = *GetParam().customParams;
         const char *endpoint = std::getenv("NIXL_OBJ_ENDPOINT_OVERRIDE");
         if (endpoint && endpoint[0] != '\0') {
-            obj_crt_params["endpoint_override"] = endpoint;
+            localParams_["endpoint_override"] = endpoint;
+            localParams_["req_checksum"] = "required";
         }
-        localBackendEngine_ = std::make_shared<nixlObjEngine>(&GetParam());
+        nixlBackendInitParams initParams = GetParam();
+        initParams.customParams = &localParams_;
+        localBackendEngine_ = std::make_shared<nixlObjEngine>(&initParams);
     }
 };
 


### PR DESCRIPTION
## What?

The plugin_gtest now supports the Dell ObjectScale accelerated engine and the ability to specify the endpoint of an ObjectScale cluster for testing.  All previous tests utilize an AWS S3 endpoint, with no opportunity to override.

## Why?

Using unit tests alone the end-to-end client transfer path cannot be exercised.  With this change, this test can be run against a Dell ObjectScale cluster supporting S3 over RDMA acceleration.  This ensures test coverage for code which is otherwise mocked in unit tests.

## How?

Introduces the NIXL_OBJ_ENDPOINT_OVERRIDE environment variable for setting the endpoint of the Dell ObjectScale cluster.  Adds support for VRAM_SEG tests utilizing CUDA memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added GPU (VRAM) memory handler and GPU-backed transfer tests (enabled when CUDA is available).
  * Split accelerated OBJ tests into a dedicated accelerated suite and added a Dell OBJ suite; added CUDA-conditional VRAM transfer variants.
  * OBJ tests accept a runtime endpoint override via an environment variable and adjust/skip fixtures accordingly.
* **Chores**
  * Enabled conditional CUDA compilation for the test plugin build.
* **Documentation**
  * Updated test-suite descriptions and runtime/compilation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->