### PR TITLE
feat(libfabric): add LTTng-UST tracepoints for performance profiling

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,3 +36,6 @@ option('build_tests', type: 'boolean', value: true, description: 'Build all test
 option('build_examples', type: 'boolean', value: true, description: 'Build all examples')
 option('build_nixl_ep', type: 'boolean', value: false, description: 'Build nixl_ep example (requires sm_90)')
 option('test_all_plugins', type: 'boolean', value: false, description: 'Testing all plugins in addition to the mocks..')
+
+# Tracing
+option('enable_trace', type: 'boolean', value: false, description: 'Enable LTTng-UST tracepoints for libfabric backend')

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1070,6 +1070,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
             conn_it->second->rail_remote_addr_list_,
             conn_it->second->agent_index_,
             backend_handle->post_xfer_id,
+            device_id,
             [backend_handle]() {
                 backend_handle->increment_completed_requests();
             }, // Completion callback

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1039,7 +1039,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                << " XFER_ID=" << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr=" << dest_addr << std::dec << " context=" << &req->ctx;
 
-    NIXL_TRACE_POST_SEND_BEGIN(rail_id, req->buffer_size);
+    NIXL_TRACE_POST_SEND_BEGIN(rail_id, req->buffer_size, req->xfer_id);
     // Retry indefinitely until senddata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1062,7 +1062,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
             NIXL_TRACE << "Send posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
-            NIXL_TRACE_POST_SEND_END(rail_id, req->buffer_size, attempt);
+            NIXL_TRACE_POST_SEND_END(rail_id, req->buffer_size, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -873,6 +873,11 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
                        << req->xfer_id;
+            NIXL_TRACE_LOCAL_TRANSFER_COMPLETION(
+                req->device_id,
+                rail_id,
+                req->operation_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE : NIXL_TP_OP_READ,
+                req->xfer_id);
             req->completion_callback();
             NIXL_TRACE << "Completion callback completed for " << operation_type;
         }
@@ -1039,7 +1044,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                << " XFER_ID=" << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr=" << dest_addr << std::dec << " context=" << &req->ctx;
 
-    NIXL_TRACE_POST_SEND_BEGIN(rail_id, req->buffer_size, req->xfer_id);
+    NIXL_TRACE_POST_SEND_BEGIN(req->device_id, rail_id, req->buffer_size, req->xfer_id);
     // Retry indefinitely until senddata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1062,7 +1067,8 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
             NIXL_TRACE << "Send posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
-            NIXL_TRACE_POST_SEND_END(rail_id, req->buffer_size, attempt, req->xfer_id);
+            NIXL_TRACE_POST_SEND_END(
+                req->device_id, rail_id, req->buffer_size, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 
@@ -1124,7 +1130,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
     // Retry indefinitely until writedata succeeds or fails for all providers
-    NIXL_TRACE_POST_WRITE_BEGIN(rail_id, length, req->xfer_id);
+    NIXL_TRACE_POST_WRITE_BEGIN(req->device_id, rail_id, length, req->xfer_id);
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
@@ -1148,7 +1154,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
             NIXL_TRACE << "RDMA write posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
-            NIXL_TRACE_POST_WRITE_END(rail_id, length, attempt, req->xfer_id);
+            NIXL_TRACE_POST_WRITE_END(req->device_id, rail_id, length, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 
@@ -1208,7 +1214,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
                << " dest_addr=" << dest_addr << " remote_addr=" << (void *)remote_addr
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
-    NIXL_TRACE_POST_READ_BEGIN(rail_id, length, req->xfer_id);
+    NIXL_TRACE_POST_READ_BEGIN(req->device_id, rail_id, length, req->xfer_id);
     // Retry indefinitely until readdata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1232,7 +1238,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
             NIXL_TRACE << "RDMA read posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
-            NIXL_TRACE_POST_READ_END(rail_id, length, attempt, req->xfer_id);
+            NIXL_TRACE_POST_READ_END(req->device_id, rail_id, length, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -869,15 +869,15 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
     // Find the request from context to access the completion callback
     nixlLibfabricReq *req = findRequestFromContext(comp->op_context);
     if (req && req->in_use) { // Only process if request is still valid and in use
+        NIXL_TRACE_LOCAL_TRANSFER_COMPLETION(
+            req->device_id,
+            rail_id,
+            req->operation_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE : NIXL_TP_OP_READ,
+            req->xfer_id);
         // Call completion callback if it exists
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
                        << req->xfer_id;
-            NIXL_TRACE_LOCAL_TRANSFER_COMPLETION(
-                req->device_id,
-                rail_id,
-                req->operation_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE : NIXL_TP_OP_READ,
-                req->xfer_id);
             req->completion_callback();
             NIXL_TRACE << "Completion callback completed for " << operation_type;
         }
@@ -906,7 +906,7 @@ nixlLibfabricRail::processRecvCompletion(struct fi_cq_data_entry *comp) const {
     // Decode the immediate data format
     uint64_t msg_type = NIXL_GET_MSG_TYPE_FROM_IMM(comp->data);
     uint16_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(comp->data);
-    uint32_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
+    uint16_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
     NIXL_TRACE_RECV_COMPLETION(rail_id, agent_idx, xfer_id, comp->len);
     NIXL_TRACE << "Received control message type " << msg_type << " agent_idx=" << agent_idx
                << " XFER_ID=" << xfer_id << " imm_data=" << std::hex << comp->data << std::dec;
@@ -961,7 +961,7 @@ nixlLibfabricRail::processRemoteWriteCompletion(struct fi_cq_data_entry *comp) c
     // Decode the immediate data format
     uint64_t msg_type = NIXL_GET_MSG_TYPE_FROM_IMM(comp->data);
     uint16_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(comp->data);
-    uint32_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
+    uint16_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
     NIXL_TRACE_REMOTE_WRITE_COMPLETION(rail_id, agent_idx, xfer_id, comp->len);
 
     // For remote write completions, we don't need to post a new receive

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -20,6 +20,7 @@
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
 #include "libfabric_common.h"
+#include "libfabric_tracepoints.h"
 
 #include <cstring>
 #include <stdexcept>
@@ -901,6 +902,7 @@ nixlLibfabricRail::processRecvCompletion(struct fi_cq_data_entry *comp) const {
     uint64_t msg_type = NIXL_GET_MSG_TYPE_FROM_IMM(comp->data);
     uint16_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(comp->data);
     uint32_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
+    NIXL_TRACE_RECV_COMPLETION(rail_id, agent_idx, xfer_id, comp->len);
     NIXL_TRACE << "Received control message type " << msg_type << " agent_idx=" << agent_idx
                << " XFER_ID=" << xfer_id << " imm_data=" << std::hex << comp->data << std::dec;
 
@@ -955,6 +957,7 @@ nixlLibfabricRail::processRemoteWriteCompletion(struct fi_cq_data_entry *comp) c
     uint64_t msg_type = NIXL_GET_MSG_TYPE_FROM_IMM(comp->data);
     uint16_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(comp->data);
     uint32_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
+    NIXL_TRACE_REMOTE_WRITE_COMPLETION(rail_id, agent_idx, xfer_id, comp->len);
 
     // For remote write completions, we don't need to post a new receive
     // The write operation doesn't consume a receive buffer
@@ -1036,6 +1039,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
                << " XFER_ID=" << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr=" << dest_addr << std::dec << " context=" << &req->ctx;
 
+    NIXL_TRACE_POST_SEND_BEGIN(rail_id, req->buffer_size);
     // Retry indefinitely until senddata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1058,6 +1062,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
             NIXL_TRACE << "Send posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_POST_SEND_END(rail_id, req->buffer_size, attempt);
             return NIXL_SUCCESS;
         }
 
@@ -1119,6 +1124,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
     // Retry indefinitely until writedata succeeds or fails for all providers
+    NIXL_TRACE_POST_WRITE_BEGIN(rail_id, length, req->xfer_id);
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
@@ -1142,6 +1148,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
             NIXL_TRACE << "RDMA write posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_POST_WRITE_END(rail_id, length, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 
@@ -1201,6 +1208,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
                << " dest_addr=" << dest_addr << " remote_addr=" << (void *)remote_addr
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
+    NIXL_TRACE_POST_READ_BEGIN(rail_id, length, req->xfer_id);
     // Retry indefinitely until readdata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1224,6 +1232,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
             NIXL_TRACE << "RDMA read posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_POST_READ_END(rail_id, length, attempt, req->xfer_id);
             return NIXL_SUCCESS;
         }
 

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -42,6 +42,7 @@ struct nixlLibfabricReq {
     size_t rail_id; ///< Rail ID that owns this request
     size_t pool_index; ///< Index in the pool for deque compatibility
     uint32_t xfer_id; ///< Pre-assigned globally unique transfer ID
+    int device_id; ///< Source device (GPU) index for tracing
     void *buffer; ///< Pre-assigned buffer for CONTROL operations, nullptr for DATA
     struct fid_mr *mr; ///< Pre-assigned memory registration for CONTROL, nullptr for DATA
     size_t buffer_size; ///< Pre-assigned buffer size for CONTROL (2KB), 0 for DATA
@@ -62,6 +63,7 @@ struct nixlLibfabricReq {
         : rail_id(0),
           pool_index(0),
           xfer_id(0),
+          device_id(-1),
           buffer(nullptr),
           mr(nullptr),
           buffer_size(0),

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -19,6 +19,7 @@
 #include "libfabric_rail_manager.h"
 #include "libfabric/libfabric_common.h"
 #include "libfabric/libfabric_topology.h"
+#include "libfabric/libfabric_tracepoints.h"
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
 #include <sstream>
@@ -362,6 +363,12 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 
     // Determine striping strategy
     bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
+    NIXL_TRACE_TRANSFER_BEGIN(op_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE :
+                                                                   NIXL_TP_OP_READ,
+                              transfer_size,
+                              (int)selected_rails.size(),
+                              use_striping ? 1 : 0,
+                              xfer_id);
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
         // Round-robin: use one rail for entire transfer
@@ -517,6 +524,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     }
 
     NIXL_DEBUG << "Successfully submitted requests for " << transfer_size << " bytes";
+    NIXL_TRACE_TRANSFER_END(submitted_count_out, xfer_id);
 
     return NIXL_SUCCESS;
 }

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -351,6 +351,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     const std::unordered_map<size_t, std::vector<fi_addr_t>> &dest_addrs,
     uint16_t agent_idx,
     uint16_t xfer_id,
+    int device_id,
     std::function<void()> completion_callback,
     size_t &submitted_count_out) {
     // Initialize output parameter
@@ -363,7 +364,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 
     // Determine striping strategy
     bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
-    NIXL_TRACE_TRANSFER_BEGIN(op_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE :
+    NIXL_TRACE_TRANSFER_BEGIN(device_id,
+                              op_type == nixlLibfabricReq::WRITE ? NIXL_TP_OP_WRITE :
                                                                    NIXL_TP_OP_READ,
                               transfer_size,
                               (int)selected_rails.size(),
@@ -381,11 +383,12 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
         if (!req) {
             NIXL_ERROR << "Failed to allocate request for rail " << rail_id;
-            NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
+            NIXL_TRACE_TRANSFER_SUBMITTED(device_id, 0, xfer_id);
             return NIXL_ERR_BACKEND;
         }
         // Set completion callback and populate request
         req->completion_callback = completion_callback;
+        req->device_id = device_id;
         req->chunk_offset = 0;
         req->chunk_size = transfer_size;
         req->local_addr = local_addr;
@@ -434,7 +437,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             NIXL_ERROR << "Failed to submit "
                        << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
                        << rail_id << ", request released";
-            NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
+            NIXL_TRACE_TRANSFER_SUBMITTED(device_id, 0, xfer_id);
             return status;
         }
 
@@ -460,11 +463,12 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
             if (!req) {
                 NIXL_ERROR << "Failed to allocate request for rail " << rail_id;
+                NIXL_TRACE_TRANSFER_SUBMITTED(device_id, 0, xfer_id);
                 return NIXL_ERR_BACKEND;
-                NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             }
 
             req->completion_callback = completion_callback;
+            req->device_id = device_id;
 
             // Calculate and populate chunk info
             size_t chunk_offset = i * chunk_size;
@@ -516,8 +520,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                 NIXL_ERROR << "Failed to submit "
                            << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
                            << rail_id << ", request released";
+                NIXL_TRACE_TRANSFER_SUBMITTED(device_id, 0, xfer_id);
                 return status;
-                NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             }
 
             // Track submitted request
@@ -528,7 +532,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     }
 
     NIXL_DEBUG << "Successfully submitted requests for " << transfer_size << " bytes";
-    NIXL_TRACE_TRANSFER_SUBMITTED(submitted_count_out, xfer_id);
+    NIXL_TRACE_TRANSFER_SUBMITTED(device_id, submitted_count_out, xfer_id);
 
     return NIXL_SUCCESS;
 }

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -381,6 +381,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
         if (!req) {
             NIXL_ERROR << "Failed to allocate request for rail " << rail_id;
+            NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             return NIXL_ERR_BACKEND;
         }
         // Set completion callback and populate request
@@ -433,6 +434,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             NIXL_ERROR << "Failed to submit "
                        << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
                        << rail_id << ", request released";
+            NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             return status;
         }
 
@@ -459,6 +461,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             if (!req) {
                 NIXL_ERROR << "Failed to allocate request for rail " << rail_id;
                 return NIXL_ERR_BACKEND;
+                NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             }
 
             req->completion_callback = completion_callback;
@@ -514,6 +517,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                            << (op_type == nixlLibfabricReq::WRITE ? "write" : "read") << " on rail "
                            << rail_id << ", request released";
                 return status;
+                NIXL_TRACE_TRANSFER_SUBMITTED(0, xfer_id);
             }
 
             // Track submitted request
@@ -524,7 +528,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     }
 
     NIXL_DEBUG << "Successfully submitted requests for " << transfer_size << " bytes";
-    NIXL_TRACE_TRANSFER_END(submitted_count_out, xfer_id);
+    NIXL_TRACE_TRANSFER_SUBMITTED(submitted_count_out, xfer_id);
 
     return NIXL_SUCCESS;
 }

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -212,6 +212,7 @@ public:
                              const std::unordered_map<size_t, std::vector<fi_addr_t>> &dest_addrs,
                              uint16_t agent_idx,
                              uint16_t xfer_id,
+                             int device_id,
                              std::function<void()> completion_callback,
                              size_t &submitted_count_out);
     /** Determine if striping should be used for given transfer size

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -195,6 +195,7 @@ public:
      * @param dest_addrs Destination addresses for each rail
      * @param agent_idx Remote agent index for immediate data
      * @param xfer_id Transfer ID for tracking
+     * @param device_id Device index for tracing
      * @param completion_callback Callback for completion notification
      * @param submitted_count_out Number of requests successfully submitted
      * @return NIXL_SUCCESS on success, error code on failure

--- a/src/utils/libfabric/libfabric_tracepoints.cpp
+++ b/src/utils/libfabric/libfabric_tracepoints.cpp
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * LTTng-UST tracepoints for NIXL libfabric backend.
+ */
+
+#if HAVE_LIBLTTNG_UST == 1
+
+#define TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "libfabric_tracepoints.h"
+
+#endif /* HAVE_LIBLTTNG_UST == 1 */

--- a/src/utils/libfabric/libfabric_tracepoints.h
+++ b/src/utils/libfabric/libfabric_tracepoints.h
@@ -49,6 +49,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     transfer_begin,
     LTTNG_UST_TP_ARGS(int,
+                      dev,
+                      int,
                       op_type,
                       size_t,
                       transfer_size,
@@ -58,77 +60,96 @@ LTTNG_UST_TRACEPOINT_EVENT(
                       use_striping,
                       uint16_t,
                       xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, op_type, op_type)
-                            lttng_ust_field_integer(size_t, transfer_size, transfer_size)
-                                lttng_ust_field_integer(int, num_rails, num_rails)
-                                    lttng_ust_field_integer(int, use_striping, use_striping)
-                                        lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(int, op_type, op_type)
+                                lttng_ust_field_integer(size_t, transfer_size, transfer_size)
+                                    lttng_ust_field_integer(int, num_rails, num_rails)
+                                        lttng_ust_field_integer(int, use_striping, use_striping)
+                                            lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     transfer_submitted,
-    LTTNG_UST_TP_ARGS(size_t, submitted_count, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, submitted_count, submitted_count)
-                            lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, submitted_count, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, submitted_count, submitted_count)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 /* ===== RDMA write ===== */
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_write_begin,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_write_end,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(int, attempts, attempts)
-                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, int, retries, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(int, retries, retries)
+                                        lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 /* ===== RDMA read ===== */
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_read_begin,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_read_end,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(int, attempts, attempts)
-                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, int, retries, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(int, retries, retries)
+                                        lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 /* ===== Send ===== */
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_send_begin,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_send_end,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
-    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                            lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(int, attempts, attempts)
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, size_t, length, int, retries, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(size_t, length, length)
+                                    lttng_ust_field_integer(int, retries, retries)
+                                        lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+/* ===== Local completion events (initiator side) ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    local_transfer_completion,
+    LTTNG_UST_TP_ARGS(int, dev, size_t, rail_id, int, op_type, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, dev, dev)
+                            lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                lttng_ust_field_integer(int, op_type, op_type)
                                     lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
-/* ===== Completion events (receiver side) ===== */
+/* ===== Remote completion events (target side) ===== */
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
@@ -167,25 +188,28 @@ LTTNG_UST_TRACEPOINT_EVENT(
 #define NIXL_TP_OP_READ 1
 #define NIXL_TP_OP_SEND 2
 
-#define NIXL_TRACE_TRANSFER_BEGIN(op, sz, nr, stripe, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, transfer_begin, op, sz, nr, stripe, xid)
-#define NIXL_TRACE_TRANSFER_SUBMITTED(cnt, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, transfer_submitted, cnt, xid)
+#define NIXL_TRACE_TRANSFER_BEGIN(dev, op, sz, nr, stripe, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, transfer_begin, dev, op, sz, nr, stripe, xid)
+#define NIXL_TRACE_TRANSFER_SUBMITTED(dev, cnt, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, transfer_submitted, dev, cnt, xid)
 
-#define NIXL_TRACE_POST_WRITE_BEGIN(rail, len, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_write_begin, rail, len, xid)
-#define NIXL_TRACE_POST_WRITE_END(rail, len, att, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_write_end, rail, len, att, xid)
+#define NIXL_TRACE_POST_WRITE_BEGIN(dev, rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_write_begin, dev, rail, len, xid)
+#define NIXL_TRACE_POST_WRITE_END(dev, rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_write_end, dev, rail, len, att, xid)
 
-#define NIXL_TRACE_POST_READ_BEGIN(rail, len, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_read_begin, rail, len, xid)
-#define NIXL_TRACE_POST_READ_END(rail, len, att, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_read_end, rail, len, att, xid)
+#define NIXL_TRACE_POST_READ_BEGIN(dev, rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_read_begin, dev, rail, len, xid)
+#define NIXL_TRACE_POST_READ_END(dev, rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_read_end, dev, rail, len, att, xid)
 
-#define NIXL_TRACE_POST_SEND_BEGIN(rail, len, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_send_begin, rail, len, xid)
-#define NIXL_TRACE_POST_SEND_END(rail, len, att, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, post_send_end, rail, len, att, xid)
+#define NIXL_TRACE_POST_SEND_BEGIN(dev, rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_begin, dev, rail, len, xid)
+#define NIXL_TRACE_POST_SEND_END(dev, rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_end, dev, rail, len, att, xid)
+
+#define NIXL_TRACE_LOCAL_TRANSFER_COMPLETION(dev, rail, op, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, local_transfer_completion, dev, rail, op, xid)
 
 #define NIXL_TRACE_REMOTE_WRITE_COMPLETION(rail, aidx, xid, len) \
     lttng_ust_tracepoint(nixl_libfabric, remote_write_completion, rail, aidx, xid, len)

--- a/src/utils/libfabric/libfabric_tracepoints.h
+++ b/src/utils/libfabric/libfabric_tracepoints.h
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * LTTng-UST tracepoint definitions for NIXL libfabric backend.
+ * All timed operations use begin/end pairs for duration measurement.
+ *
+ * Usage:
+ *   lttng create nixl-session
+ *   lttng enable-event -u 'nixl_libfabric:*'
+ *   lttng start
+ *   <run workload>
+ *   lttng stop && lttng destroy
+ *   babeltrace ~/lttng-traces/nixl-session*
+ */
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER nixl_libfabric
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "libfabric_tracepoints.h"
+
+#if HAVE_LIBLTTNG_UST == 1
+
+#if !defined(NIXL_LIBFABRIC_TRACEPOINTS_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define NIXL_LIBFABRIC_TRACEPOINTS_H
+
+#include <lttng/tracepoint.h>
+
+/* ===== Transfer lifecycle ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    transfer_begin,
+    LTTNG_UST_TP_ARGS(int,
+                      op_type,
+                      size_t,
+                      transfer_size,
+                      int,
+                      num_rails,
+                      int,
+                      use_striping,
+                      uint16_t,
+                      xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(int, op_type, op_type)
+                            lttng_ust_field_integer(size_t, transfer_size, transfer_size)
+                                lttng_ust_field_integer(int, num_rails, num_rails)
+                                    lttng_ust_field_integer(int, use_striping, use_striping)
+                                        lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    transfer_end,
+    LTTNG_UST_TP_ARGS(size_t, submitted_count, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, submitted_count, submitted_count)
+                            lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+/* ===== RDMA write ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_write_begin,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_write_end,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(int, attempts, attempts)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+/* ===== RDMA read ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_read_begin,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_read_end,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(int, attempts, attempts)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
+
+/* ===== Send ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(nixl_libfabric,
+                           post_send_begin,
+                           LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length),
+                           LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                                                   lttng_ust_field_integer(size_t, length, length)))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_send_end,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(int, attempts, attempts)))
+
+/* ===== Completion events (receiver side) ===== */
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    remote_write_completion,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, uint16_t, agent_idx, uint16_t, xfer_id, size_t, length),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(uint16_t, agent_idx, agent_idx)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)
+                                    lttng_ust_field_integer(size_t, length, length)))
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    recv_completion,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, uint16_t, agent_idx, uint16_t, xfer_id, size_t, length),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(uint16_t, agent_idx, agent_idx)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)
+                                    lttng_ust_field_integer(size_t, length, length)))
+
+#endif /* !defined(NIXL_LIBFABRIC_TRACEPOINTS_H) || \
+          defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ) */
+
+#include <lttng/tracepoint-event.h>
+
+#else /* HAVE_LIBLTTNG_UST != 1 */
+
+#define lttng_ust_tracepoint(...)
+
+#endif /* HAVE_LIBLTTNG_UST == 1 */
+
+/*
+ * Wrapper macros — compile to nothing when LTTng is disabled.
+ */
+
+#define NIXL_TP_OP_WRITE 0
+#define NIXL_TP_OP_READ 1
+#define NIXL_TP_OP_SEND 2
+
+#define NIXL_TRACE_TRANSFER_BEGIN(op, sz, nr, stripe, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, transfer_begin, op, sz, nr, stripe, xid)
+#define NIXL_TRACE_TRANSFER_END(cnt, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, transfer_end, cnt, xid)
+
+#define NIXL_TRACE_POST_WRITE_BEGIN(rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_write_begin, rail, len, xid)
+#define NIXL_TRACE_POST_WRITE_END(rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_write_end, rail, len, att, xid)
+
+#define NIXL_TRACE_POST_READ_BEGIN(rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_read_begin, rail, len, xid)
+#define NIXL_TRACE_POST_READ_END(rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_read_end, rail, len, att, xid)
+
+#define NIXL_TRACE_POST_SEND_BEGIN(rail, len) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_begin, rail, len)
+#define NIXL_TRACE_POST_SEND_END(rail, len, att) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_end, rail, len, att)
+
+#define NIXL_TRACE_REMOTE_WRITE_COMPLETION(rail, aidx, xid, len) \
+    lttng_ust_tracepoint(nixl_libfabric, remote_write_completion, rail, aidx, xid, len)
+
+#define NIXL_TRACE_RECV_COMPLETION(rail, aidx, xid, len) \
+    lttng_ust_tracepoint(nixl_libfabric, recv_completion, rail, aidx, xid, len)

--- a/src/utils/libfabric/libfabric_tracepoints.h
+++ b/src/utils/libfabric/libfabric_tracepoints.h
@@ -160,6 +160,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
                                 lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)
                                     lttng_ust_field_integer(size_t, length, length)))
 
+/* Recv completion: notification/control message received on target side */
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     recv_completion,
@@ -186,7 +187,6 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 #define NIXL_TP_OP_WRITE 0
 #define NIXL_TP_OP_READ 1
-#define NIXL_TP_OP_SEND 2
 
 #define NIXL_TRACE_TRANSFER_BEGIN(dev, op, sz, nr, stripe, xid) \
     lttng_ust_tracepoint(nixl_libfabric, transfer_begin, dev, op, sz, nr, stripe, xid)

--- a/src/utils/libfabric/libfabric_tracepoints.h
+++ b/src/utils/libfabric/libfabric_tracepoints.h
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- * SPDX-FileCopyrightText: Copyright (c) 2026 Amazon.com, Inc. and affiliates.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,8 +37,9 @@
 
 #if HAVE_LIBLTTNG_UST == 1
 
-#if !defined(NIXL_LIBFABRIC_TRACEPOINTS_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define NIXL_LIBFABRIC_TRACEPOINTS_H
+#if !defined(NIXL_SRC_UTILS_LIBFABRIC_LIBFABRIC_TRACEPOINTS_H) || \
+    defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define NIXL_SRC_UTILS_LIBFABRIC_LIBFABRIC_TRACEPOINTS_H
 
 #include <lttng/tracepoint.h>
 
@@ -65,7 +66,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
-    transfer_end,
+    transfer_submitted,
     LTTNG_UST_TP_ARGS(size_t, submitted_count, uint16_t, xfer_id),
     LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, submitted_count, submitted_count)
                             lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
@@ -110,19 +111,22 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 /* ===== Send ===== */
 
-LTTNG_UST_TRACEPOINT_EVENT(nixl_libfabric,
-                           post_send_begin,
-                           LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length),
-                           LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
-                                                   lttng_ust_field_integer(size_t, length, length)))
+LTTNG_UST_TRACEPOINT_EVENT(
+    nixl_libfabric,
+    post_send_begin,
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, uint16_t, xfer_id),
+    LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
+                            lttng_ust_field_integer(size_t, length, length)
+                                lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nixl_libfabric,
     post_send_end,
-    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts),
+    LTTNG_UST_TP_ARGS(size_t, rail_id, size_t, length, int, attempts, uint16_t, xfer_id),
     LTTNG_UST_TP_FIELDS(lttng_ust_field_integer(size_t, rail_id, rail_id)
                             lttng_ust_field_integer(size_t, length, length)
-                                lttng_ust_field_integer(int, attempts, attempts)))
+                                lttng_ust_field_integer(int, attempts, attempts)
+                                    lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)))
 
 /* ===== Completion events (receiver side) ===== */
 
@@ -144,7 +148,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
                                 lttng_ust_field_integer(uint16_t, xfer_id, xfer_id)
                                     lttng_ust_field_integer(size_t, length, length)))
 
-#endif /* !defined(NIXL_LIBFABRIC_TRACEPOINTS_H) || \
+#endif /* !defined(NIXL_SRC_UTILS_LIBFABRIC_LIBFABRIC_TRACEPOINTS_H) || \
           defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ) */
 
 #include <lttng/tracepoint-event.h>
@@ -165,8 +169,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 #define NIXL_TRACE_TRANSFER_BEGIN(op, sz, nr, stripe, xid) \
     lttng_ust_tracepoint(nixl_libfabric, transfer_begin, op, sz, nr, stripe, xid)
-#define NIXL_TRACE_TRANSFER_END(cnt, xid) \
-    lttng_ust_tracepoint(nixl_libfabric, transfer_end, cnt, xid)
+#define NIXL_TRACE_TRANSFER_SUBMITTED(cnt, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, transfer_submitted, cnt, xid)
 
 #define NIXL_TRACE_POST_WRITE_BEGIN(rail, len, xid) \
     lttng_ust_tracepoint(nixl_libfabric, post_write_begin, rail, len, xid)
@@ -178,10 +182,10 @@ LTTNG_UST_TRACEPOINT_EVENT(
 #define NIXL_TRACE_POST_READ_END(rail, len, att, xid) \
     lttng_ust_tracepoint(nixl_libfabric, post_read_end, rail, len, att, xid)
 
-#define NIXL_TRACE_POST_SEND_BEGIN(rail, len) \
-    lttng_ust_tracepoint(nixl_libfabric, post_send_begin, rail, len)
-#define NIXL_TRACE_POST_SEND_END(rail, len, att) \
-    lttng_ust_tracepoint(nixl_libfabric, post_send_end, rail, len, att)
+#define NIXL_TRACE_POST_SEND_BEGIN(rail, len, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_begin, rail, len, xid)
+#define NIXL_TRACE_POST_SEND_END(rail, len, att, xid) \
+    lttng_ust_tracepoint(nixl_libfabric, post_send_end, rail, len, att, xid)
 
 #define NIXL_TRACE_REMOTE_WRITE_COMPLETION(rail, aidx, xid, len) \
     lttng_ust_tracepoint(nixl_libfabric, remote_write_completion, rail, aidx, xid, len)

--- a/src/utils/libfabric/meson.build
+++ b/src/utils/libfabric/meson.build
@@ -37,6 +37,14 @@ hwloc_dep = dependency('hwloc', required: true)
 # Find numa dependency
 numa_dep = dependency('numa', required: true)
 
+# Optional LTTng-UST tracepoint support
+if get_option('enable_trace')
+    lttng_ust_dep = dependency('lttng-ust', required: true)
+    libfabric_utils_sources += files('libfabric_tracepoints.cpp')
+else
+    lttng_ust_dep = disabler()
+endif
+
 # Set up dependencies and compile args
 libfabric_utils_deps = [
     libfabric_dep,
@@ -46,6 +54,11 @@ libfabric_utils_deps = [
 ]
 
 libfabric_utils_cpp_args = []
+
+if get_option('enable_trace')
+    libfabric_utils_deps += [lttng_ust_dep]
+    libfabric_utils_cpp_args += ['-DHAVE_LIBLTTNG_UST=1']
+endif
 
 # Detect optional libfabric features at compile time to enable/disable
 # functionality based on the installed libfabric version

--- a/src/utils/libfabric/meson.build
+++ b/src/utils/libfabric/meson.build
@@ -58,6 +58,8 @@ libfabric_utils_cpp_args = []
 if get_option('enable_trace')
     libfabric_utils_deps += [lttng_ust_dep]
     libfabric_utils_cpp_args += ['-DHAVE_LIBLTTNG_UST=1']
+else
+    libfabric_utils_cpp_args += ['-DHAVE_LIBLTTNG_UST=0']
 endif
 
 # Detect optional libfabric features at compile time to enable/disable


### PR DESCRIPTION
## What?

Add pairs of tracepoint events to the libfabric backend controlled by meson option `-Denable_trace=true`; validated it compiles to zero overhead when disabled and also traces are collected successfully when enabled.

Events: transfer_submit/done, post_write/read/send and the corresponding remote completions.

## Why?

Need fine-grained visibility into per-op latency to find performance bottlenecks. 

## How?

Added tracepoint pattern - `LTTNG_UST_TRACEPOINT_EVENT` definitions with `NIXL_TRACE_*` wrapper macros that compile to nothing when disabled.

Validated on p6-B200 cluster: default build shows no regression; LTTng build captures all event types successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional build toggle (off by default) to enable LTTng-UST tracing for the libfabric backend.
  * When enabled, the backend emits detailed runtime trace events for transfer lifecycle, per-operation begin/end, submitted counts (including zero-on-failure), and remote/receive completions to improve observability and diagnostics.
  * Tracing compiles out cleanly when disabled so runtime behavior and failure paths remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->