### PR TITLE
Nixlbench improvements

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -63,6 +63,12 @@ static std::pair<size_t, size_t> getStrideScheme(xferBenchWorker &worker, int nu
     }
     stride = buffer_size / count;
 
+    // For hugepages: ensure stride is a multiple of 2MB so addresses stay 2MB-aligned
+    // This ensures dev_offset = (i * stride) % iov.len is always a multiple of 2MB
+    if (xferBenchConfig::use_hugepages) {
+        stride = ROUND_UP(stride, HUGEPAGE_SIZE);
+    }
+
     return std::make_pair(count, stride);
 }
 

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -114,11 +114,9 @@ static int processBatchSizes(xferBenchWorker &worker,
          !worker.signaled() &&
              batch_size <= xferBenchConfig::max_batch_size;
          batch_size *= 2) {
-        auto local_trans_lists = createTransferDescLists(worker,
-                                                         iov_lists,
-                                                         block_size,
-                                                         batch_size,
-                                                         num_threads);
+        size_t effective_batch = batch_size * xferBenchConfig::pipeline_depth;
+        auto local_trans_lists =
+            createTransferDescLists(worker, iov_lists, block_size, effective_batch, num_threads);
 
         if (worker.isTarget()) {
             if (xferBenchConfig::isStorageBackend()) {

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -273,6 +273,7 @@ int xferBenchConfig::posix_kernel_queue_size = 0;
 std::string xferBenchConfig::filepath = "";
 std::string xferBenchConfig::filenames = "";
 bool xferBenchConfig::storage_enable_direct = false;
+bool xferBenchConfig::recreate_xfer = false;
 long xferBenchConfig::page_size = sysconf(_SC_PAGESIZE);
 std::string xferBenchConfig::obj_access_key = "";
 std::string xferBenchConfig::obj_secret_key = "";
@@ -693,6 +694,8 @@ xferBenchConfig::printConfig() {
             printOption("Number of files (--num_files=N)", std::to_string(num_files));
             printOption("Storage enable direct (--storage_enable_direct=[0,1])",
                         std::to_string(storage_enable_direct));
+            printOption("Recreate xfer request (--recreate_xfer=[0,1])",
+                        std::to_string(recreate_xfer));
         }
 
         // Print DOCA GPUNetIO options if backend is DOCA GPUNetIO

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -274,6 +274,7 @@ std::string xferBenchConfig::filepath = "";
 std::string xferBenchConfig::filenames = "";
 bool xferBenchConfig::storage_enable_direct = false;
 bool xferBenchConfig::recreate_xfer = false;
+bool xferBenchConfig::reregister_mem = false;
 long xferBenchConfig::page_size = sysconf(_SC_PAGESIZE);
 std::string xferBenchConfig::obj_access_key = "";
 std::string xferBenchConfig::obj_secret_key = "";
@@ -486,6 +487,7 @@ xferBenchConfig::loadParams(void) {
     posix_api_type = NB_ARG(posix_api_type);
     storage_enable_direct = NB_ARG(storage_enable_direct);
     recreate_xfer = NB_ARG(recreate_xfer);
+    reregister_mem = NB_ARG(reregister_mem);
     use_hugepages = NB_ARG(use_hugepages);
     if (use_hugepages && (total_buffer_size % HUGEPAGE_SIZE) != 0) {
         size_t hugepage_aligned_size = ROUND_UP(total_buffer_size, HUGEPAGE_SIZE);
@@ -495,6 +497,11 @@ xferBenchConfig::loadParams(void) {
     }
     if (!recreate_xfer && XFERBENCH_BACKEND_GUSLI == backend) {
         std::cout << "GUSLI backend requires per-iteration request creation due to library bug."
+                  << " Setting recreate_xfer to true." << std::endl;
+        recreate_xfer = true;
+    }
+    if (!recreate_xfer && reregister_mem) {
+        std::cout << "reregister_mem requires per-iteration request creation."
                   << " Setting recreate_xfer to true." << std::endl;
         recreate_xfer = true;
     }
@@ -629,6 +636,8 @@ xferBenchConfig::printConfig() {
         printOption("Enable VMM (--enable_vmm=[0,1])", std::to_string(enable_vmm));
         printOption("Recreate xfer each iteration (--recreate_xfer=[0,1])",
                     std::to_string(recreate_xfer));
+        printOption("Re-register memory each iteration (--reregister_mem=[0,1])",
+                    std::to_string(reregister_mem));
         printOption("Use hugepages (--use_hugepages=[0,1])", std::to_string(use_hugepages));
 
         // Print GDS options if backend is GDS
@@ -696,6 +705,8 @@ xferBenchConfig::printConfig() {
                         std::to_string(storage_enable_direct));
             printOption("Recreate xfer request (--recreate_xfer=[0,1])",
                         std::to_string(recreate_xfer));
+            printOption("Re-register memory (--reregister_mem=[0,1])",
+                        std::to_string(reregister_mem));
         }
 
         // Print DOCA GPUNetIO options if backend is DOCA GPUNetIO

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -85,6 +85,8 @@ NB_ARG_INT32(num_iter, 1000, "Max iterations");
 NB_ARG_BOOL(recreate_xfer,
             false,
             "Recreate xfer each iteration (default: false for all backends, true for GUSLI)");
+NB_ARG_BOOL(reregister_mem, false, "Register and deregister memory on every iteration");
+NB_ARG_INT32(pipeline_depth, 1, "Number of transfer requests in flight simultaneously");
 NB_ARG_INT32(large_blk_iter_ftr,
              16,
              "factor to reduce test iteration when testing large block size(>1MB)");
@@ -273,8 +275,8 @@ int xferBenchConfig::posix_kernel_queue_size = 0;
 std::string xferBenchConfig::filepath = "";
 std::string xferBenchConfig::filenames = "";
 bool xferBenchConfig::storage_enable_direct = false;
-bool xferBenchConfig::recreate_xfer = false;
 bool xferBenchConfig::reregister_mem = false;
+int xferBenchConfig::pipeline_depth = 1;
 long xferBenchConfig::page_size = sysconf(_SC_PAGESIZE);
 std::string xferBenchConfig::obj_access_key = "";
 std::string xferBenchConfig::obj_secret_key = "";
@@ -475,6 +477,10 @@ xferBenchConfig::loadParams(void) {
     start_batch_size = NB_ARG(start_batch_size);
     max_batch_size = NB_ARG(max_batch_size);
     num_iter = NB_ARG(num_iter);
+    if (num_iter < 1) {
+        std::cerr << "num_iter must be >= 1" << std::endl;
+        return -1;
+    }
     large_blk_iter_ftr = NB_ARG(large_blk_iter_ftr);
     warmup_iter = NB_ARG(warmup_iter);
     num_threads = NB_ARG(num_threads);
@@ -488,6 +494,11 @@ xferBenchConfig::loadParams(void) {
     storage_enable_direct = NB_ARG(storage_enable_direct);
     recreate_xfer = NB_ARG(recreate_xfer);
     reregister_mem = NB_ARG(reregister_mem);
+    pipeline_depth = NB_ARG(pipeline_depth);
+    if (pipeline_depth < 1) {
+        std::cerr << "pipeline_depth must be >= 1" << std::endl;
+        return -1;
+    }
     use_hugepages = NB_ARG(use_hugepages);
     if (use_hugepages && (total_buffer_size % HUGEPAGE_SIZE) != 0) {
         size_t hugepage_aligned_size = ROUND_UP(total_buffer_size, HUGEPAGE_SIZE);
@@ -638,6 +649,7 @@ xferBenchConfig::printConfig() {
                     std::to_string(recreate_xfer));
         printOption("Re-register memory each iteration (--reregister_mem=[0,1])",
                     std::to_string(reregister_mem));
+        printOption("Pipeline depth (--pipeline_depth=N)", std::to_string(pipeline_depth));
         printOption("Use hugepages (--use_hugepages=[0,1])", std::to_string(use_hugepages));
 
         // Print GDS options if backend is GDS
@@ -703,10 +715,6 @@ xferBenchConfig::printConfig() {
             printOption("Number of files (--num_files=N)", std::to_string(num_files));
             printOption("Storage enable direct (--storage_enable_direct=[0,1])",
                         std::to_string(storage_enable_direct));
-            printOption("Recreate xfer request (--recreate_xfer=[0,1])",
-                        std::to_string(recreate_xfer));
-            printOption("Re-register memory (--reregister_mem=[0,1])",
-                        std::to_string(reregister_mem));
         }
 
         // Print DOCA GPUNetIO options if backend is DOCA GPUNetIO

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -99,6 +99,7 @@ NB_ARG_INT32(num_target_dev, 1, "Number of device in target process");
 NB_ARG_BOOL(enable_pt, false, "Enable Progress Thread (only used with nixl worker)");
 NB_ARG_UINT64(progress_threads, 0, "Number of progress threads");
 NB_ARG_BOOL(enable_vmm, false, "Enable VMM memory allocation when DRAM is requested");
+NB_ARG_BOOL(use_hugepages, false, "Allocate data buffers using hugepages (2MB pages)");
 
 // Storage backend(GDS, GDS_MT, POSIX, HF3FS, OBJ) options
 NB_ARG_STRING(filepath, "", "File path for storage operations");
@@ -253,6 +254,7 @@ int xferBenchConfig::num_threads = 0;
 bool xferBenchConfig::enable_pt = false;
 size_t xferBenchConfig::progress_threads = 0;
 bool xferBenchConfig::enable_vmm = false;
+bool xferBenchConfig::use_hugepages = false;
 std::string xferBenchConfig::device_list = "";
 std::string xferBenchConfig::etcd_endpoints = "";
 std::string xferBenchConfig::asio_address = "127.0.0.1";
@@ -483,6 +485,13 @@ xferBenchConfig::loadParams(void) {
     posix_api_type = NB_ARG(posix_api_type);
     storage_enable_direct = NB_ARG(storage_enable_direct);
     recreate_xfer = NB_ARG(recreate_xfer);
+    use_hugepages = NB_ARG(use_hugepages);
+    if (use_hugepages && (total_buffer_size % HUGEPAGE_SIZE) != 0) {
+        size_t hugepage_aligned_size = ROUND_UP(total_buffer_size, HUGEPAGE_SIZE);
+        std::cout << "Rounding total_buffer_size from " << total_buffer_size << " to "
+                  << hugepage_aligned_size << " for 2MB hugepage alignment." << std::endl;
+        total_buffer_size = hugepage_aligned_size;
+    }
     if (!recreate_xfer && XFERBENCH_BACKEND_GUSLI == backend) {
         std::cout << "GUSLI backend requires per-iteration request creation due to library bug."
                   << " Setting recreate_xfer to true." << std::endl;
@@ -619,6 +628,7 @@ xferBenchConfig::printConfig() {
         printOption("Enable VMM (--enable_vmm=[0,1])", std::to_string(enable_vmm));
         printOption("Recreate xfer each iteration (--recreate_xfer=[0,1])",
                     std::to_string(recreate_xfer));
+        printOption("Use hugepages (--use_hugepages=[0,1])", std::to_string(use_hugepages));
 
         // Print GDS options if backend is GDS
         if (backend == XFERBENCH_BACKEND_GDS) {

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -173,6 +173,7 @@ public:
     static int posix_kernel_queue_size;
     static bool storage_enable_direct;
     static bool reregister_mem;
+    static int pipeline_depth;
     static int gds_batch_pool_size;
     static int gds_batch_limit;
     static int gds_mt_num_threads;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -172,6 +172,7 @@ public:
     static int posix_ios_pool_size;
     static int posix_kernel_queue_size;
     static bool storage_enable_direct;
+    static bool reregister_mem;
     static int gds_batch_pool_size;
     static int gds_batch_limit;
     static int gds_mt_num_threads;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -59,6 +59,9 @@
 // TODO: This is true for CX-7, need support for other CX cards and NVLink
 #define MAXBW 50.0 // 400 Gbps or 50 GB/sec
 #define LARGE_BLOCK_SIZE (1LL * (1 << 20))
+#define HUGEPAGE_SIZE (2 * 1024 * 1024)
+#define ROUND_UP(value, granularity) \
+    ((((value) + (granularity) - 1) / (granularity)) * (granularity))
 
 #define XFERBENCH_INITIATOR_BUFFER_ELEMENT 0xbb
 #define XFERBENCH_TARGET_BUFFER_ELEMENT 0xaa
@@ -163,6 +166,7 @@ public:
     static std::string filepath;
     static std::string filenames;
     static bool enable_vmm;
+    static bool use_hugepages;
     static int num_files;
     static std::string posix_api_type;
     static int posix_ios_pool_size;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -17,6 +17,7 @@
 
 #include "worker/nixl/nixl_worker.h"
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <cstring>
@@ -27,6 +28,7 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include "utils/neuron.h"
 #include "utils/utils.h"
@@ -34,11 +36,14 @@
 #include <utility>
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #include <utils/serdes/serdes.h>
 #include <omp.h>
 
-#define ROUND_UP(value, granularity) \
-    ((((value) + (granularity) - 1) / (granularity)) * (granularity))
+// MAP_HUGE_2MB may not be defined on all systems, define it if needed
+#ifndef MAP_HUGE_2MB
+#define MAP_HUGE_2MB (21 << 26) // 2MB hugepage size encoding
+#endif
 
 #define CHECK_NIXL_ERROR(result, message)                                                     \
     do {                                                                                      \
@@ -363,42 +368,156 @@ iovListToNixlXferDlist(const std::vector<xferBenchIOV> &iov_list, nixl_xfer_dlis
     }
 }
 
-static bool
-allocateXferMemory(size_t buffer_size, void **addr) {
-    if (!addr) {
-        std::cerr << "Invalid address" << std::endl;
-        return false;
+namespace {
+
+// RAII wrapper for an xfer-memory buffer. The factory make() selects heap or
+// hugepages based on xferBenchConfig::use_hugepages; subclass destructors
+// handle the matching deallocation. Code paths that store the raw address in
+// xferBenchIOV use release() to hand off ownership and adopt() to take it
+// back at cleanup time.
+class nixlAlloc {
+public:
+    static std::unique_ptr<nixlAlloc>
+    make(size_t size);
+    static std::unique_ptr<nixlAlloc>
+    adopt(void *addr, size_t size);
+
+    virtual ~nixlAlloc() = default;
+
+    nixlAlloc(const nixlAlloc &) = delete;
+    nixlAlloc &
+    operator=(const nixlAlloc &) = delete;
+
+    void *
+    addr() const noexcept {
+        return addr_;
     }
-    if (buffer_size == 0) {
+
+    size_t
+    size() const noexcept {
+        return size_;
+    }
+
+    void *
+    release() noexcept {
+        void *p = addr_;
+        addr_ = nullptr;
+        return p;
+    }
+
+protected:
+    nixlAlloc(void *addr, size_t size) : addr_(addr), size_(size) {}
+
+    void *addr_;
+    size_t size_;
+};
+
+class nixlHeapAlloc final : public nixlAlloc {
+public:
+    nixlHeapAlloc(void *addr, size_t size) : nixlAlloc(addr, size) {}
+
+    ~nixlHeapAlloc() override {
+        if (addr_) {
+            free(addr_);
+        }
+    }
+};
+
+class nixlHugepagesAlloc final : public nixlAlloc {
+public:
+    nixlHugepagesAlloc(void *addr, size_t size) : nixlAlloc(addr, size) {}
+
+    ~nixlHugepagesAlloc() override {
+        if (!addr_) {
+            return;
+        }
+        const size_t aligned = ROUND_UP(size_, HUGEPAGE_SIZE);
+        if (munmap(addr_, aligned) != 0) {
+            std::cerr << "Warning: Failed to unmap hugepage memory: " << strerror(errno)
+                      << std::endl;
+        }
+    }
+};
+
+static std::unique_ptr<nixlAlloc>
+makeHugepagesAlloc(size_t size) {
+    const size_t aligned = ROUND_UP(size, HUGEPAGE_SIZE);
+    void *addr = mmap(nullptr,
+                      aligned,
+                      PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB | MAP_POPULATE,
+                      -1,
+                      0);
+    if (addr == MAP_FAILED) {
+        std::cerr << "Error: Hugepage allocation failed (" << strerror(errno) << ")" << std::endl;
+        std::cerr << "Hugepages may not be available. Check /proc/sys/vm/nr_hugepages and "
+                  << "ensure sufficient hugepages are configured, or run without "
+                  << "--use_hugepages" << std::endl;
+        return nullptr;
+    }
+
+    assert(reinterpret_cast<uintptr_t>(addr) % HUGEPAGE_SIZE == 0);
+
+    std::cout << "Allocated hugepage buffer: addr=0x" << std::hex
+              << reinterpret_cast<uintptr_t>(addr) << std::dec << ", requested_size=" << size
+              << ", allocated_size=" << aligned << std::endl;
+
+    return std::make_unique<nixlHugepagesAlloc>(addr, size);
+}
+
+static std::unique_ptr<nixlAlloc>
+makeHeapAlloc(size_t size) {
+    void *addr = nullptr;
+    int rc = posix_memalign(&addr, xferBenchConfig::page_size, size);
+    if (rc != 0 || !addr) {
+        std::cerr << "Failed to allocate " << size << " bytes of page-aligned DRAM memory"
+                  << std::endl;
+        return nullptr;
+    }
+    memset(addr, 0, size);
+    return std::make_unique<nixlHeapAlloc>(addr, size);
+}
+
+std::unique_ptr<nixlAlloc>
+nixlAlloc::make(size_t size) {
+    if (size == 0) {
         std::cerr << "Invalid buffer size" << std::endl;
-        return false;
+        return nullptr;
     }
     if (xferBenchConfig::page_size == 0) {
         std::cerr << "Error: Invalid page size returned by sysconf" << std::endl;
-        return false;
+        return nullptr;
     }
 
-    int rc = posix_memalign(addr, xferBenchConfig::page_size, buffer_size);
-    if (rc != 0 || !*addr) {
-        std::cerr << "Failed to allocate " << buffer_size << " bytes of page-aligned DRAM memory"
-                  << std::endl;
-        return false;
+    if (xferBenchConfig::use_hugepages) {
+        return makeHugepagesAlloc(size);
     }
-    memset(*addr, 0, buffer_size);
-    return true;
+    return makeHeapAlloc(size);
 }
+
+std::unique_ptr<nixlAlloc>
+nixlAlloc::adopt(void *addr, size_t size) {
+    if (xferBenchConfig::use_hugepages) {
+        return std::make_unique<nixlHugepagesAlloc>(addr, size);
+    }
+    return std::make_unique<nixlHeapAlloc>(addr, size);
+}
+
+} // namespace
 
 std::optional<xferBenchIOV>
 xferBenchNixlWorker::initBasicDescDram(size_t buffer_size, int mem_dev_id) {
-    void *addr;
-
-    if (!allocateXferMemory(buffer_size, &addr)) {
+    auto alloc = nixlAlloc::make(buffer_size);
+    if (!alloc) {
         std::cerr << "Failed to allocate " << buffer_size << " bytes of DRAM memory" << std::endl;
         return std::nullopt;
     }
 
+    // Ownership of the underlying buffer is handed off to the iov; the matching
+    // cleanupBasicDescDram() reclaims it via nixlAlloc::adopt().
     // TODO: Does device id need to be set for DRAM?
-    return std::optional<xferBenchIOV>(std::in_place, (uintptr_t)addr, buffer_size, mem_dev_id);
+    return std::optional<xferBenchIOV>(
+        std::in_place, reinterpret_cast<uintptr_t>(alloc->release()), buffer_size, mem_dev_id);
 }
 
 static std::optional<xferBenchIOV>
@@ -637,31 +756,31 @@ xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, xferFileState &fstate
     }
 
     // Fill up with data
-    void *buf;
-    if (!allocateXferMemory(buffer_size, &buf)) {
+    auto alloc = nixlAlloc::make(buffer_size);
+    if (!alloc) {
         std::cerr << "Failed to allocate " << buffer_size << " bytes of memory" << std::endl;
         return std::nullopt;
     }
+    void *buf = alloc->addr();
 
     // File is always initialized with XFERBENCH_TARGET_BUFFER_ELEMENT
     memset(buf, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size);
 
     size_t offset = start_offset;
     char *write_ptr = static_cast<char *>(buf);
-    while (buffer_size > 0) {
-        ssize_t rc = pwrite(fd, write_ptr, buffer_size, offset);
+    size_t remaining = buffer_size;
+    while (remaining > 0) {
+        ssize_t rc = pwrite(fd, write_ptr, remaining, offset);
         if (rc < 0) {
             std::cerr << "Failed to write to file: " << fd << " with error: " << strerror(errno)
                       << std::endl;
             return std::nullopt;
         }
 
-        buffer_size -= rc;
+        remaining -= rc;
         offset += rc;
         write_ptr += rc;
     }
-
-    free(buf);
 
     if (end_offset > fstate.file_size) fstate.file_size = end_offset;
 
@@ -675,7 +794,9 @@ xferBenchNixlWorker::initBasicDescObj(size_t buffer_size, int mem_dev_id, std::s
 
 void
 xferBenchNixlWorker::cleanupBasicDescDram(xferBenchIOV &iov) {
-    free((void *)iov.addr);
+    // Reclaim ownership of the buffer handed out by initBasicDescDram(); the
+    // returned wrapper goes out of scope here and frees the buffer.
+    nixlAlloc::adopt(reinterpret_cast<void *>(iov.addr), iov.len);
 }
 
 void
@@ -734,9 +855,9 @@ xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &devic
     }
 
     // Sample one page at the offset GUSLI will read from
-    void *check_buf;
     bool needs_write = true;
-    if (allocateXferMemory(xferBenchConfig::page_size, &check_buf)) {
+    if (auto check_alloc = nixlAlloc::make(xferBenchConfig::page_size)) {
+        void *check_buf = check_alloc->addr();
         ssize_t rd = pread(fd, check_buf, xferBenchConfig::page_size, device.dev_offset);
         if (rd == (ssize_t)xferBenchConfig::page_size) {
             needs_write = false;
@@ -748,7 +869,6 @@ xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &devic
                 }
             }
         }
-        free(check_buf);
     }
 
     if (needs_write) {
@@ -757,11 +877,12 @@ xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &devic
                   << (int)XFERBENCH_TARGET_BUFFER_ELEMENT << std::dec << "). Overwriting."
                   << std::endl;
 
-        void *buf;
-        if (!allocateXferMemory(size, &buf)) {
+        auto alloc = nixlAlloc::make(size);
+        if (!alloc) {
             close(fd);
             return false;
         }
+        void *buf = alloc->addr();
         memset(buf, XFERBENCH_TARGET_BUFFER_ELEMENT, size);
 
         size_t remaining = size;
@@ -772,7 +893,6 @@ xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &devic
             if (rc < 0) {
                 std::cerr << "Failed to write to " << device.device_path << " at offset " << offset
                           << ": " << strerror(errno) << std::endl;
-                free(buf);
                 close(fd);
                 return false;
             }
@@ -780,7 +900,6 @@ xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &devic
             offset += rc;
             write_ptr += rc;
         }
-        free(buf);
     } else {
         std::cout << "GUSLI file '" << device.device_path << "' at offset " << device.dev_offset
                   << " already contains expected pattern (0x" << std::hex

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1324,24 +1324,6 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     return res;
 }
 
-// Helper to execute a single transfer iteration
-static inline nixl_status_t
-execSingleTransfer(nixlAgent *agent,
-                   nixlXferReqH *req,
-                   xferBenchTimer &timer,
-                   xferBenchStats &thread_stats,
-                   const std::atomic<int> *terminate_ptr = nullptr) {
-    nixl_status_t rc = agent->postXferReq(req);
-    thread_stats.post_duration.add(timer.lap());
-    while (NIXL_IN_PROG == rc) {
-        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
-            break;
-        }
-        rc = agent->getXferStatus(req);
-    }
-    return rc;
-}
-
 // Helper to prepare transfer descriptors based on backend type
 static void
 prepareTransferDescriptors(nixl_xfer_dlist_t &local_desc,
@@ -1425,123 +1407,233 @@ deregisterIterationMem(nixlAgent *agent,
     return NIXL_SUCCESS;
 }
 
-static int
-execTransferIterations(nixlAgent *agent,
-                       const nixl_xfer_op_t op,
-                       nixl_xfer_dlist_t &local_desc,
-                       nixl_xfer_dlist_t &remote_desc,
-                       const std::string &target,
-                       nixl_opt_args_t &params,
-                       const int num_iter,
-                       xferBenchTimer &timer,
-                       xferBenchStats &thread_stats,
-                       const std::vector<xferBenchIOV> &local_iov,
-                       const std::vector<xferBenchIOV> &remote_iov,
-                       nixlBackendH *backend_engine,
-                       const std::atomic<int> *terminate_ptr = nullptr) {
+// Per-slot state for execTransferLoop. A slot owns its slice of the IOV
+// vector for the lifetime of the run; req/registered track the current
+// nixlXferReqH and registration state so the prepare/post/recycle helpers
+// can be called idempotently.
+struct slotState {
+    std::vector<xferBenchIOV> local_iov;
+    std::vector<xferBenchIOV> remote_iov;
     nixlXferReqH *req = nullptr;
-    nixlTime::us_t total_prepare_duration = 0;
-    const bool recreate_per_iteration = xferBenchConfig::recreate_xfer;
+    bool in_flight = false;
+    bool registered = false;
+    nixlTime::us_t post_ts = 0;
+};
+
+// Register memory (if --reregister_mem) and create the XferReq for a slot
+// that doesn't already have one. Records the wall-clock time as
+// prepare_duration.
+static nixl_status_t
+prepareSlot(nixlAgent *agent,
+            nixlBackendH *backend_engine,
+            const nixl_xfer_op_t op,
+            const std::string &target,
+            nixl_opt_args_t &params,
+            xferBenchStats &thread_stats,
+            slotState &slot) {
     const bool reregister = xferBenchConfig::reregister_mem;
+    const nixlTime::us_t prep_start = nixlTime::getUs();
 
-    if (!recreate_per_iteration) {
-        nixl_status_t create_rc =
-            agent->createXferReq(op, local_desc, remote_desc, target, req, &params);
-        if (NIXL_SUCCESS != create_rc) {
-            std::cerr << "createXferReq failed: " << nixlEnumStrings::statusStr(create_rc)
+    if (reregister && !slot.registered) {
+        nixl_status_t rc =
+            registerIterationMem(agent, slot.local_iov, slot.remote_iov, backend_engine);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        slot.registered = true;
+    }
+
+    if (!slot.req) {
+        nixl_xfer_dlist_t ld(GET_SEG_TYPE(true));
+        nixl_xfer_dlist_t rd(GET_SEG_TYPE(false));
+        prepareTransferDescriptors(ld, rd, slot.local_iov, slot.remote_iov);
+        nixl_status_t rc = agent->createXferReq(op, ld, rd, target, slot.req, &params);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+    }
+
+    thread_stats.prepare_duration.add(nixlTime::getUs() - prep_start);
+    return NIXL_SUCCESS;
+}
+
+// Post the slot's request and record post_duration. Marks the slot
+// in-flight; the caller drives completion via getXferStatus.
+static nixl_status_t
+postSlot(nixlAgent *agent, xferBenchStats &thread_stats, slotState &slot) {
+    const nixlTime::us_t post_start = nixlTime::getUs();
+    nixl_status_t rc = agent->postXferReq(slot.req);
+    if (rc != NIXL_SUCCESS && rc != NIXL_IN_PROG) {
+        return rc;
+    }
+    slot.post_ts = nixlTime::getUs();
+    thread_stats.post_duration.add(slot.post_ts - post_start);
+    slot.in_flight = true;
+    return NIXL_SUCCESS;
+}
+
+// Tear down the request and (if --reregister_mem) the registration so the
+// next prepareSlot exercises the full lifecycle.
+static nixl_status_t
+recycleSlot(nixlAgent *agent, nixlBackendH *backend_engine, slotState &slot) {
+    if (slot.req) {
+        agent->releaseXferReq(slot.req);
+        slot.req = nullptr;
+    }
+    if (xferBenchConfig::reregister_mem && slot.registered) {
+        nixl_status_t rc =
+            deregisterIterationMem(agent, slot.local_iov, slot.remote_iov, backend_engine);
+        slot.registered = false;
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+    }
+    return NIXL_SUCCESS;
+}
+
+// Best-effort teardown for early-exit / error paths.
+static void
+cleanupSlots(nixlAgent *agent, nixlBackendH *backend_engine, std::vector<slotState> &slots) {
+    for (auto &slot : slots) {
+        if (slot.req) {
+            agent->releaseXferReq(slot.req);
+            slot.req = nullptr;
+        }
+        if (xferBenchConfig::reregister_mem && slot.registered) {
+            deregisterIterationMem(agent, slot.local_iov, slot.remote_iov, backend_engine);
+            slot.registered = false;
+        }
+    }
+}
+
+// Run num_iter transfers using a sliding window of pipeline_depth in-flight
+// requests. Depth=1 collapses to the original "one create, N posts, one
+// release" baseline (the previous execTransferIterations); --recreate_xfer
+// tears down and rebuilds the request between iterations, --reregister_mem
+// adds the matching registerMem/deregisterMem cycle.
+static int
+execTransferLoop(nixlAgent *agent,
+                 nixlBackendH *backend_engine,
+                 const nixl_xfer_op_t op,
+                 const std::string &target,
+                 nixl_opt_args_t &params,
+                 const int num_iter,
+                 xferBenchStats &thread_stats,
+                 const std::vector<xferBenchIOV> &local_iov,
+                 const std::vector<xferBenchIOV> &remote_iov,
+                 const std::atomic<int> *terminate_ptr = nullptr) {
+    const int depth = std::min(xferBenchConfig::pipeline_depth, num_iter);
+    if (depth < xferBenchConfig::pipeline_depth) {
+        std::cout << "Warning: pipeline_depth (" << xferBenchConfig::pipeline_depth
+                  << ") exceeds num_iter (" << num_iter << "), capping to " << depth << std::endl;
+    }
+    const bool recreate = xferBenchConfig::recreate_xfer;
+
+    if (local_iov.size() % depth != 0) {
+        std::cerr << "Error: descriptor count (" << local_iov.size()
+                  << ") is not evenly divisible by pipeline depth (" << depth << ")" << std::endl;
+        return -1;
+    }
+    const size_t entries_per_slot = local_iov.size() / depth;
+
+    std::vector<slotState> slots(depth);
+    for (int s = 0; s < depth; s++) {
+        auto lb = local_iov.begin() + s * entries_per_slot;
+        auto rb = remote_iov.begin() + s * entries_per_slot;
+        slots[s].local_iov.assign(lb, lb + entries_per_slot);
+        slots[s].remote_iov.assign(rb, rb + entries_per_slot);
+    }
+
+    int issued = 0;
+    int completed = 0;
+
+    for (int s = 0; s < depth; s++) {
+        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            cleanupSlots(agent, backend_engine, slots);
+            return -1;
+        }
+        nixl_status_t rc =
+            prepareSlot(agent, backend_engine, op, target, params, thread_stats, slots[s]);
+        if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+            std::cerr << "prepareSlot failed for slot " << s << ": "
+                      << nixlEnumStrings::statusStr(rc) << std::endl;
+            cleanupSlots(agent, backend_engine, slots);
+            return -1;
+        }
+        rc = postSlot(agent, thread_stats, slots[s]);
+        if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+            std::cerr << "postSlot failed for slot " << s << ": " << nixlEnumStrings::statusStr(rc)
                       << std::endl;
+            cleanupSlots(agent, backend_engine, slots);
             return -1;
         }
-        thread_stats.prepare_duration.add(timer.lap());
+        issued++;
     }
 
-    // Execute transfer iterations
-    // Branch prediction hint: most backends don't recreate per iteration
-    if (__builtin_expect(recreate_per_iteration, 0)) {
-        for (int i = 0; i < num_iter; ++i) {
-            if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+    while (completed < num_iter) {
+        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            cleanupSlots(agent, backend_engine, slots);
+            return -1;
+        }
+        for (int s = 0; s < depth; s++) {
+            if (!slots[s].in_flight) {
+                continue;
+            }
+
+            nixl_status_t rc = agent->getXferStatus(slots[s].req);
+            if (rc == NIXL_IN_PROG) {
+                continue;
+            }
+
+            if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                std::cerr << "Transfer failed on slot " << s << ": "
+                          << nixlEnumStrings::statusStr(rc) << std::endl;
+                cleanupSlots(agent, backend_engine, slots);
                 return -1;
             }
-            if (reregister) {
-                nixl_status_t reg_rc =
-                    registerIterationMem(agent, local_iov, remote_iov, backend_engine);
-                if (__builtin_expect(reg_rc != NIXL_SUCCESS, 0)) {
-                    std::cerr << "registerMem failed during iteration" << std::endl;
+
+            completed++;
+            thread_stats.transfer_duration.add(nixlTime::getUs() - slots[s].post_ts);
+            slots[s].in_flight = false;
+
+            if (issued >= num_iter) {
+                continue;
+            }
+
+            if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+                cleanupSlots(agent, backend_engine, slots);
+                return -1;
+            }
+
+            if (recreate) {
+                rc = recycleSlot(agent, backend_engine, slots[s]);
+                if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                    std::cerr << "recycleSlot failed for slot " << s << ": "
+                              << nixlEnumStrings::statusStr(rc) << std::endl;
+                    cleanupSlots(agent, backend_engine, slots);
+                    return -1;
+                }
+                rc = prepareSlot(agent, backend_engine, op, target, params, thread_stats, slots[s]);
+                if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                    std::cerr << "prepareSlot failed on resubmit for slot " << s << ": "
+                              << nixlEnumStrings::statusStr(rc) << std::endl;
+                    cleanupSlots(agent, backend_engine, slots);
                     return -1;
                 }
             }
 
-
-            nixl_status_t create_rc =
-                agent->createXferReq(op, local_desc, remote_desc, target, req, &params);
-            if (__builtin_expect(create_rc != NIXL_SUCCESS, 0)) {
-                std::cerr << "createXferReq failed: " << nixlEnumStrings::statusStr(create_rc)
-                          << std::endl;
-                if (reregister) {
-                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
-                }
-                return -1;
-            }
-            total_prepare_duration += timer.lap();
-
-            nixl_status_t rc = execSingleTransfer(agent, req, timer, thread_stats, terminate_ptr);
-
+            rc = postSlot(agent, thread_stats, slots[s]);
             if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
-                std::cerr << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
-                          << std::endl;
-                agent->releaseXferReq(req);
-                if (reregister) {
-                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
-                }
+                std::cerr << "postSlot failed on resubmit for slot " << s << ": "
+                          << nixlEnumStrings::statusStr(rc) << std::endl;
+                cleanupSlots(agent, backend_engine, slots);
                 return -1;
             }
-            thread_stats.transfer_duration.add(timer.lap());
-
-            if (__builtin_expect(agent->releaseXferReq(req) != NIXL_SUCCESS, 0)) {
-                std::cerr << "NIXL releaseXferReq failed" << std::endl;
-                if (reregister) {
-                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
-                }
-                return -1;
-            }
-
-            if (reregister) {
-                nixl_status_t dereg_rc =
-                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
-                if (__builtin_expect(dereg_rc != NIXL_SUCCESS, 0)) {
-                    std::cerr << "deregisterMem failed during iteration" << std::endl;
-                    return -1;
-                }
-            }
-        }
-        // Average prepare duration across iterations
-        thread_stats.prepare_duration.add(total_prepare_duration / num_iter);
-    } else {
-        // Standard path: Single request for all iterations
-        for (int i = 0; i < num_iter; ++i) {
-            // Check for signal (SIGTERM/SIGINT) to allow fast exit on peer death
-            if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
-                agent->releaseXferReq(req);
-                return -1;
-            }
-            nixl_status_t rc = execSingleTransfer(agent, req, timer, thread_stats, terminate_ptr);
-
-            if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
-                std::cerr << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
-                          << std::endl;
-                agent->releaseXferReq(req);
-                return -1;
-            }
-            thread_stats.transfer_duration.add(timer.lap());
-        }
-
-        // Release request once after all iterations
-        if (__builtin_expect(agent->releaseXferReq(req) != NIXL_SUCCESS, 0)) {
-            std::cerr << "NIXL releaseXferReq failed" << std::endl;
-            return -1;
+            issued++;
         }
     }
 
+    cleanupSlots(agent, backend_engine, slots);
     return 0;
 }
 
@@ -1563,15 +1655,9 @@ execTransfer(nixlAgent *agent,
     {
         xferBenchStats thread_stats;
         thread_stats.reserve(num_iter);
-        xferBenchTimer timer;
         const int tid = omp_get_thread_num();
         const auto &local_iov = local_iovs[tid];
         const auto &remote_iov = remote_iovs[tid];
-
-        // Prepare transfer descriptors
-        nixl_xfer_dlist_t local_desc(GET_SEG_TYPE(true));
-        nixl_xfer_dlist_t remote_desc(GET_SEG_TYPE(false));
-        prepareTransferDescriptors(local_desc, remote_desc, local_iov, remote_iov);
 
         // Setup transfer parameters
         nixl_opt_args_t params;
@@ -1580,20 +1666,16 @@ execTransfer(nixlAgent *agent,
             params.notif = "0xBEEF";
         }
 
-        // Execute transfers
-        const int result = execTransferIterations(agent,
-                                                  op,
-                                                  local_desc,
-                                                  remote_desc,
-                                                  target,
-                                                  params,
-                                                  num_iter,
-                                                  timer,
-                                                  thread_stats,
-                                                  local_iov,
-                                                  remote_iov,
-                                                  backend_engine,
-                                                  terminate_ptr);
+        int result = execTransferLoop(agent,
+                                      backend_engine,
+                                      op,
+                                      target,
+                                      params,
+                                      num_iter,
+                                      thread_stats,
+                                      local_iov,
+                                      remote_iov,
+                                      terminate_ptr);
 
         if (__builtin_expect(result != 0, 0)) {
             ret = result;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1361,8 +1361,70 @@ prepareTransferDescriptors(nixl_xfer_dlist_t &local_desc,
     iovListToNixlXferDlist(remote_iov, remote_desc);
 }
 
-// Execute transfers with configurable request lifecycle behavior
-// recreate_per_iteration: true for GUSLI (bug workaround), false for standard backends
+static nixl_mem_t
+getRemoteSegType() {
+    if (xferBenchConfig::isObjStorageBackend()) {
+        return OBJ_SEG;
+    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+        return BLK_SEG;
+    } else if (xferBenchConfig::isStorageBackend()) {
+        return FILE_SEG;
+    }
+    return GET_SEG_TYPE(false);
+}
+
+// Register local and remote memory with the agent.
+static nixl_status_t
+registerIterationMem(nixlAgent *agent,
+                     const std::vector<xferBenchIOV> &local_iov,
+                     const std::vector<xferBenchIOV> &remote_iov,
+                     nixlBackendH *backend_engine) {
+    nixl_opt_args_t reg_args;
+    reg_args.backends.push_back(backend_engine);
+
+    nixl_reg_dlist_t local_reg(GET_SEG_TYPE(true));
+    iovListToNixlRegDlist(local_iov, local_reg);
+    nixl_status_t rc = agent->registerMem(local_reg, &reg_args);
+    if (rc != NIXL_SUCCESS) {
+        return rc;
+    }
+
+    nixl_reg_dlist_t remote_reg(getRemoteSegType());
+    iovListToNixlRegDlist(remote_iov, remote_reg);
+    rc = agent->registerMem(remote_reg, &reg_args);
+    if (rc != NIXL_SUCCESS) {
+        return rc;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+// Deregister local and remote memory from the agent.
+static nixl_status_t
+deregisterIterationMem(nixlAgent *agent,
+                       const std::vector<xferBenchIOV> &local_iov,
+                       const std::vector<xferBenchIOV> &remote_iov,
+                       nixlBackendH *backend_engine) {
+    nixl_opt_args_t reg_args;
+    reg_args.backends.push_back(backend_engine);
+
+    nixl_reg_dlist_t local_reg(GET_SEG_TYPE(true));
+    iovListToNixlRegDlist(local_iov, local_reg);
+    nixl_status_t rc = agent->deregisterMem(local_reg, &reg_args);
+    if (rc != NIXL_SUCCESS) {
+        return rc;
+    }
+
+    nixl_reg_dlist_t remote_reg(getRemoteSegType());
+    iovListToNixlRegDlist(remote_iov, remote_reg);
+    rc = agent->deregisterMem(remote_reg, &reg_args);
+    if (rc != NIXL_SUCCESS) {
+        return rc;
+    }
+
+    return NIXL_SUCCESS;
+}
+
 static int
 execTransferIterations(nixlAgent *agent,
                        const nixl_xfer_op_t op,
@@ -1373,12 +1435,15 @@ execTransferIterations(nixlAgent *agent,
                        const int num_iter,
                        xferBenchTimer &timer,
                        xferBenchStats &thread_stats,
-                       const bool recreate_per_iteration,
+                       const std::vector<xferBenchIOV> &local_iov,
+                       const std::vector<xferBenchIOV> &remote_iov,
+                       nixlBackendH *backend_engine,
                        const std::atomic<int> *terminate_ptr = nullptr) {
     nixlXferReqH *req = nullptr;
     nixlTime::us_t total_prepare_duration = 0;
+    const bool recreate_per_iteration = xferBenchConfig::recreate_xfer;
+    const bool reregister = xferBenchConfig::reregister_mem;
 
-    // Create request once if not recreating per iteration
     if (!recreate_per_iteration) {
         nixl_status_t create_rc =
             agent->createXferReq(op, local_desc, remote_desc, target, req, &params);
@@ -1393,17 +1458,28 @@ execTransferIterations(nixlAgent *agent,
     // Execute transfer iterations
     // Branch prediction hint: most backends don't recreate per iteration
     if (__builtin_expect(recreate_per_iteration, 0)) {
-        // GUSLI path: Create/execute/release per iteration
         for (int i = 0; i < num_iter; ++i) {
-            // Check for signal (SIGTERM/SIGINT) to allow fast exit on peer death
             if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
                 return -1;
             }
+            if (reregister) {
+                nixl_status_t reg_rc =
+                    registerIterationMem(agent, local_iov, remote_iov, backend_engine);
+                if (__builtin_expect(reg_rc != NIXL_SUCCESS, 0)) {
+                    std::cerr << "registerMem failed during iteration" << std::endl;
+                    return -1;
+                }
+            }
+
+
             nixl_status_t create_rc =
                 agent->createXferReq(op, local_desc, remote_desc, target, req, &params);
             if (__builtin_expect(create_rc != NIXL_SUCCESS, 0)) {
                 std::cerr << "createXferReq failed: " << nixlEnumStrings::statusStr(create_rc)
                           << std::endl;
+                if (reregister) {
+                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
+                }
                 return -1;
             }
             total_prepare_duration += timer.lap();
@@ -1411,16 +1487,31 @@ execTransferIterations(nixlAgent *agent,
             nixl_status_t rc = execSingleTransfer(agent, req, timer, thread_stats, terminate_ptr);
 
             if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
-                std::cout << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
+                std::cerr << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
                           << std::endl;
                 agent->releaseXferReq(req);
+                if (reregister) {
+                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
+                }
                 return -1;
             }
             thread_stats.transfer_duration.add(timer.lap());
 
             if (__builtin_expect(agent->releaseXferReq(req) != NIXL_SUCCESS, 0)) {
-                std::cout << "NIXL releaseXferReq failed" << std::endl;
+                std::cerr << "NIXL releaseXferReq failed" << std::endl;
+                if (reregister) {
+                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
+                }
                 return -1;
+            }
+
+            if (reregister) {
+                nixl_status_t dereg_rc =
+                    deregisterIterationMem(agent, local_iov, remote_iov, backend_engine);
+                if (__builtin_expect(dereg_rc != NIXL_SUCCESS, 0)) {
+                    std::cerr << "deregisterMem failed during iteration" << std::endl;
+                    return -1;
+                }
             }
         }
         // Average prepare duration across iterations
@@ -1436,7 +1527,7 @@ execTransferIterations(nixlAgent *agent,
             nixl_status_t rc = execSingleTransfer(agent, req, timer, thread_stats, terminate_ptr);
 
             if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
-                std::cout << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
+                std::cerr << "NIXL Xfer failed with status: " << nixlEnumStrings::statusStr(rc)
                           << std::endl;
                 agent->releaseXferReq(req);
                 return -1;
@@ -1446,7 +1537,7 @@ execTransferIterations(nixlAgent *agent,
 
         // Release request once after all iterations
         if (__builtin_expect(agent->releaseXferReq(req) != NIXL_SUCCESS, 0)) {
-            std::cout << "NIXL releaseXferReq failed" << std::endl;
+            std::cerr << "NIXL releaseXferReq failed" << std::endl;
             return -1;
         }
     }
@@ -1456,6 +1547,7 @@ execTransferIterations(nixlAgent *agent,
 
 static int
 execTransfer(nixlAgent *agent,
+             nixlBackendH *backend_engine,
              const std::vector<std::vector<xferBenchIOV>> &local_iovs,
              const std::vector<std::vector<xferBenchIOV>> &remote_iovs,
              const nixl_xfer_op_t op,
@@ -1498,7 +1590,9 @@ execTransfer(nixlAgent *agent,
                                                   num_iter,
                                                   timer,
                                                   thread_stats,
-                                                  xferBenchConfig::recreate_xfer,
+                                                  local_iov,
+                                                  remote_iov,
+                                                  backend_engine,
                                                   terminate_ptr);
 
         if (__builtin_expect(result != 0, 0)) {
@@ -1523,7 +1617,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
     xferBenchStats stats;
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
-    // int completion_flag = 1;
 
     if (!rt->checkKeepAlive()) { // also refreshes the lease internally.
         std::cerr << "nixlbench: keepalive failed before transfer — aborting" << std::endl;
@@ -1538,6 +1631,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     if (skip > 0) {
         ret = execTransfer(agent,
+                           backend_engine,
                            local_iovs,
                            remote_iovs,
                            xfer_op,
@@ -1556,6 +1650,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
     stats.clear();
 
     ret = execTransfer(agent,
+                       backend_engine,
                        local_iovs,
                        remote_iovs,
                        xfer_op,


### PR DESCRIPTION
## What?
Add four different options to nixlbench to allow simulation of more complex workloads using nixlbench

## Why?
These are all hot code paths we have observed in various inference frameworks and we want to be able to recreate the NIXL API usage in nixlbench.

## How?
Each commit adds a different option to add a new nixlbench behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options for hugepage-backed allocations, pipeline depth, and optional per-iteration memory (re)registration.
  * Implemented a pipelined transfer mode that issues multiple concurrent requests based on configured depth.
  * Allocations and buffers are auto-aligned to 2MB when hugepage mode is enabled; batch handling scales by pipeline depth while preserving reported stats.

* **Bug Fixes / Validation**
  * Validates pipeline depth (must be >=1) and reports adjustments to buffer sizing and memory-registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->