### PR TITLE
feat: range-aware memory registration cache in UCX backend

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -954,31 +954,74 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
 
 /****************************************
  * Memory management
-*****************************************/
-nixl_status_t nixlUcxEngine::registerMem (const nixlBlobDesc &mem,
-                                          const nixl_mem_t &nixl_mem,
-                                          nixlBackendMD* &out)
-{
+ *****************************************/
+nixl_status_t
+nixlUcxEngine::registerMem(const nixlBlobDesc &mem,
+                           const nixl_mem_t &nixl_mem,
+                           nixlBackendMD *&out) {
     auto priv = std::make_unique<nixlUcxPrivateMetadata>();
 
+    uintptr_t descAddr = mem.addr;
+    uintptr_t descEnd = descAddr + mem.len;
+
+    // Check if this descriptor falls within an already-registered range.
+    // regRangeCache is ordered by base address; find the last entry whose
+    // base is <= descAddr, then verify the range covers the descriptor.
+    auto it = regRangeCache.upper_bound(descAddr);
+    if (it != regRangeCache.begin()) {
+        --it;
+        uintptr_t rangeBase = it->first;
+        uintptr_t rangeEnd = rangeBase + it->second.mem->getSize();
+        if (descAddr >= rangeBase && descEnd <= rangeEnd) {
+            priv->mem = it->second.mem;
+            priv->rkeyStr = it->second.rkeyStr;
+            out = priv.release();
+            return NIXL_SUCCESS;
+        }
+    }
+
+    // No covering range found; perform a new registration.
+    auto ucxMem = std::make_shared<nixlUcxMem>();
     // TODO: Add nixl_mem check?
-    const int ret = uc->memReg((void*) mem.addr, mem.len, priv->mem, nixl_mem);
+    const int ret = uc->memReg((void *)mem.addr, mem.len, *ucxMem, nixl_mem);
     if (ret) {
         return NIXL_ERR_BACKEND;
     }
-    priv->rkeyStr = uc->packRkey(priv->mem);
+    nixl_blob_t rkeyStr = uc->packRkey(*ucxMem);
 
-    if (priv->rkeyStr.empty()) {
+    if (rkeyStr.empty()) {
+        uc->memDereg(*ucxMem);
         return NIXL_ERR_BACKEND;
     }
+
+    priv->mem = ucxMem;
+    priv->rkeyStr = rkeyStr;
+
+    regRangeCache[descAddr] = RegRange{ucxMem, rkeyStr};
+
     out = priv.release();
     return NIXL_SUCCESS;
 }
 
-nixl_status_t nixlUcxEngine::deregisterMem (nixlBackendMD* meta)
-{
-    nixlUcxPrivateMetadata *priv = (nixlUcxPrivateMetadata*) meta;
-    uc->memDereg(priv->mem);
+nixl_status_t
+nixlUcxEngine::deregisterMem(nixlBackendMD *meta) {
+    nixlUcxPrivateMetadata *priv = (nixlUcxPrivateMetadata *)meta;
+
+    // Check whether the cache still holds this exact registration.
+    // A cache overwrite (e.g. registering a larger range at the same base)
+    // can replace the cache entry, leaving older descriptors with no cache
+    // reference. We must compare the shared_ptr, not just the base address.
+    const uintptr_t base = (uintptr_t)priv->mem->getBase();
+    auto it = regRangeCache.find(base);
+    const bool cacheOwnsThisMem = it != regRangeCache.end() && it->second.mem == priv->mem;
+    const long useCount = priv->mem.use_count();
+    if ((cacheOwnsThisMem && useCount == 2) || (!cacheOwnsThisMem && useCount == 1)) {
+        if (cacheOwnsThisMem) {
+            regRangeCache.erase(it);
+        }
+        uc->memDereg(*priv->mem);
+    }
+
     delete priv;
     return NIXL_SUCCESS;
 }
@@ -1201,8 +1244,8 @@ nixlUcxEngine::sendXferRangeBatch(nixlUcxEp &ep,
         ++result.size;
         nixlUcxReq req;
         nixl_status_t ret = operation == NIXL_READ ?
-            ep.read(raddr, rmd->getRkey(worker_id), laddr, lmd->mem, lsize, req) :
-            ep.write(laddr, lmd->mem, raddr, rmd->getRkey(worker_id), lsize, req);
+            ep.read(raddr, rmd->getRkey(worker_id), laddr, *lmd->mem, lsize, req) :
+            ep.write(laddr, *lmd->mem, raddr, rmd->getRkey(worker_id), lsize, req);
 
         if (ret == NIXL_IN_PROG) {
             if (__builtin_expect(result.req != nullptr, 1)) {

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -18,6 +18,7 @@
 #define NIXL_SRC_PLUGINS_UCX_UCX_BACKEND_H
 
 #include <vector>
+#include <map>
 #include <cstring>
 #include <iostream>
 #include <thread>
@@ -57,22 +58,22 @@ using ucx_connection_ptr_t = std::shared_ptr<nixlUcxConnection>;
 
 // A private metadata has to implement get, and has all the metadata
 class nixlUcxPrivateMetadata : public nixlBackendMD {
-    private:
-        nixlUcxMem mem;
-        nixl_blob_t rkeyStr;
+private:
+    std::shared_ptr<nixlUcxMem> mem;
+    nixl_blob_t rkeyStr;
 
-    public:
-        nixlUcxPrivateMetadata() : nixlBackendMD(true) {
-        }
+public:
+    nixlUcxPrivateMetadata() : nixlBackendMD(true) {}
 
-        [[nodiscard]] const std::string& get() const noexcept {
-            return rkeyStr;
-        }
+    [[nodiscard]] const std::string &
+    get() const noexcept {
+        return rkeyStr;
+    }
 
-        [[nodiscard]] const nixlUcxMem &
-        getMem() const noexcept {
-            return mem;
-        }
+    [[nodiscard]] const nixlUcxMem &
+    getMem() const noexcept {
+        return *mem;
+    }
 
     friend class nixlUcxEngine;
 };
@@ -304,6 +305,17 @@ private:
 
     // Map of agent name to saved nixlUcxConnection info
     std::unordered_map<std::string, ucx_connection_ptr_t> remoteConnMap;
+
+    // Range-aware memory registration cache.
+    // Maps base address to a shared registration covering [base, base+size).
+    // When a new descriptor falls entirely within an existing range, the
+    // registration is reused instead of calling ucp_mem_map again.
+    struct RegRange {
+        std::shared_ptr<nixlUcxMem> mem;
+        nixl_blob_t rkeyStr;
+    };
+
+    std::map<uintptr_t, RegRange> regRangeCache;
 };
 
 class nixlUcxThread;


### PR DESCRIPTION
## What?

Add a registration cache to the UCX backend that reuses an existing `ucp_mem_h` and rkey when a new descriptor falls within an already-registered memory range, instead of calling `ucp_mem_map` (`ibv_reg_mr`) again.

## Why?

When model weights are allocated in a contiguous VMM region but registered with NIXL as individual tensors, every tensor triggers a separate `ibv_reg_mr` kernel call. For large models (1265 tensors, 51 GB/worker on Hermes 405B FP8 TP8), this takes 2.4s. With the range cache, the first registration covers the full VMM range and subsequent per-tensor registrations are cache hits, dropping total registration to ~17ms.

## How?

- Add `regRangeCache` (ordered `std::map`) to `nixlUcxEngine` mapping base address to shared registration
- `registerMem` checks cache for a covering range before calling `ucp_mem_map`
- `deregisterMem` uses `shared_ptr` refcount to defer `ucp_mem_dereg` until the last descriptor in a range is removed
- `nixlUcxPrivateMetadata::mem` changed to `shared_ptr<nixlUcxMem>` for shared ownership, consistent with existing patterns (`ucx_connection_ptr_t`, plugin handles)
- Backward compatible: non-overlapping descriptors register normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster data transfers by reusing prior memory registrations when possible, reducing registration overhead.
  * Smarter deregistration to avoid unnecessary unregister operations, improving stability under load.
  * More efficient local memory handling during reads/writes, yielding lower latency and improved throughput.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->