### PR TITLE
nixl_ep: Fixes to high-throughput commit

### DIFF
--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -183,8 +183,8 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
                                      dst_expert_local_idx * num_ranks * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                                      rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                                      slot_idx * num_bytes_per_msg;
-                void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
                 if (not is_rank_masked<true>(mask_buffer_ptr, dst_rank)) {
+                    void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
                     if (dst_p2p_ptr == 0) {
                         nixlMemViewElem src_mdesc{nixl_ctx.local_mvh, 0, nixl_ctx.offset_get(src_ptr)};
                         nixlMemViewElem dst_mdesc{nixl_ctx.remote_mvh, (size_t) dst_rank, nixl_ctx.offset_get(dst_ptr)};
@@ -252,8 +252,8 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
         // Wait local sends issued and send expert counts
         while (ld_acquire_global(atomic_finish_counter_per_expert + responsible_expert_idx) != FINISHED_SUM_TAG * 2);
         auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_count + dst_expert_local_idx * num_ranks + rank);
-        void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
         if (not is_rank_masked(mask_buffer_ptr, dst_rank)) {
+            void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
             if (dst_p2p_ptr == 0) {
                 nixlMemViewElem dst_mdesc{nixl_ctx.remote_mvh, static_cast<size_t>(dst_rank), nixl_ctx.offset_get(dst_ptr)};
                 EP_DEVICE_ASSERT(nixlAtomicAdd(num_tokens_sent + 1, dst_mdesc, dst_expert_local_idx) == NIXL_IN_PROG);
@@ -801,8 +801,8 @@ combine(void* combined_x,
         if (sub_warp_id == 1 and lane_id == 0) {
             while (ld_acquire_global(atomic_clean_flag) == 0);
             auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_flag + global_expert_idx);
-            void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
             if (not is_rank_masked(mask_buffer_ptr, dst_rank)) {
+                void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
                 if (dst_p2p_ptr == 0) {
                     nixlMemViewElem dst_mdesc{nixl_ctx.remote_mvh, (size_t) dst_rank, nixl_ctx.offset_get(dst_ptr)};
                     EP_DEVICE_ASSERT(nixlAtomicAdd(1, dst_mdesc, local_expert_idx) == NIXL_IN_PROG);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -128,21 +128,24 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     workspace = m_workspace_alloc->ptr();
     CUDA_CHECK(cudaMemsetAsync(workspace, 0, NUM_WORKSPACE_BYTES, comm_stream));
 
-    // MoE counter
-    CUDA_CHECK(cudaMallocHost(&moe_recv_counter, sizeof(int64_t), cudaHostAllocMapped));
-    CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_counter_mapped, const_cast<int*>(moe_recv_counter), 0));
-    *moe_recv_counter = -1;
+    if (!low_latency_mode) {
+        // MoE counter
+        CUDA_CHECK(cudaMallocHost(&moe_recv_counter, sizeof(int), cudaHostAllocMapped));
+        CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_counter_mapped, const_cast<int*>(moe_recv_counter), 0));
+        *moe_recv_counter = -1;
 
-    // MoE expert-level counter
-    CUDA_CHECK(cudaMallocHost(&moe_recv_expert_counter, sizeof(int) * NUM_MAX_LOCAL_EXPERTS, cudaHostAllocMapped));
-    CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_expert_counter_mapped, const_cast<int*>(moe_recv_expert_counter), 0));
-    for (int i = 0; i < NUM_MAX_LOCAL_EXPERTS; ++ i)
-        moe_recv_expert_counter[i] = -1;
+        // MoE expert-level counter
+        CUDA_CHECK(cudaMallocHost(&moe_recv_expert_counter, sizeof(int) * NUM_MAX_LOCAL_EXPERTS, cudaHostAllocMapped));
+        CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_expert_counter_mapped, const_cast<int*>(moe_recv_expert_counter), 0));
+        for (int i = 0; i < NUM_MAX_LOCAL_EXPERTS; ++ i)
+            moe_recv_expert_counter[i] = -1;
 
-    // MoE RDMA-level counter
-    CUDA_CHECK(cudaMallocHost(&moe_recv_rdma_counter, sizeof(int), cudaHostAllocMapped));
-    CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_rdma_counter_mapped, const_cast<int*>(moe_recv_rdma_counter), 0));
-    *moe_recv_rdma_counter = -1;
+        // MoE RDMA-level counter
+        CUDA_CHECK(cudaMallocHost(&moe_recv_rdma_counter, sizeof(int), cudaHostAllocMapped));
+        CUDA_CHECK(cudaHostGetDevicePointer(&moe_recv_rdma_counter_mapped, const_cast<int*>(moe_recv_rdma_counter), 0));
+        *moe_recv_rdma_counter = -1;
+    }
+
     EP_HOST_ASSERT(max_experts_per_rank > 0);
     m_rdma_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_rdma_bytes));
     rdma_buffer_ptr = m_rdma_alloc->ptr();
@@ -163,11 +166,13 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     CUDA_CHECK(cudaMemset(sync_buffer_ptr, 0, num_sync_buffer_bytes));
     CUDA_CHECK(cudaMemset(sync_count_ptr, 0, num_sync_buffer_bytes));
 
-    // Allocate barrier counters for high-throughput mode
-    CUDA_CHECK(cudaMalloc(&local_ht_barrier_counter, sizeof(uint64_t)));
-    CUDA_CHECK(cudaMemset(local_ht_barrier_counter, 0, sizeof(uint64_t)));
-    CUDA_CHECK(cudaMalloc(&last_ht_barrier_counter, sizeof(uint64_t)));
-    CUDA_CHECK(cudaMemset(last_ht_barrier_counter, 0, sizeof(uint64_t)));
+    if (!low_latency_mode) {
+        CUDA_CHECK(cudaMalloc(&local_ht_barrier_counter, sizeof(uint64_t)));
+        CUDA_CHECK(cudaMemset(local_ht_barrier_counter, 0, sizeof(uint64_t)));
+        CUDA_CHECK(cudaMalloc(&last_ht_barrier_counter, sizeof(uint64_t)));
+        CUDA_CHECK(cudaMemset(last_ht_barrier_counter, 0, sizeof(uint64_t)));
+    }
+
     CUDA_CHECK(cudaDeviceSynchronize());
 
     my_peer_info.rdma_buffer_ptr = rdma_buffer_ptr;
@@ -259,16 +264,16 @@ void Buffer::destroy() {
 
     if (num_nvl_bytes > 0) {
         intranode::barrier(barrier_signal_ptrs_gpu, nvl_rank, num_nvl_ranks, comm_stream);
-        CUDA_CHECK(cudaDeviceSynchronize());
+        warn_cuda(cudaDeviceSynchronize(), "synchronize device after intranode barrier");
 
         // Close remote IPC
         if (is_available()) {
             for (int i = 0; i < num_nvl_ranks; ++ i) if (i != nvl_rank)
-                CUDA_CHECK(cudaIpcCloseMemHandle(buffer_ptrs[i]));
+                warn_cuda(cudaIpcCloseMemHandle(buffer_ptrs[i]), "close remote IPC handle");
         }
 
         // Free local buffer
-        CUDA_CHECK(cudaFree(buffer_ptrs[nvl_rank]));
+        warn_cuda(cudaFree(buffer_ptrs[nvl_rank]), "free local NVL buffer");
     }
 
     if (nixl_agent_info and nixl_agent_info->agent != nullptr) {
@@ -288,6 +293,11 @@ void Buffer::destroy() {
                       nixl_agent_info->sync_count_reg_descs,
                       &nixl_agent_info->extra_params),
                   "deregister sync-count memory");
+        if (local_ht_barrier_counter != nullptr) {
+            warn_nixl(nixl_agent_info->agent->deregisterMem(
+                          nixl_agent_info->ht_barrier_reg_descs),
+                      "deregister ht barrier memory");
+        }
 
         nixl_agent_info.reset();
     }
@@ -301,15 +311,24 @@ void Buffer::destroy() {
     m_sync_count_alloc.reset();
     sync_count_ptr = nullptr;
 
-    warn_cuda(cudaFree(local_ht_barrier_counter), "free local ht barrier counter");
-    warn_cuda(cudaFree(last_ht_barrier_counter), "free last ht barrier counter");
+    if (!low_latency_mode) {
+        warn_cuda(cudaFree(local_ht_barrier_counter), "free local ht barrier counter");
+        local_ht_barrier_counter = nullptr;
+        warn_cuda(cudaFree(last_ht_barrier_counter), "free last ht barrier counter");
+        last_ht_barrier_counter = nullptr;
+    }
+
+    if (!low_latency_mode) {
+        warn_cuda(cudaFreeHost(const_cast<int*>(moe_recv_counter)), "free moe receive counter");
+        moe_recv_counter = nullptr;
+        warn_cuda(cudaFreeHost(const_cast<int*>(moe_recv_expert_counter)), "free moe receive expert counter");
+        moe_recv_expert_counter = nullptr;
+        warn_cuda(cudaFreeHost(const_cast<int*>(moe_recv_rdma_counter)), "free moe receive rdma counter");
+        moe_recv_rdma_counter = nullptr;
+    }
 
     m_workspace_alloc.reset();
     workspace = nullptr;
-
-    CUDA_CHECK(cudaFreeHost(const_cast<int*>(moe_recv_counter)));
-    CUDA_CHECK(cudaFreeHost(const_cast<int*>(moe_recv_expert_counter)));
-    CUDA_CHECK(cudaFreeHost(const_cast<int*>(moe_recv_rdma_counter)));
 
     destroyed = true;
     available = false;
@@ -1326,15 +1345,16 @@ void Buffer::_nixl_agent_init() {
     nixl_agent_info->sync_count_reg_descs.clear();
     nixl_agent_info->sync_count_reg_descs.addDesc(
         nixlBlobDesc(reinterpret_cast<uintptr_t>(sync_count_ptr), max_num_ranks * sizeof(int), device_id, ""));
+    nixl_agent_info->ht_barrier_reg_descs.clear();
 
     EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->rdma_reg_descs, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
     EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->sync_reg_descs, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
     EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->sync_count_reg_descs, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
 
     if (!low_latency_mode && local_ht_barrier_counter) {
-        nixl_reg_dlist_t ht_barrier_dlist(VRAM_SEG);
-        ht_barrier_dlist.addDesc(nixlBlobDesc((uintptr_t)(local_ht_barrier_counter), sizeof(uint64_t), get_local_device_id(), ""));
-        EP_HOST_ASSERT(agent->registerMem(ht_barrier_dlist) == NIXL_SUCCESS);
+        nixl_agent_info->ht_barrier_reg_descs.addDesc(
+            nixlBlobDesc((uintptr_t)(local_ht_barrier_counter), sizeof(uint64_t), get_local_device_id(), ""));
+        EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->ht_barrier_reg_descs) == NIXL_SUCCESS);
     }
 
     if (getenv("NIXL_ETCD_ENDPOINTS")) {

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -162,8 +162,6 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     sync_count_ptr = static_cast<int *>(m_sync_count_alloc->ptr());
     CUDA_CHECK(cudaMemset(sync_buffer_ptr, 0, num_sync_buffer_bytes));
     CUDA_CHECK(cudaMemset(sync_count_ptr, 0, num_sync_buffer_bytes));
-    CUDA_CHECK(cudaMalloc(&local_barrier_cnt_ptr, num_sync_buffer_bytes));
-    CUDA_CHECK(cudaMemset(local_barrier_cnt_ptr, 0, num_sync_buffer_bytes));
 
     // Allocate barrier counters for high-throughput mode
     CUDA_CHECK(cudaMalloc(&local_ht_barrier_counter, sizeof(uint64_t)));
@@ -303,7 +301,6 @@ void Buffer::destroy() {
     m_sync_count_alloc.reset();
     sync_count_ptr = nullptr;
 
-    warn_cuda(cudaFree(local_barrier_cnt_ptr), "free local barrier count");
     warn_cuda(cudaFree(local_ht_barrier_counter), "free local ht barrier counter");
     warn_cuda(cudaFree(last_ht_barrier_counter), "free last ht barrier counter");
 
@@ -438,7 +435,6 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
         new_ranks.push_back(remote_rank);
         CUDA_CHECK(cudaMemset(mask_buffer_ptr + remote_rank, 0, sizeof(int)));
         CUDA_CHECK(cudaMemset(sync_count_ptr + remote_rank, 0, sizeof(int)));
-        CUDA_CHECK(cudaMemset(local_barrier_cnt_ptr + remote_rank, 0, sizeof(int)));
         CUDA_CHECK(cudaMemset(sync_buffer_ptr + remote_rank, 0, sizeof(int)));
 
         if (remote_mds.has_value())

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -316,9 +316,6 @@ void Buffer::destroy() {
         local_ht_barrier_counter = nullptr;
         warn_cuda(cudaFree(last_ht_barrier_counter), "free last ht barrier counter");
         last_ht_barrier_counter = nullptr;
-    }
-
-    if (!low_latency_mode) {
         warn_cuda(cudaFreeHost(const_cast<int*>(moe_recv_counter)), "free moe receive counter");
         moe_recv_counter = nullptr;
         warn_cuda(cudaFreeHost(const_cast<int*>(moe_recv_expert_counter)), "free moe receive expert counter");

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1348,7 +1348,7 @@ void Buffer::_nixl_agent_init() {
     EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->sync_reg_descs, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
     EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->sync_count_reg_descs, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
 
-    if (!low_latency_mode && local_ht_barrier_counter) {
+    if (local_ht_barrier_counter) {
         nixl_agent_info->ht_barrier_reg_descs.addDesc(
             nixlBlobDesc((uintptr_t)(local_ht_barrier_counter), sizeof(uint64_t), get_local_device_id(), ""));
         EP_HOST_ASSERT(agent->registerMem(nixl_agent_info->ht_barrier_reg_descs) == NIXL_SUCCESS);

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -73,6 +73,7 @@ struct NixlAgentInfo
     nixl_reg_dlist_t rdma_reg_descs{VRAM_SEG};
     nixl_reg_dlist_t sync_reg_descs{VRAM_SEG};
     nixl_reg_dlist_t sync_count_reg_descs{VRAM_SEG};
+    nixl_reg_dlist_t ht_barrier_reg_descs{VRAM_SEG};
     std::vector<bool> wire_up_done; // [num_peers]
 };
 
@@ -95,7 +96,6 @@ private:
     int *mask_buffer_ptr = nullptr;
     int *sync_buffer_ptr = nullptr;
     int *sync_count_ptr = nullptr;
-    int *local_barrier_cnt_ptr = nullptr;
 
     /* Owning VMM allocations (keep raw ptrs above as aliases) */
     std::unique_ptr<vmm_region> m_rdma_alloc;


### PR DESCRIPTION
Several fixes to small issues introduced by #1341:

1. Remove a duplicated unused allocation 
2. Fix ht destruction flow so nixl_ep.Buffer's dtor never crashes and ht allocations only happen on ht mode
3. Only call p2p_ptr_get under is_rank_masked guard- this was already fixed in #1478 but accidentally reverted during the rebase of #1341 over main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary work and conditionalized resource allocation to lower overhead in low-latency mode; improved registration and teardown ordering for barrier descriptors.

* **Bug Fixes**
  * Fixed destination lookup timing so masked destinations no longer trigger unnecessary RDMA/zero-copy checks.

* **Chores**
  * Streamlined internal descriptor/state handling and safer resource cleanup to reduce teardown failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->