### PR TITLE
Add @anshumang to Libfabric Plugins maintainers in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,9 +31,9 @@ CODEOWNERS @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
 /benchmark @aranadive @ovidiusm @brminich
 
 # Libfabric Plugins
-/src/plugins/libfabric* @amitrad-aws @yexiang-aws @akkart-aws @fengjica
-/src/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica
-/test/unit/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica
+/src/plugins/libfabric* @amitrad-aws @yexiang-aws @akkart-aws @fengjica @anshumang
+/src/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica @anshumang
+/test/unit/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica @anshumang
 
 # NIXL EP example
 /examples/device/ep @itayalroy @ebarilanM @ofirfarjun7 @ai-dynamo/nixl-maintainers


### PR DESCRIPTION
## What?
Add @anshumang as a maintainer for the Libfabric plugins section in CODEOWNERS.

## Why?
Per discussion with @yexiang-aws — contributing to the libfabric backend (e.g., PR #1462).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership records to add an additional owner for several Libfabric-related areas in repository metadata.

* **Impact**
  * No user-facing changes; no API, functional, or UX impact.
  * Internal ownership metadata only; normal workflows and behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->