### PR TITLE
libfabric: fix multi-GPU memory registration

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -710,23 +710,23 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
             if (cuda_addr_wa_) {
                 bool need_restart;
                 if (vramUpdateCtx((void *)mem.addr, mem.devId, need_restart)) {
-                    NIXL_WARN << "CUDA address workaround failed for device " << mem.devId
-                              << ", disabling workaround for multi-GPU support";
-                    cuda_addr_wa_ = false; // Disable workaround for subsequent registrations
+                    NIXL_INFO << "Multi-GPU detected (device " << mem.devId
+                              << "), using cudaSetDevice fallback";
+                    cuda_addr_wa_ = false;
                 } else if (need_restart) {
-                    // Restart progress thread if needed
                     NIXL_DEBUG << "CUDA context updated, restarting progress thread";
                     vramApplyCtx();
                 }
-            } else {
-                // Set CUDA device context directly for multi-GPU support
+            }
+            // Fallback: set device via runtime API (uses primary context)
+            if (!cuda_addr_wa_) {
                 cudaError_t cuda_ret = cudaSetDevice(mem.devId);
                 if (cuda_ret != cudaSuccess) {
                     NIXL_ERROR << "Failed to set CUDA device " << mem.devId << ": "
                                << cudaGetErrorString(cuda_ret);
                     return NIXL_ERR_NOT_SUPPORTED;
                 }
-                NIXL_DEBUG << "Set CUDA device context to GPU " << mem.devId;
+                NIXL_INFO << "Set CUDA device context to GPU " << mem.devId;
             }
 
             // Query PCI bus ID from memory address (AFTER setting context)


### PR DESCRIPTION
## What?
PR https://github.com/ai-dynamo/nixl/pull/1258 changed two independent if-statements into if/else in
registerMem(), breaking the fallthrough that calls cudaSetDevice()
when the CUDA address workaround is disabled for device N>0 in Multiple-GPU per process case.

Without cudaSetDevice(), cuMemGetAddressRange() fails inside EFA's
dmabuf path for large buffers, causing fi_mr_key to return
`FI_KEY_NOTAVAIL`. Blackwell (B200) requires the correct CUDA context
for cuMemGetAddressRange; Hopper (H200) seems still working based on tests

Restore the original two-if pattern and downgrade the expected
multi-GPU detection log from WARN to INFO.

Validated with nixlbench --scheme tp --mode MG --num-initiator-dev 4
--num-target-dev 8 --check-consistency on p6 B200 instances.

Failure patten before current fix:
```
W libfabric_backend.cpp:713] CUDA address workaround failed for device 1, disabling workaround for multi-GPU support
libfabric:core:cuda_get_base_addr():455<warn> Failed to perform cuMemGetAddressRange: CUDA_ERROR_NOT_FOUND:named symbol not found
libfabric:efa:mr:efa_mr_reg_ibv_mr():713<warn> ofi_hmem_get_dmabuf_fd failed for iface=1: ret=-5 (Input/output error)
libfabric:efa:mr:efa_mr_reg_impl():1076<warn> Unable to register MR of 2147483648 bytes
E libfabric_rail.cpp:1385] fi_mr_key returned FI_KEY_NOTAVAIL on rail 1
E libfabric_rail_manager.cpp:728] Failed to register memory on rail 1
E libfabric_backend.cpp:784] Rail Manager registerMemory failed
E nixl_agent.cpp:484] registerMem: registration failed for the specified or all potential backends
NIXL: registerMem failed (Error code: 0)
```

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-GPU CUDA memory registration handling to ensure consistent device context management during memory operations.
  * Enhanced logging for multi-GPU scenarios to provide clearer diagnostic information during memory registration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->