### PR TITLE
EXAMPLES/DEVICE/EP/CSRS/KERNELS: Removed unused variable.

### DIFF
--- a/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
@@ -589,7 +589,6 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
     __shared__ int rdma_send_channel_lock[kNumRDMARanks];
     __shared__ int rdma_send_channel_tail[kNumRDMARanks];
     __shared__ uint32_t rdma_send_channel_window[kNumRDMARanks];
-    __shared__ nixlGpuXferStatusH rdma_put_xfer_status;
     auto sync_rdma_sender_smem = []() { asm volatile("barrier.sync 0, %0;" ::"r"((kNumDispatchRDMASenderWarps + 1) * 32)); };
 
     // TMA stuffs


### PR DESCRIPTION
## What?
Removed unused variable.

## Why?
```
../examples/device/ep/csrc/kernels/nixl_ep_ht.cu(592): warning #177-D: variable "rdma_put_xfer_status" was declared but never referenced
      __attribute__((shared)) nixlGpuXferStatusH rdma_put_xfer_status;
```