### PR TITLE
libfabric: fix active rail tracking

### DIFF
--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -712,9 +712,11 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
             for (size_t j = 0; j < i; ++j) {
                 const size_t cleanup_idx = selected_rails[j];
                 if (mr_list_out[cleanup_idx]) {
-                    rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]);
+                    if (rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]) ==
+                        NIXL_SUCCESS) {
+                        decRailActive(cleanup_idx);
+                    }
                     mr_list_out[cleanup_idx] = nullptr;
-                    decRailActive(cleanup_idx);
                 }
             }
             return NIXL_ERR_INVALID_PARAM;
@@ -731,9 +733,11 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
             for (size_t j = 0; j < i; ++j) {
                 const size_t cleanup_idx = selected_rails[j];
                 if (mr_list_out[cleanup_idx]) {
-                    rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]);
+                    if (rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]) ==
+                        NIXL_SUCCESS) {
+                        decRailActive(cleanup_idx);
+                    }
                     mr_list_out[cleanup_idx] = nullptr;
-                    decRailActive(cleanup_idx);
                 }
             }
             return status;
@@ -772,11 +776,12 @@ nixlLibfabricRailManager::deregisterMemory(const std::vector<size_t> &selected_r
 
         if (mr_list[rail_idx]) {
             nixl_status_t status = rails_[rail_idx]->deregisterMemory(mr_list[rail_idx]);
-            if (status != NIXL_SUCCESS) {
+            if (status == NIXL_SUCCESS) {
+                decRailActive(rail_idx);
+            } else {
                 NIXL_ERROR << "Failed to deregister memory on rail " << rail_idx;
                 overall_status = status;
             }
-            decRailActive(rail_idx);
         }
     }
 
@@ -889,9 +894,6 @@ nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
 
     NIXL_DEBUG << "Sending control message type " << msg_type_value << " agent_idx=" << agent_idx
                << " XFER_ID=" << xfer_id << " imm_data=" << imm_data << " on rail " << rail_id;
-
-    // Mark rail 0 as active so its CQ gets progressed
-    incRailActive(rail_id);
 
     // Use rail 0 for notifications
     nixl_status_t status = rails_[rail_id]->postSend(imm_data, dest_addr, req);
@@ -1152,7 +1154,11 @@ nixlLibfabricRailManager::decRailActive(size_t rail_id) {
     std::lock_guard<std::mutex> lock(active_rails_mutex_);
     auto it = active_rails_.find(rail_id);
     if (it != active_rails_.end()) {
-        it->second--;
+        // The reference count is always non-zero under normal situation.
+        // Here is a defensive check, assuming a bug somewhere else set it to zero.
+        if (it->second > 0) {
+            it->second--;
+        }
         if (it->second == 0) {
             active_rails_.erase(it);
             NIXL_DEBUG << "decRailActive rail " << rail_id

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -714,6 +714,7 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
                 if (mr_list_out[cleanup_idx]) {
                     rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]);
                     mr_list_out[cleanup_idx] = nullptr;
+                    decRailActive(cleanup_idx);
                 }
             }
             return NIXL_ERR_INVALID_PARAM;
@@ -732,6 +733,7 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
                 if (mr_list_out[cleanup_idx]) {
                     rails_[cleanup_idx]->deregisterMemory(mr_list_out[cleanup_idx]);
                     mr_list_out[cleanup_idx] = nullptr;
+                    decRailActive(cleanup_idx);
                 }
             }
             return status;
@@ -741,7 +743,7 @@ nixlLibfabricRailManager::registerMemory(void *buffer,
         key_list_out[rail_idx] = key;
 
         // Mark rail as active for progress tracking optimization
-        markRailActive(rail_idx);
+        incRailActive(rail_idx);
 
         NIXL_DEBUG << "Registered memory on rail " << rail_idx
                    << " (mr=" << static_cast<const void *>(mr) << ", key=" << key << ")";
@@ -774,7 +776,7 @@ nixlLibfabricRailManager::deregisterMemory(const std::vector<size_t> &selected_r
                 NIXL_ERROR << "Failed to deregister memory on rail " << rail_idx;
                 overall_status = status;
             }
-            markRailInactive(rail_idx);
+            decRailActive(rail_idx);
         }
     }
 
@@ -889,7 +891,7 @@ nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
                << " XFER_ID=" << xfer_id << " imm_data=" << imm_data << " on rail " << rail_id;
 
     // Mark rail 0 as active so its CQ gets progressed
-    markRailActive(rail_id);
+    incRailActive(rail_id);
 
     // Use rail 0 for notifications
     nixl_status_t status = rails_[rail_id]->postSend(imm_data, dest_addr, req);
@@ -913,7 +915,9 @@ nixlLibfabricRailManager::progressActiveRails() {
         std::lock_guard<std::mutex> lock(active_rails_mutex_);
         // Always progress rail 0 for notifications (SEND/RECV)
         rails_to_process.insert(0);
-        rails_to_process.insert(active_rails_.begin(), active_rails_.end());
+        for (const auto &[rail_id, refcount] : active_rails_) {
+            rails_to_process.insert(rail_id);
+        }
     }
 
     // Process rails without holding the lock
@@ -1131,30 +1135,31 @@ nixlLibfabricRailManager::deserializeRailEndpoints(
 }
 
 void
-nixlLibfabricRailManager::markRailActive(size_t rail_id) {
+nixlLibfabricRailManager::incRailActive(size_t rail_id) {
     if (rail_id >= rails_.size()) {
-        NIXL_ERROR << "Invalid rail ID for markRailActive: " << rail_id;
+        NIXL_ERROR << "Invalid rail ID for incRailActive: " << rail_id;
         return;
     }
 
     std::lock_guard<std::mutex> lock(active_rails_mutex_);
-    bool was_inserted = active_rails_.insert(rail_id).second;
-
-    if (was_inserted) {
-        NIXL_DEBUG << "Marked rail " << rail_id
-                   << " as active (total active: " << active_rails_.size() << ")";
-    } else {
-        NIXL_TRACE << "Rail " << rail_id << " was already active";
-    }
+    active_rails_[rail_id]++;
+    NIXL_DEBUG << "incRailActive rail " << rail_id << " (refcount: " << active_rails_[rail_id]
+               << ", total active: " << active_rails_.size() << ")";
 }
 
 void
-nixlLibfabricRailManager::markRailInactive(size_t rail_id) {
+nixlLibfabricRailManager::decRailActive(size_t rail_id) {
     std::lock_guard<std::mutex> lock(active_rails_mutex_);
-    size_t erased = active_rails_.erase(rail_id);
-    if (erased > 0) {
-        NIXL_DEBUG << "Marked rail " << rail_id
-                   << " as inactive (total active: " << active_rails_.size() << ")";
+    auto it = active_rails_.find(rail_id);
+    if (it != active_rails_.end()) {
+        it->second--;
+        if (it->second == 0) {
+            active_rails_.erase(it);
+            NIXL_DEBUG << "decRailActive rail " << rail_id
+                       << " now inactive (total active: " << active_rails_.size() << ")";
+        } else {
+            NIXL_DEBUG << "decRailActive rail " << rail_id << " (refcount: " << it->second << ")";
+        }
     } else {
         NIXL_TRACE << "Rail " << rail_id << " was not in active set";
     }

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -253,13 +253,13 @@ public:
     validateAllRailsInitialized();
 
     // Active Rail Management APIs
-    /** Mark rail as active for progress tracking optimization */
+    /** Increment active reference count on a rail */
     void
-    markRailActive(size_t rail_id);
+    incRailActive(size_t rail_id);
 
-    /** Mark rail as inactive for progress tracking optimization */
+    /** Decrement active reference count on a rail; rail becomes inactive when count reaches zero */
     void
-    markRailInactive(size_t rail_id);
+    decRailActive(size_t rail_id);
 
     /** Clear all active rail markings */
     void
@@ -351,8 +351,8 @@ private:
     // EFA device to rail mapping
     std::unordered_map<std::string, size_t> efa_device_to_rail_map;
 
-    // Active Rail Tracking System
-    std::unordered_set<size_t> active_rails_;
+    // active rails with reference counting (always positive)
+    std::unordered_map<size_t, size_t> active_rails_;
     mutable std::mutex active_rails_mutex_;
 
     // rail selection policy for DRAM memory type

--- a/test/unit/utils/libfabric/libfabric_mock_stubs.h
+++ b/test/unit/utils/libfabric/libfabric_mock_stubs.h
@@ -1,0 +1,273 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Shared libfabric stub ops for unit tests that need to construct a
+ * nixlLibfabricRailManager without real hardware.  Include this header
+ * in exactly one translation unit per test executable (it contains
+ * definitions, not just declarations).
+ */
+#ifndef NIXL_TEST_UNIT_UTILS_LIBFABRIC_LIBFABRIC_MOCK_STUBS_H
+#define NIXL_TEST_UNIT_UTILS_LIBFABRIC_LIBFABRIC_MOCK_STUBS_H
+
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+
+// helper template for allocating zeroed C structs (free()-able)
+template<typename T>
+T *
+malloc_zero() {
+    T *res = (T *)calloc(1, sizeof(T));
+    if (res == nullptr) {
+        std::stringstream ss;
+        ss << "Failed to allocate " << sizeof(T) << " bytes";
+        throw std::runtime_error(ss.str());
+    }
+    return res;
+}
+
+// --- AV stubs ---
+
+static int
+fi_av_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static struct fi_ops fi_av_fid_ops_stub{
+    .close = fi_av_close_stub,
+};
+
+static fi_ops_av av_ops_stub = {};
+
+static int
+fi_av_open_stub(struct fid_domain *domain,
+                struct fi_av_attr *attr,
+                struct fid_av **av,
+                void *context) {
+    *av = malloc_zero<fid_av>();
+    (*av)->fid.ops = &fi_av_fid_ops_stub;
+    (*av)->ops = &av_ops_stub;
+    return 0;
+}
+
+// --- CQ stubs ---
+
+static int
+fi_cq_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static struct fi_ops fi_cq_fid_ops_stub{
+    .close = fi_cq_close_stub,
+};
+
+static fi_ops_cq cq_ops_stub = {};
+
+static int
+fi_cq_open_stub(struct fid_domain *domain,
+                struct fi_cq_attr *attr,
+                struct fid_cq **cq,
+                void *context) {
+    *cq = malloc_zero<fid_cq>();
+    (*cq)->fid.ops = &fi_cq_fid_ops_stub;
+    (*cq)->ops = &cq_ops_stub;
+    return 0;
+}
+
+// --- EP stubs ---
+
+static int
+fi_ep_setopt_stub(fid_t fid, int level, int optname, const void *optval, size_t optlen) {
+    return 0;
+}
+
+static fi_ops_ep fi_ep_ops_stub = {
+    .setopt = fi_ep_setopt_stub,
+};
+
+static int
+fi_ep_bind_stub(struct fid *fid, struct fid *bfid, uint64_t flags) {
+    return 0;
+}
+
+static int
+fi_ep_control_stub(struct fid *fid, int command, void *arg) {
+    return 0;
+}
+
+static int
+fi_ep_cm_getname_stub(fid_t fid, void *addr, size_t *addrlen) {
+    return 0;
+}
+
+static int
+fi_ep_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static struct fi_ops fi_ep_fid_ops_stub{
+    .close = fi_ep_close_stub,
+    .bind = fi_ep_bind_stub,
+    .control = fi_ep_control_stub,
+};
+
+static struct fi_ops_cm fi_ep_cm_ops_stub{
+    .getname = fi_ep_cm_getname_stub,
+};
+
+static ssize_t
+fi_ep_recvmsg_stub(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags) {
+    return 0;
+}
+
+static fi_ops_msg fi_ep_msg_ops_stub{
+    .recvmsg = fi_ep_recvmsg_stub,
+};
+
+static int
+fi_endpoint_stub(struct fid_domain *domain,
+                 struct fi_info *info,
+                 struct fid_ep **ep,
+                 void *context) {
+    *ep = malloc_zero<fid_ep>();
+    (*ep)->ops = &fi_ep_ops_stub;
+    (*ep)->fid.ops = &fi_ep_fid_ops_stub;
+    (*ep)->cm = &fi_ep_cm_ops_stub;
+    (*ep)->msg = &fi_ep_msg_ops_stub;
+    return 0;
+}
+
+// --- MR stubs ---
+
+static int
+fi_mr_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static fi_ops fi_mr_self_ops_stub = {
+    .close = fi_mr_close_stub,
+};
+
+static int
+fi_mr_reg_stub(struct fid *fid,
+               const void *buf,
+               size_t len,
+               uint64_t access,
+               uint64_t offset,
+               uint64_t requested_key,
+               uint64_t flags,
+               struct fid_mr **mr,
+               void *context) {
+    *mr = malloc_zero<fid_mr>();
+    (*mr)->fid.ops = &fi_mr_self_ops_stub;
+    return 0;
+}
+
+static int
+fi_mr_regattr_stub(struct fid *fid,
+                   const struct fi_mr_attr *attr,
+                   uint64_t flags,
+                   struct fid_mr **mr) {
+    *mr = malloc_zero<fid_mr>();
+    (*mr)->fid.ops = &fi_mr_self_ops_stub;
+    return 0;
+}
+
+static fi_ops_mr fi_mr_ops_stub{
+    .reg = fi_mr_reg_stub,
+    .regv = nullptr,
+    .regattr = fi_mr_regattr_stub,
+};
+
+// --- Domain stubs ---
+
+static fi_ops_domain domain_ops_stub = {.av_open = fi_av_open_stub,
+                                        .cq_open = fi_cq_open_stub,
+                                        .endpoint = fi_endpoint_stub,
+                                        .scalable_ep = nullptr,
+                                        .cntr_open = nullptr,
+                                        .poll_open = nullptr,
+                                        .stx_ctx = nullptr,
+                                        .srx_ctx = nullptr,
+                                        .query_atomic = nullptr,
+                                        .query_collective = nullptr,
+                                        .endpoint2 = nullptr};
+
+static int
+fi_domain_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static struct fi_ops fi_domain_ops_stub{
+    .close = fi_domain_close_stub,
+};
+
+static int
+fi_domain_stub(struct fid_fabric *fabric,
+               struct fi_info *info,
+               struct fid_domain **domain,
+               void *context) {
+    *domain = malloc_zero<fid_domain>();
+    (*domain)->fid.ops = &fi_domain_ops_stub;
+    (*domain)->ops = &domain_ops_stub;
+    (*domain)->mr = &fi_mr_ops_stub;
+    return 0;
+}
+
+// --- Fabric stubs ---
+
+static fi_ops_fabric fabric_ops_stub{.domain = fi_domain_stub,
+                                     .passive_ep = nullptr,
+                                     .eq_open = nullptr,
+                                     .wait_open = nullptr,
+                                     .trywait = nullptr,
+                                     .domain2 = nullptr};
+
+static int
+fi_fabric_close_stub(struct fid *fid) {
+    free(fid);
+    return 0;
+}
+
+static struct fi_ops fi_fabric_ops_stub{
+    .close = fi_fabric_close_stub,
+};
+
+// Helper: build a mock fid_fabric using the stubs above
+static struct fid_fabric *
+mock_fabric_create() {
+    fid_fabric *fabric = malloc_zero<fid_fabric>();
+    fabric->fid.ops = &fi_fabric_ops_stub;
+    fabric->ops = &fabric_ops_stub;
+    return fabric;
+}
+
+#endif // NIXL_TEST_UNIT_UTILS_LIBFABRIC_LIBFABRIC_MOCK_STUBS_H

--- a/test/unit/utils/libfabric/libfabric_topology_test.cpp
+++ b/test/unit/utils/libfabric/libfabric_topology_test.cpp
@@ -548,19 +548,8 @@ __wrap_get_mempolicy(int *mode,
     return 0;
 }
 
-// helper template function for allocating flat type zeroed memory with malloc but keeping new
-// operator semantics of throwing bad_alloc when allocation fails
-template<typename T>
-T *
-malloc_zero() {
-    T *res = (T *)calloc(1, sizeof(T));
-    if (res == nullptr) {
-        std::stringstream ss;
-        ss << "Failed to allocate " << sizeof(T) << " bytes";
-        throw std::runtime_error(ss.str());
-    }
-    return res;
-}
+// shared stub ops for mocking libfabric objects
+#include "libfabric_mock_stubs.h"
 
 // mock fi_getinfo by current topology in use
 extern "C" int
@@ -631,195 +620,6 @@ __wrap_fi_getinfo(uint32_t version,
     return 0; // or FI_SUCCESS
 }
 
-// stubs
-static int
-fi_av_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-struct fi_ops fi_av_fid_ops_stub{
-    .close = fi_av_close_stub,
-};
-
-static fi_ops_av av_ops_stub = {};
-
-static int
-fi_av_open_stub(struct fid_domain *domain,
-                struct fi_av_attr *attr,
-                struct fid_av **av,
-                void *context) {
-    *av = malloc_zero<fid_av>();
-    (*av)->fid.ops = &fi_av_fid_ops_stub;
-    (*av)->ops = &av_ops_stub;
-    return 0;
-}
-
-static int
-fi_cq_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-struct fi_ops fi_cq_fid_ops_stub{
-    .close = fi_cq_close_stub,
-};
-
-static fi_ops_cq cq_ops_stub = {};
-
-static int
-fi_cq_open_stub(struct fid_domain *domain,
-                struct fi_cq_attr *attr,
-                struct fid_cq **cq,
-                void *context) {
-    *cq = malloc_zero<fid_cq>();
-    (*cq)->fid.ops = &fi_cq_fid_ops_stub;
-    (*cq)->ops = &cq_ops_stub;
-    return 0;
-}
-
-static int
-fi_ep_setopt_stub(fid_t fid, int level, int optname, const void *optval, size_t optlen) {
-    return 0;
-}
-
-static fi_ops_ep fi_ep_ops_stub = {
-    .setopt = fi_ep_setopt_stub,
-};
-
-static int
-fi_ep_bind_stub(struct fid *fid, struct fid *bfid, uint64_t flags) {
-    return 0;
-}
-
-static int
-fi_ep_control_stub(struct fid *fid, int command, void *arg) {
-    return 0;
-}
-
-static int
-fi_ep_cm_getname_stub(fid_t fid, void *addr, size_t *addrlen) {
-    return 0;
-}
-
-static int
-fi_ep_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-struct fi_ops fi_ep_fid_ops_stub{
-    .close = fi_ep_close_stub,
-    .bind = fi_ep_bind_stub,
-    .control = fi_ep_control_stub,
-};
-
-struct fi_ops_cm fi_ep_cm_ops_stub{
-    .getname = fi_ep_cm_getname_stub,
-};
-
-static ssize_t
-fi_ep_recvmsg_stub(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags) {
-    return 0;
-}
-
-static fi_ops_msg fi_ep_msg_ops_stub{
-    .recvmsg = fi_ep_recvmsg_stub,
-};
-
-static int
-fi_endpoint_stub(struct fid_domain *domain,
-                 struct fi_info *info,
-                 struct fid_ep **ep,
-                 void *context) {
-    *ep = malloc_zero<fid_ep>();
-    (*ep)->ops = &fi_ep_ops_stub;
-    (*ep)->fid.ops = &fi_ep_fid_ops_stub;
-    (*ep)->cm = &fi_ep_cm_ops_stub;
-    (*ep)->msg = &fi_ep_msg_ops_stub;
-    return 0;
-}
-
-static fi_ops_domain domain_ops_stub = {.av_open = fi_av_open_stub,
-                                        .cq_open = fi_cq_open_stub,
-                                        .endpoint = fi_endpoint_stub,
-                                        .scalable_ep = nullptr,
-                                        .cntr_open = nullptr,
-                                        .poll_open = nullptr,
-                                        .stx_ctx = nullptr,
-                                        .srx_ctx = nullptr,
-                                        .query_atomic = nullptr,
-                                        .query_collective = nullptr,
-                                        .endpoint2 = nullptr};
-
-static int
-fi_mr_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-static fi_ops fi_mr_self_ops_stub = {
-    .close = fi_mr_close_stub,
-};
-
-static int
-fi_mr_reg_stub(struct fid *fid,
-               const void *buf,
-               size_t len,
-               uint64_t access,
-               uint64_t offset,
-               uint64_t requested_key,
-               uint64_t flags,
-               struct fid_mr **mr,
-               void *context) {
-    *mr = malloc_zero<fid_mr>();
-    (*mr)->fid.ops = &fi_mr_self_ops_stub;
-    return 0;
-}
-
-static fi_ops_mr fi_mr_ops_stub{
-    .reg = fi_mr_reg_stub,
-};
-
-static int
-fi_domain_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-struct fi_ops fi_domain_ops_stub{
-    .close = fi_domain_close_stub,
-};
-
-static int
-fi_domain_stub(struct fid_fabric *fabric,
-               struct fi_info *info,
-               struct fid_domain **domain,
-               void *context) {
-    *domain = malloc_zero<fid_domain>();
-    (*domain)->fid.ops = &fi_domain_ops_stub;
-    (*domain)->ops = &domain_ops_stub;
-    (*domain)->mr = &fi_mr_ops_stub;
-    return 0;
-}
-
-static fi_ops_fabric fabric_ops_stub{.domain = fi_domain_stub,
-                                     .passive_ep = nullptr,
-                                     .eq_open = nullptr,
-                                     .wait_open = nullptr,
-                                     .trywait = nullptr,
-                                     .domain2 = nullptr};
-
-static int
-fi_fabric_close_stub(struct fid *fid) {
-    free(fid);
-    return 0;
-}
-
-struct fi_ops fi_fabric_ops_stub{
-    .close = fi_fabric_close_stub,
-};
-
 // mock fi_fabric to get past rail manager constructor
 extern "C" int
 __wrap_fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context) {
@@ -829,9 +629,7 @@ __wrap_fi_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *
         return __real_fi_fabric(attr, fabric, context);
     }
 
-    *fabric = malloc_zero<fid_fabric>();
-    (*fabric)->fid.ops = &fi_fabric_ops_stub;
-    (*fabric)->ops = &fabric_ops_stub;
+    *fabric = mock_fabric_create();
     return 0;
 }
 

--- a/test/unit/utils/libfabric/meson.build
+++ b/test/unit/utils/libfabric/meson.build
@@ -45,4 +45,21 @@ if get_option('buildtype') != 'release'
     # install topology test files
     install_subdir('topo', strip_directory : true, install_dir : get_option('bindir'))
 
+    rail_active_refcount_test_link_args = [
+        '-Wl,--wrap=fi_getinfo',
+        '-Wl,--wrap=numa_max_node',
+        '-Wl,--wrap=numa_num_configured_nodes',
+        '-Wl,--wrap=fi_fabric' ]
+
+    rail_active_refcount_test_bin = executable('rail_active_refcount_test',
+               'rail_active_refcount_test.cpp',
+               dependencies: libfabric_utils_dep,
+               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               link_with: libfabric_utils_lib,
+               cpp_args: libfabric_test_cpp_args,
+               link_args: rail_active_refcount_test_link_args,
+               install: true)
+
+    test('rail_active_refcount_test', rail_active_refcount_test_bin)
+
 endif

--- a/test/unit/utils/libfabric/rail_active_refcount_test.cpp
+++ b/test/unit/utils/libfabric/rail_active_refcount_test.cpp
@@ -232,6 +232,40 @@ testRegisterDeregisterRefcount(nixlLibfabricRailManager &mgr) {
     return 0;
 }
 
+static int
+fi_mr_close_fail(struct fid * /*fid*/) {
+    return -FI_EIO;
+}
+
+static int
+testDeregisterFailureKeepsRailActive(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testDeregisterFailureKeepsRailActive";
+
+    char buf[4096] = {};
+    std::vector<struct fid_mr *> mr_list;
+    std::vector<uint64_t> key_list;
+    std::vector<size_t> selected_rails;
+
+    nixl_status_t st =
+        mgr.registerMemory(buf, sizeof(buf), DRAM_SEG, 0, "", mr_list, key_list, selected_rails);
+    TEST_ASSERT(st == NIXL_SUCCESS, "registerMemory succeeded");
+    TEST_ASSERT(mgr.getActiveRailCount() == NUM_FAKE_RAILS, "all rails active after register");
+
+    // Make fi_close fail so deregisterMemory fails
+    fi_mr_self_ops_stub.close = fi_mr_close_fail;
+    st = mgr.deregisterMemory(selected_rails, mr_list);
+    fi_mr_self_ops_stub.close = fi_mr_close_stub;
+
+    TEST_ASSERT(st != NIXL_SUCCESS, "deregisterMemory should fail");
+    TEST_ASSERT(mgr.getActiveRailCount() == NUM_FAKE_RAILS,
+                "all rails still active after failed deregister");
+
+    // Clean up: successful deregister to reset state
+    st = mgr.deregisterMemory(selected_rails, mr_list);
+    mgr.clearActiveRails();
+    return 0;
+}
+
 int
 main() {
     NIXL_INFO << "=== Rail Active Refcount Test ===";
@@ -249,6 +283,7 @@ main() {
     if ((res = testClearActiveRails(mgr)) != 0) return res;
     if ((res = testMultipleRailsIndependent(mgr)) != 0) return res;
     if ((res = testRegisterDeregisterRefcount(mgr)) != 0) return res;
+    if ((res = testDeregisterFailureKeepsRailActive(mgr)) != 0) return res;
 
     NIXL_INFO << "=== All rail active refcount tests PASSED ===";
     return 0;

--- a/test/unit/utils/libfabric/rail_active_refcount_test.cpp
+++ b/test/unit/utils/libfabric/rail_active_refcount_test.cpp
@@ -1,0 +1,255 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 Amazon.com, Inc. and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Unit test for active rail reference counting in nixlLibfabricRailManager.
+ */
+
+#include "libfabric/libfabric_rail_manager.h"
+#include "libfabric/libfabric_common.h"
+#include "common/nixl_log.h"
+#include "libfabric_mock_stubs.h"
+
+#include <cassert>
+#include <iostream>
+
+// Number of fake EFA devices to create
+static const size_t NUM_FAKE_RAILS = 4;
+
+// --- Unconditional __wrap_* functions (no isTesting gate needed) ---
+
+extern "C" int
+__wrap_numa_max_node() {
+    return 1;
+}
+
+extern "C" int
+__wrap_numa_num_configured_nodes() {
+    return 2;
+}
+
+extern "C" int
+__wrap_fi_getinfo(uint32_t /*version*/,
+                  const char * /*node*/,
+                  const char * /*service*/,
+                  uint64_t /*flags*/,
+                  const struct fi_info * /*hints*/,
+                  struct fi_info **info) {
+    // Build a linked list of NUM_FAKE_RAILS fake EFA devices
+    fi_info *head = nullptr;
+    fi_info *prev = nullptr;
+    for (size_t i = 0; i < NUM_FAKE_RAILS; ++i) {
+        fi_info *fi = malloc_zero<fi_info>();
+
+        fi->domain_attr = malloc_zero<fi_domain_attr>();
+        std::string name = "efa_" + std::to_string(i);
+        fi->domain_attr->name = strdup(name.c_str());
+
+        fi->fabric_attr = malloc_zero<fi_fabric_attr>();
+        fi->fabric_attr->prov_name = strdup("efa");
+        fi->fabric_attr->name = strdup("efa");
+
+        fi->ep_attr = malloc_zero<fi_ep_attr>();
+        fi->ep_attr->type = FI_EP_RDM;
+
+        fi->nic = malloc_zero<fid_nic>();
+        fi->nic->bus_attr = malloc_zero<fi_bus_attr>();
+        fi->nic->bus_attr->bus_type = FI_BUS_PCI;
+        fi->nic->bus_attr->attr.pci.domain_id = 0;
+        fi->nic->bus_attr->attr.pci.bus_id = static_cast<uint8_t>(i);
+        fi->nic->bus_attr->attr.pci.device_id = 0;
+        fi->nic->bus_attr->attr.pci.function_id = 0;
+
+        fi->nic->link_attr = malloc_zero<fi_link_attr>();
+        fi->nic->link_attr->speed = 100ull * NIXL_LIBFABRIC_GIGA;
+
+        if (prev) {
+            prev->next = fi;
+        } else {
+            head = fi;
+        }
+        prev = fi;
+    }
+    *info = head;
+    return 0;
+}
+
+extern "C" int
+__wrap_fi_fabric(struct fi_fabric_attr * /*attr*/, struct fid_fabric **fabric, void * /*context*/) {
+    *fabric = mock_fabric_create();
+    return 0;
+}
+
+// --- Test helpers ---
+
+#define TEST_ASSERT(cond, msg)                                                           \
+    do {                                                                                 \
+        if (!(cond)) {                                                                   \
+            std::cerr << "FAIL: " << (msg) << " [" << __FILE__ << ":" << __LINE__ << "]" \
+                      << std::endl;                                                      \
+            return 1;                                                                    \
+        }                                                                                \
+    } while (0)
+
+// --- Tests ---
+
+static int
+testIncDecBasic(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testIncDecBasic";
+
+    // inc rail 0 twice
+    mgr.incRailActive(0);
+    mgr.incRailActive(0);
+    TEST_ASSERT(mgr.getActiveRailCount() == 1, "one rail active after two incs on same rail");
+
+    // dec once — refcount drops to 1, rail still active
+    mgr.decRailActive(0);
+    TEST_ASSERT(mgr.getActiveRailCount() == 1, "rail still active after one dec");
+
+    // dec again — refcount drops to 0, rail removed
+    mgr.decRailActive(0);
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "rail removed after second dec");
+
+    return 0;
+}
+
+static int
+testDecNonExistent(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testDecNonExistent";
+
+    // dec on a rail that was never inc'd — should not crash
+    mgr.decRailActive(1);
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "count unchanged after dec on non-existent rail");
+
+    return 0;
+}
+
+static int
+testIncInvalidRailId(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testIncInvalidRailId";
+
+    // inc with rail_id >= rails_.size() — should be a no-op
+    mgr.incRailActive(NUM_FAKE_RAILS + 10);
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "no-op for invalid rail id");
+
+    return 0;
+}
+
+static int
+testClearActiveRails(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testClearActiveRails";
+
+    mgr.incRailActive(0);
+    mgr.incRailActive(1);
+    mgr.incRailActive(2);
+    TEST_ASSERT(mgr.getActiveRailCount() == 3, "three rails active");
+
+    mgr.clearActiveRails();
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "all rails cleared");
+
+    return 0;
+}
+
+static int
+testMultipleRailsIndependent(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testMultipleRailsIndependent";
+
+    // rail 0: refcount 3, rail 1: refcount 1, rail 2: refcount 2
+    mgr.incRailActive(0);
+    mgr.incRailActive(0);
+    mgr.incRailActive(0);
+    mgr.incRailActive(1);
+    mgr.incRailActive(2);
+    mgr.incRailActive(2);
+    TEST_ASSERT(mgr.getActiveRailCount() == 3, "three distinct rails active");
+
+    // remove rail 1 entirely
+    mgr.decRailActive(1);
+    TEST_ASSERT(mgr.getActiveRailCount() == 2, "rail 1 removed, two rails remain");
+
+    // dec rail 0 once — still active (refcount 2)
+    mgr.decRailActive(0);
+    TEST_ASSERT(mgr.getActiveRailCount() == 2, "rail 0 still active after one dec");
+
+    // clean up
+    mgr.clearActiveRails();
+    return 0;
+}
+
+static int
+testRegisterDeregisterRefcount(nixlLibfabricRailManager &mgr) {
+    NIXL_INFO << "  testRegisterDeregisterRefcount";
+
+    // Allocate a DRAM buffer to register
+    char buf[4096] = {};
+    std::vector<struct fid_mr *> mr_list;
+    std::vector<uint64_t> key_list;
+    std::vector<size_t> selected_rails;
+
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "no active rails before register");
+
+    nixl_status_t st =
+        mgr.registerMemory(buf, sizeof(buf), DRAM_SEG, 0, "", mr_list, key_list, selected_rails);
+    TEST_ASSERT(st == NIXL_SUCCESS, "registerMemory succeeded");
+    TEST_ASSERT(mgr.getActiveRailCount() == NUM_FAKE_RAILS, "all rails active after DRAM register");
+
+    // Register a second time — refcounts should increase but active count stays the same
+    std::vector<struct fid_mr *> mr_list2;
+    std::vector<uint64_t> key_list2;
+    std::vector<size_t> selected_rails2;
+    st =
+        mgr.registerMemory(buf, sizeof(buf), DRAM_SEG, 0, "", mr_list2, key_list2, selected_rails2);
+    TEST_ASSERT(st == NIXL_SUCCESS, "second registerMemory succeeded");
+    TEST_ASSERT(mgr.getActiveRailCount() == NUM_FAKE_RAILS,
+                "active count unchanged after second register");
+
+    // Deregister first — rails still active (refcount > 0)
+    st = mgr.deregisterMemory(selected_rails, mr_list);
+    TEST_ASSERT(st == NIXL_SUCCESS, "first deregisterMemory succeeded");
+    TEST_ASSERT(mgr.getActiveRailCount() == NUM_FAKE_RAILS,
+                "all rails still active after first deregister");
+
+    // Deregister second — refcounts drop to 0, rails removed
+    st = mgr.deregisterMemory(selected_rails2, mr_list2);
+    TEST_ASSERT(st == NIXL_SUCCESS, "second deregisterMemory succeeded");
+    TEST_ASSERT(mgr.getActiveRailCount() == 0, "no active rails after full deregister");
+
+    return 0;
+}
+
+int
+main() {
+    NIXL_INFO << "=== Rail Active Refcount Test ===";
+    NIXL_INFO << "Using mock stubs (__wrap_fi_getinfo, __wrap_fi_fabric, etc.)";
+
+    // Construct rail manager with mocked hardware (NUM_FAKE_RAILS rails)
+    nixlLibfabricRailManager mgr(0);
+    TEST_ASSERT(mgr.getNumRails() == NUM_FAKE_RAILS,
+                "expected " + std::to_string(NUM_FAKE_RAILS) + " rails");
+
+    int res;
+    if ((res = testIncDecBasic(mgr)) != 0) return res;
+    if ((res = testDecNonExistent(mgr)) != 0) return res;
+    if ((res = testIncInvalidRailId(mgr)) != 0) return res;
+    if ((res = testClearActiveRails(mgr)) != 0) return res;
+    if ((res = testMultipleRailsIndependent(mgr)) != 0) return res;
+    if ((res = testRegisterDeregisterRefcount(mgr)) != 0) return res;
+
+    NIXL_INFO << "=== All rail active refcount tests PASSED ===";
+    return 0;
+}


### PR DESCRIPTION
Fix active rail tracking in libfabric backend.

## What?
Today there is no reference counting to correctly keep track of the status of rails. In addition to fixing that, I add a unit test with some code refactoring to avoid duplicating the common test code.

## Why?
It is a bug without this mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active-rail tracking now uses per-rail reference counts; rails become inactive only when their count reaches zero.

* **Tests**
  * Added a comprehensive unit test covering refcount transitions, edge cases, memory-registration interactions, and multi-rail behavior.

* **Chores**
  * Added shared test stubs/helpers and a new test executable to support the refcounting tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->