### PR TITLE
libfabric: fix duplicate fragment in multi-process PP scenarios

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -297,6 +297,16 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 
     NIXL_DEBUG << "Initializing Libfabric Backend";
 
+    // Compute compact sender ID from agent UUID for cross-process uniqueness.
+    // Each NIXL agent has a unique UUID name. XOR-fold all bytes to 8 bits.
+    // With only 2-3 senders per receiver (PP ranks), collision probability is <1%.
+    {
+        uint8_t id = 0;
+        for (char c : localAgent) id ^= static_cast<uint8_t>(c);
+        my_sender_id_ = id;
+        NIXL_INFO << "Agent " << localAgent << " sender_id=" << static_cast<int>(my_sender_id_);
+    }
+
     // this is required for loading rail selection policy by configuration
     if (rail_manager.init(getCustomParams()) != NIXL_SUCCESS) {
         throw std::runtime_error("Failed to initialize the rail manager");
@@ -361,7 +371,8 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
             rail_manager.getRail(rail_id).setXferIdCallback([this](uint64_t imm_data) {
                 // Extract XFER_ID from immediate data
                 uint16_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(imm_data);
-                addReceivedXferId(xfer_id);
+                uint8_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(imm_data);
+                addReceivedXferId(agent_idx, xfer_id);
             });
             NIXL_DEBUG << "Set XFER_ID callback for rail " << rail_id;
         }
@@ -1068,7 +1079,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
             remote_md->rail_remote_key_list_,
             remote_md->remote_selected_endpoints_,
             conn_it->second->rail_remote_addr_list_,
-            conn_it->second->agent_index_,
+            my_sender_id_,
             backend_handle->post_xfer_id,
             [backend_handle]() {
                 backend_handle->increment_completed_requests();
@@ -1238,6 +1249,8 @@ nixlLibfabricEngine::fragmentNotificationMessage(
         // Set header fields
         BinaryNotificationHeader header;
         header.notif_xfer_id = 0; // Will be set later in notifSendPriv
+        header.sender_agent_idx = 0; // Will be set later in notifSendPriv
+        header.reserved_ = 0;
         header.notif_seq_id = static_cast<uint16_t>(frag_idx);
         header.notif_seq_len = static_cast<uint16_t>(num_fragments);
 
@@ -1303,6 +1316,7 @@ nixlLibfabricEngine::notifSendPriv(const std::string &remote_agent,
         // Update header fields for this notification
         BinaryNotificationHeader header = binary_notification.getHeader();
         header.notif_xfer_id = notif_xfer_id;
+        header.sender_agent_idx = my_sender_id_;
         binary_notification.setHeader(header);
 
         // Update first fragment header with expected_completions (only for fragment 0)
@@ -1338,7 +1352,7 @@ nixlLibfabricEngine::notifSendPriv(const std::string &remote_agent,
             nixlLibfabricRailManager::ControlMessageType::NOTIFICATION,
             control_request,
             connection->rail_remote_addr_list_[rail_id][0],
-            connection->agent_index_);
+            my_sender_id_);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "postControlMessage failed on rail " << rail_id << " for fragment "
@@ -1451,6 +1465,7 @@ nixlLibfabricEngine::processNotification(const std::string &serialized_notif) {
     uint16_t notif_xfer_id = header.notif_xfer_id;
     uint16_t notif_seq_id = header.notif_seq_id;
     uint16_t notif_seq_len = header.notif_seq_len;
+    uint8_t sender_agent_idx = header.sender_agent_idx;
 
     // Get payload chunk (combined agent_name + message chunk for all fragments)
     const std::string &payload_chunk = binary_notif.getPayload();
@@ -1475,7 +1490,8 @@ nixlLibfabricEngine::processNotification(const std::string &serialized_notif) {
         std::lock_guard<std::mutex> lock(receiver_tracking_mutex_);
 
         // Use try_emplace to construct in-place - eliminates extra copy
-        auto [it, inserted] = pending_notifications_.try_emplace(notif_xfer_id, notif_xfer_id);
+        PendingNotifKey key{sender_agent_idx, notif_xfer_id};
+        auto [it, inserted] = pending_notifications_.try_emplace(key, notif_xfer_id);
 
         if (inserted) {
             NIXL_DEBUG << "Created pending notification" << " notif_xfer_id=" << notif_xfer_id
@@ -1529,14 +1545,15 @@ nixlLibfabricEngine::processNotification(const std::string &serialized_notif) {
  *****************************************/
 
 void
-nixlLibfabricEngine::addReceivedXferId(uint16_t xfer_id) {
+nixlLibfabricEngine::addReceivedXferId(uint8_t agent_idx, uint16_t xfer_id) {
     {
         std::lock_guard<std::mutex> lock(receiver_tracking_mutex_);
 
         // Use try_emplace to construct in-place - eliminates extra copy
         // First parameter: map key for lookup
         // Second parameter: constructor argument for PendingNotification
-        auto [it, inserted] = pending_notifications_.try_emplace(xfer_id, xfer_id);
+        PendingNotifKey key{agent_idx, xfer_id};
+        auto [it, inserted] = pending_notifications_.try_emplace(key, xfer_id);
 
         if (inserted) {
             // Set placeholder values for write-arrived-first case

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -176,6 +176,10 @@ private:
     // Store user's original progress thread preference
     bool progress_thread_enabled_;
 
+    // Compact sender ID derived from agent UUID, used in notifications and IMM data
+    // to uniquely identify this engine across processes (e.g., different PP ranks).
+    uint8_t my_sender_id_;
+
     // Progress thread delay in microseconds
     std::chrono::microseconds progress_thread_delay_;
 
@@ -220,6 +224,26 @@ private:
     std::mutex receiver_tracking_mutex_;
     std::unordered_set<uint32_t> received_remote_writes_; // All received XFER_IDs (global)
 
+    // Compound key for pending notifications: (sender_agent_idx, notif_xfer_id)
+    // This disambiguates notifications from different senders (e.g., PP ranks)
+    // that may have the same notif_xfer_id due to independent counters.
+    struct PendingNotifKey {
+        uint8_t sender_agent_idx;
+        uint16_t notif_xfer_id;
+
+        bool operator==(const PendingNotifKey &other) const {
+            return sender_agent_idx == other.sender_agent_idx &&
+                   notif_xfer_id == other.notif_xfer_id;
+        }
+    };
+
+    struct PendingNotifKeyHash {
+        size_t operator()(const PendingNotifKey &k) const {
+            return std::hash<uint32_t>()(
+                (static_cast<uint32_t>(k.sender_agent_idx) << 16) | k.notif_xfer_id);
+        }
+    };
+
     // Notification Queuing
     struct PendingNotification {
         std::string remote_agent;
@@ -244,7 +268,7 @@ private:
     };
 
     // O(1) lookup with postXferID key
-    std::unordered_map<uint16_t, PendingNotification> pending_notifications_;
+    std::unordered_map<PendingNotifKey, PendingNotification, PendingNotifKeyHash> pending_notifications_;
 
     // Connection management helpers
     nixl_status_t
@@ -583,7 +607,7 @@ public:
      * @param[in] xfer_id 16-bit transfer ID that was received
      */
     void
-    addReceivedXferId(uint16_t xfer_id);
+    addReceivedXferId(uint8_t agent_idx, uint16_t xfer_id);
 
     // Notification Queuing Helper Methods
     /**

--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -106,6 +106,8 @@ struct BinaryNotificationHeader {
     uint16_t notif_seq_id; // Fragment index (0, 1, 2...)
     uint16_t notif_seq_len; // Total number of fragments
     uint32_t payload_length; // Message bytes of this fragment
+    uint8_t sender_agent_idx; // Sender's agent index (for multi-sender disambiguation)
+    uint8_t reserved_; // Padding for alignment
 } __attribute__((packed));
 
 /**


### PR DESCRIPTION
When multiple processes (e.g., PP ranks in pipeline parallelism) send notifications to the same receiver, their independent notif_xfer_id counters can generate identical values. The receiver's pending_notifications_ map, keyed solely by notif_xfer_id, cannot distinguish these senders, causing "Duplicate fragment" warnings and waiting_timeout failures.

This is observed in SGLang PD disaggregation with PP=2, where two prefill PP ranks each send KV cache + notifications to the decode node. With input >= 4K tokens, the timing overlap causes xfer_id collisions that block KV transfer completion.

Fix:
- Add sender_agent_idx field to BinaryNotificationHeader (8-bit, derived from XOR-fold of the sender's UUID agent name)
- Use compound key (sender_agent_idx, notif_xfer_id) in pending_notifications_ map to disambiguate senders
- Propagate sender identity consistently through RDMA write IMM data, notification headers, and control message IMM data

The connection->agent_index_ (local sequential index) was not suitable as sender identifier because each process assigns indices independently, resulting in the same value (typically 0) across all senders.

Tested with SGLang GLM-5-FP8 (754B MoE) on 3x p5en.48xlarge (H200):
- PP=2 prefill + 1 decode, LIBFABRIC backend over EFA
- All input lengths (2K-50K) pass with 0 duplicate fragments
- Previously: 4K+ input caused immediate failures

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced multi-sender notification tracking to reliably identify and process transfer messages from multiple sources.
  * Improved transfer validation infrastructure for more robust message delivery in distributed communication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->