### PR TITLE
PLUGINS/UCX: Removed unused class field.

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -932,20 +932,13 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
 
     nixlSerDes::_stringToBytes(addr.data(), remote_conn_info, size);
     std::shared_ptr<nixlUcxConnection> conn = std::make_shared<nixlUcxConnection>();
-    bool error = false;
     for (auto &uw: uws) {
         auto result = uw->connect(addr.data(), size);
         if (!result.ok()) {
-            error = true;
-            break;
+            return NIXL_ERR_BACKEND;
         }
         conn->eps.push_back(std::move(*result));
     }
-
-    if (error)
-        return NIXL_ERR_BACKEND;
-
-    conn->remoteAgent = remote_agent;
 
     remoteConnMap.insert({remote_agent, conn});
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -42,7 +42,6 @@ enum ucx_cb_op_t { NOTIF_STR };
 
 class nixlUcxConnection : public nixlBackendConnMD {
     private:
-        std::string remoteAgent;
         std::vector<std::unique_ptr<nixlUcxEp>> eps;
 
     public:


### PR DESCRIPTION
## What?
Deleted the unused field `nixlUcxConnection::RemoteAgent`.
Deleted the unnecessary variable from `nixlUcxEngine::loadRemoteConnInfo`.