### PR TITLE
Fix unbounded growth of in-memory telemetry event buffer

### DIFF
--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -98,6 +98,8 @@ nixlTelemetry::initializeTelemetry() {
         throw std::invalid_argument("Telemetry buffer size cannot be 0");
     }
 
+    maxBufferedEvents_ = buffer_size;
+
     const std::optional<std::string> exporter_name = getExporterName();
 
     if (!exporter_name) {
@@ -172,6 +174,9 @@ nixlTelemetry::updateData(const std::string &event_name,
                           uint64_t value) {
     // agent can be multi-threaded
     std::lock_guard<std::mutex> lock(mutex_);
+    if (events_.size() >= maxBufferedEvents_) {
+        return;
+    }
     events_.emplace_back(std::chrono::duration_cast<std::chrono::microseconds>(
                              std::chrono::system_clock::now().time_since_epoch())
                              .count(),
@@ -235,6 +240,9 @@ nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, u
                           .count();
 
     const std::lock_guard lock(mutex_);
+    if (events_.size() + 3 > maxBufferedEvents_) {
+        return;
+    }
     events_.emplace_back(time,
                          nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                          "agent_xfer_time",

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -91,14 +91,12 @@ getExporterName() {
 
 void
 nixlTelemetry::initializeTelemetry() {
-    const auto buffer_size = nixl::config::getValueDefaulted<size_t>(TELEMETRY_BUFFER_SIZE_VAR,
-                                                                     DEFAULT_TELEMETRY_BUFFER_SIZE);
+    maxBufferedEvents_ = nixl::config::getValueDefaulted<size_t>(TELEMETRY_BUFFER_SIZE_VAR,
+                                                                 DEFAULT_TELEMETRY_BUFFER_SIZE);
 
-    if (buffer_size == 0) {
+    if (maxBufferedEvents_ == 0) {
         throw std::invalid_argument("Telemetry buffer size cannot be 0");
     }
-
-    maxBufferedEvents_ = buffer_size;
 
     const std::optional<std::string> exporter_name = getExporterName();
 
@@ -114,7 +112,7 @@ nixlTelemetry::initializeTelemetry() {
         throw std::runtime_error("Failed to load telemetry plugin: " + *exporter_name);
     }
 
-    const nixlTelemetryExporterInitParams init_params{agentName_, buffer_size};
+    const nixlTelemetryExporterInitParams init_params{agentName_, maxBufferedEvents_};
     exporter_ = plugin_handle->createExporter(init_params);
     if (!exporter_) {
         NIXL_ERROR << "Failed to create telemetry exporter: " << *exporter_name;
@@ -136,8 +134,7 @@ nixlTelemetry::initializeTelemetry() {
 bool
 nixlTelemetry::writeEventHelper() {
     std::vector<nixlTelemetryEvent> next_queue;
-    // assume next buffer will be the same size as the current one
-    next_queue.reserve(exporter_->getMaxEventsBuffered());
+    next_queue.reserve(maxBufferedEvents_);
     {
         std::lock_guard<std::mutex> lock(mutex_);
         events_.swap(next_queue);

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -85,6 +85,7 @@ private:
     std::unique_ptr<nixlTelemetryExporter> exporter_;
     std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
     std::vector<nixlTelemetryEvent> events_;
+    size_t maxBufferedEvents_;
     std::mutex mutex_;
     asio::thread_pool pool_;
     periodicTask writeTask_;


### PR DESCRIPTION
The events_ vector grew without limit between periodic flushes. Enforce the configured buffer size (NIXL_TELEMETRY_BUFFER_SIZE) by dropping new events when the buffer is full (drop-newest policy).

## What?
Enforce the configured buffer size (`NIXL_TELEMETRY_BUFFER_SIZE`, default 4096) on the in-memory `events_` vector in `nixlTelemetry`, dropping new events when the buffer is full.

## Why?
The `events_` vector in `nixlTelemetry` grows without bound between periodic flushes. Both `updateData()` and `addXferTime()` unconditionally call `emplace_back()` with no size check. Under burst conditions (or if events are produced faster than the flush interval drains them), this leads to unbounded memory growth. The `buffer_size` config was read but only forwarded to the exporter — it was never used to limit the in-memory staging vector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry now strictly honors the configured buffer capacity; once full, additional events are dropped instead of growing the buffer.
  * Related performance/transfer events are now blocked from being enqueued when doing so would exceed capacity, preventing buffer overruns and reducing unexpected memory growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->