### PR TITLE
nixl_ep: Make GPU timeouts configurable 

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -32,7 +32,7 @@ namespace nixl_ep {
 
 namespace intranode {
 
-void barrier(int** barrier_signal_ptrs, int rank, int num_nvl_ranks, cudaStream_t stream);
+void barrier(int** barrier_signal_ptrs, int rank, int num_nvl_ranks, uint64_t timeout_cycles, cudaStream_t stream);
 
 }  // namespace intranode
 
@@ -105,6 +105,7 @@ void notify_dispatch(const int* num_tokens_per_rank,
                      cudaStream_t stream,
                      int64_t num_rdma_bytes,
                      int64_t num_nvl_bytes,
+                     uint64_t timeout_cycles,
                      bool low_latency_mode,
                      gpu_nixl_ctx nixl_ctx);
 
@@ -144,6 +145,7 @@ void dispatch(void* recv_x,
               bool is_cached_dispatch,
               cudaStream_t stream,
               int num_channels,
+              uint64_t timeout_cycles,
               bool low_latency_mode,
               gpu_nixl_ctx nixl_ctx);
 
@@ -167,6 +169,7 @@ void cached_notify(int hidden_int4,
                    cudaStream_t stream,
                    int64_t num_rdma_bytes,
                    int64_t num_nvl_bytes,
+                   uint64_t timeout_cycles,
                    bool is_cached_dispatch,
                    bool low_latency_mode,
                    gpu_nixl_ctx nixl_ctx);
@@ -199,6 +202,7 @@ void combine(cudaDataType_t type,
              int num_ranks,
              cudaStream_t stream,
              int num_channels,
+             uint64_t timeout_cycles,
              bool low_latency_mode,
              gpu_nixl_ctx nixl_ctx);
 
@@ -224,6 +228,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
               int num_topk, int num_experts, int rank, int num_ranks,
               bool use_fp8, bool round_scale, bool use_ue8m0,
+              uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
               cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx);
 
@@ -236,11 +241,11 @@ void combine(void* combined_x,
              uint64_t* next_clean, int num_next_clean_int,
              int num_combined_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
              int num_topk, int num_experts, int rank, int num_ranks,
-             bool use_logfmt,
+             bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx);
 
-void barrier(gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, cudaStream_t stream);
+void barrier(gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream);
 
 void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
 

--- a/examples/device/ep/csrc/kernels/configs.cuh
+++ b/examples/device/ep/csrc/kernels/configs.cuh
@@ -33,10 +33,8 @@
 
 #ifndef ENABLE_FAST_DEBUG
 #define NUM_CPU_TIMEOUT_SECS 100
-#define NUM_TIMEOUT_CYCLES 200000000000ull // 200G cycles ~= 100s
 #else
 #define NUM_CPU_TIMEOUT_SECS 10
-#define NUM_TIMEOUT_CYCLES 20000000000ull // 20G cycles ~= 10s
 #endif
 
 #define EP_SEND_PHASE 1

--- a/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
@@ -156,6 +156,7 @@ __global__ void notify_dispatch(const int* num_tokens_per_rank,
                                 void** buffer_ptrs,
                                 int** barrier_signal_ptrs,
                                 int rank,
+                                uint64_t timeout_cycles,
                                 nixl_ep::gpu_nixl_ctx nixl_ctx) {
     auto sm_id = static_cast<int>(blockIdx.x);
     auto thread_id = static_cast<int>(threadIdx.x), warp_id = thread_id / 32, lane_id = get_lane_id();
@@ -177,7 +178,7 @@ __global__ void notify_dispatch(const int* num_tokens_per_rank,
             if (lane_id == 0)
                 nixl_barrier_wait(nixl_ctx, num_channels);
         }
-        barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank);
+        barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank, timeout_cycles);
 
         // Send numbers of tokens per rank/expert to RDMA ranks
         auto rdma_buffer_ptr_int = static_cast<int*>(rdma_buffer_ptr);
@@ -288,7 +289,7 @@ __global__ void notify_dispatch(const int* num_tokens_per_rank,
             for (int i = 0; i < num_nvl_experts; ++i)
                 nvl_send_num_tokens_per_expert.buffer(nvl_rank)[i] = nvl_reduced_num_tokens_per_expert[thread_id * num_nvl_experts + i];
         }
-        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
+        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank, timeout_cycles);
 
         // Reduce the number of tokens per rank/expert
         EP_DEVICE_ASSERT(num_nvl_experts <= num_threads);
@@ -319,7 +320,7 @@ __global__ void notify_dispatch(const int* num_tokens_per_rank,
             if (lane_id == 0)
                 nixl_barrier_wait(nixl_ctx, num_channels);
         }
-        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
+        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank, timeout_cycles);
     } else {
         // Calculate meta data
         int dst_rdma_rank = sm_id - 1;
@@ -402,6 +403,7 @@ void notify_dispatch(const int* num_tokens_per_rank,
                      cudaStream_t stream,
                      int64_t num_rdma_bytes,
                      int64_t num_nvl_bytes,
+                     uint64_t timeout_cycles,
                      bool low_latency_mode,
                      nixl_ep::gpu_nixl_ctx nixl_ctx) {
 #define NOTIFY_DISPATCH_LAUNCH_CASE(num_rdma_ranks)                                                                                    \
@@ -433,6 +435,7 @@ void notify_dispatch(const int* num_tokens_per_rank,
                       buffer_ptrs,                                                                                                     \
                       barrier_signal_ptrs,                                                                                             \
                       rank,                                                                                                            \
+                      timeout_cycles,                                                                                                  \
                       nixl_ctx);                                                                                                       \
     }                                                                                                                                  \
     break
@@ -508,6 +511,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
              int num_max_nvl_chunked_recv_tokens,
              int rank,
              int num_ranks,
+             uint64_t timeout_cycles,
              nixl_ep::gpu_nixl_ctx nixl_ctx) {
     enum class WarpRole { kRDMASender, kRDMASenderCoordinator, kRDMAAndNVLForwarder, kForwarderCoordinator, kNVLReceivers };
 
@@ -676,7 +680,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
                 cached_rdma_channel_head = static_cast<int>(ld_volatile_global(rdma_channel_head.buffer(lane_id)));
 
                 // Timeout check
-                if (clock64() - start_time >= NUM_TIMEOUT_CYCLES) {
+                if (clock64() - start_time >= timeout_cycles) {
                     printf("NixlEP dispatch RDMA sender timeout, channel: %d, RDMA: %d, nvl: %d, dst RDMA lane: %d, head: %d, tail: %d\n",
                            channel_id,
                            rdma_rank,
@@ -807,7 +811,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
         auto start_time = clock64();
         while (__any_sync(0xffffffff, num_tokens_to_send > 0)) {
             // Timeout check
-            if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < kNumRDMARanks) {
+            if (clock64() - start_time > timeout_cycles and lane_id < kNumRDMARanks) {
                 printf("NixlEP RDMA sender coordinator timeout, channel: %d, IB: %d, nvl %d, dst IB: %d, tail: %d, remaining: %d\n",
                        channel_id,
                        rdma_rank,
@@ -913,7 +917,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
                 }
 
                 // Timeout check
-                if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                if (clock64() - start_time > timeout_cycles) {
                     printf(
                         "NixlEP dispatch forwarder timeout (RDMA meta), channel: %d, RDMA: %d, nvl: %d, src RDMA lane: %d, dst NVL: %d, meta: %d, %d, %d, %d\n",
                         channel_id,
@@ -952,7 +956,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
                 cached_nvl_channel_head = __shfl_sync(0xffffffffu, ld_volatile_global(nvl_channel_head.buffer()), 0);
 
                 // Timeout check
-                if (elect_one_sync() and clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                if (elect_one_sync() and clock64() - start_time > timeout_cycles) {
                     printf(
                         "NixlEP dispatch forwarder timeout (NVL check), channel: %d, RDMA: %d, nvl: %d, dst NVL: %d, head: %d, tail: %d\n",
                         channel_id,
@@ -981,7 +985,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
                 }
 
                 // Timeout check
-                if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < kNumRDMARanks) {
+                if (clock64() - start_time > timeout_cycles and lane_id < kNumRDMARanks) {
                     printf(
                         "NixlEP dispatch forwarder timeout (RDMA check), channel: %d, RDMA: %d, nvl: %d, dst NVL: %d, src RDMA lane: %d, "
                         "head: %d, tail: %d, expected: %d\n",
@@ -1128,7 +1132,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
             }
 
             // Timeout check
-            if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+            if (clock64() - start_time > timeout_cycles) {
                 printf(
                     "NixlEP dispatch NVL receiver timeout, channel: %d, RDMA: %d, nvl: %d, src RDMA: %d, src nvl: %d, start: %d, end: %d\n",
                     channel_id,
@@ -1159,7 +1163,7 @@ __global__ void __launch_bounds__(((kNumDispatchRDMASenderWarps + 1 + NUM_MAX_NV
                 cached_channel_tail_idx = __shfl_sync(0xffffffff, ld_acquire_sys_global(nvl_channel_tail.buffer()), 0);
 
                 // Timeout check
-                if (elect_one_sync() and clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                if (elect_one_sync() and clock64() - start_time > timeout_cycles) {
                     printf("NixlEP dispatch NVL receiver timeout, channel: %d, RDMA: %d, nvl: %d, src NVL: %d, head: %d, tail: %d\n",
                            channel_id,
                            rdma_rank,
@@ -1278,6 +1282,7 @@ void dispatch(void* recv_x,
               bool is_cached_dispatch,
               cudaStream_t stream,
               int num_channels,
+              uint64_t timeout_cycles,
               bool low_latency_mode,
               gpu_nixl_ctx nixl_ctx) {
     constexpr int kNumDispatchRDMASenderWarps = 7;
@@ -1330,6 +1335,7 @@ void dispatch(void* recv_x,
                       num_max_nvl_chunked_recv_tokens,                                                                         \
                       rank,                                                                                                    \
                       num_ranks,                                                                                               \
+                      timeout_cycles,                                                                                          \
                       nixl_ctx);                                                                                               \
     }                                                                                                                          \
     break
@@ -1358,6 +1364,7 @@ __global__ void cached_notify(const int rdma_clean_offset,
                               int** barrier_signal_ptrs,
                               int rank,
                               int num_ranks,
+                              uint64_t timeout_cycles,
                               bool is_cached_dispatch,
                               gpu_nixl_ctx nixl_ctx) {
     auto sm_id = static_cast<int>(blockIdx.x);
@@ -1382,7 +1389,7 @@ __global__ void cached_notify(const int rdma_clean_offset,
         }
 
         // Barrier for NVL
-        barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank);
+        barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank, timeout_cycles);
 
         // Clean RDMA buffer
         auto rdma_buffer_ptr_int = static_cast<int*>(rdma_buffer_ptr);
@@ -1403,7 +1410,7 @@ __global__ void cached_notify(const int rdma_clean_offset,
             if (lane_id == 0)
                 nixl_barrier_wait(nixl_ctx, num_channels);
         }
-        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
+        barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank, timeout_cycles);
     } else if (sm_id == 1) {
         if (is_cached_dispatch)
             return;
@@ -1521,6 +1528,7 @@ void cached_notify(int hidden_int4,
                    cudaStream_t stream,
                    int64_t num_rdma_bytes,
                    int64_t num_nvl_bytes,
+                   uint64_t timeout_cycles,
                    bool is_cached_dispatch,
                    bool low_latency_mode,
                    gpu_nixl_ctx nixl_ctx) {
@@ -1569,6 +1577,7 @@ void cached_notify(int hidden_int4,
                   barrier_signal_ptrs,
                   rank,
                   num_ranks,
+                  timeout_cycles,
                   is_cached_dispatch,
                   nixl_ctx);
 }
@@ -1773,6 +1782,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
                                                                         int num_max_nvl_chunked_recv_tokens,
                                                                         int rank,
                                                                         int num_ranks,
+                                                                        uint64_t timeout_cycles,
                                                                         gpu_nixl_ctx nixl_ctx) {
     enum class WarpRole { kNVLSender, kNVLAndRDMAForwarder, kRDMAReceiver, kCoordinator };
 
@@ -1883,7 +1893,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
                     cached_channel_head_idx = ld_volatile_global(nvl_channel_head.buffer() + lane_id);
 
                 // Timeout check
-                if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < kNumRDMARanks) {
+                if (clock64() - start_time > timeout_cycles and lane_id < kNumRDMARanks) {
                     printf(
                         "NixlEP combine NVL sender timeout, channel: %d, RDMA: %d, nvl: %d, dst NVL: %d, RDMA lane: %d, head: %d, tail: "
                         "%d, start: %d, end: %d\n",
@@ -2055,7 +2065,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
                         break;
 
                     // Timeout check
-                    if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    if (clock64() - start_time > timeout_cycles) {
                         printf(
                             "NixlEP combine forwarder (RDMA check) timeout, channel: %d, RDMA: %d, nvl: %d, dst RDMA: %d, head: %ld, tail: "
                             "%d, chunked: %d\n",
@@ -2088,7 +2098,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
                         cached_nvl_channel_tail_idx = ld_acquire_sys_global(nvl_channel_tail.buffer(lane_id));
 
                         // Timeout check
-                        if (clock64() - start_time > NUM_TIMEOUT_CYCLES and lane_id < NUM_MAX_NVL_PEERS) {
+                        if (clock64() - start_time > timeout_cycles and lane_id < NUM_MAX_NVL_PEERS) {
                             printf(
                                 "NixlEP combine forwarder (NVL check) timeout, channel: %d, RDMA: %d, nvl: %d, src NVL: %d, dst RDMA: %d, "
                                 "tail: %d, waiting: %d, total: %d, sub: %d, large: %d, expected: %d\n",
@@ -2212,7 +2222,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * 32, 1) combine(int4* co
                     cached_channel_tail_idx = static_cast<int>(ld_acquire_sys_global(rdma_channel_tail.buffer(lane_id)));
 
                     // Timeout check
-                    if (clock64() - start_time > NUM_TIMEOUT_CYCLES) {
+                    if (clock64() - start_time > timeout_cycles) {
                         printf(
                             "NixlEP combine RDMA receiver timeout, channel: %d, RDMA: %d, nvl: %d, src RDMA: %d, tail: %d, waiting: %ld, "
                             "expect: %d\n",
@@ -2346,6 +2356,7 @@ void combine(cudaDataType_t type,
              int num_ranks,
              cudaStream_t stream,
              int num_channels,
+             uint64_t timeout_cycles,
              bool low_latency_mode,
              gpu_nixl_ctx nixl_ctx) {
     constexpr int kNumCombineForwarderWarps = 24;
@@ -2396,6 +2407,7 @@ void combine(cudaDataType_t type,
                       num_max_nvl_chunked_recv_tokens,                                \
                       rank,                                                           \
                       num_ranks,                                                      \
+                      timeout_cycles,                                                 \
                       nixl_ctx);                                                      \
     }                                                                                 \
     break

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -74,7 +74,7 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
          int num_tokens, int num_max_dispatch_tokens_per_rank,
          int num_topk, int num_experts, int rank, int num_ranks,
          int num_warp_groups, int num_warps_per_group,
-         bool round_scale, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+         bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx) {
     const auto sm_id = static_cast<int>(blockIdx.x);
     const auto thread_id = static_cast<int>(threadIdx.x);
     const auto warp_id = thread_id / 32, lane_id = get_lane_id();
@@ -308,7 +308,7 @@ DISPATCH_RECV:
             if (not is_rank_masked(mask_buffer_ptr, src_rank)) {
                 while ((num_recv_tokens = ld_acquire_sys_global(rdma_recv_count + local_expert_idx * num_ranks + src_rank)) ==
                            0                                                               // data not arrived
-                       && (wait_recv_cost = clock64() - start_time) <= NUM_TIMEOUT_CYCLES  // not timeout
+                       && (wait_recv_cost = clock64() - start_time) <= timeout_cycles       // not timeout
                 )
                     ;
             }
@@ -316,7 +316,7 @@ DISPATCH_RECV:
             if (num_recv_tokens == 0)
                 num_recv_tokens = 1;
             // Mask rank if timeout
-            if (wait_recv_cost > NUM_TIMEOUT_CYCLES) {
+            if (wait_recv_cost > timeout_cycles) {
                 printf("Warning: NIXL-EP timeout for dispatch receive, rank %d, local_expert_idx %d, src_rank %d\n",
                        rank,
                        local_expert_idx,
@@ -395,6 +395,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
               int num_topk, int num_experts, int rank, int num_ranks,
               bool use_fp8, bool round_scale, bool use_ue8m0,
+              uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
               cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx) {
     constexpr int kNumMaxTopK = 11;
@@ -436,7 +437,7 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
               num_tokens, num_max_dispatch_tokens_per_rank, \
               num_topk, num_experts, rank, num_ranks, \
               num_warp_groups, num_warps_per_group, \
-              round_scale, phases, nixl_ctx); } break
+              round_scale, timeout_cycles, phases, nixl_ctx); } break
 
     SETUP_LAUNCH_CONFIG(num_sms, num_warps * 32, stream);
     SWITCH_HIDDEN(DISPATCH_LAUNCH_CASE);
@@ -616,7 +617,7 @@ combine(void* combined_x,
         int num_max_dispatch_tokens_per_rank,
         int num_experts, int rank, int num_ranks,
         int num_warp_groups, int num_warps_per_group,
-        int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+        uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx) {
     const auto sm_id = __shfl_sync(0xffffffff, static_cast<int>(blockIdx.x), 0);
     const auto num_sms = __shfl_sync(0xffffffff, static_cast<int>(gridDim.x), 0);
     const auto thread_id = static_cast<int>(threadIdx.x);
@@ -836,12 +837,12 @@ COMBINE_RECV:
             uint64_t wait_recv_cost = 0;
             if (not is_rank_masked(mask_buffer_ptr, src_rank)) {
                 while (ld_acquire_sys_global(rdma_recv_flag + responsible_expert_idx) == 0  // recv not ready
-                       && (wait_recv_cost = clock64() - start_time) <= NUM_TIMEOUT_CYCLES   // not timeout
+                       && (wait_recv_cost = clock64() - start_time) <= timeout_cycles        // not timeout
                 )
                     ;
             }
             // Mask rank if timeout
-            if (wait_recv_cost > NUM_TIMEOUT_CYCLES) {
+            if (wait_recv_cost > timeout_cycles) {
                 printf("Warning: NIXL-EP timeout for combine receive, rank %d, local_expert_idx %d, src_rank %d\n",
                        rank,
                        responsible_expert_idx % num_local_experts,
@@ -1007,7 +1008,7 @@ void combine(void* combined_x,
              uint64_t* next_clean, int num_next_clean_int,
              int num_combined_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
              int num_topk, int num_experts, int rank, int num_ranks,
-             bool use_logfmt,
+             bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx) {
     constexpr int kNumMaxTopk = 11;
@@ -1061,7 +1062,7 @@ LAUNCH_KERNEL(&cfg, combine_func, \
               num_max_dispatch_tokens_per_rank, \
               num_experts, rank, num_ranks, \
               num_warp_groups, num_warps_per_group, \
-              phases, zero_copy, nixl_ctx); } break
+              timeout_cycles, phases, zero_copy, nixl_ctx); } break
 
     SETUP_LAUNCH_CONFIG(num_sms, num_warps * 32, stream);
     SWITCH_HIDDEN(COMBINE_LAUNCH_CASE);
@@ -1120,7 +1121,7 @@ void clean_mask_buffer(int* mask_buffer_ptr, int num_ranks, cudaStream_t stream)
 }
 
 template <int kNumThreads>
-__forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, int thread_id) {
+__forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, int thread_id, uint64_t timeout_cycles) {
     EP_DEVICE_ASSERT(kNumThreads >= nixl_ctx.max_num_ranks);
 
     if (thread_id < nixl_ctx.max_num_ranks && thread_id != nixl_ctx.rank) {
@@ -1135,9 +1136,9 @@ __forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mas
             auto start_time = clock64();
             uint64_t wait_recv_cost = 0;
             while (ld_acquire_sys_global(nixl_ctx.sync_buffer_ptr + dst_rank) != expected_cnt
-                   && (wait_recv_cost = clock64() - start_time) <= NUM_TIMEOUT_CYCLES);
+                   && (wait_recv_cost = clock64() - start_time) <= timeout_cycles);
 
-            if (wait_recv_cost > NUM_TIMEOUT_CYCLES) {
+            if (wait_recv_cost > timeout_cycles) {
                 printf("Warning: NixlEP timeout for barrier, rank %d, thread %d, dst_rank %d, expected value %d, actual value %d\n",
                        nixl_ctx.rank, thread_id, dst_rank, expected_cnt, ld_acquire_global(nixl_ctx.sync_buffer_ptr + dst_rank));
                 if (mask_buffer_ptr == nullptr)
@@ -1150,15 +1151,15 @@ __forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mas
 }
 
 template <int kNumThreads>
-__global__ void barrier_kernel(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr) {
+__global__ void barrier_kernel(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles) {
     const auto thread_id = static_cast<int>(threadIdx.x);
-    barrier<kNumThreads>(nixl_ctx, mask_buffer_ptr, thread_id);
+    barrier<kNumThreads>(nixl_ctx, mask_buffer_ptr, thread_id, timeout_cycles);
 }
 
-void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, cudaStream_t stream) {
+void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream) {
     constexpr int kNumThreads = 32;
     SETUP_LAUNCH_CONFIG(1, kNumThreads, stream);
-    LAUNCH_KERNEL(&cfg, barrier_kernel<kNumThreads>, nixl_ctx, mask_buffer_ptr);
+    LAUNCH_KERNEL(&cfg, barrier_kernel<kNumThreads>, nixl_ctx, mask_buffer_ptr, timeout_cycles);
 }
 } // namespace ep_kernels
 

--- a/examples/device/ep/csrc/kernels/runtime.cu
+++ b/examples/device/ep/csrc/kernels/runtime.cu
@@ -35,13 +35,13 @@ namespace nixl_ep {
 namespace intranode {
 
 template <int kNumRanks>
-__global__ void barrier(int** barrier_signal_ptrs, int rank) {
-    barrier_block<kNumRanks>(barrier_signal_ptrs, rank);
+__global__ void barrier(int** barrier_signal_ptrs, int rank, uint64_t timeout_cycles) {
+    barrier_block<kNumRanks>(barrier_signal_ptrs, rank, timeout_cycles);
 }
 
-void barrier(int** barrier_signal_ptrs, int rank, int num_nvl_ranks, cudaStream_t stream) {
+void barrier(int** barrier_signal_ptrs, int rank, int num_nvl_ranks, uint64_t timeout_cycles, cudaStream_t stream) {
 #define BARRIER_LAUNCH_CASE(ranks)                                  \
-    LAUNCH_KERNEL(&cfg, barrier<ranks>, barrier_signal_ptrs, rank); \
+    LAUNCH_KERNEL(&cfg, barrier<ranks>, barrier_signal_ptrs, rank, timeout_cycles); \
     break
 
     SETUP_LAUNCH_CONFIG(1, 32, stream);

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -466,7 +466,7 @@ __forceinline__ __device__ out_dtype_t extract_required_scale_format(float value
 
 template <int kNumRanks, bool kSyncOnly = false>
 __forceinline__ __device__ void
-barrier_block(int** barrier_signal_ptrs, int rank) {
+barrier_block(int** barrier_signal_ptrs, int rank, uint64_t timeout_cycles) {
     auto thread_id = static_cast<int>(threadIdx.x);
 
     // For non-sync-only cases, the memory operations by other threads in the block must be visible to the `sys` scope
@@ -489,7 +489,7 @@ barrier_block(int** barrier_signal_ptrs, int rank) {
         if (__all_sync(0xffffffff, value <= 0))
             break;
 
-        if (clock64() - start_time > NUM_TIMEOUT_CYCLES and thread_id < kNumRanks) {
+        if (clock64() - start_time > timeout_cycles and thread_id < kNumRanks) {
             printf("NixlEP timeout check failed: rank = %d, thread = %d, value = %d)\n", rank, thread_id, value);
             trap();
         }

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -24,6 +24,7 @@
 #include <ATen/cuda/CUDADataType.h>
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -58,6 +59,12 @@ static void sleep_ms(int milliseconds) {
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
+static uint64_t milliseconds_to_cycles(double milliseconds, int device_clock_rate_khz) {
+    EP_HOST_ASSERT(device_clock_rate_khz > 0);
+    const auto timeout_cycles = static_cast<long double>(milliseconds) * static_cast<long double>(device_clock_rate_khz);
+    return static_cast<uint64_t>(std::ceil(timeout_cycles));
+}
+
 void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes)
 {
     if (!available) {
@@ -68,8 +75,9 @@ void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int6
     }
 }
 
-Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode):
+Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, double timeout_ms):
         low_latency_mode(low_latency_mode),
+        timeout_ms(timeout_ms),
         rank(rank), num_ranks(1),
         explicitly_destroy(explicitly_destroy),
         comm_stream(at::cuda::getStreamFromPool(true)) {}
@@ -105,6 +113,9 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     cudaDeviceProp device_prop = {};
     CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_id));
     num_device_sms = device_prop.multiProcessorCount;
+    device_clock_rate_khz = device_prop.clockRate;
+    EP_HOST_ASSERT(device_clock_rate_khz > 0);
+    timeout_cycles = milliseconds_to_cycles(timeout_ms, device_clock_rate_khz);
     int denom_sms = std::max(1, num_device_sms / 2);
     auto per_channel_bytes = ceil_div<int64_t>(num_rdma_bytes, denom_sms);
     EP_HOST_ASSERT(per_channel_bytes < std::numeric_limits<int>::max());
@@ -263,7 +274,7 @@ void Buffer::destroy() {
     _nixl_ep_destroy();
 
     if (num_nvl_bytes > 0) {
-        intranode::barrier(barrier_signal_ptrs_gpu, nvl_rank, num_nvl_ranks, comm_stream);
+        intranode::barrier(barrier_signal_ptrs_gpu, nvl_rank, num_nvl_ranks, timeout_cycles, comm_stream);
         warn_cuda(cudaDeviceSynchronize(), "synchronize device after intranode barrier");
 
         // Close remote IPC
@@ -333,7 +344,7 @@ void Buffer::destroy() {
 
 void Buffer::barrier() {
     auto compute_stream = at::cuda::getCurrentCUDAStream();
-    ep_kernels::barrier(gpu_ctx, mask_buffer_ptr, compute_stream);
+    ep_kernels::barrier(gpu_ctx, mask_buffer_ptr, timeout_cycles, compute_stream);
 }
 
 void Buffer::_nixl_agents_connect(const std::vector<int>& ranks, const std::vector<nixl_blob_t>& remote_mds) {
@@ -709,7 +720,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
                                  buffer_ptrs_gpu, config.num_max_nvl_chunked_recv_tokens,
                                  barrier_signal_ptrs_gpu, rank, comm_stream,
                                  config.get_rdma_buffer_size_hint(hidden_int4 * sizeof(int4), num_ranks),
-                                 num_nvl_bytes, true, low_latency_mode, gpu_ctx);
+                                 num_nvl_bytes, timeout_cycles, true, low_latency_mode, gpu_ctx);
     } else {
         rdma_channel_prefix_matrix = torch::empty({num_rdma_ranks, num_channels}, dtype(torch::kInt32).device(torch::kCUDA));
         recv_rdma_rank_prefix_sum = torch::empty({num_rdma_ranks}, dtype(torch::kInt32).device(torch::kCUDA));
@@ -731,7 +742,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
                                    buffer_ptrs_gpu, config.num_max_nvl_chunked_recv_tokens,
                                    barrier_signal_ptrs_gpu, rank, comm_stream,
                                    config.get_rdma_buffer_size_hint(hidden_int4 * sizeof(int4), num_ranks),
-                                   num_nvl_bytes, low_latency_mode, gpu_ctx);
+                                   num_nvl_bytes, timeout_cycles, low_latency_mode, gpu_ctx);
 
         // Synchronize total received tokens and tokens per expert
         auto start_time = std::chrono::high_resolution_clock::now();
@@ -815,7 +826,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
                         rdma_buffer_ptr, config.num_max_rdma_chunked_send_tokens, config.num_max_rdma_chunked_recv_tokens,
                         buffer_ptrs_gpu, config.num_max_nvl_chunked_send_tokens, config.num_max_nvl_chunked_recv_tokens,
                         rank, num_ranks, cached_mode,
-                        comm_stream, num_channels, low_latency_mode, gpu_ctx);
+                        comm_stream, num_channels, timeout_cycles, low_latency_mode, gpu_ctx);
 
     // Wait streams
     std::optional<EventHandle> event;
@@ -928,7 +939,7 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
                              buffer_ptrs_gpu, config.num_max_nvl_chunked_recv_tokens,
                              barrier_signal_ptrs_gpu, rank, comm_stream,
                              config.get_rdma_buffer_size_hint(hidden_int4 * sizeof(int4), num_ranks),
-                             num_nvl_bytes, false, low_latency_mode, gpu_ctx);
+                             num_nvl_bytes, timeout_cycles, false, low_latency_mode, gpu_ctx);
 
     // Assign bias pointers
     auto bias_opts = std::vector<std::optional<torch::Tensor>>({bias_0, bias_1});
@@ -952,7 +963,7 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
                        num_tokens, num_combined_tokens, hidden, num_topk,
                        rdma_buffer_ptr, config.num_max_rdma_chunked_send_tokens, config.num_max_rdma_chunked_recv_tokens,
                        buffer_ptrs_gpu, config.num_max_nvl_chunked_send_tokens, config.num_max_nvl_chunked_recv_tokens,
-                       rank, num_ranks, comm_stream, num_channels, low_latency_mode, gpu_ctx);
+                       rank, num_ranks, comm_stream, num_channels, timeout_cycles, low_latency_mode, gpu_ctx);
 
     // Wait streams
     std::optional<EventHandle> event;
@@ -1072,6 +1083,7 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                                num_tokens, hidden, num_max_dispatch_tokens_per_rank,
                                num_topk, num_experts, rank, num_ranks,
                                use_fp8, round_scale, use_ue8m0,
+                               timeout_cycles,
                                workspace, num_device_sms,
                                launch_stream, phases, gpu_ctx);
     };
@@ -1169,7 +1181,7 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
                               next_clean_meta.first, next_clean_meta.second,
                               num_combined_tokens, hidden, num_max_dispatch_tokens_per_rank,
                               num_topk, num_experts, rank, num_ranks,
-                              use_logfmt,
+                             use_logfmt, timeout_cycles,
                               workspace, num_device_sms,
                               launch_stream, phases, zero_copy, gpu_ctx);
     };
@@ -1428,7 +1440,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("current_stream_wait", &nixl_ep::EventHandle::current_stream_wait);
 
     pybind11::class_<nixl_ep::Buffer>(m, "Buffer")
-        .def(pybind11::init<int, bool, bool>())
+        .def(pybind11::init<int, bool, bool, double>())
         .def("update_memory_buffers", &nixl_ep::Buffer::update_memory_buffers)
         .def("barrier", &nixl_ep::Buffer::barrier)
         .def("connect_ranks", [](nixl_ep::Buffer &buffer, const std::vector<int>& remote_ranks, const std::optional<std::vector<pybind11::bytes>>& remote_mds, const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles) {

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -24,7 +24,6 @@
 #include <ATen/cuda/CUDADataType.h>
 #include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -59,10 +58,10 @@ static void sleep_ms(int milliseconds) {
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
-static uint64_t milliseconds_to_cycles(double milliseconds, int device_clock_rate_khz) {
+static uint64_t milliseconds_to_cycles(int milliseconds, int device_clock_rate_khz) {
+    EP_HOST_ASSERT(milliseconds >= 0);
     EP_HOST_ASSERT(device_clock_rate_khz > 0);
-    const auto timeout_cycles = static_cast<long double>(milliseconds) * static_cast<long double>(device_clock_rate_khz);
-    return static_cast<uint64_t>(std::ceil(timeout_cycles));
+    return static_cast<uint64_t>(milliseconds) * static_cast<uint64_t>(device_clock_rate_khz);
 }
 
 void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes)
@@ -75,7 +74,7 @@ void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int6
     }
 }
 
-Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, double timeout_ms):
+Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int timeout_ms):
         low_latency_mode(low_latency_mode),
         timeout_ms(timeout_ms),
         rank(rank), num_ranks(1),
@@ -1438,7 +1437,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("current_stream_wait", &nixl_ep::EventHandle::current_stream_wait);
 
     pybind11::class_<nixl_ep::Buffer>(m, "Buffer")
-        .def(pybind11::init<int, bool, bool, double>())
+        .def(pybind11::init<int, bool, bool, int>())
         .def("update_memory_buffers", &nixl_ep::Buffer::update_memory_buffers)
         .def("barrier", &nixl_ep::Buffer::barrier)
         .def("connect_ranks", [](nixl_ep::Buffer &buffer, const std::vector<int>& remote_ranks, const std::optional<std::vector<pybind11::bytes>>& remote_mds, const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles) {

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -110,10 +110,8 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     num_rdma_ranks = std::max(1, num_ranks / NUM_MAX_NVL_PEERS), num_nvl_ranks = std::min(num_ranks, NUM_MAX_NVL_PEERS);
 
     // Get device info
-    cudaDeviceProp device_prop = {};
-    CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_id));
-    num_device_sms = device_prop.multiProcessorCount;
-    device_clock_rate_khz = device_prop.clockRate;
+    CUDA_CHECK(cudaDeviceGetAttribute(&num_device_sms, cudaDevAttrMultiProcessorCount, device_id));
+    CUDA_CHECK(cudaDeviceGetAttribute(&device_clock_rate_khz, cudaDevAttrClockRate, device_id));
     EP_HOST_ASSERT(device_clock_rate_khz > 0);
     timeout_cycles = milliseconds_to_cycles(timeout_ms, device_clock_rate_khz);
     int denom_sms = std::max(1, num_device_sms / 2);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -54,15 +54,18 @@
 
 namespace nixl_ep {
 
-static void sleep_ms(int milliseconds) {
+namespace {
+
+void sleep_ms(int milliseconds) {
     std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds));
 }
 
-static uint64_t milliseconds_to_cycles(int milliseconds, int device_clock_rate_khz) {
-    EP_HOST_ASSERT(milliseconds >= 0);
+uint64_t milliseconds_to_cycles(uint64_t milliseconds, int device_clock_rate_khz) {
     EP_HOST_ASSERT(device_clock_rate_khz > 0);
-    return static_cast<uint64_t>(milliseconds) * static_cast<uint64_t>(device_clock_rate_khz);
+    return milliseconds * static_cast<uint64_t>(device_clock_rate_khz);
 }
+
+} // namespace
 
 void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes)
 {
@@ -76,7 +79,10 @@ void Buffer::update_memory_buffers(int num_ranks, int num_experts_per_rank, int6
 
 Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int timeout_ms):
         low_latency_mode(low_latency_mode),
-        timeout_ms(timeout_ms),
+        timeout_ms([timeout_ms] {
+            EP_HOST_ASSERT(timeout_ms >= 0);
+            return static_cast<uint64_t>(timeout_ms);
+        }()),
         rank(rank), num_ranks(1),
         explicitly_destroy(explicitly_destroy),
         comm_stream(at::cuda::getStreamFromPool(true)) {}
@@ -109,9 +115,9 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     num_rdma_ranks = std::max(1, num_ranks / NUM_MAX_NVL_PEERS), num_nvl_ranks = std::min(num_ranks, NUM_MAX_NVL_PEERS);
 
     // Get device info
+    int device_clock_rate_khz = 0;
     CUDA_CHECK(cudaDeviceGetAttribute(&num_device_sms, cudaDevAttrMultiProcessorCount, device_id));
     CUDA_CHECK(cudaDeviceGetAttribute(&device_clock_rate_khz, cudaDevAttrClockRate, device_id));
-    EP_HOST_ASSERT(device_clock_rate_khz > 0);
     timeout_cycles = milliseconds_to_cycles(timeout_ms, device_clock_rate_khz);
     int denom_sms = std::max(1, num_device_sms / 2);
     auto per_channel_bytes = ceil_div<int64_t>(num_rdma_bytes, denom_sms);

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -83,6 +83,7 @@ struct Buffer {
 private:
     int buffer_idx = 0; // Double buffering index
     bool low_latency_mode = false;
+    double timeout_ms = 30000.0;
 
     // NVLink Buffer
     int64_t num_nvl_bytes;
@@ -107,6 +108,8 @@ private:
     // Device info and communication
     int device_id;
     int num_device_sms;
+    int device_clock_rate_khz = 0;
+    uint64_t timeout_cycles = 0;
     int rank, rdma_rank, nvl_rank;
     int num_ranks, num_rdma_ranks, num_nvl_ranks;
     std::vector<int> remote_ranks; /* global ranks */
@@ -167,7 +170,7 @@ private:
     void _ipc_handles_sync(const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles);
 
 public:
-    Buffer(int rank, bool explicitly_destroy, bool low_latency_mode = true);
+    Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, double timeout_ms);
 
     void update_memory_buffers(int num_ranks, int max_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes = 0);
 

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -83,7 +83,7 @@ struct Buffer {
 private:
     int buffer_idx = 0; // Double buffering index
     bool low_latency_mode = false;
-    int timeout_ms = 30000;
+    uint64_t timeout_ms = 30000;
 
     // NVLink Buffer
     int64_t num_nvl_bytes;
@@ -108,7 +108,6 @@ private:
     // Device info and communication
     int device_id;
     int num_device_sms;
-    int device_clock_rate_khz = 0;
     uint64_t timeout_cycles = 0;
     int rank, rdma_rank, nvl_rank;
     int num_ranks, num_rdma_ranks, num_nvl_ranks;

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -83,7 +83,7 @@ struct Buffer {
 private:
     int buffer_idx = 0; // Double buffering index
     bool low_latency_mode = false;
-    double timeout_ms = 30000.0;
+    int timeout_ms = 30000;
 
     // NVLink Buffer
     int64_t num_nvl_bytes;
@@ -170,7 +170,7 @@ private:
     void _ipc_handles_sync(const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles);
 
 public:
-    Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, double timeout_ms);
+    Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int timeout_ms);
 
     void update_memory_buffers(int num_ranks, int max_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes = 0);
 

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     import mpi4py  # noqa: F401
 
 
+DEFAULT_TIMEOUT_MS = 30_000.0
+
+
 class Buffer:
     """
     The core expert-parallel (EP) communication buffers for Mixture of Experts (MoE) model, which supports dispatch and combine operations using NVLink and RDMA.
@@ -59,6 +62,7 @@ class Buffer:
         group: Optional[dist.ProcessGroup] = None,
         comm: Optional["mpi4py.MPI.Comm"] = None,
         tcp_store_group: Optional[dist.TCPStore] = None,
+        timeout_ms: float = DEFAULT_TIMEOUT_MS,
     ) -> None:
         """
         Initialize the nixl communication buffer.
@@ -73,10 +77,15 @@ class Buffer:
             group: the communication group (optional).
             comm: the mpi4py.MPI.Comm communicator to use in case the group parameter is absent (optional).
             tcp_store_group: TCPStore for metadata exchange (optional).
+            timeout_ms: GPU kernel timeout in milliseconds.
+                In low-latency paths, a timeout marks the rank invalid and masks it out.
+                In high-throughput paths, a timeout is fatal and traps.
+                Default: 30000 ms.
         """
         self.rank = rank
         self.group_size = 0  # Will be updated by `update_memory_buffers`
         self.low_latency_mode = low_latency_mode
+        self.timeout_ms = timeout_ms
 
         self.explicitly_destroy = explicitly_destroy
         self.group = group
@@ -88,7 +97,7 @@ class Buffer:
             os.environ["UCX_TLS"] = "^cuda_ipc"
 
         self.runtime = nixl_ep_cpp.Buffer(
-            self.rank, explicitly_destroy, low_latency_mode
+            self.rank, explicitly_destroy, low_latency_mode, timeout_ms
         )
 
     def destroy(self):
@@ -875,7 +884,9 @@ class Buffer:
 
     def barrier(self) -> None:
         """
-        barrier for all active ranks.
-        notice that this barrier does not flush the network QPs as it is currently doesn't have any use-case that requires it
+        Barrier for all active ranks.
+
+        Updates the rank mask on timeout.
+        Does not flush network QPs, since there is currently no use case that requires it.
         """
         self.runtime.barrier()

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     import mpi4py  # noqa: F401
 
 
-DEFAULT_TIMEOUT_MS = 30_000.0
+DEFAULT_TIMEOUT_MS = 30_000
 
 
 class Buffer:
@@ -62,7 +62,7 @@ class Buffer:
         group: Optional[dist.ProcessGroup] = None,
         comm: Optional["mpi4py.MPI.Comm"] = None,
         tcp_store_group: Optional[dist.TCPStore] = None,
-        timeout_ms: float = DEFAULT_TIMEOUT_MS,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
     ) -> None:
         """
         Initialize the nixl communication buffer.

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -642,7 +642,7 @@ def main():
     parser.add_argument(
         "--timeout-ms",
         type=non_negative_int,
-        default=int(DEFAULT_TIMEOUT_MS),
+        default=DEFAULT_TIMEOUT_MS,
         help="GPU timeout in milliseconds (non-negative integer)",
     )
 

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -50,6 +50,16 @@ TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
 
 
+def non_negative_int(value: str) -> int:
+    try:
+        int_value = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a non-negative integer") from exc
+    if int_value < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return int_value
+
+
 def handle_sigterm(
     signum,
     frame,
@@ -631,9 +641,9 @@ def main():
     )
     parser.add_argument(
         "--timeout-ms",
-        type=float,
-        default=DEFAULT_TIMEOUT_MS,
-        help="GPU timeout in milliseconds",
+        type=non_negative_int,
+        default=int(DEFAULT_TIMEOUT_MS),
+        help="GPU timeout in milliseconds (non-negative integer)",
     )
 
     args = parser.parse_args()

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -32,6 +32,7 @@ import nixl_ep
 import rank_server
 import store_group
 import torch
+from nixl_ep.buffer import DEFAULT_TIMEOUT_MS
 from plan import Plan
 
 # Add tests directory to path to import test utils
@@ -494,6 +495,7 @@ def worker(torch_rank: int, args: argparse.Namespace):
         disable_ll_nvlink=args.disable_ll_nvlink,
         explicitly_destroy=True,
         tcp_store_group=tcp_store,
+        timeout_ms=args.timeout_ms,
     )
     buffer.update_memory_buffers(
         num_ranks=max_num_ranks,
@@ -626,6 +628,12 @@ def main():
         "--disable-ll-nvlink",
         action="store_true",
         help="Disable NVLink communication for low-latency kernels",
+    )
+    parser.add_argument(
+        "--timeout-ms",
+        type=float,
+        default=DEFAULT_TIMEOUT_MS,
+        help="GPU timeout in milliseconds",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
EP GPU timeouts were hardcoded to 100 seconds, which surfaced in multiple contexts.

- vLLM fault-tolerance architecture discussions asked whether nixl_ep could support dynamic kernel-side timeout configuration, and noted that some systems may need sub-second timeouts.
- CI fault-tolerance tests take too long when failures are only detected after a 100 second timeout.

Make it configurable. Start with a buffer-scoped timeout, and add per-operation timeout controls incrementally if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable GPU communication timeout: Buffer now accepts timeout_ms (default 30,000 ms). Runtime timeout values are applied to GPU kernels, barrier synchronization, and dispatch/notify/combine paths; CLI test gains --timeout-ms to control this.

* **Documentation**
  * Constructor and barrier docs updated to explain timeout behavior and barrier timeout semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->