### PR TITLE
Fix IB warning test failure in CI

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -640,8 +640,7 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
                   << "GPU memory is not supported.";
     }
 
-    if (ucpVersion_ >= UCP_VERSION(1, 22)) {
-        // `UCS_MEMORY_TYPE_RDMA` to be checked explicitly only from UCX 1.22
+    if (ucpVersion_ >= ucp_version_mem_type_rdma) {
         if (hw_info.numIbDevices > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_RDMA)) {
             NIXL_WARN << hw_info.numIbDevices
                       << " IB device(s) were detected, but accelerated IB support was not found! "

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -34,6 +34,10 @@ enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
 
 inline constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
 
+// The API `ucp_context_query(ctx, &attr)` sets `UCS_MEMORY_TYPE_RDMA` in `attr.memory_types`
+// field only from UCX 1.22
+inline constexpr unsigned ucp_version_mem_type_rdma = UCP_VERSION(1, 22);
+
 template<typename Enum>
 [[nodiscard]] constexpr auto
 enumToInteger(const Enum e) noexcept {

--- a/test/gtest/common.cpp
+++ b/test/gtest/common.cpp
@@ -188,7 +188,6 @@ LogProblemCounter::Send(const absl::LogEntry &entry) {
         for (auto &[rx, count] : log_problem_ignore) {
             if (std::regex_search(msg, rx)) {
                 ++count;
-                return;
             }
         }
         ++global_problem_count;

--- a/test/gtest/common.cpp
+++ b/test/gtest/common.cpp
@@ -182,14 +182,21 @@ LogProblemCounter::Send(const absl::LogEntry &entry) {
         return;
     }
 
+    bool matched = false;
     const std::string msg(entry.text_message());
     {
         const std::lock_guard lock(log_problem_mutex);
         for (auto &[rx, count] : log_problem_ignore) {
             if (std::regex_search(msg, rx)) {
+                matched = true;
                 ++count;
             }
         }
+
+        if (matched) {
+            return;
+        }
+
         ++global_problem_count;
     }
 

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -74,11 +74,11 @@ TEST_F(HardwareWarningTest, WarnWhenGpuPresentButCudaNotSupported) {
  * Test that a warning is logged when IB devices are present but UCX
  * RDMA support is not available.
  *
- * Note: This warning only triggers for UCX >= 1.21.
+ * Note: This warning only triggers for UCX >= 1.22.
  */
 TEST_F(HardwareWarningTest, WarnWhenIbPresentButRdmaNotSupported) {
-    if (ucpVersion_ < UCP_VERSION(1, 21)) {
-        GTEST_SKIP() << "UCX version is less than 1.21, skipping test";
+    if (ucpVersion_ < UCP_VERSION(1, 22)) {
+        GTEST_SKIP() << "UCX version is less than 1.22, skipping test";
     }
 
     const auto &hw_info = nixl::hwInfo::instance();

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -73,12 +73,10 @@ TEST_F(HardwareWarningTest, WarnWhenGpuPresentButCudaNotSupported) {
 /**
  * Test that a warning is logged when IB devices are present but UCX
  * RDMA support is not available.
- *
- * Note: This warning only triggers for UCX >= 1.22.
  */
 TEST_F(HardwareWarningTest, WarnWhenIbPresentButRdmaNotSupported) {
-    if (ucpVersion_ < UCP_VERSION(1, 22)) {
-        GTEST_SKIP() << "UCX version is less than 1.22, skipping test";
+    if (ucpVersion_ < ucp_version_mem_type_rdma) {
+        GTEST_SKIP() << "UCX version too old for RDMA memory type check, skipping test";
     }
 
     const auto &hw_info = nixl::hwInfo::instance();


### PR DESCRIPTION
## What?
- Bump UCX version check from `1.21` to `1.22` (it was previously done partially in #1445)
- Fix warning counting to count all matches instead of exiting early

## Why?
These two issues caused the test `WarnWhenIbPresentButRdmaNotSupported` to fail in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Ignored log entries are now recorded and still contribute to overall problem totals.
  * A hardware-warning test now skips using an RDMA-specific version threshold and shows an updated skip message.

* **Bug Fixes**
  * Hardware-support warnings for RDMA memory-type detection are now gated by a defined version threshold for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->