### PR TITLE
ucx: Add version compatibility checks at backend initialization

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -451,6 +451,21 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
     config.modify("IB_PCI_RELAXED_ORDERING", "try");
     config.modify("RCACHE_MAX_UNRELEASED", "1024");
 
+    if (ucpVersion_ <= UCP_VERSION(1, 13)) {
+        throw std::runtime_error("UCX version 1.13 or older is not supported by NIXL. "
+                                 "Please upgrade to UCX 1.14 or newer.");
+    }
+
+    if (ucpVersion_ <= UCP_VERSION(1, 17)) {
+        NIXL_WARN << "UCX version is 1.17 or older: cuda_ipc transport is not supported, "
+                  << "NVLink will not be available.";
+    }
+
+    if (ucpVersion_ <= UCP_VERSION(1, 18)) {
+        NIXL_WARN << "UCX version is 1.18 or older: gdr_copy has known bugs, "
+                  << "multi-GPU support is not available, and EFA is not supported.";
+    }
+
     if (ucpVersion_ >= UCP_VERSION(1, 21)) {
         config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
     }


### PR DESCRIPTION
## Summary
- Reject UCX <= 1.13 (unsupported entirely) with a runtime error at backend initialization
- Warn about known limitations for UCX <= 1.17 (no `cuda_ipc` transport, no NVLink)
- Warn about known limitations for UCX <= 1.18 (`gdr_copy` bugs, no multi-GPU support, no EFA)

Follows the existing version checking pattern already in `nixlUcxContext` constructor (e.g., the UCX < 1.19 CUDA warning).

Fixes #166

## Changes
- `src/plugins/ucx/ucx_utils.cpp`: Added 3 version checks in `nixlUcxContext::nixlUcxContext()` before existing version-gated config modifications

## Build & Test Evidence

### Build (meson + ninja) — PASS
All 260 targets compiled successfully with no errors or warnings, including `libplugin_UCX.so`:

```
[249/260] Compiling C++ object src/plugins/ucx/libplugin_UCX.so.p/ucx_backend.cpp.o
[250/260] Linking target src/plugins/ucx/libplugin_UCX.so
[251/260] Compiling C++ object src/core/libnixl.so.p/nixl_agent.cpp.o
[252/260] Linking target src/core/libnixl.so
...
[260/260] Linking target src/bindings/python/_bindings.cpython-310-x86_64-linux-gnu.so
```

## Test plan
- [x] Verify build passes on CI