### PR TITLE
telemetry: replace string event names with enum type

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -19,7 +19,7 @@ Custom telemetry exporter plug-ins can be created according to [src/plugins/tele
 
 Each telemetry event contains:
 - **Category**: Event category for filtering and aggregation
-- **Event Name**: Descriptive name/identifier for the event
+- **Event type**: Descriptive name/identifier for the event
 - **Value**: Numeric value associated with the event
 
 ### Event Categories

--- a/examples/cpp/telemetry_reader.cpp
+++ b/examples/cpp/telemetry_reader.cpp
@@ -67,7 +67,8 @@ print_telemetry_event(const nixlTelemetryEvent &event) {
     std::cout << "\n=== NIXL Telemetry Event ===" << std::endl;
     std::cout << "Category: " << nixlEnumStrings::telemetryCategoryStr(event.category_)
               << std::endl;
-    std::cout << "Event name: " << event.eventName_ << std::endl;
+    std::cout << "Event name: " << nixlEnumStrings::telemetryEventTypeStr(event.eventType_)
+              << std::endl;
     std::cout << "Value: " << event.value_ << std::endl;
 
     std::cout << "===========================" << std::endl;

--- a/examples/python/telemetry_reader.py
+++ b/examples/python/telemetry_reader.py
@@ -67,7 +67,6 @@ AGENT_ERR_NOT_SUPPORTED = 16
 AGENT_ERR_REMOTE_DISCONNECT = 17
 AGENT_ERR_CANCELED = 18
 AGENT_ERR_NO_TELEMETRY = 19
-AGENT_BACKEND = 20
 
 # Global flag for graceful shutdown
 running = True
@@ -263,7 +262,6 @@ _EVENT_TYPE_STRINGS = {
     AGENT_ERR_REMOTE_DISCONNECT: "agent_err_remote_disconnect",
     AGENT_ERR_CANCELED: "agent_err_canceled",
     AGENT_ERR_NO_TELEMETRY: "agent_err_no_telemetry",
-    AGENT_BACKEND: "agent_backend",
 }
 
 

--- a/examples/python/telemetry_reader.py
+++ b/examples/python/telemetry_reader.py
@@ -55,8 +55,19 @@ AGENT_MEMORY_REGISTERED = 4
 AGENT_MEMORY_DEREGISTERED = 5
 AGENT_XFER_TIME = 6
 AGENT_XFER_POST_TIME = 7
-AGENT_ERROR = 8
-AGENT_BACKEND = 9
+AGENT_ERR_NOT_POSTED = 8
+AGENT_ERR_INVALID_PARAM = 9
+AGENT_ERR_BACKEND = 10
+AGENT_ERR_NOT_FOUND = 11
+AGENT_ERR_MISMATCH = 12
+AGENT_ERR_NOT_ALLOWED = 13
+AGENT_ERR_REPOST_ACTIVE = 14
+AGENT_ERR_UNKNOWN = 15
+AGENT_ERR_NOT_SUPPORTED = 16
+AGENT_ERR_REMOTE_DISCONNECT = 17
+AGENT_ERR_CANCELED = 18
+AGENT_ERR_NO_TELEMETRY = 19
+AGENT_BACKEND = 20
 
 # Global flag for graceful shutdown
 running = True
@@ -240,7 +251,18 @@ _EVENT_TYPE_STRINGS = {
     AGENT_MEMORY_DEREGISTERED: "agent_memory_deregistered",
     AGENT_XFER_TIME: "agent_xfer_time",
     AGENT_XFER_POST_TIME: "agent_xfer_post_time",
-    AGENT_ERROR: "agent_error",
+    AGENT_ERR_NOT_POSTED: "agent_err_not_posted",
+    AGENT_ERR_INVALID_PARAM: "agent_err_invalid_param",
+    AGENT_ERR_BACKEND: "agent_err_backend",
+    AGENT_ERR_NOT_FOUND: "agent_err_not_found",
+    AGENT_ERR_MISMATCH: "agent_err_mismatch",
+    AGENT_ERR_NOT_ALLOWED: "agent_err_not_allowed",
+    AGENT_ERR_REPOST_ACTIVE: "agent_err_repost_active",
+    AGENT_ERR_UNKNOWN: "agent_err_unknown",
+    AGENT_ERR_NOT_SUPPORTED: "agent_err_not_supported",
+    AGENT_ERR_REMOTE_DISCONNECT: "agent_err_remote_disconnect",
+    AGENT_ERR_CANCELED: "agent_err_canceled",
+    AGENT_ERR_NO_TELEMETRY: "agent_err_no_telemetry",
     AGENT_BACKEND: "agent_backend",
 }
 

--- a/examples/python/telemetry_reader.py
+++ b/examples/python/telemetry_reader.py
@@ -34,7 +34,6 @@ logger = logging.getLogger(__name__)
 
 # Constants from telemetry_event.h
 TELEMETRY_VERSION = 2
-MAX_EVENT_NAME_LEN = 32
 
 # NIXL telemetry categories
 NIXL_TELEMETRY_MEMORY = 0
@@ -46,6 +45,18 @@ NIXL_TELEMETRY_PERFORMANCE = 5
 NIXL_TELEMETRY_SYSTEM = 6
 NIXL_TELEMETRY_CUSTOM = 7
 NIXL_TELEMETRY_MAX = 8
+
+# NIXL telemetry event types (nixl_telemetry_event_type_t)
+AGENT_TX_BYTES = 0
+AGENT_RX_BYTES = 1
+AGENT_TX_REQUESTS_NUM = 2
+AGENT_RX_REQUESTS_NUM = 3
+AGENT_MEMORY_REGISTERED = 4
+AGENT_MEMORY_DEREGISTERED = 5
+AGENT_XFER_TIME = 6
+AGENT_XFER_POST_TIME = 7
+AGENT_ERROR = 8
+AGENT_BACKEND = 9
 
 # Global flag for graceful shutdown
 running = True
@@ -65,8 +76,8 @@ class NixlTelemetryEvent(ctypes.Structure):
     _pack_ = 1
     _fields_ = [
         ("category", ctypes.c_int),
-        ("event_name", ctypes.c_char * MAX_EVENT_NAME_LEN),
-        ("_padding", ctypes.c_uint32),
+        ("event_type", ctypes.c_uint8),
+        ("_padding", ctypes.c_char * 3),
         ("value", ctypes.c_uint64),
     ]
 
@@ -209,27 +220,46 @@ def format_bytes(bytes_val):
     return f"{value:.2f} {units[unit_index]}"
 
 
+_CATEGORY_STRINGS = {
+    NIXL_TELEMETRY_MEMORY: "MEMORY",
+    NIXL_TELEMETRY_TRANSFER: "TRANSFER",
+    NIXL_TELEMETRY_CONNECTION: "CONNECTION",
+    NIXL_TELEMETRY_BACKEND: "BACKEND",
+    NIXL_TELEMETRY_ERROR: "ERROR",
+    NIXL_TELEMETRY_PERFORMANCE: "PERFORMANCE",
+    NIXL_TELEMETRY_SYSTEM: "SYSTEM",
+    NIXL_TELEMETRY_CUSTOM: "CUSTOM",
+}
+
+_EVENT_TYPE_STRINGS = {
+    AGENT_TX_BYTES: "agent_tx_bytes",
+    AGENT_RX_BYTES: "agent_rx_bytes",
+    AGENT_TX_REQUESTS_NUM: "agent_tx_requests_num",
+    AGENT_RX_REQUESTS_NUM: "agent_rx_requests_num",
+    AGENT_MEMORY_REGISTERED: "agent_memory_registered",
+    AGENT_MEMORY_DEREGISTERED: "agent_memory_deregistered",
+    AGENT_XFER_TIME: "agent_xfer_time",
+    AGENT_XFER_POST_TIME: "agent_xfer_post_time",
+    AGENT_ERROR: "agent_error",
+    AGENT_BACKEND: "agent_backend",
+}
+
+
 def get_telemetry_category_string(category):
     """Get string representation of telemetry category"""
-    category_strings = {
-        NIXL_TELEMETRY_MEMORY: "MEMORY",
-        NIXL_TELEMETRY_TRANSFER: "TRANSFER",
-        NIXL_TELEMETRY_CONNECTION: "CONNECTION",
-        NIXL_TELEMETRY_BACKEND: "BACKEND",
-        NIXL_TELEMETRY_ERROR: "ERROR",
-        NIXL_TELEMETRY_PERFORMANCE: "PERFORMANCE",
-        NIXL_TELEMETRY_SYSTEM: "SYSTEM",
-        NIXL_TELEMETRY_CUSTOM: "CUSTOM",
-    }
-    return category_strings.get(category, f"UNKNOWN_CATEGORY_{category}")
+    return _CATEGORY_STRINGS.get(category, f"UNKNOWN_CATEGORY_{category}")
+
+
+def get_telemetry_event_type_string(event_type):
+    """Get string representation of telemetry event type enum"""
+    return _EVENT_TYPE_STRINGS.get(event_type, f"unknown_event_{event_type}")
 
 
 def print_telemetry_event(event):
     """Print telemetry event in a formatted way"""
     logger.info("\n=== NIXL Telemetry Event ===")
 
-    # Decode event name
-    event_name = event.event_name.decode("utf-8").rstrip("\x00")
+    event_name = get_telemetry_event_type_string(event.event_type)
     category_str = get_telemetry_category_string(event.category)
 
     logger.info("Category: %s", category_str)

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -66,9 +66,8 @@ class nixlBackendEngine {
             if (!enableTelemetry_) return;
             if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
             std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
-            telemetryEvents_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND,
-                                          event_type,
-                                          value);
+            telemetryEvents_.emplace_back(
+                nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND, event_type, value);
         }
 
     public:

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -62,12 +62,13 @@ class nixlBackendEngine {
         }
 
         void
-        addTelemetryEvent(const std::string &event_name, uint64_t value) {
+        addTelemetryEvent(nixl_telemetry_event_type_t event_type, uint64_t value) {
             if (!enableTelemetry_) return;
             if (telemetryEvents_.size() >= MAX_TELEMETRY_QUEUE_SIZE) return;
             std::lock_guard<std::mutex> lock(telemetryEventsMutex_);
-            telemetryEvents_.emplace_back(
-                nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND, event_name, value);
+            telemetryEvents_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_BACKEND,
+                                          event_type,
+                                          value);
         }
 
     public:

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -33,7 +33,7 @@
 using namespace std::chrono_literals;
 namespace fs = std::filesystem;
 
-nixl_telemetry_event_type_t
+[[nodiscard]] nixl_telemetry_event_type_t
 nixlTelemetryEventTypeForStatus(nixl_status_t s) {
     switch (s) {
     case NIXL_ERR_NOT_POSTED:
@@ -242,7 +242,7 @@ nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
     NIXL_ASSERT_ALWAYS(static_cast<int>(error_type) < 0)
         << "nixlTelemetry::updateErrorCount expects a negative nixl_status_t error code";
     const auto event_type = nixlTelemetryEventTypeForStatus(error_type);
-    updateData(*event_type, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
+    updateData(event_type, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
 }
 
 void

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -33,12 +33,9 @@
 using namespace std::chrono_literals;
 namespace fs = std::filesystem;
 
-std::optional<nixl_telemetry_event_type_t>
+nixl_telemetry_event_type_t
 nixlTelemetryEventTypeForStatus(nixl_status_t s) {
     switch (s) {
-    case NIXL_SUCCESS:
-    case NIXL_IN_PROG:
-        return std::nullopt;
     case NIXL_ERR_NOT_POSTED:
         return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
     case NIXL_ERR_INVALID_PARAM:

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -245,9 +245,6 @@ nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
     NIXL_ASSERT_ALWAYS(static_cast<int>(error_type) < 0)
         << "nixlTelemetry::updateErrorCount expects a negative nixl_status_t error code";
     const auto event_type = nixlTelemetryEventTypeForStatus(error_type);
-    NIXL_ASSERT_ALWAYS(event_type.has_value())
-        << "nixlTelemetryEventTypeForStatus missing mapping for nixl_status_t "
-        << static_cast<int>(error_type);
     updateData(*event_type, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -65,8 +65,7 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) {
         return nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY;
     }
     NIXL_ASSERT_ALWAYS(false) << "nixlTelemetryEventTypeForStatus: unhandled nixl_status_t "
-                              << static_cast<int>(s)
-                              << "; add a case when extending nixl_status_t";
+                              << static_cast<int>(s) << "; add a case when extending nixl_status_t";
 }
 
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -20,7 +20,6 @@
 #include <filesystem>
 #include <unistd.h>
 #include <cstdlib>
-#include <cstring>
 #include <algorithm>
 
 #include "common/configuration.h"
@@ -166,7 +165,7 @@ nixlTelemetry::registerPeriodicTask(periodicTask &task) {
 }
 
 void
-nixlTelemetry::updateData(const std::string &event_name,
+nixlTelemetry::updateData(nixl_telemetry_event_type_t event_type,
                           nixl_telemetry_category_t category,
                           uint64_t value) {
     // agent can be multi-threaded
@@ -174,73 +173,80 @@ nixlTelemetry::updateData(const std::string &event_name,
     if (events_.size() >= maxBufferedEvents_) {
         return;
     }
-    events_.emplace_back(category, event_name, value);
+    events_.emplace_back(category, event_type, value);
 }
 
 // The next 4 methods might be removed, as addXferTime covers them.
 void
 nixlTelemetry::updateTxBytes(uint64_t tx_bytes) {
-    updateData("agent_tx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, tx_bytes);
+    updateData(nixl_telemetry_event_type_t::AGENT_TX_BYTES,
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+               tx_bytes);
 }
 
 void
 nixlTelemetry::updateRxBytes(uint64_t rx_bytes) {
-    updateData("agent_rx_bytes", nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, rx_bytes);
+    updateData(nixl_telemetry_event_type_t::AGENT_RX_BYTES,
+               nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+               rx_bytes);
 }
 
 void
 nixlTelemetry::updateTxRequestsNum(uint32_t tx_requests_num) {
-    updateData("agent_tx_requests_num",
+    updateData(nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM,
                nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                tx_requests_num);
 }
 
 void
 nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
-    updateData("agent_rx_requests_num",
+    updateData(nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM,
                nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
                rx_requests_num);
 }
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData(
-        nixlEnumStrings::statusStr(error_type), nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
+    updateData(nixl_telemetry_event_type_t::AGENT_ERROR,
+               nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
+               static_cast<uint64_t>(error_type));
 }
 
 void
 nixlTelemetry::updateMemoryRegistered(uint64_t memory_registered) {
-    updateData("agent_memory_registered",
+    updateData(nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED,
                nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_registered);
 }
 
 void
 nixlTelemetry::updateMemoryDeregistered(uint64_t memory_deregistered) {
-    updateData("agent_memory_deregistered",
+    updateData(nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED,
                nixl_telemetry_category_t::NIXL_TELEMETRY_MEMORY,
                memory_deregistered);
 }
 
 void
 nixlTelemetry::addXferTime(std::chrono::microseconds xfer_time, bool is_write, uint64_t bytes) {
-    const char *bytes_name = is_write ? "agent_tx_bytes" : "agent_rx_bytes";
-    const char *requests_name = is_write ? "agent_tx_requests_num" : "agent_rx_requests_num";
+    const auto bytes_type = is_write ? nixl_telemetry_event_type_t::AGENT_TX_BYTES :
+                                       nixl_telemetry_event_type_t::AGENT_RX_BYTES;
+    const auto requests_type = is_write ? nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM :
+                                          nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM;
 
     const std::lock_guard lock(mutex_);
     if (events_.size() + 3 > maxBufferedEvents_) {
         return;
     }
     events_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-                         "agent_xfer_time",
-                         xfer_time.count());
-    events_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_name, bytes);
-    events_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_name, 1);
+                         nixl_telemetry_event_type_t::AGENT_XFER_TIME,
+                         static_cast<uint64_t>(xfer_time.count()));
+    events_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, bytes_type, bytes);
+    events_.emplace_back(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, requests_type, 1);
 }
 
 void
 nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
-    updateData("agent_xfer_post_time",
+    updateData(nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME,
                nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
                post_time.count());
 }

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -33,6 +33,42 @@
 using namespace std::chrono_literals;
 namespace fs = std::filesystem;
 
+std::optional<nixl_telemetry_event_type_t>
+nixlTelemetryEventTypeForStatus(nixl_status_t s) {
+    switch (s) {
+    case NIXL_SUCCESS:
+    case NIXL_IN_PROG:
+        return std::nullopt;
+    case NIXL_ERR_NOT_POSTED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
+    case NIXL_ERR_INVALID_PARAM:
+        return nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM;
+    case NIXL_ERR_BACKEND:
+        return nixl_telemetry_event_type_t::AGENT_ERR_BACKEND;
+    case NIXL_ERR_NOT_FOUND:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND;
+    case NIXL_ERR_MISMATCH:
+        return nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH;
+    case NIXL_ERR_NOT_ALLOWED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED;
+    case NIXL_ERR_REPOST_ACTIVE:
+        return nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE;
+    case NIXL_ERR_UNKNOWN:
+        return nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN;
+    case NIXL_ERR_NOT_SUPPORTED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED;
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        return nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT;
+    case NIXL_ERR_CANCELED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_CANCELED;
+    case NIXL_ERR_NO_TELEMETRY:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY;
+    }
+    NIXL_ASSERT_ALWAYS(false) << "nixlTelemetryEventTypeForStatus: unhandled nixl_status_t "
+                              << static_cast<int>(s)
+                              << "; add a case when extending nixl_status_t";
+}
+
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;
 constexpr size_t DEFAULT_TELEMETRY_BUFFER_SIZE = 4096;
 constexpr const char *defaultTelemetryPlugin = "BUFFER";
@@ -207,10 +243,12 @@ nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
+    NIXL_ASSERT_ALWAYS(static_cast<int>(error_type) < 0)
+        << "nixlTelemetry::updateErrorCount expects a negative nixl_status_t error code";
     const auto event_type = nixlTelemetryEventTypeForStatus(error_type);
-    if (!event_type) {
-        return;
-    }
+    NIXL_ASSERT_ALWAYS(event_type.has_value())
+        << "nixlTelemetryEventTypeForStatus missing mapping for nixl_status_t "
+        << static_cast<int>(error_type);
     updateData(*event_type, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -38,7 +38,8 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) {
     switch (s) {
     case NIXL_SUCCESS:
     case NIXL_IN_PROG:
-        NIXL_ASSERT_ALWAYS(false) << "nixlTelemetryEventTypeForStatus expects a negative nixl_status_t error code";
+        NIXL_ASSERT_ALWAYS(false)
+            << "nixlTelemetryEventTypeForStatus expects a negative nixl_status_t error code";
     case NIXL_ERR_NOT_POSTED:
         return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
     case NIXL_ERR_INVALID_PARAM:

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -36,6 +36,9 @@ namespace fs = std::filesystem;
 [[nodiscard]] nixl_telemetry_event_type_t
 nixlTelemetryEventTypeForStatus(nixl_status_t s) {
     switch (s) {
+    case NIXL_SUCCESS:
+    case NIXL_IN_PROG:
+        NIXL_ASSERT_ALWAYS(false) << "nixlTelemetryEventTypeForStatus expects a negative nixl_status_t error code";
     case NIXL_ERR_NOT_POSTED:
         return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
     case NIXL_ERR_INVALID_PARAM:

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -248,7 +248,7 @@ void
 nixlTelemetry::addPostTime(std::chrono::microseconds post_time) {
     updateData(nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME,
                nixl_telemetry_category_t::NIXL_TELEMETRY_PERFORMANCE,
-               post_time.count());
+               static_cast<uint64_t>(post_time.count()));
 }
 
 std::string

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -207,9 +207,11 @@ nixlTelemetry::updateRxRequestsNum(uint32_t rx_requests_num) {
 
 void
 nixlTelemetry::updateErrorCount(nixl_status_t error_type) {
-    updateData(nixl_telemetry_event_type_t::AGENT_ERROR,
-               nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR,
-               static_cast<uint64_t>(error_type));
+    const auto event_type = nixlTelemetryEventTypeForStatus(error_type);
+    if (!event_type) {
+        return;
+    }
+    updateData(*event_type, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR, 1);
 }
 
 void

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -79,7 +79,9 @@ private:
     void
     registerPeriodicTask(periodicTask &task);
     void
-    updateData(const std::string &event_name, nixl_telemetry_category_t category, uint64_t value);
+    updateData(nixl_telemetry_event_type_t event_type,
+               nixl_telemetry_category_t category,
+               uint64_t value);
     bool
     writeEventHelper();
     std::unique_ptr<nixlTelemetryExporter> exporter_;

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -99,9 +99,11 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) noexcept {
         return nixl_telemetry_event_type_t::AGENT_ERR_CANCELED;
     case NIXL_ERR_NO_TELEMETRY:
         return nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY;
-    default:
+    case NIXL_SUCCESS:
+    case NIXL_IN_PROG:
         return std::nullopt;
     }
+    return std::nullopt;
 }
 
 namespace nixlEnumStrings {
@@ -110,7 +112,7 @@ telemetryCategoryStr(const nixl_telemetry_category_t &category);
 
 [[nodiscard]] constexpr std::string_view
 telemetryEventTypeStr(nixl_telemetry_event_type_t type) noexcept {
-    switch (name) {
+    switch (type) {
     case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
         return "agent_tx_bytes";
     case nixl_telemetry_event_type_t::AGENT_RX_BYTES:

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -72,39 +72,8 @@ enum class nixl_telemetry_event_type_t : uint8_t {
     AGENT_BACKEND = 20,
 };
 
-[[nodiscard]] inline std::optional<nixl_telemetry_event_type_t>
-nixlTelemetryEventTypeForStatus(nixl_status_t s) noexcept {
-    switch (s) {
-    case NIXL_ERR_NOT_POSTED:
-        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
-    case NIXL_ERR_INVALID_PARAM:
-        return nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM;
-    case NIXL_ERR_BACKEND:
-        return nixl_telemetry_event_type_t::AGENT_ERR_BACKEND;
-    case NIXL_ERR_NOT_FOUND:
-        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND;
-    case NIXL_ERR_MISMATCH:
-        return nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH;
-    case NIXL_ERR_NOT_ALLOWED:
-        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED;
-    case NIXL_ERR_REPOST_ACTIVE:
-        return nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE;
-    case NIXL_ERR_UNKNOWN:
-        return nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN;
-    case NIXL_ERR_NOT_SUPPORTED:
-        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED;
-    case NIXL_ERR_REMOTE_DISCONNECT:
-        return nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT;
-    case NIXL_ERR_CANCELED:
-        return nixl_telemetry_event_type_t::AGENT_ERR_CANCELED;
-    case NIXL_ERR_NO_TELEMETRY:
-        return nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY;
-    case NIXL_SUCCESS:
-    case NIXL_IN_PROG:
-        return std::nullopt;
-    }
-    return std::nullopt;
-}
+[[nodiscard]] std::optional<nixl_telemetry_event_type_t>
+nixlTelemetryEventTypeForStatus(nixl_status_t s);
 
 namespace nixlEnumStrings {
 std::string

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -65,7 +65,7 @@ std::string
 telemetryCategoryStr(const nixl_telemetry_category_t &category);
 
 [[nodiscard]] constexpr std::string_view
-telemetryEventTypeStr(nixl_telemetry_event_type_t name) noexcept {
+telemetryEventTypeStr(nixl_telemetry_event_type_t type) noexcept {
     switch (name) {
     case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
         return "agent_tx_bytes";

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -45,7 +45,7 @@ enum class nixl_telemetry_category_t {
 
 /**
  * @enum nixl_telemetry_event_type_t
- * @brief Enumerates all known telemetry event types, avoiding per-event string copies.
+ * @brief Enumerates all known telemetry event types.
  */
 enum class nixl_telemetry_event_type_t : uint8_t {
     AGENT_TX_BYTES = 0,

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -18,9 +18,8 @@
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
 #include <cstdint>
-#include <cstring>
-
 #include <string>
+#include <string_view>
 
 #include "nixl_types.h"
 
@@ -28,7 +27,6 @@ constexpr char TELEMETRY_BUFFER_SIZE_VAR[] = "NIXL_TELEMETRY_BUFFER_SIZE";
 constexpr char TELEMETRY_RUN_INTERVAL_VAR[] = "NIXL_TELEMETRY_RUN_INTERVAL";
 
 constexpr inline int TELEMETRY_VERSION = 2;
-constexpr inline size_t MAX_EVENT_NAME_LEN = 32;
 
 /**
  * @enum nixl_telemetry_category_t
@@ -45,9 +43,53 @@ enum class nixl_telemetry_category_t {
     NIXL_TELEMETRY_CUSTOM = 7, // Custom/user-defined events
 };
 
+/**
+ * @enum nixl_telemetry_event_type_t
+ * @brief Enumerates all known telemetry event types, avoiding per-event string copies.
+ */
+enum class nixl_telemetry_event_type_t : uint8_t {
+    AGENT_TX_BYTES = 0,
+    AGENT_RX_BYTES = 1,
+    AGENT_TX_REQUESTS_NUM = 2,
+    AGENT_RX_REQUESTS_NUM = 3,
+    AGENT_MEMORY_REGISTERED = 4,
+    AGENT_MEMORY_DEREGISTERED = 5,
+    AGENT_XFER_TIME = 6,
+    AGENT_XFER_POST_TIME = 7,
+    AGENT_ERROR = 8,
+    AGENT_BACKEND = 9,
+};
+
 namespace nixlEnumStrings {
 std::string
 telemetryCategoryStr(const nixl_telemetry_category_t &category);
+
+[[nodiscard]] constexpr std::string_view
+telemetryEventTypeStr(nixl_telemetry_event_type_t name) noexcept {
+    switch (name) {
+    case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
+        return "agent_tx_bytes";
+    case nixl_telemetry_event_type_t::AGENT_RX_BYTES:
+        return "agent_rx_bytes";
+    case nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM:
+        return "agent_tx_requests_num";
+    case nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM:
+        return "agent_rx_requests_num";
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED:
+        return "agent_memory_registered";
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED:
+        return "agent_memory_deregistered";
+    case nixl_telemetry_event_type_t::AGENT_XFER_TIME:
+        return "agent_xfer_time";
+    case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
+        return "agent_xfer_post_time";
+    case nixl_telemetry_event_type_t::AGENT_ERROR:
+        return "agent_error";
+    case nixl_telemetry_event_type_t::AGENT_BACKEND:
+        return "agent_backend";
+    }
+    return "unknown_event";
+}
 }
 
 /**
@@ -56,24 +98,17 @@ telemetryCategoryStr(const nixl_telemetry_category_t &category);
  */
 struct nixlTelemetryEvent {
     nixl_telemetry_category_t category_; // Main event category for filtering
-    char eventName_[MAX_EVENT_NAME_LEN]; // Detailed event name/identifier
+    nixl_telemetry_event_type_t eventType_; // Detailed event type/identifier
     uint64_t value_; // Numeric value associated with the event
 
     nixlTelemetryEvent() noexcept = default;
 
     nixlTelemetryEvent(nixl_telemetry_category_t category,
-                       const char *event_name,
+                       nixl_telemetry_event_type_t event_type,
                        uint64_t value) noexcept
         : category_(category),
-          value_(value) {
-        strncpy(eventName_, event_name, MAX_EVENT_NAME_LEN - 1);
-        eventName_[MAX_EVENT_NAME_LEN - 1] = '\0';
-    }
-
-    nixlTelemetryEvent(nixl_telemetry_category_t category,
-                       const std::string &event_name,
-                       uint64_t value) noexcept
-        : nixlTelemetryEvent(category, event_name.c_str(), value) {}
+          eventType_(event_type),
+          value_(value) {}
 };
 
 #endif

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -18,6 +18,7 @@
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -56,9 +57,52 @@ enum class nixl_telemetry_event_type_t : uint8_t {
     AGENT_MEMORY_DEREGISTERED = 5,
     AGENT_XFER_TIME = 6,
     AGENT_XFER_POST_TIME = 7,
-    AGENT_ERROR = 8,
-    AGENT_BACKEND = 9,
+    AGENT_ERR_NOT_POSTED = 8,
+    AGENT_ERR_INVALID_PARAM = 9,
+    AGENT_ERR_BACKEND = 10,
+    AGENT_ERR_NOT_FOUND = 11,
+    AGENT_ERR_MISMATCH = 12,
+    AGENT_ERR_NOT_ALLOWED = 13,
+    AGENT_ERR_REPOST_ACTIVE = 14,
+    AGENT_ERR_UNKNOWN = 15,
+    AGENT_ERR_NOT_SUPPORTED = 16,
+    AGENT_ERR_REMOTE_DISCONNECT = 17,
+    AGENT_ERR_CANCELED = 18,
+    AGENT_ERR_NO_TELEMETRY = 19,
+    AGENT_BACKEND = 20,
 };
+
+[[nodiscard]] inline std::optional<nixl_telemetry_event_type_t>
+nixlTelemetryEventTypeForStatus(nixl_status_t s) noexcept {
+    switch (s) {
+    case NIXL_ERR_NOT_POSTED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED;
+    case NIXL_ERR_INVALID_PARAM:
+        return nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM;
+    case NIXL_ERR_BACKEND:
+        return nixl_telemetry_event_type_t::AGENT_ERR_BACKEND;
+    case NIXL_ERR_NOT_FOUND:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND;
+    case NIXL_ERR_MISMATCH:
+        return nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH;
+    case NIXL_ERR_NOT_ALLOWED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED;
+    case NIXL_ERR_REPOST_ACTIVE:
+        return nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE;
+    case NIXL_ERR_UNKNOWN:
+        return nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN;
+    case NIXL_ERR_NOT_SUPPORTED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED;
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        return nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT;
+    case NIXL_ERR_CANCELED:
+        return nixl_telemetry_event_type_t::AGENT_ERR_CANCELED;
+    case NIXL_ERR_NO_TELEMETRY:
+        return nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY;
+    default:
+        return std::nullopt;
+    }
+}
 
 namespace nixlEnumStrings {
 std::string
@@ -83,8 +127,30 @@ telemetryEventTypeStr(nixl_telemetry_event_type_t type) noexcept {
         return "agent_xfer_time";
     case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
         return "agent_xfer_post_time";
-    case nixl_telemetry_event_type_t::AGENT_ERROR:
-        return "agent_error";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED:
+        return "agent_err_not_posted";
+    case nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM:
+        return "agent_err_invalid_param";
+    case nixl_telemetry_event_type_t::AGENT_ERR_BACKEND:
+        return "agent_err_backend";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND:
+        return "agent_err_not_found";
+    case nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH:
+        return "agent_err_mismatch";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED:
+        return "agent_err_not_allowed";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE:
+        return "agent_err_repost_active";
+    case nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN:
+        return "agent_err_unknown";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED:
+        return "agent_err_not_supported";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
+        return "agent_err_remote_disconnect";
+    case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
+        return "agent_err_canceled";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
+        return "agent_err_no_telemetry";
     case nixl_telemetry_event_type_t::AGENT_BACKEND:
         return "agent_backend";
     }

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -18,7 +18,6 @@
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
 #include <cstdint>
-#include <optional>
 #include <string>
 #include <string_view>
 
@@ -48,7 +47,7 @@ enum class nixl_telemetry_category_t {
  * @enum nixl_telemetry_event_type_t
  * @brief Enumerates all known telemetry event types.
  */
-enum class nixl_telemetry_event_type_t : uint8_t {
+enum class nixl_telemetry_event_type_t : uint32_t {
     AGENT_TX_BYTES = 0,
     AGENT_RX_BYTES = 1,
     AGENT_TX_REQUESTS_NUM = 2,
@@ -69,10 +68,9 @@ enum class nixl_telemetry_event_type_t : uint8_t {
     AGENT_ERR_REMOTE_DISCONNECT = 17,
     AGENT_ERR_CANCELED = 18,
     AGENT_ERR_NO_TELEMETRY = 19,
-    AGENT_BACKEND = 20,
 };
 
-[[nodiscard]] std::optional<nixl_telemetry_event_type_t>
+[[nodiscard]] nixl_telemetry_event_type_t
 nixlTelemetryEventTypeForStatus(nixl_status_t s);
 
 namespace nixlEnumStrings {
@@ -80,7 +78,7 @@ std::string
 telemetryCategoryStr(const nixl_telemetry_category_t &category);
 
 [[nodiscard]] constexpr std::string_view
-telemetryEventTypeStr(nixl_telemetry_event_type_t type) noexcept {
+telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
     switch (type) {
     case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
         return "agent_tx_bytes";
@@ -122,8 +120,6 @@ telemetryEventTypeStr(nixl_telemetry_event_type_t type) noexcept {
         return "agent_err_canceled";
     case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
         return "agent_err_no_telemetry";
-    case nixl_telemetry_event_type_t::AGENT_BACKEND:
-        return "agent_backend";
     }
     return "unknown_event";
 }

--- a/src/plugins/telemetry/README.md
+++ b/src/plugins/telemetry/README.md
@@ -84,7 +84,7 @@ nixlTelemetryCsvExporter::nixlTelemetryCsvExporter(
     }
 
     // Write CSV header
-    file_ << "category,event_name,value\n";
+    file_ << "category,event_type,value\n";
     NIXL_INFO << "CSV exporter initialized: " << file_path;
 }
 
@@ -96,7 +96,7 @@ nixlTelemetryCsvExporter::exportEvent(const nixlTelemetryEvent &event) {
 
     try {
         file_ << static_cast<int>(event.category_) << ","
-              << event.eventName_ << ","
+              << nixlEnumStrings::telemetryEventTypeStr(event.eventType_) << ","
               << event.value_ << "\n";
         file_.flush();
         return NIXL_SUCCESS;

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -77,7 +77,7 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_requests_num` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | No |
 | `agent_xfer_time` | `NIXL_TELEMETRY_PERFORMANCE` | Yes | No | No |
 | `agent_xfer_post_time` | `NIXL_TELEMETRY_PERFORMANCE` | Yes | No | No |
-| Error status type | `NIXL_TELEMETRY_ERROR` | No | No | No |
+| Error event types (`agent_err_*`) | `NIXL_TELEMETRY_ERROR` | No | No | No |
 
 **Counter, Gauge, Histogram** - as implemented by the Prometheus exporter
 - **Counter**: Instance lifetime count of the related value. Summed over the separate events' values. Counter metrics have suffix '_total'

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -77,7 +77,7 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_requests_num` | `NIXL_TELEMETRY_TRANSFER` | Yes | No | No |
 | `agent_xfer_time` | `NIXL_TELEMETRY_PERFORMANCE` | Yes | No | No |
 | `agent_xfer_post_time` | `NIXL_TELEMETRY_PERFORMANCE` | Yes | No | No |
-| Error status strings | `NIXL_TELEMETRY_ERROR` | No | No | No |
+| Error status type | `NIXL_TELEMETRY_ERROR` | No | No | No |
 
 **Counter, Gauge, Histogram** - as implemented by the Prometheus exporter
 - **Counter**: Instance lifetime count of the related value. Summed over the separate events' values. Counter metrics have suffix '_total'

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -124,7 +124,7 @@ nixlTelemetryPrometheusExporter::registerGauge(const std::string &name,
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
-        const std::string event_name(event.eventName_);
+        const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
 
         switch (event.category_) {
         case nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER:

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -123,6 +123,8 @@ nixlTelemetryPrometheusExporter::registerGauge(const std::string &name,
 
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
+    // TODO(C++20): use std::string_view for lookup keys and transparent hash/equal_to
+    // on counters_/gauges_ to avoid allocating a std::string per event when feasible.
     try {
         const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
 

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -163,8 +163,8 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERROR);
-    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERR_BACKEND);
+    EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
     EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED);
     EXPECT_EQ(event.value_, 1024);
@@ -350,8 +350,7 @@ TEST_F(telemetryTest, TelemetryAgentEventsTwo) {
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERROR);
-    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERR_BACKEND);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR);
 
     envHelper_.popVar();

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -151,45 +151,46 @@ TEST_F(telemetryTest, TransferBytesTracking) {
     EXPECT_EQ(buffer->full(), false);
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_RX_BYTES);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_requests_num");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_,
-                 nixlEnumStrings::statusStr(nixl_status_t::NIXL_ERR_BACKEND).c_str());
-    EXPECT_EQ(event.value_, 1);
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERROR);
+    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_memory_registered");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_memory_deregistered");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED);
     EXPECT_EQ(event.value_, 1024);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_xfer_time");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_XFER_TIME);
     EXPECT_EQ(event.value_, 100);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.value_, 2000);
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_requests_num");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM);
     EXPECT_EQ(event.value_, 1);
     envHelper_.popVar();
 }
 
 TEST_F(telemetryTest, TelemetryEventStructure) {
-    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER, "test_event", 42);
+    nixlTelemetryEvent event1(nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER,
+                              nixl_telemetry_event_type_t::AGENT_TX_BYTES,
+                              42);
 
     EXPECT_EQ(event1.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
     EXPECT_EQ(event1.value_, 42);
-    EXPECT_STREQ(event1.eventName_, "test_event");
+    EXPECT_EQ(event1.eventType_, nixl_telemetry_event_type_t::AGENT_TX_BYTES);
 }
 
 TEST_F(telemetryTest, ShortRunInterval) {
@@ -314,11 +315,11 @@ TEST_F(telemetryTest, TelemetryAgentEventsOne) {
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_rx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_RX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     envHelper_.popVar();
@@ -345,12 +346,12 @@ TEST_F(telemetryTest, TelemetryAgentEventsTwo) {
 
     nixlTelemetryEvent event;
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_, "agent_tx_bytes");
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_TX_BYTES);
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_TRANSFER);
 
     buffer->pop(event);
-    EXPECT_STREQ(event.eventName_,
-                 nixlEnumStrings::statusStr(nixl_status_t::NIXL_ERR_BACKEND).c_str());
+    EXPECT_EQ(event.eventType_, nixl_telemetry_event_type_t::AGENT_ERROR);
+    EXPECT_EQ(event.value_, static_cast<uint64_t>(nixl_status_t::NIXL_ERR_BACKEND));
     EXPECT_EQ(event.category_, nixl_telemetry_category_t::NIXL_TELEMETRY_ERROR);
 
     envHelper_.popVar();


### PR DESCRIPTION
## What?
Replaces per-telemetry-event string storage with a fixed nixl_telemetry_event_type_t enum (uint8_t) and renames the field from eventName_ to eventType_. Events are still described as strings where needed via nixlEnumStrings::telemetryEventTypeStr() (constexpr string_view).

## Why?
Save string copy on the hot path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry now uses a strongly-typed event type classification for consistent event identities.

* **Bug Fixes**
  * Event buffering/reporting switched from freeform names to typed event types; unmapped statuses no longer emit events.

* **Documentation**
  * Event field label changed to "Event type"; CSV and Prometheus docs updated to reflect type-based output.

* **Tests**
  * Tests updated to assert typed telemetry event identifiers.

* **Examples**
  * Example readers now print mapped event-type strings instead of raw event-name text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->