### PR TITLE
Pin direct dependency to exact version in package template

### DIFF
--- a/src/bindings/python/nixl-meta/pyproject.toml.in
+++ b/src/bindings/python/nixl-meta/pyproject.toml.in
@@ -29,7 +29,7 @@ authors = [
   {name = "NIXL Developers", email = "nixl-developers@nvidia.com"}
 ]
 
-dependencies = ["@WHEEL_DEP@>=@VERSION@"]
+dependencies = ["@WHEEL_DEP@==@VERSION@"]
 
 [project.optional-dependencies]
 cu12 = ["nixl-cu12==@VERSION@"]


### PR DESCRIPTION
## What?
All nixl wheels should match version exactly

## Why?
Pinning `nixl` version in pip should pin also `nixl-cu12` and `nixl-cu13`.

Currently `uv pip install nixl[cu13]` triggers an upgrade of nixl-cu12
