### PR TITLE
Set default build type to release in all CI environments

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -39,11 +39,7 @@ UCX_REF=${UCX_REF:-v1.21.x}
 BUILD_NIXL_EP="true"
 OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
-if [ "$CI" = "true" ]; then
-    BUILD_TYPE="debug"
-else
-    BUILD_TYPE="release"
-fi
+BUILD_TYPE="release"
 
 get_options() {
     while :; do


### PR DESCRIPTION
## What?
Set default build type to release in all containers

## Why?
CI was using debug builds on some workers, causing a mix of optimized and debug compilation flags that caused a build failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default build type to "release" for all build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->