### PR TITLE
NIXL/UCX: enforce VRAM memtype hint query behavior and add tests

### DIFF
--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -161,6 +161,24 @@ When user asks for a specific backend for its name, alongside a list of paramete
 
 In this step, if the plugin supports talking to remote agents, the required connection data for other agents to talk to it is acquired through **getConnInfo** in SB API. And/or if it supports within node transfers, a **connection** call to itself is called, as some backends might require that.
 
+#### UCX backend options (common)
+
+The UCX plugin exposes initialization options through `getPluginParams("UCX", ...)` in C++
+or `get_plugin_params("UCX")` in Python. Two commonly used options are:
+
+| Option key | Default | Description |
+| ---------- | ------- | ----------- |
+| `ucx_error_handling_mode` | `peer` | UCX endpoint error handling policy. `peer` enables peer failure reporting; `none` disables it. |
+| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported policies are `auto`, `none`, and explicit accelerator policies (CUDA/CUDA managed/ROCm/ZE device). |
+
+Notes:
+
+* `ucx_error_handling_mode` and `ucx_vram_memtype_hint` are independent options. You do not need to set one to use the other.
+* `ucx_vram_memtype_hint=auto` is the recommended default for general use.
+* Matching for `ucx_vram_memtype_hint` values is case-sensitive.
+* If an explicit VRAM hint is configured but not supported by the current UCX context,
+  backend creation fails with an invalid-argument error.
+
 ### Make connections (optional):
 
 When a connection is requested to an remote agent, which is possible if the remote agent’s metadata is already loaded, the local Agent would look for common backend plugins between itself and the remote agent, and for each of them initiate a connect by using the **connect** API in SB API of such backends.

--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -169,7 +169,7 @@ or `get_plugin_params("UCX")` in Python. Two commonly used options are:
 | Option key | Default | Description |
 | ---------- | ------- | ----------- |
 | `ucx_error_handling_mode` | `peer` | UCX endpoint error handling policy. `peer` enables peer failure reporting; `none` disables it. |
-| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported policies are `auto`, `none`, and explicit accelerator policies (CUDA/CUDA managed/ROCm/ZE device). |
+| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported values are exactly: `auto`, `none`, `cuda`, `cuda-managed`, `rocm`, `ze-device`. |
 
 Notes:
 
@@ -178,6 +178,7 @@ Notes:
 * Matching for `ucx_vram_memtype_hint` values is case-sensitive.
 * If an explicit VRAM hint is configured but not supported by the current UCX context,
   backend creation fails with an invalid-argument error.
+* If UCX context memory types cannot be queried, explicit hints (`cuda`, `cuda-managed`, `rocm`, `ze-device`) fail backend creation; `auto`/`none` continue without hinting.
 
 ### Make connections (optional):
 

--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -166,6 +166,24 @@ When user asks for a specific backend for its name, alongside a list of paramete
 
 In this step, if the plugin supports talking to remote agents, the required connection data for other agents to talk to it is acquired through **getConnInfo** in SB API. And/or if it supports within node transfers, a **connection** call to itself is called, as some backends might require that.
 
+#### UCX backend options (common)
+
+The UCX plugin exposes initialization options through `getPluginParams("UCX", ...)` in C++
+or `get_plugin_params("UCX")` in Python. Two commonly used options are:
+
+| Option key | Default | Description |
+| ---------- | ------- | ----------- |
+| `ucx_error_handling_mode` | `peer` | UCX endpoint error handling policy. `peer` enables peer failure reporting; `none` disables it. |
+| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported policies are `auto`, `none`, and explicit accelerator policies (CUDA/CUDA managed/ROCm/ZE device). |
+
+Notes:
+
+* `ucx_error_handling_mode` and `ucx_vram_memtype_hint` are independent options. You do not need to set one to use the other.
+* `ucx_vram_memtype_hint=auto` is the recommended default for general use.
+* Matching for `ucx_vram_memtype_hint` values is case-sensitive.
+* If an explicit VRAM hint is configured but not supported by the current UCX context,
+  backend creation fails with an invalid-argument error.
+
 ### Make connections (optional):
 
 When a connection is requested to an remote agent, which is possible if the remote agent’s metadata is already loaded, the local Agent would look for common backend plugins between itself and the remote agent, and for each of them initiate a connect by using the **connect** API in SB API of such backends.

--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -174,7 +174,7 @@ or `get_plugin_params("UCX")` in Python. Two commonly used options are:
 | Option key | Default | Description |
 | ---------- | ------- | ----------- |
 | `ucx_error_handling_mode` | `peer` | UCX endpoint error handling policy. `peer` enables peer failure reporting; `none` disables it. |
-| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported policies are `auto`, `none`, and explicit accelerator policies (CUDA/CUDA managed/ROCm/ZE device). |
+| `ucx_vram_memtype_hint` | `auto` | Controls how NIXL hints UCX memory type during VRAM registration. Supported values are exactly: `auto`, `none`, `cuda`, `cuda-managed`, `rocm`, `ze-device`. |
 
 Notes:
 
@@ -183,6 +183,7 @@ Notes:
 * Matching for `ucx_vram_memtype_hint` values is case-sensitive.
 * If an explicit VRAM hint is configured but not supported by the current UCX context,
   backend creation fails with an invalid-argument error.
+* If UCX context memory types cannot be queried, explicit hints (`cuda`, `cuda-managed`, `rocm`, `ze-device`) fail backend creation; `auto`/`none` continue without hinting.
 
 ### Make connections (optional):
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -41,3 +41,25 @@ See the [Python examples](../examples/python/) directory for complete working ex
 - [nixl_api_example.py](../examples/python/nixl_api_example.py) - General API usage
 - [basic_two_peers.py](../examples/python/basic_two_peers.py) - Basic transfer operations
 - [partial_md_example.py](../examples/python/partial_md_example.py) - Partial metadata handling
+
+## Backend initialization parameters
+
+Backends can expose initialization parameters through `get_plugin_params(backend)`.
+You can override values before calling `create_backend`.
+
+```python
+params = agent.get_plugin_params("UCX")
+
+# Common UCX options.
+params["ucx_error_handling_mode"] = "peer"   # or "none"
+params["ucx_vram_memtype_hint"] = "auto"     # recommended default
+
+agent.create_backend("UCX", params)
+```
+
+For `ucx_vram_memtype_hint`:
+
+- `auto` is the recommended default.
+- `none` disables NIXL memory-type hinting and leaves detection to UCX.
+- Explicit accelerator hints are also supported for advanced tuning.
+- Values are case-sensitive.

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -63,4 +63,4 @@ For `ucx_vram_memtype_hint`:
 - `none` disables NIXL memory-type hinting and leaves detection to UCX.
 - Explicit accelerator hints are also supported for advanced tuning: `cuda`, `cuda-managed`, `rocm`, `ze-device`.
 - Values are case-sensitive.
-- If UCX context memory types cannot be queried, explicit hints fail backend creation; `auto` and `none` continue without hinting.
+- Explicit hints fail backend creation when UCX context memory types cannot be queried, or when the queried UCX context does not advertise the requested memtype (for example, `cuda`/`rocm`/`ze-device` selected but not supported by the current UCX context). `auto` and `none` continue without hinting.

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -61,5 +61,6 @@ For `ucx_vram_memtype_hint`:
 
 - `auto` is the recommended default.
 - `none` disables NIXL memory-type hinting and leaves detection to UCX.
-- Explicit accelerator hints are also supported for advanced tuning.
+- Explicit accelerator hints are also supported for advanced tuning: `cuda`, `cuda-managed`, `rocm`, `ze-device`.
 - Values are case-sensitive.
+- If UCX context memory types cannot be queried, explicit hints fail backend creation; `auto` and `none` continue without hinting.

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1343,6 +1343,8 @@ void Buffer::_nixl_agent_init() {
     const char* num_channels_env = std::getenv("NIXL_EP_NUM_CHANNELS");
     init_params["ucx_num_device_channels"] = num_channels_env ? num_channels_env : "4";
     init_params["ucx_error_handling_mode"] = "none";
+    // hint VRAM memory type policy; keep "auto" unless tuning a specific platform.
+    init_params["ucx_vram_memtype_hint"] = "auto";
     init_params["num_workers"] = std::to_string(1);
 
     nixlBackendH* ucx_backend = nullptr;

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1411,6 +1411,8 @@ void Buffer::_nixl_agent_init() {
     const char* num_channels_env = std::getenv("NIXL_EP_NUM_CHANNELS");
     init_params["ucx_num_device_channels"] = num_channels_env ? num_channels_env : "4";
     init_params["ucx_error_handling_mode"] = "none";
+    // hint VRAM memory type policy; keep "auto" unless tuning a specific platform.
+    init_params["ucx_vram_memtype_hint"] = "auto";
     init_params["num_workers"] = std::to_string(1);
 
     nixlBackendH* ucx_backend = nullptr;

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -852,8 +852,7 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
     if (vram_memtype_hint_it == custom_params->end()) {
         vram_memtype_hint_policy = nixl_ucx_vram_memtype_hint_t::AUTO;
     } else {
-        vram_memtype_hint_policy =
-            ucx_vram_memtype_hint_from_string(vram_memtype_hint_it->second);
+        vram_memtype_hint_policy = ucx_vram_memtype_hint_from_string(vram_memtype_hint_it->second);
     }
 
     const auto engine_config_it = custom_params->find("engine_config");

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -846,6 +846,16 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
         err_handling_mode = ucx_err_mode_from_string(err_handling_mode_it->second);
     }
 
+    nixl_ucx_vram_memtype_hint_t vram_memtype_hint_policy;
+    const auto vram_memtype_hint_it =
+        custom_params->find(std::string(nixl_ucx_vram_memtype_hint_param_name));
+    if (vram_memtype_hint_it == custom_params->end()) {
+        vram_memtype_hint_policy = nixl_ucx_vram_memtype_hint_t::AUTO;
+    } else {
+        vram_memtype_hint_policy =
+            ucx_vram_memtype_hint_from_string(vram_memtype_hint_it->second);
+    }
+
     const auto engine_config_it = custom_params->find("engine_config");
     const auto engine_config =
         (engine_config_it != custom_params->end()) ? engine_config_it->second : "";
@@ -855,7 +865,8 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
                                           num_workers,
                                           init_params.syncMode,
                                           num_device_channels,
-                                          engine_config);
+                                          engine_config,
+                                          vram_memtype_hint_policy);
 
     uc->warnAboutHardwareSupportMismatch();
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -801,6 +801,12 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
 
     const uint32_t ep_close_flags = epCloseFlags(custom_params);
 
+    nixl_ucx_vram_memtype_hint_t vram_memtype_hint_policy = nixl_ucx_vram_memtype_hint_t::AUTO;
+    if (const auto opt = nixl::getBackendParamOptional<std::string>(
+            custom_params, std::string(nixl_ucx_vram_memtype_hint_param_name))) {
+        vram_memtype_hint_policy = ucx_vram_memtype_hint_from_string(*opt);
+    }
+
     const auto engine_config =
         nixl::getBackendParamDefaulted(custom_params, "engine_config", std::string());
 
@@ -810,7 +816,8 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
                                           init_params.syncMode,
                                           num_device_channels,
                                           engine_config,
-                                          localAgent);
+                                          localAgent,
+                                          vram_memtype_hint_policy);
 
     uc->warnAboutHardwareSupportMismatch();
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -582,7 +582,13 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
                                  std::string(ucs_status_string(status)));
     }
 
-    resolveMemoryTypeConfig();
+    try {
+        resolveMemoryTypeConfig();
+    }
+    catch (...) {
+        ucp_cleanup(ctx);
+        throw;
+    }
 }
 
 nixlUcxContext::~nixlUcxContext() {

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -467,7 +467,7 @@ makeMtType(const bool prog_thread, const nixl_thread_sync_t sync_mode) noexcept 
 [[nodiscard]] std::string_view
 ucx_memory_type_to_string(const ucs_memory_type_t mem_type) {
     const auto mem_type_index = static_cast<unsigned>(mem_type);
-    if (mem_type_index > static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
+    if (mem_type_index >= static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
         return "invalid";
     }
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -18,6 +18,7 @@
 #include "ucx_utils.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <exception>
 #include <stdexcept>
@@ -40,6 +41,8 @@ get_ucx_backend_common_options() {
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));
+    params.emplace(nixl_ucx_vram_memtype_hint_param_name,
+                   ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t::AUTO));
     return params;
 }
 
@@ -101,6 +104,56 @@ ucx_err_mode_from_string(std::string_view s) {
         }
     }
 
+    err_msg << ">";
+    throw std::invalid_argument(err_msg.str());
+}
+
+[[nodiscard]] std::string_view
+ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t t) {
+    switch (t) {
+    case nixl_ucx_vram_memtype_hint_t::AUTO:
+        return "auto";
+    case nixl_ucx_vram_memtype_hint_t::NONE:
+        return "none";
+    case nixl_ucx_vram_memtype_hint_t::CUDA:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_CUDA];
+    case nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_CUDA_MANAGED];
+    case nixl_ucx_vram_memtype_hint_t::ROCM:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_ROCM];
+    case nixl_ucx_vram_memtype_hint_t::ZE_DEVICE:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_ZE_DEVICE];
+    }
+    throw std::invalid_argument(std::to_string(enumToInteger(t)));
+}
+
+[[nodiscard]] nixl_ucx_vram_memtype_hint_t
+ucx_vram_memtype_hint_from_string(std::string_view s) {
+    constexpr std::array<nixl_ucx_vram_memtype_hint_t, 6> hint_modes = {
+        nixl_ucx_vram_memtype_hint_t::AUTO,
+        nixl_ucx_vram_memtype_hint_t::NONE,
+        nixl_ucx_vram_memtype_hint_t::CUDA,
+        nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED,
+        nixl_ucx_vram_memtype_hint_t::ROCM,
+        nixl_ucx_vram_memtype_hint_t::ZE_DEVICE,
+    };
+
+    for (const auto hint_mode : hint_modes) {
+        const auto mode_name = ucx_vram_memtype_hint_to_string(hint_mode);
+        if (mode_name == s) {
+            return hint_mode;
+        }
+    }
+
+    std::stringstream err_msg;
+    err_msg << "Invalid VRAM memtype hint mode: " << s
+        << ". Matching is case-sensitive; use exact values. Valid values are: <";
+    for (size_t i = 0; i < hint_modes.size(); ++i) {
+        err_msg << ucx_vram_memtype_hint_to_string(hint_modes[i]);
+        if (i < hint_modes.size() - 1) {
+            err_msg << "|";
+        }
+    }
     err_msg << ">";
     throw std::invalid_argument(err_msg.str());
 }
@@ -411,6 +464,53 @@ makeMtType(const bool prog_thread, const nixl_thread_sync_t sync_mode) noexcept 
         nixl_ucx_mt_t::SINGLE;
 }
 
+[[nodiscard]] std::string_view
+ucx_memory_type_to_string(const ucs_memory_type_t mem_type) {
+    const auto mem_type_index = static_cast<unsigned>(mem_type);
+    if (mem_type_index > static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
+        return "invalid";
+    }
+
+    return ucs_memory_type_names[mem_type_index];
+}
+
+[[nodiscard]] std::optional<ucs_memory_type_t>
+ucx_auto_detect_vram_hint(const uint64_t memory_types_mask) {
+    // AUTO is intentionally conservative: only auto-hint ZE on ZE-only accelerator stacks.
+    // CUDA is left to UCX auto-detection by default because it is reliable with shared
+    // primary context, and mixed accelerator environments are treated as ambiguous.
+    const bool has_ze = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_ZE_DEVICE);
+    const bool has_cuda = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_CUDA) ||
+        UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    const bool has_rocm = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_ROCM);
+
+    if (has_ze && !has_cuda && !has_rocm) {
+        return UCS_MEMORY_TYPE_ZE_DEVICE;
+    }
+
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<ucs_memory_type_t>
+ucx_policy_to_mem_type(const nixl_ucx_vram_memtype_hint_t policy) {
+    switch (policy) {
+    case nixl_ucx_vram_memtype_hint_t::AUTO:
+    case nixl_ucx_vram_memtype_hint_t::NONE:
+        return std::nullopt;
+    case nixl_ucx_vram_memtype_hint_t::CUDA:
+        return UCS_MEMORY_TYPE_CUDA;
+    case nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED:
+        return UCS_MEMORY_TYPE_CUDA_MANAGED;
+    case nixl_ucx_vram_memtype_hint_t::ROCM:
+        return UCS_MEMORY_TYPE_ROCM;
+    case nixl_ucx_vram_memtype_hint_t::ZE_DEVICE:
+        return UCS_MEMORY_TYPE_ZE_DEVICE;
+    }
+
+    NIXL_FATAL << "Invalid VRAM memtype hint mode: " << enumToInteger(policy);
+    std::terminate();
+}
+
 } // namespace
 
 nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
@@ -418,9 +518,11 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
                                unsigned long num_workers,
                                nixl_thread_sync_t sync_mode,
                                size_t num_device_channels,
-                               const std::string &engine_config)
+                               const std::string &engine_config,
+                               nixl_ucx_vram_memtype_hint_t vram_mem_type_hint_policy)
     : mtType_(makeMtType(prog_thread, sync_mode)),
-      ucpVersion_(makeUcpVersion()) {
+      ucpVersion_(makeUcpVersion()),
+      vramMemTypeHintPolicy_(vram_mem_type_hint_policy) {
 
     ucp_params_t ucp_params;
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
@@ -479,10 +581,60 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         throw std::runtime_error("Failed to create UCX context: " +
                                  std::string(ucs_status_string(status)));
     }
+
+    resolveMemoryTypeConfig();
 }
 
 nixlUcxContext::~nixlUcxContext() {
     ucp_cleanup(ctx);
+}
+
+void
+nixlUcxContext::resolveMemoryTypeConfig() {
+    ucp_context_attr_t context_attr = {
+        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
+    };
+
+    const auto status = ucp_context_query(ctx, &context_attr);
+    if (status != UCS_OK) {
+        NIXL_WARN << "Failed to query UCX context memory types: " << ucs_status_string(status)
+                  << ", VRAM memory type hinting will be disabled";
+        return;
+    }
+
+    supportedMemoryTypesMask_ = context_attr.memory_types;
+
+    if (vramMemTypeHintPolicy_ == nixl_ucx_vram_memtype_hint_t::AUTO) {
+        vramMemTypeHint_ = ucx_auto_detect_vram_hint(supportedMemoryTypesMask_);
+        if (vramMemTypeHint_.has_value()) {
+            NIXL_INFO << "VRAM memtype hint mode is auto, selected "
+                      << ucx_memory_type_to_string(*vramMemTypeHint_) << " based on UCX context";
+        } else {
+            NIXL_DEBUG << "VRAM memtype hint mode is auto, no unambiguous accelerator memory type"
+                          " found; UCX auto-detection will be used";
+        }
+        return;
+    }
+
+    if (vramMemTypeHintPolicy_ == nixl_ucx_vram_memtype_hint_t::NONE) {
+        NIXL_DEBUG << "VRAM memtype hint mode is none, UCX auto-detection will be used";
+        return;
+    }
+
+    const auto configured_hint = ucx_policy_to_mem_type(vramMemTypeHintPolicy_);
+    NIXL_ASSERT(configured_hint.has_value());
+
+    if (!UCS_BIT_GET(supportedMemoryTypesMask_, *configured_hint)) {
+        throw std::invalid_argument(
+            "Configured VRAM memtype hint '" +
+            std::string(ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_)) +
+            "' is not supported by current UCX context");
+    }
+
+    vramMemTypeHint_ = configured_hint;
+    NIXL_INFO << "VRAM memtype hint mode is "
+              << ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_) << ", using "
+              << ucx_memory_type_to_string(*vramMemTypeHint_);
 }
 
 namespace {
@@ -572,6 +724,13 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         .length = mem.size,
     };
 
+    if (nixl_mem_type == nixl_mem_t::VRAM_SEG && vramMemTypeHint_.has_value()) {
+        mem_params.field_mask |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE;
+        mem_params.memory_type = *vramMemTypeHint_;
+        NIXL_DEBUG << "memReg: hinting " << ucx_memory_type_to_string(mem_params.memory_type)
+                   << " for VRAM_SEG";
+    }
+
     ucs_status_t status = ucp_mem_map(ctx, &mem_params, &mem.memh);
     if (status != UCS_OK) {
         NIXL_ERROR << "Failed to ucp_mem_map: " << ucs_status_string(status);
@@ -590,7 +749,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
 
         if (attr.mem_type == UCS_MEMORY_TYPE_HOST) {
             NIXL_ERROR << "VRAM memory is detected as host by UCX. "
-                          "UCX is likely not configured with CUDA support. "
+                          "UCX memory type detection/configuration is likely mismatched. "
                           "VRAM registration cannot proceed.";
             ucp_mem_unmap(ctx, mem.memh);
             return -1;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -147,7 +147,7 @@ ucx_vram_memtype_hint_from_string(std::string_view s) {
 
     std::stringstream err_msg;
     err_msg << "Invalid VRAM memtype hint mode: " << s
-        << ". Matching is case-sensitive; use exact values. Valid values are: <";
+            << ". Matching is case-sensitive; use exact values. Valid values are: <";
     for (size_t i = 0; i < hint_modes.size(); ++i) {
         err_msg << ucx_vram_memtype_hint_to_string(hint_modes[i]);
         if (i < hint_modes.size() - 1) {

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -597,6 +597,15 @@ nixlUcxContext::resolveMemoryTypeConfig() {
 
     const auto status = ucp_context_query(ctx, &context_attr);
     if (status != UCS_OK) {
+        if (vramMemTypeHintPolicy_ != nixl_ucx_vram_memtype_hint_t::AUTO &&
+            vramMemTypeHintPolicy_ != nixl_ucx_vram_memtype_hint_t::NONE) {
+            throw std::runtime_error(
+                "Failed to query UCX context memory types: " +
+                std::string(ucs_status_string(status)) +
+                ". This query is required for explicit ucx_vram_memtype_hint='" +
+                std::string(ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_)) + "'");
+        }
+
         NIXL_WARN << "Failed to query UCX context memory types: " << ucs_status_string(status)
                   << ", VRAM memory type hinting will be disabled";
         return;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -648,6 +648,15 @@ nixlUcxContext::resolveMemoryTypeConfig() {
 
     const auto status = ucp_context_query(ctx, &context_attr);
     if (status != UCS_OK) {
+        if (vramMemTypeHintPolicy_ != nixl_ucx_vram_memtype_hint_t::AUTO &&
+            vramMemTypeHintPolicy_ != nixl_ucx_vram_memtype_hint_t::NONE) {
+            throw std::runtime_error(
+                "Failed to query UCX context memory types: " +
+                std::string(ucs_status_string(status)) +
+                ". This query is required for explicit ucx_vram_memtype_hint='" +
+                std::string(ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_)) + "'");
+        }
+
         NIXL_WARN << "Failed to query UCX context memory types: " << ucs_status_string(status)
                   << ", VRAM memory type hinting will be disabled";
         return;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -497,7 +497,7 @@ makeMtType(const bool prog_thread, const nixl_thread_sync_t sync_mode) noexcept 
 [[nodiscard]] std::string_view
 ucx_memory_type_to_string(const ucs_memory_type_t mem_type) {
     const auto mem_type_index = static_cast<unsigned>(mem_type);
-    if (mem_type_index > static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
+    if (mem_type_index >= static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
         return "invalid";
     }
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -18,6 +18,7 @@
 #include "ucx_utils.h"
 
 #include <algorithm>
+#include <array>
 #include <cstring>
 #include <exception>
 #include <stdexcept>
@@ -37,6 +38,8 @@ get_ucx_backend_common_options() {
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));
+    params.emplace(nixl_ucx_vram_memtype_hint_param_name,
+                   ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t::AUTO));
     return params;
 }
 
@@ -74,6 +77,57 @@ ucx_err_mode_from_string(std::string_view s) {
         }
     }
 
+    err_msg << ">";
+    throw std::invalid_argument(err_msg.str());
+}
+
+[[nodiscard]] std::string_view
+ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t t) {
+    switch (t) {
+    case nixl_ucx_vram_memtype_hint_t::AUTO:
+        return "auto";
+    case nixl_ucx_vram_memtype_hint_t::NONE:
+        return "none";
+    case nixl_ucx_vram_memtype_hint_t::CUDA:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_CUDA];
+    case nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_CUDA_MANAGED];
+    case nixl_ucx_vram_memtype_hint_t::ROCM:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_ROCM];
+    case nixl_ucx_vram_memtype_hint_t::ZE_DEVICE:
+        return ucs_memory_type_names[UCS_MEMORY_TYPE_ZE_DEVICE];
+    }
+    throw std::invalid_argument(
+        std::to_string(static_cast<std::underlying_type_t<nixl_ucx_vram_memtype_hint_t>>(t)));
+}
+
+[[nodiscard]] nixl_ucx_vram_memtype_hint_t
+ucx_vram_memtype_hint_from_string(std::string_view s) {
+    constexpr std::array<nixl_ucx_vram_memtype_hint_t, 6> hint_modes = {
+        nixl_ucx_vram_memtype_hint_t::AUTO,
+        nixl_ucx_vram_memtype_hint_t::NONE,
+        nixl_ucx_vram_memtype_hint_t::CUDA,
+        nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED,
+        nixl_ucx_vram_memtype_hint_t::ROCM,
+        nixl_ucx_vram_memtype_hint_t::ZE_DEVICE,
+    };
+
+    for (const auto hint_mode : hint_modes) {
+        const auto mode_name = ucx_vram_memtype_hint_to_string(hint_mode);
+        if (mode_name == s) {
+            return hint_mode;
+        }
+    }
+
+    std::stringstream err_msg;
+    err_msg << "Invalid VRAM memtype hint mode: " << s
+        << ". Matching is case-sensitive; use exact values. Valid values are: <";
+    for (size_t i = 0; i < hint_modes.size(); ++i) {
+        err_msg << ucx_vram_memtype_hint_to_string(hint_modes[i]);
+        if (i < hint_modes.size() - 1) {
+            err_msg << "|";
+        }
+    }
     err_msg << ">";
     throw std::invalid_argument(err_msg.str());
 }
@@ -440,6 +494,54 @@ makeMtType(const bool prog_thread, const nixl_thread_sync_t sync_mode) noexcept 
         nixl::ucx::mt_mode_t::SINGLE;
 }
 
+[[nodiscard]] std::string_view
+ucx_memory_type_to_string(const ucs_memory_type_t mem_type) {
+    const auto mem_type_index = static_cast<unsigned>(mem_type);
+    if (mem_type_index > static_cast<unsigned>(UCS_MEMORY_TYPE_LAST)) {
+        return "invalid";
+    }
+
+    return ucs_memory_type_names[mem_type_index];
+}
+
+[[nodiscard]] std::optional<ucs_memory_type_t>
+ucx_auto_detect_vram_hint(const uint64_t memory_types_mask) {
+    // AUTO is intentionally conservative: only auto-hint ZE on ZE-only accelerator stacks.
+    // CUDA is left to UCX auto-detection by default because it is reliable with shared
+    // primary context, and mixed accelerator environments are treated as ambiguous.
+    const bool has_ze = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_ZE_DEVICE);
+    const bool has_cuda = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_CUDA) ||
+        UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_CUDA_MANAGED);
+    const bool has_rocm = UCS_BIT_GET(memory_types_mask, UCS_MEMORY_TYPE_ROCM);
+
+    if (has_ze && !has_cuda && !has_rocm) {
+        return UCS_MEMORY_TYPE_ZE_DEVICE;
+    }
+
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<ucs_memory_type_t>
+ucx_policy_to_mem_type(const nixl_ucx_vram_memtype_hint_t policy) {
+    switch (policy) {
+    case nixl_ucx_vram_memtype_hint_t::AUTO:
+    case nixl_ucx_vram_memtype_hint_t::NONE:
+        return std::nullopt;
+    case nixl_ucx_vram_memtype_hint_t::CUDA:
+        return UCS_MEMORY_TYPE_CUDA;
+    case nixl_ucx_vram_memtype_hint_t::CUDA_MANAGED:
+        return UCS_MEMORY_TYPE_CUDA_MANAGED;
+    case nixl_ucx_vram_memtype_hint_t::ROCM:
+        return UCS_MEMORY_TYPE_ROCM;
+    case nixl_ucx_vram_memtype_hint_t::ZE_DEVICE:
+        return UCS_MEMORY_TYPE_ZE_DEVICE;
+    }
+
+    NIXL_FATAL << "Invalid VRAM memtype hint mode: "
+               << static_cast<std::underlying_type_t<nixl_ucx_vram_memtype_hint_t>>(policy);
+    std::terminate();
+}
+
 } // namespace
 
 nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
@@ -448,10 +550,12 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
                                nixl_thread_sync_t sync_mode,
                                size_t num_device_channels,
                                const std::string &engine_config,
-                               const std::string &name)
+                               const std::string &name,
+                               nixl_ucx_vram_memtype_hint_t vram_mem_type_hint_policy)
     : mtType_(makeMtType(prog_thread, sync_mode)),
       ucpVersion_(makeUcpVersion()),
-      name_(name) {
+      name_(name),
+      vramMemTypeHintPolicy_(vram_mem_type_hint_policy) {
 
     ucp_params_t ucp_params;
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
@@ -523,6 +627,8 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         throw std::runtime_error(std::string("Failed to create UCX context ") + name_ + ": " +
                                  std::string(ucs_status_string(status)));
     }
+
+    resolveMemoryTypeConfig();
 }
 
 nixlUcxContext::~nixlUcxContext() {
@@ -532,6 +638,54 @@ nixlUcxContext::~nixlUcxContext() {
 std::ostream &
 operator<<(std::ostream &os, const nixlUcxContext &ctx) {
     return os << "nixlUcxContext " << ctx.getName();
+}
+
+void
+nixlUcxContext::resolveMemoryTypeConfig() {
+    ucp_context_attr_t context_attr = {
+        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
+    };
+
+    const auto status = ucp_context_query(ctx, &context_attr);
+    if (status != UCS_OK) {
+        NIXL_WARN << "Failed to query UCX context memory types: " << ucs_status_string(status)
+                  << ", VRAM memory type hinting will be disabled";
+        return;
+    }
+
+    supportedMemoryTypesMask_ = context_attr.memory_types;
+
+    if (vramMemTypeHintPolicy_ == nixl_ucx_vram_memtype_hint_t::AUTO) {
+        vramMemTypeHint_ = ucx_auto_detect_vram_hint(supportedMemoryTypesMask_);
+        if (vramMemTypeHint_.has_value()) {
+            NIXL_INFO << "VRAM memtype hint mode is auto, selected "
+                      << ucx_memory_type_to_string(*vramMemTypeHint_) << " based on UCX context";
+        } else {
+            NIXL_DEBUG << "VRAM memtype hint mode is auto, no unambiguous accelerator memory type"
+                          " found; UCX auto-detection will be used";
+        }
+        return;
+    }
+
+    if (vramMemTypeHintPolicy_ == nixl_ucx_vram_memtype_hint_t::NONE) {
+        NIXL_DEBUG << "VRAM memtype hint mode is none, UCX auto-detection will be used";
+        return;
+    }
+
+    const auto configured_hint = ucx_policy_to_mem_type(vramMemTypeHintPolicy_);
+    NIXL_ASSERT(configured_hint.has_value());
+
+    if (!UCS_BIT_GET(supportedMemoryTypesMask_, *configured_hint)) {
+        throw std::invalid_argument(
+            "Configured VRAM memtype hint '" +
+            std::string(ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_)) +
+            "' is not supported by current UCX context");
+    }
+
+    vramMemTypeHint_ = configured_hint;
+    NIXL_INFO << "VRAM memtype hint mode is "
+              << ucx_vram_memtype_hint_to_string(vramMemTypeHintPolicy_) << ", using "
+              << ucx_memory_type_to_string(*vramMemTypeHint_);
 }
 
 namespace {
@@ -639,6 +793,13 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         .length = mem.size,
     };
 
+    if (nixl_mem_type == nixl_mem_t::VRAM_SEG && vramMemTypeHint_.has_value()) {
+        mem_params.field_mask |= UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE;
+        mem_params.memory_type = *vramMemTypeHint_;
+        NIXL_DEBUG << "memReg: hinting " << ucx_memory_type_to_string(mem_params.memory_type)
+                   << " for VRAM_SEG";
+    }
+
     ucs_status_t status = ucp_mem_map(ctx, &mem_params, &mem.memh);
     if (status != UCS_OK) {
         NIXL_ERROR << *this << ": failed to ucp_mem_map: " << ucs_status_string(status);
@@ -658,7 +819,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         if (attr.mem_type == UCS_MEMORY_TYPE_HOST) {
             NIXL_ERROR << *this
                        << ": VRAM memory is detected as host by UCX. "
-                          "UCX is likely not configured with CUDA/ROCm support. "
+                          "UCX memory type detection/configuration is likely mismatched. "
                           "VRAM registration cannot proceed.";
             ucp_mem_unmap(ctx, mem.memh);
             return -1;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -97,8 +97,7 @@ ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t t) {
     case nixl_ucx_vram_memtype_hint_t::ZE_DEVICE:
         return ucs_memory_type_names[UCS_MEMORY_TYPE_ZE_DEVICE];
     }
-    throw std::invalid_argument(
-        std::to_string(static_cast<std::underlying_type_t<nixl_ucx_vram_memtype_hint_t>>(t)));
+    throw std::invalid_argument(std::to_string(static_cast<int>(t)));
 }
 
 [[nodiscard]] nixl_ucx_vram_memtype_hint_t
@@ -537,8 +536,7 @@ ucx_policy_to_mem_type(const nixl_ucx_vram_memtype_hint_t policy) {
         return UCS_MEMORY_TYPE_ZE_DEVICE;
     }
 
-    NIXL_FATAL << "Invalid VRAM memtype hint mode: "
-               << static_cast<std::underlying_type_t<nixl_ucx_vram_memtype_hint_t>>(policy);
+    NIXL_FATAL << "Invalid VRAM memtype hint mode: " << static_cast<int>(policy);
     std::terminate();
 }
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -628,7 +628,13 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
                                  std::string(ucs_status_string(status)));
     }
 
-    resolveMemoryTypeConfig();
+    try {
+        resolveMemoryTypeConfig();
+    }
+    catch (...) {
+        ucp_cleanup(ctx);
+        throw;
+    }
 }
 
 nixlUcxContext::~nixlUcxContext() {

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -121,7 +121,7 @@ ucx_vram_memtype_hint_from_string(std::string_view s) {
 
     std::stringstream err_msg;
     err_msg << "Invalid VRAM memtype hint mode: " << s
-        << ". Matching is case-sensitive; use exact values. Valid values are: <";
+            << ". Matching is case-sensitive; use exact values. Valid values are: <";
     for (size_t i = 0; i < hint_modes.size(); ++i) {
         err_msg << ucx_vram_memtype_hint_to_string(hint_modes[i]);
         if (i < hint_modes.size() - 1) {

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -44,8 +44,7 @@ enum class nixl_ucx_vram_memtype_hint_t {
 };
 
 inline constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
-inline constexpr std::string_view nixl_ucx_vram_memtype_hint_param_name =
-    "ucx_vram_memtype_hint";
+inline constexpr std::string_view nixl_ucx_vram_memtype_hint_param_name = "ucx_vram_memtype_hint";
 
 // The API `ucp_context_query(ctx, &attr)` sets `UCS_MEMORY_TYPE_RDMA` in `attr.memory_types`
 // field only from UCX 1.22

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -18,6 +18,8 @@
 #define NIXL_SRC_UTILS_UCX_UCX_UTILS_H
 
 #include <memory>
+#include <optional>
+#include <string_view>
 #include <type_traits>
 
 extern "C" {
@@ -32,7 +34,18 @@ extern "C" {
 
 enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
 
+enum class nixl_ucx_vram_memtype_hint_t {
+    AUTO,
+    NONE,
+    CUDA,
+    CUDA_MANAGED,
+    ROCM,
+    ZE_DEVICE,
+};
+
 inline constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
+inline constexpr std::string_view nixl_ucx_vram_memtype_hint_param_name =
+    "ucx_vram_memtype_hint";
 
 // The API `ucp_context_query(ctx, &attr)` sets `UCS_MEMORY_TYPE_RDMA` in `attr.memory_types`
 // field only from UCX 1.22
@@ -205,6 +218,12 @@ private:
     ucp_context_h ctx;
     const nixl_ucx_mt_t mtType_;
     const unsigned ucpVersion_;
+    const nixl_ucx_vram_memtype_hint_t vramMemTypeHintPolicy_;
+    uint64_t supportedMemoryTypesMask_{0};
+    std::optional<ucs_memory_type_t> vramMemTypeHint_;
+
+    void
+    resolveMemoryTypeConfig();
 
 public:
     nixlUcxContext(const std::vector<std::string> &devs,
@@ -212,7 +231,9 @@ public:
                    unsigned long num_workers,
                    nixl_thread_sync_t sync_mode,
                    size_t num_device_channels,
-                   const std::string &engine_conf = "");
+                   const std::string &engine_conf = "",
+                   nixl_ucx_vram_memtype_hint_t vram_mem_type_hint_policy =
+                       nixl_ucx_vram_memtype_hint_t::AUTO);
     ~nixlUcxContext();
 
     nixlUcxContext(nixlUcxContext &&) = delete;
@@ -308,5 +329,11 @@ ucx_err_mode_to_string(ucp_err_handling_mode_t t);
 
 [[nodiscard]] ucp_err_handling_mode_t
 ucx_err_mode_from_string(std::string_view s);
+
+[[nodiscard]] std::string_view
+ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t t);
+
+[[nodiscard]] nixl_ucx_vram_memtype_hint_t
+ucx_vram_memtype_hint_from_string(std::string_view s);
 
 #endif

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -19,6 +19,8 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
+#include <string_view>
 #include <type_traits>
 
 extern "C" {
@@ -32,7 +34,17 @@ extern "C" {
 
 #include "absl/strings/numbers.h"
 
+enum class nixl_ucx_vram_memtype_hint_t {
+    AUTO,
+    NONE,
+    CUDA,
+    CUDA_MANAGED,
+    ROCM,
+    ZE_DEVICE,
+};
+
 inline constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
+inline constexpr std::string_view nixl_ucx_vram_memtype_hint_param_name = "ucx_vram_memtype_hint";
 
 // The API `ucp_context_query(ctx, &attr)` sets `UCS_MEMORY_TYPE_RDMA` in `attr.memory_types`
 // field only from UCX 1.22
@@ -163,6 +175,12 @@ private:
     const nixl::ucx::mt_mode_t mtType_;
     const unsigned ucpVersion_;
     const std::string name_;
+    const nixl_ucx_vram_memtype_hint_t vramMemTypeHintPolicy_;
+    uint64_t supportedMemoryTypesMask_{0};
+    std::optional<ucs_memory_type_t> vramMemTypeHint_;
+
+    void
+    resolveMemoryTypeConfig();
 
 public:
     nixlUcxContext(const std::vector<std::string> &devs,
@@ -171,7 +189,9 @@ public:
                    nixl_thread_sync_t sync_mode,
                    size_t num_device_channels,
                    const std::string &engine_conf = "",
-                   const std::string &name = "");
+                   const std::string &name = "",
+                   nixl_ucx_vram_memtype_hint_t vram_mem_type_hint_policy =
+                       nixl_ucx_vram_memtype_hint_t::AUTO);
     ~nixlUcxContext();
 
     nixlUcxContext(nixlUcxContext &&) = delete;
@@ -294,5 +314,11 @@ ucx_err_mode_to_string(ucp_err_handling_mode_t t);
 
 [[nodiscard]] ucp_err_handling_mode_t
 ucx_err_mode_from_string(std::string_view s);
+
+[[nodiscard]] std::string_view
+ucx_vram_memtype_hint_to_string(nixl_ucx_vram_memtype_hint_t t);
+
+[[nodiscard]] nixl_ucx_vram_memtype_hint_t
+ucx_vram_memtype_hint_from_string(std::string_view s);
 
 #endif

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -23,10 +23,15 @@
 
 namespace gtest {
 namespace nixl {
-    constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
-    constexpr const char* ucx_err_handling_mode_peer = "peer";
-    constexpr const char* ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
-    constexpr const char* ucx_vram_memtype_hint_auto = "auto";
+    constexpr const char *ucx_err_handling_mode_key = "ucx_error_handling_mode";
+    constexpr const char *ucx_err_handling_mode_peer = "peer";
+    constexpr const char *ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
+    constexpr const char *ucx_vram_memtype_hint_auto = "auto";
+
+    void
+    setUcxPluginDir(ScopedEnv &env) {
+        env.addVar("NIXL_PLUGIN_DIR", std::string(BUILD_DIR) + "/src/plugins/ucx");
+    }
 
     static nixlBackendH *
     createUcxBackend(nixlAgent &agent,
@@ -259,7 +264,7 @@ TestErrorHandling::TestErrorHandling()
     m_env.addVar("UCX_RC_TIMEOUT", "100us");
     m_env.addVar("UCX_RC_RETRY_COUNT", "4");
     m_env.addVar("UCX_UD_TIMEOUT", "3s");
-    m_env.addVar("NIXL_PLUGIN_DIR", std::string(BUILD_DIR) + "/src/plugins/ucx");
+    nixl::setUcxPluginDir(m_env);
 }
 
 template<TestErrorHandling::TestType test_type, enum nixl_xfer_op_t op>
@@ -439,6 +444,9 @@ TEST_P(TestErrorHandling, XferPostThenFail) {
 }
 
 TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
     nixlAgentConfig cfg;
     cfg.useProgThread = true;
     nixlAgent agent("ucx_param_defaults", cfg);
@@ -458,6 +466,9 @@ TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
 }
 
 TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
     nixlAgentConfig cfg;
     cfg.useProgThread = true;
     nixlAgent agent("ucx_param_invalid_case", cfg);
@@ -481,6 +492,56 @@ TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
     nixlBackendH *backend = nullptr;
     EXPECT_NE(NIXL_SUCCESS, agent.createBackend(*it, params, backend));
     EXPECT_EQ(nullptr, backend);
+}
+
+TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
+    constexpr const char *explicit_hints[] = {"cuda", "cuda-managed", "rocm", "ze-device"};
+    bool found_runtime_unsupported_path = false;
+
+    for (const auto *hint : explicit_hints) {
+        nixlAgentConfig cfg;
+        cfg.useProgThread = true;
+        nixlAgent agent(std::string("ucx_param_runtime_hint_") + hint, cfg);
+
+        std::vector<nixl_backend_t> plugins;
+        ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+        auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+        if (it == plugins.end()) {
+            GTEST_SKIP() << "UCX plugin not available";
+        }
+
+        nixl_mem_list_t mems;
+        nixl_b_params_t params;
+        ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+        params[nixl::ucx_vram_memtype_hint_key] = hint;
+
+        const LogIgnoreGuard lig_expected_runtime_unsupported(
+            "Failed to create engine: Configured VRAM memtype hint '.*' is not supported by "
+            "current "
+            "UCX context");
+        const LogIgnoreGuard lig_expected_runtime_query_failure(
+            "Failed to create engine: Failed to query UCX context memory types: .*");
+        const LogIgnoreGuard lig_expected_backend_failure(
+            "backend (creation failed|initialization error) for 'UCX'");
+
+        nixlBackendH *backend = nullptr;
+        const auto status = agent.createBackend(*it, params, backend);
+        if (status != NIXL_SUCCESS) {
+            EXPECT_EQ(nullptr, backend);
+            if (lig_expected_runtime_unsupported.getIgnoredCount() > 0) {
+                found_runtime_unsupported_path = true;
+                break;
+            }
+        }
+    }
+
+    if (!found_runtime_unsupported_path) {
+        GTEST_SKIP()
+            << "No explicit hint exercised the unsupported-memtype runtime path on this system";
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestErrorHandling, testing::Values(std::make_tuple("UCX", 1, 0)));

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -531,7 +531,9 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
         const auto status = agent.createBackend(*it, params, backend);
         if (status != NIXL_SUCCESS) {
             EXPECT_EQ(nullptr, backend);
-            if (lig_expected_runtime_unsupported.getIgnoredCount() > 0) {
+            if ((backend == nullptr) &&
+                ((lig_expected_runtime_unsupported.getIgnoredCount() > 0) ||
+                 (lig_expected_runtime_query_failure.getIgnoredCount() > 0))) {
                 found_runtime_unsupported_path = true;
                 break;
             }

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -25,6 +25,8 @@ namespace gtest {
 namespace nixl {
     constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
     constexpr const char* ucx_err_handling_mode_peer = "peer";
+    constexpr const char* ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
+    constexpr const char* ucx_vram_memtype_hint_auto = "auto";
 
     static nixlBackendH *
     createUcxBackend(nixlAgent &agent,
@@ -44,6 +46,7 @@ namespace nixl {
 
         nixlBackendH* backend_handle = nullptr;
         EXPECT_EQ(ucx_err_handling_mode_peer, params[ucx_err_handling_mode_key]);
+        EXPECT_EQ(ucx_vram_memtype_hint_auto, params[ucx_vram_memtype_hint_key]);
         params["num_workers"] = std::to_string(num_workers);
         params["num_threads"] = std::to_string(num_threads);
         // If threadpool is configured always force split
@@ -433,6 +436,51 @@ TEST_P(TestErrorHandling, XferFailRestore) {
 TEST_P(TestErrorHandling, XferPostThenFail) {
     testXfer<TestType::FAIL_AFTER_POST, NIXL_WRITE>();
     testXfer<TestType::FAIL_AFTER_POST, NIXL_READ>();
+}
+
+TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
+    nixlAgentConfig cfg;
+    cfg.useProgThread = true;
+    nixlAgent agent("ucx_param_defaults", cfg);
+
+    std::vector<nixl_backend_t> plugins;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+    auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+    if (it == plugins.end()) {
+        GTEST_SKIP() << "UCX plugin not available";
+    }
+
+    nixl_mem_list_t mems;
+    nixl_b_params_t params;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+    ASSERT_TRUE(params.find(nixl::ucx_vram_memtype_hint_key) != params.end());
+    EXPECT_EQ(nixl::ucx_vram_memtype_hint_auto, params[nixl::ucx_vram_memtype_hint_key]);
+}
+
+TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
+    nixlAgentConfig cfg;
+    cfg.useProgThread = true;
+    nixlAgent agent("ucx_param_invalid_case", cfg);
+
+    std::vector<nixl_backend_t> plugins;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+    auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+    if (it == plugins.end()) {
+        GTEST_SKIP() << "UCX plugin not available";
+    }
+
+    nixl_mem_list_t mems;
+    nixl_b_params_t params;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+    params[nixl::ucx_vram_memtype_hint_key] = "CUDA";
+
+    const LogIgnoreGuard lig_expected_engine_failure(
+        "Failed to create engine: Invalid VRAM memtype hint mode: .*");
+    const LogIgnoreGuard lig_expected_backend_failure(
+        "backend (creation failed|initialization error) for 'UCX'");
+    nixlBackendH *backend = nullptr;
+    EXPECT_NE(NIXL_SUCCESS, agent.createBackend(*it, params, backend));
+    EXPECT_EQ(nullptr, backend);
 }
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestErrorHandling, testing::Values(std::make_tuple("UCX", 1, 0)));

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -499,7 +499,7 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
     nixl::setUcxPluginDir(env);
 
     constexpr const char *explicit_hints[] = {"cuda", "cuda-managed", "rocm", "ze-device"};
-    bool found_runtime_unsupported_path = false;
+    bool found_expected_runtime_failure = false;
 
     for (const auto *hint : explicit_hints) {
         nixlAgentConfig cfg;
@@ -520,8 +520,7 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
 
         const LogIgnoreGuard lig_expected_runtime_unsupported(
             "Failed to create engine: Configured VRAM memtype hint '.*' is not supported by "
-            "current "
-            "UCX context");
+            "current UCX context");
         const LogIgnoreGuard lig_expected_runtime_query_failure(
             "Failed to create engine: Failed to query UCX context memory types: .*");
         const LogIgnoreGuard lig_expected_backend_failure(
@@ -529,20 +528,29 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
 
         nixlBackendH *backend = nullptr;
         const auto status = agent.createBackend(*it, params, backend);
-        if (status != NIXL_SUCCESS) {
-            EXPECT_EQ(nullptr, backend);
-            if ((backend == nullptr) &&
-                ((lig_expected_runtime_unsupported.getIgnoredCount() > 0) ||
-                 (lig_expected_runtime_query_failure.getIgnoredCount() > 0))) {
-                found_runtime_unsupported_path = true;
-                break;
-            }
+        if (status == NIXL_SUCCESS) {
+            ASSERT_NE(nullptr, backend) << "Successful createBackend returned null handle";
+            // Loop-local agent owns backend and cleans it up on iteration exit.
+            continue;
         }
+
+        const bool saw_runtime_unsupported = lig_expected_runtime_unsupported.getIgnoredCount() > 0;
+        const bool saw_runtime_query_failure =
+            lig_expected_runtime_query_failure.getIgnoredCount() > 0;
+        ASSERT_EQ(nullptr, backend)
+            << "createBackend() failed for hint '" << hint << "' but returned a non-null backend";
+        ASSERT_TRUE(saw_runtime_unsupported || saw_runtime_query_failure)
+            << "createBackend() failed for hint '" << hint
+            << "' without expected runtime failure path. " << "backend=" << backend
+            << ", saw_unsupported=" << saw_runtime_unsupported
+            << ", saw_query_failure=" << saw_runtime_query_failure;
+        found_expected_runtime_failure = true;
+        break;
     }
 
-    if (!found_runtime_unsupported_path) {
+    if (!found_expected_runtime_failure) {
         GTEST_SKIP()
-            << "No explicit hint exercised the unsupported-memtype runtime path on this system";
+            << "No explicit hint exercised an expected runtime failure path on this system";
     }
 }
 

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -572,7 +572,9 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
         const auto status = agent.createBackend(*it, params, backend);
         if (status != NIXL_SUCCESS) {
             EXPECT_EQ(nullptr, backend);
-            if (lig_expected_runtime_unsupported.getIgnoredCount() > 0) {
+            if ((backend == nullptr) &&
+                ((lig_expected_runtime_unsupported.getIgnoredCount() > 0) ||
+                 (lig_expected_runtime_query_failure.getIgnoredCount() > 0))) {
                 found_runtime_unsupported_path = true;
                 break;
             }

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -26,10 +26,15 @@
 
 namespace gtest {
 namespace nixl {
-    constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
-    constexpr const char* ucx_err_handling_mode_peer = "peer";
-    constexpr const char* ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
-    constexpr const char* ucx_vram_memtype_hint_auto = "auto";
+    constexpr const char *ucx_err_handling_mode_key = "ucx_error_handling_mode";
+    constexpr const char *ucx_err_handling_mode_peer = "peer";
+    constexpr const char *ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
+    constexpr const char *ucx_vram_memtype_hint_auto = "auto";
+
+    void
+    setUcxPluginDir(ScopedEnv &env) {
+        env.addVar("NIXL_PLUGIN_DIR", std::string(BUILD_DIR) + "/src/plugins/ucx");
+    }
 
     static nixlBackendH *
     createUcxBackend(nixlAgent &agent,
@@ -273,7 +278,7 @@ TestErrorHandling::TestErrorHandling()
     m_env.addVar("UCX_RC_TIMEOUT", "100us");
     m_env.addVar("UCX_RC_RETRY_COUNT", "4");
     m_env.addVar("UCX_UD_TIMEOUT", "3s");
-    m_env.addVar("NIXL_PLUGIN_DIR", std::string(BUILD_DIR) + "/src/plugins/ucx");
+    nixl::setUcxPluginDir(m_env);
 }
 
 template<TestErrorHandling::TestType test_type, enum nixl_xfer_op_t op>
@@ -480,6 +485,9 @@ TEST_P(TestErrorHandling, ErrorCallbackMarksEndpointFailedWithoutClosingIt) {
 #endif
 
 TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
     nixlAgentConfig cfg;
     cfg.useProgThread = true;
     nixlAgent agent("ucx_param_defaults", cfg);
@@ -499,6 +507,9 @@ TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
 }
 
 TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
     nixlAgentConfig cfg;
     cfg.useProgThread = true;
     nixlAgent agent("ucx_param_invalid_case", cfg);
@@ -522,6 +533,56 @@ TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
     nixlBackendH *backend = nullptr;
     EXPECT_NE(NIXL_SUCCESS, agent.createBackend(*it, params, backend));
     EXPECT_EQ(nullptr, backend);
+}
+
+TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
+    ScopedEnv env;
+    nixl::setUcxPluginDir(env);
+
+    constexpr const char *explicit_hints[] = {"cuda", "cuda-managed", "rocm", "ze-device"};
+    bool found_runtime_unsupported_path = false;
+
+    for (const auto *hint : explicit_hints) {
+        nixlAgentConfig cfg;
+        cfg.useProgThread = true;
+        nixlAgent agent(std::string("ucx_param_runtime_hint_") + hint, cfg);
+
+        std::vector<nixl_backend_t> plugins;
+        ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+        auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+        if (it == plugins.end()) {
+            GTEST_SKIP() << "UCX plugin not available";
+        }
+
+        nixl_mem_list_t mems;
+        nixl_b_params_t params;
+        ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+        params[nixl::ucx_vram_memtype_hint_key] = hint;
+
+        const LogIgnoreGuard lig_expected_runtime_unsupported(
+            "Failed to create engine: Configured VRAM memtype hint '.*' is not supported by "
+            "current "
+            "UCX context");
+        const LogIgnoreGuard lig_expected_runtime_query_failure(
+            "Failed to create engine: Failed to query UCX context memory types: .*");
+        const LogIgnoreGuard lig_expected_backend_failure(
+            "backend (creation failed|initialization error) for 'UCX'");
+
+        nixlBackendH *backend = nullptr;
+        const auto status = agent.createBackend(*it, params, backend);
+        if (status != NIXL_SUCCESS) {
+            EXPECT_EQ(nullptr, backend);
+            if (lig_expected_runtime_unsupported.getIgnoredCount() > 0) {
+                found_runtime_unsupported_path = true;
+                break;
+            }
+        }
+    }
+
+    if (!found_runtime_unsupported_path) {
+        GTEST_SKIP()
+            << "No explicit hint exercised the unsupported-memtype runtime path on this system";
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestErrorHandling, testing::Values(std::make_tuple("UCX", 1, 0)));

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -28,6 +28,8 @@ namespace gtest {
 namespace nixl {
     constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
     constexpr const char* ucx_err_handling_mode_peer = "peer";
+    constexpr const char* ucx_vram_memtype_hint_key = "ucx_vram_memtype_hint";
+    constexpr const char* ucx_vram_memtype_hint_auto = "auto";
 
     static nixlBackendH *
     createUcxBackend(nixlAgent &agent,
@@ -47,6 +49,7 @@ namespace nixl {
 
         nixlBackendH* backend_handle = nullptr;
         EXPECT_EQ(ucx_err_handling_mode_peer, params[ucx_err_handling_mode_key]);
+        EXPECT_EQ(ucx_vram_memtype_hint_auto, params[ucx_vram_memtype_hint_key]);
         params["num_workers"] = std::to_string(num_workers);
         params["num_threads"] = std::to_string(num_threads);
         // If threadpool is configured always force split
@@ -475,6 +478,51 @@ TEST_P(TestErrorHandling, ErrorCallbackMarksEndpointFailedWithoutClosingIt) {
     EXPECT_EQ(endpoint->getEp(), native_endpoint);
 }
 #endif
+
+TEST(UcxBackendParams, ExposesVramMemtypeHintDefault) {
+    nixlAgentConfig cfg;
+    cfg.useProgThread = true;
+    nixlAgent agent("ucx_param_defaults", cfg);
+
+    std::vector<nixl_backend_t> plugins;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+    auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+    if (it == plugins.end()) {
+        GTEST_SKIP() << "UCX plugin not available";
+    }
+
+    nixl_mem_list_t mems;
+    nixl_b_params_t params;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+    ASSERT_TRUE(params.find(nixl::ucx_vram_memtype_hint_key) != params.end());
+    EXPECT_EQ(nixl::ucx_vram_memtype_hint_auto, params[nixl::ucx_vram_memtype_hint_key]);
+}
+
+TEST(UcxBackendParams, RejectsCaseMismatchedVramHint) {
+    nixlAgentConfig cfg;
+    cfg.useProgThread = true;
+    nixlAgent agent("ucx_param_invalid_case", cfg);
+
+    std::vector<nixl_backend_t> plugins;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getAvailPlugins(plugins));
+    auto it = std::find(plugins.begin(), plugins.end(), "UCX");
+    if (it == plugins.end()) {
+        GTEST_SKIP() << "UCX plugin not available";
+    }
+
+    nixl_mem_list_t mems;
+    nixl_b_params_t params;
+    ASSERT_EQ(NIXL_SUCCESS, agent.getPluginParams(*it, mems, params));
+    params[nixl::ucx_vram_memtype_hint_key] = "CUDA";
+
+    const LogIgnoreGuard lig_expected_engine_failure(
+        "Failed to create engine: Invalid VRAM memtype hint mode: .*");
+    const LogIgnoreGuard lig_expected_backend_failure(
+        "backend (creation failed|initialization error) for 'UCX'");
+    nixlBackendH *backend = nullptr;
+    EXPECT_NE(NIXL_SUCCESS, agent.createBackend(*it, params, backend));
+    EXPECT_EQ(nullptr, backend);
+}
 
 INSTANTIATE_TEST_SUITE_P(ucx, TestErrorHandling, testing::Values(std::make_tuple("UCX", 1, 0)));
 INSTANTIATE_TEST_SUITE_P(ucx_threadpool,

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -540,7 +540,7 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
     nixl::setUcxPluginDir(env);
 
     constexpr const char *explicit_hints[] = {"cuda", "cuda-managed", "rocm", "ze-device"};
-    bool found_runtime_unsupported_path = false;
+    bool found_expected_runtime_failure = false;
 
     for (const auto *hint : explicit_hints) {
         nixlAgentConfig cfg;
@@ -561,8 +561,7 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
 
         const LogIgnoreGuard lig_expected_runtime_unsupported(
             "Failed to create engine: Configured VRAM memtype hint '.*' is not supported by "
-            "current "
-            "UCX context");
+            "current UCX context");
         const LogIgnoreGuard lig_expected_runtime_query_failure(
             "Failed to create engine: Failed to query UCX context memory types: .*");
         const LogIgnoreGuard lig_expected_backend_failure(
@@ -570,20 +569,29 @@ TEST(UcxBackendParams, RejectsUnsupportedExplicitVramHintAtRuntime) {
 
         nixlBackendH *backend = nullptr;
         const auto status = agent.createBackend(*it, params, backend);
-        if (status != NIXL_SUCCESS) {
-            EXPECT_EQ(nullptr, backend);
-            if ((backend == nullptr) &&
-                ((lig_expected_runtime_unsupported.getIgnoredCount() > 0) ||
-                 (lig_expected_runtime_query_failure.getIgnoredCount() > 0))) {
-                found_runtime_unsupported_path = true;
-                break;
-            }
+        if (status == NIXL_SUCCESS) {
+            ASSERT_NE(nullptr, backend) << "Successful createBackend returned null handle";
+            // Loop-local agent owns backend and cleans it up on iteration exit.
+            continue;
         }
+
+        const bool saw_runtime_unsupported = lig_expected_runtime_unsupported.getIgnoredCount() > 0;
+        const bool saw_runtime_query_failure =
+            lig_expected_runtime_query_failure.getIgnoredCount() > 0;
+        ASSERT_EQ(nullptr, backend)
+            << "createBackend() failed for hint '" << hint << "' but returned a non-null backend";
+        ASSERT_TRUE(saw_runtime_unsupported || saw_runtime_query_failure)
+            << "createBackend() failed for hint '" << hint
+            << "' without expected runtime failure path. " << "backend=" << backend
+            << ", saw_unsupported=" << saw_runtime_unsupported
+            << ", saw_query_failure=" << saw_runtime_query_failure;
+        found_expected_runtime_failure = true;
+        break;
     }
 
-    if (!found_runtime_unsupported_path) {
+    if (!found_expected_runtime_failure) {
         GTEST_SKIP()
-            << "No explicit hint exercised the unsupported-memtype runtime path on this system";
+            << "No explicit hint exercised an expected runtime failure path on this system";
     }
 }
 


### PR DESCRIPTION
## What?
This PR hardens UCX VRAM memtype hint handling and aligns documentation and
tests with runtime behavior.

- Enforce fail-fast behavior when an explicit `ucx_vram_memtype_hint` is set
  but UCX context memory types cannot be queried.
- Keep `auto` and `none` as non-failing modes that proceed without hinting
  when memory-type queries are unavailable.
- Document the exact supported values for `ucx_vram_memtype_hint`:
  `auto`, `none`, `cuda`, `cuda-managed`, `rocm`, `ze-device`.
- Clarify case-sensitive parsing and failure behavior for explicit hints.
- Add gtests to verify default parameter exposure and rejection of
  case-mismatched values (e.g. `CUDA`).
- Suppress expected error logs in negative-path tests to avoid triggering
  global log-failure checks.

## Why?
Previous behavior around explicit VRAM memtype hints was not fully documented
or covered by tests, which could lead to confusion and fragile failure paths.

This change improves correctness and predictability by:
- Making explicit-hint behavior deterministic when UCX cannot report
  memory-type capabilities.
- Ensuring documentation reflects actual accepted values and parsing rules.
- Adding regression coverage for default and invalid-input paths.

## How?
- Update UCX memory-type resolution to require a successful UCX context
  memory-type query for explicit hint modes.
- Keep `auto` and `none` permissive when queries are unavailable.
- Update backend and Python documentation to reflect exact values and
  failure semantics.
- Add UCX backend parameter tests covering:
  - default `ucx_vram_memtype_hint` exposure (`auto`)
  - rejection of case-mismatched hint values
- Add log-ignore guards for expected error paths in negative tests.

## Testing performed
- Ran the targeted gtest suite via the Meson test wrapper.
- Result: **12 tests from 3 suites passed, 0 failed**.

## Credits
Co-authored-by: Daniel Socek <daniel.socek@intel.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for UCX backend initialization parameters and how to override them; documented ucx_error_handling_mode and ucx_vram_memtype_hint, accepted values, defaults, case-sensitivity, and failure semantics.

* **New Features**
  * Added ucx_vram_memtype_hint backend option to control VRAM memory-type hinting (auto, none, explicit accelerator hints; default: auto). Hint is resolved at backend init and applied to VRAM registrations when available.

* **Tests**
  * Added tests verifying ucx_vram_memtype_hint default, case-sensitive handling, and behavior when explicit hints are unsupported or unqueryable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->