### PR TITLE
nixl_ep: Simplify test_ht.py usage

### DIFF
--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -19,6 +19,7 @@
 # limitations under the License.
 
 import os
+import time
 from contextlib import contextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
@@ -829,23 +830,32 @@ class Buffer:
             self.tcp_store_group.delete_key(md_key)
 
     def _ht_connect_ranks(self, remote_ranks: List[int]) -> None:
-        if self.group is not None:
-
-            def all_gather_object(obj):
-                object_list = [None] * self.group_size
-                dist.all_gather_object(object_list, obj, self.group)
-                return object_list
-
-        elif self.comm is not None:
-
-            def all_gather_object(obj):
-                return self.comm.allgather(obj)
-
-        else:
-            raise ValueError("Either 'group' or 'comm' must be configured.")
-
         local_ipc_handle = self.runtime.get_local_ipc_handle()
-        ipc_handles = all_gather_object(local_ipc_handle)
+
+        if (
+            self.tcp_store_group is not None
+            and self.group is None
+            and self.comm is None
+        ):
+            ipc_key = f"NIXL_EP_IPC/{self.rank}"
+            self.tcp_store_group.set(ipc_key, local_ipc_handle)
+            self.tcp_store_group.add("nixl_ep_ipc_ready", 1)
+            while int(self.tcp_store_group.get("nixl_ep_ipc_ready")) < self.group_size:
+                time.sleep(0.01)
+            ipc_handles = [
+                bytearray(self.tcp_store_group.get(f"NIXL_EP_IPC/{r}"))
+                for r in range(self.group_size)
+            ]
+        elif self.group is not None:
+            object_list = [None] * self.group_size
+            dist.all_gather_object(object_list, local_ipc_handle, self.group)
+            ipc_handles = object_list
+        elif self.comm is not None:
+            ipc_handles = self.comm.allgather(local_ipc_handle)
+        else:
+            raise ValueError(
+                "Either 'tcp_store_group', 'group', or 'comm' must be configured for HT mode."
+            )
 
         if self.tcp_store_group is not None:
             with self._fetch_remote_metadata_from_tcp_store(remote_ranks) as remote_mds:

--- a/examples/device/ep/tests/test_ht.py
+++ b/examples/device/ep/tests/test_ht.py
@@ -29,20 +29,66 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "elastic"))
 import nixl_ep  # noqa: E402
 import store_group  # noqa: E402
 import torch  # noqa: E402
-import torch.distributed as dist  # noqa: E402
 
 from utils import (  # noqa: E402
     bench,
     bench_kineto,
     calc_diff,
     create_grouped_scores,
-    init_dist,
     inplace_unique,
     per_token_cast_back,
     per_token_cast_to_fp8,
 )
 
+
+def store_barrier(store, world_size, tag):
+    """Barrier using TCPStore add/get."""
+    key = f"bar/{tag}"
+    store.add(key, 1)
+    while int(store.get(key)) < world_size:
+        time.sleep(0.001)
+
+
+def store_all_reduce_sum(store, rank, world_size, tensor, tag):
+    """All-reduce (sum) via TCPStore. Returns reduced tensor on all ranks."""
+    key = f"red/{tag}"
+    store.set(f"{key}/{rank}", tensor.cpu().numpy().tobytes())
+    store_barrier(store, world_size, f"{key}")
+    result = torch.zeros_like(tensor)
+    for r in range(world_size):
+        data = bytes(store.get(f"{key}/{r}"))
+        result += (
+            torch.frombuffer(bytearray(data), dtype=tensor.dtype)
+            .reshape(tensor.shape)
+            .to(tensor.device)
+        )
+    return result
+
+
+def store_all_gather_tensor(store, rank, world_size, tensor, tag):
+    """All-gather a 1D tensor via TCPStore. Returns list of tensors from all ranks."""
+    key = f"gat/{tag}"
+    store.set(f"{key}/{rank}", tensor.cpu().numpy().tobytes())
+    store_barrier(store, world_size, f"{key}")
+    results = []
+    for r in range(world_size):
+        data = bytes(store.get(f"{key}/{r}"))
+        results.append(
+            torch.frombuffer(bytearray(data), dtype=tensor.dtype)
+            .reshape(tensor.shape)
+            .to(tensor.device)
+        )
+    return results
+
+
 TCP_STORE_PORT = 9999
+_barrier_counter = 0
+
+
+def next_barrier_tag():
+    global _barrier_counter
+    _barrier_counter += 1
+    return str(_barrier_counter)
 
 
 # noinspection PyShadowingNames
@@ -55,7 +101,7 @@ def test_main(
     num_nodes: int,
     rank: int,
     buffer: nixl_ep.Buffer,
-    group: dist.ProcessGroup,
+    store,
 ):
     # Settings
     num_tokens, hidden = args.num_tokens, args.hidden
@@ -114,8 +160,9 @@ def test_main(
     num_tokens_per_expert = torch.zeros((num_experts,), dtype=torch.int, device="cuda")
     for i in range(num_experts):
         num_tokens_per_expert[i] = (topk_idx == i).sum()
-    gbl_num_tokens_per_expert = num_tokens_per_expert.clone()
-    dist.all_reduce(gbl_num_tokens_per_expert, group=group)
+    gbl_num_tokens_per_expert = store_all_reduce_sum(
+        store, rank, num_ranks, num_tokens_per_expert, "expert"
+    )
 
     # Rank layout meta
     num_tokens_per_rank = torch.empty((num_ranks,), dtype=torch.int, device="cuda")
@@ -136,8 +183,9 @@ def test_main(
         num_tokens_per_rdma_rank[i] = (rdma_rank_idx == i).sum()
     token_idx_in_rank = token_idx_in_rank.T.contiguous().to(torch.int)
     is_token_in_rank = token_idx_in_rank >= 0
-    gbl_num_tokens_per_rank = num_tokens_per_rank.clone()
-    dist.all_reduce(gbl_num_tokens_per_rank, group=group)
+    gbl_num_tokens_per_rank = store_all_reduce_sum(
+        store, rank, num_ranks, num_tokens_per_rank, "rank"
+    )
 
     (
         ref_num_tokens_per_rank,
@@ -154,7 +202,7 @@ def test_main(
     if local_rank == 0:
         print(f"[layout] Kernel performance: {t * 1000:.3f} ms", flush=True)
         print("", flush=True)
-    group.barrier()
+    store_barrier(store, num_ranks, next_barrier_tag())
     time.sleep(1)
 
     # Config
@@ -329,10 +377,10 @@ def test_main(
                     combine_bf16_rdma_recv_bytes = dispatch_bf16_rdma_send_bytes
 
                     # Sync all ranks before printing passed
-                    group.barrier()
+                    store_barrier(store, num_ranks, next_barrier_tag())
                     if local_rank == 0:
                         print(" passed", flush=True)
-                    group.barrier()
+                    store_barrier(store, num_ranks, next_barrier_tag())
     if local_rank == 0:
         print("", flush=True)
 
@@ -386,12 +434,8 @@ def test_main(
         if isinstance(current_x, tuple):
             # Gather FP8 the best config from rank 0
             best_dispatch_results = torch.tensor([best_results[0], best_results[1], best_results[2]], dtype=torch.int32, device="cuda")  # type: ignore[index]
-            all_best_fp8_results_list = [
-                torch.zeros_like(best_dispatch_results)
-                for _ in range(torch.distributed.get_world_size())
-            ]
-            dist.all_gather(
-                all_best_fp8_results_list, best_dispatch_results, group=group
+            all_best_fp8_results_list = store_all_gather_tensor(
+                store, rank, num_ranks, best_dispatch_results, "fp8_tune"
             )
             best_dispatch_results = all_best_fp8_results_list[0].tolist()
     dispatch_config = nixl_ep.Config(best_dispatch_results[0], best_dispatch_results[1], nvl_buffer_size, best_dispatch_results[2], rdma_buffer_size)  # type: ignore[index]
@@ -441,16 +485,17 @@ def test_main(
 
 # noinspection PyUnboundLocalVariable,PyShadowingNames
 def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
-    # Pin each process to a distinct GPU so NCCL does not see duplicate devices.
-    # Use local_rank so NCCL gets correct device_id; avoid CUDA_VISIBLE_DEVICES
+    # Pin each process to a distinct GPU; avoid CUDA_VISIBLE_DEVICES
     # so that UCX/DOCA can see all GPUs for GPU-initiated RDMA when needed.
     torch.set_default_dtype(torch.bfloat16)
     torch.set_default_device("cuda")
     torch.cuda.set_device(local_rank % 8)
 
     num_nodes = int(os.getenv("WORLD_SIZE", 1))
+    node_rank = int(os.getenv("RANK", 0))
+    rank = node_rank * num_local_ranks + local_rank
+    num_ranks = num_nodes * num_local_ranks
 
-    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
     print(
         f"pid: {os.getpid()}, rank: {rank}, num_ranks: {num_ranks} ,local_rank: {local_rank}",
         flush=True,
@@ -464,13 +509,15 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     )
 
     # Create TCPStore client for NIXL metadata exchange
-    tcp_server = args.tcp_server if args.tcp_server else os.getenv("MASTER_ADDR", "127.0.0.1")
+    tcp_server = (
+        args.tcp_server if args.tcp_server else os.getenv("MASTER_ADDR", "127.0.0.1")
+    )
     tcp_store = store_group.create_client_store(
         master_addr=tcp_server,
         port=TCP_STORE_PORT,
     )
 
-    # Initialize NIXL buffer with group (for IPC handles) and TCPStore (for NIXL metadata)
+    # Initialize NIXL buffer with TCPStore (for both NIXL metadata and IPC handle exchange)
     print(
         f"pid: {os.getpid()}, rank: {rank}, num_ranks: {num_ranks}, initializing buffer",
         flush=True,
@@ -479,7 +526,6 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         rank=rank,
         low_latency_mode=False,
         explicitly_destroy=True,
-        group=group,
         tcp_store_group=tcp_store,
     )
     buffer.update_memory_buffers(
@@ -503,15 +549,14 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             num_nodes,
             rank,
             buffer,
-            group,
+            tcp_store,
         )
         if local_rank == 0:
             print("", flush=True)
 
-    # Destroy the buffer runtime and communication group
+    # Destroy the buffer runtime
     buffer.destroy()
-    dist.barrier()
-    dist.destroy_process_group()
+    store_barrier(tcp_store, num_ranks, "shutdown")
 
 
 def run_server():

--- a/examples/device/ep/tests/test_ht.py
+++ b/examples/device/ep/tests/test_ht.py
@@ -450,7 +450,9 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     num_nodes = int(os.getenv("WORLD_SIZE", 1))
 
-    rank, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    rank, num_ranks, group = init_dist(
+        local_rank, num_local_ranks, master_addr=args.tcp_server
+    )
     print(
         f"pid: {os.getpid()}, rank: {rank}, num_ranks: {num_ranks} ,local_rank: {local_rank}",
         flush=True,
@@ -464,7 +466,9 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     )
 
     # Create TCPStore client for NIXL metadata exchange
-    tcp_server = args.tcp_server if args.tcp_server else os.getenv("MASTER_ADDR", "127.0.0.1")
+    tcp_server = (
+        args.tcp_server if args.tcp_server else os.getenv("MASTER_ADDR", "127.0.0.1")
+    )
     tcp_store = store_group.create_client_store(
         master_addr=tcp_server,
         port=TCP_STORE_PORT,

--- a/examples/device/ep/tests/test_ht.py
+++ b/examples/device/ep/tests/test_ht.py
@@ -464,7 +464,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     )
 
     # Create TCPStore client for NIXL metadata exchange
-    tcp_server = args.tcp_server if args.tcp_server else "127.0.0.1"
+    tcp_server = args.tcp_server if args.tcp_server else os.getenv("MASTER_ADDR", "127.0.0.1")
     tcp_store = store_group.create_client_store(
         master_addr=tcp_server,
         port=TCP_STORE_PORT,
@@ -555,7 +555,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tcp-server",
         type=str,
-        help="TCP server address (for both TCPStore and rank server). If not set, both will be started locally.",
+        help="TCP server address for NIXL metadata exchange. Defaults to MASTER_ADDR env var, or 127.0.0.1 if unset.",
     )
     args = parser.parse_args()
 
@@ -571,8 +571,8 @@ if __name__ == "__main__":
         args.num_topk_groups = min(num_nodes, 4)
 
     num_processes = args.num_processes
-    # 2-node run (WORLD_SIZE=2): run on both nodes with same MASTER_ADDR/MASTER_PORT; node1 needs --tcp-server <node0_ip>.
-    # NVL/RDMA timeouts across nodes usually mean RDMA/IB/UCX between nodes is broken or slow (e.g. "accelerated IB support was not found" on one node).
+    # 2-node run (WORLD_SIZE=2): run on both nodes with same MASTER_ADDR/MASTER_PORT.
+    # --tcp-server defaults to MASTER_ADDR so no need to pass it separately.
     torch.multiprocessing.spawn(
         test_loop, args=(num_processes, args), nprocs=num_processes
     )

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -31,16 +31,20 @@ import torch
 import torch.distributed as dist
 
 
-def init_dist(local_rank: int, num_local_ranks: int):
+def init_dist(
+    local_rank: int,
+    num_local_ranks: int,
+    master_addr: Optional[str] = None,
+):
     # NOTES: you may rewrite this function with your own cluster settings
-    ip = os.getenv("MASTER_ADDR", "127.0.0.1")
+    ip = master_addr or os.getenv("MASTER_ADDR", "127.0.0.1")
     port = int(os.getenv("MASTER_PORT", "8361"))
     num_nodes = int(os.getenv("WORLD_SIZE", 1))
     node_rank = int(os.getenv("RANK", 0))
 
     sig = inspect.signature(dist.init_process_group)
     params = {
-        "backend": "nccl",
+        "backend": "gloo",
         "init_method": f"tcp://{ip}:{port}",
         "world_size": num_nodes * num_local_ranks,
         "rank": node_rank * num_local_ranks + local_rank,


### PR DESCRIPTION
## What?

Simplify `test_ht.py` setup by streamlining the initialization flow and reducing the number of arguments needed for multi-node runs.

## Why?

Running the HT test across multiple nodes required passing redundant arguments (`--tcp-server`, `MASTER_ADDR`) that serve the same purpose, making the setup error-prone. The test also had unnecessary dependencies for its needs.

## How?

- Use TCPStore for all coordination in `test_ht.py` and remove unnecessary dependencies.
- Default `--tcp-server` to `MASTER_ADDR` env var so it no longer needs to be passed separately.
- Derive `rank` / `num_ranks` directly from `RANK` and `WORLD_SIZE` env vars.

New usage:


Multi-node with `MASTER_ADDR` (e.g. 2 nodes):
```bash
# Node 0
RANK=0 WORLD_SIZE=2 python test_ht.py

# Node 1
MASTER_ADDR=<node0_ip> RANK=1 WORLD_SIZE=2 python test_ht.py
```

Multi-node with explicit `--tcp-server` (no `MASTER_ADDR` needed):
```bash
# Node 0 (server)
RANK=0 WORLD_SIZE=2 python test_ht.py

# Node 1 (client)
RANK=1 WORLD_SIZE=2 python test_ht.py --tcp-server <node0_ip>
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Master address for distributed training can now be configured via environment variable, with fallback support for command-line arguments.

* **Infrastructure Changes**
  * Updated distributed process group initialization backend to improve compatibility and flexibility across different deployment scenarios.
  * Enhanced documentation to clarify the role of configuration options in the distributed training setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->