### PR TITLE
PLUGINS/UCX: Clean up enums.

### DIFF
--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -21,9 +21,9 @@ ucx_backend_sources = ['config.cpp',
                        'mem_list.cpp',
                        'rkey.cpp',
                        'ucx_backend.cpp',
+                       'ucx_enums.cpp',
                        'ucx_plugin.cpp',
-                       'ucx_utils.cpp',
-                       'ucx_enums.cpp']
+                       'ucx_utils.cpp']
 
 ucx_backend_dependencies = [asio_dep,
                             cuda_dep,

--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -22,7 +22,8 @@ ucx_backend_sources = ['config.cpp',
                        'rkey.cpp',
                        'ucx_backend.cpp',
                        'ucx_plugin.cpp',
-                       'ucx_utils.cpp']
+                       'ucx_utils.cpp',
+                       'ucx_enums.cpp']
 
 ucx_backend_dependencies = [asio_dep,
                             cuda_dep,

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -122,7 +122,7 @@ public:
     release() {
         // TODO: Error log: uncompleted requests found! Cancelling ...
         for (nixlUcxReq req : requests_) {
-            const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+            const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
             if (ret == NIXL_IN_PROG) {
                 // TODO: Need process this properly.
                 // it may not be enough to cancel UCX request
@@ -150,7 +150,7 @@ public:
         /* If last request is incomplete, return NIXL_IN_PROG early without
          * checking other requests */
         nixlUcxReq req = requests_.back();
-        const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+        const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
         if (ret == NIXL_IN_PROG) {
             return NIXL_IN_PROG;
         } else if (ret != NIXL_SUCCESS) {
@@ -162,7 +162,7 @@ public:
         size_t incomplete_reqs = 0;
         nixl_status_t out_ret = NIXL_SUCCESS;
         for (nixlUcxReq req : requests_) {
-            const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+            const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
             if (__builtin_expect(ret == NIXL_SUCCESS, 0)) {
                 worker->reqRelease(req);
             } else if (ret == NIXL_IN_PROG) {
@@ -375,7 +375,7 @@ private:
 
 nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_params)
     : nixlUcxEngine(init_params) {
-    if (!nixlUcxMtLevelIsSupported(nixl_ucx_mt_t::WORKER)) {
+    if (!nixlUcxMtLevelIsSupported(nixl::ucx::mt_mode_t::WORKER)) {
         throw std::invalid_argument("UCX library does not support multi-threading");
     }
 
@@ -865,7 +865,7 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
 
     auto &uw = uws.front();
     workerAddr = uw->epAddr();
-    uw->regAmCallback(nixl_ucx_cb_op_t::NOTIF_STR, notifAmCb, this);
+    uw->regAmCallback(nixl::ucx::am_cb_op_t::NOTIF_STR, notifAmCb, this);
 }
 
 nixl_mem_list_t nixlUcxEngine::getSupportedMems () const {
@@ -1393,7 +1393,7 @@ nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
         }
     };
 
-    return ep->sendAm(nixl_ucx_cb_op_t::NOTIF_STR,
+    return ep->sendAm(nixl::ucx::am_cb_op_t::NOTIF_STR,
                       nullptr,
                       0,
                       (void *)buffer->data(),

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -122,7 +122,7 @@ public:
     release() {
         // TODO: Error log: uncompleted requests found! Cancelling ...
         for (nixlUcxReq req : requests_) {
-            nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+            const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
             if (ret == NIXL_IN_PROG) {
                 // TODO: Need process this properly.
                 // it may not be enough to cancel UCX request
@@ -150,7 +150,7 @@ public:
         /* If last request is incomplete, return NIXL_IN_PROG early without
          * checking other requests */
         nixlUcxReq req = requests_.back();
-        nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+        const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
         if (ret == NIXL_IN_PROG) {
             return NIXL_IN_PROG;
         } else if (ret != NIXL_SUCCESS) {
@@ -162,7 +162,7 @@ public:
         size_t incomplete_reqs = 0;
         nixl_status_t out_ret = NIXL_SUCCESS;
         for (nixlUcxReq req : requests_) {
-            nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
+            const nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
             if (__builtin_expect(ret == NIXL_SUCCESS, 0)) {
                 worker->reqRelease(req);
             } else if (ret == NIXL_IN_PROG) {

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -122,7 +122,7 @@ public:
     release() {
         // TODO: Error log: uncompleted requests found! Cancelling ...
         for (nixlUcxReq req : requests_) {
-            nixl_status_t ret = ucx_status_to_nixl(ucp_request_check_status(req));
+            nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
             if (ret == NIXL_IN_PROG) {
                 // TODO: Need process this properly.
                 // it may not be enough to cancel UCX request
@@ -150,7 +150,7 @@ public:
         /* If last request is incomplete, return NIXL_IN_PROG early without
          * checking other requests */
         nixlUcxReq req = requests_.back();
-        nixl_status_t ret = ucx_status_to_nixl(ucp_request_check_status(req));
+        nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
         if (ret == NIXL_IN_PROG) {
             return NIXL_IN_PROG;
         } else if (ret != NIXL_SUCCESS) {
@@ -162,7 +162,7 @@ public:
         size_t incomplete_reqs = 0;
         nixl_status_t out_ret = NIXL_SUCCESS;
         for (nixlUcxReq req : requests_) {
-            nixl_status_t ret = ucx_status_to_nixl(ucp_request_check_status(req));
+            nixl_status_t ret = ucxStatusToNixlStatus(ucp_request_check_status(req));
             if (__builtin_expect(ret == NIXL_SUCCESS, 0)) {
                 worker->reqRelease(req);
             } else if (ret == NIXL_IN_PROG) {
@@ -865,7 +865,7 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
 
     auto &uw = uws.front();
     workerAddr = uw->epAddr();
-    uw->regAmCallback(NOTIF_STR, notifAmCb, this);
+    uw->regAmCallback(nixl_ucx_cb_op_t::NOTIF_STR, notifAmCb, this);
 }
 
 nixl_mem_list_t nixlUcxEngine::getSupportedMems () const {
@@ -1393,7 +1393,7 @@ nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
         }
     };
 
-    return ep->sendAm(NOTIF_STR,
+    return ep->sendAm(nixl_ucx_cb_op_t::NOTIF_STR,
                       nullptr,
                       0,
                       (void *)buffer->data(),

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -30,14 +30,14 @@
 #include <optional>
 
 #include "nixl.h"
-#include "backend/backend_engine.h"
 
-// Local includes
+#include "backend/backend_engine.h"
 #include "common/nixl_time.h"
+
 #include "mem_list.h"
 #include "rkey.h"
-#include "ucx_utils.h"
 #include "ucx_enums.h"
+#include "ucx_utils.h"
 
 class nixlUcxConnection : public nixlBackendConnMD {
     private:

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -37,8 +37,7 @@
 #include "mem_list.h"
 #include "rkey.h"
 #include "ucx_utils.h"
-
-enum ucx_cb_op_t { NOTIF_STR };
+#include "ucx_enums.h"
 
 class nixlUcxConnection : public nixlBackendConnMD {
     private:

--- a/src/plugins/ucx/ucx_enums.cpp
+++ b/src/plugins/ucx/ucx_enums.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common/nixl_log.h"
+
+#include "ucx_enums.h"
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_mt_t t) {
+    toStream(os, t);
+    return os;
+}
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_ep_state_t t) {
+    toStream(os, t);
+    return os;
+}
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_cb_op_t t) {
+    toStream(os, t);
+    return os;
+}
+
+nixl_status_t
+ucxStatusToNixlStatus(const ucs_status_t t) {
+    if (t == UCS_OK) {
+        return NIXL_SUCCESS;
+    }
+
+    switch (t) {
+    case UCS_INPROGRESS:
+    case UCS_ERR_BUSY:
+        return NIXL_IN_PROG;
+    case UCS_ERR_NOT_CONNECTED:
+    case UCS_ERR_CONNECTION_RESET:
+    case UCS_ERR_ENDPOINT_TIMEOUT:
+        return NIXL_ERR_REMOTE_DISCONNECT;
+    case UCS_ERR_INVALID_PARAM:
+        return NIXL_ERR_INVALID_PARAM;
+    case UCS_ERR_CANCELED:
+        return NIXL_ERR_CANCELED;
+    default:
+        NIXL_WARN << "Unexpected UCX error: " << ucs_status_string(t);
+        return NIXL_ERR_BACKEND;
+    }
+}

--- a/src/plugins/ucx/ucx_enums.cpp
+++ b/src/plugins/ucx/ucx_enums.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-#include "common/nixl_log.h"
-
 #include "ucx_enums.h"
+
+#include "common/nixl_log.h"
 
 std::ostream &
 operator<<(std::ostream &os, const nixl_ucx_mt_t t) {
@@ -39,7 +39,7 @@ operator<<(std::ostream &os, const nixl_ucx_cb_op_t t) {
 
 nixl_status_t
 ucxStatusToNixlStatus(const ucs_status_t t) {
-    if (t == UCS_OK) {
+    if (__builtin_expect(t == UCS_OK, 1)) {
         return NIXL_SUCCESS;
     }
 

--- a/src/plugins/ucx/ucx_enums.cpp
+++ b/src/plugins/ucx/ucx_enums.cpp
@@ -19,31 +19,31 @@
 
 #include "common/nixl_log.h"
 
+namespace nixl::ucx {
+
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_mt_t t) {
+operator<<(std::ostream &os, const mt_mode_t t) {
     toStream(os, t);
     return os;
 }
 
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_ep_state_t t) {
+operator<<(std::ostream &os, const ep_state_t t) {
     toStream(os, t);
     return os;
 }
 
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_cb_op_t t) {
+operator<<(std::ostream &os, const am_cb_op_t t) {
     toStream(os, t);
     return os;
 }
 
 nixl_status_t
-ucxStatusToNixlStatus(const ucs_status_t t) {
-    if (__builtin_expect(t == UCS_OK, 1)) {
+ucsToNixlStatus(const ucs_status_t t) {
+    switch (__builtin_expect(t, UCS_OK)) {
+    case UCS_OK:
         return NIXL_SUCCESS;
-    }
-
-    switch (t) {
     case UCS_INPROGRESS:
     case UCS_ERR_BUSY:
         return NIXL_IN_PROG;
@@ -60,3 +60,5 @@ ucxStatusToNixlStatus(const ucs_status_t t) {
         return NIXL_ERR_BACKEND;
     }
 }
+
+} // namespace nixl::ucx

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_UTILS_UCX_UCX_ENUMS_H
+#define NIXL_SRC_UTILS_UCX_UCX_ENUMS_H
+
+#include <ostream>
+#include <string_view>
+#include <type_traits>
+
+#include <ucs/type/status.h>
+
+#include "nixl_types.h"
+
+constexpr inline std::string_view nixl_ucx_invalid = "INVALID";
+
+enum class nixl_ucx_mt_t {
+    SINGLE,
+    CTX,
+    WORKER
+};
+
+[[nodiscard]] constexpr std::string_view
+toStringView(const nixl_ucx_mt_t t) noexcept {
+    switch (t) {
+    case nixl_ucx_mt_t::SINGLE:
+        return "SINGLE";
+    case nixl_ucx_mt_t::CTX:
+        return "CTX";
+    case nixl_ucx_mt_t::WORKER:
+        return "WORKER";
+    }
+    return nixl_ucx_invalid;
+}
+
+enum class nixl_ucx_ep_state_t {
+    NULL_,
+    CONNECTED,
+    FAILED,
+    DISCONNECTED
+};
+
+[[nodiscard]] constexpr std::string_view
+toStringView(const nixl_ucx_ep_state_t t) noexcept {
+    switch (t) {
+    case nixl_ucx_ep_state_t::NULL_:
+        return "NULL";
+    case nixl_ucx_ep_state_t::CONNECTED:
+        return "CONNECTED";
+    case nixl_ucx_ep_state_t::FAILED:
+        return "FAILED";
+    case nixl_ucx_ep_state_t::DISCONNECTED:
+        return "DISCONNECTED";
+    }
+    return nixl_ucx_invalid;
+}
+
+enum class nixl_ucx_cb_op_t {
+    NOTIF_STR
+};
+
+[[nodiscard]] constexpr std::string_view
+toStringView(const nixl_ucx_cb_op_t t) noexcept {
+    switch (t) {
+    case nixl_ucx_cb_op_t::NOTIF_STR:
+        return "NOTIF_STR";
+    }
+    return nixl_ucx_invalid;
+}
+
+template<typename Enum>
+[[nodiscard]] constexpr auto
+toInteger(const Enum e) noexcept {
+    static_assert(std::is_enum_v<Enum>);
+    return std::underlying_type_t<Enum>(e);
+}
+
+template<typename Enum>
+inline void
+toStream(std::ostream& os, const Enum t) {
+    static_assert(std::is_enum_v<Enum>);
+
+    const auto view = toStringView(t);
+
+    if (view != nixl_ucx_invalid) {
+        os << view;
+    } else {
+        os << toInteger(t);
+    }
+}
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_mt_t t);
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_ep_state_t t);
+
+std::ostream &
+operator<<(std::ostream &os, const nixl_ucx_cb_op_t t);
+
+[[nodiscard]] constexpr nixl_status_t
+toNixlStatus(const nixl_ucx_ep_state_t t) noexcept {
+    switch (t) {
+    case nixl_ucx_ep_state_t::CONNECTED:
+        return NIXL_SUCCESS;
+    case nixl_ucx_ep_state_t::FAILED:
+        return NIXL_ERR_REMOTE_DISCONNECT;
+    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::DISCONNECTED:
+        return NIXL_ERR_BACKEND;
+    }
+    return NIXL_ERR_BACKEND;
+}
+
+// Functions for weakly typed enums.
+
+// Prints warning for unexpected values.
+[[nodiscard]] nixl_status_t
+ucxStatusToNixlStatus(const ucs_status_t t);
+
+#endif

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,9 +25,17 @@
 
 #include "nixl_types.h"
 
-inline constexpr std::string_view nixl_ucx_invalid = "INVALID";
+namespace nixl::ucx {
 
-enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
+inline constexpr std::string_view invalid_string = "INVALID";
+
+} // namespace nixl::ucx
+
+enum class nixl_ucx_mt_t {
+    SINGLE,
+    CTX,
+    WORKER,
+};
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_mt_t t) noexcept {
@@ -39,16 +47,21 @@ toStringView(const nixl_ucx_mt_t t) noexcept {
     case nixl_ucx_mt_t::WORKER:
         return "WORKER";
     }
-    return nixl_ucx_invalid;
+    return nixl::ucx::invalid_string;
 }
 
-enum class nixl_ucx_ep_state_t { NULL_, CONNECTED, FAILED, DISCONNECTED };
+enum class nixl_ucx_ep_state_t {
+    UNINITIALIZED,
+    CONNECTED,
+    FAILED,
+    DISCONNECTED,
+};
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_ep_state_t t) noexcept {
     switch (t) {
-    case nixl_ucx_ep_state_t::NULL_:
-        return "NULL";
+    case nixl_ucx_ep_state_t::UNINITIALIZED:
+        return "UNINITIALIZED";
     case nixl_ucx_ep_state_t::CONNECTED:
         return "CONNECTED";
     case nixl_ucx_ep_state_t::FAILED:
@@ -56,10 +69,12 @@ toStringView(const nixl_ucx_ep_state_t t) noexcept {
     case nixl_ucx_ep_state_t::DISCONNECTED:
         return "DISCONNECTED";
     }
-    return nixl_ucx_invalid;
+    return nixl::ucx::invalid_string;
 }
 
-enum class nixl_ucx_cb_op_t { NOTIF_STR };
+enum class nixl_ucx_cb_op_t {
+    NOTIF_STR
+};
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_cb_op_t t) noexcept {
@@ -67,7 +82,7 @@ toStringView(const nixl_ucx_cb_op_t t) noexcept {
     case nixl_ucx_cb_op_t::NOTIF_STR:
         return "NOTIF_STR";
     }
-    return nixl_ucx_invalid;
+    return nixl::ucx::invalid_string;
 }
 
 template<typename Enum>
@@ -84,7 +99,7 @@ toStream(std::ostream &os, const Enum t) {
 
     const auto view = toStringView(t);
 
-    if (view != nixl_ucx_invalid) {
+    if (view != nixl::ucx::invalid_string) {
         os << view;
     } else {
         os << toInteger(t);
@@ -107,7 +122,7 @@ toNixlStatus(const nixl_ucx_ep_state_t t) noexcept {
         return NIXL_SUCCESS;
     case nixl_ucx_ep_state_t::FAILED:
         return NIXL_ERR_REMOTE_DISCONNECT;
-    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::UNINITIALIZED:
     case nixl_ucx_ep_state_t::DISCONNECTED:
         return NIXL_ERR_BACKEND;
     }

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -29,28 +29,26 @@ namespace nixl::ucx {
 
 inline constexpr std::string_view invalid_string = "INVALID";
 
-} // namespace nixl::ucx
-
-enum class nixl_ucx_mt_t {
+enum class mt_mode_t {
     SINGLE,
-    CTX,
+    CONTEXT,
     WORKER,
 };
 
 [[nodiscard]] constexpr std::string_view
-toStringView(const nixl_ucx_mt_t t) noexcept {
+toStringView(const mt_mode_t t) noexcept {
     switch (t) {
-    case nixl_ucx_mt_t::SINGLE:
+    case mt_mode_t::SINGLE:
         return "SINGLE";
-    case nixl_ucx_mt_t::CTX:
-        return "CTX";
-    case nixl_ucx_mt_t::WORKER:
+    case mt_mode_t::CONTEXT:
+        return "CONTEXT";
+    case mt_mode_t::WORKER:
         return "WORKER";
     }
     return nixl::ucx::invalid_string;
 }
 
-enum class nixl_ucx_ep_state_t {
+enum class ep_state_t {
     UNINITIALIZED,
     CONNECTED,
     FAILED,
@@ -58,28 +56,28 @@ enum class nixl_ucx_ep_state_t {
 };
 
 [[nodiscard]] constexpr std::string_view
-toStringView(const nixl_ucx_ep_state_t t) noexcept {
+toStringView(const ep_state_t t) noexcept {
     switch (t) {
-    case nixl_ucx_ep_state_t::UNINITIALIZED:
+    case ep_state_t::UNINITIALIZED:
         return "UNINITIALIZED";
-    case nixl_ucx_ep_state_t::CONNECTED:
+    case ep_state_t::CONNECTED:
         return "CONNECTED";
-    case nixl_ucx_ep_state_t::FAILED:
+    case ep_state_t::FAILED:
         return "FAILED";
-    case nixl_ucx_ep_state_t::DISCONNECTED:
+    case ep_state_t::DISCONNECTED:
         return "DISCONNECTED";
     }
     return nixl::ucx::invalid_string;
 }
 
-enum class nixl_ucx_cb_op_t {
+enum class am_cb_op_t {
     NOTIF_STR,
 };
 
 [[nodiscard]] constexpr std::string_view
-toStringView(const nixl_ucx_cb_op_t t) noexcept {
+toStringView(const am_cb_op_t t) noexcept {
     switch (t) {
-    case nixl_ucx_cb_op_t::NOTIF_STR:
+    case am_cb_op_t::NOTIF_STR:
         return "NOTIF_STR";
     }
     return nixl::ucx::invalid_string;
@@ -107,23 +105,23 @@ toStream(std::ostream &os, const Enum t) {
 }
 
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_mt_t t);
+operator<<(std::ostream &os, const mt_mode_t t);
 
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_ep_state_t t);
+operator<<(std::ostream &os, const ep_state_t t);
 
 std::ostream &
-operator<<(std::ostream &os, const nixl_ucx_cb_op_t t);
+operator<<(std::ostream &os, const am_cb_op_t t);
 
 [[nodiscard]] constexpr nixl_status_t
-toNixlStatus(const nixl_ucx_ep_state_t t) noexcept {
+toNixlStatus(const ep_state_t t) noexcept {
     switch (t) {
-    case nixl_ucx_ep_state_t::CONNECTED:
+    case ep_state_t::CONNECTED:
         return NIXL_SUCCESS;
-    case nixl_ucx_ep_state_t::FAILED:
+    case ep_state_t::FAILED:
         return NIXL_ERR_REMOTE_DISCONNECT;
-    case nixl_ucx_ep_state_t::UNINITIALIZED:
-    case nixl_ucx_ep_state_t::DISCONNECTED:
+    case ep_state_t::UNINITIALIZED:
+    case ep_state_t::DISCONNECTED:
         return NIXL_ERR_BACKEND;
     }
     return NIXL_ERR_BACKEND;
@@ -133,6 +131,8 @@ toNixlStatus(const nixl_ucx_ep_state_t t) noexcept {
 
 // Prints warning for unexpected values.
 [[nodiscard]] nixl_status_t
-ucxStatusToNixlStatus(const ucs_status_t t);
+ucsToNixlStatus(const ucs_status_t t);
+
+} // namespace nixl::ucx
 
 #endif

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NIXL_SRC_UTILS_UCX_UCX_ENUMS_H
-#define NIXL_SRC_UTILS_UCX_UCX_ENUMS_H
+#ifndef NIXL_SRC_PLUGINS_UCX_UCX_ENUMS_H
+#define NIXL_SRC_PLUGINS_UCX_UCX_ENUMS_H
 
 #include <ostream>
 #include <string_view>
@@ -25,7 +25,7 @@
 
 #include "nixl_types.h"
 
-constexpr inline std::string_view nixl_ucx_invalid = "INVALID";
+inline constexpr std::string_view nixl_ucx_invalid = "INVALID";
 
 enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
 

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -73,7 +73,7 @@ toStringView(const nixl_ucx_ep_state_t t) noexcept {
 }
 
 enum class nixl_ucx_cb_op_t {
-    NOTIF_STR
+    NOTIF_STR,
 };
 
 [[nodiscard]] constexpr std::string_view

--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -27,11 +27,7 @@
 
 constexpr inline std::string_view nixl_ucx_invalid = "INVALID";
 
-enum class nixl_ucx_mt_t {
-    SINGLE,
-    CTX,
-    WORKER
-};
+enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_mt_t t) noexcept {
@@ -46,12 +42,7 @@ toStringView(const nixl_ucx_mt_t t) noexcept {
     return nixl_ucx_invalid;
 }
 
-enum class nixl_ucx_ep_state_t {
-    NULL_,
-    CONNECTED,
-    FAILED,
-    DISCONNECTED
-};
+enum class nixl_ucx_ep_state_t { NULL_, CONNECTED, FAILED, DISCONNECTED };
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_ep_state_t t) noexcept {
@@ -68,9 +59,7 @@ toStringView(const nixl_ucx_ep_state_t t) noexcept {
     return nixl_ucx_invalid;
 }
 
-enum class nixl_ucx_cb_op_t {
-    NOTIF_STR
-};
+enum class nixl_ucx_cb_op_t { NOTIF_STR };
 
 [[nodiscard]] constexpr std::string_view
 toStringView(const nixl_ucx_cb_op_t t) noexcept {
@@ -90,7 +79,7 @@ toInteger(const Enum e) noexcept {
 
 template<typename Enum>
 inline void
-toStream(std::ostream& os, const Enum t) {
+toStream(std::ostream &os, const Enum t) {
     static_assert(std::is_enum_v<Enum>);
 
     const auto view = toStringView(t);

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -96,14 +96,14 @@ nixlUcxEp::err_cb(ucp_ep_h ucp_ep, ucs_status_t status) {
     NIXL_ASSERT(eph == ucp_ep);
 
     switch (state) {
-    case nixl_ucx_ep_state_t::UNINITIALIZED:
-    case nixl_ucx_ep_state_t::FAILED:
+    case nixl::ucx::ep_state_t::UNINITIALIZED:
+    case nixl::ucx::ep_state_t::FAILED:
         // The error was already handled, nothing to do
-    case nixl_ucx_ep_state_t::DISCONNECTED:
+    case nixl::ucx::ep_state_t::DISCONNECTED:
         // The EP has been disconnected, nothing to do
         return;
-    case nixl_ucx_ep_state_t::CONNECTED:
-        setState(nixl_ucx_ep_state_t::FAILED);
+    case nixl::ucx::ep_state_t::CONNECTED:
+        setState(nixl::ucx::ep_state_t::FAILED);
         request = ucp_ep_close_nb(ucp_ep, UCP_EP_CLOSE_MODE_FORCE);
         if (UCS_PTR_IS_PTR(request)) {
             ucp_request_free(request);
@@ -115,7 +115,7 @@ nixlUcxEp::err_cb(ucp_ep_h ucp_ep, ucs_status_t status) {
 }
 
 void
-nixlUcxEp::setState(nixl_ucx_ep_state_t new_state) {
+nixlUcxEp::setState(nixl::ucx::ep_state_t new_state) {
     NIXL_ASSERT(new_state != state);
     NIXL_DEBUG << "ep " << eph << ": state " << state << " -> " << new_state;
     state = new_state;
@@ -127,17 +127,17 @@ nixlUcxEp::closeImpl(ucp_ep_close_flags_t flags) {
     ucp_request_param_t req_param = {.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS, .flags = flags};
 
     switch (state) {
-    case nixl_ucx_ep_state_t::UNINITIALIZED:
-    case nixl_ucx_ep_state_t::DISCONNECTED:
+    case nixl::ucx::ep_state_t::UNINITIALIZED:
+    case nixl::ucx::ep_state_t::DISCONNECTED:
         // The EP has not been connected, or already disconnected.
         // Nothing to do.
         NIXL_ASSERT(eph == nullptr);
         return NIXL_SUCCESS;
-    case nixl_ucx_ep_state_t::FAILED:
+    case nixl::ucx::ep_state_t::FAILED:
         // The EP was closed in error callback, just return error.
         eph = nullptr;
         return NIXL_ERR_REMOTE_DISCONNECT;
-    case nixl_ucx_ep_state_t::CONNECTED:
+    case nixl::ucx::ep_state_t::CONNECTED:
         request = ucp_ep_close_nbx(eph, &req_param);
         if (request == nullptr) {
             eph = nullptr;
@@ -146,7 +146,7 @@ nixlUcxEp::closeImpl(ucp_ep_close_flags_t flags) {
 
         if (UCS_PTR_IS_ERR(request)) {
             eph = nullptr;
-            return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
+            return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
         }
 
         ucp_request_free(request);
@@ -168,9 +168,9 @@ nixlUcxEp::nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t er
     ep_params.err_handler.arg = static_cast<void *>(this);
     ep_params.address = reinterpret_cast<ucp_address_t *>(addr);
 
-    status = ucxStatusToNixlStatus(ucp_ep_create(worker, &ep_params, &eph));
+    status = nixl::ucx::ucsToNixlStatus(ucp_ep_create(worker, &ep_params, &eph));
     if (status == NIXL_SUCCESS)
-        setState(nixl_ucx_ep_state_t::CONNECTED);
+        setState(nixl::ucx::ep_state_t::CONNECTED);
     else
         throw std::runtime_error("failed to create ep");
 }
@@ -207,7 +207,7 @@ nixlUcxEp::sendAmCallback(void *request, ucs_status_t status, void *user_data) {
 }
 
 nixl_status_t
-nixlUcxEp::sendAm(nixl_ucx_cb_op_t msg_id,
+nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
                   void *hdr,
                   size_t hdr_len,
                   void *buffer,
@@ -245,7 +245,7 @@ nixlUcxEp::sendAm(nixl_ucx_cb_op_t msg_id,
         deleter(nullptr, buffer);
     }
 
-    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
+    return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 /* ===========================================
@@ -275,7 +275,7 @@ nixlUcxEp::read(uint64_t raddr,
         return NIXL_IN_PROG;
     }
 
-    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
+    return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 nixl_status_t
@@ -301,7 +301,7 @@ nixlUcxEp::write(void *laddr,
         return NIXL_IN_PROG;
     }
 
-    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
+    return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 nixl_status_t
@@ -345,20 +345,20 @@ nixlUcxEp::flushEp(nixlUcxReq &req) {
         return NIXL_IN_PROG;
     }
 
-    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
+    return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 bool
-nixlUcxMtLevelIsSupported(const nixl_ucx_mt_t mt_type) noexcept {
+nixlUcxMtLevelIsSupported(const nixl::ucx::mt_mode_t mt_type) noexcept {
     ucp_lib_attr_t attr;
     attr.field_mask = UCP_LIB_ATTR_FIELD_MAX_THREAD_LEVEL;
     ucp_lib_query(&attr);
 
     switch (mt_type) {
-    case nixl_ucx_mt_t::SINGLE:
+    case nixl::ucx::mt_mode_t::SINGLE:
         return attr.max_thread_level >= UCS_THREAD_MODE_SERIALIZED;
-    case nixl_ucx_mt_t::CTX:
-    case nixl_ucx_mt_t::WORKER:
+    case nixl::ucx::mt_mode_t::CONTEXT:
+    case nixl::ucx::mt_mode_t::WORKER:
         return attr.max_thread_level >= UCS_THREAD_MODE_MULTI;
     }
     NIXL_FATAL << "invalid mt type: " << toInteger(mt_type);
@@ -374,15 +374,15 @@ makeUcpVersion() noexcept {
     return UCP_VERSION(major_version, minor_version);
 }
 
-[[nodiscard]] nixl_ucx_mt_t
+[[nodiscard]] nixl::ucx::mt_mode_t
 makeMtType(const bool prog_thread, const nixl_thread_sync_t sync_mode) noexcept {
     // With strict synchronization model nixlAgent serializes access to backends, with more
     // permissive models backends need to account for concurrent access and ensure their internal
     // state is properly protected. Progress thread creates internal concurrency in UCX backend
     // irrespective of nixlAgent synchronization model.
     return (sync_mode == nixl_thread_sync_t::NIXL_THREAD_SYNC_RW || prog_thread) ?
-        nixl_ucx_mt_t::WORKER :
-        nixl_ucx_mt_t::SINGLE;
+        nixl::ucx::mt_mode_t::WORKER :
+        nixl::ucx::mt_mode_t::SINGLE;
 }
 
 } // namespace
@@ -461,22 +461,22 @@ nixlUcxContext::~nixlUcxContext() {
 
 namespace {
 [[nodiscard]] ucs_thread_mode_t
-toUcsThreadModeChecked(const nixl_ucx_mt_t t) {
+toUcsThreadModeChecked(const nixl::ucx::mt_mode_t t) {
     switch (t) {
-    case nixl_ucx_mt_t::CTX:
+    case nixl::ucx::mt_mode_t::CONTEXT:
         return UCS_THREAD_MODE_SINGLE;
-    case nixl_ucx_mt_t::SINGLE:
+    case nixl::ucx::mt_mode_t::SINGLE:
         return UCS_THREAD_MODE_SERIALIZED;
-    case nixl_ucx_mt_t::WORKER:
+    case nixl::ucx::mt_mode_t::WORKER:
         return UCS_THREAD_MODE_MULTI;
     }
     NIXL_FATAL << "Invalid UCX worker type: "
-               << static_cast<std::underlying_type_t<nixl_ucx_mt_t>>(t);
+               << static_cast<std::underlying_type_t<nixl::ucx::mt_mode_t>>(t);
     std::terminate();
 }
 
 struct nixlUcpWorkerParams : ucp_worker_params_t {
-    explicit nixlUcpWorkerParams(const nixl_ucx_mt_t t) {
+    explicit nixlUcpWorkerParams(const nixl::ucx::mt_mode_t t) {
         field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
         thread_mode = toUcsThreadModeChecked(t);
     }
@@ -628,7 +628,7 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
  * =========================================== */
 
 int
-nixlUcxWorker::regAmCallback(nixl_ucx_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg) {
+nixlUcxWorker::regAmCallback(nixl::ucx::am_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg) {
     ucp_am_handler_param_t params = {0};
 
     params.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID | UCP_AM_HANDLER_PARAM_FIELD_CB |
@@ -662,7 +662,7 @@ nixlUcxWorker::test(nixlUcxReq req) {
         return NIXL_SUCCESS;
     }
     ucp_worker_progress(worker.get());
-    return ucxStatusToNixlStatus(ucp_request_check_status(req));
+    return nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
 }
 
 void
@@ -677,7 +677,7 @@ nixlUcxWorker::reqCancel(nixlUcxReq req) {
 
 nixl_status_t
 nixlUcxWorker::arm() const noexcept {
-    return ucxStatusToNixlStatus(ucp_worker_arm(worker.get()));
+    return nixl::ucx::ucsToNixlStatus(ucp_worker_arm(worker.get()));
 }
 
 int

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -96,7 +96,7 @@ nixlUcxEp::err_cb(ucp_ep_h ucp_ep, ucs_status_t status) {
     NIXL_ASSERT(eph == ucp_ep);
 
     switch (state) {
-    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::UNINITIALIZED:
     case nixl_ucx_ep_state_t::FAILED:
         // The error was already handled, nothing to do
     case nixl_ucx_ep_state_t::DISCONNECTED:
@@ -127,7 +127,7 @@ nixlUcxEp::closeImpl(ucp_ep_close_flags_t flags) {
     ucp_request_param_t req_param = {.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS, .flags = flags};
 
     switch (state) {
-    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::UNINITIALIZED:
     case nixl_ucx_ep_state_t::DISCONNECTED:
         // The EP has not been connected, or already disconnected.
         // Nothing to do.

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -43,30 +43,6 @@ get_ucx_backend_common_options() {
     return params;
 }
 
-nixl_status_t
-ucx_status_to_nixl(ucs_status_t status) {
-    if (status == UCS_OK) {
-        return NIXL_SUCCESS;
-    }
-
-    switch (status) {
-    case UCS_INPROGRESS:
-    case UCS_ERR_BUSY:
-        return NIXL_IN_PROG;
-    case UCS_ERR_NOT_CONNECTED:
-    case UCS_ERR_CONNECTION_RESET:
-    case UCS_ERR_ENDPOINT_TIMEOUT:
-        return NIXL_ERR_REMOTE_DISCONNECT;
-    case UCS_ERR_INVALID_PARAM:
-        return NIXL_ERR_INVALID_PARAM;
-    case UCS_ERR_CANCELED:
-        return NIXL_ERR_CANCELED;
-    default:
-        NIXL_WARN << "Unexpected UCX error: " << ucs_status_string(status);
-        return NIXL_ERR_BACKEND;
-    }
-}
-
 [[nodiscard]] std::string_view
 ucx_err_mode_to_string(ucp_err_handling_mode_t t) {
     switch (t) {
@@ -122,14 +98,14 @@ nixlUcxEp::err_cb(ucp_ep_h ucp_ep, ucs_status_t status) {
     NIXL_ASSERT(eph == ucp_ep);
 
     switch (state) {
-    case NIXL_UCX_EP_STATE_NULL:
-    case NIXL_UCX_EP_STATE_FAILED:
+    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::FAILED:
         // The error was already handled, nothing to do
-    case NIXL_UCX_EP_STATE_DISCONNECTED:
+    case nixl_ucx_ep_state_t::DISCONNECTED:
         // The EP has been disconnected, nothing to do
         return;
-    case NIXL_UCX_EP_STATE_CONNECTED:
-        setState(NIXL_UCX_EP_STATE_FAILED);
+    case nixl_ucx_ep_state_t::CONNECTED:
+        setState(nixl_ucx_ep_state_t::FAILED);
         request = ucp_ep_close_nb(ucp_ep, UCP_EP_CLOSE_MODE_FORCE);
         if (UCS_PTR_IS_PTR(request)) {
             ucp_request_free(request);
@@ -153,17 +129,17 @@ nixlUcxEp::closeImpl(ucp_ep_close_flags_t flags) {
     ucp_request_param_t req_param = {.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS, .flags = flags};
 
     switch (state) {
-    case NIXL_UCX_EP_STATE_NULL:
-    case NIXL_UCX_EP_STATE_DISCONNECTED:
+    case nixl_ucx_ep_state_t::NULL_:
+    case nixl_ucx_ep_state_t::DISCONNECTED:
         // The EP has not been connected, or already disconnected.
         // Nothing to do.
         NIXL_ASSERT(eph == nullptr);
         return NIXL_SUCCESS;
-    case NIXL_UCX_EP_STATE_FAILED:
+    case nixl_ucx_ep_state_t::FAILED:
         // The EP was closed in error callback, just return error.
         eph = nullptr;
         return NIXL_ERR_REMOTE_DISCONNECT;
-    case NIXL_UCX_EP_STATE_CONNECTED:
+    case nixl_ucx_ep_state_t::CONNECTED:
         request = ucp_ep_close_nbx(eph, &req_param);
         if (request == nullptr) {
             eph = nullptr;
@@ -172,7 +148,7 @@ nixlUcxEp::closeImpl(ucp_ep_close_flags_t flags) {
 
         if (UCS_PTR_IS_ERR(request)) {
             eph = nullptr;
-            return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+            return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
         }
 
         ucp_request_free(request);
@@ -194,9 +170,9 @@ nixlUcxEp::nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t er
     ep_params.err_handler.arg = static_cast<void *>(this);
     ep_params.address = reinterpret_cast<ucp_address_t *>(addr);
 
-    status = ucx_status_to_nixl(ucp_ep_create(worker, &ep_params, &eph));
+    status = ucxStatusToNixlStatus(ucp_ep_create(worker, &ep_params, &eph));
     if (status == NIXL_SUCCESS)
-        setState(NIXL_UCX_EP_STATE_CONNECTED);
+        setState(nixl_ucx_ep_state_t::CONNECTED);
     else
         throw std::runtime_error("failed to create ep");
 }
@@ -233,7 +209,7 @@ nixlUcxEp::sendAmCallback(void *request, ucs_status_t status, void *user_data) {
 }
 
 nixl_status_t
-nixlUcxEp::sendAm(unsigned msg_id,
+nixlUcxEp::sendAm(nixl_ucx_cb_op_t msg_id,
                   void *hdr,
                   size_t hdr_len,
                   void *buffer,
@@ -260,7 +236,7 @@ nixlUcxEp::sendAm(unsigned msg_id,
     }
 
     const ucs_status_ptr_t request =
-        ucp_am_send_nbx(eph, msg_id, hdr, hdr_len, buffer, len, &param);
+        ucp_am_send_nbx(eph, unsigned(msg_id), hdr, hdr_len, buffer, len, &param);
     if (UCS_PTR_IS_PTR(request)) {
         ctx.release();
         if (req != nullptr) {
@@ -271,7 +247,7 @@ nixlUcxEp::sendAm(unsigned msg_id,
         deleter(nullptr, buffer);
     }
 
-    return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 /* ===========================================
@@ -301,7 +277,7 @@ nixlUcxEp::read(uint64_t raddr,
         return NIXL_IN_PROG;
     }
 
-    return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 nixl_status_t
@@ -327,7 +303,7 @@ nixlUcxEp::write(void *laddr,
         return NIXL_IN_PROG;
     }
 
-    return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 nixl_status_t
@@ -371,7 +347,7 @@ nixlUcxEp::flushEp(nixlUcxReq &req) {
         return NIXL_IN_PROG;
     }
 
-    return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+    return ucxStatusToNixlStatus(UCS_PTR_STATUS(request));
 }
 
 bool
@@ -387,7 +363,7 @@ nixlUcxMtLevelIsSupported(const nixl_ucx_mt_t mt_type) noexcept {
     case nixl_ucx_mt_t::WORKER:
         return attr.max_thread_level >= UCS_THREAD_MODE_MULTI;
     }
-    NIXL_FATAL << "invalid mt type: " << enumToInteger(mt_type);
+    NIXL_FATAL << "invalid mt type: " << toInteger(mt_type);
     std::terminate();
 }
 
@@ -654,13 +630,13 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
  * =========================================== */
 
 int
-nixlUcxWorker::regAmCallback(unsigned msg_id, ucp_am_recv_callback_t cb, void *arg) {
+nixlUcxWorker::regAmCallback(nixl_ucx_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg) {
     ucp_am_handler_param_t params = {0};
 
     params.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID | UCP_AM_HANDLER_PARAM_FIELD_CB |
         UCP_AM_HANDLER_PARAM_FIELD_ARG;
 
-    params.id = msg_id;
+    params.id = unsigned(msg_id);
     params.cb = cb;
     params.arg = arg;
 
@@ -688,7 +664,7 @@ nixlUcxWorker::test(nixlUcxReq req) {
         return NIXL_SUCCESS;
     }
     ucp_worker_progress(worker.get());
-    return ucx_status_to_nixl(ucp_request_check_status(req));
+    return ucxStatusToNixlStatus(ucp_request_check_status(req));
 }
 
 void
@@ -703,7 +679,7 @@ nixlUcxWorker::reqCancel(nixlUcxReq req) {
 
 nixl_status_t
 nixlUcxWorker::arm() const noexcept {
-    return ucx_status_to_nixl(ucp_worker_arm(worker.get()));
+    return ucxStatusToNixlStatus(ucp_worker_arm(worker.get()));
 }
 
 int

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -65,7 +65,7 @@ class nixlUcxMem;
 class nixlUcxEp {
 private:
     ucp_ep_h eph{nullptr};
-    nixl_ucx_ep_state_t state = nixl_ucx_ep_state_t::NULL_;
+    nixl_ucx_ep_state_t state = nixl_ucx_ep_state_t::UNINITIALIZED;
 
     void
     setState(nixl_ucx_ep_state_t new_state);

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -26,36 +26,16 @@ extern "C" {
 
 #include <nixl_types.h>
 
+#include "ucx_enums.h"
+
 #include "absl/status/statusor.h"
 #include "absl/strings/numbers.h"
-
-
-enum class nixl_ucx_mt_t { SINGLE, CTX, WORKER };
 
 inline constexpr std::string_view nixl_ucx_err_handling_param_name = "ucx_error_handling_mode";
 
 // The API `ucp_context_query(ctx, &attr)` sets `UCS_MEMORY_TYPE_RDMA` in `attr.memory_types`
 // field only from UCX 1.22
 inline constexpr unsigned ucp_version_mem_type_rdma = UCP_VERSION(1, 22);
-
-template<typename Enum>
-[[nodiscard]] constexpr auto
-enumToInteger(const Enum e) noexcept {
-    static_assert(std::is_enum_v<Enum>);
-    return std::underlying_type_t<Enum>(e);
-}
-
-[[nodiscard]] std::string_view constexpr to_string_view(const nixl_ucx_mt_t t) noexcept {
-    switch (t) {
-    case nixl_ucx_mt_t::SINGLE:
-        return "SINGLE";
-    case nixl_ucx_mt_t::CTX:
-        return "CTX";
-    case nixl_ucx_mt_t::WORKER:
-        return "WORKER";
-    }
-    return "INVALID"; // It is not a to_string function's job to validate.
-}
 
 template<typename T>
 [[nodiscard]] T
@@ -83,16 +63,9 @@ class rkey;
 class nixlUcxMem;
 
 class nixlUcxEp {
-    enum nixl_ucx_ep_state_t {
-        NIXL_UCX_EP_STATE_NULL,
-        NIXL_UCX_EP_STATE_CONNECTED,
-        NIXL_UCX_EP_STATE_FAILED,
-        NIXL_UCX_EP_STATE_DISCONNECTED
-    };
-
 private:
     ucp_ep_h eph{nullptr};
-    nixl_ucx_ep_state_t state{NIXL_UCX_EP_STATE_NULL};
+    nixl_ucx_ep_state_t state = nixl_ucx_ep_state_t::NULL_;
 
     void
     setState(nixl_ucx_ep_state_t new_state);
@@ -110,18 +83,9 @@ public:
     void
     err_cb(ucp_ep_h ucp_ep, ucs_status_t status);
 
-    nixl_status_t
-    checkTxState() const {
-        switch (state) {
-        case NIXL_UCX_EP_STATE_CONNECTED:
-            return NIXL_SUCCESS;
-        case NIXL_UCX_EP_STATE_FAILED:
-            return NIXL_ERR_REMOTE_DISCONNECT;
-        case NIXL_UCX_EP_STATE_NULL:
-        case NIXL_UCX_EP_STATE_DISCONNECTED:
-        default:
-            return NIXL_ERR_BACKEND;
-        }
+    [[nodiscard]] nixl_status_t
+    checkTxState() const noexcept {
+        return toNixlStatus(state);
     }
 
     nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t err_handling_mode);
@@ -134,7 +98,7 @@ public:
 
     /* Active message handling */
     nixl_status_t
-    sendAm(unsigned msg_id,
+    sendAm(nixl_ucx_cb_op_t msg_id,
            void *hdr,
            size_t hdr_len,
            void *buffer,
@@ -261,7 +225,7 @@ public:
 
     /* Active message handling */
     int
-    regAmCallback(unsigned msg_id, ucp_am_recv_callback_t cb, void *arg);
+    regAmCallback(nixl_ucx_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg);
 
     /* Data access */
     int
@@ -299,9 +263,6 @@ private:
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options();
-
-[[nodiscard]] nixl_status_t
-ucx_status_to_nixl(ucs_status_t status);
 
 [[nodiscard]] std::string_view
 ucx_err_mode_to_string(ucp_err_handling_mode_t t);

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -65,10 +65,10 @@ class nixlUcxMem;
 class nixlUcxEp {
 private:
     ucp_ep_h eph{nullptr};
-    nixl_ucx_ep_state_t state = nixl_ucx_ep_state_t::UNINITIALIZED;
+    nixl::ucx::ep_state_t state = nixl::ucx::ep_state_t::UNINITIALIZED;
 
     void
-    setState(nixl_ucx_ep_state_t new_state);
+    setState(nixl::ucx::ep_state_t new_state);
     nixl_status_t
     closeImpl(ucp_ep_close_flags_t flags);
 
@@ -85,7 +85,7 @@ public:
 
     [[nodiscard]] nixl_status_t
     checkTxState() const noexcept {
-        return toNixlStatus(state);
+        return nixl::ucx::toNixlStatus(state);
     }
 
     nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t err_handling_mode);
@@ -98,7 +98,7 @@ public:
 
     /* Active message handling */
     nixl_status_t
-    sendAm(nixl_ucx_cb_op_t msg_id,
+    sendAm(nixl::ucx::am_cb_op_t msg_id,
            void *hdr,
            size_t hdr_len,
            void *buffer,
@@ -167,7 +167,7 @@ class nixlUcxContext {
 private:
     /* Local UCX stuff */
     ucp_context_h ctx;
-    const nixl_ucx_mt_t mtType_;
+    const nixl::ucx::mt_mode_t mtType_;
     const unsigned ucpVersion_;
 
 public:
@@ -202,7 +202,7 @@ public:
 };
 
 [[nodiscard]] bool
-nixlUcxMtLevelIsSupported(const nixl_ucx_mt_t) noexcept;
+nixlUcxMtLevelIsSupported(const nixl::ucx::mt_mode_t) noexcept;
 
 class nixlUcxWorker {
 public:
@@ -225,7 +225,7 @@ public:
 
     /* Active message handling */
     int
-    regAmCallback(nixl_ucx_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg);
+    regAmCallback(nixl::ucx::am_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg);
 
     /* Data access */
     int

--- a/test/unit/plugins/ucx/ucx_am_test.cpp
+++ b/test/unit/plugins/ucx/ucx_am_test.cpp
@@ -63,7 +63,8 @@ main() {
     uint64_t buffer;
     int ret, i;
 
-    unsigned check_cb_id = 1, rndv_cb_id = 2;
+    const auto check_cb_id = nixl_ucx_cb_op_t(42);
+    const auto rndv_cb_id = nixl_ucx_cb_op_t(43);
 
     void *big_buffer = calloc(1, 8192);
     struct sample_header hdr = {0};

--- a/test/unit/plugins/ucx/ucx_am_test.cpp
+++ b/test/unit/plugins/ucx/ucx_am_test.cpp
@@ -63,8 +63,8 @@ main() {
     uint64_t buffer;
     int ret, i;
 
-    const auto check_cb_id = nixl_ucx_cb_op_t(42);
-    const auto rndv_cb_id = nixl_ucx_cb_op_t(43);
+    const auto check_cb_id = nixl::ucx::am_cb_op_t(42);
+    const auto rndv_cb_id = nixl::ucx::am_cb_op_t(43);
 
     void *big_buffer = calloc(1, 8192);
     struct sample_header hdr = {0};


### PR DESCRIPTION
## What?
Clean up some enums and related functions in the UCX plugin.

## Why?
- Consistent naming.
- Consistent semantics.
- Type safety.
- Smaller source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced strongly-typed UCX enums and migrated internal APIs to use them for safer, clearer backend interactions.
* **Bug Fixes**
  * Centralized UCX→internal status mapping with improved handling and warnings for unknown statuses.
* **Tests**
  * Updated unit tests to use the new typed callback identifiers.
* **Chores**
  * Build system updated to include the new compilation unit supporting these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->