### PR TITLE
gtest: allow to test without UCX

### DIFF
--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -81,7 +81,7 @@ else
     device_api_dep = []
 endif
 
-if ucx_dep.found()
+if ucx_dep.found() and is_variable('ucx_backend_interface')
     gtest_sources += 'hw_warning_test.cpp'
     ucx_hw_warning_dep = [ucx_backend_interface, ucx_dep]
 else

--- a/test/meson.build
+++ b/test/meson.build
@@ -16,6 +16,4 @@
 subdir('nixl')
 subdir('unit')
 
-if enabled_plugins.get('UCX') and ucx_dep.found()
-    subdir('gtest')
-endif
+subdir('gtest')


### PR DESCRIPTION
## What?
Don't condition gtest on UCX availability.

## Why?
The gtest suite was only built when UCX was enabled, which meant OBJ plugin unit tests were silently skipped on builds without UCX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified test build configuration to always include the gtest test suite during test builds.
  * Refined conditional dependencies for hardware warning tests to ensure proper test execution when required components are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->