### PR TITLE
nixlbench: fix stats computation and memory management bugs

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -1081,10 +1081,12 @@ xferBenchUtils::printStats(bool is_target,
     double avg_latency = 0, throughput_gb = 0;
     double totalbw = 0;
 
-    int num_iter = xferBenchConfig::num_iter;
+    int total_iter = xferBenchConfig::num_iter;
+    int per_thread_iter = total_iter / xferBenchConfig::num_threads;
 
     if (block_size > LARGE_BLOCK_SIZE) {
-        num_iter /= xferBenchConfig::large_blk_iter_ftr;
+        total_iter /= xferBenchConfig::large_blk_iter_ftr;
+        per_thread_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
     // Targets don't participate in reduction - they have no throughput to contribute
@@ -1094,8 +1096,8 @@ xferBenchUtils::printStats(bool is_target,
 
     double total_duration = stats.total_duration.avg();
 
-    total_data_transferred = ((block_size * batch_size) * num_iter); // In Bytes
-    avg_latency = (total_duration / (num_iter * batch_size)); // In microsec
+    total_data_transferred = ((block_size * batch_size) * total_iter); // In Bytes
+    avg_latency = (total_duration / (per_thread_iter * batch_size)); // In microsec
     if (IS_PAIRWISE_AND_MG() ||
         (IS_PAIRWISE_AND_SG() && xferBenchConfig::num_initiator_dev > 1 && rt->getSize() == 1)) {
         total_data_transferred *= xferBenchConfig::num_initiator_dev; // In Bytes

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1011,12 +1011,12 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
         }
     } else if (xferBenchConfig::isStorageBackend()) {
         for (auto &iov_list : remote_iovs) {
-            for (auto &iov : iov_list) {
-                cleanupBasicDescFile(iov);
-            }
             nixl_reg_dlist_t desc_list(FILE_SEG);
             iovListToNixlRegDlist(iov_list, desc_list);
             CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+            for (auto &iov : iov_list) {
+                cleanupBasicDescFile(iov);
+            }
         }
     }
 

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1002,12 +1002,12 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
         }
     } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_GUSLI) {
         for (auto &iov_list : remote_iovs) {
-            for (auto &iov : iov_list) {
-                cleanupBasicDescBlk(iov);
-            }
             nixl_reg_dlist_t desc_list(BLK_SEG);
             iovListToNixlRegDlist(iov_list, desc_list);
             CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+            for (auto &iov : iov_list) {
+                cleanupBasicDescBlk(iov);
+            }
         }
     } else if (xferBenchConfig::isStorageBackend()) {
         for (auto &iov_list : remote_iovs) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -973,9 +973,9 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         if (seg_type == DRAM_SEG && xferBenchConfig::check_consistency) {
             for (auto &iov : iov_list) {
                 if (isInitiator()) {
-                    memset((void *)iov.addr, XFERBENCH_INITIATOR_BUFFER_ELEMENT, buffer_size);
+                    memset((void *)iov.addr, XFERBENCH_INITIATOR_BUFFER_ELEMENT, iov.len);
                 } else if (isTarget()) {
-                    memset((void *)iov.addr, XFERBENCH_TARGET_BUFFER_ELEMENT, buffer_size);
+                    memset((void *)iov.addr, XFERBENCH_TARGET_BUFFER_ELEMENT, iov.len);
                 }
             }
         }
@@ -990,34 +990,15 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
 
 
     opt_args.backends.push_back(backend_engine);
-    for (auto &iov_list : iov_lists) {
-        nixl_reg_dlist_t desc_list(seg_type);
-        iovListToNixlRegDlist(iov_list, desc_list);
-        CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
-
-        for (auto &iov : iov_list) {
-            switch (seg_type) {
-            case DRAM_SEG:
-                cleanupBasicDescDram(iov);
-                break;
-            case VRAM_SEG:
-                cleanupBasicDescVram(iov);
-                break;
-            default:
-                std::cerr << "Unsupported mem type: " << seg_type << std::endl;
-                exit(EXIT_FAILURE);
-            }
-        }
-    }
 
     if (xferBenchConfig::isObjStorageBackend()) {
         for (auto &iov_list : remote_iovs) {
-            for (auto &iov : iov_list) {
-                cleanupBasicDescObj(iov);
-            }
             nixl_reg_dlist_t desc_list(OBJ_SEG);
             iovListToNixlRegDlist(iov_list, desc_list);
             CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+            for (auto &iov : iov_list) {
+                cleanupBasicDescObj(iov);
+            }
         }
     } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_GUSLI) {
         for (auto &iov_list : remote_iovs) {
@@ -1036,6 +1017,26 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
             nixl_reg_dlist_t desc_list(FILE_SEG);
             iovListToNixlRegDlist(iov_list, desc_list);
             CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+        }
+    }
+
+    for (auto &iov_list : iov_lists) {
+        nixl_reg_dlist_t desc_list(seg_type);
+        iovListToNixlRegDlist(iov_list, desc_list);
+        CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+
+        for (auto &iov : iov_list) {
+            switch (seg_type) {
+            case DRAM_SEG:
+                cleanupBasicDescDram(iov);
+                break;
+            case VRAM_SEG:
+                cleanupBasicDescVram(iov);
+                break;
+            default:
+                std::cerr << "Unsupported mem type: " << seg_type << std::endl;
+                exit(EXIT_FAILURE);
+            }
         }
     }
 }


### PR DESCRIPTION
  ## What?                                                                                                                                                                              
                  
  Fix two bugs in nixlbench:

  1. **Incorrect iteration counts in `printStats`**: Throughput was computed                                                                                                            
     using per-thread iterations instead of total iterations (all threads
     combined), and latency used total iterations instead of per-thread                                                                                                                 
     iterations. Since wall time covers all threads running in parallel,
     throughput needs the total count, while latency (per-thread sequential)                                                                                                            
     needs the per-thread count.                                                                                                                                                        
                                                                                                                                                                                        
  2. **Memory management issues in `deallocateMemory`/`allocateMemory`**:                                                                                                               
     - `deallocateMemory` deregistered IOVs in the wrong order — remote IOVs                                                                                                            
       (OBJ/BLK/FILE) must be deregistered before local IOVs, and for OBJ                                                                                                               
       the deregistration must happen before cleanup to avoid use-after-free.                                                                                                           
     - `memset` in `allocateMemory` used `buffer_size` instead of `iov.len`,                                                                                                            
       which could be wrong when the actual allocation size differs.  
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/nixl/pull/1548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected benchmark metric calculations to use per-thread iteration counts so latency and throughput are normalized accurately.
  * Fixed memory initialization to use each segment’s actual size, preventing incorrect initialization and improving measurement fidelity.

* **Refactor**
  * Reordered and deferred resource cleanup and deregistration for a more reliable, deterministic teardown and reduced risk of premature cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->