### PR TITLE
Fix NIXL_ERR_NOT_FOUND when deregistering FILE/BLK/OBJ with len==0

### DIFF
--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -119,6 +119,20 @@ private:
 using nixl_sec_dlist_t = nixlSecDescList;
 using section_map_t = std::map<section_key_t, nixlSecDescList>;
 
+/**
+ * @brief Normalize a section descriptor for file-like segments.
+ *
+ * For BLK_SEG, OBJ_SEG, and FILE_SEG, a zero-length registration is stored
+ * internally with len = SIZE_MAX (unlimited range).
+ */
+inline nixlBasicDesc
+normalizeSecDesc(const nixlBasicDesc &desc, nixl_mem_t type) {
+    if ((type == BLK_SEG || type == OBJ_SEG || type == FILE_SEG) && desc.len == 0) {
+        return nixlBasicDesc(desc.addr, SIZE_MAX, desc.devId);
+    }
+    return desc;
+}
+
 class nixlMemSection {
     protected:
         std::array<backend_set_t, FILE_SEG+1>         memToBackend;

--- a/src/infra/nixl_descriptors.cpp
+++ b/src/infra/nixl_descriptors.cpp
@@ -446,8 +446,10 @@ nixlSecDescList::addDescs(nixlSecDescList &&other) {
 
 int
 nixlSecDescList::getIndex(const nixlBasicDesc &query) const {
-    auto itr = std::lower_bound(this->descs.begin(), this->descs.end(), query);
-    if (itr == this->descs.end() || static_cast<const nixlBasicDesc &>(*itr) != query)
+    const nixlBasicDesc adjusted_query = normalizeSecDesc(query, this->getType());
+
+    auto itr = std::lower_bound(this->descs.begin(), this->descs.end(), adjusted_query);
+    if (itr == this->descs.end() || static_cast<const nixlBasicDesc &>(*itr) != adjusted_query)
         return NIXL_ERR_NOT_FOUND;
     return static_cast<int>(itr - this->descs.begin());
 }

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -228,13 +228,21 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
     // First check if the mem_elms are present in the list,
     // don't deregister anything in case any is missing.
     for (auto & elm : mem_elms) {
-        int index = target.getIndex(elm);
+        nixlBasicDesc query = elm;
+        if (((nixl_mem == BLK_SEG) || (nixl_mem == OBJ_SEG) || (nixl_mem == FILE_SEG)) &&
+            (query.len == 0))
+            query.len = SIZE_MAX;
+        int index = target.getIndex(query);
         if (index < 0)
             return NIXL_ERR_NOT_FOUND;
     }
 
     for (auto & elm : mem_elms) {
-        int index = target.getIndex(elm);
+        nixlBasicDesc query = elm;
+        if (((nixl_mem == BLK_SEG) || (nixl_mem == OBJ_SEG) || (nixl_mem == FILE_SEG)) &&
+            (query.len == 0))
+            query.len = SIZE_MAX;
+        int index = target.getIndex(query);
         // Already checked, elm should always be found. Can add a check in debug mode.
         backend->deregisterMem(target[index].metadataP);
         target.remDesc(index);

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -181,10 +181,7 @@ nixlLocalSection::addDescList(const nixl_reg_dlist_t &mem_elms,
             }
         }
 
-        *lp = mem; // Copy the basic desc part
-        if (((nixl_mem == BLK_SEG) || (nixl_mem == OBJ_SEG) ||
-             (nixl_mem == FILE_SEG)) && (lp->len==0))
-            lp->len = SIZE_MAX; // File has no range limit
+        *lp = normalizeSecDesc(mem, nixl_mem); // Copy the basic desc part
 
         local_batch.push_back(local_sec);
 

--- a/test/gtest/unit/descriptors/sec_desc_list.cpp
+++ b/test/gtest/unit/descriptors/sec_desc_list.cpp
@@ -212,4 +212,53 @@ TEST_F(secDescListTest, AddRandomBatches) {
     }
 }
 
+TEST_F(secDescListTest, ZeroLenFileSegQuery) {
+    nixlSecDescList list(FILE_SEG);
+    // Simulate addDescList behavior: zero-length FILE_SEG is stored as SIZE_MAX
+    nixlSectionDesc desc(0, SIZE_MAX, 0);
+    list.addDesc(desc);
+
+    // Query with len=0 should match the stored SIZE_MAX entry
+    nixlBasicDesc query(0, 0, 0);
+    EXPECT_EQ(list.getIndex(query), 0);
+}
+
+TEST_F(secDescListTest, ZeroLenBlkSegQuery) {
+    nixlSecDescList list(BLK_SEG);
+    nixlSectionDesc desc(100, SIZE_MAX, 1);
+    list.addDesc(desc);
+
+    nixlBasicDesc query(100, 0, 1);
+    EXPECT_EQ(list.getIndex(query), 0);
+}
+
+TEST_F(secDescListTest, ZeroLenObjSegQuery) {
+    nixlSecDescList list(OBJ_SEG);
+    nixlSectionDesc desc(200, SIZE_MAX, 2);
+    list.addDesc(desc);
+
+    nixlBasicDesc query(200, 0, 2);
+    EXPECT_EQ(list.getIndex(query), 0);
+}
+
+TEST_F(secDescListTest, ZeroLenQueryNotFound) {
+    nixlSecDescList list(FILE_SEG);
+    nixlSectionDesc desc(0, SIZE_MAX, 0);
+    list.addDesc(desc);
+
+    // Different addr should not match
+    nixlBasicDesc query(1, 0, 0);
+    EXPECT_EQ(list.getIndex(query), NIXL_ERR_NOT_FOUND);
+}
+
+TEST_F(secDescListTest, ZeroLenDramSegQueryNotRewritten) {
+    nixlSecDescList list(DRAM_SEG);
+    // For DRAM_SEG, len=0 must remain len=0 — a stored SIZE_MAX entry must NOT match.
+    nixlSectionDesc stored(0, SIZE_MAX, 0);
+    list.addDesc(stored);
+
+    nixlBasicDesc query(0, 0, 0);
+    EXPECT_EQ(list.getIndex(query), NIXL_ERR_NOT_FOUND);
+}
+
 } // namespace descriptors


### PR DESCRIPTION
## What?
Fix deregisterMem returning `NIXL_ERR_NOT_FOUND` for `FILE_SEG`, `BLK_SEG`, and `OBJ_SEG` descriptors that were registered with `len == 0`.

In `nixlLocalSection::addDescList`, zero-length descriptors of these types are internally stored with `len = SIZE_MAX`("File has no range limit"). However, `nixlLocalSection::remDescList` performed lookups using the original `len == 0`, causing getIndex to fail because the stored and queried lengths no longer match.

This change aligns the lookup logic in `remDescList` with the storage logic in `addDescList`.

## Why?
When a plugin or application registers a file-like segment without knowing its exact size upfront (e.g., `len = 0`), NIXL core silently upgrades the stored length to `SIZE_MAX`. During cleanup, `deregisterMem` fails because `remDescList` cannot find the original (`addr=0, len=0`) descriptor in a list where it was stored as (`addr=0, len=SIZE_MAX`).

## How?
In `remDescList`, before each `target.getIndex()` call, construct a temporary `nixlBasicDesc` query from the user-provided element. If the memory type is `FILE_SEG`, `BLK_SEG`, or `OBJ_SEG` and `query.len == 0`, set `query.len = SIZE_MAX` so that the lookup matches the internal representation created by `addDescList`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-length queries for file, block, and object segments now consistently match stored entries by address and identifier; DRAM segment behavior unchanged. This reduces incorrect "not found" results for those queries.

* **Refactor**
  * Centralized query normalization so lookups behave uniformly across code paths.

* **Tests**
  * Added unit tests covering matching and non-matching zero-length query scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->