### PR TITLE
PLUGINS/UCX: Add SGL support for data transfers

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -30,6 +30,8 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include <asio.hpp>
+
+#include "common/configuration.h"
 namespace {
     void moveNotifList(notif_list_t &src, notif_list_t &tgt)
     {
@@ -62,6 +64,8 @@ private:
     };
     std::optional<Notif> notif;
 
+    nixlUcxSgl sgl_handle_;
+
     nixl_status_t
     checkConnection(nixl_status_t status = NIXL_SUCCESS) const {
         NIXL_ASSERT(!connections_.empty());
@@ -78,6 +82,21 @@ public:
     nixlUcxBackendH(nixlUcxWorker *worker, size_t worker_id)
         : worker(worker),
           worker_id(worker_id) {}
+
+    void
+    setPreparedSgl(nixlUcxSgl handle) {
+        sgl_handle_ = std::move(handle);
+    }
+
+    nixlUcxSglDesc *
+    getSglHandle() const {
+        return sgl_handle_.get();
+    }
+
+    void
+    releaseSgl() {
+        sgl_handle_.reset();
+    }
 
     auto &
     notification() {
@@ -475,6 +494,9 @@ struct nixlUcxBackendSharedState {
 void
 nixlUcxChunkBackendH::complete(nixl_status_t status) {
     NIXL_ASSERT(sharedState_.get() != nullptr);
+
+    releaseSgl();
+
     if (status != NIXL_SUCCESS) {
         nixlUcxBackendH::release();
         sharedState_->status.store(status);
@@ -698,6 +720,59 @@ nixlUcxThreadPoolEngine::~nixlUcxThreadPoolEngine() {
 }
 
 nixl_status_t
+nixlUcxThreadPoolEngine::postSglForChunk(const nixl_xfer_op_t &operation,
+                                         const nixl_meta_dlist_t &local,
+                                         const nixl_meta_dlist_t &remote,
+                                         const std::string &remote_agent,
+                                         nixlUcxChunkBackendH *chunk_handle,
+                                         size_t worker_id,
+                                         size_t start_idx,
+                                         size_t end_idx) const {
+    ucx_connection_ptr_t conn = getConnection(remote_agent);
+    if (!conn) {
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    auto &ep = conn->getEp(worker_id);
+    chunk_handle->reserve(3);
+
+    nixlUcxSgl sgl;
+    nixl_status_t ret = prepareSglForRange(operation,
+                                           local,
+                                           remote,
+                                           worker_id,
+                                           start_idx,
+                                           end_idx,
+                                           sgl);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    nixlUcxReq sgl_req = nullptr;
+    ret = ep->postSgl(sgl.get(), sgl_req);
+    if (ret < NIXL_SUCCESS) {
+        return ret;
+    }
+
+    chunk_handle->setPreparedSgl(std::move(sgl));
+
+    ret = chunk_handle->append(ret, sgl_req, conn);
+    if (ret != NIXL_SUCCESS) {
+        chunk_handle->releaseSgl();
+        return ret;
+    }
+
+    nixlUcxReq flush_req;
+    nixl_status_t flush_ret = ep->flushEp(flush_req);
+    ret = chunk_handle->append(flush_ret, flush_req, conn);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
 nixlUcxThreadPoolEngine::prepXfer(const nixl_xfer_op_t &operation,
                                   const nixl_meta_dlist_t &local,
                                   const nixl_meta_dlist_t &remote,
@@ -755,8 +830,22 @@ nixlUcxThreadPoolEngine::sendXferRange(const nixl_xfer_op_t &operation,
 
             size_t start_idx = i * chunk_size;
             size_t end_idx = std::min(start_idx + chunk_size, (size_t)local.descCount());
-            nixl_status_t ret = nixlUcxEngine::sendXferRange(
-                operation, local, remote, remote_agent, chunk_handle, start_idx, end_idx);
+
+            nixl_status_t ret;
+            if (isSglApiEnabled() && operation == NIXL_WRITE) {
+                ret = postSglForChunk(operation,
+                                      local,
+                                      remote,
+                                      remote_agent,
+                                      chunk_handle,
+                                      thread->getWorkerId(),
+                                      start_idx,
+                                      end_idx);
+            } else {
+                ret = nixlUcxEngine::sendXferRange(
+                    operation, local, remote, remote_agent, chunk_handle, start_idx, end_idx);
+            }
+
             if (ret != NIXL_SUCCESS) {
                 status.store(ret);
                 chunk_handle->complete(ret);
@@ -821,7 +910,9 @@ nixlUcxEngine::create(const nixlBackendInitParams &init_params) {
 nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
     : nixlBackendEngine(&init_params),
       sharedWorkerIndex_(1),
-      progressThreadEnabled_(init_params.enableProgTh) {
+      progressThreadEnabled_(init_params.enableProgTh),
+      sglApiEnabled_(
+          nixl::config::getValueDefaulted<bool>("NIXL_UCX_ENABLE_SGL_API", false)) {
     std::vector<std::string> devs; /* Empty vector */
     nixl_b_params_t *custom_params = init_params.customParams;
 
@@ -1091,6 +1182,35 @@ nixlUcxEngine::getWorkerIdFromOptArgs(const nixl_opt_b_args_t &opt_args) const n
     }
 }
 
+nixl_status_t
+nixlUcxEngine::prepareSglForRange(const nixl_xfer_op_t &operation,
+                                  const nixl_meta_dlist_t &local,
+                                  const nixl_meta_dlist_t &remote,
+                                  size_t worker_id,
+                                  size_t start_idx,
+                                  size_t end_idx,
+                                  nixlUcxSgl &sgl_handle) const {
+    size_t sgl_size = end_idx - start_idx;
+
+    auto sgl = std::make_unique<nixlUcxSglDesc>();
+    sgl->resize(sgl_size);
+
+    for (size_t i = start_idx; i < end_idx; i++) {
+        size_t idx = i - start_idx;
+        auto lmd = static_cast<nixlUcxPrivateMetadata *>(local[i].metadataP);
+        auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[i].metadataP);
+
+        sgl->localVas[idx] = (void *)local[i].addr;
+        sgl->remoteVas[idx] = static_cast<uint64_t>(remote[i].addr);
+        sgl->lengths[idx] = local[i].len;
+        sgl->memhs[idx] = lmd->mem.getMemh();
+        sgl->rkeys[idx] = rmd->getRkey(worker_id).get();
+    }
+
+    sgl_handle = std::move(sgl);
+    return NIXL_SUCCESS;
+}
+
 nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
                                        const nixl_meta_dlist_t &local,
                                        const nixl_meta_dlist_t &remote,
@@ -1108,6 +1228,35 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
     auto *ucx_handle = new nixlUcxBackendH(getWorker(worker_id).get(), worker_id);
 
     handle = ucx_handle;
+
+    if (isSglApiEnabled() && operation == NIXL_WRITE) {
+        ucx_connection_ptr_t conn = getConnection(remote_agent);
+        if (!conn) {
+            NIXL_ERROR << "No connection found for remote agent: " << remote_agent;
+            delete ucx_handle;
+            handle = nullptr;
+            return NIXL_ERR_NOT_FOUND;
+        }
+
+        size_t lcnt = local.descCount();
+
+        nixlUcxSgl sgl;
+        nixl_status_t sgl_status = prepareSglForRange(operation,
+                                                      local,
+                                                      remote,
+                                                      worker_id,
+                                                      0,
+                                                      lcnt,
+                                                      sgl);
+
+        if (sgl_status != NIXL_SUCCESS) {
+            delete ucx_handle;
+            handle = nullptr;
+            return sgl_status;
+        }
+
+        ucx_handle->setPreparedSgl(std::move(sgl));
+    }
 
     return NIXL_SUCCESS;
 }
@@ -1168,15 +1317,15 @@ nixl_status_t nixlUcxEngine::estimateXferCost (const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
-nixlUcxEngine::batchResult
-nixlUcxEngine::sendXferRangeBatch(nixlUcxEp &ep,
-                                  nixl_xfer_op_t operation,
-                                  const nixl_meta_dlist_t &local,
-                                  const nixl_meta_dlist_t &remote,
-                                  size_t worker_id,
-                                  size_t start_idx,
-                                  size_t end_idx) {
-    batchResult result = {NIXL_SUCCESS, 0, nullptr};
+nixlUcxEngine::sglResult
+nixlUcxEngine::sendXferRangeSgl(nixlUcxEp &ep,
+                                nixl_xfer_op_t operation,
+                                const nixl_meta_dlist_t &local,
+                                const nixl_meta_dlist_t &remote,
+                                size_t worker_id,
+                                size_t start_idx,
+                                size_t end_idx) {
+    sglResult result = {NIXL_SUCCESS, 0, nullptr};
 
     for (size_t i = start_idx; i < end_idx; ++i) {
         void *laddr = (void *)local[i].addr;
@@ -1238,11 +1387,15 @@ nixlUcxEngine::sendXferRange(const nixl_xfer_op_t &operation,
      * one flush request, and one notification request */
     intHandle->reserve(3);
 
+    if (operation == NIXL_WRITE && intHandle->getSglHandle() != nullptr) {
+        return postPreparedSgl(intHandle, remote_agent);
+    }
+
     for (size_t i = start_idx; i < end_idx;) {
         /* Send requests to a single EP */
         auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[i].metadataP);
         auto &ep = rmd->conn->getEp(workerId);
-        auto result = sendXferRangeBatch(*ep, operation, local, remote, workerId, i, end_idx);
+        auto result = sendXferRangeSgl(*ep, operation, local, remote, workerId, i, end_idx);
 
         /* Append a single pending request for the entire EP batch */
         ret = intHandle->append(result.status, result.req, rmd->conn);
@@ -1271,6 +1424,76 @@ nixlUcxEngine::sendXferRange(const nixl_xfer_op_t &operation,
 }
 
 nixl_status_t
+nixlUcxEngine::postPreparedSgl(nixlUcxBackendH *int_handle,
+                               const std::string &remote_agent) const {
+    ucx_connection_ptr_t conn = getConnection(remote_agent);
+    if (!conn) {
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    size_t worker_id = int_handle->getWorkerId();
+    auto &ep = conn->getEp(worker_id);
+    nixlUcxSglDesc *sgl = int_handle->getSglHandle();
+
+    NIXL_ASSERT(sgl != nullptr);
+
+    int_handle->reserve(3);
+
+    nixlUcxReq sgl_req = nullptr;
+    nixl_status_t ret = ep->postSgl(sgl, sgl_req);
+
+    if (ret < NIXL_SUCCESS) {
+        return ret;
+    }
+
+    ret = int_handle->append(ret, sgl_req, conn);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    nixlUcxReq flush_req;
+    ret = ep->flushEp(flush_req);
+    if (int_handle->append(ret, flush_req, conn) != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxEngine::postXferSgl(nixlUcxBackendH *int_handle,
+                           const std::string &remote_agent,
+                           const nixl_opt_b_args_t *opt_args) const {
+    nixl_status_t ret = postPreparedSgl(int_handle, remote_agent);
+    if (ret != NIXL_SUCCESS) {
+        return ret;
+    }
+
+    ret = int_handle->status();
+    if (opt_args && opt_args->hasNotif) {
+        if (ret == NIXL_SUCCESS) {
+            ucx_connection_ptr_t conn = getConnection(remote_agent);
+            if (!conn) {
+                return NIXL_ERR_NOT_FOUND;
+            }
+            nixlUcxReq notif_req;
+            ret = notifSendPriv(remote_agent,
+                                opt_args->notifMsg,
+                                conn->getEp(int_handle->getWorkerId()),
+                                &notif_req);
+            if (int_handle->append(ret, notif_req, conn) != NIXL_SUCCESS) {
+                return ret;
+            }
+            ret = int_handle->status();
+        } else if (ret == NIXL_IN_PROG) {
+            int_handle->notification().emplace(remote_agent, opt_args->notifMsg);
+        }
+    }
+
+    return ret;
+}
+
+nixl_status_t
 nixlUcxEngine::postXfer(const nixl_xfer_op_t &operation,
                         const nixl_meta_dlist_t &local,
                         const nixl_meta_dlist_t &remote,
@@ -1289,6 +1512,10 @@ nixlUcxEngine::postXfer(const nixl_xfer_op_t &operation,
     }
 
     // TODO: assert that handle is empty/completed, as we can't post request before completion
+
+    if (operation == NIXL_WRITE && int_handle->getSglHandle() != nullptr) {
+        return postXferSgl(int_handle, remote_agent, opt_args);
+    }
 
     ret = sendXferRange(operation, local, remote, remote_agent, handle, 0, lcnt);
     if (ret != NIXL_SUCCESS) {
@@ -1352,6 +1579,9 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
 nixl_status_t nixlUcxEngine::releaseReqH(nixlBackendReqH* handle) const
 {
     nixlUcxBackendH *intHandle = (nixlUcxBackendH *)handle;
+
+    intHandle->releaseSgl();
+
     nixl_status_t status = intHandle->release();
 
     /* TODO: return to a pool instead. */

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -54,6 +54,8 @@ class nixlUcxConnection : public nixlBackendConnMD {
 
 using ucx_connection_ptr_t = std::shared_ptr<nixlUcxConnection>;
 
+class nixlUcxBackendH;
+
 // A private metadata has to implement get, and has all the metadata
 class nixlUcxPrivateMetadata : public nixlBackendMD {
     private:
@@ -74,6 +76,7 @@ class nixlUcxPrivateMetadata : public nixlBackendMD {
         }
 
     friend class nixlUcxEngine;
+    friend class nixlUcxThreadPoolEngine;
 };
 
 // A public metadata has to implement put, and only has the remote metadata
@@ -173,6 +176,14 @@ public:
                      const nixl_opt_args_t *opt_args = nullptr) const override;
 
     nixl_status_t
+    postPreparedSgl(nixlUcxBackendH *int_handle, const std::string &remote_agent) const;
+
+    [[nodiscard]] nixl_status_t
+    postXferSgl(nixlUcxBackendH *int_handle,
+                const std::string &remote_agent,
+                const nixl_opt_b_args_t *opt_args) const;
+
+    nixl_status_t
     postXfer(const nixl_xfer_op_t &operation,
              const nixl_meta_dlist_t &local,
              const nixl_meta_dlist_t &remote,
@@ -228,6 +239,11 @@ protected:
         return uws.size();
     }
 
+    [[nodiscard]] bool
+    isSglApiEnabled() const noexcept {
+        return sglApiEnabled_;
+    }
+
     void
     getNotifsImpl(notif_list_t &notif_list);
 
@@ -243,8 +259,19 @@ protected:
                   size_t start_idx,
                   size_t end_idx) const;
 
-    nixlUcxEngine(const nixlBackendInitParams &init_params);
+    ucx_connection_ptr_t
+    getConnection(const std::string &remote_agent) const;
 
+    nixl_status_t
+    prepareSglForRange(const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       size_t worker_id,
+                       size_t start_idx,
+                       size_t end_idx,
+                       nixlUcxSgl &sgl_handle) const;
+
+    nixlUcxEngine(const nixlBackendInitParams &init_params);
 private:
     // Memory management helpers
     nixl_status_t
@@ -265,23 +292,20 @@ private:
                   const std::unique_ptr<nixlUcxEp> &ep,
                   nixlUcxReq *req = nullptr) const;
 
-    ucx_connection_ptr_t
-    getConnection(const std::string &remote_agent) const;
-
-    struct batchResult {
+    struct sglResult {
         nixl_status_t status;
         size_t size;
         nixlUcxReq req;
     };
 
-    static batchResult
-    sendXferRangeBatch(nixlUcxEp &ep,
-                       nixl_xfer_op_t operation,
-                       const nixl_meta_dlist_t &local,
-                       const nixl_meta_dlist_t &remote,
-                       size_t worker_id,
-                       size_t start_idx,
-                       size_t end_idx);
+    static sglResult
+    sendXferRangeSgl(nixlUcxEp &ep,
+                     nixl_xfer_op_t operation,
+                     const nixl_meta_dlist_t &local,
+                     const nixl_meta_dlist_t &remote,
+                     size_t worker_id,
+                     size_t start_idx,
+                     size_t end_idx);
 
     /**
      * Get the worker ID from the optional arguments.
@@ -297,6 +321,11 @@ private:
     mutable std::atomic<size_t> sharedWorkerIndex_;
 
     const bool progressThreadEnabled_;
+
+    // Runtime gate for the SGL fast path, set from NIXL_UCX_ENABLE_SGL_API.
+    // TODO: replace with a compile-time #ifdef once the UCX SGL API is
+    //       fully supported and meson detection is in place.
+    const bool sglApiEnabled_;
 
     /* Notifications */
     notif_list_t notifMainList;
@@ -331,6 +360,8 @@ private:
 namespace asio {
 class io_context;
 }
+
+class nixlUcxChunkBackendH;
 
 class nixlUcxThreadPoolEngine : public nixlUcxEngine {
 public:
@@ -367,6 +398,16 @@ protected:
                   size_t end_idx) const override;
 
 private:
+    nixl_status_t
+    postSglForChunk(const nixl_xfer_op_t &operation,
+                    const nixl_meta_dlist_t &local,
+                    const nixl_meta_dlist_t &remote,
+                    const std::string &remote_agent,
+                    nixlUcxChunkBackendH *chunk_handle,
+                    size_t worker_id,
+                    size_t start_idx,
+                    size_t end_idx) const;
+
     std::unique_ptr<asio::io_context> io_;
     std::unique_ptr<nixlUcxThread> sharedThread_;
     std::vector<std::unique_ptr<nixlUcxThread>> dedicatedThreads_;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -372,6 +372,48 @@ nixlUcxEp::flushEp(nixlUcxReq &req) {
     return ucx_status_to_nixl(UCS_PTR_STATUS(request));
 }
 
+nixl_status_t
+nixlUcxEp::postSgl(const nixlUcxSglDesc *sgl, nixlUcxReq &req) {
+    nixl_status_t status = checkTxState();
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    if (sgl == nullptr || sgl->localVas.empty()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    size_t count = sgl->localVas.size();
+    ucp_dt_local_sgl_t local_sgl = sgl->toLocalSgl();
+    ucp_dt_remote_sgl_t remote_sgl = sgl->toRemoteSgl();
+
+    ucp_request_param_t param = {
+        .op_attr_mask = UCP_OP_ATTR_FIELD_DATATYPE |
+                        UCP_OP_ATTR_FIELD_REMOTE_DATATYPE |
+                        UCP_OP_ATTR_FIELD_REMOTE |
+                        UCP_OP_ATTR_FIELD_REMOTE_COUNT,
+        .datatype = ucp_dt_make_sgl(),
+        .remote_datatype = ucp_dt_make_sgl(),
+        .remote = &remote_sgl,
+        .remote_count = count
+    };
+
+    ucs_status_ptr_t request = ucp_put_nbx(eph,
+                                           &local_sgl,
+                                           count,
+                                           UCP_REMOTE_ADDR_INVALID,
+                                           UCP_RKEY_INVALID,
+                                           &param);
+
+    if (UCS_PTR_IS_PTR(request)) {
+        req = request;
+        return NIXL_IN_PROG;
+    }
+
+    req = nullptr;
+    return ucx_status_to_nixl(UCS_PTR_STATUS(request));
+}
+
 bool
 nixlUcxMtLevelIsSupported(const nixl_ucx_mt_t mt_type) noexcept {
     ucp_lib_attr_t attr;

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -77,6 +77,48 @@ nixl_b_params_get(const nixl_b_params_t *custom_params, const std::string &key, 
 
 using nixlUcxReq = void *;
 
+struct nixlUcxSglDesc {
+    std::vector<void *> localVas;
+    std::vector<uint64_t> remoteVas;
+    std::vector<size_t> lengths;
+    std::vector<ucp_mem_h> memhs;
+    std::vector<ucp_rkey_h> rkeys;
+
+    void
+    resize(size_t n) {
+        localVas.resize(n);
+        remoteVas.resize(n);
+        lengths.resize(n);
+        memhs.resize(n);
+        rkeys.resize(n);
+    }
+
+    ucp_dt_local_sgl_t
+    toLocalSgl() const {
+        ucp_dt_local_sgl_t v = {};
+        v.field_mask = UCP_DT_LOCAL_SGL_FIELD_BUFFERS |
+                       UCP_DT_LOCAL_SGL_FIELD_LENGTHS |
+                       UCP_DT_LOCAL_SGL_FIELD_MEMHS;
+        v.buffers = localVas.data();
+        v.lengths = lengths.data();
+        v.memhs = memhs.data();
+        return v;
+    }
+
+    ucp_dt_remote_sgl_t
+    toRemoteSgl() const {
+        ucp_dt_remote_sgl_t v = {};
+        v.field_mask = UCP_DT_REMOTE_SGL_FIELD_REMOTE_ADDRS |
+                       UCP_DT_REMOTE_SGL_FIELD_LENGTHS |
+                       UCP_DT_REMOTE_SGL_FIELD_RKEYS;
+        v.remote_addrs = remoteVas.data();
+        v.lengths = lengths.data();
+        v.rkeys = rkeys.data();
+        return v;
+    }
+};
+using nixlUcxSgl = std::unique_ptr<nixlUcxSglDesc>;
+
 namespace nixl::ucx {
 class rkey;
 }
@@ -165,6 +207,9 @@ public:
                  nixl_cost_t &method);
     nixl_status_t
     flushEp(nixlUcxReq &req);
+
+    [[nodiscard]] nixl_status_t
+    postSgl(const nixlUcxSglDesc *sgl, nixlUcxReq &req);
 
     [[nodiscard]] ucp_ep_h
     getEp() const noexcept {


### PR DESCRIPTION
## What?
Adds an opt-in UCX SGL (scatter-gather list) fast path for `NIXL_WRITE` transfers in the UCX backend, gated at runtime by the `NIXL_UCX_ENABLE_SGL_API` environment variable. Depends on the UCX-side SGL datatype API added in [openucx/ucx#11258](https://github.com/openucx/ucx/pull/11258) and follow-ups PRs.

## Why?
Posting a batch of writes via per-descriptor `ucp_put_nbx()` calls is a measurable bottleneck for multi-segment transfers. With the new SGL datatype from [openucx/ucx#11258](https://github.com/openucx/ucx/pull/11258), the whole batch can be issued in a single `ucp_put_nbx()` per EP, cutting down per-segment call/setup overhead.

## How?
- New `nixlUcxSglDesc` (parallel arrays of local/remote VAs, lengths, memhs, rkeys) and `nixlUcxEp::postSgl()` wrapping `ucp_put_nbx` with `ucp_dt_make_sgl()` from [openucx/ucx#11258](https://github.com/openucx/ucx/pull/11258).
- `nixlUcxEngine::prepXfer()` builds the SGL once and attaches it to the backend handle; `sendXferRange()` / `postXfer()` short-circuit to `postPreparedSgl()` / `postXferSgl()` when an SGL is attached. Thread-pool engine builds and posts a per-chunk SGL via `postSglForChunk()`.
- The path is fully opt-in: `nixlUcxEngine::sglApiEnabled_` is read from `NIXL_UCX_ENABLE_SGL_API` in the ctor (default off), exposed to subclasses via `isSglApiEnabled()`. With the env var unset, behavior is identical to today.
- TODO left on `sglApiEnabled_` to switch to a compile-time `#ifdef` once meson detection for the SGL API lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scatter-Gather List (SGL) support for data transfers with an optional configuration flag (`NIXL_UCX_ENABLE_SGL_API`) to enable the feature
  * Enhanced data transfer preparation and execution with SGL-based operations for improved flexibility

* **Chores**
  * Improved resource management and lifecycle handling for transfer operations
  * Extended support for SGL operations in threadpool-based chunking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->