### PR TITLE
nixlbench: add support for device API

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -155,10 +155,6 @@ if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
 
-if cuda_available
-    add_languages('cuda', native: false)
-endif
-
 ucx_device_cpp_args = []
 ucx_device_cuda_args = []
 ucx_device_override_options = []
@@ -169,6 +165,7 @@ if ucx_device_include_path != ''
     elif nvshmem_available
         warning('Ignoring -Ducx_device_include_path because NVSHMEM build path is enabled.')
     else
+        add_languages('cuda', native: false)
         build_nixlbench_kernels = true
         ucx_device_cpp_args = ['-I' + ucx_device_include_path]
         ucx_device_cuda_args = [

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -30,6 +30,7 @@ fs = import('fs')
 cuda_inc_path = get_option('cudapath_inc')
 cuda_lib_path = get_option('cudapath_lib')
 cuda_stub_path = get_option('cudapath_stub')
+ucx_device_include_path = get_option('ucx_device_include_path')
 # ETCD
 etcd_inc_path = get_option('etcd_inc_path')
 etcd_lib_path = get_option('etcd_lib_path')
@@ -158,6 +159,28 @@ if cuda_available
     add_languages('cuda', native: false)
 endif
 
+ucx_device_cpp_args = []
+ucx_device_cuda_args = []
+ucx_device_override_options = []
+build_nixlbench_kernels = false
+if ucx_device_include_path != ''
+    if not cuda_available
+        warning('Ignoring -Ducx_device_include_path because CUDA is unavailable.')
+    elif nvshmem_available
+        warning('Ignoring -Ducx_device_include_path because NVSHMEM build path is enabled.')
+    else
+        build_nixlbench_kernels = true
+        ucx_device_cpp_args = ['-I' + ucx_device_include_path]
+        ucx_device_cuda_args = [
+            '-I' + ucx_device_include_path,
+            '-gencode=arch=compute_80,code=sm_80',
+            '-gencode=arch=compute_90,code=sm_90',
+        ]
+        ucx_device_override_options = ['optimization=0']
+        add_project_arguments(ucx_device_cpp_args, language: 'cpp')
+    endif
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')
@@ -172,6 +195,7 @@ configure_file(
         'HAVE_NVSHMEM': nvshmem_available ? '1' : '0',
         'HAVE_CUDA': cuda_available ? '1' : '0',
         'HAVE_CUDA_FABRIC': cuda_fabric_available ? '1' : '0',
+        'HAVE_UCX_DEVICE_KERNEL': build_nixlbench_kernels ? '1' : '0',
     },
     install: true,
     install_dir: get_option('includedir') / 'nixlbench'
@@ -183,7 +207,10 @@ if etcd_available
     deps += [etcd_dep]
 endif
 if cuda_available
-    deps += [cuda_dep, nixlbench_kernels_dep]
+    deps += [cuda_dep]
+endif
+if build_nixlbench_kernels
+    deps += [nixlbench_kernels_dep]
 endif
 if nvshmem_available
     deps += [nvshmem_lib]
@@ -220,7 +247,7 @@ if nvshmem_available
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/runtime']
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/worker']
     nvcc_args += ['-lnixl', '-lnixl_build', '-lserdes', '-lcuda', '-lcudart', '-lnvshmem']
-    if cuda_available
+    if build_nixlbench_kernels
         nvcc_args += ['-L' + meson.current_build_dir() + '/src/kernels', '-lnixlbench_kernels']
     endif
     nvcc_args += args
@@ -249,7 +276,7 @@ if nvshmem_available
         install: true,
         install_dir: get_option('bindir'),
         depends: [nixlbench_runtimes, utils_lib, worker_libs] +
-            (cuda_available ? [nixlbench_kernels_lib] : []))
+            (build_nixlbench_kernels ? [nixlbench_kernels_lib] : []))
 else
     executable('nixlbench', 'src/main.cpp',
                 include_directories: inc_dir,

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -154,10 +154,15 @@ if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
 
+if cuda_available
+    add_languages('cuda', native: false)
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')
 subdir('src/worker')
+subdir('src/kernels')
 
 # Configure header file
 configure_file(
@@ -178,7 +183,7 @@ if etcd_available
     deps += [etcd_dep]
 endif
 if cuda_available
-    deps += [cuda_dep]
+    deps += [cuda_dep, nixlbench_kernels_dep]
 endif
 if nvshmem_available
     deps += [nvshmem_lib]
@@ -215,6 +220,9 @@ if nvshmem_available
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/runtime']
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/worker']
     nvcc_args += ['-lnixl', '-lnixl_build', '-lserdes', '-lcuda', '-lcudart', '-lnvshmem']
+    if cuda_available
+        nvcc_args += ['-L' + meson.current_build_dir() + '/src/kernels', '-lnixlbench_kernels']
+    endif
     nvcc_args += args
     nvcc_cmd_files = [
                  meson.current_build_dir() + '/src/utils/libutils.a.p/utils.cpp.o',
@@ -240,7 +248,8 @@ if nvshmem_available
         build_by_default: true,
         install: true,
         install_dir: get_option('bindir'),
-        depends: [nixlbench_runtimes, utils_lib, worker_libs])
+        depends: [nixlbench_runtimes, utils_lib, worker_libs] +
+            (cuda_available ? [nixlbench_kernels_lib] : []))
 else
     executable('nixlbench', 'src/main.cpp',
                 include_directories: inc_dir,

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -154,10 +154,6 @@ if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
 
-if cuda_available
-    add_languages('cuda', native: false)
-endif
-
 ucx_device_cpp_args = []
 ucx_device_cuda_args = []
 ucx_device_override_options = []
@@ -168,6 +164,7 @@ if ucx_device_include_path != ''
     elif nvshmem_available
         warning('Ignoring -Ducx_device_include_path because NVSHMEM build path is enabled.')
     else
+        add_languages('cuda', native: false)
         build_nixlbench_kernels = true
         ucx_device_cpp_args = ['-I' + ucx_device_include_path]
         ucx_device_cuda_args = [

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -30,6 +30,7 @@ fs = import('fs')
 cuda_inc_path = get_option('cudapath_inc')
 cuda_lib_path = get_option('cudapath_lib')
 cuda_stub_path = get_option('cudapath_stub')
+ucx_device_include_path = get_option('ucx_device_include_path')
 # ETCD
 etcd_inc_path = get_option('etcd_inc_path')
 etcd_lib_path = get_option('etcd_lib_path')
@@ -157,6 +158,28 @@ if cuda_available
     add_languages('cuda', native: false)
 endif
 
+ucx_device_cpp_args = []
+ucx_device_cuda_args = []
+ucx_device_override_options = []
+build_nixlbench_kernels = false
+if ucx_device_include_path != ''
+    if not cuda_available
+        warning('Ignoring -Ducx_device_include_path because CUDA is unavailable.')
+    elif nvshmem_available
+        warning('Ignoring -Ducx_device_include_path because NVSHMEM build path is enabled.')
+    else
+        build_nixlbench_kernels = true
+        ucx_device_cpp_args = ['-I' + ucx_device_include_path]
+        ucx_device_cuda_args = [
+            '-I' + ucx_device_include_path,
+            '-gencode=arch=compute_80,code=sm_80',
+            '-gencode=arch=compute_90,code=sm_90',
+        ]
+        ucx_device_override_options = ['optimization=0']
+        add_project_arguments(ucx_device_cpp_args, language: 'cpp')
+    endif
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')
@@ -171,6 +194,7 @@ configure_file(
         'HAVE_NVSHMEM': nvshmem_available ? '1' : '0',
         'HAVE_CUDA': cuda_available ? '1' : '0',
         'HAVE_CUDA_FABRIC': cuda_fabric_available ? '1' : '0',
+        'HAVE_UCX_DEVICE_KERNEL': build_nixlbench_kernels ? '1' : '0',
     },
     install: true,
     install_dir: get_option('includedir') / 'nixlbench'
@@ -182,7 +206,10 @@ if etcd_available
     deps += [etcd_dep]
 endif
 if cuda_available
-    deps += [cuda_dep, nixlbench_kernels_dep]
+    deps += [cuda_dep]
+endif
+if build_nixlbench_kernels
+    deps += [nixlbench_kernels_dep]
 endif
 if nvshmem_available
     deps += [nvshmem_lib]
@@ -219,7 +246,7 @@ if nvshmem_available
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/runtime']
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/worker']
     nvcc_args += ['-lnixl', '-lnixl_build', '-lserdes', '-lcuda', '-lcudart', '-lnvshmem']
-    if cuda_available
+    if build_nixlbench_kernels
         nvcc_args += ['-L' + meson.current_build_dir() + '/src/kernels', '-lnixlbench_kernels']
     endif
     nvcc_args += args
@@ -248,7 +275,7 @@ if nvshmem_available
         install: true,
         install_dir: get_option('bindir'),
         depends: [nixlbench_runtimes, utils_lib, worker_libs] +
-            (cuda_available ? [nixlbench_kernels_lib] : []))
+            (build_nixlbench_kernels ? [nixlbench_kernels_lib] : []))
 else
     executable('nixlbench', 'src/main.cpp',
                 include_directories: inc_dir,

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -153,10 +153,15 @@ if cuda_fabric_available
     add_project_arguments('-DHAVE_CUDA_FABRIC', language: 'cpp')
 endif
 
+if cuda_available
+    add_languages('cuda', native: false)
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')
 subdir('src/worker')
+subdir('src/kernels')
 
 # Configure header file
 configure_file(
@@ -177,7 +182,7 @@ if etcd_available
     deps += [etcd_dep]
 endif
 if cuda_available
-    deps += [cuda_dep]
+    deps += [cuda_dep, nixlbench_kernels_dep]
 endif
 if nvshmem_available
     deps += [nvshmem_lib]
@@ -214,6 +219,9 @@ if nvshmem_available
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/runtime']
     nvcc_args += ['-L' + meson.current_build_dir() + '/src/worker']
     nvcc_args += ['-lnixl', '-lnixl_build', '-lserdes', '-lcuda', '-lcudart', '-lnvshmem']
+    if cuda_available
+        nvcc_args += ['-L' + meson.current_build_dir() + '/src/kernels', '-lnixlbench_kernels']
+    endif
     nvcc_args += args
     nvcc_cmd_files = [
                  meson.current_build_dir() + '/src/utils/libutils.a.p/utils.cpp.o',
@@ -239,7 +247,8 @@ if nvshmem_available
         build_by_default: true,
         install: true,
         install_dir: get_option('bindir'),
-        depends: [nixlbench_runtimes, utils_lib, worker_libs])
+        depends: [nixlbench_runtimes, utils_lib, worker_libs] +
+            (cuda_available ? [nixlbench_kernels_lib] : []))
 else
     executable('nixlbench', 'src/main.cpp',
                 include_directories: inc_dir,

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -16,6 +16,8 @@
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
+option('ucx_device_include_path', type: 'string', value: '',
+       description: 'Path to UCX headers providing gpu/ucx/nixl_device.cuh for Device API kernels')
 option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD C++ Client includes')
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD C++ Client library')
 option('nixl_path', type: 'string', value: '/usr/local', description: 'Path to NiXL')

--- a/benchmark/nixlbench/src/kernels/meson.build
+++ b/benchmark/nixlbench/src/kernels/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 nixlbench_kernels_dep = []

--- a/benchmark/nixlbench/src/kernels/meson.build
+++ b/benchmark/nixlbench/src/kernels/meson.build
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 nixlbench_kernels_dep = []
+nixlbench_kernels_lib = []
 
-if cuda_available
+if build_nixlbench_kernels
   nixlbench_kernels_lib = static_library(
     'nixlbench_kernels',
     'nixlbench_device_launch.cu',
     include_directories: [inc_dir, include_directories('.')],
     dependencies: [cuda_dep],
+    cuda_args: ucx_device_cuda_args,
+    override_options: ucx_device_override_options,
   )
   nixlbench_kernels_dep = declare_dependency(
     link_with: nixlbench_kernels_lib,

--- a/benchmark/nixlbench/src/kernels/meson.build
+++ b/benchmark/nixlbench/src/kernels/meson.build
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+nixlbench_kernels_dep = []
+
+if cuda_available
+  nixlbench_kernels_lib = static_library(
+    'nixlbench_kernels',
+    'nixlbench_device_launch.cu',
+    include_directories: [inc_dir, include_directories('.')],
+    dependencies: [cuda_dep],
+  )
+  nixlbench_kernels_dep = declare_dependency(
+    link_with: nixlbench_kernels_lib,
+    include_directories: include_directories('.'),
+  )
+endif

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -23,24 +23,22 @@ namespace {
 /** Lane-0 xfer status slots per warp when blockDim.x <= 1024 (32 warps). */
 constexpr unsigned nixlbench_max_warps = 32u;
 
-template <nixl_gpu_level_t Level>
+template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchPutLevel(nixlbenchDeviceXferParams params,
                   size_t region_idx,
                   nixlGpuXferStatusH &xfer_status) {
     const nixlMemViewElem src{params.localMvh, region_idx, 0};
     const nixlMemViewElem dst{params.remoteMvh, region_idx, 0};
-    nixl_status_t status =
-        nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
+    nixl_status_t status = nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
     if (status != NIXL_IN_PROG) {
-        printf(
-            "[nixlbenchPutLevel] nixlPut did not return NIXL_IN_PROG: "
-            "region=%zu threadIdx.x=%u blockIdx.x=%u blockDim.x=%u status=%d\n",
-            region_idx,
-            threadIdx.x,
-            blockIdx.x,
-            blockDim.x,
-            static_cast<int>(status));
+        printf("[nixlbenchPutLevel] nixlPut did not return NIXL_IN_PROG: "
+               "region=%zu threadIdx.x=%u blockIdx.x=%u blockDim.x=%u status=%d\n",
+               region_idx,
+               threadIdx.x,
+               blockIdx.x,
+               blockDim.x,
+               static_cast<int>(status));
         return false;
     }
 
@@ -49,21 +47,20 @@ nixlbenchPutLevel(nixlbenchDeviceXferParams params,
     } while (status == NIXL_IN_PROG);
 
     if (status != NIXL_SUCCESS) {
-        printf(
-            "[nixlbenchPutLevel] transfer did not complete: region=%zu "
-            "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
-            region_idx,
-            threadIdx.x,
-            blockIdx.x,
-            blockDim.x,
-            static_cast<int>(status));
+        printf("[nixlbenchPutLevel] transfer did not complete: region=%zu "
+               "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
+               region_idx,
+               threadIdx.x,
+               blockIdx.x,
+               blockDim.x,
+               static_cast<int>(status));
         return false;
     }
 
     return true;
 }
 
-template <nixl_gpu_level_t Level>
+template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
                        size_t counter_offset,
@@ -86,23 +83,22 @@ nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
         status = nixlGpuGetXferStatus<Level>(xfer_status);
     } while (status == NIXL_IN_PROG);
     if (status != NIXL_SUCCESS) {
-        printf(
-            "[nixlbenchSignalCounter] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
-            counter_name,
-            static_cast<int>(status));
+        printf("[nixlbenchSignalCounter] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
+               counter_name,
+               static_cast<int>(status));
         return false;
     }
     return true;
 }
 
-template <nixl_gpu_level_t Level>
+template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchSignalCompletion(nixlbenchDeviceXferParams params) {
     return nixlbenchSignalCounter<Level>(
         params, params.completionCounterOffsetBytes, 1ull, "completion");
 }
 
-template <nixl_gpu_level_t Level>
+template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchSignalError(nixlbenchDeviceXferParams params) {
     return nixlbenchSignalCounter<Level>(params, params.errorCounterOffsetBytes, 1ull, "error");
@@ -126,29 +122,31 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
     const bool use_thread_level = blockDim.x <= static_cast<unsigned>(warpSize);
     const unsigned lane = use_thread_level ? 0 : (threadIdx.x % warpSize);
     const unsigned group_id = use_thread_level ? threadIdx.x : (threadIdx.x / warpSize);
-    const unsigned num_groups = use_thread_level ? blockDim.x : ((blockDim.x + warpSize - 1) / warpSize);
+    const unsigned num_groups =
+        use_thread_level ? blockDim.x : ((blockDim.x + warpSize - 1) / warpSize);
     if (group_id >= num_groups || group_id >= nixlbench_max_warps) {
-        printf(
-            "[nixlbenchPutKernel] group_id out of range: "
-            "group_id=%u num_groups=%u max_warps=%u "
-            "threadIdx.x=%u blockDim.x=%u\n",
-            group_id,
-            num_groups,
-            nixlbench_max_warps,
-            threadIdx.x, blockDim.x);
+        printf("[nixlbenchPutKernel] group_id out of range: "
+               "group_id=%u num_groups=%u max_warps=%u "
+               "threadIdx.x=%u blockDim.x=%u\n",
+               group_id,
+               num_groups,
+               nixlbench_max_warps,
+               threadIdx.x,
+               blockDim.x);
         if (lane == 0) {
             atomicAdd(&put_fail_count, 1u);
         }
     } else {
         nixlGpuXferStatusH xfer_status{};
         bool put_failed = false;
-        for (size_t region_idx = group_id; region_idx < params.numRegions; region_idx += num_groups) {
+        for (size_t region_idx = group_id; region_idx < params.numRegions;
+             region_idx += num_groups) {
             if (use_thread_level) {
-                put_failed = !nixlbenchPutLevel<nixl_gpu_level_t::THREAD>(
-                    params, region_idx, xfer_status);
+                put_failed =
+                    !nixlbenchPutLevel<nixl_gpu_level_t::THREAD>(params, region_idx, xfer_status);
             } else {
-                put_failed = !nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
-                    params, region_idx, xfer_status);
+                put_failed =
+                    !nixlbenchPutLevel<nixl_gpu_level_t::WARP>(params, region_idx, xfer_status);
             }
             if (put_failed) {
                 break;
@@ -160,7 +158,7 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
                 atomicAdd(&put_fail_count, 1u);
             }
         } else if (__any_sync(__activemask(), put_failed) && lane == 0) {
-                atomicAdd(&put_fail_count, 1u);
+            atomicAdd(&put_fail_count, 1u);
         }
     }
 
@@ -186,10 +184,9 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
 } // namespace
 
 nixl_status_t
-nixlbenchLaunchDevicePut(
-    const nixlbenchDeviceXferParams &params,
-    unsigned block_threads,
-    cudaStream_t stream) {
+nixlbenchLaunchDevicePut(const nixlbenchDeviceXferParams &params,
+                         unsigned block_threads,
+                         cudaStream_t stream) {
     if (block_threads == 0 || block_threads > 1024u) {
         std::cerr << "nixlbench: nixlbenchLaunchDevicePut: invalid block_threads=" << block_threads
                   << " (must be 1..1024)\n";

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * GPU-side nixlPut after host-side prepMemView (see xferBenchNixlWorker::prepareGPULocalView
@@ -187,9 +187,18 @@ nixl_status_t
 nixlbenchLaunchDevicePut(const nixlbenchDeviceXferParams &params,
                          unsigned block_threads,
                          cudaStream_t stream) {
+    constexpr unsigned kWarpSize = 32;
+
     if (block_threads == 0 || block_threads > 1024u) {
         std::cerr << "nixlbench: nixlbenchLaunchDevicePut: invalid block_threads=" << block_threads
                   << " (must be 1..1024)\n";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (block_threads > kWarpSize && (block_threads % kWarpSize) != 0) {
+        std::cerr << "nixlbench: nixlbenchLaunchDevicePut: block_threads (" << block_threads
+                  << " ) must be <= or a multiple of " << kWarpSize
+                  << " (WARP-level nixlPut requires full warps)\n";
         return NIXL_ERR_INVALID_PARAM;
     }
 

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -124,51 +124,43 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
     __syncthreads();
 
     const bool use_thread_level = blockDim.x <= static_cast<unsigned>(warpSize);
-
-    if (use_thread_level) {
+    const unsigned lane = use_thread_level ? 0 : (threadIdx.x % warpSize);
+    const unsigned group_id = use_thread_level ? threadIdx.x : (threadIdx.x / warpSize);
+    const unsigned num_groups = use_thread_level ? blockDim.x : ((blockDim.x + warpSize - 1) / warpSize);
+    if (group_id >= num_groups || group_id >= nixlbench_max_warps) {
+        printf(
+            "[nixlbenchPutKernel] group_id out of range: "
+            "group_id=%u num_groups=%u max_warps=%u "
+            "threadIdx.x=%u blockDim.x=%u\n",
+            group_id,
+            num_groups,
+            nixlbench_max_warps,
+            threadIdx.x, blockDim.x);
+        if (lane == 0) {
+            atomicAdd(&put_fail_count, 1u);
+        }
+    } else {
         nixlGpuXferStatusH xfer_status{};
-        for (size_t region_idx = threadIdx.x; region_idx < params.numRegions;
-             region_idx += blockDim.x) {
-            if (!nixlbenchPutLevel<nixl_gpu_level_t::THREAD>(
-                    params, region_idx, xfer_status)) {
-                atomicAdd(&put_fail_count, 1u);
+        bool put_failed = false;
+        for (size_t region_idx = group_id; region_idx < params.numRegions; region_idx += num_groups) {
+            if (use_thread_level) {
+                put_failed = !nixlbenchPutLevel<nixl_gpu_level_t::THREAD>(
+                    params, region_idx, xfer_status);
+            } else {
+                put_failed = !nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
+                    params, region_idx, xfer_status);
+            }
+            if (put_failed) {
                 break;
             }
         }
-    } else {
-        const unsigned lane = threadIdx.x % warpSize;
-        const unsigned warp_id = threadIdx.x / warpSize;
-        const unsigned num_warps = (blockDim.x + warpSize - 1) / warpSize;
 
-        if (warp_id >= num_warps || warp_id >= nixlbench_max_warps) {
-            printf(
-                "[nixlbenchPutKernel] warp_id out of range: "
-                "warp_id=%u num_warps=%u max_warps=%u "
-                "threadIdx.x=%u blockDim.x=%u\n",
-                warp_id,
-                num_warps,
-                nixlbench_max_warps,
-                threadIdx.x,
-                blockDim.x);
-            if (lane == 0) {
+        if (use_thread_level) {
+            if (put_failed && lane == 0) {
                 atomicAdd(&put_fail_count, 1u);
             }
-        } else {
-            nixlGpuXferStatusH xfer_status{};
-            // Per-lane local failure bit; the warp-level call is collective, so we reduce later.
-            bool put_failed = false;
-            for (size_t region_idx = warp_id; region_idx < params.numRegions;
-                 region_idx += num_warps) {
-                if (!nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
-                        params, region_idx, xfer_status)) {
-                    put_failed = true;
-                    break;
-                }
-            }
-            // Report one failure count per warp (not per lane) to avoid redundant atomics.
-            if (__any_sync(__activemask(), put_failed) && lane == 0) {
+        } else if (__any_sync(__activemask(), put_failed) && lane == 0) {
                 atomicAdd(&put_fail_count, 1u);
-            }
         }
     }
 

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -34,7 +34,7 @@ nixlbenchPutLevel(nixlbenchDeviceXferParams params,
         nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
     if (status != NIXL_IN_PROG) {
         printf(
-            "[nixlbenchPutKernel] nixlPut did not return NIXL_IN_PROG: "
+            "[nixlbenchPutLevel] nixlPut did not return NIXL_IN_PROG: "
             "region=%zu threadIdx.x=%u blockIdx.x=%u blockDim.x=%u status=%d\n",
             region_idx,
             threadIdx.x,
@@ -50,7 +50,7 @@ nixlbenchPutLevel(nixlbenchDeviceXferParams params,
 
     if (status != NIXL_SUCCESS) {
         printf(
-            "[nixlbenchPutKernel] transfer did not complete: region=%zu "
+            "[nixlbenchPutLevel] transfer did not complete: region=%zu "
             "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
             region_idx,
             threadIdx.x,
@@ -77,7 +77,7 @@ nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
     nixl_status_t status = nixlAtomicAdd<Level>(value, counter, 0, 0, &xfer_status);
     if (status != NIXL_IN_PROG) {
         printf(
-            "[nixlbenchPutKernel] nixlAtomicAdd(%s) did not return NIXL_IN_PROG: status=%d\n",
+            "[nixlbenchSignalCounter] nixlAtomicAdd(%s) did not return NIXL_IN_PROG: status=%d\n",
             counter_name,
             static_cast<int>(status));
         return false;
@@ -87,7 +87,7 @@ nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
     } while (status == NIXL_IN_PROG);
     if (status != NIXL_SUCCESS) {
         printf(
-            "[nixlbenchPutKernel] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
+            "[nixlbenchSignalCounter] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
             counter_name,
             static_cast<int>(status));
         return false;
@@ -109,22 +109,21 @@ nixlbenchSignalError(nixlbenchDeviceXferParams params) {
 }
 
 /**
- * If blockDim.x < warpSize: THREAD-level nixlPut; each thread uses regions
+ * If blockDim.x <= warpSize: THREAD-level nixlPut; each thread uses regions
  * region_idx = threadIdx.x, threadIdx.x + blockDim.x, ...
- * Else: WARP-level nixlPut; lane 0 of each warp strides by num_warps.
+ * Else: WARP-level nixlPut; each warp strides by num_warps and all lanes in a warp participate.
  * After all puts complete, thread 0 increments done counter by 1. If any put fails, thread 0
  * increments error counter by 1.
  */
 __global__ void
 nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
     __shared__ unsigned put_fail_count;
-    __shared__ nixlGpuXferStatusH xfer_statuses[nixlbench_max_warps];
     if (threadIdx.x == 0) {
         put_fail_count = 0;
     }
     __syncthreads();
 
-    const bool use_thread_level = blockDim.x < static_cast<unsigned>(warpSize);
+    const bool use_thread_level = blockDim.x <= static_cast<unsigned>(warpSize);
 
     if (use_thread_level) {
         nixlGpuXferStatusH xfer_status{};
@@ -141,28 +140,34 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
         const unsigned warp_id = threadIdx.x / warpSize;
         const unsigned num_warps = (blockDim.x + warpSize - 1) / warpSize;
 
-        if (lane == 0) {
-            if (warp_id >= num_warps || warp_id >= nixlbench_max_warps) {
-                printf(
-                    "[nixlbenchPutKernel] warp_id out of range: "
-                    "warp_id=%u num_warps=%u max_warps=%u "
-                    "threadIdx.x=%u blockDim.x=%u\n",
-                    warp_id,
-                    num_warps,
-                    nixlbench_max_warps,
-                    threadIdx.x,
-                    blockDim.x);
+        if (warp_id >= num_warps || warp_id >= nixlbench_max_warps) {
+            printf(
+                "[nixlbenchPutKernel] warp_id out of range: "
+                "warp_id=%u num_warps=%u max_warps=%u "
+                "threadIdx.x=%u blockDim.x=%u\n",
+                warp_id,
+                num_warps,
+                nixlbench_max_warps,
+                threadIdx.x,
+                blockDim.x);
+            if (lane == 0) {
                 atomicAdd(&put_fail_count, 1u);
-            } else {
-                nixlGpuXferStatusH &xfer_status = xfer_statuses[warp_id];
-                for (size_t region_idx = warp_id; region_idx < params.numRegions;
-                     region_idx += num_warps) {
-                    if (!nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
-                            params, region_idx, xfer_status)) {
-                        atomicAdd(&put_fail_count, 1u);
-                        break;
-                    }
+            }
+        } else {
+            nixlGpuXferStatusH xfer_status{};
+            // Per-lane local failure bit; the warp-level call is collective, so we reduce later.
+            bool put_failed = false;
+            for (size_t region_idx = warp_id; region_idx < params.numRegions;
+                 region_idx += num_warps) {
+                if (!nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
+                        params, region_idx, xfer_status)) {
+                    put_failed = true;
+                    break;
                 }
+            }
+            // Report one failure count per warp (not per lane) to avoid redundant atomics.
+            if (__any_sync(__activemask(), put_failed) && lane == 0) {
+                atomicAdd(&put_fail_count, 1u);
             }
         }
     }
@@ -171,31 +176,16 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
 
     if (threadIdx.x == 0) {
         if (put_fail_count > 0) {
-            if (use_thread_level) {
-                if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
-                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (THREAD) failed\n");
-                }
-            } else {
-                if (!nixlbenchSignalError<nixl_gpu_level_t::WARP>(params)) {
-                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (WARP) failed\n");
-                }
+            if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+                printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
             }
             return;
         }
 
-        if (use_thread_level) {
-            if (!nixlbenchSignalCompletion<nixl_gpu_level_t::THREAD>(params)) {
-                printf("[nixlbenchPutKernel] completion nixlAtomicAdd (THREAD) failed\n");
-                if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
-                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (THREAD) failed\n");
-                }
-            }
-        } else {
-            if (!nixlbenchSignalCompletion<nixl_gpu_level_t::WARP>(params)) {
-                printf("[nixlbenchPutKernel] completion nixlAtomicAdd (WARP) failed\n");
-                if (!nixlbenchSignalError<nixl_gpu_level_t::WARP>(params)) {
-                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (WARP) failed\n");
-                }
+        if (!nixlbenchSignalCompletion<nixl_gpu_level_t::THREAD>(params)) {
+            printf("[nixlbenchPutKernel] completion nixlAtomicAdd failed\n");
+            if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+                printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
             }
         }
     }

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -1,0 +1,238 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * GPU-side nixlPut after host-side prepMemView (see xferBenchNixlWorker::prepareGPULocalView
+ * and prepareGPURemoteView in nixl_worker.cpp).
+ *
+ * Flattening order (must match prepMemView):
+ *   for each inner list in local_trans_lists / remote_trans_lists:
+ *     for each IOV:
+ *       addDesc -> consecutive indices 0 .. numRegions-1
+ */
+
+#include "nixlbench_device_launch.cuh"
+
+#include <gpu/ucx/nixl_device.cuh>
+
+#include <cstdio>
+#include <iostream>
+
+namespace {
+
+/** Lane-0 xfer status slots per warp when blockDim.x <= 1024 (32 warps). */
+constexpr unsigned nixlbench_max_warps = 32u;
+
+template <nixl_gpu_level_t Level>
+__device__ bool
+nixlbenchPutLevel(nixlbenchDeviceXferParams params,
+                  size_t region_idx,
+                  nixlGpuXferStatusH &xfer_status) {
+    const nixlMemViewElem src{params.localMvh, region_idx, 0};
+    const nixlMemViewElem dst{params.remoteMvh, region_idx, 0};
+    nixl_status_t status =
+        nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
+    if (status != NIXL_IN_PROG) {
+        printf(
+            "[nixlbenchPutKernel] nixlPut did not return NIXL_IN_PROG: "
+            "region=%zu threadIdx.x=%u blockIdx.x=%u blockDim.x=%u status=%d\n",
+            region_idx,
+            threadIdx.x,
+            blockIdx.x,
+            blockDim.x,
+            static_cast<int>(status));
+        return false;
+    }
+
+    do {
+        status = nixlGpuGetXferStatus<Level>(xfer_status);
+    } while (status == NIXL_IN_PROG);
+
+    if (status != NIXL_SUCCESS) {
+        printf(
+            "[nixlbenchPutKernel] transfer did not complete: region=%zu "
+            "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
+            region_idx,
+            threadIdx.x,
+            blockIdx.x,
+            blockDim.x,
+            static_cast<int>(status));
+        return false;
+    }
+
+    return true;
+}
+
+template <nixl_gpu_level_t Level>
+__device__ bool
+nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
+                       size_t counter_offset,
+                       uint64_t value,
+                       const char *counter_name) {
+    if (!params.signalRemoteCompletion || params.remoteMvh == nullptr) {
+        return true;
+    }
+    const nixlMemViewElem counter{params.remoteMvh, params.numRegions, counter_offset};
+    nixlGpuXferStatusH xfer_status{};
+    nixl_status_t status = nixlAtomicAdd<Level>(value, counter, 0, 0, &xfer_status);
+    if (status != NIXL_IN_PROG) {
+        printf(
+            "[nixlbenchPutKernel] nixlAtomicAdd(%s) did not return NIXL_IN_PROG: status=%d\n",
+            counter_name,
+            static_cast<int>(status));
+        return false;
+    }
+    do {
+        status = nixlGpuGetXferStatus<Level>(xfer_status);
+    } while (status == NIXL_IN_PROG);
+    if (status != NIXL_SUCCESS) {
+        printf(
+            "[nixlbenchPutKernel] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
+            counter_name,
+            static_cast<int>(status));
+        return false;
+    }
+    return true;
+}
+
+template <nixl_gpu_level_t Level>
+__device__ bool
+nixlbenchSignalCompletion(nixlbenchDeviceXferParams params) {
+    return nixlbenchSignalCounter<Level>(
+        params, params.completionCounterOffsetBytes, 1ull, "completion");
+}
+
+template <nixl_gpu_level_t Level>
+__device__ bool
+nixlbenchSignalError(nixlbenchDeviceXferParams params) {
+    return nixlbenchSignalCounter<Level>(params, params.errorCounterOffsetBytes, 1ull, "error");
+}
+
+/**
+ * If blockDim.x < warpSize: THREAD-level nixlPut; each thread uses regions
+ * region_idx = threadIdx.x, threadIdx.x + blockDim.x, ...
+ * Else: WARP-level nixlPut; lane 0 of each warp strides by num_warps.
+ * After all puts complete, thread 0 increments done counter by 1. If any put fails, thread 0
+ * increments error counter by 1.
+ */
+__global__ void
+nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
+    __shared__ unsigned put_fail_count;
+    __shared__ nixlGpuXferStatusH xfer_statuses[nixlbench_max_warps];
+    if (threadIdx.x == 0) {
+        put_fail_count = 0;
+    }
+    __syncthreads();
+
+    const bool use_thread_level = blockDim.x < static_cast<unsigned>(warpSize);
+
+    if (use_thread_level) {
+        nixlGpuXferStatusH xfer_status{};
+        for (size_t region_idx = threadIdx.x; region_idx < params.numRegions;
+             region_idx += blockDim.x) {
+            if (!nixlbenchPutLevel<nixl_gpu_level_t::THREAD>(
+                    params, region_idx, xfer_status)) {
+                atomicAdd(&put_fail_count, 1u);
+                break;
+            }
+        }
+    } else {
+        const unsigned lane = threadIdx.x % warpSize;
+        const unsigned warp_id = threadIdx.x / warpSize;
+        const unsigned num_warps = (blockDim.x + warpSize - 1) / warpSize;
+
+        if (lane == 0) {
+            if (warp_id >= num_warps || warp_id >= nixlbench_max_warps) {
+                printf(
+                    "[nixlbenchPutKernel] warp_id out of range: "
+                    "warp_id=%u num_warps=%u max_warps=%u "
+                    "threadIdx.x=%u blockDim.x=%u\n",
+                    warp_id,
+                    num_warps,
+                    nixlbench_max_warps,
+                    threadIdx.x,
+                    blockDim.x);
+                atomicAdd(&put_fail_count, 1u);
+            } else {
+                nixlGpuXferStatusH &xfer_status = xfer_statuses[warp_id];
+                for (size_t region_idx = warp_id; region_idx < params.numRegions;
+                     region_idx += num_warps) {
+                    if (!nixlbenchPutLevel<nixl_gpu_level_t::WARP>(
+                            params, region_idx, xfer_status)) {
+                        atomicAdd(&put_fail_count, 1u);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        if (put_fail_count > 0) {
+            if (use_thread_level) {
+                if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (THREAD) failed\n");
+                }
+            } else {
+                if (!nixlbenchSignalError<nixl_gpu_level_t::WARP>(params)) {
+                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (WARP) failed\n");
+                }
+            }
+            return;
+        }
+
+        if (use_thread_level) {
+            if (!nixlbenchSignalCompletion<nixl_gpu_level_t::THREAD>(params)) {
+                printf("[nixlbenchPutKernel] completion nixlAtomicAdd (THREAD) failed\n");
+                if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (THREAD) failed\n");
+                }
+            }
+        } else {
+            if (!nixlbenchSignalCompletion<nixl_gpu_level_t::WARP>(params)) {
+                printf("[nixlbenchPutKernel] completion nixlAtomicAdd (WARP) failed\n");
+                if (!nixlbenchSignalError<nixl_gpu_level_t::WARP>(params)) {
+                    printf("[nixlbenchPutKernel] error nixlAtomicAdd (WARP) failed\n");
+                }
+            }
+        }
+    }
+}
+
+} // namespace
+
+nixl_status_t
+nixlbenchLaunchDevicePut(
+    const nixlbenchDeviceXferParams &params,
+    unsigned block_threads,
+    cudaStream_t stream) {
+    if (block_threads == 0 || block_threads > 1024u) {
+        std::cerr << "nixlbench: nixlbenchLaunchDevicePut: invalid block_threads=" << block_threads
+                  << " (must be 1..1024)\n";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    nixlbenchPutKernel<<<1, block_threads, 0, stream>>>(params);
+
+    cudaError_t cuda_err = cudaGetLastError();
+    if (cuda_err != cudaSuccess) {
+        std::cerr << "nixlbench: nixlbenchLaunchDevicePut: cudaGetLastError after launch: "
+                  << cudaGetErrorString(cuda_err) << '\n';
+        return NIXL_ERR_BACKEND;
+    }
+
+    if (stream == nullptr) {
+        cuda_err = cudaDeviceSynchronize();
+    } else {
+        cuda_err = cudaStreamSynchronize(stream);
+    }
+    if (cuda_err != cudaSuccess) {
+        std::cerr << "nixlbench: nixlbenchLaunchDevicePut: synchronize failed: "
+                  << cudaGetErrorString(cuda_err) << '\n';
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -25,7 +25,7 @@ constexpr unsigned nixlbench_max_warps = 32u;
 
 template<nixl_gpu_level_t Level>
 __device__ bool
-nixlbenchPutLevel(nixlbenchDeviceXferParams params,
+nixlbenchPutLevel(const nixlbenchDeviceXferParams &params,
                   size_t region_idx,
                   nixlGpuXferStatusH &xfer_status) {
     const nixlMemViewElem src{params.localMvh, region_idx, 0};
@@ -62,7 +62,7 @@ nixlbenchPutLevel(nixlbenchDeviceXferParams params,
 
 template<nixl_gpu_level_t Level>
 __device__ bool
-nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
+nixlbenchSignalCounter(const nixlbenchDeviceXferParams &params,
                        size_t counter_offset,
                        uint64_t value,
                        const char *counter_name) {
@@ -70,7 +70,7 @@ nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
         return true;
     }
     const nixlMemViewElem counter{params.remoteMvh, params.numRegions, counter_offset};
-    nixlGpuXferStatusH xfer_status{};
+    nixlGpuXferStatusH xfer_status;
     nixl_status_t status = nixlAtomicAdd<Level>(value, counter, 0, 0, &xfer_status);
     if (status != NIXL_IN_PROG) {
         printf(
@@ -91,17 +91,16 @@ nixlbenchSignalCounter(nixlbenchDeviceXferParams params,
     return true;
 }
 
-template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchSignalCompletion(nixlbenchDeviceXferParams params) {
-    return nixlbenchSignalCounter<Level>(
+    return nixlbenchSignalCounter<nixl_gpu_level_t::THREAD>(
         params, params.completionCounterOffsetBytes, 1ull, "completion");
 }
 
-template<nixl_gpu_level_t Level>
 __device__ bool
 nixlbenchSignalError(nixlbenchDeviceXferParams params) {
-    return nixlbenchSignalCounter<Level>(params, params.errorCounterOffsetBytes, 1ull, "error");
+    return nixlbenchSignalCounter<nixl_gpu_level_t::THREAD>(
+        params, params.errorCounterOffsetBytes, 1ull, "error");
 }
 
 /**
@@ -137,7 +136,7 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
             atomicAdd(&put_fail_count, 1u);
         }
     } else {
-        nixlGpuXferStatusH xfer_status{};
+        nixlGpuXferStatusH xfer_status;
         bool put_failed = false;
         for (size_t region_idx = group_id; region_idx < params.numRegions;
              region_idx += num_groups) {
@@ -166,15 +165,15 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
 
     if (threadIdx.x == 0) {
         if (put_fail_count > 0) {
-            if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+            if (!nixlbenchSignalError(params)) {
                 printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
             }
             return;
         }
 
-        if (!nixlbenchSignalCompletion<nixl_gpu_level_t::THREAD>(params)) {
+        if (!nixlbenchSignalCompletion(params)) {
             printf("[nixlbenchPutKernel] completion nixlAtomicAdd failed\n");
-            if (!nixlbenchSignalError<nixl_gpu_level_t::THREAD>(params)) {
+            if (!nixlbenchSignalError(params)) {
                 printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
             }
         }

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
@@ -28,13 +28,13 @@
  * no counter atomic is issued.
  */
 struct nixlbenchDeviceXferParams {
-    nixlMemViewH localMvh;   ///< Local memory view from prepMemView
-    nixlMemViewH remoteMvh;  ///< Remote memory view from prepMemView
-    size_t numRegions;       ///< Data region count (puts); completion index when signaling
-    size_t regionSize;       ///< Bytes per region for this transfer pattern
+    nixlMemViewH localMvh; ///< Local memory view from prepMemView
+    nixlMemViewH remoteMvh; ///< Remote memory view from prepMemView
+    size_t numRegions; ///< Data region count (puts); completion index when signaling
+    size_t regionSize; ///< Bytes per region for this transfer pattern
     bool signalRemoteCompletion; ///< If true, counter region exists at index @a numRegions
     size_t completionCounterOffsetBytes; ///< Done counter offset in the counter region
-    size_t errorCounterOffsetBytes;      ///< Error counter offset in the counter region
+    size_t errorCounterOffsetBytes; ///< Error counter offset in the counter region
 };
 
 /**
@@ -59,9 +59,8 @@ struct nixlbenchDeviceXferParams {
  *         NIXL_ERR_BACKEND for CUDA launch or synchronize failures.
  */
 nixl_status_t
-nixlbenchLaunchDevicePut(
-    const nixlbenchDeviceXferParams &params,
-    unsigned block_threads,
-    cudaStream_t stream = nullptr);
+nixlbenchLaunchDevicePut(const nixlbenchDeviceXferParams &params,
+                         unsigned block_threads,
+                         cudaStream_t stream = nullptr);
 
-#endif  // NIXL_BENCHMARK_NIXLBENCH_SRC_KERNELS_NIXLBENCH_DEVICE_LAUNCH_CUH
+#endif // NIXL_BENCHMARK_NIXLBENCH_SRC_KERNELS_NIXLBENCH_DEVICE_LAUNCH_CUH

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_BENCHMARK_NIXLBENCH_SRC_KERNELS_NIXLBENCH_DEVICE_LAUNCH_CUH
+#define NIXL_BENCHMARK_NIXLBENCH_SRC_KERNELS_NIXLBENCH_DEVICE_LAUNCH_CUH
+
+#include <nixl_types.h>
+#include <cuda_runtime.h>
+#include <stddef.h>
+
+/**
+ * @brief Parameters for @ref nixlbenchPutKernel (passed by value to the device).
+ *
+ * @a localMvh and @a remoteMvh must come from nixlAgent::prepMemView using the same flattening
+ * order as xferBenchNixlWorker::prepareGPULocalView / prepareGPURemoteView (outer vector = thread
+ * lists, inner vector = IOVs for that thread).
+ *
+ * @a numRegions is the **data** region count (put loop uses indices @c 0 .. @a numRegions-1). When
+ * @a signalRemoteCompletion is true, the host must have appended a counter buffer as the last
+ * remote descriptor so the view has @a numRegions + 1 regions. The counter buffer stores:
+ * - done counter at byte offset @a completionCounterOffsetBytes
+ * - error counter at byte offset @a errorCounterOffsetBytes
+ *
+ * Kernel uses @c nixlAtomicAdd on @c { remoteMvh, numRegions, offset }.
+ * When @a signalRemoteCompletion is false, @a remoteMvh has exactly @a numRegions regions and
+ * no counter atomic is issued.
+ */
+struct nixlbenchDeviceXferParams {
+    nixlMemViewH localMvh;   ///< Local memory view from prepMemView
+    nixlMemViewH remoteMvh;  ///< Remote memory view from prepMemView
+    size_t numRegions;       ///< Data region count (puts); completion index when signaling
+    size_t regionSize;       ///< Bytes per region for this transfer pattern
+    bool signalRemoteCompletion; ///< If true, counter region exists at index @a numRegions
+    size_t completionCounterOffsetBytes; ///< Done counter offset in the counter region
+    size_t errorCounterOffsetBytes;      ///< Error counter offset in the counter region
+};
+
+/**
+ * @brief Launches @ref nixlbenchPutKernel with a 1-D block of @a block_threads threads.
+ *
+ * If @a block_threads is less than the GPU warp size (32), @c nixl_gpu_level_t::THREAD is used;
+ * otherwise @c nixl_gpu_level_t::WARP is used (lane 0 per warp strides over regions). Typical
+ * @a block_threads matches nixlbench @c --num_threads.
+ *
+ * Requires UCX with GPU device API (gpu/ucx/nixl_device.cuh). @a block_threads must be in
+ * [1, 1024] (CUDA block limit; at most 32 warps for shared status slots).
+ *
+ * On failure, logs to stderr. Synchronizes @a stream (or the device if null) so device printf
+ * output from the kernel is flushed before returning.
+ *
+ * @param params        Transfer parameters (handles, counts, size).
+ * @param block_threads CUDA block dimension in the x direction.
+ * @param stream        CUDA stream, or nullptr for the default stream.
+ * @return NIXL_SUCCESS on success; NIXL_ERR_INVALID_PARAM for invalid @a block_threads;
+ *         NIXL_ERR_BACKEND for CUDA launch or synchronize failures.
+ */
+nixl_status_t
+nixlbenchLaunchDevicePut(
+    const nixlbenchDeviceXferParams &params,
+    unsigned block_threads,
+    cudaStream_t stream = nullptr);
+
+#endif  // NIXL_BENCHMARK_NIXLBENCH_SRC_KERNELS_NIXLBENCH_DEVICE_LAUNCH_CUH

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
@@ -40,12 +40,14 @@ struct nixlbenchDeviceXferParams {
 /**
  * @brief Launches @ref nixlbenchPutKernel with a 1-D block of @a block_threads threads.
  *
- * If @a block_threads is less than the GPU warp size (32), @c nixl_gpu_level_t::THREAD is used;
- * otherwise @c nixl_gpu_level_t::WARP is used (lane 0 per warp strides over regions). Typical
+ * If @a block_threads is less than or equal to the GPU warp size (32),
+ * @c nixl_gpu_level_t::THREAD is used;
+ * otherwise @c nixl_gpu_level_t::WARP is used (each warp strides over regions and all lanes in
+ * the warp participate in each device API call). Typical
  * @a block_threads matches nixlbench @c --num_threads.
  *
  * Requires UCX with GPU device API (gpu/ucx/nixl_device.cuh). @a block_threads must be in
- * [1, 1024] (CUDA block limit; at most 32 warps for shared status slots).
+ * [1, 1024] (CUDA block limit).
  *
  * On failure, logs to stderr. Synchronizes @a stream (or the device if null) so device printf
  * output from the kernel is flushed before returning.

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -120,9 +120,25 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return EXIT_FAILURE;
             }
 
+#if HAVE_CUDA
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->prepareGPULocalView(local_trans_lists);
+                }
+            }
+
+#endif
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
 
+#if HAVE_CUDA
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->releaseGPULocalView();
+                }
+            }
+
+#endif
             if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
                 return EXIT_FAILURE;
             }
@@ -135,7 +151,26 @@ static int processBatchSizes(xferBenchWorker &worker,
             std::vector<std::vector<xferBenchIOV>> remote_trans_lists(
                 worker.exchangeIOV(local_trans_lists, block_size));
 
+#if HAVE_CUDA
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->prepareGPULocalView(local_trans_lists);
+                    nixl_worker->prepareGPURemoteView(remote_trans_lists);
+                }
+            }
+
+#endif
             auto result = worker.transfer(block_size, local_trans_lists, remote_trans_lists);
+
+#if HAVE_CUDA
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->releaseGPURemoteView();
+                    nixl_worker->releaseGPULocalView();
+                }
+            }
+
+#endif
             if (std::holds_alternative<int>(result)) {
                 return 1;
             }

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -120,7 +120,7 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return EXIT_FAILURE;
             }
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
             if (xferBenchConfig::use_device_api) {
                 if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
                     nixl_worker->prepareGPULocalView(local_trans_lists);
@@ -131,7 +131,7 @@ static int processBatchSizes(xferBenchWorker &worker,
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
             if (xferBenchConfig::use_device_api) {
                 if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
                     nixl_worker->releaseGPULocalView();
@@ -151,7 +151,7 @@ static int processBatchSizes(xferBenchWorker &worker,
             std::vector<std::vector<xferBenchIOV>> remote_trans_lists(
                 worker.exchangeIOV(local_trans_lists, block_size));
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
             if (xferBenchConfig::use_device_api) {
                 if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
                     nixl_worker->prepareGPULocalView(local_trans_lists);
@@ -162,7 +162,7 @@ static int processBatchSizes(xferBenchWorker &worker,
 #endif
             auto result = worker.transfer(block_size, local_trans_lists, remote_trans_lists);
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
             if (xferBenchConfig::use_device_api) {
                 if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
                     nixl_worker->releaseGPURemoteView();

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -122,7 +122,7 @@ static int processBatchSizes(xferBenchWorker &worker,
 
 #if HAVE_UCX_DEVICE_KERNEL
             if (xferBenchConfig::use_device_api) {
-                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                if (auto nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
                     nixl_worker->prepareGPULocalView(local_trans_lists);
                 }
             }

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -296,6 +296,7 @@ std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
 bool xferBenchConfig::use_device_api = false;
+int xferBenchConfig::device_kernel_block_thread_count = 1;
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -506,6 +507,34 @@ xferBenchConfig::loadParams(void) {
         }
     }
 
+    // nixlbench to support device API
+    use_device_api = NB_ARG(use_device_api);
+    if (use_device_api) {
+#if HAVE_CUDA
+        if (worker_type != XFERBENCH_WORKER_NIXL
+            || backend != XFERBENCH_BACKEND_UCX
+            || op_type != XFERBENCH_OP_WRITE
+            || initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM
+            || target_seg_type != XFERBENCH_SEG_TYPE_VRAM
+            || !enable_pt
+        ) {
+            std::cout << "Invalid configuration for NIXL Device API, reset to false" << std::endl;
+            use_device_api = false;
+        } else {
+            std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
+            if (num_threads < 1 || num_threads > 1024) {
+                std::cout << "Invalid value for --num-threads, reset --num-threads to 1" << std::endl;
+                num_threads = 1;
+            }
+            device_kernel_block_thread_count = num_threads;
+            num_threads = 1;
+        }
+#else
+        std::cout << "NIXL Device API is not supported without CUDA" << std::endl;
+        use_device_api = false;
+#endif
+    }
+
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {
         if (!((XFERBENCH_SEG_TYPE_VRAM == initiator_seg_type) &&
               (XFERBENCH_SEG_TYPE_VRAM == target_seg_type) && (1 == num_threads) &&
@@ -579,32 +608,6 @@ xferBenchConfig::loadParams(void) {
                   << ", next such value is "
                   << total_buffer_size + partition - (total_buffer_size % partition) << std::endl;
         return -1;
-    }
-
-
-    use_device_api = NB_ARG(use_device_api);
-    if (use_device_api) {
-#if HAVE_CUDA
-        if (worker_type != XFERBENCH_WORKER_NIXL
-            || backend != XFERBENCH_BACKEND_UCX
-            || op_type != XFERBENCH_OP_WRITE
-            || initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM
-            || target_seg_type != XFERBENCH_SEG_TYPE_VRAM
-            || !enable_pt
-        ) {
-            std::cout << "Invalid configuration for NIXL Device API, reset to false" << std::endl;
-            use_device_api = false;
-        } else {
-            std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
-            if (num_threads < 1 || num_threads > 1024) {
-                std::cout << "Invalid value for --num-threads, reset --num-threads to 1" << std::endl;
-                num_threads = 1;
-            }
-        }
-#else
-        std::cout << "NIXL Device API is not supported without CUDA" << std::endl;
-        use_device_api = false;
-#endif
     }
 
     return 0;
@@ -742,7 +745,7 @@ xferBenchConfig::printConfig() {
     printOption("Warmup iter (--warmup_iter=N)", std::to_string(warmup_iter));
     printOption("Large block iter factor (--large_blk_iter_ftr=N)",
                 std::to_string(large_blk_iter_ftr));
-    printOption("Num threads (--num_threads=N)", std::to_string(num_threads));
+    printOption("Num threads (--num_threads=N)", use_device_api ? std::to_string(device_kernel_block_thread_count) : std::to_string(num_threads));
     printSeparator('-');
     std::cout << std::endl;
 }

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -516,9 +516,12 @@ xferBenchConfig::loadParams(void) {
                       << ". Reset use_device_api to false" << std::endl;
             use_device_api = false;
         } else {
-            std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
+            std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block "
+                         "thread count with value 1 - 1024"
+                      << std::endl;
             if (num_threads < 1 || num_threads > 1024) {
-                std::cout << "Invalid value for --num-threads, reset --num-threads to 1" << std::endl;
+                std::cout << "Invalid value for --num-threads, reset --num-threads to 1"
+                          << std::endl;
                 num_threads = 1;
             }
             device_kernel_block_thread_count = num_threads;
@@ -736,7 +739,9 @@ xferBenchConfig::printConfig() {
     printOption("Warmup iter (--warmup_iter=N)", std::to_string(warmup_iter));
     printOption("Large block iter factor (--large_blk_iter_ftr=N)",
                 std::to_string(large_blk_iter_ftr));
-    printOption("Num threads (--num_threads=N)", use_device_api ? std::to_string(device_kernel_block_thread_count) : std::to_string(num_threads));
+    printOption("Num threads (--num_threads=N)",
+                use_device_api ? std::to_string(device_kernel_block_thread_count) :
+                                 std::to_string(num_threads));
     printSeparator('-');
     std::cout << std::endl;
 }
@@ -790,9 +795,8 @@ xferBenchConfig::isDeviceAPISupported(std::string *reason) {
 #if HAVE_CUDA
 #if !HAVE_UCX_DEVICE_KERNEL
     if (reason) {
-        *reason =
-            "UCX device kernel support is not enabled in this build. "
-            "Set -Ducx_device_include_path=<path>";
+        *reason = "UCX device kernel support is not enabled in this build. "
+                  "Set -Ducx_device_include_path=<path>";
     }
     return false;
 #endif

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -513,7 +513,7 @@ xferBenchConfig::loadParams(void) {
         std::string device_api_reason;
         if (!isDeviceAPISupported(&device_api_reason)) {
             std::cout << "Invalid configuration for NIXL Device API: " << device_api_reason
-                      << ", reset to false" << std::endl;
+                      << ". Reset use_device_api to false" << std::endl;
             use_device_api = false;
         } else {
             std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
@@ -788,6 +788,14 @@ xferBenchConfig::isObjStorageBackend() {
 bool
 xferBenchConfig::isDeviceAPISupported(std::string *reason) {
 #if HAVE_CUDA
+#if !HAVE_UCX_DEVICE_KERNEL
+    if (reason) {
+        *reason =
+            "UCX device kernel support is not enabled in this build. "
+            "Set -Ducx_device_include_path=<path>";
+    }
+    return false;
+#endif
     if (xferBenchConfig::worker_type != XFERBENCH_WORKER_NIXL) {
         if (reason) {
             *reason = "worker_type must be nixl";

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -520,9 +520,10 @@ xferBenchConfig::loadParams(void) {
                          "thread count with value 1 - 1024"
                       << std::endl;
             if (num_threads < 1 || num_threads > 1024) {
-                std::cout << "Invalid value for --num-threads, reset --num-threads to 1"
+                std::cerr << "Invalid value for --num-threads: " << num_threads
+                          << ". Device API requires a GPU kernel block thread count in [1, 1024]"
                           << std::endl;
-                num_threads = 1;
+                return -1;
             }
             device_kernel_block_thread_count = num_threads;
             num_threads = 1;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -510,15 +510,10 @@ xferBenchConfig::loadParams(void) {
     // nixlbench to support device API
     use_device_api = NB_ARG(use_device_api);
     if (use_device_api) {
-#if HAVE_CUDA
-        if (worker_type != XFERBENCH_WORKER_NIXL
-            || backend != XFERBENCH_BACKEND_UCX
-            || op_type != XFERBENCH_OP_WRITE
-            || initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM
-            || target_seg_type != XFERBENCH_SEG_TYPE_VRAM
-            || !enable_pt
-        ) {
-            std::cout << "Invalid configuration for NIXL Device API, reset to false" << std::endl;
+        std::string device_api_reason;
+        if (!isDeviceAPISupported(&device_api_reason)) {
+            std::cout << "Invalid configuration for NIXL Device API: " << device_api_reason
+                      << ", reset to false" << std::endl;
             use_device_api = false;
         } else {
             std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
@@ -529,10 +524,6 @@ xferBenchConfig::loadParams(void) {
             device_kernel_block_thread_count = num_threads;
             num_threads = 1;
         }
-#else
-        std::cout << "NIXL Device API is not supported without CUDA" << std::endl;
-        use_device_api = false;
-#endif
     }
 
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {
@@ -793,6 +784,61 @@ xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend);
 };
+
+bool
+xferBenchConfig::isDeviceAPISupported(std::string *reason) {
+#if HAVE_CUDA
+    if (xferBenchConfig::worker_type != XFERBENCH_WORKER_NIXL) {
+        if (reason) {
+            *reason = "worker_type must be nixl";
+        }
+        return false;
+    }
+    if (xferBenchConfig::backend != XFERBENCH_BACKEND_UCX) {
+        if (reason) {
+            *reason = "backend must be UCX";
+        }
+        return false;
+    }
+    if (xferBenchConfig::op_type != XFERBENCH_OP_WRITE) {
+        if (reason) {
+            *reason = "op_type must be WRITE";
+        }
+        return false;
+    }
+    if (xferBenchConfig::initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM ||
+        xferBenchConfig::target_seg_type != XFERBENCH_SEG_TYPE_VRAM) {
+        if (reason) {
+            *reason = "initiator_seg_type and target_seg_type must be VRAM";
+        }
+        return false;
+    }
+    if (!xferBenchConfig::enable_pt) {
+        if (reason) {
+            *reason = "--enable_pt must be set";
+        }
+        return false;
+    }
+    if (xferBenchConfig::mode != XFERBENCH_MODE_SG) {
+        if (reason) {
+            *reason = "mode must be SG";
+        }
+        return false;
+    }
+    if (xferBenchConfig::scheme != XFERBENCH_SCHEME_PAIRWISE) {
+        if (reason) {
+            *reason = "scheme must be pairwise";
+        }
+        return false;
+    }
+    return true;
+#else
+    if (reason) {
+        *reason = "CUDA is not available in this build";
+    }
+    return false;
+#endif
+}
 
 /**********
  * xferBench Utils

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -221,6 +221,7 @@ NB_ARG_STRING(gusli_device_security,
               "If empty or fewer than devices, uses 'sec=0x3' as default. "
               "For GUSLI backend, use device_list in format 'id:type:path' where type is F (file) "
               "or K (kernel device).");
+NB_ARG_BOOL(use_device_api, false, "Enable NIXL Device API.");
 
 
 #undef NB_ARG_INT32
@@ -294,6 +295,7 @@ int xferBenchConfig::gusli_max_simultaneous_requests = 0;
 std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
+bool xferBenchConfig::use_device_api = false;
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -579,6 +581,32 @@ xferBenchConfig::loadParams(void) {
         return -1;
     }
 
+
+    use_device_api = NB_ARG(use_device_api);
+    if (use_device_api) {
+#if HAVE_CUDA
+        if (worker_type != XFERBENCH_WORKER_NIXL
+            || backend != XFERBENCH_BACKEND_UCX
+            || op_type != XFERBENCH_OP_WRITE
+            || initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM
+            || target_seg_type != XFERBENCH_SEG_TYPE_VRAM
+            || !enable_pt
+        ) {
+            std::cout << "Invalid configuration for NIXL Device API, reset to false" << std::endl;
+            use_device_api = false;
+        } else {
+            std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block thread count with value 1 - 1024" << std::endl;
+            if (num_threads < 1 || num_threads > 1024) {
+                std::cout << "Invalid value for --num-threads, reset --num-threads to 1" << std::endl;
+                num_threads = 1;
+            }
+        }
+#else
+        std::cout << "NIXL Device API is not supported without CUDA" << std::endl;
+        use_device_api = false;
+#endif
+    }
+
     return 0;
 #undef NB_ARG
 }
@@ -691,6 +719,10 @@ xferBenchConfig::printConfig() {
                         gpunetio_device_list);
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
+        }
+
+        if (backend == XFERBENCH_BACKEND_UCX) {
+            printOption("Use Device API (--use_device_api=[0,1])", std::to_string(use_device_api));
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -142,6 +142,46 @@ validateAsioPort(const char *flagname, std::uint32_t value) {
               << std::endl;
     return false;
 }
+
+bool
+isDeviceAPISupported() {
+    auto reject = [](const char *reason) {
+        std::cout << "Invalid configuration for NIXL Device API: " << reason
+                  << ". Reset use_device_api to false" << std::endl;
+        return false;
+    };
+#if HAVE_CUDA
+#if !HAVE_UCX_DEVICE_KERNEL
+    return reject("UCX device kernel support is not enabled in this build. "
+                  "Set -Ducx_device_include_path=<path>");
+#endif
+    if (xferBenchConfig::worker_type != XFERBENCH_WORKER_NIXL) {
+        return reject("worker_type must be nixl");
+    }
+    if (xferBenchConfig::backend != XFERBENCH_BACKEND_UCX) {
+        return reject("backend must be UCX");
+    }
+    if (xferBenchConfig::op_type != XFERBENCH_OP_WRITE) {
+        return reject("op_type must be WRITE");
+    }
+    if (xferBenchConfig::initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM ||
+        xferBenchConfig::target_seg_type != XFERBENCH_SEG_TYPE_VRAM) {
+        return reject("initiator_seg_type and target_seg_type must be VRAM");
+    }
+    if (!xferBenchConfig::enable_pt) {
+        return reject("--enable_pt must be set");
+    }
+    if (xferBenchConfig::mode != XFERBENCH_MODE_SG) {
+        return reject("mode must be SG");
+    }
+    if (xferBenchConfig::scheme != XFERBENCH_SCHEME_PAIRWISE) {
+        return reject("scheme must be pairwise");
+    }
+    return true;
+#else
+    return reject("CUDA is not available in this build");
+#endif
+}
 } // namespace
 
 DEFINE_validator(asio_port, &validateAsioPort);
@@ -510,10 +550,7 @@ xferBenchConfig::loadParams(void) {
     // nixlbench to support device API
     use_device_api = NB_ARG(use_device_api);
     if (use_device_api) {
-        std::string device_api_reason;
-        if (!isDeviceAPISupported(&device_api_reason)) {
-            std::cout << "Invalid configuration for NIXL Device API: " << device_api_reason
-                      << ". Reset use_device_api to false" << std::endl;
+        if (!isDeviceAPISupported()) {
             use_device_api = false;
         } else {
             std::cout << "NIXL Device API is enabled, --num-threads used as GPU kernel block "
@@ -790,68 +827,6 @@ xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend);
 };
-
-bool
-xferBenchConfig::isDeviceAPISupported(std::string *reason) {
-#if HAVE_CUDA
-#if !HAVE_UCX_DEVICE_KERNEL
-    if (reason) {
-        *reason = "UCX device kernel support is not enabled in this build. "
-                  "Set -Ducx_device_include_path=<path>";
-    }
-    return false;
-#endif
-    if (xferBenchConfig::worker_type != XFERBENCH_WORKER_NIXL) {
-        if (reason) {
-            *reason = "worker_type must be nixl";
-        }
-        return false;
-    }
-    if (xferBenchConfig::backend != XFERBENCH_BACKEND_UCX) {
-        if (reason) {
-            *reason = "backend must be UCX";
-        }
-        return false;
-    }
-    if (xferBenchConfig::op_type != XFERBENCH_OP_WRITE) {
-        if (reason) {
-            *reason = "op_type must be WRITE";
-        }
-        return false;
-    }
-    if (xferBenchConfig::initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM ||
-        xferBenchConfig::target_seg_type != XFERBENCH_SEG_TYPE_VRAM) {
-        if (reason) {
-            *reason = "initiator_seg_type and target_seg_type must be VRAM";
-        }
-        return false;
-    }
-    if (!xferBenchConfig::enable_pt) {
-        if (reason) {
-            *reason = "--enable_pt must be set";
-        }
-        return false;
-    }
-    if (xferBenchConfig::mode != XFERBENCH_MODE_SG) {
-        if (reason) {
-            *reason = "mode must be SG";
-        }
-        return false;
-    }
-    if (xferBenchConfig::scheme != XFERBENCH_SCHEME_PAIRWISE) {
-        if (reason) {
-            *reason = "scheme must be pairwise";
-        }
-        return false;
-    }
-    return true;
-#else
-    if (reason) {
-        *reason = "CUDA is not available in this build";
-    }
-    return false;
-#endif
-}
 
 /**********
  * xferBench Utils

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -213,6 +213,8 @@ public:
     isStorageBackend();
     static bool
     isObjStorageBackend();
+    static bool
+    isDeviceAPISupported(std::string *reason = nullptr);
 
 protected:
     static int

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -197,6 +197,7 @@ public:
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
     static bool use_device_api;
+    static int device_kernel_block_thread_count;
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -196,6 +196,7 @@ public:
     static std::string gusli_config_file;
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
+    static bool use_device_api;
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -213,8 +213,6 @@ public:
     isStorageBackend();
     static bool
     isObjStorageBackend();
-    static bool
-    isDeviceAPISupported(std::string *reason = nullptr);
 
 protected:
     static int

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -20,7 +20,7 @@
 #include <cctype>
 #include <chrono>
 #include <cstring>
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include "kernels/nixlbench_device_launch.cuh"
@@ -329,10 +329,8 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
-#if HAVE_CUDA
         releaseGPURemoteView();
         releaseGPULocalView();
-#endif
         delete agent;
         agent = nullptr;
     }
@@ -1527,7 +1525,7 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 // Descriptor count after the same flattening as prepareGPULocalView.
 static size_t
 countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
@@ -1634,7 +1632,7 @@ resetDeviceCounters(const xferBenchIOV &counter_iov) {
                      "Failed to reset completion counters in VRAM");
 }
 
-#endif  // HAVE_CUDA
+#endif  // HAVE_UCX_DEVICE_KERNEL
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1653,7 +1651,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
     }
 
     if (skip > 0) {
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api) {
             size_t num_regions = countFlattenedRegions(remote_iovs);
             const bool signal_remote_completion =
@@ -1696,7 +1694,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     stats.clear();
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api) {
         size_t num_regions = countFlattenedRegions(remote_iovs);
         const bool signal_remote_completion =
@@ -1770,7 +1768,7 @@ xferBenchNixlWorker::poll(size_t block_size) {
         }
     };
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     const bool use_device_completion_counter =
         xferBenchConfig::use_device_api &&
         completion_counter_iov.has_value();

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1551,8 +1551,8 @@ execDeviceTransfer(nixlMemViewH local_mvh,
                    xferBenchStats &stats) {
     stats.clear();
 
-    if (num_threads < 1) {
-        std::cerr << "execDeviceTransfer: num_threads must be >= 1" << std::endl;
+    if (num_threads < 1 || num_threads > 1024) {
+        std::cerr << "execDeviceTransfer: num_threads must be >= 1 and <= 1024" << std::endl;
         return -1;
     }
 
@@ -1639,20 +1639,8 @@ std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
                               const std::vector<std::vector<xferBenchIOV>> &remote_iovs) {
-    int num_iter = 0;
-    int skip = 0;
-#if HAVE_CUDA
-    if (xferBenchConfig::use_device_api) {
-        num_iter = xferBenchConfig::num_iter;
-        skip = xferBenchConfig::warmup_iter;
-    } else {
-        num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-        skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
-    }
-#else
-    num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-    skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
-#endif
+    int num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+    int skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
     xferBenchStats stats;
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
@@ -1674,7 +1662,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
                 remote_mvh,
                 signal_remote_completion,
                 skip,
-                xferBenchConfig::num_threads,
+                xferBenchConfig::device_kernel_block_thread_count,
                 num_regions,
                 block_size,
                 stats);
@@ -1717,7 +1705,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
             remote_mvh,
             signal_remote_completion,
             num_iter,
-            xferBenchConfig::num_threads,
+            xferBenchConfig::device_kernel_block_thread_count,
             num_regions,
             block_size,
             stats);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -78,7 +78,7 @@ resolveVramSegment() {
         _seg_type;                                                                          \
     })
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 constexpr size_t kDeviceCounterDoneOffsetBytes = 0;
 constexpr size_t kDeviceCounterErrorOffsetBytes = sizeof(uint64_t);
 constexpr size_t kDeviceCounterBytes = 2 * sizeof(uint64_t);
@@ -1267,7 +1267,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 res.emplace_back(nixlXferDlistToIOVList(remote_desc));
             }
         }
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
             if (isTarget() && completion_counter_iov.has_value()) {
                 nixlSerDes cc_ser;
@@ -1737,8 +1737,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                        xfer_op,
                        num_iter,
                        xferBenchConfig::num_threads,
-                      stats,
-                      &terminate);
+                       stats,
+                       &terminate);
 #endif
 
     if (ret < 0) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1547,7 +1547,8 @@ execDeviceTransfer(nixlMemViewH local_mvh,
                    const int num_threads,
                    size_t num_regions,
                    size_t region_size,
-                   xferBenchStats &stats) {
+                   xferBenchStats &stats,
+                   const std::atomic<int> *terminate_ptr = nullptr) {
     stats.clear();
 
     if (num_threads < 1 || num_threads > 1024) {
@@ -1570,6 +1571,10 @@ execDeviceTransfer(nixlMemViewH local_mvh,
     xferBenchTimer timer;
 
     for (int i = 0; i < num_iter; ++i) {
+        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
         nixl_status_t st =
             nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads), nullptr);
         if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
@@ -1604,25 +1609,34 @@ readDeviceCounters(const xferBenchIOV &counter_iov) {
     return counters;
 }
 
-static bool
-waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
-                               uint64_t expected_value,
-                               const char *phase) {
+bool
+xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                                                    uint64_t expected_value,
+                                                    const char *phase,
+                                                    const std::function<void()> &checkLiveness) {
     if (expected_value == 0) {
         return true;
     }
-    while (true) {
+    while (!signaled()) {
         const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
         if (counters.error > 0) {
-            std::cerr << "NIXL Device API " << phase << " failed: remote error counter is "
+            std::cerr << "NIXL Device API: " << phase << " failed: remote error counter is "
                       << counters.error << std::endl;
+            terminate.store(1);
             return false;
         }
         if (counters.done >= expected_value) {
             return true;
         }
+        checkLiveness();
+        if (signaled()) {
+            std::cerr << "NIXL Device API: " << phase
+                      << " wait interrupted by signal/liveness failure" << std::endl;
+            return false;
+        }
         std::this_thread::yield();
     }
+    return false;
 }
 
 static void
@@ -1677,7 +1691,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                                      xferBenchConfig::device_kernel_block_thread_count,
                                      num_regions,
                                      block_size,
-                                     stats);
+                                     stats,
+                                     &terminate);
         } else {
             ret = execTransfer(agent,
                                local_iovs,
@@ -1719,7 +1734,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                                  xferBenchConfig::device_kernel_block_thread_count,
                                  num_regions,
                                  block_size,
-                                 stats);
+                                 stats,
+                                 &terminate);
     } else {
         ret = execTransfer(agent,
                            local_iovs,
@@ -1786,12 +1802,13 @@ xferBenchNixlWorker::poll(size_t block_size) {
         xferBenchConfig::use_device_api && completion_counter_iov.has_value();
     if (use_device_completion_counter) {
         const xferBenchIOV &counter_iov = completion_counter_iov.value();
-        if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(skip), "warmup", checkLiveness)) {
             return;
         }
         synchronize();
         if (!waitForDeviceCompletionCounter(
-                counter_iov, static_cast<uint64_t>(total_iter), "transfer")) {
+                counter_iov, static_cast<uint64_t>(total_iter), "transfer", checkLiveness)) {
             return;
         }
         synchronize();

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -23,11 +23,13 @@
 #if HAVE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "kernels/nixlbench_device_launch.cuh"
 #endif
 #include <fcntl.h>
 #include <filesystem>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 #include "utils/neuron.h"
 #include "utils/utils.h"
 #include <unistd.h>
@@ -75,6 +77,12 @@ resolveVramSegment() {
         _seg_type;                                                                          \
     })
 
+#if HAVE_CUDA
+constexpr size_t kDeviceCounterDoneOffsetBytes = 0;
+constexpr size_t kDeviceCounterErrorOffsetBytes = sizeof(uint64_t);
+constexpr size_t kDeviceCounterBytes = 2 * sizeof(uint64_t);
+
+#endif
 // Reuse parser from utils
 
 // Generate GUSLI config file from device configurations
@@ -97,7 +105,7 @@ generateGusliConfigFile(const std::vector<GusliDeviceConfig> &devices) {
 }
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
-    : xferBenchWorker() {
+    : xferBenchWorker(), local_mvh(nullptr), remote_mvh(nullptr) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
     int rank;
@@ -321,6 +329,10 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
+#if HAVE_CUDA
+        releaseGPURemoteView();
+        releaseGPULocalView();
+#endif
         delete agent;
         agent = nullptr;
     }
@@ -514,6 +526,38 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
     std::cerr << "VRAM not supported without CUDA or Neuron" << std::endl;
     return std::nullopt;
 #endif
+}
+
+/** Allocate @a nbytes of VRAM on @a devid with all bytes set to zero. */
+static std::optional<xferBenchIOV>
+allocVramValueZero(int devid, size_t nbytes) {
+    if (neuronCoreCount() > 0) {
+        return getVramDescNeuron(devid, nbytes, 0);
+    }
+
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
+    if (xferBenchConfig::enable_vmm) {
+        return getVramDescCudaVmm(devid, nbytes, 0);
+    }
+    return getVramDescCuda(devid, nbytes, 0);
+}
+
+std::optional<xferBenchIOV>
+xferBenchNixlWorker::initCompletionCounterVram() {
+    if (!xferBenchConfig::use_device_api || !isTarget() || seg_type != VRAM_SEG) {
+        return std::nullopt;
+    }
+
+    int counter_dev = 0;
+    if (IS_PAIRWISE_AND_SG()) {
+        int devid = rt->getRank();
+        if (isTarget()) {
+            devid -= xferBenchConfig::num_initiator_dev;
+        }
+        counter_dev = devid;
+    }
+
+    return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
 
 std::optional<xferBenchIOV>
@@ -981,6 +1025,19 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         }
     }
 
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+        completion_counter_iov = initCompletionCounterVram();
+        if (completion_counter_iov.has_value()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc(VRAM_SEG);
+            iovListToNixlRegDlist(cc_list, cc_desc);
+            CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
+                "registerMem failed for completion counter");
+        }
+    }
+
+#endif
     return iov_lists;
 }
 
@@ -990,6 +1047,21 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
 
 
     opt_args.backends.push_back(backend_engine);
+
+#if HAVE_CUDA
+    if (completion_counter_iov.has_value()) {
+        if (isTarget()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc(VRAM_SEG);
+            iovListToNixlRegDlist(cc_list, cc_desc);
+            CHECK_NIXL_ERROR(agent->deregisterMem(cc_desc, &opt_args),
+                "deregisterMem failed for completion counter");
+            cleanupBasicDescVram(completion_counter_iov.value());
+        }
+        completion_counter_iov.reset();
+    }
+
+#endif
     for (auto &iov_list : iov_lists) {
         nixl_reg_dlist_t desc_list(seg_type);
         iovListToNixlRegDlist(iov_list, desc_list);
@@ -1069,7 +1141,6 @@ xferBenchNixlWorker::exchangeMetadata() {
         rt->sendInt(&meta_sz, destrank);
         rt->sendChar((char *)buffer, meta_sz, destrank);
     } else if (isInitiator()) {
-        std::string remote_agent;
         int srcrank;
 
         if (IS_PAIRWISE_AND_SG()) {
@@ -1093,7 +1164,7 @@ xferBenchNixlWorker::exchangeMetadata() {
             return ret;
         }
 
-        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent);
+        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent_name);
         if (status != NIXL_SUCCESS) {
             std::cerr << "NIXL: loadRemoteMD failed: " << nixlEnumStrings::statusStr(status)
                       << std::endl;
@@ -1197,6 +1268,69 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 res.emplace_back(nixlXferDlistToIOVList(remote_desc));
             }
         }
+#if HAVE_CUDA
+        if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+            if (isTarget() && completion_counter_iov.has_value()) {
+                nixlSerDes cc_ser;
+                nixl_xfer_dlist_t cc_dlist(seg_type);
+                nixlBasicDesc cc_basic;
+                const xferBenchIOV &cc = completion_counter_iov.value();
+                cc_basic.addr = cc.addr;
+                cc_basic.len = cc.len;
+                cc_basic.devId = cc.devId;
+                cc_dlist.addDesc(cc_basic);
+                cc_dlist.serialize(&cc_ser);
+                std::string cc_export = cc_ser.exportStr();
+
+                int destrank;
+                if (IS_PAIRWISE_AND_SG()) {
+                    destrank = rt->getRank() - xferBenchConfig::num_target_dev;
+                } else {
+                    destrank = 0;
+                }
+                desc_str_sz = static_cast<int>(cc_export.size());
+                rt->sendInt(&desc_str_sz, destrank);
+                rt->sendChar(cc_export.data(), cc_export.size(), destrank);
+            } else if (isInitiator()) {
+                nixlSerDes cc_ser;
+                int srcrank;
+                if (IS_PAIRWISE_AND_SG()) {
+                    srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
+                } else {
+                    srcrank = 1;
+                }
+                completion_counter_iov.reset();
+                if (rt->recvInt(&desc_str_sz, srcrank) != 0) {
+                    std::cerr << "NIXL: failed to receive completion counter descriptor size"
+                              << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+                std::string cc_str;
+                cc_str.resize(static_cast<size_t>(desc_str_sz), '\0');
+                if (rt->recvChar(cc_str.data(), cc_str.size(), srcrank) != 0) {
+                    std::cerr << "NIXL: failed to receive completion counter descriptor"
+                              << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+                cc_ser.importStr(cc_str);
+                nixl_xfer_dlist_t remote_cc(&cc_ser);
+                std::vector<xferBenchIOV> cc_iovs = nixlXferDlistToIOVList(remote_cc);
+                if (cc_iovs.size() != 1) {
+                    std::cerr << "NIXL: expected 1 completion counter descriptor, got "
+                              << cc_iovs.size() << std::endl;
+                    std::exit(EXIT_FAILURE);
+                } else {
+                    completion_counter_iov = cc_iovs[0];
+                    if (completion_counter_iov->len < kDeviceCounterBytes) {
+                        std::cerr << "NIXL: completion counter descriptor too small: "
+                                  << completion_counter_iov->len << " bytes" << std::endl;
+                        std::exit(EXIT_FAILURE);
+                    }
+                }
+            }
+        }
+
+#endif
     }
     // Ensure all processes have completed the exchange with a barrier/sync
     synchronize();
@@ -1393,12 +1527,132 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
+#if HAVE_CUDA
+// Descriptor count after the same flattening as prepareGPULocalView.
+static size_t
+countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
+    size_t n = 0;
+    for (const auto &lst : local_iovs) {
+        n += lst.size();
+    }
+    return n;
+}
+
+// Device PUT: MVHs from prepMemView; runs num_iter launches with CUDA block size num_threads.
+// signal_remote_completion: host appended counter as last remote region.
+static int
+execDeviceTransfer(nixlMemViewH local_mvh,
+                   nixlMemViewH remote_mvh,
+                   bool signal_remote_completion,
+                   const int num_iter,
+                   const int num_threads,
+                   size_t num_regions,
+                   size_t region_size,
+                   xferBenchStats &stats) {
+    stats.clear();
+
+    if (num_threads < 1) {
+        std::cerr << "execDeviceTransfer: num_threads must be >= 1" << std::endl;
+        return -1;
+    }
+
+    nixlbenchDeviceXferParams params;
+    params.localMvh = local_mvh;
+    params.remoteMvh = remote_mvh;
+    params.numRegions = num_regions;
+    params.regionSize = region_size;
+    params.signalRemoteCompletion = signal_remote_completion;
+    params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
+    params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
+
+    xferBenchTimer total_timer;
+    xferBenchStats iter_stats;
+    iter_stats.reserve(num_iter);
+    xferBenchTimer timer;
+
+    for (int i = 0; i < num_iter; ++i) {
+        nixl_status_t st =
+            nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads), nullptr);
+        if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
+            std::cerr << "nixlbenchLaunchDevicePut failed: " << nixlEnumStrings::statusStr(st)
+                      << std::endl;
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
+        iter_stats.transfer_duration.add(timer.lap());
+    }
+
+    stats.add(iter_stats);
+    stats.total_duration.add(total_timer.lap());
+    return 0;
+}
+
+struct xferBenchDeviceCounters {
+    uint64_t done;
+    uint64_t error;
+};
+
+static xferBenchDeviceCounters
+readDeviceCounters(const xferBenchIOV &counter_iov) {
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
+
+    xferBenchDeviceCounters counters{};
+    CHECK_CUDA_ERROR(cudaMemcpy(&counters,
+                                reinterpret_cast<const void *>(counter_iov.addr),
+                                sizeof(counters),
+                                cudaMemcpyDeviceToHost),
+                     "Failed to read completion counters from VRAM");
+    return counters;
+}
+
+static bool
+waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                               uint64_t expected_value,
+                               const char *phase) {
+    if (expected_value == 0) {
+        return true;
+    }
+    while (true) {
+        const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
+        if (counters.error > 0) {
+            std::cerr << "NIXL Device API " << phase
+                      << " failed: remote error counter is " << counters.error << std::endl;
+            return false;
+        }
+        if (counters.done >= expected_value) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+}
+
+static void
+resetDeviceCounters(const xferBenchIOV &counter_iov) {
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
+    CHECK_CUDA_ERROR(cudaMemset(
+                         reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
+                     "Failed to reset completion counters in VRAM");
+}
+
+#endif  // HAVE_CUDA
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
                               const std::vector<std::vector<xferBenchIOV>> &remote_iovs) {
-    int num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-    int skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+    int num_iter = 0;
+    int skip = 0;
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api) {
+        num_iter = xferBenchConfig::num_iter;
+        skip = xferBenchConfig::warmup_iter;
+    } else {
+        num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+        skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+    }
+#else
+    num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+    skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+#endif
     xferBenchStats stats;
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
@@ -1411,6 +1665,30 @@ xferBenchNixlWorker::transfer(size_t block_size,
     }
 
     if (skip > 0) {
+#if HAVE_CUDA
+        if (xferBenchConfig::use_device_api) {
+            size_t num_regions = countFlattenedRegions(remote_iovs);
+            const bool signal_remote_completion =
+                completion_counter_iov.has_value() && remote_mvh != nullptr;
+            ret = execDeviceTransfer(local_mvh,
+                remote_mvh,
+                signal_remote_completion,
+                skip,
+                xferBenchConfig::num_threads,
+                num_regions,
+                block_size,
+                stats);
+        } else {
+            ret = execTransfer(agent,
+                               local_iovs,
+                               remote_iovs,
+                               xfer_op,
+                               skip,
+                               xferBenchConfig::num_threads,
+                               stats,
+                               &terminate);
+        }
+#else
         ret = execTransfer(agent,
                            local_iovs,
                            remote_iovs,
@@ -1419,6 +1697,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
                            xferBenchConfig::num_threads,
                            stats,
                            &terminate);
+#endif
         if (ret < 0) {
             return std::variant<xferBenchStats, int>(ret);
         }
@@ -1429,14 +1708,40 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     stats.clear();
 
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api) {
+        size_t num_regions = countFlattenedRegions(remote_iovs);
+        const bool signal_remote_completion =
+            completion_counter_iov.has_value() && remote_mvh != nullptr;
+        ret = execDeviceTransfer(local_mvh,
+            remote_mvh,
+            signal_remote_completion,
+            num_iter,
+            xferBenchConfig::num_threads,
+            num_regions,
+            block_size,
+            stats);
+    } else {
+        ret = execTransfer(agent,
+                           local_iovs,
+                           remote_iovs,
+                           xfer_op,
+                           num_iter,
+                           xferBenchConfig::num_threads,
+                           stats,
+                           &terminate);
+    }
+#else
     ret = execTransfer(agent,
                        local_iovs,
                        remote_iovs,
                        xfer_op,
                        num_iter,
                        xferBenchConfig::num_threads,
-                       stats,
-                       &terminate);
+                      stats,
+                      &terminate);
+#endif
+
     if (ret < 0) {
         return std::variant<xferBenchStats, int>(ret);
     }
@@ -1477,6 +1782,26 @@ xferBenchNixlWorker::poll(size_t block_size) {
         }
     };
 
+#if HAVE_CUDA
+    const bool use_device_completion_counter =
+        xferBenchConfig::use_device_api &&
+        completion_counter_iov.has_value();
+    if (use_device_completion_counter) {
+        const xferBenchIOV &counter_iov = completion_counter_iov.value();
+        if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
+            return;
+        }
+        synchronize();
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(total_iter), "transfer")) {
+            return;
+        }
+        synchronize();
+        resetDeviceCounters(counter_iov);
+        return;
+    }
+
+#endif
     /* Ensure warmup is done*/
     do {
         status = agent->getNotifs(notifs);
@@ -1514,4 +1839,66 @@ xferBenchNixlWorker::synchronizeStart() {
         return 0;
     }
     return -1;
+}
+
+void
+xferBenchNixlWorker::prepareGPULocalView(
+    const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) {
+    nixl_xfer_dlist_t local_list(VRAM_SEG);
+    for (const auto &local_iov_list : local_iov_lists) {
+        nixlBasicDesc localDesc;
+        for (const auto &iov : local_iov_list) {
+            localDesc.addr = iov.addr;
+            localDesc.len = iov.len;
+            localDesc.devId = iov.devId;
+            local_list.addDesc(localDesc);
+        }
+    }
+    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh),
+                     "prepMemView on local view failed");
+}
+
+void
+xferBenchNixlWorker::prepareGPURemoteView(
+    const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
+    // prepare remote memory view
+    if (!remote_agent_name.empty()) {
+        nixl_remote_dlist_t remote_list(VRAM_SEG);
+        for (const auto &remote_iov_list : remote_iov_lists) {
+            nixlRemoteDesc remoteDesc;
+            for (const auto &iov : remote_iov_list) {
+                remoteDesc.addr = iov.addr;
+                remoteDesc.len = iov.len;
+                remoteDesc.devId = iov.devId;
+                remoteDesc.remoteAgent = remote_agent_name;
+                remote_list.addDesc(remoteDesc);
+            }
+        }
+        if (completion_counter_iov.has_value()) {
+            nixlRemoteDesc remoteDesc;
+            remoteDesc.addr = completion_counter_iov->addr;
+            remoteDesc.len = completion_counter_iov->len;
+            remoteDesc.devId = completion_counter_iov->devId;
+            remoteDesc.remoteAgent = remote_agent_name;
+            remote_list.addDesc(remoteDesc);
+        }
+        CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
+                         "prepMemView on remote view failed");
+    }
+}
+
+void
+xferBenchNixlWorker::releaseGPULocalView() {
+    if (local_mvh != nullptr) {
+        agent->releaseMemView(local_mvh);
+        local_mvh = nullptr;
+    }
+}
+
+void
+xferBenchNixlWorker::releaseGPURemoteView() {
+    if (remote_mvh != nullptr) {
+        agent->releaseMemView(remote_mvh);
+        remote_mvh = nullptr;
+    }
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -105,7 +105,9 @@ generateGusliConfigFile(const std::vector<GusliDeviceConfig> &devices) {
 }
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
-    : xferBenchWorker(), local_mvh(nullptr), remote_mvh(nullptr) {
+    : xferBenchWorker(),
+      local_mvh(nullptr),
+      remote_mvh(nullptr) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
     int rank;
@@ -1031,7 +1033,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             nixl_reg_dlist_t cc_desc(VRAM_SEG);
             iovListToNixlRegDlist(cc_list, cc_desc);
             CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
-                "registerMem failed for completion counter");
+                             "registerMem failed for completion counter");
         }
     }
 
@@ -1053,7 +1055,7 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
             nixl_reg_dlist_t cc_desc(VRAM_SEG);
             iovListToNixlRegDlist(cc_list, cc_desc);
             CHECK_NIXL_ERROR(agent->deregisterMem(cc_desc, &opt_args),
-                "deregisterMem failed for completion counter");
+                             "deregisterMem failed for completion counter");
             cleanupBasicDescVram(completion_counter_iov.value());
         }
         completion_counter_iov.reset();
@@ -1613,8 +1615,8 @@ waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
     while (true) {
         const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
         if (counters.error > 0) {
-            std::cerr << "NIXL Device API " << phase
-                      << " failed: remote error counter is " << counters.error << std::endl;
+            std::cerr << "NIXL Device API " << phase << " failed: remote error counter is "
+                      << counters.error << std::endl;
             return false;
         }
         if (counters.done >= expected_value) {
@@ -1627,12 +1629,11 @@ waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
 static void
 resetDeviceCounters(const xferBenchIOV &counter_iov) {
     CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
-    CHECK_CUDA_ERROR(cudaMemset(
-                         reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
+    CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
                      "Failed to reset completion counters in VRAM");
 }
 
-#endif  // HAVE_UCX_DEVICE_KERNEL
+#endif // HAVE_UCX_DEVICE_KERNEL
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1657,13 +1658,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
             const bool signal_remote_completion =
                 completion_counter_iov.has_value() && remote_mvh != nullptr;
             ret = execDeviceTransfer(local_mvh,
-                remote_mvh,
-                signal_remote_completion,
-                skip,
-                xferBenchConfig::device_kernel_block_thread_count,
-                num_regions,
-                block_size,
-                stats);
+                                     remote_mvh,
+                                     signal_remote_completion,
+                                     skip,
+                                     xferBenchConfig::device_kernel_block_thread_count,
+                                     num_regions,
+                                     block_size,
+                                     stats);
         } else {
             ret = execTransfer(agent,
                                local_iovs,
@@ -1700,13 +1701,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
         const bool signal_remote_completion =
             completion_counter_iov.has_value() && remote_mvh != nullptr;
         ret = execDeviceTransfer(local_mvh,
-            remote_mvh,
-            signal_remote_completion,
-            num_iter,
-            xferBenchConfig::device_kernel_block_thread_count,
-            num_regions,
-            block_size,
-            stats);
+                                 remote_mvh,
+                                 signal_remote_completion,
+                                 num_iter,
+                                 xferBenchConfig::device_kernel_block_thread_count,
+                                 num_regions,
+                                 block_size,
+                                 stats);
     } else {
         ret = execTransfer(agent,
                            local_iovs,
@@ -1770,8 +1771,7 @@ xferBenchNixlWorker::poll(size_t block_size) {
 
 #if HAVE_UCX_DEVICE_KERNEL
     const bool use_device_completion_counter =
-        xferBenchConfig::use_device_api &&
-        completion_counter_iov.has_value();
+        xferBenchConfig::use_device_api && completion_counter_iov.has_value();
     if (use_device_completion_counter) {
         const xferBenchIOV &counter_iov = completion_counter_iov.value();
         if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
@@ -1840,8 +1840,7 @@ xferBenchNixlWorker::prepareGPULocalView(
             local_list.addDesc(localDesc);
         }
     }
-    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh),
-                     "prepMemView on local view failed");
+    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh), "prepMemView on local view failed");
 }
 
 void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -17,6 +17,7 @@
 
 #include "worker/nixl/nixl_worker.h"
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <cstring>
@@ -550,11 +551,7 @@ xferBenchNixlWorker::initCompletionCounterVram() {
 
     int counter_dev = 0;
     if (IS_PAIRWISE_AND_SG()) {
-        int devid = rt->getRank();
-        if (isTarget()) {
-            devid -= xferBenchConfig::num_initiator_dev;
-        }
-        counter_dev = devid;
+        counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev;
     }
 
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
@@ -1651,10 +1648,24 @@ xferBenchNixlWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
+#if HAVE_UCX_DEVICE_KERNEL
+    size_t num_regions = 0;
+    if (xferBenchConfig::use_device_api) {
+        const size_t local_regions = countFlattenedRegions(local_iovs);
+        const size_t remote_regions = countFlattenedRegions(remote_iovs);
+        assert(local_regions == remote_regions);
+        if (__builtin_expect(local_regions != remote_regions, 0)) {
+            std::cerr << "NIXL Device API requires equal flattened local/remote region counts: "
+                      << "local=" << local_regions << ", remote=" << remote_regions << std::endl;
+            return std::variant<xferBenchStats, int>(-1);
+        }
+        num_regions = remote_regions;
+    }
+
+#endif
     if (skip > 0) {
 #if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api) {
-            size_t num_regions = countFlattenedRegions(remote_iovs);
             const bool signal_remote_completion =
                 completion_counter_iov.has_value() && remote_mvh != nullptr;
             ret = execDeviceTransfer(local_mvh,
@@ -1697,7 +1708,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
 #if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api) {
-        size_t num_regions = countFlattenedRegions(remote_iovs);
         const bool signal_remote_completion =
             completion_counter_iov.has_value() && remote_mvh != nullptr;
         ret = execDeviceTransfer(local_mvh,

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -529,6 +529,7 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
 #endif
 }
 
+#if HAVE_UCX_DEVICE_KERNEL
 /** Allocate @a nbytes of VRAM on @a devid with all bytes set to zero. */
 static std::optional<xferBenchIOV>
 allocVramValueZero(int devid, size_t nbytes) {
@@ -556,6 +557,7 @@ xferBenchNixlWorker::initCompletionCounterVram() {
 
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
+#endif
 
 std::optional<xferBenchIOV>
 xferBenchNixlWorker::initBasicDescVram(size_t buffer_size, int mem_dev_id) {
@@ -1022,7 +1024,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         }
     }
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
         completion_counter_iov = initCompletionCounterVram();
         if (completion_counter_iov.has_value()) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -80,7 +80,7 @@ resolveVramSegment() {
         _seg_type;                                                                          \
     })
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 constexpr size_t kDeviceCounterDoneOffsetBytes = 0;
 constexpr size_t kDeviceCounterErrorOffsetBytes = sizeof(uint64_t);
 constexpr size_t kDeviceCounterBytes = 2 * sizeof(uint64_t);
@@ -1269,7 +1269,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 res.emplace_back(nixlXferDlistToIOVList(remote_desc));
             }
         }
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
             if (isTarget() && completion_counter_iov.has_value()) {
                 nixlSerDes cc_ser;
@@ -1744,8 +1744,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                        xfer_op,
                        num_iter,
                        xferBenchConfig::num_threads,
-                      stats,
-                      &terminate);
+                       stats,
+                       &terminate);
 #endif
 
     if (ret < 0) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -20,7 +20,7 @@
 #include <cctype>
 #include <chrono>
 #include <cstring>
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include "kernels/nixlbench_device_launch.cuh"
@@ -331,10 +331,8 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
-#if HAVE_CUDA
         releaseGPURemoteView();
         releaseGPULocalView();
-#endif
         delete agent;
         agent = nullptr;
     }
@@ -1529,7 +1527,7 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
 // Descriptor count after the same flattening as prepareGPULocalView.
 static size_t
 countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
@@ -1636,7 +1634,7 @@ resetDeviceCounters(const xferBenchIOV &counter_iov) {
                      "Failed to reset completion counters in VRAM");
 }
 
-#endif  // HAVE_CUDA
+#endif  // HAVE_UCX_DEVICE_KERNEL
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1660,7 +1658,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
     }
 
     if (skip > 0) {
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api) {
             size_t num_regions = countFlattenedRegions(remote_iovs);
             const bool signal_remote_completion =
@@ -1703,7 +1701,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     stats.clear();
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api) {
         size_t num_regions = countFlattenedRegions(remote_iovs);
         const bool signal_remote_completion =
@@ -1777,7 +1775,7 @@ xferBenchNixlWorker::poll(size_t block_size) {
         }
     };
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     const bool use_device_completion_counter =
         xferBenchConfig::use_device_api &&
         completion_counter_iov.has_value();

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1873,7 +1873,7 @@ xferBenchNixlWorker::prepareGPULocalView(
     nixl_xfer_dlist_t local_list(VRAM_SEG);
     for (const auto &local_iov_list : local_iov_lists) {
         for (const auto &iov : local_iov_list) {
-            const nixlBasicDesc localDesc{iov.addr, iov.len, iov.devId};
+            const nixlBasicDesc localDesc{iov.addr, iov.len, static_cast<uint64_t>(iov.devId)};
             local_list.addDesc(localDesc);
         }
     }
@@ -1888,14 +1888,14 @@ xferBenchNixlWorker::prepareGPURemoteView(
         nixl_remote_dlist_t remote_list(VRAM_SEG);
         for (const auto &remote_iov_list : remote_iov_lists) {
             for (const auto &iov : remote_iov_list) {
-                const nixlRemoteDesc remoteDesc{iov.addr, iov.len, iov.devId, remote_agent_name};
+                const nixlRemoteDesc remoteDesc{iov.addr, iov.len, static_cast<uint64_t>(iov.devId), remote_agent_name};
                 remote_list.addDesc(remoteDesc);
             }
         }
         if (completion_counter_iov.has_value()) {
             const nixlRemoteDesc remoteDesc{completion_counter_iov.value().addr,
                                             completion_counter_iov.value().len,
-                                            completion_counter_iov.value().devId,
+                                            static_cast<uint64_t>(completion_counter_iov.value().devId),
                                             remote_agent_name};
             remote_list.addDesc(remoteDesc);
         }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -107,7 +107,9 @@ generateGusliConfigFile(const std::vector<GusliDeviceConfig> &devices) {
 }
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
-    : xferBenchWorker(), local_mvh(nullptr), remote_mvh(nullptr) {
+    : xferBenchWorker(),
+      local_mvh(nullptr),
+      remote_mvh(nullptr) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
     int rank;
@@ -1033,7 +1035,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             nixl_reg_dlist_t cc_desc(VRAM_SEG);
             iovListToNixlRegDlist(cc_list, cc_desc);
             CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
-                "registerMem failed for completion counter");
+                             "registerMem failed for completion counter");
         }
     }
 
@@ -1055,7 +1057,7 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
             nixl_reg_dlist_t cc_desc(VRAM_SEG);
             iovListToNixlRegDlist(cc_list, cc_desc);
             CHECK_NIXL_ERROR(agent->deregisterMem(cc_desc, &opt_args),
-                "deregisterMem failed for completion counter");
+                             "deregisterMem failed for completion counter");
             cleanupBasicDescVram(completion_counter_iov.value());
         }
         completion_counter_iov.reset();
@@ -1615,8 +1617,8 @@ waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
     while (true) {
         const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
         if (counters.error > 0) {
-            std::cerr << "NIXL Device API " << phase
-                      << " failed: remote error counter is " << counters.error << std::endl;
+            std::cerr << "NIXL Device API " << phase << " failed: remote error counter is "
+                      << counters.error << std::endl;
             return false;
         }
         if (counters.done >= expected_value) {
@@ -1629,12 +1631,11 @@ waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
 static void
 resetDeviceCounters(const xferBenchIOV &counter_iov) {
     CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
-    CHECK_CUDA_ERROR(cudaMemset(
-                         reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
+    CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
                      "Failed to reset completion counters in VRAM");
 }
 
-#endif  // HAVE_UCX_DEVICE_KERNEL
+#endif // HAVE_UCX_DEVICE_KERNEL
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1664,13 +1665,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
             const bool signal_remote_completion =
                 completion_counter_iov.has_value() && remote_mvh != nullptr;
             ret = execDeviceTransfer(local_mvh,
-                remote_mvh,
-                signal_remote_completion,
-                skip,
-                xferBenchConfig::device_kernel_block_thread_count,
-                num_regions,
-                block_size,
-                stats);
+                                     remote_mvh,
+                                     signal_remote_completion,
+                                     skip,
+                                     xferBenchConfig::device_kernel_block_thread_count,
+                                     num_regions,
+                                     block_size,
+                                     stats);
         } else {
             ret = execTransfer(agent,
                                local_iovs,
@@ -1707,13 +1708,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
         const bool signal_remote_completion =
             completion_counter_iov.has_value() && remote_mvh != nullptr;
         ret = execDeviceTransfer(local_mvh,
-            remote_mvh,
-            signal_remote_completion,
-            num_iter,
-            xferBenchConfig::device_kernel_block_thread_count,
-            num_regions,
-            block_size,
-            stats);
+                                 remote_mvh,
+                                 signal_remote_completion,
+                                 num_iter,
+                                 xferBenchConfig::device_kernel_block_thread_count,
+                                 num_regions,
+                                 block_size,
+                                 stats);
     } else {
         ret = execTransfer(agent,
                            local_iovs,
@@ -1777,8 +1778,7 @@ xferBenchNixlWorker::poll(size_t block_size) {
 
 #if HAVE_UCX_DEVICE_KERNEL
     const bool use_device_completion_counter =
-        xferBenchConfig::use_device_api &&
-        completion_counter_iov.has_value();
+        xferBenchConfig::use_device_api && completion_counter_iov.has_value();
     if (use_device_completion_counter) {
         const xferBenchIOV &counter_iov = completion_counter_iov.value();
         if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
@@ -1847,8 +1847,7 @@ xferBenchNixlWorker::prepareGPULocalView(
             local_list.addDesc(localDesc);
         }
     }
-    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh),
-                     "prepMemView on local view failed");
+    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh), "prepMemView on local view failed");
 }
 
 void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1029,6 +1029,10 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
 #if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
         completion_counter_iov = initCompletionCounterVram();
+        if (isTarget() && !completion_counter_iov.has_value()) {
+            std::cerr << "NIXL: failed to allocate completion counter for Device API" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
         if (completion_counter_iov.has_value()) {
             std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
             nixl_reg_dlist_t cc_desc(VRAM_SEG);
@@ -1868,11 +1872,8 @@ xferBenchNixlWorker::prepareGPULocalView(
     const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) {
     nixl_xfer_dlist_t local_list(VRAM_SEG);
     for (const auto &local_iov_list : local_iov_lists) {
-        nixlBasicDesc localDesc;
         for (const auto &iov : local_iov_list) {
-            localDesc.addr = iov.addr;
-            localDesc.len = iov.len;
-            localDesc.devId = iov.devId;
+            const nixlBasicDesc localDesc{iov.addr, iov.len, iov.devId};
             local_list.addDesc(localDesc);
         }
     }
@@ -1886,21 +1887,16 @@ xferBenchNixlWorker::prepareGPURemoteView(
     if (!remote_agent_name.empty()) {
         nixl_remote_dlist_t remote_list(VRAM_SEG);
         for (const auto &remote_iov_list : remote_iov_lists) {
-            nixlRemoteDesc remoteDesc;
             for (const auto &iov : remote_iov_list) {
-                remoteDesc.addr = iov.addr;
-                remoteDesc.len = iov.len;
-                remoteDesc.devId = iov.devId;
-                remoteDesc.remoteAgent = remote_agent_name;
+                const nixlRemoteDesc remoteDesc{iov.addr, iov.len, iov.devId, remote_agent_name};
                 remote_list.addDesc(remoteDesc);
             }
         }
         if (completion_counter_iov.has_value()) {
-            nixlRemoteDesc remoteDesc;
-            remoteDesc.addr = completion_counter_iov->addr;
-            remoteDesc.len = completion_counter_iov->len;
-            remoteDesc.devId = completion_counter_iov->devId;
-            remoteDesc.remoteAgent = remote_agent_name;
+            const nixlRemoteDesc remoteDesc{completion_counter_iov.value().addr,
+                                            completion_counter_iov.value().len,
+                                            completion_counter_iov.value().devId,
+                                            remote_agent_name};
             remote_list.addDesc(remoteDesc);
         }
         CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
@@ -1909,17 +1905,19 @@ xferBenchNixlWorker::prepareGPURemoteView(
 }
 
 void
-xferBenchNixlWorker::releaseGPULocalView() {
-    if (local_mvh != nullptr) {
-        agent->releaseMemView(local_mvh);
-        local_mvh = nullptr;
+xferBenchNixlWorker::releaseMemView(nixlMemViewH &mvh) {
+    if (mvh != nullptr) {
+        agent->releaseMemView(mvh);
+        mvh = nullptr;
     }
 }
 
 void
+xferBenchNixlWorker::releaseGPULocalView() {
+    releaseMemView(local_mvh);
+}
+
+void
 xferBenchNixlWorker::releaseGPURemoteView() {
-    if (remote_mvh != nullptr) {
-        agent->releaseMemView(remote_mvh);
-        remote_mvh = nullptr;
-    }
+    releaseMemView(remote_mvh);
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -17,6 +17,7 @@
 
 #include "worker/nixl/nixl_worker.h"
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <cstring>
@@ -552,11 +553,7 @@ xferBenchNixlWorker::initCompletionCounterVram() {
 
     int counter_dev = 0;
     if (IS_PAIRWISE_AND_SG()) {
-        int devid = rt->getRank();
-        if (isTarget()) {
-            devid -= xferBenchConfig::num_initiator_dev;
-        }
-        counter_dev = devid;
+        counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev;
     }
 
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
@@ -1658,10 +1655,24 @@ xferBenchNixlWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
+#if HAVE_UCX_DEVICE_KERNEL
+    size_t num_regions = 0;
+    if (xferBenchConfig::use_device_api) {
+        const size_t local_regions = countFlattenedRegions(local_iovs);
+        const size_t remote_regions = countFlattenedRegions(remote_iovs);
+        assert(local_regions == remote_regions);
+        if (__builtin_expect(local_regions != remote_regions, 0)) {
+            std::cerr << "NIXL Device API requires equal flattened local/remote region counts: "
+                      << "local=" << local_regions << ", remote=" << remote_regions << std::endl;
+            return std::variant<xferBenchStats, int>(-1);
+        }
+        num_regions = remote_regions;
+    }
+
+#endif
     if (skip > 0) {
 #if HAVE_UCX_DEVICE_KERNEL
         if (xferBenchConfig::use_device_api) {
-            size_t num_regions = countFlattenedRegions(remote_iovs);
             const bool signal_remote_completion =
                 completion_counter_iov.has_value() && remote_mvh != nullptr;
             ret = execDeviceTransfer(local_mvh,
@@ -1704,7 +1715,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
 #if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api) {
-        size_t num_regions = countFlattenedRegions(remote_iovs);
         const bool signal_remote_completion =
             completion_counter_iov.has_value() && remote_mvh != nullptr;
         ret = execDeviceTransfer(local_mvh,

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -531,6 +531,7 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
 #endif
 }
 
+#if HAVE_UCX_DEVICE_KERNEL
 /** Allocate @a nbytes of VRAM on @a devid with all bytes set to zero. */
 static std::optional<xferBenchIOV>
 allocVramValueZero(int devid, size_t nbytes) {
@@ -558,6 +559,7 @@ xferBenchNixlWorker::initCompletionCounterVram() {
 
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
+#endif
 
 std::optional<xferBenchIOV>
 xferBenchNixlWorker::initBasicDescVram(size_t buffer_size, int mem_dev_id) {
@@ -1024,7 +1026,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         }
     }
 
-#if HAVE_CUDA
+#if HAVE_UCX_DEVICE_KERNEL
     if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
         completion_counter_iov = initCompletionCounterVram();
         if (completion_counter_iov.has_value()) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1553,8 +1553,8 @@ execDeviceTransfer(nixlMemViewH local_mvh,
                    xferBenchStats &stats) {
     stats.clear();
 
-    if (num_threads < 1) {
-        std::cerr << "execDeviceTransfer: num_threads must be >= 1" << std::endl;
+    if (num_threads < 1 || num_threads > 1024) {
+        std::cerr << "execDeviceTransfer: num_threads must be >= 1 and <= 1024" << std::endl;
         return -1;
     }
 
@@ -1641,20 +1641,8 @@ std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
                               const std::vector<std::vector<xferBenchIOV>> &remote_iovs) {
-    int num_iter = 0;
-    int skip = 0;
-#if HAVE_CUDA
-    if (xferBenchConfig::use_device_api) {
-        num_iter = xferBenchConfig::num_iter;
-        skip = xferBenchConfig::warmup_iter;
-    } else {
-        num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-        skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
-    }
-#else
-    num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-    skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
-#endif
+    int num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+    int skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
     xferBenchStats stats;
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
@@ -1681,7 +1669,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
                 remote_mvh,
                 signal_remote_completion,
                 skip,
-                xferBenchConfig::num_threads,
+                xferBenchConfig::device_kernel_block_thread_count,
                 num_regions,
                 block_size,
                 stats);
@@ -1724,7 +1712,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
             remote_mvh,
             signal_remote_completion,
             num_iter,
-            xferBenchConfig::num_threads,
+            xferBenchConfig::device_kernel_block_thread_count,
             num_regions,
             block_size,
             stats);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1549,7 +1549,8 @@ execDeviceTransfer(nixlMemViewH local_mvh,
                    const int num_threads,
                    size_t num_regions,
                    size_t region_size,
-                   xferBenchStats &stats) {
+                   xferBenchStats &stats,
+                   const std::atomic<int> *terminate_ptr = nullptr) {
     stats.clear();
 
     if (num_threads < 1 || num_threads > 1024) {
@@ -1572,6 +1573,10 @@ execDeviceTransfer(nixlMemViewH local_mvh,
     xferBenchTimer timer;
 
     for (int i = 0; i < num_iter; ++i) {
+        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
         nixl_status_t st =
             nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads), nullptr);
         if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
@@ -1606,25 +1611,34 @@ readDeviceCounters(const xferBenchIOV &counter_iov) {
     return counters;
 }
 
-static bool
-waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
-                               uint64_t expected_value,
-                               const char *phase) {
+bool
+xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                                                    uint64_t expected_value,
+                                                    const char *phase,
+                                                    const std::function<void()> &checkLiveness) {
     if (expected_value == 0) {
         return true;
     }
-    while (true) {
+    while (!signaled()) {
         const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
         if (counters.error > 0) {
-            std::cerr << "NIXL Device API " << phase << " failed: remote error counter is "
+            std::cerr << "NIXL Device API: " << phase << " failed: remote error counter is "
                       << counters.error << std::endl;
+            terminate.store(1);
             return false;
         }
         if (counters.done >= expected_value) {
             return true;
         }
+        checkLiveness();
+        if (signaled()) {
+            std::cerr << "NIXL Device API: " << phase
+                      << " wait interrupted by signal/liveness failure" << std::endl;
+            return false;
+        }
         std::this_thread::yield();
     }
+    return false;
 }
 
 static void
@@ -1684,7 +1698,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                                      xferBenchConfig::device_kernel_block_thread_count,
                                      num_regions,
                                      block_size,
-                                     stats);
+                                     stats,
+                                     &terminate);
         } else {
             ret = execTransfer(agent,
                                local_iovs,
@@ -1726,7 +1741,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                                  xferBenchConfig::device_kernel_block_thread_count,
                                  num_regions,
                                  block_size,
-                                 stats);
+                                 stats,
+                                 &terminate);
     } else {
         ret = execTransfer(agent,
                            local_iovs,
@@ -1793,12 +1809,13 @@ xferBenchNixlWorker::poll(size_t block_size) {
         xferBenchConfig::use_device_api && completion_counter_iov.has_value();
     if (use_device_completion_counter) {
         const xferBenchIOV &counter_iov = completion_counter_iov.value();
-        if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(skip), "warmup", checkLiveness)) {
             return;
         }
         synchronize();
         if (!waitForDeviceCompletionCounter(
-                counter_iov, static_cast<uint64_t>(total_iter), "transfer")) {
+                counter_iov, static_cast<uint64_t>(total_iter), "transfer", checkLiveness)) {
             return;
         }
         synchronize();

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -23,11 +23,13 @@
 #if HAVE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include "kernels/nixlbench_device_launch.cuh"
 #endif
 #include <fcntl.h>
 #include <filesystem>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 #include "utils/neuron.h"
 #include "utils/utils.h"
 #include <unistd.h>
@@ -77,6 +79,12 @@ resolveVramSegment() {
         _seg_type;                                                                          \
     })
 
+#if HAVE_CUDA
+constexpr size_t kDeviceCounterDoneOffsetBytes = 0;
+constexpr size_t kDeviceCounterErrorOffsetBytes = sizeof(uint64_t);
+constexpr size_t kDeviceCounterBytes = 2 * sizeof(uint64_t);
+
+#endif
 // Reuse parser from utils
 
 // Generate GUSLI config file from device configurations
@@ -99,7 +107,7 @@ generateGusliConfigFile(const std::vector<GusliDeviceConfig> &devices) {
 }
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
-    : xferBenchWorker() {
+    : xferBenchWorker(), local_mvh(nullptr), remote_mvh(nullptr) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
     int rank;
@@ -323,6 +331,10 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
+#if HAVE_CUDA
+        releaseGPURemoteView();
+        releaseGPULocalView();
+#endif
         delete agent;
         agent = nullptr;
     }
@@ -516,6 +528,38 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
     std::cerr << "VRAM not supported without CUDA or Neuron" << std::endl;
     return std::nullopt;
 #endif
+}
+
+/** Allocate @a nbytes of VRAM on @a devid with all bytes set to zero. */
+static std::optional<xferBenchIOV>
+allocVramValueZero(int devid, size_t nbytes) {
+    if (neuronCoreCount() > 0) {
+        return getVramDescNeuron(devid, nbytes, 0);
+    }
+
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
+    if (xferBenchConfig::enable_vmm) {
+        return getVramDescCudaVmm(devid, nbytes, 0);
+    }
+    return getVramDescCuda(devid, nbytes, 0);
+}
+
+std::optional<xferBenchIOV>
+xferBenchNixlWorker::initCompletionCounterVram() {
+    if (!xferBenchConfig::use_device_api || !isTarget() || seg_type != VRAM_SEG) {
+        return std::nullopt;
+    }
+
+    int counter_dev = 0;
+    if (IS_PAIRWISE_AND_SG()) {
+        int devid = rt->getRank();
+        if (isTarget()) {
+            devid -= xferBenchConfig::num_initiator_dev;
+        }
+        counter_dev = devid;
+    }
+
+    return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
 
 std::optional<xferBenchIOV>
@@ -983,6 +1027,19 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         }
     }
 
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+        completion_counter_iov = initCompletionCounterVram();
+        if (completion_counter_iov.has_value()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc(VRAM_SEG);
+            iovListToNixlRegDlist(cc_list, cc_desc);
+            CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
+                "registerMem failed for completion counter");
+        }
+    }
+
+#endif
     return iov_lists;
 }
 
@@ -992,6 +1049,21 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
 
 
     opt_args.backends.push_back(backend_engine);
+
+#if HAVE_CUDA
+    if (completion_counter_iov.has_value()) {
+        if (isTarget()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc(VRAM_SEG);
+            iovListToNixlRegDlist(cc_list, cc_desc);
+            CHECK_NIXL_ERROR(agent->deregisterMem(cc_desc, &opt_args),
+                "deregisterMem failed for completion counter");
+            cleanupBasicDescVram(completion_counter_iov.value());
+        }
+        completion_counter_iov.reset();
+    }
+
+#endif
     for (auto &iov_list : iov_lists) {
         nixl_reg_dlist_t desc_list(seg_type);
         iovListToNixlRegDlist(iov_list, desc_list);
@@ -1071,7 +1143,6 @@ xferBenchNixlWorker::exchangeMetadata() {
         rt->sendInt(&meta_sz, destrank);
         rt->sendChar((char *)buffer, meta_sz, destrank);
     } else if (isInitiator()) {
-        std::string remote_agent;
         int srcrank;
 
         if (IS_PAIRWISE_AND_SG()) {
@@ -1095,7 +1166,7 @@ xferBenchNixlWorker::exchangeMetadata() {
             return ret;
         }
 
-        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent);
+        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent_name);
         if (status != NIXL_SUCCESS) {
             std::cerr << "NIXL: loadRemoteMD failed: " << nixlEnumStrings::statusStr(status)
                       << std::endl;
@@ -1199,6 +1270,69 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 res.emplace_back(nixlXferDlistToIOVList(remote_desc));
             }
         }
+#if HAVE_CUDA
+        if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+            if (isTarget() && completion_counter_iov.has_value()) {
+                nixlSerDes cc_ser;
+                nixl_xfer_dlist_t cc_dlist(seg_type);
+                nixlBasicDesc cc_basic;
+                const xferBenchIOV &cc = completion_counter_iov.value();
+                cc_basic.addr = cc.addr;
+                cc_basic.len = cc.len;
+                cc_basic.devId = cc.devId;
+                cc_dlist.addDesc(cc_basic);
+                cc_dlist.serialize(&cc_ser);
+                std::string cc_export = cc_ser.exportStr();
+
+                int destrank;
+                if (IS_PAIRWISE_AND_SG()) {
+                    destrank = rt->getRank() - xferBenchConfig::num_target_dev;
+                } else {
+                    destrank = 0;
+                }
+                desc_str_sz = static_cast<int>(cc_export.size());
+                rt->sendInt(&desc_str_sz, destrank);
+                rt->sendChar(cc_export.data(), cc_export.size(), destrank);
+            } else if (isInitiator()) {
+                nixlSerDes cc_ser;
+                int srcrank;
+                if (IS_PAIRWISE_AND_SG()) {
+                    srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
+                } else {
+                    srcrank = 1;
+                }
+                completion_counter_iov.reset();
+                if (rt->recvInt(&desc_str_sz, srcrank) != 0) {
+                    std::cerr << "NIXL: failed to receive completion counter descriptor size"
+                              << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+                std::string cc_str;
+                cc_str.resize(static_cast<size_t>(desc_str_sz), '\0');
+                if (rt->recvChar(cc_str.data(), cc_str.size(), srcrank) != 0) {
+                    std::cerr << "NIXL: failed to receive completion counter descriptor"
+                              << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+                cc_ser.importStr(cc_str);
+                nixl_xfer_dlist_t remote_cc(&cc_ser);
+                std::vector<xferBenchIOV> cc_iovs = nixlXferDlistToIOVList(remote_cc);
+                if (cc_iovs.size() != 1) {
+                    std::cerr << "NIXL: expected 1 completion counter descriptor, got "
+                              << cc_iovs.size() << std::endl;
+                    std::exit(EXIT_FAILURE);
+                } else {
+                    completion_counter_iov = cc_iovs[0];
+                    if (completion_counter_iov->len < kDeviceCounterBytes) {
+                        std::cerr << "NIXL: completion counter descriptor too small: "
+                                  << completion_counter_iov->len << " bytes" << std::endl;
+                        std::exit(EXIT_FAILURE);
+                    }
+                }
+            }
+        }
+
+#endif
     }
     // Ensure all processes have completed the exchange with a barrier/sync
     synchronize();
@@ -1395,12 +1529,132 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
+#if HAVE_CUDA
+// Descriptor count after the same flattening as prepareGPULocalView.
+static size_t
+countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
+    size_t n = 0;
+    for (const auto &lst : local_iovs) {
+        n += lst.size();
+    }
+    return n;
+}
+
+// Device PUT: MVHs from prepMemView; runs num_iter launches with CUDA block size num_threads.
+// signal_remote_completion: host appended counter as last remote region.
+static int
+execDeviceTransfer(nixlMemViewH local_mvh,
+                   nixlMemViewH remote_mvh,
+                   bool signal_remote_completion,
+                   const int num_iter,
+                   const int num_threads,
+                   size_t num_regions,
+                   size_t region_size,
+                   xferBenchStats &stats) {
+    stats.clear();
+
+    if (num_threads < 1) {
+        std::cerr << "execDeviceTransfer: num_threads must be >= 1" << std::endl;
+        return -1;
+    }
+
+    nixlbenchDeviceXferParams params;
+    params.localMvh = local_mvh;
+    params.remoteMvh = remote_mvh;
+    params.numRegions = num_regions;
+    params.regionSize = region_size;
+    params.signalRemoteCompletion = signal_remote_completion;
+    params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
+    params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
+
+    xferBenchTimer total_timer;
+    xferBenchStats iter_stats;
+    iter_stats.reserve(num_iter);
+    xferBenchTimer timer;
+
+    for (int i = 0; i < num_iter; ++i) {
+        nixl_status_t st =
+            nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads), nullptr);
+        if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
+            std::cerr << "nixlbenchLaunchDevicePut failed: " << nixlEnumStrings::statusStr(st)
+                      << std::endl;
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
+        iter_stats.transfer_duration.add(timer.lap());
+    }
+
+    stats.add(iter_stats);
+    stats.total_duration.add(total_timer.lap());
+    return 0;
+}
+
+struct xferBenchDeviceCounters {
+    uint64_t done;
+    uint64_t error;
+};
+
+static xferBenchDeviceCounters
+readDeviceCounters(const xferBenchIOV &counter_iov) {
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
+
+    xferBenchDeviceCounters counters{};
+    CHECK_CUDA_ERROR(cudaMemcpy(&counters,
+                                reinterpret_cast<const void *>(counter_iov.addr),
+                                sizeof(counters),
+                                cudaMemcpyDeviceToHost),
+                     "Failed to read completion counters from VRAM");
+    return counters;
+}
+
+static bool
+waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                               uint64_t expected_value,
+                               const char *phase) {
+    if (expected_value == 0) {
+        return true;
+    }
+    while (true) {
+        const xferBenchDeviceCounters counters = readDeviceCounters(counter_iov);
+        if (counters.error > 0) {
+            std::cerr << "NIXL Device API " << phase
+                      << " failed: remote error counter is " << counters.error << std::endl;
+            return false;
+        }
+        if (counters.done >= expected_value) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+}
+
+static void
+resetDeviceCounters(const xferBenchIOV &counter_iov) {
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
+    CHECK_CUDA_ERROR(cudaMemset(
+                         reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
+                     "Failed to reset completion counters in VRAM");
+}
+
+#endif  // HAVE_CUDA
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
                               const std::vector<std::vector<xferBenchIOV>> &remote_iovs) {
-    int num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
-    int skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+    int num_iter = 0;
+    int skip = 0;
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api) {
+        num_iter = xferBenchConfig::num_iter;
+        skip = xferBenchConfig::warmup_iter;
+    } else {
+        num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+        skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+    }
+#else
+    num_iter = xferBenchConfig::num_iter / xferBenchConfig::num_threads;
+    skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
+#endif
     xferBenchStats stats;
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
@@ -1418,6 +1672,30 @@ xferBenchNixlWorker::transfer(size_t block_size,
     }
 
     if (skip > 0) {
+#if HAVE_CUDA
+        if (xferBenchConfig::use_device_api) {
+            size_t num_regions = countFlattenedRegions(remote_iovs);
+            const bool signal_remote_completion =
+                completion_counter_iov.has_value() && remote_mvh != nullptr;
+            ret = execDeviceTransfer(local_mvh,
+                remote_mvh,
+                signal_remote_completion,
+                skip,
+                xferBenchConfig::num_threads,
+                num_regions,
+                block_size,
+                stats);
+        } else {
+            ret = execTransfer(agent,
+                               local_iovs,
+                               remote_iovs,
+                               xfer_op,
+                               skip,
+                               xferBenchConfig::num_threads,
+                               stats,
+                               &terminate);
+        }
+#else
         ret = execTransfer(agent,
                            local_iovs,
                            remote_iovs,
@@ -1426,6 +1704,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
                            xferBenchConfig::num_threads,
                            stats,
                            &terminate);
+#endif
         if (ret < 0) {
             return std::variant<xferBenchStats, int>(ret);
         }
@@ -1436,14 +1715,40 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     stats.clear();
 
+#if HAVE_CUDA
+    if (xferBenchConfig::use_device_api) {
+        size_t num_regions = countFlattenedRegions(remote_iovs);
+        const bool signal_remote_completion =
+            completion_counter_iov.has_value() && remote_mvh != nullptr;
+        ret = execDeviceTransfer(local_mvh,
+            remote_mvh,
+            signal_remote_completion,
+            num_iter,
+            xferBenchConfig::num_threads,
+            num_regions,
+            block_size,
+            stats);
+    } else {
+        ret = execTransfer(agent,
+                           local_iovs,
+                           remote_iovs,
+                           xfer_op,
+                           num_iter,
+                           xferBenchConfig::num_threads,
+                           stats,
+                           &terminate);
+    }
+#else
     ret = execTransfer(agent,
                        local_iovs,
                        remote_iovs,
                        xfer_op,
                        num_iter,
                        xferBenchConfig::num_threads,
-                       stats,
-                       &terminate);
+                      stats,
+                      &terminate);
+#endif
+
     if (ret < 0) {
         return std::variant<xferBenchStats, int>(ret);
     }
@@ -1484,6 +1789,26 @@ xferBenchNixlWorker::poll(size_t block_size) {
         }
     };
 
+#if HAVE_CUDA
+    const bool use_device_completion_counter =
+        xferBenchConfig::use_device_api &&
+        completion_counter_iov.has_value();
+    if (use_device_completion_counter) {
+        const xferBenchIOV &counter_iov = completion_counter_iov.value();
+        if (!waitForDeviceCompletionCounter(counter_iov, static_cast<uint64_t>(skip), "warmup")) {
+            return;
+        }
+        synchronize();
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(total_iter), "transfer")) {
+            return;
+        }
+        synchronize();
+        resetDeviceCounters(counter_iov);
+        return;
+    }
+
+#endif
     /* Ensure warmup is done*/
     do {
         status = agent->getNotifs(notifs);
@@ -1521,4 +1846,66 @@ xferBenchNixlWorker::synchronizeStart() {
         return 0;
     }
     return -1;
+}
+
+void
+xferBenchNixlWorker::prepareGPULocalView(
+    const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) {
+    nixl_xfer_dlist_t local_list(VRAM_SEG);
+    for (const auto &local_iov_list : local_iov_lists) {
+        nixlBasicDesc localDesc;
+        for (const auto &iov : local_iov_list) {
+            localDesc.addr = iov.addr;
+            localDesc.len = iov.len;
+            localDesc.devId = iov.devId;
+            local_list.addDesc(localDesc);
+        }
+    }
+    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh),
+                     "prepMemView on local view failed");
+}
+
+void
+xferBenchNixlWorker::prepareGPURemoteView(
+    const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
+    // prepare remote memory view
+    if (!remote_agent_name.empty()) {
+        nixl_remote_dlist_t remote_list(VRAM_SEG);
+        for (const auto &remote_iov_list : remote_iov_lists) {
+            nixlRemoteDesc remoteDesc;
+            for (const auto &iov : remote_iov_list) {
+                remoteDesc.addr = iov.addr;
+                remoteDesc.len = iov.len;
+                remoteDesc.devId = iov.devId;
+                remoteDesc.remoteAgent = remote_agent_name;
+                remote_list.addDesc(remoteDesc);
+            }
+        }
+        if (completion_counter_iov.has_value()) {
+            nixlRemoteDesc remoteDesc;
+            remoteDesc.addr = completion_counter_iov->addr;
+            remoteDesc.len = completion_counter_iov->len;
+            remoteDesc.devId = completion_counter_iov->devId;
+            remoteDesc.remoteAgent = remote_agent_name;
+            remote_list.addDesc(remoteDesc);
+        }
+        CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
+                         "prepMemView on remote view failed");
+    }
+}
+
+void
+xferBenchNixlWorker::releaseGPULocalView() {
+    if (local_mvh != nullptr) {
+        agent->releaseMemView(local_mvh);
+        local_mvh = nullptr;
+    }
+}
+
+void
+xferBenchNixlWorker::releaseGPURemoteView() {
+    if (remote_mvh != nullptr) {
+        agent->releaseMemView(remote_mvh);
+        remote_mvh = nullptr;
+    }
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1888,15 +1888,17 @@ xferBenchNixlWorker::prepareGPURemoteView(
         nixl_remote_dlist_t remote_list(VRAM_SEG);
         for (const auto &remote_iov_list : remote_iov_lists) {
             for (const auto &iov : remote_iov_list) {
-                const nixlRemoteDesc remoteDesc{iov.addr, iov.len, static_cast<uint64_t>(iov.devId), remote_agent_name};
+                const nixlRemoteDesc remoteDesc{
+                    iov.addr, iov.len, static_cast<uint64_t>(iov.devId), remote_agent_name};
                 remote_list.addDesc(remoteDesc);
             }
         }
         if (completion_counter_iov.has_value()) {
-            const nixlRemoteDesc remoteDesc{completion_counter_iov.value().addr,
-                                            completion_counter_iov.value().len,
-                                            static_cast<uint64_t>(completion_counter_iov.value().devId),
-                                            remote_agent_name};
+            const nixlRemoteDesc remoteDesc{
+                completion_counter_iov.value().addr,
+                completion_counter_iov.value().len,
+                static_cast<uint64_t>(completion_counter_iov.value().devId),
+                remote_agent_name};
             remote_list.addDesc(remoteDesc);
         }
         CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -26,6 +26,7 @@
 #include <optional>
 #include <memory>
 #include <nixl.h>
+#include <nixl_types.h>
 #include "utils/utils.h"
 #include "worker/worker.h"
 
@@ -45,6 +46,13 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::vector<xferFileState> remote_fds;
         std::vector<std::vector<xferBenchIOV>> remote_iovs;
         std::vector<GusliDeviceConfig> gusli_devices;
+        nixlMemViewH local_mvh;
+        nixlMemViewH remote_mvh;
+        std::string remote_agent_name;
+        /// Device API: target holds local registered counter buffer (done + error uint64_t
+        /// counters); initiator holds peer descriptor after exchangeIOV (no local alloc on
+        /// initiator).
+        std::optional<xferBenchIOV> completion_counter_iov;
 
     public:
         explicit xferBenchNixlWorker(const std::vector<std::string> &devices);
@@ -70,6 +78,17 @@ class xferBenchNixlWorker: public xferBenchWorker {
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
+        void
+        prepareGPULocalView(
+            const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
+        void
+        prepareGPURemoteView(
+            const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
+        void
+        releaseGPULocalView();
+        void
+        releaseGPURemoteView();
+
     private:
         std::optional<xferBenchIOV>
         initBasicDescDram(size_t buffer_size, int mem_dev_id);
@@ -78,6 +97,8 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::optional<xferBenchIOV> initBasicDescVram(size_t buffer_size, int mem_dev_id);
         void
         cleanupBasicDescVram(xferBenchIOV &basic_desc);
+        std::optional<xferBenchIOV>
+        initCompletionCounterVram();
         std::optional<xferBenchIOV>
         initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);
         void cleanupBasicDescFile(xferBenchIOV &basic_desc);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <optional>
 #include <memory>
+#include <functional>
 #include <nixl.h>
 #include <nixl_types.h>
 #include "utils/utils.h"
@@ -98,6 +99,11 @@ class xferBenchNixlWorker: public xferBenchWorker {
 #if HAVE_UCX_DEVICE_KERNEL
         std::optional<xferBenchIOV>
         initCompletionCounterVram();
+        bool
+        waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                                       uint64_t expected_value,
+                                       const char *phase,
+                                       const std::function<void()> &checkLiveness);
 #endif
         std::optional<xferBenchIOV>
         initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -95,8 +95,10 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::optional<xferBenchIOV> initBasicDescVram(size_t buffer_size, int mem_dev_id);
         void
         cleanupBasicDescVram(xferBenchIOV &basic_desc);
+#if HAVE_UCX_DEVICE_KERNEL
         std::optional<xferBenchIOV>
         initCompletionCounterVram();
+#endif
         std::optional<xferBenchIOV>
         initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);
         void cleanupBasicDescFile(xferBenchIOV &basic_desc);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -79,11 +79,9 @@ class xferBenchNixlWorker: public xferBenchWorker {
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
         void
-        prepareGPULocalView(
-            const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
+        prepareGPULocalView(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
         void
-        prepareGPURemoteView(
-            const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
+        prepareGPURemoteView(const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
         void
         releaseGPULocalView();
         void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -89,6 +89,8 @@ class xferBenchNixlWorker: public xferBenchWorker {
         releaseGPURemoteView();
 
     private:
+        void
+        releaseMemView(nixlMemViewH &mvh);
         std::optional<xferBenchIOV>
         initBasicDescDram(size_t buffer_size, int mem_dev_id);
         void


### PR DESCRIPTION
## What?
Added a new Device API path for nixlbench.
The change introduces GPU-kernel-driven transfer execution, completion-counter-based signaling, and the required build/runtime gating for this feature.

## Why?
This improves nixlbench path by support transfer using GPU kernel device API.

## How?
1. Added nixlbench config flag "--use_device_api" to select device API, provided config validation (isDeviceAPISupported). Handled "--num_threads" as kernel block thread count for device API.
2. Added nixlbench Meson build gating with -Ducx_device_include_path and HAVE_UCX_DEVICE_KERNEL so kernels are compiled only when UCX device headers and prerequisites are available.
3. Added device API kernel launch implementation (nixlbench_device_launch.cu/.cuh) with THREAD/WARP level and done/error signaling.
4. Extended xferBenchNixlWorker to prepare/release GPU memviews, manage VRAM completion counters, exchange counter descriptors, and use device-based transfer/poll flow.
5. Kept fallback behavior: unsupported or disabled device API configurations automatically use the original host API transfer path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to enable GPU device-API transfers with runtime support checks and explanatory failure reasons.
  * New GPU-side transfer path with kernel launches, VRAM-based completion/error counters, and prepare/release lifecycle integrated into worker flows.
  * Configurable device-kernel block thread count (1–1024) shown in config output and used for kernel launches.

* **Chores**
  * Build option to supply UCX device include path and conditional CUDA kernel build/link with warnings when ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->