### PR TITLE
CI: Add sleep to prevent both nixlbench processes becoming clients

### DIFF
--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -80,7 +80,7 @@ run_nixlbench_two_workers_asio() {
     args="$@"
     asio_port=$(get_random_tcp_port)
     command_line="./bin/nixlbench --runtime_type=ASIO --asio_port=$asio_port $DEFAULT_NB_PARAMS $args"
-    parallel --line-buffer --halt now,fail=1 ::: "$command_line" "$command_line"
+    parallel --line-buffer --halt now,fail=1 ::: "$command_line" "sleep 4 ; $command_line"
 }
 
 for op_type in READ WRITE; do


### PR DESCRIPTION
## What?
Fix a race condition in the ASIO nixlbench CI test that causes both workers to fail on startup.

## Why?
`run_nixlbench_two_workers_asio` launches two workers simultaneously via `parallel`. The ASIO runtime elects a server by having both processes race on `bind()`. The first to succeed becomes the server (rank 0), the other falls back to client (rank 1).

However, because both sockets set `SO_REUSEADDR` and `parallel` starts them at the same instant, the kernel can allow both `bind()` calls to succeed before either calls `listen()`, after which both `listen()` calls fail. Both processes become clients, neither listens, and both crash with `ASIO Connection failed: Connection refused`.

This is an intermittent race that depends on scheduler timing. It reproduces more readily on aarch64 (2 of 3 containers failed) while x86\_64 passes consistently.

## How?
Add a sleep before the second worker, matching the pattern already used by `run_nixlbench_two_workers_etcd`. This ensures the first worker completes `bind()` + `listen()` before the second starts, making role election deterministic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test infrastructure timing for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->