### PR TITLE
PLUGINS/POSIX: Remove dangling pointer.

### DIFF
--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -157,12 +157,10 @@ logOnPercentStep(unsigned int completed, unsigned int total) {
 nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
                                            const nixl_meta_dlist_t &loc,
                                            const nixl_meta_dlist_t &rem,
-                                           const nixl_opt_b_args_t *args,
                                            std::unique_ptr<nixlPosixIOQueue> &io_queue)
     : operation(op),
       local(loc),
       remote(rem),
-      opt_args(args),
       queue_depth_(loc.descCount()),
       num_confirmed_ios_(queue_depth_),
       io_queue_(io_queue) {
@@ -275,7 +273,7 @@ nixlPosixEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     try {
         auto posix_handle =
-            std::make_unique<nixlPosixBackendReqH>(operation, local, remote, opt_args, io_queue_);
+            std::make_unique<nixlPosixBackendReqH>(operation, local, remote, io_queue_);
         NIXL_LOCK_GUARD(io_queue_lock_);
         nixl_status_t status = posix_handle->prepXfer();
         if (status != NIXL_SUCCESS) {

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -18,10 +18,12 @@
 #ifndef NIXL_SRC_PLUGINS_POSIX_POSIX_BACKEND_H
 #define NIXL_SRC_PLUGINS_POSIX_POSIX_BACKEND_H
 
+#include <exception>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
-#include <absl/strings/str_format.h>
+
 #include "backend/backend_engine.h"
 #include "io_queue.h"
 #include "sync.h"
@@ -151,4 +153,4 @@ public:
     }
 };
 
-#endif // POSIX_BACKEND_H
+#endif

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef POSIX_BACKEND_H
-#define POSIX_BACKEND_H
+#ifndef NIXL_SRC_PLUGINS_POSIX_POSIX_BACKEND_H
+#define NIXL_SRC_PLUGINS_POSIX_POSIX_BACKEND_H
 
 #include <memory>
 #include <string>
@@ -31,7 +31,6 @@ private:
     const nixl_xfer_op_t &operation; // The transfer operation (read/write)
     const nixl_meta_dlist_t &local; // Local memory descriptor list
     const nixl_meta_dlist_t &remote; // Remote memory descriptor list
-    const nixl_opt_b_args_t *opt_args; // Optional backend-specific arguments
     const int queue_depth_; // Queue depth for async I/O
     int num_confirmed_ios_; // Number of confirmed IOs
     std::unique_ptr<nixlPosixIOQueue> &io_queue_; // Async I/O queue instance
@@ -45,7 +44,6 @@ public:
     nixlPosixBackendReqH(const nixl_xfer_op_t &operation,
                          const nixl_meta_dlist_t &local,
                          const nixl_meta_dlist_t &remote,
-                         const nixl_opt_b_args_t *opt_args,
                          std::unique_ptr<nixlPosixIOQueue> &io_queue);
     ~nixlPosixBackendReqH() {};
 


### PR DESCRIPTION
## What?
Remove the `opt_args` pointer from class `nixlPosixBackendReqH`.

Also fixes the include guards and list of includes for `posix_backend.h`.

## Why?
1. The pointer is not used.
2. It is a dangling pointer.

(It points to a stack-allocated object from the NIXL agent functions that call `prepXfer()`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * POSIX backend request handling simplified: request objects no longer retain backend option arguments and the transfer preparation flow was updated accordingly.
  * Header and build artifacts tidied (include guards and includes adjusted) to streamline internal implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->