### PR TITLE
Plugin Manager: Defer plugin load to the point where they are actuall…

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -208,10 +208,6 @@ class nixl_agent:
 
         self.plugin_b_options: dict[str, dict[str, str]] = {}
         self.plugin_mem_types: dict[str, list[str]] = {}
-        for plugin in self.plugin_list:
-            (backend_options, mem_types) = self.agent.getPluginParams(plugin)
-            self.plugin_b_options[plugin] = backend_options
-            self.plugin_mem_types[plugin] = mem_types
 
         if instantiate_all:
             nixl_conf.backends = self.plugin_list
@@ -271,6 +267,16 @@ class nixl_agent:
     @return List of plugin names.
     """
 
+    def _load_plugin_params(self, plugin: str):
+        if plugin not in self.plugin_list:
+            return
+        try:
+            (backend_options, mem_types) = self.agent.getPluginParams(plugin)
+            self.plugin_b_options[plugin] = backend_options
+            self.plugin_mem_types[plugin] = mem_types
+        except Exception:
+            logger.warning("Failed to load params for plugin %s", plugin, exc_info=True)
+
     def get_plugin_list(self) -> list[str]:
         return self.plugin_list
 
@@ -282,13 +288,14 @@ class nixl_agent:
     """
 
     def get_plugin_mem_types(self, backend: str) -> list[str]:
-        if backend in self.plugin_mem_types:
-            return self.plugin_mem_types[backend]
-        else:
+        if backend not in self.plugin_mem_types:
+            self._load_plugin_params(backend)
+        if backend not in self.plugin_mem_types:
             logger.warning(
                 "Plugin %s is not available to get its supported mem types.", backend
             )
             return []
+        return self.plugin_mem_types[backend]
 
     """
     @brief Get the initialization parameters of a plugin.
@@ -299,11 +306,12 @@ class nixl_agent:
     """
 
     def get_plugin_params(self, backend: str) -> dict[str, str]:
-        if backend in self.plugin_b_options:
-            return self.plugin_b_options[backend]
-        else:
+        if backend not in self.plugin_b_options:
+            self._load_plugin_params(backend)
+        if backend not in self.plugin_b_options:
             logger.warning("Plugin %s is not available to get its parameters.", backend)
             return {}
+        return self.plugin_b_options[backend]
 
     """
     @brief  Get the memory types supported by a backend.

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -221,7 +221,7 @@ nixlAgent::~nixlAgent() {
 nixl_status_t
 nixlAgent::getAvailPlugins (std::vector<nixl_backend_t> &plugins) {
     auto& plugin_manager = nixlPluginManager::getInstance();
-    plugins = plugin_manager.getLoadedBackendPluginNames();
+    plugins = plugin_manager.getAvailBackendPluginNames();
     return NIXL_SUCCESS;
 }
 

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -252,20 +252,23 @@ nixlPluginManager::loadPluginFromPath(const std::string &plugin_path, nixlPlugin
 }
 
 void
-nixlPluginManager::loadPluginsFromList(const std::string &filename) {
+nixlPluginManager::discoverPluginsFromList(const std::string &filename) {
     auto plugins = loadPluginList(filename);
 
-    lock_guard lg(lock);
+    const lock_guard lg(lock);
 
     for (const auto& pair : plugins) {
         const std::string& name = pair.first;
         const std::string& path = pair.second;
 
-        auto plugin_handle = loadPluginFromPath(path, backendLoader);
-        if (plugin_handle) {
-            auto backend_plugin =
-                std::dynamic_pointer_cast<const nixlBackendPluginHandle>(plugin_handle);
-            loaded_backend_plugins_[name] = backend_plugin;
+        if (loaded_backend_plugins_.find(name) == loaded_backend_plugins_.end()) {
+            discovered_backend_plugins_.insert(name);
+            if (!path.empty()) {
+                explicit_plugin_paths_[name] = path;
+                NIXL_INFO << "Discovered backend plugin from list: " << name << " (" << path << ")";
+            } else {
+                NIXL_INFO << "Discovered backend plugin from list: " << name;
+            }
         }
     }
 }
@@ -296,7 +299,7 @@ nixlPluginManager::nixlPluginManager() {
     NIXL_DEBUG << "Loading plugins from file: " << NIXL_USE_PLUGIN_FILE;
     std::string plugin_file = NIXL_USE_PLUGIN_FILE;
     if (std::filesystem::exists(plugin_file)) {
-        loadPluginsFromList(plugin_file);
+        discoverPluginsFromList(plugin_file);
     }
 #endif
 
@@ -373,6 +376,21 @@ nixlPluginManager::loadBackendPlugin(const std::string &plugin_name) {
     auto it = loaded_backend_plugins_.find(plugin_name);
     if (it != loaded_backend_plugins_.end()) {
         return it->second;
+    }
+
+    // Try the explicit path from the plugin list file first
+    auto path_it = explicit_plugin_paths_.find(plugin_name);
+    if (path_it != explicit_plugin_paths_.end()) {
+        const std::string &plugin_path = path_it->second;
+        if (std::filesystem::exists(plugin_path)) {
+            auto plugin_handle = loadPluginFromPath(plugin_path, backendLoader);
+            if (plugin_handle) {
+                auto backend_plugin =
+                    std::dynamic_pointer_cast<const nixlBackendPluginHandle>(plugin_handle);
+                loaded_backend_plugins_[plugin_name] = backend_plugin;
+                return backend_plugin;
+            }
+        }
     }
 
     // Try to load the plugin from all registered directories
@@ -457,9 +475,11 @@ void
 nixlPluginManager::discoverBackendPlugin(const std::string &filename) {
     if (startsWith(filename, backendPluginPrefix) && endsWith(filename, kPluginSuffix)) {
         std::string plugin_name = extractPluginName(filename, backendPluginPrefix);
-        auto plugin = loadBackendPlugin(plugin_name);
-        if (plugin) {
-            NIXL_INFO << "Discovered and loaded backend plugin: " << plugin_name;
+
+        const lock_guard lg(lock);
+        if (loaded_backend_plugins_.find(plugin_name) == loaded_backend_plugins_.end()) {
+            discovered_backend_plugins_.insert(plugin_name);
+            NIXL_INFO << "Discovered backend plugin: " << plugin_name;
         }
     }
 }
@@ -468,11 +488,7 @@ void
 nixlPluginManager::discoverTelemetryPlugin(const std::string &filename) {
     if (startsWith(filename, telemetryPluginPrefix) && endsWith(filename, kPluginSuffix)) {
         std::string plugin_name = extractPluginName(filename, telemetryPluginPrefix);
-
-        auto plugin = loadTelemetryPlugin(plugin_name);
-        if (plugin) {
-            NIXL_INFO << "Discovered and loaded telemetry plugin: " << plugin_name;
-        }
+        NIXL_INFO << "Discovered telemetry plugin: " << plugin_name;
     }
 }
 
@@ -566,6 +582,23 @@ nixlPluginManager::getLoadedBackendPluginNames() {
     std::vector<nixl_backend_t> names;
     for (const auto &pair : loaded_backend_plugins_) {
         names.push_back(pair.first);
+    }
+    return names;
+}
+
+std::vector<nixl_backend_t>
+nixlPluginManager::getAvailBackendPluginNames() {
+    const lock_guard lg(lock);
+
+    std::vector<nixl_backend_t> names;
+    for (const auto &pair : loaded_backend_plugins_) {
+        names.push_back(pair.first);
+    }
+    for (const auto &name : discovered_backend_plugins_) {
+        // Skip discovered plugins that are already loaded to avoid duplicates
+        if (loaded_backend_plugins_.find(name) == loaded_backend_plugins_.end()) {
+            names.push_back(name);
+        }
     }
     return names;
 }

--- a/src/core/plugin_manager.h
+++ b/src/core/plugin_manager.h
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include <string>
 #include <map>
+#include <set>
 #include <memory>
 #include <vector>
 #include <mutex>
@@ -110,7 +111,7 @@ public:
     nixlPluginManager& operator=(const nixlPluginManager&) = delete;
 
     void
-    loadPluginsFromList(const std::string &filename);
+    discoverPluginsFromList(const std::string &filename);
 
     // Load a specific backend plugin
     std::shared_ptr<const nixlBackendPluginHandle>
@@ -140,6 +141,10 @@ public:
     std::vector<nixl_backend_t>
     getLoadedBackendPluginNames();
 
+    // Get all available backend plugin names (loaded + discovered on disk)
+    std::vector<nixl_backend_t>
+    getAvailBackendPluginNames();
+
     // Get all loaded telemetry plugin names
     std::vector<nixl_telemetry_plugin_t>
     getLoadedTelemetryPluginNames();
@@ -160,6 +165,10 @@ private:
         loaded_backend_plugins_;
     std::map<nixl_telemetry_plugin_t, std::shared_ptr<const nixlTelemetryPluginHandle>>
         loaded_telemetry_plugins_;
+    // Plugins discovered on disk but not yet dlopen'd
+    std::set<nixl_backend_t> discovered_backend_plugins_;
+    // Explicit paths from the plugin list file (name -> .so path)
+    std::map<nixl_backend_t, std::string> explicit_plugin_paths_;
     std::vector<std::string> plugin_dirs_;
     std::vector<nixlBackendStaticPluginInfo> backend_static_plugins_;
     std::vector<nixlTelemetryStaticPluginInfo> telemetry_static_plugins_;

--- a/test/gtest/plugin_manager.cpp
+++ b/test/gtest/plugin_manager.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -167,6 +167,29 @@ TEST_P(LoadMultiplePluginsTestFixture, SimpleLifeCycleTest) {
 
 TEST_F(LoadedPluginTestFixture, NoLoadedPluginsTest) {
   EXPECT_TRUE(HasOnlyLoadedPlugins());
+}
+
+TEST_F(LoadedPluginTestFixture, DeferredDiscoveryTest) {
+    auto mock = GetMockBackendName();
+    auto avail = plugin_manager_.getAvailBackendPluginNames();
+    auto loaded = plugin_manager_.getLoadedBackendPluginNames();
+
+    // Available plugins should include discovered-but-not-loaded ones
+    EXPECT_GT(avail.size(), loaded.size());
+    EXPECT_NE(std::find(avail.begin(), avail.end(), mock), avail.end());
+    EXPECT_EQ(std::find(loaded.begin(), loaded.end(), mock), loaded.end());
+
+    // After loading, it should appear in both
+    EXPECT_TRUE(LoadPlugin(mock));
+    loaded = plugin_manager_.getLoadedBackendPluginNames();
+    EXPECT_NE(std::find(loaded.begin(), loaded.end(), mock), loaded.end());
+
+    // After unloading, still available (discovered on disk) but not loaded
+    UnloadPlugin(mock);
+    loaded = plugin_manager_.getLoadedBackendPluginNames();
+    EXPECT_EQ(std::find(loaded.begin(), loaded.end(), mock), loaded.end());
+    avail = plugin_manager_.getAvailBackendPluginNames();
+    EXPECT_NE(std::find(avail.begin(), avail.end(), mock), avail.end());
 }
 
 TEST_F(LoadedPluginTestFixture, LoadSinglePluginTest) {


### PR DESCRIPTION
## What?

Defer plugin `dlopen` from discovery time to first use. Plugins found on disk are now recorded by name only; the actual `dlopen` happens when `createBackend()` or `getPluginParams()` is called for that specific plugin.

## Why?

https://github.com/vllm-project/vllm/issues/39521

Creating a `nixl_agent` crashes with a segfault on some systems (RHEL 9 / Rocky 9 bare-metal DGX H100) due to eager plugin loading.

During `nixlPluginManager` construction, every plugin `.so` in the plugins directory is `dlopen`'d, including plugins the user never requested (e.g. LIBFABRIC on InfiniBand systems). The `dlopen` triggers transitive dependency initialization (`libnuma` -> `numa_hook.so`) which crashes before any NIXL code even executes. The Python `nixl_agent.__init__` further aggravates this by calling `getPluginParams()` on every discovered plugin, forcing a second `dlopen` attempt for each.

## How?

**C++ (`plugin_manager.h`, `nixl_plugin_manager.cpp`, `nixl_agent.cpp`):**
- Add `discovered_backend_plugins_` and `discovered_telemetry_plugins_` sets to track plugin names found on disk without loading them.
- Add `explicit_plugin_paths_` map to preserve exact `.so` paths from the plugin list file, so `loadBackendPlugin()` tries those first before scanning directories.
- `discoverBackendPlugin()` / `discoverTelemetryPlugin()`: record the plugin name instead of calling `loadBackendPlugin()`.
- `loadPluginsFromList()`: same, record names and paths instead of `dlopen`'ing.
- Add `getAvailBackendPluginNames()` which returns loaded + discovered names. `getAvailPlugins()` calls this instead of `getLoadedBackendPluginNames()`.
- `getLoadedBackendPluginNames()` / `getLoadedTelemetryPluginNames()` remain unchanged (loaded only).

**Python (`_api.py`):**
- Remove the `for plugin in self.plugin_list: getPluginParams(plugin)` loop from `nixl_agent.__init__`.
- Add `_load_plugin_params()` helper that lazily populates the cache on first access.
- `get_plugin_params()` and `get_plugin_mem_types()` call the helper before returning.

No API changes. `get_plugin_list()` returns the same names. `create_backend()`, `getPluginParams()`, and `instantiate_all=True` all work identically. The `dlopen` just happens on demand instead of unconditionally at init.
