### PR TITLE
PLUGINS/UCX: Improve progress and notif handling.

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1398,6 +1398,7 @@ nixlUcxEngine::getConnection(const std::string &remote_agent) const {
 
 void
 nixlUcxEngine::appendNotif(std::string &&remote_name, std::string &&msg) {
+    // In the "no progress thread" case the lock in nixlAgent is sufficient.
     notifList_.emplace_back(std::move(remote_name), std::move(msg));
 }
 
@@ -1432,6 +1433,7 @@ nixlUcxEngine::getNotifs(notif_list_t &notif_list) {
 
     progressLoop();
 
+    // In the "no progress thread" case the lock in nixlAgent is sufficient.
     notifList_.swap(notif_list);
     return NIXL_SUCCESS;
 }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -393,7 +393,6 @@ nixlUcxThreadEngine::getNotifs(notif_list_t &notif_list) {
 
     const std::lock_guard lock(notifMutex_);
     notifList_.swap(notif_list);
-    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 
@@ -778,7 +777,6 @@ nixlUcxThreadPoolEngine::getNotifs(notif_list_t &notif_list) {
 
     const std::lock_guard lock(notifMutex_);
     notifList_.swap(notif_list);
-    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 
@@ -1435,7 +1433,6 @@ nixlUcxEngine::getNotifs(notif_list_t &notif_list) {
     progressLoop();
 
     notifList_.swap(notif_list);
-    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -30,15 +30,6 @@
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
 #include <asio.hpp>
-namespace {
-    void moveNotifList(notif_list_t &src, notif_list_t &tgt)
-    {
-        if (src.size() > 0) {
-            std::move(src.begin(), src.end(), std::back_inserter(tgt));
-            src.clear();
-        }
-    }
-}
 
 /****************************************
  * Backend request management
@@ -143,9 +134,7 @@ public:
             return NIXL_SUCCESS;
         }
 
-        /* Maximum progress */
-        while (worker->progress())
-            ;
+        worker->progressLoop();
 
         /* If last request is incomplete, return NIXL_IN_PROG early without
          * checking other requests */
@@ -341,8 +330,7 @@ protected:
                 pollFds_[i].revents = 0;
                 nixlUcxWorker *worker = getWorkers()[i];
                 do {
-                    while (worker->progress())
-                        ;
+                    worker->progressLoop();
                 } while (worker->arm() == NIXL_IN_PROG);
             }
             timeout = false;
@@ -392,23 +380,24 @@ nixlUcxThreadEngine::~nixlUcxThreadEngine() {
 }
 
 void
-nixlUcxThreadEngine::appendNotif(std::string remote_name, std::string msg) {
-    if (nixlUcxThread::isProgressThread(this)) {
-        /* Append to the private list to allow batching */
-        const std::lock_guard<std::mutex> lock(notifMtx_);
-        notifPthr_.push_back(std::make_pair(std::move(remote_name), std::move(msg)));
-    } else {
-        nixlUcxEngine::appendNotif(std::move(remote_name), std::move(msg));
-    }
+nixlUcxThreadEngine::appendNotif(std::string &&remote_name, std::string &&msg) {
+    const std::lock_guard lock(notifMutex_);
+    notifList_.emplace_back(std::move(remote_name), std::move(msg));
 }
 
 nixl_status_t
 nixlUcxThreadEngine::getNotifs(notif_list_t &notif_list) {
-    if (!notif_list.empty()) return NIXL_ERR_INVALID_PARAM;
+    if (!notif_list.empty()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    getNotifsImpl(notif_list);
-    const std::lock_guard<std::mutex> lock(notifMtx_);
-    moveNotifList(notifPthr_, notif_list);
+    std::size_t size;
+    {
+        const std::lock_guard lock(notifMutex_);
+        notifList_.swap(notif_list);
+        size = notif_list.size();
+    }
+    notifList_.reserve(size);
     return NIXL_SUCCESS;
 }
 
@@ -559,8 +548,7 @@ public:
 
     nixl_status_t
     status() override {
-        while (getWorker()->progress())
-            ;
+        getWorker()->progressLoop();
 
         if (sharedState_->pendingReqs.load()) {
             return NIXL_IN_PROG;
@@ -777,26 +765,28 @@ nixlUcxThreadPoolEngine::sendXferRange(const nixl_xfer_op_t &operation,
 }
 
 void
-nixlUcxThreadPoolEngine::appendNotif(std::string remote_name, std::string msg) {
-    if (nixlUcxThread::isProgressThread(this)) {
-        std::lock_guard<std::mutex> lock(notifMutex_);
-        notifThread_.emplace_back(std::move(remote_name), std::move(msg));
-    } else {
-        nixlUcxEngine::appendNotif(std::move(remote_name), std::move(msg));
-    }
+nixlUcxThreadPoolEngine::appendNotif(std::string &&remote_name, std::string &&msg) {
+    const std::lock_guard lock(notifMutex_);
+    notifList_.emplace_back(std::move(remote_name), std::move(msg));
 }
 
 nixl_status_t
 nixlUcxThreadPoolEngine::getNotifs(notif_list_t &notif_list) {
-    if (!notif_list.empty()) return NIXL_ERR_INVALID_PARAM;
-
-    if (!sharedThread_) {
-        progress();
+    if (!notif_list.empty()) {
+        return NIXL_ERR_INVALID_PARAM;
     }
 
-    getNotifsImpl(notif_list);
-    std::lock_guard<std::mutex> lock(notifMutex_);
-    moveNotifList(notifThread_, notif_list);
+    if (!sharedThread_) {
+        progressLoop();
+    }
+
+    std::size_t size;
+    {
+        const std::lock_guard lock(notifMutex_);
+        notifList_.swap(notif_list);
+        size = notif_list.size();
+    }
+    notifList_.reserve(size);
     return NIXL_SUCCESS;
 }
 
@@ -820,8 +810,7 @@ nixlUcxEngine::create(const nixlBackendInitParams &init_params) {
 
 nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
     : nixlBackendEngine(&init_params),
-      sharedWorkerIndex_(1),
-      progressThreadEnabled_(init_params.enableProgTh) {
+      sharedWorkerIndex_(1) {
     std::vector<std::string> devs; /* Empty vector */
     nixl_b_params_t *custom_params = init_params.customParams;
 
@@ -1360,12 +1349,20 @@ nixl_status_t nixlUcxEngine::releaseReqH(nixlBackendReqH* handle) const
     return status;
 }
 
-int nixlUcxEngine::progress() {
+unsigned
+nixlUcxEngine::progress() {
     // TODO: add listen for connection handling if necessary
-    int ret = 0;
-    for (auto &uw: uws)
+    unsigned ret = 0;
+    for (auto &uw: uws) {
         ret += uw->progress();
+    }
     return ret;
+}
+
+void
+nixlUcxEngine::progressLoop() {
+    while (progress() != 0)
+        ;
 }
 
 /****************************************
@@ -1410,8 +1407,8 @@ nixlUcxEngine::getConnection(const std::string &remote_agent) const {
 }
 
 void
-nixlUcxEngine::appendNotif(std::string remote_name, std::string msg) {
-    notifMainList.emplace_back(std::move(remote_name), std::move(msg));
+nixlUcxEngine::appendNotif(std::string &&remote_name, std::string &&msg) {
+    notifList_.emplace_back(std::move(remote_name), std::move(msg));
 }
 
 ucs_status_t
@@ -1437,18 +1434,17 @@ nixlUcxEngine::notifAmCb(void *arg, const void *header,
     return UCS_OK;
 }
 
-void
-nixlUcxEngine::getNotifsImpl(notif_list_t &notif_list) {
-    moveNotifList(notifMainList, notif_list);
-}
-
-nixl_status_t nixlUcxEngine::getNotifs(notif_list_t &notif_list)
+nixl_status_t
+nixlUcxEngine::getNotifs(notif_list_t &notif_list)
 {
-    if (!notif_list.empty()) return NIXL_ERR_INVALID_PARAM;
+    if (!notif_list.empty()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    while (progress())
-        ;
-    getNotifsImpl(notif_list);
+    progressLoop();
+
+    notifList_.swap(notif_list);
+    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -391,13 +391,9 @@ nixlUcxThreadEngine::getNotifs(notif_list_t &notif_list) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    std::size_t size;
-    {
-        const std::lock_guard lock(notifMutex_);
-        notifList_.swap(notif_list);
-        size = notif_list.size();
-    }
-    notifList_.reserve(size);
+    const std::lock_guard lock(notifMutex_);
+    notifList_.swap(notif_list);
+    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 
@@ -780,13 +776,9 @@ nixlUcxThreadPoolEngine::getNotifs(notif_list_t &notif_list) {
         progressLoop();
     }
 
-    std::size_t size;
-    {
-        const std::lock_guard lock(notifMutex_);
-        notifList_.swap(notif_list);
-        size = notif_list.size();
-    }
-    notifList_.reserve(size);
+    const std::lock_guard lock(notifMutex_);
+    notifList_.swap(notif_list);
+    notifList_.reserve(notif_list.size());
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1353,7 +1353,7 @@ unsigned
 nixlUcxEngine::progress() {
     // TODO: add listen for connection handling if necessary
     unsigned ret = 0;
-    for (auto &uw: uws) {
+    for (auto &uw : uws) {
         ret += uw->progress();
     }
     return ret;
@@ -1435,8 +1435,7 @@ nixlUcxEngine::notifAmCb(void *arg, const void *header,
 }
 
 nixl_status_t
-nixlUcxEngine::getNotifs(notif_list_t &notif_list)
-{
+nixlUcxEngine::getNotifs(notif_list_t &notif_list) {
     if (!notif_list.empty()) {
         return NIXL_ERR_INVALID_PARAM;
     }

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -184,8 +184,11 @@ public:
     nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 
-    int
+    unsigned
     progress();
+
+    void
+    progressLoop();
 
     nixl_status_t
     getNotifs(notif_list_t &notif_list) override;
@@ -227,11 +230,8 @@ protected:
         return uws.size();
     }
 
-    void
-    getNotifsImpl(notif_list_t &notif_list);
-
     virtual void
-    appendNotif(std::string remote_name, std::string msg);
+    appendNotif(std::string &&remote_name, std::string &&msg);
 
     virtual nixl_status_t
     sendXferRange(const nixl_xfer_op_t &operation,
@@ -243,6 +243,8 @@ protected:
                   size_t end_idx) const;
 
     nixlUcxEngine(const nixlBackendInitParams &init_params);
+
+    notif_list_t notifList_;
 
 private:
     // Memory management helpers
@@ -295,11 +297,6 @@ private:
     std::string workerAddr;
     mutable std::atomic<size_t> sharedWorkerIndex_;
 
-    const bool progressThreadEnabled_;
-
-    /* Notifications */
-    notif_list_t notifMainList;
-
     // Map of agent name to saved nixlUcxConnection info
     std::unordered_map<std::string, ucx_connection_ptr_t> remoteConnMap;
 };
@@ -319,12 +316,11 @@ public:
 
 protected:
     void
-    appendNotif(std::string remote_name, std::string msg) override;
+    appendNotif(std::string &&remote_name, std::string &&msg) override;
 
 private:
     std::unique_ptr<nixlUcxThread> thread_;
-    std::mutex notifMtx_;
-    notif_list_t notifPthr_;
+    std::mutex notifMutex_;
 };
 
 namespace asio {
@@ -354,7 +350,7 @@ public:
 
 protected:
     void
-    appendNotif(std::string remote_name, std::string msg) override;
+    appendNotif(std::string &&remote_name, std::string &&msg) override;
 
     nixl_status_t
     sendXferRange(const nixl_xfer_op_t &operation,
@@ -371,7 +367,6 @@ private:
     std::vector<std::unique_ptr<nixlUcxThread>> dedicatedThreads_;
     size_t numSharedWorkers_;
     std::mutex notifMutex_;
-    notif_list_t notifThread_;
     size_t splitBatchSize_;
 };
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -656,9 +656,15 @@ nixlUcxWorker::regAmCallback(nixl::ucx::am_cb_op_t msg_id, ucp_am_recv_callback_
  * Data transfer
  * =========================================== */
 
-int
+unsigned
 nixlUcxWorker::progress() {
     return ucp_worker_progress(worker.get());
+}
+
+void
+nixlUcxWorker::progressLoop() {
+    while (progress() != 0)
+        ;
 }
 
 nixl_status_t

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -228,8 +228,12 @@ public:
     regAmCallback(nixl::ucx::am_cb_op_t msg_id, ucp_am_recv_callback_t cb, void *arg);
 
     /* Data access */
-    int
+    unsigned
     progress();
+
+    void
+    progressLoop();
+
     [[nodiscard]] nixl_status_t
     test(nixlUcxReq req);
 


### PR DESCRIPTION
## What?
- Simplify and optimize notif handling in the UCX backend.
- Add a `progressLoop()` function and call it consistently.

## How?
- Remove the second `notif_list_t` from some NIXL UCX engines.
- Simplify `getNotifs()` to a single `std::vector::swap()` with lock.
- Change the return type of `progress()` to match that of `ucp_worker_progress()`.
- Add `progressLoop()` functions that loop until zero, and use them where possible.
- Consistently call `progressLoop()` in `getNotifs()` where applicable.
- Remove the unused member variable `nixlUcxEngine:: progressThreadEnabled_`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified notification queuing into a single, thread-safe path for more reliable and consistent delivery.
  * Replaced busy-wait progress polling with a centralized progress loop to reduce CPU spin and improve responsiveness.
  * Simplified engine threading/state variants for more predictable backend behavior and consistent notification retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->