### PR TITLE
TEST/UCX: Make thread safe.

### DIFF
--- a/test/unit/plugins/ucx/ucx_backend_multi.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_multi.cpp
@@ -22,10 +22,6 @@
 #include "ucx_backend.h"
 #include "test_utils.h"
 
-// TODO: Find out what this comment means:
-// Temporarily while fixing CI/CD pipeline
-// #define USE_PTHREAD false
-
 std::atomic<bool> ready[2];
 std::atomic<bool> done[2];
 std::atomic<bool> disconnect[2];

--- a/test/unit/plugins/ucx/ucx_backend_multi.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_multi.cpp
@@ -33,8 +33,7 @@ std::atomic<bool> disconnect[2];
 std::string conn_info[2];
 
 void
-test_thread(const unsigned id, const bool progress_thread)
-{
+test_thread(const unsigned id, const bool progress_thread) {
     const std::string my_name = "Agent" + std::to_string(id);
     const std::string other = "Agent" + std::to_string(1 - id);
 
@@ -56,19 +55,20 @@ test_thread(const unsigned id, const bool progress_thread)
     ucx->getConnInfo(conn_info[id]);
 
     ready[id].store(true);
-    while(!ready[!id].load());
+    while (!ready[!id].load())
+        ;
 
     const auto ret = ucx->loadRemoteConnInfo(other, conn_info[!id]);
     nixl_exit_on_failure((ret == NIXL_SUCCESS), "Failed to load remote conn info", my_name);
 
     //one-sided connect
-    if(!id) {
+    if (!id) {
         const auto ret = ucx->connect(other);
         nixl_exit_on_failure((ret == NIXL_SUCCESS), "Failed to connect", my_name);
     }
 
     done[id].store(true);
-    while(!done[!id].load()) {
+    while (!done[!id].load()) {
         if (id && !progress_thread) {
             ucx->progress();
         }
@@ -77,13 +77,14 @@ test_thread(const unsigned id, const bool progress_thread)
     std::cout << "Thread passed with id " << id << "\n";
 
     //test one-sided disconnect
-    if(!id) {
+    if (!id) {
         ucx->disconnect(other);
     }
 
     disconnect[id].store(true);
     //wait for other
-    while(!disconnect[!id].load());
+    while (!disconnect[!id].load())
+        ;
 
     if (!progress_thread) {
         ucx->progress();
@@ -115,8 +116,8 @@ test_perform(const unsigned first, const bool progress_thread) {
     std::cout << "Multithread test done\n";
 }
 
-int main()
-{
+int
+main() {
     for (unsigned i = 0; i < 12; ++i) {
         test_perform(i & 1, true);
         test_perform(i & 1, false);

--- a/test/unit/plugins/ucx/ucx_backend_multi.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_multi.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,88 +14,112 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <atomic>
 #include <iostream>
+#include <string>
 #include <thread>
 
 #include "ucx_backend.h"
 #include "test_utils.h"
 
-
+// TODO: Find out what this comment means:
 // Temporarily while fixing CI/CD pipeline
-#define USE_PTHREAD false
+// #define USE_PTHREAD false
 
-volatile bool ready[2]  = {false, false};
-volatile bool done[2]  = {false, false};
-volatile bool disconnect[2]  = {false, false};
+std::atomic<bool> ready[2];
+std::atomic<bool> done[2];
+std::atomic<bool> disconnect[2];
+
 std::string conn_info[2];
 
-void test_thread(int id)
+void
+test_thread(const unsigned id, const bool progress_thread)
 {
+    const std::string my_name = "Agent" + std::to_string(id);
+    const std::string other = "Agent" + std::to_string(1 - id);
+
+    nixl_b_params_t custom_params;
     nixlBackendInitParams init_params;
-    nixl_b_params_t       custom_params;
-    nixl_status_t         ret;
-
-    std::string my_name("Agent1");
-    std::string other("Agent2");
-
-    if(id){
-        my_name = "Agent2";
-        other = "Agent1";
-    }
-
-    init_params.localAgent   = my_name;
-    init_params.enableProgTh = USE_PTHREAD;
+    init_params.localAgent = my_name;
+    init_params.enableProgTh = progress_thread;
     init_params.customParams = &custom_params;
-    init_params.type         = "UCX";
+    init_params.type = "UCX";
 
     std::cout << my_name << " Started\n";
 
-    auto ucx = nixlUcxEngine::create(init_params).release();
+    const auto ucx = nixlUcxEngine::create(init_params);
 
-    if (!USE_PTHREAD) ucx->progress();
+    if (!progress_thread) {
+        ucx->progress();
+    }
 
     ucx->getConnInfo(conn_info[id]);
 
-    ready[id] = true;
-    //wait for other
-    while(!ready[!id]);
+    ready[id].store(true);
+    while(!ready[!id].load());
 
-    ret = ucx->loadRemoteConnInfo(other, conn_info[!id]);
+    const auto ret = ucx->loadRemoteConnInfo(other, conn_info[!id]);
     nixl_exit_on_failure((ret == NIXL_SUCCESS), "Failed to load remote conn info", my_name);
 
     //one-sided connect
-    if(!id)
-        ret = ucx->connect(other);
+    if(!id) {
+        const auto ret = ucx->connect(other);
+        nixl_exit_on_failure((ret == NIXL_SUCCESS), "Failed to connect", my_name);
+    }
 
-    nixl_exit_on_failure((ret == NIXL_SUCCESS), "Failed to connect", my_name);
-
-    done[id] = true;
-    while(!done[!id])
-        if (!USE_PTHREAD && id) ucx->progress();
+    done[id].store(true);
+    while(!done[!id].load()) {
+        if (id && !progress_thread) {
+            ucx->progress();
+        }
+    }
 
     std::cout << "Thread passed with id " << id << "\n";
 
     //test one-sided disconnect
-    if(!id)
+    if(!id) {
         ucx->disconnect(other);
+    }
 
-    disconnect[id] = true;
+    disconnect[id].store(true);
     //wait for other
-    while(!disconnect[!id]);
+    while(!disconnect[!id].load());
 
-    if (!USE_PTHREAD) ucx->progress();
+    if (!progress_thread) {
+        ucx->progress();
+    }
 
     std::cout << "Thread disconnected with id " << id << "\n";
+}
 
-    delete ucx;
+void
+test_perform(const unsigned first, const bool progress_thread) {
+    conn_info[0].clear();
+    conn_info[1].clear();
+    ready[0].store(false);
+    ready[1].store(false);
+    done[0].store(false);
+    done[1].store(false);
+    disconnect[0].store(false);
+    disconnect[1].store(false);
+
+    std::cout << "Multithread test start\n";
+    std::cout << "Progress thread " << progress_thread << "\n";
+
+    std::thread th1(test_thread, first, progress_thread);
+    std::thread th2(test_thread, 1 - first, progress_thread);
+
+    th1.join();
+    th2.join();
+
+    std::cout << "Multithread test done\n";
 }
 
 int main()
 {
-    std::cout << "Multithread test start \n";
-    std::thread th1(test_thread, 0);
-    std::thread th2(test_thread, 1);
-
-    th1.join();
-    th2.join();
+    for (unsigned i = 0; i < 12; ++i) {
+        test_perform(i & 1, true);
+        test_perform(i & 1, false);
+    }
+    return 0;
 }

--- a/test/unit/plugins/ucx/ucx_backend_multi.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_multi.cpp
@@ -43,6 +43,7 @@ test_thread(const unsigned id, const bool progress_thread) {
     std::cout << my_name << " Started\n";
 
     const auto ucx = nixlUcxEngine::create(init_params);
+    nixl_exit_on_failure(ucx && !ucx->getInitErr(), "Failed to initialize engine", my_name);
 
     if (!progress_thread) {
         ucx->progress();


### PR DESCRIPTION
## What?
Makes the multi-threaded `ucx_backend_multi` thread safe.

## Why?
It was using `volatile` for thread synchronization which is always wrong and possibly leading to spurious failures of some CI jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced unsafe busy-wait primitives with atomic synchronization for more reliable multi-threaded test runs.
  * Introduced configurable progress-driving mode and repeated iterations to better exercise thread interactions and timing.
  * Adjusted test lifecycle and failure checks for more consistent start/stop behavior and clearer failure reporting across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->