### PR TITLE
nixlbench: fix ttl for immature expiration because of late first refresh

### DIFF
--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -30,7 +30,7 @@
 
 namespace {
 // Lease TTL in seconds: rank key auto-expires this long after the last keepalive.
-constexpr int lease_ttl_s = 15;
+constexpr int lease_ttl_s = 30;
 } // namespace
 
 // ETCD Runtime implementation
@@ -149,6 +149,21 @@ xferBenchEtcdRT::cleanupForExit() {
     if (client) {
         client->rmdir(makeKey(""), true);
     }
+}
+
+bool
+xferBenchEtcdRT::checkKeepAlive() {
+    if (keepalive) {
+        try {
+            keepalive->Check();
+        }
+        catch (const std::exception &e) {
+            std::cerr << "nixlbench: keepalive Check() returns a failure detected in the past: "
+                      << e.what() << std::endl;
+            return false;
+        }
+    }
+    return true;
 }
 
 bool

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -107,7 +107,7 @@ public:
 
     // Check if the keepalive lease is still valid
     bool
-    checkKeepAlive();
+    checkKeepAlive() override;
 
     // Cancel keepalive and remove namespace keys before a forced _Exit()
     void

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -105,6 +105,10 @@ public:
     bool
     areAllPeersAlive() override;
 
+    // Check if the keepalive lease is still valid
+    bool
+    checkKeepAlive();
+
     // Cancel keepalive and remove namespace keys before a forced _Exit()
     void
     cleanupForExit() override;

--- a/benchmark/nixlbench/src/runtime/runtime.h
+++ b/benchmark/nixlbench/src/runtime/runtime.h
@@ -48,6 +48,12 @@ class xferBenchRT {
             return true;
         }
 
+        // Check if the keepalive lease is still valid; returns true by default
+        [[nodiscard]] virtual bool
+        checkKeepAlive() {
+            return true;
+        }
+
         // Best-effort cleanup of runtime state (e.g. etcd keys) before a
         // forced exit that bypasses normal destructors.
         virtual void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1472,8 +1472,8 @@ xferBenchNixlWorker::poll(size_t block_size) {
     // Fires at most once every liveness_check_interval to avoid
     // saturating etcd with get() calls during tight polling loops.
     using namespace std::chrono_literals;
-    auto last_liveness_check = std::chrono::steady_clock::now();
     constexpr auto liveness_check_interval = 5s;
+    auto last_liveness_check = std::chrono::steady_clock::time_point::min(); // never done before.
     auto checkLiveness = [&]() {
         const auto now = std::chrono::steady_clock::now();
         if (now - last_liveness_check >= liveness_check_interval) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "worker/nixl/nixl_worker.h"
+#include "runtime/etcd/etcd_rt.h"
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -1403,6 +1404,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
     int ret = 0;
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
     // int completion_flag = 1;
+
+    if (auto *etcd_rt = dynamic_cast<xferBenchEtcdRT *>(rt)) {
+        if (!etcd_rt->checkKeepAlive()) { // also refreshes the lease internally.
+            std::cerr << "nixlbench: keepalive failed before transfer — aborting" << std::endl;
+            return std::variant<xferBenchStats, int>(-1);
+        }
+    }
 
     // Reduce skip by 10x for large block sizes
     if (block_size > LARGE_BLOCK_SIZE) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "worker/nixl/nixl_worker.h"
-#include "runtime/etcd/etcd_rt.h"
 #include <algorithm>
 #include <cctype>
 #include <chrono>
@@ -1405,11 +1404,9 @@ xferBenchNixlWorker::transfer(size_t block_size,
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
     // int completion_flag = 1;
 
-    if (auto *etcd_rt = dynamic_cast<xferBenchEtcdRT *>(rt)) {
-        if (!etcd_rt->checkKeepAlive()) { // also refreshes the lease internally.
-            std::cerr << "nixlbench: keepalive failed before transfer — aborting" << std::endl;
-            return std::variant<xferBenchStats, int>(-1);
-        }
+    if (!rt->checkKeepAlive()) { // also refreshes the lease internally.
+        std::cerr << "nixlbench: keepalive failed before transfer — aborting" << std::endl;
+        return std::variant<xferBenchStats, int>(-1);
     }
 
     // Reduce skip by 10x for large block sizes


### PR DESCRIPTION
- add Check() in etcd runtime, and call at the start of transfer(), to surface any KeepAlive object's error in previous attempts to refresh the lease. Note that Check() internally refreshes the lease as well.

- add a longer (30 sec) ttl as the first refresh attempt may be late.
  - The first refresh from the dedicated thread inside KeepAlive object may be late, due to overhead to start the thread.
  - The first refresh from the first Check() in transfer() may be late due to nixlbench start up overhead.

## What?
We see keepAlive object fails to refresh the lease, and the target poll loop fails at check liveness and then is aborted. The failure is due to late first attempt to refresh, initiated from the dedicated thread in KeepAlive object. This affects multiple aws instance types, and can be repeatedly reproduced on a c7gd (arm-based cpu) instance. 

## Why?
The first attempt to refresh the lease needs to happen before the lease expire after TTL. Today this happened after TTL - 1 sec:
https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/blob/master/src/KeepAlive.cpp#L207,
which is after the thread is started.
So, it assumes that one sec is enough from the time the lease is created to when it tries to refresh, which may not be enough.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keepalive validation before transfer operations to detect stale or broken connections.
  * Transfers now abort early and surface failures when keepalive validation fails.
  * Liveness checks run immediately on start to detect issues sooner rather than waiting.
  * Lease timeout increased to improve connection reliability and reduce premature expirations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->