### PR TITLE
NIXLBENCH: Fix cuda fabric meson check

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -97,8 +97,7 @@ endif
 
 cuda_fabric_available = false
 if cuda_available
-    if cpp.has_header_symbol('cuda.h', 'CU_MEM_HANDLE_TYPE_FABRIC',
-                             args: cuda_inc_path != '' ? '-I' + cuda_inc_path : [])
+    if cpp.has_header_symbol('cuda.h', 'CU_MEM_HANDLE_TYPE_FABRIC', dependencies: cuda_dep)
         cuda_fabric_available = true
     endif
 endif


### PR DESCRIPTION
## What?
Fix meson check for detecting cuda fabric memory support, which is required for multi-node NVLink



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined CUDA fabric capability detection in the build system by leveraging dependency management tools more efficiently, simplifying the detection process while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->