### PR TITLE
Use liburing wrap

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -43,7 +43,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260426-1"
+  CI_IMAGE_TAG: "20260427-1"
 
 
 runs_on_dockers:

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -43,7 +43,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260427-1"
+  CI_IMAGE_TAG: "20260506-3"
 
 
 runs_on_dockers:

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -52,7 +52,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260426-1"
+  CI_IMAGE_TAG: "20260427-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -52,7 +52,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260427-1"
+  CI_IMAGE_TAG: "20260506-3"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -50,7 +50,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260426-1"
+  CI_IMAGE_TAG: "20260427-1"
 
 empty_volumes:
   - {mountPath: /root, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -50,7 +50,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260427-1"
+  CI_IMAGE_TAG: "20260506-3"
 
 empty_volumes:
   - {mountPath: /root, memory: false}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cufile.log
 
 # Asio
 subprojects/asio-*
+
+# liburing
+subprojects/liburing-*

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -101,7 +101,6 @@ else
                                  libprotobuf-dev \
                                  libcpprest-dev \
                                  libaio-dev \
-                                 liburing-dev \
                                  libelf-dev \
                                  libgflags-dev \
                                  patchelf \

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -123,6 +123,7 @@ else
                                  libhwloc-dev \
                                  libxml2-dev \
                                  libcurl4-openssl-dev zlib1g-dev # aws-sdk-cpp dependencies
+    $SUDO apt-mark hold liburing2 liburing-dev
 
     # Ubuntu 22.04 specific setup
     if grep -q "Ubuntu 22.04" /etc/os-release 2>/dev/null; then
@@ -294,6 +295,7 @@ else
       echo "MOONCAKE_VERSION: ${MOONCAKE_VERSION}" && \
       git clone --depth 1 --branch "${MOONCAKE_VERSION}" https://github.com/kvcache-ai/Mooncake.git && \
       cd Mooncake && \
+      sed -i '/liburing-dev/d' dependencies.sh
       $SUDO bash dependencies.sh -y && \
       mkdir build && cd build && \
       cmake .. -DBUILD_SHARED_LIBS=ON -DWITH_STORE=OFF -G Ninja && \

--- a/ATTRIBUTIONS-CPP.md
+++ b/ATTRIBUTIONS-CPP.md
@@ -898,7 +898,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-## liburing - 2.12
+## liburing - 2.14
 
 - **Repository URL**: https://github.com/axboe/liburing
 - **License URL**: https://github.com/axboe/liburing/blob/master/LICENSE

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -221,7 +221,7 @@ sudo apt-get update && sudo apt-get install -y \
   autotools-dev automake libtool libz-dev flex \
   libgtest-dev hwloc libhwloc-dev libgflags-dev \
   libgrpc-dev libgrpc++-dev libprotobuf-dev \
-  libaio-dev liburing-dev protobuf-compiler-grpc \
+  libaio-dev protobuf-compiler-grpc \
   libcpprest-dev etcd-server etcd-client \
   pybind11-dev libclang-dev libcurl4-openssl-dev \
   libssl-dev uuid-dev libxml2-dev zlib1g-dev python3-dev python3-pip

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -35,7 +35,6 @@ RUN apt-get update -y && \
     libgflags-dev \
     libprotobuf-dev \
     libaio-dev \
-    liburing-dev \
     protobuf-compiler-grpc \
     libcpprest-dev \
     etcd-server \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -50,7 +50,6 @@ RUN apt-get update -y && \
     libgflags-dev \
     libprotobuf-dev \
     libaio-dev \
-    liburing-dev \
     libcpprest-dev \
     etcd-server \
     etcd-client \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -23,7 +23,6 @@ ARG ARCH="x86_64"
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG HWLOC_VERSION="2.12.2"
 ARG BUILD_TYPE="release"
-ARG URING_TAG="liburing-2.13"
 ARG BUILD_NIXL_EP="true"
 ARG ABSL_TAG="lts_2025_08_14"
 ARG GRPC_TAG="v1.73.0"
@@ -167,14 +166,6 @@ RUN mkdir aws_sdk_build && cd aws_sdk_build && \
         -DCURL_INCLUDE_DIR=/usr/local/include \
         -DOPENSSL_USE_STATIC_LIBS=OFF && \
     make -j${NPROC:-$(nproc)} && make install
-
-RUN git clone https://github.com/axboe/liburing.git && \
-     cd liburing && \
-     git checkout $URING_TAG && \
-     ./configure --cc=gcc --cxx=g++ && \
-    make -j${NPROC:-$(nproc)} library && make liburing.pc && make install && \
-     ldconfig && \
-     cd ..
 
 ENV PKG_CONFIG_PATH=/usr/lib/pkgconfig:$PKG_CONFIG_PATH
 

--- a/meson.build
+++ b/meson.build
@@ -79,6 +79,17 @@ dl_dep = cpp.find_library('dl', required: true)
 rt_dep = cpp.find_library('rt', required: true)
 thread_dep = dependency('threads')
 
+# Forced to ignore this error due to:
+# https://github.com/abseil/abseil-cpp/issues/1779
+# This must be global since subprojects cannot be assigned with arguments.
+# Adding this configuration only for release build to consider it while developing.
+# NOTE: Must be declared before any subproject fallback that builds a target
+# (e.g. liburing wrap), because Meson forbids add_global_arguments after targets.
+if get_option('buildtype') == 'release'
+  abseil_flags = cpp.get_supported_arguments('-Wno-error=maybe-uninitialized', '-Wno-maybe-uninitialized')
+  add_global_arguments(abseil_flags, language: 'cpp')
+endif
+
 # Check for libaio (for LINUX AIO plugin and test)
 has_linux_aio = false
 linux_aio_dep = cpp.find_library('aio', required: false)
@@ -88,9 +99,15 @@ endif
 
 # Check for liburing
 has_io_uring = false
-io_uring_dep = dependency('liburing', required: false)
+io_uring_dep = dependency('liburing', required: false,
+                          fallback: ['liburing', 'liburing_dep'],
+                          default_options: ['default_library=shared, follow_symlinks=true'])
 if io_uring_dep.found()
-    has_io_uring = cpp.has_function('io_uring_queue_init_params', prefix: '#include <liburing.h>',  dependencies: [io_uring_dep])
+  # Use has_header_symbol instead of has_function so the check works for both
+  # system-installed and subproject (internal) liburing — has_header_symbol only
+  # needs headers (no linking), so it succeeds even before the subproject is compiled.
+  has_io_uring = cpp.has_header_symbol('liburing.h', 'io_uring_queue_init_params',
+                                       dependencies: [io_uring_dep])
 endif
 
 # Check for POSIX aio
@@ -103,15 +120,6 @@ has_posix_plugin = has_linux_aio or has_io_uring or has_posix_aio
 cuobj_dep = dependency('cuobjclient-13.1', required: false)
 if cuobj_dep.found()
     add_project_arguments('-DHAVE_CUOBJ_CLIENT', language: ['cpp'])
-endif
-
-# Forced to ignore this error due to:
-# https://github.com/abseil/abseil-cpp/issues/1779
-# This must be global since subprojects cannot be assigned with arguments.
-# Adding this configuration only for release build to consider it while developing.
-if get_option('buildtype') == 'release'
-  abseil_flags = cpp.get_supported_arguments('-Wno-error=maybe-uninitialized', '-Wno-maybe-uninitialized')
-  add_global_arguments(abseil_flags, language: 'cpp')
 endif
 
 # Search for Abseil dependencies in the system first

--- a/meson.build
+++ b/meson.build
@@ -99,15 +99,21 @@ endif
 
 # Check for liburing
 has_io_uring = false
-io_uring_dep = dependency('liburing', required: false,
-                          fallback: ['liburing', 'liburing_dep'],
+io_uring_dep = dependency('liburing',
                           default_options: ['default_library=shared, follow_symlinks=true'])
 if io_uring_dep.found()
-  # Use has_header_symbol instead of has_function so the check works for both
-  # system-installed and subproject (internal) liburing — has_header_symbol only
-  # needs headers (no linking), so it succeeds even before the subproject is compiled.
-  has_io_uring = cpp.has_header_symbol('liburing.h', 'io_uring_queue_init_params',
-                                       dependencies: [io_uring_dep])
+  if io_uring_dep.type_name() == 'internal'
+    # Internal (subproject) deps cannot be passed to compiler checks in meson
+    # < 1.5.  Retrieve the include dirs from the already-configured subproject
+    # and probe the header directly.
+    liburing_subproj = subproject('liburing')
+    has_io_uring = cpp.has_header_symbol('liburing.h', 'io_uring_queue_init_params',
+                                         include_directories: liburing_subproj.get_variable('inc'))
+  else
+    has_io_uring = cpp.has_function('io_uring_queue_init_params',
+                                    prefix: '#include <liburing.h>',
+                                    dependencies: [io_uring_dep])
+  endif
 endif
 
 # Check for POSIX aio

--- a/meson.build
+++ b/meson.build
@@ -99,8 +99,9 @@ endif
 
 # Check for liburing
 has_io_uring = false
-io_uring_dep = dependency('liburing',
-                          default_options: ['default_library=shared, follow_symlinks=true'])
+io_uring_dep = dependency('liburing', required: false,
+                          fallback: ['liburing'],
+                          default_options: ['default_library=shared'])
 if io_uring_dep.found()
   if io_uring_dep.type_name() == 'internal'
     # Internal (subproject) deps cannot be passed to compiler checks in meson

--- a/src/plugins/posix/README.md
+++ b/src/plugins/posix/README.md
@@ -31,15 +31,9 @@ sudo apt-get install libaio-dev
 sudo dnf install libaio-devel
 ```
 
+### liburing
 
-To enable liburing support you need to install the liburing package:
-
-```bash
-# Ubuntu/Debian
-sudo apt install liburing-dev
-# RHEL/CentOS/Fedora
-sudo dnf install liburing-devel
-```
+liburing support is enabled automatically via the Meson wrap under `subprojects/liburing.wrap` (pinned to WrapDB `liburing_2.14-1`). `meson setup` builds it from source when a system `liburing` is not found via pkg-config, so no manual install is required.
 
 To use liburing with POSIX plugin use params["use_uring"] = "true"
 

--- a/src/plugins/posix/io_uring_io_queue.cpp
+++ b/src/plugins/posix/io_uring_io_queue.cpp
@@ -66,9 +66,10 @@ private:
 nixlPosixIOQueueUring::nixlPosixIOQueueUring(uint32_t ios_pool_size, uint32_t kernel_queue_size)
     : nixlPosixIOQueueImpl<nixlPosixIoUringIO>(ios_pool_size, kernel_queue_size) {
     io_uring_params params = {};
-    if (io_uring_queue_init_params(kernel_queue_size_, &uring, &params) < 0) {
+    int ret = io_uring_queue_init_params(kernel_queue_size_, &uring, &params);
+    if (ret < 0) {
         throw std::runtime_error(
-            absl::StrFormat("Failed to initialize io_uring instance: %s", nixl_strerror(errno)));
+            absl::StrFormat("Failed to initialize io_uring instance: %s", nixl_strerror(-ret)));
     }
 }
 

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -11,4 +11,4 @@ patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libu
 wrapdb_version = 2.14-1
 
 [provide]
-liburing = liburing_dep
+dependency_names = liburing

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -3,12 +3,9 @@ directory = liburing-liburing-2.14
 source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.14.tar.gz
 source_filename = liburing-2.14.tar.gz
 source_hash = 5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c
-patch_filename = liburing_2.14-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.14-1/get_patch
-patch_hash = 4d0ba8f507c25c4fb9a31507a5c06d2a6c253822828084a0101e2bea27dba62a
 source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.14-1/liburing-2.14.tar.gz
-patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.14-1/liburing_2.14-1_patch.zip
 wrapdb_version = 2.14-1
+patch_directory = liburing
 
 [provide]
 dependency_names = liburing

--- a/subprojects/liburing.wrap
+++ b/subprojects/liburing.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = liburing-liburing-2.14
+source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.14.tar.gz
+source_filename = liburing-2.14.tar.gz
+source_hash = 5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c
+patch_filename = liburing_2.14-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.14-1/get_patch
+patch_hash = 4d0ba8f507c25c4fb9a31507a5c06d2a6c253822828084a0101e2bea27dba62a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.14-1/liburing-2.14.tar.gz
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.14-1/liburing_2.14-1_patch.zip
+wrapdb_version = 2.14-1
+
+[provide]
+liburing = liburing_dep

--- a/subprojects/packagefiles/liburing/meson.build
+++ b/subprojects/packagefiles/liburing/meson.build
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+project(
+  'liburing',
+  ['c', 'cpp'],
+  version: '2.14',
+  license: '(MIT OR LGPL-2.1-only) AND (MIT OR GPL-2.0-only WITH Linux-syscall-note)',
+  meson_version: '>=0.63.0',
+  default_options: [
+    'default_library=both',
+    'c_std=c11',
+    'cpp_std=c++11',
+    'warning_level=2',
+  ],
+)
+
+if host_machine.system() != 'linux'
+  error('Everything except Linux is unsupported. uring is a Linux framework')
+endif
+
+sanitize_opt = get_option('b_sanitize')
+
+use_asan = sanitize_opt.contains('address')
+use_ubsan = sanitize_opt.contains('undefined')
+use_tsan = sanitize_opt.contains('thread')
+
+project_version = meson.project_version().split('.')
+major_version = project_version[0]
+minor_version = project_version[1]
+
+add_project_arguments(
+  '-D_GNU_SOURCE',
+  '-D__SANE_USERSPACE_TYPES__',
+  '-include',
+  meson.current_build_dir() + '/config-host.h',
+  '-fno-stack-protector',
+  '-Wno-unused-parameter',
+  language: ['c', 'cpp'],
+)
+
+thread_dep = dependency('threads')
+
+cc = meson.get_compiler('c')
+
+has_stringop_overflow = cc.has_argument('-Wstringop-overflow')
+has_array_bounds = cc.has_argument('-Warray-bounds')
+
+has__kernel_rwf_t = cc.has_type(
+  '__kernel_rwf_t',
+  prefix: '#include <linux/fs.h>',
+)
+
+has__kernel_timespec = cc.has_members(
+  'struct __kernel_timespec',
+  'tv_sec',
+  'tv_nsec',
+  prefix: '#include <linux/time_types.h>',
+)
+
+code = '''#include <sys/types.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/openat2.h>
+int main(int argc, char **argv)
+{
+  struct open_how how;
+  how.flags = 0;
+  how.mode = 0;
+  how.resolve = 0;
+  return 0;
+}
+'''
+has_open_how = cc.compiles(
+  code,
+  name: 'open_how',
+)
+
+code = '''#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/stat.h>
+int main(int argc, char **argv)
+{
+  struct statx x;
+
+  return memset(&x, 0, sizeof(x)) != NULL;
+}
+'''
+has_statx = cc.compiles(
+  code,
+  name: 'statx',
+)
+
+code = '''#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/stat.h>
+main(int argc, char **argv)
+{
+  struct statx x;
+
+  return memset(&x, 0, sizeof(x)) != NULL;
+}
+'''
+glibc_statx = cc.compiles(
+  code,
+  name: 'glibc_statx',
+)
+
+cpp = meson.get_compiler('cpp')
+
+code = '''#include <iostream>
+int main(int argc, char **argv)
+{
+  std::cout << "Test";
+  return 0;
+}
+'''
+has_cxx = cpp.compiles(
+  code,
+  name: 'C++',
+)
+
+has_ucontext = cc.has_type(
+  'ucontext_t',
+  prefix: '#include <ucontext.h>',
+) and cc.has_function(
+  'makecontext',
+  prefix: '#include <ucontext.h>',
+)
+
+has_nvme_uring_cmd = cc.has_type(
+  'struct nvme_uring_cmd',
+  prefix: '#include <linux/nvme_ioctl.h>',
+)
+
+has_memfd_create = cc.compiles(
+  '''
+#include <sys/mman.h>
+int main(int argc, char **argv)
+{
+  int memfd = memfd_create("test", 0);
+  return 0;
+}
+''',
+  name: 'Has memfd_create',
+  args: ['-Werror=implicit-function-declaration'],
+)
+
+has_futexv = cc.compiles(
+  '''
+#include <linux/futex.h>
+#include <unistd.h>
+#include <string.h>
+int main(void)
+{
+  struct futex_waitv fw;
+
+  memset(&fw, FUTEX_32, sizeof(fw));
+
+  return sizeof(struct futex_waitv);
+}
+''',
+  name: 'Has futexv',
+)
+
+ublk_header = cc.compiles(
+  '''
+#include <string.h>
+#include <sys/ioctl.h>
+#include <linux/ublk_cmd.h>
+int main(int argc, char **argv)
+{
+  struct ublksrv_ctrl_cmd cmd = { };
+
+  cmd.addr = UBLK_U_CMD_START_DEV;
+  return cmd.queue_id;
+}
+''',
+  name: 'Has ublk header',
+)
+
+conf_data = configuration_data()
+conf_data.set('CONFIG_HAVE_KERNEL_RWF_T', has__kernel_rwf_t)
+conf_data.set('CONFIG_HAVE_KERNEL_TIMESPEC', has__kernel_timespec)
+conf_data.set('CONFIG_HAVE_OPEN_HOW', has_open_how)
+conf_data.set('CONFIG_HAVE_STATX', has_statx)
+conf_data.set('CONFIG_HAVE_GLIBC_STATX', glibc_statx)
+conf_data.set('CONFIG_HAVE_CXX', has_cxx)
+conf_data.set('CONFIG_HAVE_UCONTEXT', has_ucontext)
+conf_data.set('CONFIG_HAVE_STRINGOP_OVERFLOW', has_stringop_overflow)
+conf_data.set('CONFIG_HAVE_ARRAY_BOUNDS', has_array_bounds)
+conf_data.set('CONFIG_HAVE_MEMFD_CREATE', has_memfd_create)
+conf_data.set('CONFIG_HAVE_NVME_URING', has_nvme_uring_cmd)
+conf_data.set('CONFIG_HAVE_FUTEXV', has_futexv)
+conf_data.set('CONFIG_HAVE_FANOTIFY', cc.has_header('sys/fanotify.h'))
+conf_data.set('CONFIG_HAVE_UBLK_HEADER', ublk_header)
+conf_data.set('CONFIG_USE_SANITIZER', use_asan or use_ubsan)
+conf_data.set('CONFIG_USE_TSAN', use_tsan)
+configure_file(
+  output: 'config-host.h',
+  configuration: conf_data,
+)
+
+subdir('src')

--- a/subprojects/packagefiles/liburing/src/include/liburing/compat.h.meson
+++ b/subprojects/packagefiles/liburing/src/include/liburing/compat.h.meson
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBURING_COMPAT_H
+#define LIBURING_COMPAT_H
+@__kernel_rwf_t_compat@
+@__kernel_timespec_compat@
+@open_how_compat@
+@no_glibc_statx@
+@futexv_compat@
+@block_uring_cmd_discard_compat@
+#endif

--- a/subprojects/packagefiles/liburing/src/include/liburing/meson.build
+++ b/subprojects/packagefiles/liburing/src/include/liburing/meson.build
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if has__kernel_rwf_t
+  __kernel_rwf_t_compat = ''
+else
+  __kernel_rwf_t_compat = '''typedef int __kernel_rwf_t;
+'''
+endif
+
+if has__kernel_timespec
+  __kernel_timespec_compat = '''#include <linux/time_types.h>
+
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+'''
+else
+  __kernel_timespec_compat = '''#include <stdint.h>
+
+struct __kernel_timespec {
+  int64_t    tv_sec;
+  long long  tv_nsec;
+};
+
+#define UAPI_LINUX_IO_URING_H_SKIP_LINUX_TIME_TYPES_H 1
+'''
+endif
+
+if has_open_how
+  open_how_compat = '#include <linux/openat2.h>'
+else
+  open_how_compat = '''#include <inttypes.h>
+
+struct open_how {
+  uint64_t flags;
+  uint64_t mode;
+  uint64_t resolve;
+};
+'''
+endif
+
+if has_futexv
+  futexv_compat = ''
+else
+  futexv_compat = '''#include <inttypes.h>
+
+#define FUTEX_32	2
+#define FUTEX_WAITV_MAX	128
+
+struct futex_waitv {
+	uint64_t	val;
+	uint64_t	uaddr;
+	uint32_t	flags;
+	uint32_t	__reserved;
+};
+'''
+endif
+
+has_block_uring_cmd_discard = cc.has_header_symbol(
+  'linux/blkdev.h',
+  'BLOCK_URING_CMD_DISCARD',
+)
+
+if has_block_uring_cmd_discard
+  block_uring_cmd_discard_compat = '#include <linux/blkdev.h>'
+else
+  block_uring_cmd_discard_compat = '''
+#include <linux/ioctl.h>
+
+#ifndef BLOCK_URING_CMD_DISCARD
+#define BLOCK_URING_CMD_DISCARD                        _IO(0x12, 0)
+#endif
+'''
+endif
+
+conf_data = configuration_data()
+conf_data.set('__kernel_rwf_t_compat', __kernel_rwf_t_compat)
+conf_data.set('__kernel_timespec_compat', __kernel_timespec_compat)
+conf_data.set('open_how_compat', open_how_compat)
+conf_data.set('futexv_compat', futexv_compat)
+conf_data.set('block_uring_cmd_discard_compat', block_uring_cmd_discard_compat)
+
+if not glibc_statx and has_statx
+  conf_data.set('no_glibc_statx', '#include <sys/stat.h>')
+else
+  conf_data.set('no_glibc_statx', '')
+endif
+
+configure_file(
+  input: 'compat.h.meson',
+  output: 'compat.h',
+  configuration: conf_data,
+)
+
+configure_file(
+  output: 'io_uring_version.h',
+  configuration: configuration_data(
+    {
+      'IO_URING_VERSION_MAJOR': major_version,
+      'IO_URING_VERSION_MINOR': minor_version,
+    },
+  ),
+)

--- a/subprojects/packagefiles/liburing/src/include/meson.build
+++ b/subprojects/packagefiles/liburing/src/include/meson.build
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('liburing')

--- a/subprojects/packagefiles/liburing/src/meson.build
+++ b/subprojects/packagefiles/liburing/src/meson.build
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('include')
+
+inc = include_directories(['include'])
+src = ['queue.c', 'register.c', 'setup.c', 'syscall.c', 'version.c']
+
+if use_asan or use_ubsan
+  src += 'sanitize.c'
+endif
+
+liburing = library(
+  'uring',
+  src,
+  include_directories: inc,
+  c_args: '-DLIBURING_INTERNAL',
+  link_args: '-Wl,--version-script=' + meson.current_source_dir() + '/liburing.map',
+  link_depends: 'liburing.map',
+  version: meson.project_version(),
+  install: true,
+)
+
+uring = declare_dependency(
+  link_with: liburing,
+  include_directories: inc,
+)
+
+meson.override_dependency('liburing', uring)


### PR DESCRIPTION
## What?
Replaces per-container liburing installs (apt on Ubuntu, source build on manylinux) with a single meson wrap pinned to WrapDB liburing_2.14-1. Adds subprojects/liburing.wrap, wires the fallback in meson.build, and drops liburing-dev / source-build steps from both Dockerfiles, .gitlab/build.sh, and the nixlbench/POSIX READMEs. ATTRIBUTIONS-CPP.md bumped 2.12 → 2.14.

## Why?
meson setup couldn't build NIXL from source without liburing pre-installed out-of-band, so each pipeline rolled its own install and drifted across versions. The wrap makes liburing a first-class meson dep like asio/abseil/taskflow, so posix/uring is always available off the block for Dynamo/KVBM.

## How?
Uses WrapDB's [provide] dependency_names = liburing + override_dependency so the existing dependency('liburing', ...) call resolves to the subproject when pkg-config finds nothing.                                                                     
                                                                                                                                                                                                                                                           
A minimal local patch overlay (subprojects/packagefiles/liburing/) replaces the WrapDB patch archive because meson-python cannot map liburing's man pages, pkgconfig files, headers, or static library install paths into a wheel. The overlay builds only the shared library (install: true) and suppresses all other install targets, so the .so ships in the wheel while meson setup && ninja install still works for local builds.                                                                         
                                                                                                                                                                                                                                                           
The add_global_arguments block for abseil flags is moved before the liburing dependency to avoid meson's "global arguments after build target" error when the subproject fallback is triggered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI image tags used for builds and tests.
  * Removed liburing from installer and container image build steps; manylinux image no longer builds or declares liburing.
  * Adjusted build to handle liburing via a pinned subproject (2.14).
  * Added .gitignore pattern to exclude liburing-related subprojects.

* **Documentation**
  * Updated setup and plugin docs for automatic liburing dependency resolution.
  * Bumped liburing version in attributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->