### PR TITLE
Simplify nixl installation (#1574)

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -43,7 +43,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260402-1"
+  CI_IMAGE_TAG: "20260423-2"
 
 
 runs_on_dockers:

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -49,7 +49,7 @@ env:
   SLURM_JOB_TIMEOUT: '02:20:00'
   SLURM_IMMEDIATE_TIMEOUT: "3600"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260402-1"
+  CI_IMAGE_TAG: "20260423-2"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -137,7 +137,16 @@ else
         click tabulate auditwheel tomlkit \
         pytest pytest-timeout zmq \
         mpmath typing-extensions sympy numpy \
-        networkx MarkupSafe fsspec filelock jinja2 torch
+        networkx MarkupSafe fsspec filelock jinja2
+
+    # Install torch from the CUDA-matched PyTorch index
+    cuda_version=$(nvcc --version | grep -oP 'release \K[0-9]+\.[0-9]+' | tr -d .)
+    if [ -z "$cuda_version" ]; then
+        echo "ERROR: unable to determine CUDA version from nvcc" >&2
+        exit 1
+    fi
+    $SUDO pip3 --no-cache-dir install --break-system-packages \
+        --index-url "https://download.pytorch.org/whl/cu${cuda_version}" torch
 
     # Add DOCA repository and install packages
     ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi)

--- a/README.md
+++ b/README.md
@@ -37,21 +37,13 @@ NIXL is supported on a Linux environment only. It is tested on Ubuntu (22.04/24.
 The nixl python API and libraries, including UCX, are available directly through PyPI.
 For example, if you have a GPU running on a Linux host, container, or VM, you can do the following install:
 
-It can be installed for CUDA 12 with:
+Install with:
 
-```
-pip install nixl[cu12]
-```
-
-For CUDA 13 with:
-
-```
-pip install nixl[cu13]
+```bash
+pip install nixl
 ```
 
-For backwards compatibility, `pip install nixl` installs automatically `nixl[cu12]`, continuing to work seamlessly for CUDA 12 users without requiring changes to downstream project dependencies.
-
-If both `nixl-cu12` and `nixl-cu13` are installed at the same time in an environment, `nixl-cu13` takes precedence.
+This installs both CUDA 12 and CUDA 13 backends. At runtime, the correct backend is selected automatically based on the CUDA version reported by PyTorch.
 
 ## Prerequisites for source build (Linux)
 ### Ubuntu:
@@ -195,14 +187,10 @@ NIXL provides Python bindings through pybind11. For detailed Python API document
 The preferred way to install the Python bindings is through pip from PyPI:
 
 ```bash
-pip install nixl[cu12]
+pip install nixl
 ```
 
-Or for CUDA 13 with:
-
-```bash
-pip install nixl[cu13]
-```
+This installs both CUDA 12 and CUDA 13 backends. At runtime, the correct backend is selected automatically based on the CUDA version reported by PyTorch.
 
 #### Installation from source
 

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -335,7 +335,8 @@ RUN rm -rf build && \
     fi && \
     meson setup build/ --prefix=/usr/local/nixl --buildtype=$BUILD_TYPE $NIXL_EP_FLAG -Ducx_path=/usr/local \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
-    -Dcudapath_inc="/usr/local/cuda/include" && \
+    -Dcudapath_inc="/usr/local/cuda/include" \
+    -Drelease_wheel=true && \
     cd build && \
     ninja && \
     ninja install
@@ -369,7 +370,8 @@ RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     done
 
 # Copy the meta package wheel to the dist directory, which will be used to push to PyPI.
-# Only do this for the CUDA 12 builds, since by default nixl depends on nixl-cu12.
+# The meta-wheel is identical for cu12 and cu13 builds (it pins both backends via
+# -Drelease_wheel=true), so only emit it once — arbitrarily during the cu12 build.
 RUN if [ "$(echo $CUDA_VERSION | cut -d. -f1)" = "12" ]; then \
       cp build/src/bindings/python/nixl-meta/nixl*.whl dist/; \
     fi

--- a/contrib/Dockerfile.sglang
+++ b/contrib/Dockerfile.sglang
@@ -21,9 +21,5 @@ COPY . /tmp/nixl-wheels
 
 RUN set -eux; \
     ls -lah /tmp/nixl-wheels/*.whl ; \
-    pip install --no-cache-dir --no-deps --force-reinstall /tmp/nixl-wheels/nixl-*.whl /tmp/nixl-wheels/nixl_cu12*cp312*.whl; \
-    CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
-    if [ "${CUDA_MAJOR}" = "13" ]; then \
-      pip install --no-cache-dir --no-deps --force-reinstall /tmp/nixl-wheels/nixl_cu13*cp312*.whl; \
-    fi; \
+    pip install --no-cache-dir --no-deps --force-reinstall /tmp/nixl-wheels/*.whl; \
     rm -rf /tmp/nixl-wheels

--- a/contrib/Dockerfile.vllm
+++ b/contrib/Dockerfile.vllm
@@ -21,7 +21,7 @@ COPY . /tmp/nixl-wheels
 
 RUN set -eux; \
     ls /tmp/nixl-wheels/*.whl >/dev/null; \
-    uv pip install --system --no-deps --force-reinstall /tmp/nixl-wheels/nixl-*.whl /tmp/nixl-wheels/nixl_cu12*cp312*.whl; \
+    uv pip install --system --no-deps --force-reinstall /tmp/nixl-wheels/*.whl; \
     uv pip install --system quart; \
     rm -rf /tmp/nixl-wheels
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ option('static_plugins', type: 'string', value: '', description: 'Plugins to be 
 option('enable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to build. Default (empty) builds all available plugins.')
 option('disable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to exclude from build. Cannot be used with enable_plugins.')
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
+option('release_wheel', type: 'boolean', value: false, description: 'Add nixl-cu12 and nixl-cu13 dependencies to the meta wheel')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
 

--- a/src/bindings/python/nixl-meta/README.md
+++ b/src/bindings/python/nixl-meta/README.md
@@ -1,11 +1,13 @@
 # nixl
 
-This is a *meta package* that declares optional dependencies on CUDA variants.
+This is a *meta package*. The PyPI distribution installs both the CUDA 12
+and CUDA 13 backends, and the correct one is selected automatically at
+runtime based on the CUDA version reported by PyTorch. Source builds install
+a single backend unless built with `-Drelease_wheel=true`.
 
-Install one of:
 ```bash
-pip install "nixl[cu12]"   # for CUDA 12
-pip install "nixl[cu13]"   # for CUDA 13
+pip install nixl
 ```
 
-If both are installed, the higher version will be used.
+The `nixl[cu12]` and `nixl[cu13]` extras are accepted for backwards
+compatibility but have no additional effect.

--- a/src/bindings/python/nixl-meta/meson.build
+++ b/src/bindings/python/nixl-meta/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,12 @@ build_dir = meson.current_build_dir()
 pyproject_toml = configure_file(
   input: 'pyproject.toml.in',
   output: 'pyproject.toml',
-  configuration: { 'VERSION': meson.project_version(), 'WHEEL_DEP': cuda_wheel_dir.replace('_', '-') }
+  configuration: {
+    'VERSION': meson.project_version(),
+    'WHEEL_DEPS': get_option('release_wheel') \
+      ? '"nixl-cu12==' + meson.project_version() + '", "nixl-cu13==' + meson.project_version() + '"' \
+      : '"' + cuda_wheel_dir.replace('_', '-') + '==' + meson.project_version() + '"',
+  }
 )
 
 readme_md = fs.copyfile('README.md')

--- a/src/bindings/python/nixl-meta/nixl/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl/__init__.py
@@ -17,20 +17,40 @@ import importlib
 import sys
 from typing import TYPE_CHECKING
 
-# Try packages in order
-candidates = ["nixl_cu13", "nixl_cu12"]
-_pkg = None
-for pkg in candidates:
-    try:
-        _pkg = importlib.import_module(pkg)
-        break
-    except ModuleNotFoundError:
-        continue
 
-if _pkg is None:
-    raise ImportError(
-        "Could not find CUDA-specific NIXL package. Please install NIXL with `pip install nixl[cu12]` or `pip install nixl[cu13]`"
-    )
+def _get_torch_cuda_major() -> int | None:
+    """Return the CUDA major version that torch was built for, or None."""
+    from torch.version import cuda as _torch_cuda_ver
+
+    return int(_torch_cuda_ver.split(".")[0]) if _torch_cuda_ver else None
+
+
+def _load_cuda_backend() -> str:
+    cuda_major = _get_torch_cuda_major()
+    if cuda_major is not None:
+        pip_name = f"nixl-cu{cuda_major}"
+        mod_name = f"nixl_cu{cuda_major}"
+        try:
+            return importlib.import_module(mod_name).__name__
+        except ModuleNotFoundError as e:
+            if e.name != mod_name:
+                raise
+            raise ImportError(
+                f"torch reports CUDA {cuda_major} but {pip_name} is not installed"
+            ) from e
+    # CPU-only torch — use whatever backend is installed
+    for mod_name in ("nixl_cu13", "nixl_cu12"):
+        try:
+            return importlib.import_module(mod_name).__name__
+        except ModuleNotFoundError as e:
+            if e.name != mod_name:
+                # Re-raise if the error is not about the module we're trying to import
+                raise
+            continue
+    raise ImportError("No NIXL CUDA backend found")
+
+
+_pkg = sys.modules[_load_cuda_backend()]
 
 submodules = ["_api", "_bindings", "_utils", "logging"]
 for sub_name in submodules:

--- a/src/bindings/python/nixl-meta/pyproject.toml.in
+++ b/src/bindings/python/nixl-meta/pyproject.toml.in
@@ -29,7 +29,7 @@ authors = [
   {name = "NIXL Developers", email = "nixl-developers@nvidia.com"}
 ]
 
-dependencies = ["@WHEEL_DEP@==@VERSION@"]
+dependencies = [@WHEEL_DEPS@]
 
 [project.optional-dependencies]
 cu12 = ["nixl-cu12==@VERSION@"]


### PR DESCRIPTION
## What?

`pip install nixl` now ships both `nixl-cu12` and `nixl-cu13` wheels. At `import nixl` time, the meta-package reads `torch.version.cuda` and loads the backend matching PyTorch's CUDA version.

## Why?

The `vllm/vllm-openai:latest` Docker image has both `nixl-cu12` and `nixl-cu13` installed (due to vllm's `kv_connectors.txt` listing both explicitly). The old `__init__.py` preferred cu13 over cu12 by default since that was the correct behavior when only one backend was installed. When both are present, this results in the wrong backend being loaded on CUDA 12.x environments.

The old packaging design relied on careful coordination between build-time CUDA detection, pip extras, and Dockerfile conditionals to ensure only the correct backend was installed. This worked, but downstream projects (vllm, sglang) could easily break it by installing both backends. This PR makes the meta-package robust to that scenario: always ship both, detect at runtime.

Simplifies resolution of https://github.com/vllm-project/vllm/issues/39521

## How?

**`__init__.py`**: Replaces the blind cu13-first candidate loop with `torch.version.cuda` detection. `_get_torch_cuda_major()` returns the CUDA major version from torch, and `_load_cuda_backend()` imports the matching `nixl_cu{N}` module. Clear `ImportError` if torch has no CUDA or the matching backend is missing.

**`pyproject.toml.in`**: `@WHEEL_DEP@` replaced with `@WHEEL_DEPS@` populated by meson from `cuda_wheel_dir` for dev builds (single backend), or both `nixl-cu12` and `nixl-cu13` for release builds (`-Drelease_wheel=true`).

**`Dockerfile.manylinux`**: Passes `-Drelease_wheel=true` to meson so the published meta-wheel depends on both backends.

**`Dockerfile.vllm` / `Dockerfile.sglang`**: Simplified to install all wheels unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic CUDA backend detection at runtime based on PyTorch's CUDA version.
  * Optional packaging mode to produce a meta wheel that includes both CUDA 12 and CUDA 13 backends.

* **Documentation**
  * Simplified install guidance: single `pip install nixl`; clarifies runtime backend selection and source-build vs release-wheel behavior.

* **Chores**
  * CI image tag updates; installer now detects CUDA and installs a matching PyTorch wheel; container build steps simplified to install all built wheels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->