### PR TITLE
BUILD: fix etcd Meson fallback detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -246,12 +246,11 @@ etcd_lib_path = get_option('etcd_lib_path')
 if not etcd_dep.found() and etcd_lib_path != ''
     etcd_lib = cpp.find_library('etcd-cpp-api', dirs: etcd_lib_path)
     if etcd_lib.found()
-        if cpp.has_header('Client.hpp', args : '-I' + etcd_inc_path)
+        if cpp.has_header('etcd/Client.hpp', args : '-I' + etcd_inc_path)
             etcd_inc = include_directories(etcd_inc_path, is_system: true)
             etcd_dep = declare_dependency(
                         include_directories : etcd_inc,
                         dependencies : etcd_lib)
-            break
         endif
     endif
 endif


### PR DESCRIPTION
Match the fallback header probe to NIXL's etcd include style and remove the invalid break so external etcd installs can enable HAVE_ETCD during configure.

## What?
Fix etcd fallback detection

## Why?
We should detect `etcd/Client.hpp` instead of `Client.hpp`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced build configuration system to improve dependency detection accuracy and ensure proper initialization of all required components. Refined the build workflow to prevent premature termination, allowing all configuration steps to complete successfully for improved build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->