### PR TITLE
Add LIBFABRIC postXfer thread pool

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -161,6 +161,8 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
                   << (("all" == devices[0]) ? "all" : backend_params["device_list"]) << " rank "
                   << rank << ", type " << name << ", hostname " << hostname << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_LIBFABRIC)) {
+        backend_params["num_threads"] = std::to_string(xferBenchConfig::progress_threads);
+
         if (gethostname(hostname, 256)) {
             std::cerr << "Failed to get hostname" << std::endl;
             exit(EXIT_FAILURE);
@@ -173,7 +175,8 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
 
         std::cout << "Init nixl worker, dev " << (("all" == devices[0]) ? "all" : devices[rank])
                   << " rank " << rank << ", type " << name << ", hostname " << hostname
-                  << ", nc_count " << nc_count << std::endl;
+                  << ", nc_count " << nc_count << ", post threads "
+                  << xferBenchConfig::progress_threads << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GDS)) {
         // Using default param values for GDS backend
         std::cout << "GDS backend" << std::endl;

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -243,7 +243,7 @@ class nixl_agent:
                 # TODO: improve population of init from nixl_conf
                 init: dict[str, str] = {}
                 if nixl_conf.num_threads > 0:
-                    if bknd == "UCX" or bknd == "OBJ":
+                    if bknd == "UCX" or bknd == "OBJ" or bknd == "LIBFABRIC":
                         init["num_threads"] = str(nixl_conf.num_threads)
                     elif bknd == "GDS_MT":
                         init["thread_count"] = str(nixl_conf.num_threads)

--- a/src/plugins/libfabric/README.md
+++ b/src/plugins/libfabric/README.md
@@ -102,11 +102,11 @@ used for DRAM_SEG memory type
 
 The following table summarizes briefly the plugin's runtime configuration:
 
-| Name | Effect | Environment Variable | Values | Examples | Notes |
+| Name | Effect | Configuration Source | Values | Examples | Notes |
 |--|--|--|--|--|--|
-| max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node |NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG | integer | 100, 200 | Units are Gbps (Gigabits per second), auto-computed by PCIe topology, normally does not require user override |
-| num_threads | Enables a thread pool for parallel descriptor posting in postXfer | none | integer | 4, 8 | Default 0 keeps the serial posting path |
-| split_batch_size | Minimum descriptor count before postXfer uses the posting thread pool | none | integer | 1024, 4096 | Only applies when num_threads is greater than 0 |
+| max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node | Backend init param or `NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG` environment variable | integer | 100, 200 | Units are Gbps (Gigabits per second), auto-computed by PCIe topology, normally does not require user override |
+| num_threads | Enables a thread pool for parallel descriptor posting in postXfer | Backend init param | integer | 4, 8 | Default 0 keeps the serial posting path |
+| split_batch_size | Minimum descriptor count before postXfer uses the posting thread pool | Backend init param | integer | 1024, 4096 | Only applies when num_threads is greater than 0 |
 
 ## API Reference
 

--- a/src/plugins/libfabric/README.md
+++ b/src/plugins/libfabric/README.md
@@ -105,6 +105,8 @@ The following table summarizes briefly the plugin's runtime configuration:
 | Name | Effect | Environment Variable | Values | Examples | Notes |
 |--|--|--|--|--|--|
 | max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node |NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG | integer | 100, 200 | Units are Gbps (Gigabits per second), auto-computed by PCIe topology, normally does not require user override |
+| num_threads | Enables a thread pool for parallel descriptor posting in postXfer | none | integer | 4, 8 | Default 0 keeps the serial posting path |
+| split_batch_size | Minimum descriptor count before postXfer uses the posting thread pool | none | integer | 1024, 4096 | Only applies when num_threads is greater than 0 |
 
 ## API Reference
 

--- a/src/plugins/libfabric/README.md
+++ b/src/plugins/libfabric/README.md
@@ -106,7 +106,7 @@ The following table summarizes briefly the plugin's runtime configuration:
 |--|--|--|--|--|--|
 | max_bw_per_dram_seg | Controls the bandwidth limit on DRAM_SEG memory type buffers per NUMA node | Backend init param or `NIXL_LIBFABRIC_MAX_BW_PER_DRAM_SEG` environment variable | integer | 100, 200 | Units are Gbps (Gigabits per second), auto-computed by PCIe topology, normally does not require user override |
 | num_threads | Enables a thread pool for parallel descriptor posting in postXfer | Backend init param | integer | 4, 8 | Default 0 keeps the serial posting path |
-| split_batch_size | Minimum descriptor count before postXfer uses the posting thread pool | Backend init param | integer | 1024, 4096 | Only applies when num_threads is greater than 0 |
+| split_batch_size | Minimum descriptor count before postXfer uses the posting thread pool | Backend init param | integer | 1024, 4096 | Default 1024; only applies when num_threads is greater than 0 |
 
 ## API Reference
 

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -33,20 +33,17 @@
 #include <numeric>
 #include <stdexcept>
 #include <thread>
-#include <utility>
 
 /****************************************
  * Neuron Address Query
  *****************************************/
 namespace {
 
+constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
+constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
+constexpr const char *NIXL_LIBFABRIC_POST_THREADS_PARAM = "num_threads";
+constexpr const char *NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM = "split_batch_size";
 constexpr size_t NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER = 4;
-
-size_t
-getMaxPostThreadCount() {
-    const unsigned int hw_threads = std::max(1u, std::thread::hardware_concurrency());
-    return static_cast<size_t>(hw_threads) * NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER;
-}
 
 void
 storeFirstError(std::atomic<int> &status, nixl_status_t new_status) {
@@ -81,26 +78,15 @@ public:
         stopAndJoin();
     }
 
-    template<typename Fn>
     bool
-    submit(Fn &&task) {
+    submit(std::function<void()> task) {
         {
             const std::lock_guard<std::mutex> lock(mutex_);
             if (stop_) {
                 NIXL_WARN << "Ignoring libfabric post task submission after thread pool stop";
                 return false;
             }
-            try {
-                tasks_.emplace_back(std::forward<Fn>(task));
-            }
-            catch (const std::exception &e) {
-                NIXL_ERROR << "Failed to queue libfabric post task: " << e.what();
-                return false;
-            }
-            catch (...) {
-                NIXL_ERROR << "Failed to queue libfabric post task";
-                return false;
-            }
+            tasks_.emplace_back(std::move(task));
         }
         cv_.notify_one();
         return true;
@@ -464,7 +450,6 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
     }
 
     initPostThreadPool();
-
     // Initialize Rail Manager which will discover the topology and create all rails.
     try {
         NIXL_INFO << "Rail Manager created with " << rail_manager_.getNumRails() << " rails";
@@ -540,13 +525,14 @@ void
 nixlLibfabricEngine::initPostThreadPool() {
     LibfabricUtils::getCustomIntParam(
         getCustomParams(), NIXL_LIBFABRIC_POST_THREADS_PARAM, post_thread_count_);
-    const size_t max_post_thread_count = getMaxPostThreadCount();
+    const size_t max_post_thread_count =
+        static_cast<size_t>(std::max(1u, std::thread::hardware_concurrency())) *
+        NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER;
     if (post_thread_count_ > max_post_thread_count) {
         NIXL_WARN << "Capping libfabric post thread count from " << post_thread_count_ << " to "
                   << max_post_thread_count;
         post_thread_count_ = max_post_thread_count;
     }
-
     LibfabricUtils::getCustomIntParam(
         getCustomParams(), NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM, post_split_batch_size_);
     if (post_thread_count_ > 0) {
@@ -563,7 +549,6 @@ nixlLibfabricEngine::~nixlLibfabricEngine() {
         << "Destructor starting, stopping all threads FIRST to prevent timing report interruption";
 
     post_thread_pool_.reset();
-
     if (progress_thread_enabled_) {
         progress_thread_stop_.store(true);
     }
@@ -1121,43 +1106,6 @@ nixlLibfabricEngine::estimateXferCost(const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
-#ifdef HAVE_CUDA
-nixl_status_t
-nixlLibfabricEngine::initCudaPostContext(CudaPostContext &context) const {
-    if (!context.is_cuda_vram) {
-        return NIXL_SUCCESS;
-    }
-
-    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
-    context.use_cuda_addr_wa = cuda_addr_wa_;
-    if (context.use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
-        NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
-        return NIXL_ERR_BACKEND;
-    }
-
-    return NIXL_SUCCESS;
-}
-
-nixl_status_t
-nixlLibfabricEngine::prepareCudaDescriptorPost(CudaPostContext &context,
-                                               int device_id,
-                                               int desc_idx) const {
-    if (!context.is_cuda_vram || context.use_cuda_addr_wa ||
-        device_id == context.current_cuda_device) {
-        return NIXL_SUCCESS;
-    }
-
-    cudaError_t cuda_ret = cudaSetDevice(device_id);
-    if (cuda_ret != cudaSuccess) {
-        NIXL_ERROR << "Failed to set CUDA device " << device_id << " while posting descriptor "
-                   << desc_idx << ": " << cudaGetErrorString(cuda_ret);
-        return NIXL_ERR_BACKEND;
-    }
-    context.current_cuda_device = device_id;
-    return NIXL_SUCCESS;
-}
-#endif
-
 nixl_status_t
 nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
                                          const nixl_meta_dlist_t &local,
@@ -1172,11 +1120,31 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
     submitted_count = 0;
 
 #ifdef HAVE_CUDA
-    CudaPostContext cuda_post_context;
-    cuda_post_context.is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
-    if (nixl_status_t status = initCudaPostContext(cuda_post_context); status != NIXL_SUCCESS) {
-        return status;
+    const bool is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
+    bool use_cuda_addr_wa = false;
+    int current_cuda_device = -1;
+    if (is_cuda_vram) {
+        const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+        use_cuda_addr_wa = cuda_addr_wa_;
+        if (use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
+            NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
+            return NIXL_ERR_BACKEND;
+        }
     }
+
+    auto prepare_cuda_descriptor_post = [&](int device_id, int desc_idx) -> nixl_status_t {
+        if (!is_cuda_vram || use_cuda_addr_wa || device_id == current_cuda_device) {
+            return NIXL_SUCCESS;
+        }
+        cudaError_t cuda_ret = cudaSetDevice(device_id);
+        if (cuda_ret != cudaSuccess) {
+            NIXL_ERROR << "Failed to set CUDA device " << device_id << " while posting descriptor "
+                       << desc_idx << ": " << cudaGetErrorString(cuda_ret);
+            return NIXL_ERR_BACKEND;
+        }
+        current_cuda_device = device_id;
+        return NIXL_SUCCESS;
+    };
 #endif
 
     for (int desc_idx = start_idx; desc_idx < end_idx; ++desc_idx) {
@@ -1188,8 +1156,7 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         int device_id = local[desc_idx].devId;
 
 #ifdef HAVE_CUDA
-        if (nixl_status_t status =
-                prepareCudaDescriptorPost(cuda_post_context, device_id, desc_idx);
+        if (nixl_status_t status = prepare_cuda_descriptor_post(device_id, desc_idx);
             status != NIXL_SUCCESS) {
             return status;
         }

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -82,11 +82,6 @@ public:
         stopAndJoin();
     }
 
-    size_t
-    size() const {
-        return workers_.size();
-    }
-
     void
     submit(std::function<void()> task) {
         {
@@ -469,8 +464,7 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         getCustomParams(), "split_batch_size", post_split_batch_size_);
     if (post_thread_count_ > 0) {
         post_thread_pool_ = std::make_unique<nixlLibfabricPostThreadPool>(post_thread_count_);
-        NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with "
-                   << post_thread_pool_->size()
+        NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with " << post_thread_count_
                    << " threads, split_batch_size=" << post_split_batch_size_;
     } else {
         NIXL_DEBUG << "Libfabric descriptor post thread pool disabled";
@@ -1115,7 +1109,6 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
                                          const nixl_meta_dlist_t &local,
                                          const nixl_meta_dlist_t &remote,
                                          const std::shared_ptr<nixlLibfabricConnection> &conn,
-                                         const std::string &remote_agent,
                                          nixlLibfabricBackendH *backend_handle,
                                          int start_idx,
                                          int end_idx,
@@ -1131,11 +1124,9 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
     if (is_cuda_vram) {
         const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
         use_cuda_addr_wa = cuda_addr_wa_;
-        if (use_cuda_addr_wa && cudaCtx_) {
-            if (!cudaCtx_->cudaSetCtx()) {
-                NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
-                return NIXL_ERR_BACKEND;
-            }
+        if (use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
+            NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
+            return NIXL_ERR_BACKEND;
         }
     }
 #endif
@@ -1144,17 +1135,9 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         auto *local_md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
         auto *remote_md = static_cast<nixlLibfabricPublicMetadata *>(remote[desc_idx].metadataP);
 
-        // Get transfer info for THIS descriptor
         void *transfer_addr = (void *)local[desc_idx].addr;
         size_t transfer_size = local[desc_idx].len;
         int device_id = local[desc_idx].devId;
-
-        NIXL_DEBUG << "Processing descriptor " << desc_idx << " device " << device_id
-                   << " local_addr: " << transfer_addr << " size=" << transfer_size
-                   << " remote_addr=" << (void *)remote[desc_idx].addr;
-
-        NIXL_DEBUG << "DEBUG: remote_agent='" << remote_agent << "' localAgent='" << localAgent
-                   << "'";
 
 #ifdef HAVE_CUDA
         if (is_cuda_vram && !use_cuda_addr_wa && device_id != current_cuda_device) {
@@ -1169,10 +1152,7 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         }
 #endif
 
-        // Prepare and submit transfer for remote agents
-        // Use descriptor's specific target address
         uint64_t remote_target_addr = remote[desc_idx].addr;
-
         uint64_t remote_registered_base = remote_md->remote_buf_addr_;
 
         size_t desc_submitted_count = 0;
@@ -1189,9 +1169,7 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
             conn->rail_remote_addr_list_,
             conn->agent_index_,
             backend_handle->post_xfer_id,
-            [backend_handle]() {
-                backend_handle->increment_completed_requests();
-            }, // Completion callback
+            [backend_handle]() { backend_handle->increment_completed_requests(); },
             desc_submitted_count,
             desc_idx,
             desc_count,
@@ -1204,10 +1182,6 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         }
 
         submitted_count += desc_submitted_count;
-
-        NIXL_DEBUG << "Successfully processed descriptor " << desc_idx << " with "
-                   << desc_submitted_count
-                   << " requests submitted (range accumulated: " << submitted_count << ")";
     }
 
     return NIXL_SUCCESS;
@@ -1307,7 +1281,6 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                                                    local,
                                                    remote,
                                                    conn,
-                                                   remote_agent,
                                                    backend_handle,
                                                    0,
                                                    desc_count,
@@ -1327,9 +1300,6 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         size_t remaining = num_chunks;
         size_t submitted_chunks = 0;
 
-        NIXL_DEBUG << "Processing " << desc_count << " descriptors across " << num_chunks
-                   << " libfabric post worker chunks";
-
         try {
             for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
                 const int start_idx = static_cast<int>(chunk_idx * chunk_size);
@@ -1345,7 +1315,6 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                                                      local,
                                                      remote,
                                                      conn,
-                                                     remote_agent,
                                                      backend_handle,
                                                      start_idx,
                                                      end_idx,

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1146,7 +1146,10 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
         use_cuda_addr_wa = cuda_addr_wa_;
         if (use_cuda_addr_wa && cudaCtx_) {
-            cudaCtx_->cudaSetCtx();
+            if (!cudaCtx_->cudaSetCtx()) {
+                NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
+                return NIXL_ERR_BACKEND;
+            }
         }
     }
 #endif

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -23,7 +23,6 @@
 
 #include <cstdint>
 #include <dlfcn.h>
-#include <limits>
 #include <cstring>
 #include <unistd.h>
 
@@ -35,8 +34,6 @@
 #include <stdexcept>
 #include <thread>
 
-#include "absl/strings/numbers.h"
-
 /****************************************
  * Neuron Address Query
  *****************************************/
@@ -45,27 +42,6 @@ namespace {
 constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
 constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
 constexpr size_t NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER = 4;
-
-static_assert(sizeof(size_t) == sizeof(uint64_t),
-              "LIBFABRIC backend size parsing assumes 64-bit size_t");
-
-size_t
-getSizeParam(const nixl_b_params_t &params, const std::string &key, size_t default_value) {
-    auto it = params.find(key);
-    if (it == params.end()) {
-        return default_value;
-    }
-
-    uint64_t parsed_value = 0;
-    if (!absl::SimpleAtoi(it->second, &parsed_value) ||
-        parsed_value > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
-        NIXL_WARN << "Invalid " << key << " value '" << it->second
-                  << "', using default: " << default_value;
-        return default_value;
-    }
-
-    return static_cast<size_t>(parsed_value);
-}
 
 size_t
 getMaxPostThreadCount() {
@@ -480,16 +456,17 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         NIXL_INFO << "Striping threshold: " << striping_threshold_ << " bytes (default)";
     }
 
-    post_thread_count_ =
-        getSizeParam(getCustomParams(), "num_threads", NIXL_LIBFABRIC_DEFAULT_POST_THREADS);
+    post_thread_count_ = NIXL_LIBFABRIC_DEFAULT_POST_THREADS;
+    LibfabricUtils::getCustomIntParam(getCustomParams(), "num_threads", post_thread_count_);
     const size_t max_post_thread_count = getMaxPostThreadCount();
     if (post_thread_count_ > max_post_thread_count) {
         NIXL_WARN << "Capping libfabric post thread count from " << post_thread_count_ << " to "
                   << max_post_thread_count;
         post_thread_count_ = max_post_thread_count;
     }
-    post_split_batch_size_ = getSizeParam(
-        getCustomParams(), "split_batch_size", NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE);
+    post_split_batch_size_ = NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE;
+    LibfabricUtils::getCustomIntParam(
+        getCustomParams(), "split_batch_size", post_split_batch_size_);
     if (post_thread_count_ > 0) {
         post_thread_pool_ = std::make_unique<nixlLibfabricPostThreadPool>(post_thread_count_);
         NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with "

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -46,6 +46,9 @@ constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
 constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
 constexpr size_t NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER = 4;
 
+static_assert(sizeof(size_t) == sizeof(uint64_t),
+              "LIBFABRIC backend size parsing assumes 64-bit size_t");
+
 size_t
 getSizeParam(const nixl_b_params_t &params, const std::string &key, size_t default_value) {
     auto it = params.find(key);
@@ -87,7 +90,13 @@ public:
                 workers_.emplace_back([this]() { workerLoop(); });
             }
         }
+        catch (const std::exception &e) {
+            NIXL_ERROR << "Failed to create libfabric post worker threads: " << e.what();
+            stopAndJoin();
+            throw;
+        }
         catch (...) {
+            NIXL_ERROR << "Failed to create libfabric post worker threads";
             stopAndJoin();
             throw;
         }
@@ -419,7 +428,7 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
     : nixlBackendEngine(init_params),
       progress_thread_enabled_(init_params->enableProgTh),
       progress_thread_delay_(std::chrono::microseconds(init_params->pthrDelay)),
-      rail_manager(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD),
+      rail_manager_(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD),
       post_thread_count_(NIXL_LIBFABRIC_DEFAULT_POST_THREADS),
       post_split_batch_size_(NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE),
       runtime_(FI_HMEM_SYSTEM) {
@@ -427,12 +436,12 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
     NIXL_INFO << "Initializing Libfabric Backend";
 
     // this is required for loading rail selection policy by configuration
-    if (rail_manager.init(getCustomParams()) != NIXL_SUCCESS) {
+    if (rail_manager_.init(getCustomParams()) != NIXL_SUCCESS) {
         throw std::runtime_error("Failed to initialize the rail manager");
     }
 
     // Query system runtime type from rail manager (determined once at topology discovery)
-    runtime_ = rail_manager.getRuntime();
+    runtime_ = rail_manager_.getRuntime();
 
     NIXL_INFO << "System runtime: "
               << (runtime_ == FI_HMEM_CUDA       ? "CUDA" :
@@ -492,21 +501,21 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 
     // Initialize Rail Manager which will discover the topology and create all rails.
     try {
-        NIXL_INFO << "Rail Manager created with " << rail_manager.getNumRails() << " rails";
+        NIXL_INFO << "Rail Manager created with " << rail_manager_.getNumRails() << " rails";
 
         // Set up notification callback on rail 0
         size_t notification_rail_id = 0;
         NIXL_DEBUG << "Set notification processor for rail 0";
-        rail_manager.getRail(notification_rail_id)
+        rail_manager_.getRail(notification_rail_id)
             .setNotificationCallback([this](const std::string &serialized_notif) {
                 processNotification(serialized_notif);
             });
 
         // Set up XFER_ID tracking callbacks for all rails
-        NIXL_DEBUG << "Setting up XFER_ID tracking callbacks for " << rail_manager.getNumRails()
+        NIXL_DEBUG << "Setting up XFER_ID tracking callbacks for " << rail_manager_.getNumRails()
                    << " rails";
-        for (size_t rail_id = 0; rail_id < rail_manager.getNumRails(); ++rail_id) {
-            rail_manager.getRail(rail_id).setXferIdCallback([this](uint64_t imm_data) {
+        for (size_t rail_id = 0; rail_id < rail_manager_.getNumRails(); ++rail_id) {
+            rail_manager_.getRail(rail_id).setXferIdCallback([this](uint64_t imm_data) {
                 // Extract XFER_ID from immediate data
                 uint16_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(imm_data);
                 addReceivedXferId(xfer_id);
@@ -516,12 +525,12 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 
         // Create self-connection
         std::vector<std::array<char, LF_EP_NAME_MAX_LEN>> data_endpoints(
-            rail_manager.getNumRails());
+            rail_manager_.getNumRails());
         // Prepare rail endpoints
-        for (size_t rail_id = 0; rail_id < rail_manager.getNumRails(); ++rail_id) {
+        for (size_t rail_id = 0; rail_id < rail_manager_.getNumRails(); ++rail_id) {
             std::memcpy(data_endpoints[rail_id].data(),
-                        rail_manager.getRail(rail_id).ep_name,
-                        sizeof(rail_manager.getRail(rail_id).ep_name));
+                        rail_manager_.getRail(rail_id).ep_name,
+                        sizeof(rail_manager_.getRail(rail_id).ep_name));
         }
         // Create self-connection using common method
         nixl_status_t conn_status = createAgentConnection(localAgent, data_endpoints);
@@ -532,12 +541,12 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         }
 
         NIXL_INFO << "Created self-connection for agent: " << localAgent << " on "
-                  << rail_manager.getNumRails() << " rails";
+                  << rail_manager_.getNumRails() << " rails";
 
         // Start Progress thread for rail completion processing
         if (progress_thread_enabled_) {
-            for (size_t i = 0; i < rail_manager.getNumRails(); ++i) {
-                rail_manager.getRail(i).setProgressThreadEnabled(true);
+            for (size_t i = 0; i < rail_manager_.getNumRails(); ++i) {
+                rail_manager_.getRail(i).setProgressThreadEnabled(true);
             }
 
             NIXL_INFO << "Starting Progress thread for rails with delay: "
@@ -589,24 +598,24 @@ nixlLibfabricEngine::~nixlLibfabricEngine() {
 nixl_status_t
 nixlLibfabricEngine::getConnInfo(std::string &str) const {
     // Verify all rail endpoints are initialized
-    for (size_t rail_id = 0; rail_id < rail_manager.getNumRails(); ++rail_id) {
-        if (!rail_manager.getRail(rail_id).endpoint) {
+    for (size_t rail_id = 0; rail_id < rail_manager_.getNumRails(); ++rail_id) {
+        if (!rail_manager_.getRail(rail_id).endpoint) {
             NIXL_ERROR << "Rail " << rail_id << " endpoint not initialized";
             return NIXL_ERR_BACKEND;
         }
     }
 
-    NIXL_DEBUG << "Retrieving local endpoint addresses for all " << rail_manager.getNumRails()
+    NIXL_DEBUG << "Retrieving local endpoint addresses for all " << rail_manager_.getNumRails()
                << " rails";
 
     // Use Rail Manager's connection SerDes method with "dest" prefix for remote consumption
-    nixl_status_t status = rail_manager.serializeConnectionInfo("dest", str);
+    nixl_status_t status = rail_manager_.serializeConnectionInfo("dest", str);
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Rail Manager serializeConnectionInfo failed";
         return status;
     }
 
-    NIXL_DEBUG << "Rail Manager serialized connection info for " << rail_manager.getNumRails()
+    NIXL_DEBUG << "Rail Manager serialized connection info for " << rail_manager_.getNumRails()
                << " rails, total size=" << str.length();
 
     return NIXL_SUCCESS;
@@ -626,14 +635,14 @@ nixlLibfabricEngine::loadRemoteConnInfo(const std::string &remote_agent,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    NIXL_DEBUG << "Processing " << rail_manager.getNumRails()
+    NIXL_DEBUG << "Processing " << rail_manager_.getNumRails()
                << " rails for agent: " << remote_agent;
 
     // Use Rail Manager's connection SerDes method with "dest" prefix (remote is sending us their
     // endpoints as "dest")
     std::vector<std::array<char, LF_EP_NAME_MAX_LEN>> data_endpoints;
     nixl_status_t status =
-        rail_manager.deserializeConnectionInfo("dest", remote_conn_info, data_endpoints);
+        rail_manager_.deserializeConnectionInfo("dest", remote_conn_info, data_endpoints);
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Rail Manager deserializeConnectionInfo failed";
         return status;
@@ -646,7 +655,7 @@ nixlLibfabricEngine::loadRemoteConnInfo(const std::string &remote_agent,
     }
 
     NIXL_INFO << "Successfully stored multirail connection for " << remote_agent << " on "
-              << rail_manager.getNumRails() << " rails";
+              << rail_manager_.getNumRails() << " rails";
     return NIXL_SUCCESS;
 }
 
@@ -726,8 +735,8 @@ nixlLibfabricEngine::createAgentConnection(
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    if (data_rail_endpoints.size() != rail_manager.getNumRails()) {
-        NIXL_WARN << "Rail count mismatch (local: " << rail_manager.getNumRails()
+    if (data_rail_endpoints.size() != rail_manager_.getNumRails()) {
+        NIXL_WARN << "Rail count mismatch (local: " << rail_manager_.getNumRails()
                   << ", remote: " << data_rail_endpoints.size() << ")";
     }
 
@@ -739,10 +748,10 @@ nixlLibfabricEngine::createAgentConnection(
     }
 
     conn->remoteAgent_ = agent_name;
-    conn->rail_remote_addr_list_.reserve(rail_manager.getNumRails());
+    conn->rail_remote_addr_list_.reserve(rail_manager_.getNumRails());
 
     // Process all rails in one operation
-    nixl_status_t data_status = rail_manager.insertAllAddresses(
+    nixl_status_t data_status = rail_manager_.insertAllAddresses(
         data_rail_endpoints, conn->rail_remote_addr_list_, conn->src_ep_names_);
     if (data_status != NIXL_SUCCESS) {
         NIXL_ERROR << "insertAllAddresses failed for rails with status: " << data_status;
@@ -762,7 +771,7 @@ nixlLibfabricEngine::createAgentConnection(
     connections_[agent_name] = conn;
 
     NIXL_INFO << "Successfully created connection for agent: " << agent_name << " on "
-              << rail_manager.getNumRails() << " rails";
+              << rail_manager_.getNumRails() << " rails";
 
     return NIXL_SUCCESS;
 }
@@ -785,9 +794,9 @@ nixlLibfabricEngine::establishConnection(const std::string &remote_agent) const 
     }
 
     // Verify we have addresses for all rails
-    if (it->second->rail_remote_addr_list_.size() != rail_manager.getNumRails()) {
+    if (it->second->rail_remote_addr_list_.size() != rail_manager_.getNumRails()) {
         NIXL_ERROR << "Remote connection has " << it->second->rail_remote_addr_list_.size()
-                   << " rails, expected " << rail_manager.getNumRails();
+                   << " rails, expected " << rail_manager_.getNumRails();
         return NIXL_ERR_BACKEND;
     }
 
@@ -922,9 +931,9 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
     }
 
     // Initialize vectors to accommodate all possible rails (for indexing consistency)
-    priv->rail_mr_list_.resize(rail_manager.getNumRails(), nullptr);
+    priv->rail_mr_list_.resize(rail_manager_.getNumRails(), nullptr);
     priv->rail_key_list_.clear();
-    priv->rail_key_list_.resize(rail_manager.getNumRails(), FI_KEY_NOTAVAIL);
+    priv->rail_key_list_.resize(rail_manager_.getNumRails(), FI_KEY_NOTAVAIL);
 
 #ifdef HAVE_CUDA
     // Set CUDA context before libfabric operations for VRAM
@@ -938,14 +947,14 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
                << " mem_type=" << nixl_mem << " devId=" << mem.devId
                << (nixl_mem == VRAM_SEG ? " pci_bus_id=" + pci_bus_id : "");
 
-    nixl_status_t status = rail_manager.registerMemory((void *)mem.addr,
-                                                       mem.len,
-                                                       nixl_mem,
-                                                       mem.devId,
-                                                       pci_bus_id,
-                                                       priv->rail_mr_list_,
-                                                       priv->rail_key_list_,
-                                                       priv->selected_rails_);
+    nixl_status_t status = rail_manager_.registerMemory((void *)mem.addr,
+                                                        mem.len,
+                                                        nixl_mem,
+                                                        mem.devId,
+                                                        pci_bus_id,
+                                                        priv->rail_mr_list_,
+                                                        priv->rail_key_list_,
+                                                        priv->selected_rails_);
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Rail Manager registerMemory failed";
         return status;
@@ -968,7 +977,7 @@ nixlLibfabricEngine::deregisterMem(nixlBackendMD *meta) {
     auto *priv = static_cast<nixlLibfabricPrivateMetadata *>(meta);
     // Use Rail Manager for centralized memory deregistration
     nixl_status_t status =
-        rail_manager.deregisterMemory(priv->selected_rails_, priv->rail_mr_list_);
+        rail_manager_.deregisterMemory(priv->selected_rails_, priv->rail_mr_list_);
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Rail Manager deregisterMemory failed";
         // Continue with cleanup even if deregistration failed
@@ -983,7 +992,7 @@ nixlLibfabricEngine::getPublicData(const nixlBackendMD *meta, std::string &str) 
     const nixlLibfabricPrivateMetadata *priv =
         static_cast<const nixlLibfabricPrivateMetadata *>(meta);
 
-    return rail_manager.serializeMemoryKeys(priv->rail_key_list_, priv->buffer_, str);
+    return rail_manager_.serializeMemoryKeys(priv->rail_key_list_, priv->buffer_, str);
 }
 
 nixl_status_t
@@ -1029,10 +1038,10 @@ nixlLibfabricEngine::loadRemoteMD(const nixlBlobDesc &input,
     std::vector<uint64_t> remote_keys;
     uint64_t remote_addr;
     nixl_status_t status =
-        rail_manager.deserializeMemoryKeys(input.metaInfo,
-                                           conn_it->second->rail_remote_addr_list_.at(0).size(),
-                                           remote_keys,
-                                           remote_addr);
+        rail_manager_.deserializeMemoryKeys(input.metaInfo,
+                                            conn_it->second->rail_remote_addr_list_.at(0).size(),
+                                            remote_keys,
+                                            remote_addr);
     if (status != NIXL_SUCCESS) {
         NIXL_ERROR << "Rail Manager deserializeMemoryKeys failed";
         return status;
@@ -1190,7 +1199,7 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         uint64_t remote_registered_base = remote_md->remote_buf_addr_;
 
         size_t desc_submitted_count = 0;
-        nixl_status_t status = rail_manager.prepareAndSubmitTransfer(
+        nixl_status_t status = rail_manager_.prepareAndSubmitTransfer(
             op_type,
             transfer_addr,
             transfer_size,
@@ -1289,7 +1298,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
     op_type = (operation == NIXL_WRITE) ? nixlLibfabricReq::WRITE : nixlLibfabricReq::READ;
 
     // Set initial submit request count to maximum possible requests for this xfer.
-    size_t max_possible_requests = desc_count * rail_manager.getNumRails();
+    size_t max_possible_requests = desc_count * rail_manager_.getNumRails();
     backend_handle->init_request_tracking(max_possible_requests);
 
     size_t total_submitted = 0;
@@ -1312,7 +1321,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
     }
 
     // Reserve base_offset once per transfer so all descriptors see a stable rail assignment.
-    const size_t xfer_base_offset = rail_manager.reserveBaseOffset();
+    const size_t xfer_base_offset = rail_manager_.reserveBaseOffset();
     const bool use_post_pool = post_thread_pool_ && post_thread_count_ > 0 && desc_count > 0 &&
         static_cast<size_t>(desc_count) >= post_split_batch_size_;
 
@@ -1444,7 +1453,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
 
     // Progress rails to kick off transfers
     if (!progress_thread_enabled_) {
-        nixl_status_t progress_status = rail_manager.progressActiveRails();
+        nixl_status_t progress_status = rail_manager_.progressActiveRails();
         if (progress_status != NIXL_SUCCESS && progress_status != NIXL_IN_PROG) {
             NIXL_ERROR << "Failed to progress rails in postXfer";
             return progress_status;
@@ -1475,7 +1484,7 @@ nixlLibfabricEngine::checkXfer(nixlBackendReqH *handle) const {
     auto backend_handle = static_cast<nixlLibfabricBackendH *>(handle);
 
     if (!progress_thread_enabled_) {
-        nixl_status_t progress_status = rail_manager.progressActiveRails();
+        nixl_status_t progress_status = rail_manager_.progressActiveRails();
         if (progress_status != NIXL_SUCCESS && progress_status != NIXL_IN_PROG) {
             NIXL_ERROR << "Failed to progress rails in checkXfer";
             return progress_status;
@@ -1643,7 +1652,7 @@ nixlLibfabricEngine::notifSendPriv(const std::string &remote_agent,
         size_t rail_id = 0;
         size_t max_size = BinaryNotification::MAX_FRAGMENT_SIZE;
         nixlLibfabricReq *control_request =
-            rail_manager.getRail(rail_id).allocateControlRequest(max_size, notif_xfer_id);
+            rail_manager_.getRail(rail_id).allocateControlRequest(max_size, notif_xfer_id);
 
         if (!control_request) {
             NIXL_ERROR << "Failed to allocate control request for notification fragment " << seq_id;
@@ -1660,7 +1669,7 @@ nixlLibfabricEngine::notifSendPriv(const std::string &remote_agent,
                    << " notif_xfer_id=" << header.notif_xfer_id;
 
         // Use rail 0's remote address since notifications now use rails
-        nixl_status_t status = rail_manager.postControlMessage(
+        nixl_status_t status = rail_manager_.postControlMessage(
             nixlLibfabricRailManager::ControlMessageType::NOTIFICATION,
             control_request,
             connection->rail_remote_addr_list_[rail_id][0],
@@ -1674,7 +1683,7 @@ nixlLibfabricEngine::notifSendPriv(const std::string &remote_agent,
 
         // Progress rail 0 to ensure the message is sent
         if (!progress_thread_enabled_) {
-            status = rail_manager.getRail(rail_id).progressCompletionQueue();
+            status = rail_manager_.getRail(rail_id).progressCompletionQueue();
             if (status != NIXL_SUCCESS && status != NIXL_IN_PROG) {
                 NIXL_ERROR << "Failed to progress rail 0 in notifSendPriv";
                 return status;
@@ -1703,7 +1712,7 @@ nixlLibfabricEngine::genNotif(const std::string &remote_agent, const std::string
 nixl_status_t
 nixlLibfabricEngine::getNotifs(notif_list_t &notif_list) {
     if (!progress_thread_enabled_) {
-        nixl_status_t progress_status = rail_manager.progressActiveRails();
+        nixl_status_t progress_status = rail_manager_.progressActiveRails();
         if (progress_status != NIXL_SUCCESS && progress_status != NIXL_IN_PROG) {
             NIXL_ERROR << "Failed to progress rails in getNotifs";
             return progress_status;
@@ -1744,7 +1753,7 @@ nixlLibfabricEngine::progressThread() {
     while (!progress_thread_stop_.load()) {
         // Process completions only on rails (non-blocking)
         bool any_completions = false;
-        nixl_status_t status = rail_manager.progressActiveRails();
+        nixl_status_t status = rail_manager_.progressActiveRails();
         if (status == NIXL_SUCCESS) {
             any_completions = true;
             NIXL_DEBUG << "PT: Processed completions on rails";

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -21,19 +21,143 @@
 #include "common/configuration.h"
 #include "common/nixl_log.h"
 
+#include <cstdint>
 #include <dlfcn.h>
 #include <limits>
 #include <cstring>
 #include <unistd.h>
 
+#include <algorithm>
+#include <deque>
+#include <functional>
 #include <iomanip>
 #include <numeric>
+#include <stdexcept>
+#include <thread>
 
 #include "absl/strings/numbers.h"
 
 /****************************************
  * Neuron Address Query
  *****************************************/
+namespace {
+
+constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
+constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
+constexpr size_t NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER = 4;
+
+size_t
+getSizeParam(const nixl_b_params_t &params, const std::string &key, size_t default_value) {
+    auto it = params.find(key);
+    if (it == params.end()) {
+        return default_value;
+    }
+
+    uint64_t parsed_value = 0;
+    if (!absl::SimpleAtoi(it->second, &parsed_value) ||
+        parsed_value > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+        NIXL_WARN << "Invalid " << key << " value '" << it->second
+                  << "', using default: " << default_value;
+        return default_value;
+    }
+
+    return static_cast<size_t>(parsed_value);
+}
+
+size_t
+getMaxPostThreadCount() {
+    const unsigned int hw_threads = std::max(1u, std::thread::hardware_concurrency());
+    return static_cast<size_t>(hw_threads) * NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER;
+}
+
+void
+storeFirstError(std::atomic<int> &status, nixl_status_t new_status) {
+    int expected = static_cast<int>(NIXL_SUCCESS);
+    status.compare_exchange_strong(expected, static_cast<int>(new_status));
+}
+
+} // namespace
+
+class nixlLibfabricPostThreadPool {
+public:
+    explicit nixlLibfabricPostThreadPool(size_t thread_count) {
+        workers_.reserve(thread_count);
+        try {
+            for (size_t i = 0; i < thread_count; ++i) {
+                workers_.emplace_back([this]() { workerLoop(); });
+            }
+        }
+        catch (...) {
+            stopAndJoin();
+            throw;
+        }
+    }
+
+    ~nixlLibfabricPostThreadPool() {
+        stopAndJoin();
+    }
+
+    size_t
+    size() const {
+        return workers_.size();
+    }
+
+    void
+    submit(std::function<void()> task) {
+        {
+            const std::lock_guard<std::mutex> lock(mutex_);
+            if (stop_) {
+                throw std::runtime_error("libfabric post thread pool is stopping");
+            }
+            tasks_.emplace_back(std::move(task));
+        }
+        cv_.notify_one();
+    }
+
+private:
+    void
+    stopAndJoin() {
+        {
+            const std::lock_guard<std::mutex> lock(mutex_);
+            stop_ = true;
+        }
+        // Workers drain tasks queued before stop_; submit() rejects new tasks after this point.
+        cv_.notify_all();
+
+        for (auto &worker : workers_) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+    }
+
+    void
+    workerLoop() {
+        while (true) {
+            std::function<void()> task;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                cv_.wait(lock, [this]() { return stop_ || !tasks_.empty(); });
+
+                if (stop_ && tasks_.empty()) {
+                    return;
+                }
+
+                task = std::move(tasks_.front());
+                tasks_.pop_front();
+            }
+
+            task();
+        }
+    }
+
+    std::vector<std::thread> workers_;
+    std::deque<std::function<void()>> tasks_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool stop_ = false;
+};
+
 namespace {
 
 void *
@@ -198,6 +322,7 @@ nixlLibfabricEngine::vramUpdateCtx(void *address, uint64_t devId, bool &restart_
 
     restart_reqd = false;
 
+    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
     if (!cuda_addr_wa_) {
         return 0; // Nothing to do
     }
@@ -213,6 +338,7 @@ nixlLibfabricEngine::vramUpdateCtx(void *address, uint64_t devId, bool &restart_
 
 int
 nixlLibfabricEngine::vramApplyCtx() {
+    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
     if (!cuda_addr_wa_) {
         return 0; // Nothing to do
     }
@@ -221,6 +347,7 @@ nixlLibfabricEngine::vramApplyCtx() {
 
 void
 nixlLibfabricEngine::vramFiniCtx() {
+    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
     cudaCtx_.reset();
 }
 #endif
@@ -293,6 +420,8 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
       progress_thread_enabled_(init_params->enableProgTh),
       progress_thread_delay_(std::chrono::microseconds(init_params->pthrDelay)),
       rail_manager(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD),
+      post_thread_count_(NIXL_LIBFABRIC_DEFAULT_POST_THREADS),
+      post_split_batch_size_(NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE),
       runtime_(FI_HMEM_SYSTEM) {
 
     NIXL_INFO << "Initializing Libfabric Backend";
@@ -340,6 +469,25 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         }
     } else {
         NIXL_INFO << "Striping threshold: " << striping_threshold_ << " bytes (default)";
+    }
+
+    post_thread_count_ =
+        getSizeParam(getCustomParams(), "num_threads", NIXL_LIBFABRIC_DEFAULT_POST_THREADS);
+    const size_t max_post_thread_count = getMaxPostThreadCount();
+    if (post_thread_count_ > max_post_thread_count) {
+        NIXL_WARN << "Capping libfabric post thread count from " << post_thread_count_ << " to "
+                  << max_post_thread_count;
+        post_thread_count_ = max_post_thread_count;
+    }
+    post_split_batch_size_ = getSizeParam(
+        getCustomParams(), "split_batch_size", NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE);
+    if (post_thread_count_ > 0) {
+        post_thread_pool_ = std::make_unique<nixlLibfabricPostThreadPool>(post_thread_count_);
+        NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with "
+                   << post_thread_pool_->size()
+                   << " threads, split_batch_size=" << post_split_batch_size_;
+    } else {
+        NIXL_DEBUG << "Libfabric descriptor post thread pool disabled";
     }
 
     // Initialize Rail Manager which will discover the topology and create all rails.
@@ -416,6 +564,8 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 nixlLibfabricEngine::~nixlLibfabricEngine() {
     NIXL_DEBUG
         << "Destructor starting, stopping all threads FIRST to prevent timing report interruption";
+
+    post_thread_pool_.reset();
 
     if (progress_thread_enabled_) {
         progress_thread_stop_.store(true);
@@ -711,19 +861,31 @@ nixlLibfabricEngine::registerMem(const nixlBlobDesc &mem,
         if (runtime_ == FI_HMEM_CUDA) {
             // CUDA-specific address query
             // For multi-GPU support, skip CUDA address workaround
-            if (cuda_addr_wa_) {
+            bool use_cuda_addr_wa = false;
+            {
+                const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+                use_cuda_addr_wa = cuda_addr_wa_;
+            }
+            if (use_cuda_addr_wa) {
                 bool need_restart;
                 if (vramUpdateCtx((void *)mem.addr, mem.devId, need_restart)) {
                     NIXL_INFO << "Multi-GPU detected (device " << mem.devId
                               << "), using cudaSetDevice fallback";
-                    cuda_addr_wa_ = false;
+                    {
+                        const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+                        cuda_addr_wa_ = false;
+                    }
                 } else if (need_restart) {
                     NIXL_DEBUG << "CUDA context updated, restarting progress thread";
                     vramApplyCtx();
                 }
             }
             // Fallback: set device via runtime API (uses primary context)
-            if (!cuda_addr_wa_) {
+            {
+                const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+                use_cuda_addr_wa = cuda_addr_wa_;
+            }
+            if (!use_cuda_addr_wa) {
                 cudaError_t cuda_ret = cudaSetDevice(mem.devId);
                 if (cuda_ret != cudaSuccess) {
                     NIXL_ERROR << "Failed to set CUDA device " << mem.devId << ": "
@@ -963,6 +1125,106 @@ nixlLibfabricEngine::estimateXferCost(const nixl_xfer_op_t &operation,
 }
 
 nixl_status_t
+nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
+                                         const nixl_meta_dlist_t &local,
+                                         const nixl_meta_dlist_t &remote,
+                                         const std::shared_ptr<nixlLibfabricConnection> &conn,
+                                         const std::string &remote_agent,
+                                         nixlLibfabricBackendH *backend_handle,
+                                         int start_idx,
+                                         int end_idx,
+                                         int desc_count,
+                                         size_t xfer_base_offset,
+                                         size_t &submitted_count) const {
+    submitted_count = 0;
+
+#ifdef HAVE_CUDA
+    const bool is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
+    bool use_cuda_addr_wa = false;
+    int current_cuda_device = -1;
+    if (is_cuda_vram) {
+        const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+        use_cuda_addr_wa = cuda_addr_wa_;
+        if (use_cuda_addr_wa && cudaCtx_) {
+            cudaCtx_->cudaSetCtx();
+        }
+    }
+#endif
+
+    for (int desc_idx = start_idx; desc_idx < end_idx; ++desc_idx) {
+        auto *local_md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
+        auto *remote_md = static_cast<nixlLibfabricPublicMetadata *>(remote[desc_idx].metadataP);
+
+        // Get transfer info for THIS descriptor
+        void *transfer_addr = (void *)local[desc_idx].addr;
+        size_t transfer_size = local[desc_idx].len;
+        int device_id = local[desc_idx].devId;
+
+        NIXL_DEBUG << "Processing descriptor " << desc_idx << " device " << device_id
+                   << " local_addr: " << transfer_addr << " size=" << transfer_size
+                   << " remote_addr=" << (void *)remote[desc_idx].addr;
+
+        NIXL_DEBUG << "DEBUG: remote_agent='" << remote_agent << "' localAgent='" << localAgent
+                   << "'";
+
+#ifdef HAVE_CUDA
+        if (is_cuda_vram && !use_cuda_addr_wa && device_id != current_cuda_device) {
+            cudaError_t cuda_ret = cudaSetDevice(device_id);
+            if (cuda_ret != cudaSuccess) {
+                NIXL_ERROR << "Failed to set CUDA device " << device_id
+                           << " while posting descriptor " << desc_idx << ": "
+                           << cudaGetErrorString(cuda_ret);
+                return NIXL_ERR_BACKEND;
+            }
+            current_cuda_device = device_id;
+        }
+#endif
+
+        // Prepare and submit transfer for remote agents
+        // Use descriptor's specific target address
+        uint64_t remote_target_addr = remote[desc_idx].addr;
+
+        uint64_t remote_registered_base = remote_md->remote_buf_addr_;
+
+        size_t desc_submitted_count = 0;
+        nixl_status_t status = rail_manager.prepareAndSubmitTransfer(
+            op_type,
+            transfer_addr,
+            transfer_size,
+            remote_target_addr,
+            remote_registered_base,
+            local_md->selected_rails_,
+            local_md->rail_mr_list_,
+            remote_md->rail_remote_key_list_,
+            remote_md->remote_selected_endpoints_,
+            conn->rail_remote_addr_list_,
+            conn->agent_index_,
+            backend_handle->post_xfer_id,
+            [backend_handle]() {
+                backend_handle->increment_completed_requests();
+            }, // Completion callback
+            desc_submitted_count,
+            desc_idx,
+            desc_count,
+            xfer_base_offset);
+
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx
+                       << " device " << device_id;
+            return status;
+        }
+
+        submitted_count += desc_submitted_count;
+
+        NIXL_DEBUG << "Successfully processed descriptor " << desc_idx << " with "
+                   << desc_submitted_count
+                   << " requests submitted (range accumulated: " << submitted_count << ")";
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
 nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                               const nixl_meta_dlist_t &local,
                               const nixl_meta_dlist_t &remote,
@@ -987,6 +1249,7 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         }
         NIXL_DEBUG << "Established new connection with remote_agent: " << remote_agent;
     }
+    auto conn = conn_it->second;
 
     NIXL_DEBUG << "Posting transfer for remote_agent: " << remote_agent
                << ", handle address: " << handle;
@@ -1028,9 +1291,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
 
     size_t total_submitted = 0;
 
-    // Core transfer submission to process each descriptor with direct submission
-    // Reserve base_offset once per transfer so all descriptors see a stable rail assignment
-    const size_t xfer_base_offset = rail_manager.reserveBaseOffset();
+    // Validate metadata before posting. The parallel path may post descriptors out of order, so
+    // simple input errors should be caught before any worker submits RDMA operations.
     for (int desc_idx = 0; desc_idx < desc_count; ++desc_idx) {
         auto *local_md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
         auto *remote_md = static_cast<nixlLibfabricPublicMetadata *>(remote[desc_idx].metadataP);
@@ -1040,62 +1302,114 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         }
 
         // Validate connection for this descriptor
-        if (remote_md->conn_ != conn_it->second) {
+        if (remote_md->conn_ != conn) {
             NIXL_ERROR << "Connection mismatch for descriptor " << desc_idx;
             return NIXL_ERR_MISMATCH;
         }
-        // Get transfer info for THIS descriptor
-        void *transfer_addr = (void *)local[desc_idx].addr;
-        size_t transfer_size = local[desc_idx].len;
-        int device_id = local[desc_idx].devId;
+    }
 
-        NIXL_DEBUG << "Processing descriptor " << desc_idx << " device " << device_id
-                   << " local_addr: " << transfer_addr << " size=" << transfer_size
-                   << " remote_addr=" << (void *)remote[desc_idx].addr;
+    // Reserve base_offset once per transfer so all descriptors see a stable rail assignment.
+    const size_t xfer_base_offset = rail_manager.reserveBaseOffset();
+    const bool use_post_pool = post_thread_pool_ && post_thread_count_ > 0 && desc_count > 0 &&
+        static_cast<size_t>(desc_count) >= post_split_batch_size_;
 
-        NIXL_DEBUG << "DEBUG: remote_agent='" << remote_agent << "' localAgent='" << localAgent
-                   << "'";
-
-        // Prepare and submit transfer for remote agents
-        // Use descriptor's specific target address
-        uint64_t remote_target_addr = remote[desc_idx].addr;
-
-        uint64_t remote_registered_base = remote_md->remote_buf_addr_;
-
-        size_t submitted_count = 0;
-        nixl_status_t status = rail_manager.prepareAndSubmitTransfer(
-            op_type,
-            transfer_addr,
-            transfer_size,
-            remote_target_addr,
-            remote_registered_base,
-            local_md->selected_rails_,
-            local_md->rail_mr_list_,
-            remote_md->rail_remote_key_list_,
-            remote_md->remote_selected_endpoints_,
-            conn_it->second->rail_remote_addr_list_,
-            conn_it->second->agent_index_,
-            backend_handle->post_xfer_id,
-            [backend_handle]() {
-                backend_handle->increment_completed_requests();
-            }, // Completion callback
-            submitted_count,
-            desc_idx,
-            desc_count,
-            xfer_base_offset);
-
+    if (!use_post_pool) {
+        nixl_status_t status = postXferDescriptors(op_type,
+                                                   local,
+                                                   remote,
+                                                   conn,
+                                                   remote_agent,
+                                                   backend_handle,
+                                                   0,
+                                                   desc_count,
+                                                   desc_count,
+                                                   xfer_base_offset,
+                                                   total_submitted);
         if (status != NIXL_SUCCESS) {
-            NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx
-                       << " device " << device_id;
+            return status;
+        }
+    } else {
+        const size_t num_chunks = std::min(post_thread_count_, static_cast<size_t>(desc_count));
+        const size_t chunk_size = (desc_count + num_chunks - 1) / num_chunks;
+        std::atomic<size_t> parallel_total_submitted{0};
+        std::atomic<int> first_status{static_cast<int>(NIXL_SUCCESS)};
+        std::mutex done_mutex;
+        std::condition_variable done_cv;
+        size_t remaining = num_chunks;
+        size_t submitted_chunks = 0;
+
+        NIXL_DEBUG << "Processing " << desc_count << " descriptors across " << num_chunks
+                   << " libfabric post worker chunks";
+
+        try {
+            for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
+                const int start_idx = static_cast<int>(chunk_idx * chunk_size);
+                const int end_idx = static_cast<int>(
+                    std::min(static_cast<size_t>(desc_count), (chunk_idx + 1) * chunk_size));
+
+                post_thread_pool_->submit([&, start_idx, end_idx]() {
+                    nixl_status_t status = NIXL_SUCCESS;
+                    size_t chunk_submitted = 0;
+
+                    try {
+                        status = postXferDescriptors(op_type,
+                                                     local,
+                                                     remote,
+                                                     conn,
+                                                     remote_agent,
+                                                     backend_handle,
+                                                     start_idx,
+                                                     end_idx,
+                                                     desc_count,
+                                                     xfer_base_offset,
+                                                     chunk_submitted);
+                    }
+                    catch (const std::exception &e) {
+                        NIXL_ERROR << "Exception while posting libfabric descriptors [" << start_idx
+                                   << ", " << end_idx << "): " << e.what();
+                        status = NIXL_ERR_BACKEND;
+                    }
+                    catch (...) {
+                        NIXL_ERROR << "Unknown exception while posting libfabric descriptors ["
+                                   << start_idx << ", " << end_idx << ")";
+                        status = NIXL_ERR_BACKEND;
+                    }
+
+                    if (status != NIXL_SUCCESS) {
+                        storeFirstError(first_status, status);
+                    } else {
+                        parallel_total_submitted.fetch_add(chunk_submitted);
+                    }
+
+                    {
+                        const std::lock_guard<std::mutex> lock(done_mutex);
+                        remaining--;
+                    }
+                    done_cv.notify_one();
+                });
+                submitted_chunks++;
+            }
+        }
+        catch (const std::exception &e) {
+            NIXL_ERROR << "Failed to submit libfabric descriptor post task: " << e.what();
+            std::unique_lock<std::mutex> lock(done_mutex);
+            done_cv.wait(lock, [&remaining, num_chunks, submitted_chunks]() {
+                return remaining == num_chunks - submitted_chunks;
+            });
+            return NIXL_ERR_BACKEND;
+        }
+
+        {
+            std::unique_lock<std::mutex> lock(done_mutex);
+            done_cv.wait(lock, [&remaining]() { return remaining == 0; });
+        }
+
+        nixl_status_t status = static_cast<nixl_status_t>(first_status.load());
+        if (status != NIXL_SUCCESS) {
             return status;
         }
 
-        // Add submitted requests to the total count
-        total_submitted += submitted_count;
-
-        NIXL_DEBUG << "Successfully processed descriptor " << desc_idx << " with "
-                   << submitted_count << " requests submitted (accumulated: " << total_submitted
-                   << ")";
+        total_submitted = parallel_total_submitted.load();
     }
 
     NIXL_DEBUG << "Processing complete: submitted " << total_submitted << " requests from "
@@ -1629,6 +1943,7 @@ nixlLibfabricEngine::checkPendingNotifications() {
 void
 nixlLibfabricEngine::cleanup() {
     NIXL_DEBUG << "Cleaning up all resources";
+    post_thread_pool_.reset();
 #ifdef HAVE_CUDA
     // Cleanup CUDA context
     vramFiniCtx();

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -33,14 +33,13 @@
 #include <numeric>
 #include <stdexcept>
 #include <thread>
+#include <utility>
 
 /****************************************
  * Neuron Address Query
  *****************************************/
 namespace {
 
-constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
-constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
 constexpr size_t NIXL_LIBFABRIC_POST_THREAD_HW_MULTIPLIER = 4;
 
 size_t
@@ -82,16 +81,29 @@ public:
         stopAndJoin();
     }
 
-    void
-    submit(std::function<void()> task) {
+    template<typename Fn>
+    bool
+    submit(Fn &&task) {
         {
             const std::lock_guard<std::mutex> lock(mutex_);
             if (stop_) {
-                throw std::runtime_error("libfabric post thread pool is stopping");
+                NIXL_WARN << "Ignoring libfabric post task submission after thread pool stop";
+                return false;
             }
-            tasks_.emplace_back(std::move(task));
+            try {
+                tasks_.emplace_back(std::forward<Fn>(task));
+            }
+            catch (const std::exception &e) {
+                NIXL_ERROR << "Failed to queue libfabric post task: " << e.what();
+                return false;
+            }
+            catch (...) {
+                NIXL_ERROR << "Failed to queue libfabric post task";
+                return false;
+            }
         }
         cv_.notify_one();
+        return true;
     }
 
 private:
@@ -451,24 +463,7 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         NIXL_INFO << "Striping threshold: " << striping_threshold_ << " bytes (default)";
     }
 
-    post_thread_count_ = NIXL_LIBFABRIC_DEFAULT_POST_THREADS;
-    LibfabricUtils::getCustomIntParam(getCustomParams(), "num_threads", post_thread_count_);
-    const size_t max_post_thread_count = getMaxPostThreadCount();
-    if (post_thread_count_ > max_post_thread_count) {
-        NIXL_WARN << "Capping libfabric post thread count from " << post_thread_count_ << " to "
-                  << max_post_thread_count;
-        post_thread_count_ = max_post_thread_count;
-    }
-    post_split_batch_size_ = NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE;
-    LibfabricUtils::getCustomIntParam(
-        getCustomParams(), "split_batch_size", post_split_batch_size_);
-    if (post_thread_count_ > 0) {
-        post_thread_pool_ = std::make_unique<nixlLibfabricPostThreadPool>(post_thread_count_);
-        NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with " << post_thread_count_
-                   << " threads, split_batch_size=" << post_split_batch_size_;
-    } else {
-        NIXL_DEBUG << "Libfabric descriptor post thread pool disabled";
-    }
+    initPostThreadPool();
 
     // Initialize Rail Manager which will discover the topology and create all rails.
     try {
@@ -538,6 +533,28 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
         NIXL_ERROR << "Failed to initialize libfabric backend: " << e.what();
         cleanup();
         throw;
+    }
+}
+
+void
+nixlLibfabricEngine::initPostThreadPool() {
+    LibfabricUtils::getCustomIntParam(
+        getCustomParams(), NIXL_LIBFABRIC_POST_THREADS_PARAM, post_thread_count_);
+    const size_t max_post_thread_count = getMaxPostThreadCount();
+    if (post_thread_count_ > max_post_thread_count) {
+        NIXL_WARN << "Capping libfabric post thread count from " << post_thread_count_ << " to "
+                  << max_post_thread_count;
+        post_thread_count_ = max_post_thread_count;
+    }
+
+    LibfabricUtils::getCustomIntParam(
+        getCustomParams(), NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM, post_split_batch_size_);
+    if (post_thread_count_ > 0) {
+        post_thread_pool_ = std::make_unique<nixlLibfabricPostThreadPool>(post_thread_count_);
+        NIXL_DEBUG << "Libfabric descriptor post thread pool enabled with " << post_thread_count_
+                   << " threads, split_batch_size=" << post_split_batch_size_;
+    } else {
+        NIXL_DEBUG << "Libfabric descriptor post thread pool disabled";
     }
 }
 
@@ -1104,6 +1121,43 @@ nixlLibfabricEngine::estimateXferCost(const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
+#ifdef HAVE_CUDA
+nixl_status_t
+nixlLibfabricEngine::initCudaPostContext(CudaPostContext &context) const {
+    if (!context.is_cuda_vram) {
+        return NIXL_SUCCESS;
+    }
+
+    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+    context.use_cuda_addr_wa = cuda_addr_wa_;
+    if (context.use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
+        NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlLibfabricEngine::prepareCudaDescriptorPost(CudaPostContext &context,
+                                               int device_id,
+                                               int desc_idx) const {
+    if (!context.is_cuda_vram || context.use_cuda_addr_wa ||
+        device_id == context.current_cuda_device) {
+        return NIXL_SUCCESS;
+    }
+
+    cudaError_t cuda_ret = cudaSetDevice(device_id);
+    if (cuda_ret != cudaSuccess) {
+        NIXL_ERROR << "Failed to set CUDA device " << device_id << " while posting descriptor "
+                   << desc_idx << ": " << cudaGetErrorString(cuda_ret);
+        return NIXL_ERR_BACKEND;
+    }
+    context.current_cuda_device = device_id;
+    return NIXL_SUCCESS;
+}
+#endif
+
 nixl_status_t
 nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
                                          const nixl_meta_dlist_t &local,
@@ -1118,16 +1172,10 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
     submitted_count = 0;
 
 #ifdef HAVE_CUDA
-    const bool is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
-    bool use_cuda_addr_wa = false;
-    int current_cuda_device = -1;
-    if (is_cuda_vram) {
-        const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
-        use_cuda_addr_wa = cuda_addr_wa_;
-        if (use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
-            NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
-            return NIXL_ERR_BACKEND;
-        }
+    CudaPostContext cuda_post_context;
+    cuda_post_context.is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
+    if (nixl_status_t status = initCudaPostContext(cuda_post_context); status != NIXL_SUCCESS) {
+        return status;
     }
 #endif
 
@@ -1140,15 +1188,10 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         int device_id = local[desc_idx].devId;
 
 #ifdef HAVE_CUDA
-        if (is_cuda_vram && !use_cuda_addr_wa && device_id != current_cuda_device) {
-            cudaError_t cuda_ret = cudaSetDevice(device_id);
-            if (cuda_ret != cudaSuccess) {
-                NIXL_ERROR << "Failed to set CUDA device " << device_id
-                           << " while posting descriptor " << desc_idx << ": "
-                           << cudaGetErrorString(cuda_ret);
-                return NIXL_ERR_BACKEND;
-            }
-            current_cuda_device = device_id;
+        if (nixl_status_t status =
+                prepareCudaDescriptorPost(cuda_post_context, device_id, desc_idx);
+            status != NIXL_SUCCESS) {
+            return status;
         }
 #endif
 
@@ -1300,13 +1343,12 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
         size_t remaining = num_chunks;
         size_t submitted_chunks = 0;
 
-        try {
-            for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
-                const int start_idx = static_cast<int>(chunk_idx * chunk_size);
-                const int end_idx = static_cast<int>(
-                    std::min(static_cast<size_t>(desc_count), (chunk_idx + 1) * chunk_size));
+        for (size_t chunk_idx = 0; chunk_idx < num_chunks; ++chunk_idx) {
+            const int start_idx = static_cast<int>(chunk_idx * chunk_size);
+            const int end_idx = static_cast<int>(
+                std::min(static_cast<size_t>(desc_count), (chunk_idx + 1) * chunk_size));
 
-                post_thread_pool_->submit([&, start_idx, end_idx]() {
+            if (!post_thread_pool_->submit([&, start_idx, end_idx]() {
                     nixl_status_t status = NIXL_SUCCESS;
                     size_t chunk_submitted = 0;
 
@@ -1344,12 +1386,14 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                         remaining--;
                     }
                     done_cv.notify_one();
-                });
-                submitted_chunks++;
+                })) {
+                NIXL_ERROR << "Failed to submit libfabric descriptor post task";
+                break;
             }
+            submitted_chunks++;
         }
-        catch (const std::exception &e) {
-            NIXL_ERROR << "Failed to submit libfabric descriptor post task: " << e.what();
+
+        if (submitted_chunks != num_chunks) {
             std::unique_lock<std::mutex> lock(done_mutex);
             done_cv.wait(lock, [&remaining, num_chunks, submitted_chunks]() {
                 return remaining == num_chunks - submitted_chunks;

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -303,7 +303,6 @@ private:
                         const nixl_meta_dlist_t &local,
                         const nixl_meta_dlist_t &remote,
                         const std::shared_ptr<nixlLibfabricConnection> &conn,
-                        const std::string &remote_agent,
                         nixlLibfabricBackendH *backend_handle,
                         int start_idx,
                         int end_idx,

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -26,6 +26,7 @@
 #include <condition_variable>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -41,6 +42,11 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
+
+inline constexpr const char *NIXL_LIBFABRIC_POST_THREADS_PARAM = "num_threads";
+inline constexpr const char *NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM = "split_batch_size";
+inline constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
+inline constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
 
 // Forward declarations
 class nixlLibfabricEngine;
@@ -279,8 +285,8 @@ private:
 #ifdef HAVE_CUDA
     // CUDA context management
     std::unique_ptr<nixlLibfabricCudaCtx> cudaCtx_;
-    mutable std::mutex cuda_ctx_mutex_; // Protects cudaCtx_ and cuda_addr_wa_.
     bool cuda_addr_wa_; // CUDA address workaround flag
+    mutable std::mutex cuda_ctx_mutex_; // Protects cudaCtx_ and cuda_addr_wa_.
 #endif
 
     void
@@ -298,6 +304,8 @@ private:
                        void *buffer,
                        std::shared_ptr<nixlLibfabricConnection> conn,
                        nixlBackendMD *&output);
+    void
+    initPostThreadPool();
     nixl_status_t
     postXferDescriptors(nixlLibfabricReq::OpType op_type,
                         const nixl_meta_dlist_t &local,
@@ -311,6 +319,17 @@ private:
                         size_t &submitted_count) const;
 
 #ifdef HAVE_CUDA
+    struct CudaPostContext {
+        bool is_cuda_vram = false;
+        bool use_cuda_addr_wa = false;
+        int current_cuda_device = -1;
+    };
+
+    nixl_status_t
+    initCudaPostContext(CudaPostContext &context) const;
+    nixl_status_t
+    prepareCudaDescriptorPost(CudaPostContext &context, int device_id, int desc_idx) const;
+
     // CUDA context management methods
     void
     vramInitCtx();

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -181,7 +181,7 @@ private:
     std::chrono::microseconds progress_thread_delay_;
 
     // Rail Manager - Stack allocated for better performance (mutable for const methods)
-    mutable nixlLibfabricRailManager rail_manager;
+    mutable nixlLibfabricRailManager rail_manager_;
 
     // Configurable striping threshold
     size_t striping_threshold_;
@@ -212,7 +212,7 @@ private:
     mutable std::mutex connection_state_mutex_;
 
 
-    // System runtime type (set during initialization from rail_manager)
+    // System runtime type (set during initialization from rail_manager_)
     fi_hmem_iface runtime_;
 
     void

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -26,7 +26,6 @@
 #include <condition_variable>
 #include <atomic>
 #include <chrono>
-#include <cstddef>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -42,11 +41,6 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #endif
-
-inline constexpr const char *NIXL_LIBFABRIC_POST_THREADS_PARAM = "num_threads";
-inline constexpr const char *NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM = "split_batch_size";
-inline constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_THREADS = 0;
-inline constexpr size_t NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE = 1024;
 
 // Forward declarations
 class nixlLibfabricEngine;
@@ -319,17 +313,6 @@ private:
                         size_t &submitted_count) const;
 
 #ifdef HAVE_CUDA
-    struct CudaPostContext {
-        bool is_cuda_vram = false;
-        bool use_cuda_addr_wa = false;
-        int current_cuda_device = -1;
-    };
-
-    nixl_status_t
-    initCudaPostContext(CudaPostContext &context) const;
-    nixl_status_t
-    prepareCudaDescriptorPost(CudaPostContext &context, int device_id, int desc_idx) const;
-
     // CUDA context management methods
     void
     vramInitCtx();

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -44,6 +44,7 @@
 
 // Forward declarations
 class nixlLibfabricEngine;
+class nixlLibfabricPostThreadPool;
 
 #ifdef HAVE_CUDA
 /** CUDA context management for libfabric backend */
@@ -185,6 +186,11 @@ private:
     // Configurable striping threshold
     size_t striping_threshold_;
 
+    // Descriptor-posting thread pool configuration
+    size_t post_thread_count_;
+    size_t post_split_batch_size_;
+    std::unique_ptr<nixlLibfabricPostThreadPool> post_thread_pool_;
+
     mutable size_t total_transfer_size_;
 
     // Map of agent name to connection info
@@ -273,6 +279,7 @@ private:
 #ifdef HAVE_CUDA
     // CUDA context management
     std::unique_ptr<nixlLibfabricCudaCtx> cudaCtx_;
+    mutable std::mutex cuda_ctx_mutex_; // Protects cudaCtx_ and cuda_addr_wa_.
     bool cuda_addr_wa_; // CUDA address workaround flag
 #endif
 
@@ -291,6 +298,18 @@ private:
                        void *buffer,
                        std::shared_ptr<nixlLibfabricConnection> conn,
                        nixlBackendMD *&output);
+    nixl_status_t
+    postXferDescriptors(nixlLibfabricReq::OpType op_type,
+                        const nixl_meta_dlist_t &local,
+                        const nixl_meta_dlist_t &remote,
+                        const std::shared_ptr<nixlLibfabricConnection> &conn,
+                        const std::string &remote_agent,
+                        nixlLibfabricBackendH *backend_handle,
+                        int start_idx,
+                        int end_idx,
+                        int desc_count,
+                        size_t xfer_base_offset,
+                        size_t &submitted_count) const;
 
 #ifdef HAVE_CUDA
     // CUDA context management methods

--- a/src/plugins/libfabric/libfabric_plugin.cpp
+++ b/src/plugins/libfabric/libfabric_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-FileCopyrightText: Copyright (c) 2025 Amazon.com, Inc. and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,17 +22,31 @@
 // Plugin type alias for convenience
 using libfabric_plugin_t = nixlBackendPluginCreator<nixlLibfabricEngine>;
 
+static nixl_b_params_t
+getLibfabricBackendOptions() {
+    return {
+        {"num_threads", "0"},
+        {"split_batch_size", "1024"},
+    };
+}
+
 #ifdef STATIC_PLUGIN_LIBFABRIC
 nixlBackendPlugin *
 createStaticLIBFABRICPlugin() {
-    return libfabric_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "LIBFABRIC", "0.1.0", {}, {DRAM_SEG, VRAM_SEG});
+    return libfabric_plugin_t::create(NIXL_PLUGIN_API_VERSION,
+                                      "LIBFABRIC",
+                                      "0.1.0",
+                                      getLibfabricBackendOptions(),
+                                      {DRAM_SEG, VRAM_SEG});
 }
 #else
 extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
 nixl_plugin_init() {
-    return libfabric_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "LIBFABRIC", "0.1.0", {}, {DRAM_SEG, VRAM_SEG});
+    return libfabric_plugin_t::create(NIXL_PLUGIN_API_VERSION,
+                                      "LIBFABRIC",
+                                      "0.1.0",
+                                      getLibfabricBackendOptions(),
+                                      {DRAM_SEG, VRAM_SEG});
 }
 
 extern "C" NIXL_PLUGIN_EXPORT void

--- a/src/plugins/libfabric/libfabric_plugin.cpp
+++ b/src/plugins/libfabric/libfabric_plugin.cpp
@@ -19,17 +19,14 @@
 #include "backend/backend_plugin.h"
 #include "libfabric_backend.h"
 
-#include <string>
-
 // Plugin type alias for convenience
 using libfabric_plugin_t = nixlBackendPluginCreator<nixlLibfabricEngine>;
 
 static nixl_b_params_t
 getLibfabricBackendOptions() {
     return {
-        {NIXL_LIBFABRIC_POST_THREADS_PARAM, std::to_string(NIXL_LIBFABRIC_DEFAULT_POST_THREADS)},
-        {NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM,
-         std::to_string(NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE)},
+        {"num_threads", "0"},
+        {"split_batch_size", "1024"},
     };
 }
 

--- a/src/plugins/libfabric/libfabric_plugin.cpp
+++ b/src/plugins/libfabric/libfabric_plugin.cpp
@@ -19,14 +19,17 @@
 #include "backend/backend_plugin.h"
 #include "libfabric_backend.h"
 
+#include <string>
+
 // Plugin type alias for convenience
 using libfabric_plugin_t = nixlBackendPluginCreator<nixlLibfabricEngine>;
 
 static nixl_b_params_t
 getLibfabricBackendOptions() {
     return {
-        {"num_threads", "0"},
-        {"split_batch_size", "1024"},
+        {NIXL_LIBFABRIC_POST_THREADS_PARAM, std::to_string(NIXL_LIBFABRIC_DEFAULT_POST_THREADS)},
+        {NIXL_LIBFABRIC_POST_SPLIT_BATCH_SIZE_PARAM,
+         std::to_string(NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE)},
     };
 }
 

--- a/test/gtest/plugin_manager.cpp
+++ b/test/gtest/plugin_manager.cpp
@@ -38,6 +38,9 @@ const PluginDesc ucx_plugin_desc{.name = "UCX",
                                  .type = PluginDesc::PluginType::Real};
 const PluginDesc gds_plugin_desc{.name = "GDS",
                                  .type = PluginDesc::PluginType::Real};
+#ifdef HAVE_LIBFABRIC
+const PluginDesc libfabric_plugin_desc{.name = "LIBFABRIC", .type = PluginDesc::PluginType::Real};
+#endif
 
 class LoadSinglePluginTestFixture
     : public testing::TestWithParam<PluginDesc> {
@@ -203,6 +206,25 @@ TEST_F(LoadedPluginTestFixture, LoadUnloadSimplePluginTest) {
     EXPECT_TRUE(HasOnlyLoadedPlugins());
 }
 
+TEST_F(LoadedPluginTestFixture, LibfabricPluginAdvertisesPostThreadOptions) {
+#if defined(HAVE_LIBFABRIC) && TEST_ALL_PLUGINS
+    auto plugin_handle = plugin_manager_.getBackendPlugin("LIBFABRIC");
+    if (!plugin_handle) {
+        plugin_handle = plugin_manager_.loadBackendPlugin("LIBFABRIC");
+        if (plugin_handle) loaded_plugins_.insert("LIBFABRIC");
+    }
+    ASSERT_NE(plugin_handle, nullptr);
+
+    const auto backend_options = plugin_handle->getBackendOptions();
+    ASSERT_NE(backend_options.find("num_threads"), backend_options.end());
+    ASSERT_NE(backend_options.find("split_batch_size"), backend_options.end());
+    EXPECT_EQ(backend_options.at("num_threads"), "0");
+    EXPECT_EQ(backend_options.at("split_batch_size"), "1024");
+#else
+    GTEST_SKIP();
+#endif
+}
+
 /* Load single plugins tests instantiations. */
 INSTANTIATE_TEST_SUITE_P(MockLoadPluginInstantiation,
                          LoadSinglePluginTestFixture,
@@ -214,6 +236,11 @@ INSTANTIATE_TEST_SUITE_P(UcxLoadPluginInstantiation,
 INSTANTIATE_TEST_SUITE_P(GdsLoadPluginInstantiation,
                          LoadSinglePluginTestFixture,
                          testing::Values(gds_plugin_desc));
+#ifdef HAVE_LIBFABRIC
+INSTANTIATE_TEST_SUITE_P(LibfabricLoadPluginInstantiation,
+                         LoadSinglePluginTestFixture,
+                         testing::Values(libfabric_plugin_desc));
+#endif
 
 /* Load multiple plugins tests instantiations. */
 INSTANTIATE_TEST_SUITE_P(UcxGdsLoadMultiplePluginInstantiation,

--- a/test/gtest/plugin_manager.cpp
+++ b/test/gtest/plugin_manager.cpp
@@ -211,7 +211,9 @@ TEST_F(LoadedPluginTestFixture, LibfabricPluginAdvertisesPostThreadOptions) {
     auto plugin_handle = plugin_manager_.getBackendPlugin("LIBFABRIC");
     if (!plugin_handle) {
         plugin_handle = plugin_manager_.loadBackendPlugin("LIBFABRIC");
-        if (plugin_handle) loaded_plugins_.insert("LIBFABRIC");
+        if (plugin_handle) {
+            loaded_plugins_.insert("LIBFABRIC");
+        }
     }
     ASSERT_NE(plugin_handle, nullptr);
 


### PR DESCRIPTION
## Summary
- add a configurable LIBFABRIC descriptor-posting thread pool for `postXfer()`
- consume `num_threads` for LIBFABRIC from backend options, Python config, and nixlbench
- advertise LIBFABRIC post-thread options and document defaults

Fixes #1514

## Validation
- `git diff --check`
- `python3 -m py_compile src/api/python/_api.py`
- `ninja -C build-nolibfabric`
- `meson test -C build-nolibfabric`
- Docker LIBFABRIC-only build with `libfabric-dev 1.17.0`, `libhwloc-dev`, and `libnuma-dev`: `meson setup build-libfabric -Dbuildtype=debug -Dbuild_tests=false -Dbuild_examples=false -Denable_plugins=LIBFABRIC -Dinstall_headers=false && ninja -C build-libfabric`
- AWS/EFA e2e validation on two separate GB200/EFA nodes:
  - built libfabric 1.21.0 with the EFA provider enabled
  - built NIXL from this PR with `-Denable_plugins=LIBFABRIC`
  - ran `nixlbench --backend=LIBFABRIC` with DRAM WRITE, `--check_consistency`, `--progress_threads=4`, block size 4096, batch size 2048
  - cross-node run completed successfully on both ranks: `AWS/EFA cross-node LIBFABRIC nixlbench validation passed`

## Notes
- LIBFABRIC-enabled compile was validated in Docker.
- A Docker GTest compile also verified `test/gtest/plugin_manager.cpp`; full UCX+GTest build stopped later on Debian UCX 1.13 missing newer UCX symbols used by this repo.
- POSIX fixes were moved out of this PR and are tracked separately in #1605.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional parallel transfer posting for Libfabric with configurable thread pool and batch-size threshold; CUDA context access synchronized.

* **Bug Fixes**
  * Backend initialization now consistently forwards thread-count settings to Libfabric and ensures thread-pool teardown.

* **Documentation**
  * Runtime docs updated with new Libfabric controls: num_threads and split_batch_size.

* **Tests**
  * Added/expanded tests for Libfabric and POSIX backend options and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->