### PR TITLE
DOCKER: Update curl version to 8.19.0 in manylinux Dockerfile - 1.1.0

### DIFF
--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -149,8 +149,8 @@ RUN cd /workspace && \
 
 # The base image libcurl is linked against openssl 1.x, so we need to build from source
 # in order to use openssl 3.x. This is needed to build aws-sdk-cpp.
-RUN wget https://curl.se/download/curl-8.5.0.tar.gz && \
-    tar xzf curl-8.5.0.tar.gz && cd curl-8.5.0 && \
+RUN wget https://curl.se/download/curl-8.19.0.tar.gz && \
+    tar xzf curl-8.19.0.tar.gz && cd curl-8.19.0 && \
     ./configure --prefix=/usr/local --with-ssl=/usr/local/openssl3 --enable-shared && \
     make -j$(nproc) && make install
 

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -149,7 +149,7 @@ RUN cd /workspace && \
 
 # The base image libcurl is linked against openssl 1.x, so we need to build from source
 # in order to use openssl 3.x. This is needed to build aws-sdk-cpp.
-RUN wget https://curl.se/download/curl-8.19.0.tar.gz && \
+RUN wget --tries=3 --waitretry=5 https://curl.se/download/curl-8.19.0.tar.gz && \
     tar xzf curl-8.19.0.tar.gz && cd curl-8.19.0 && \
     ./configure --prefix=/usr/local --with-ssl=/usr/local/openssl3 --enable-shared && \
     make -j$(nproc) && make install

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -151,7 +151,7 @@ RUN cd /workspace && \
 # in order to use openssl 3.x. This is needed to build aws-sdk-cpp.
 RUN wget --tries=3 --waitretry=5 https://curl.se/download/curl-8.19.0.tar.gz && \
     tar xzf curl-8.19.0.tar.gz && cd curl-8.19.0 && \
-    ./configure --prefix=/usr/local --with-ssl=/usr/local/openssl3 --enable-shared && \
+    ./configure --prefix=/usr/local --with-ssl=/usr/local/openssl3 --without-libpsl --enable-shared && \
     make -j$(nproc) && make install
 
 RUN git clone --recurse-submodules --depth 1 --shallow-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1.11.760


### PR DESCRIPTION
## What?
The manylinux Dockerfile built curl 8.5.0 from source, which was flagged in the NIXL 1.1.0 Nspect security scan as a vulnerable version. This change bumps it to 8.19.0, which contains the security fix.