### PR TITLE
nixl_ep: Preserve low-latency CUDA graphs across scale up/down

### DIFF
--- a/examples/device/ep/README.md
+++ b/examples/device/ep/README.md
@@ -40,7 +40,7 @@ buffer.disconnect_ranks(ranks)
 
 - `Buffer(rank_id, ...)`: Initialize the NIXL communication buffer
 - `update_memory_buffers(num_ranks, num_experts_per_rank, num_rdma_bytes, num_nvl_bytes=0)`: Prepare buffers for up to `num_ranks` ranks and `num_experts_per_rank` experts
-- `connect_ranks(remote_ranks)`: Establish NIXL connections to new peers (can be called multiple times)
+- `connect_ranks(remote_ranks, activate=True)`: Establish NIXL connections to new peers (can be called multiple times); in low-latency mode, use `activate=False` to keep new peers masked until explicitly unmasked.
 - `disconnect_ranks(remote_ranks)`: Clean up connections to departing peers
 
 ## Testing

--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -230,7 +230,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               bool use_fp8, bool round_scale, bool use_ue8m0,
               uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
-              cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx);
+              cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx);
 
 void combine(void* combined_x,
              void* rdma_recv_x, uint64_t* rdma_recv_flag, void* rdma_send_x,
@@ -243,9 +243,9 @@ void combine(void* combined_x,
              int num_topk, int num_experts, int rank, int num_ranks,
              bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
-             cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx);
+             cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx);
 
-void barrier(gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream);
+void barrier(gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream);
 
 void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -74,7 +74,8 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
          int num_tokens, int num_max_dispatch_tokens_per_rank,
          int num_topk, int num_experts, int rank, int num_ranks,
          int num_warp_groups, int num_warps_per_group,
-         bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+         bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
+    auto nixl_ctx = *nixl_ctx_ptr;
     const auto sm_id = static_cast<int>(blockIdx.x);
     const auto thread_id = static_cast<int>(threadIdx.x);
     const auto warp_id = thread_id / 32, lane_id = get_lane_id();
@@ -397,7 +398,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               bool use_fp8, bool round_scale, bool use_ue8m0,
               uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
-              cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+              cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
     constexpr int kNumMaxTopK = 11;
     const int num_warp_groups = ceil_div(num_experts, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
@@ -617,7 +618,8 @@ combine(void* combined_x,
         int num_max_dispatch_tokens_per_rank,
         int num_experts, int rank, int num_ranks,
         int num_warp_groups, int num_warps_per_group,
-        uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+        uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
+    auto nixl_ctx = *nixl_ctx_ptr;
     const auto sm_id = __shfl_sync(0xffffffff, static_cast<int>(blockIdx.x), 0);
     const auto num_sms = __shfl_sync(0xffffffff, static_cast<int>(gridDim.x), 0);
     const auto thread_id = static_cast<int>(threadIdx.x);
@@ -1010,7 +1012,7 @@ void combine(void* combined_x,
              int num_topk, int num_experts, int rank, int num_ranks,
              bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
-             cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx nixl_ctx) {
+             cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
     constexpr int kNumMaxTopk = 11;
     const int num_warp_groups = ceil_div(num_experts, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
@@ -1151,12 +1153,13 @@ __forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mas
 }
 
 template <int kNumThreads>
-__global__ void barrier_kernel(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles) {
+__global__ void barrier_kernel(nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr, int* mask_buffer_ptr, uint64_t timeout_cycles) {
     const auto thread_id = static_cast<int>(threadIdx.x);
+    auto nixl_ctx = *nixl_ctx_ptr;
     barrier<kNumThreads>(nixl_ctx, mask_buffer_ptr, thread_id, timeout_cycles);
 }
 
-void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream) {
+void barrier(nixl_ep::gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream) {
     constexpr int kNumThreads = 32;
     SETUP_LAUNCH_CONFIG(1, kNumThreads, stream);
     LAUNCH_KERNEL(&cfg, barrier_kernel<kNumThreads>, nixl_ctx, mask_buffer_ptr, timeout_cycles);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -347,7 +347,7 @@ void Buffer::destroy() {
 
 void Buffer::barrier() {
     auto compute_stream = at::cuda::getCurrentCUDAStream();
-    ep_kernels::barrier(gpu_ctx, mask_buffer_ptr, timeout_cycles, compute_stream);
+    ep_kernels::barrier(gpu_ctx_ptr, mask_buffer_ptr, timeout_cycles, compute_stream);
 }
 
 void Buffer::_nixl_agents_connect(const std::vector<int>& ranks, const std::vector<nixl_blob_t>& remote_mds) {
@@ -1091,7 +1091,7 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                                use_fp8, round_scale, use_ue8m0,
                                timeout_cycles,
                                workspace, num_device_sms,
-                               launch_stream, phases, gpu_ctx);
+                               launch_stream, phases, gpu_ctx_ptr);
     };
     launcher(return_recv_hook ? EP_SEND_PHASE : (EP_SEND_PHASE | EP_RECV_PHASE));
 
@@ -1190,7 +1190,7 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
                               num_topk, num_experts, rank, num_ranks,
                              use_logfmt, timeout_cycles,
                               workspace, num_device_sms,
-                              launch_stream, phases, zero_copy, gpu_ctx);
+                              launch_stream, phases, zero_copy, gpu_ctx_ptr);
     };
     launcher(return_recv_hook ? EP_SEND_PHASE : (EP_SEND_PHASE | EP_RECV_PHASE));
 
@@ -1296,6 +1296,7 @@ void Buffer::_nixl_ep_memory_views_create(void) {
             EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(ht_barrier_descs, gpu_ctx.ht_barrier_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
         }
     }
+    CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
 }
 
 void Buffer::_nixl_ep_memory_views_destroy(void) {
@@ -1320,10 +1321,16 @@ void Buffer::_nixl_ep_init(void) {
         .num_rdma_ranks = num_rdma_ranks,
         .rank = rank,
     };
+    CUDA_CHECK(cudaMalloc(&gpu_ctx_ptr, sizeof(gpu_nixl_ctx)));
+    CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
 }
 
 void Buffer::_nixl_ep_destroy(void) {
     _nixl_ep_memory_views_destroy();
+    if (gpu_ctx_ptr != nullptr) {
+        cudaFree(gpu_ctx_ptr);
+        gpu_ctx_ptr = nullptr;
+    }
 }
 
 void Buffer::_nixl_agent_init() {

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -440,13 +440,14 @@ void Buffer::_ipc_handles_sync(const std::vector<std::optional<pybind11::bytearr
 }
 
 void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds,
-    const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles) {
+    const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles, bool activate) {
     EP_HOST_ASSERT(!remote_ranks_list.empty());
     EP_HOST_ASSERT(!remote_mds.has_value() || remote_mds->size() == remote_ranks_list.size());
 
     if (!low_latency_mode && num_nvl_bytes > 0) {
         EP_HOST_ASSERT(remote_ranks.empty() && "connect_ranks called more than once in high-throughput mode; elasticity is not yet supported");
     }
+    EP_HOST_ASSERT(low_latency_mode || activate);
 
     std::vector<int> new_ranks;
     std::vector<nixl_blob_t> new_ranks_mds;
@@ -463,7 +464,8 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
             continue;
 
         new_ranks.push_back(remote_rank);
-        CUDA_CHECK(cudaMemset(mask_buffer_ptr + remote_rank, 0, sizeof(int)));
+        int mask = activate ? 0 : 1;
+        CUDA_CHECK(cudaMemcpy(mask_buffer_ptr + remote_rank, &mask, sizeof(int), cudaMemcpyHostToDevice));
         CUDA_CHECK(cudaMemset(sync_count_ptr + remote_rank, 0, sizeof(int)));
         CUDA_CHECK(cudaMemset(sync_buffer_ptr + remote_rank, 0, sizeof(int)));
 
@@ -1457,9 +1459,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def(pybind11::init<int, bool, bool, int>())
         .def("update_memory_buffers", &nixl_ep::Buffer::update_memory_buffers)
         .def("barrier", &nixl_ep::Buffer::barrier)
-        .def("connect_ranks", [](nixl_ep::Buffer &buffer, const std::vector<int>& remote_ranks, const std::optional<std::vector<pybind11::bytes>>& remote_mds, const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles) {
-            buffer.connect_ranks(remote_ranks, nixl_ep::convert_mds(remote_mds), all_gathered_handles);
-        }, py::arg("remote_ranks"), py::arg("remote_mds") = std::nullopt, py::arg("ipc_handles") = std::vector<std::optional<pybind11::bytearray>>{})
+        .def("connect_ranks", [](nixl_ep::Buffer &buffer, const std::vector<int>& remote_ranks, const std::optional<std::vector<pybind11::bytes>>& remote_mds, const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles, bool activate) {
+            buffer.connect_ranks(remote_ranks, nixl_ep::convert_mds(remote_mds), all_gathered_handles, activate);
+        }, py::arg("remote_ranks"), py::arg("remote_mds") = std::nullopt, py::arg("ipc_handles") = std::vector<std::optional<pybind11::bytearray>>{}, py::arg("activate") = true)
         .def("disconnect_ranks", &nixl_ep::Buffer::disconnect_ranks)
         .def("is_available", &nixl_ep::Buffer::is_available)
         .def("get_num_rdma_ranks", &nixl_ep::Buffer::get_num_rdma_ranks)

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -150,6 +150,7 @@ private:
     int max_num_ranks;
     int max_experts_per_rank;
     nixl_ep::gpu_nixl_ctx gpu_ctx;
+    nixl_ep::gpu_nixl_ctx* gpu_ctx_ptr = nullptr;
     uint64_t* last_ht_barrier_counter = nullptr;
     uint64_t* local_ht_barrier_counter = nullptr;
 

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -174,7 +174,7 @@ public:
 
     void update_memory_buffers(int num_ranks, int max_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes = 0);
 
-    void connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds = std::nullopt, const std::vector<std::optional<pybind11::bytearray>>& all_gathered_handles = {});
+    void connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds = std::nullopt, const std::vector<std::optional<pybind11::bytearray>>& all_gathered_handles = {}, bool activate = true);
 
     void disconnect_ranks(const std::vector<int>& remote_ranks_list);
 

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -853,23 +853,26 @@ class Buffer:
         else:
             self.runtime.connect_ranks(remote_ranks, None, ipc_handles)
 
-    def connect_ranks(self, remote_ranks: List[int]) -> None:
+    def connect_ranks(self, remote_ranks: List[int], activate: bool = True) -> None:
         """
         Add connections to remote ranks.
 
         Arguments:
             remote_ranks: List of remote rank IDs to establish connections with.
                          The current rank will be automatically filtered out.
+            activate: in low-latency mode, if False, keep newly connected ranks masked until update_mask_buffer(..., False).
         """
         if self.low_latency_mode:
             if self.tcp_store_group is not None:
                 with self._fetch_remote_metadata_from_tcp_store(
                     remote_ranks
                 ) as remote_mds:
-                    self.runtime.connect_ranks(remote_ranks, remote_mds)
+                    self.runtime.connect_ranks(remote_ranks, remote_mds, activate=activate)
             else:
-                self.runtime.connect_ranks(remote_ranks)
+                self.runtime.connect_ranks(remote_ranks, activate=activate)
         else:
+            if not activate:
+                raise ValueError("connect_ranks(activate=False) is only supported in low-latency mode")
             self._ht_connect_ranks(remote_ranks)
 
     def disconnect_ranks(self, remote_ranks: List[int]) -> None:

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -867,12 +867,16 @@ class Buffer:
                 with self._fetch_remote_metadata_from_tcp_store(
                     remote_ranks
                 ) as remote_mds:
-                    self.runtime.connect_ranks(remote_ranks, remote_mds, activate=activate)
+                    self.runtime.connect_ranks(
+                        remote_ranks, remote_mds, activate=activate
+                    )
             else:
                 self.runtime.connect_ranks(remote_ranks, activate=activate)
         else:
             if not activate:
-                raise ValueError("connect_ranks(activate=False) is only supported in low-latency mode")
+                raise ValueError(
+                    "connect_ranks(activate=False) is only supported in low-latency mode"
+                )
             self._ht_connect_ranks(remote_ranks)
 
     def disconnect_ranks(self, remote_ranks: List[int]) -> None:


### PR DESCRIPTION
Store the low-latency NIXL GPU context in stable device memory and pass that pointer to LL kernels. This keeps the kernel argument stable when replacing memory views on `connect_ranks`/`disconnect_ranks`.

Also add low-latency-only connect_ranks(..., activate=False), allowing new ranks to be connected while remaining masked until explicitly activated.

This is important for vLLM elastic EP and fault tolerance- elastic EP needs to re-use existing CUDA graphs and serve with the old group post connect_ranks until the new ranks are ready to serve, and FT needs to re-use existing CUDA graphs post rank recovery.

Validated no performance degradation for both NVLink and RDMA paths on 1-node and 2-node runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated peer-connection docs to reflect new activation option and behavior in low-latency vs high-throughput modes.

* **New Features**
  * Added an optional activate parameter to control whether newly connected peers are immediately activated (defaults to true); in low-latency mode callers can defer activation, while deferred activation is disallowed in high-throughput mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->