### PR TITLE
fix(nixlbench): fix stats computation

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -1122,10 +1122,12 @@ xferBenchUtils::printStats(bool is_target,
     double avg_latency = 0, throughput_gb = 0;
     double totalbw = 0;
 
-    int num_iter = xferBenchConfig::num_iter;
+    int total_iter = xferBenchConfig::num_iter;
+    int per_thread_iter = total_iter / xferBenchConfig::num_threads;
 
     if (block_size > LARGE_BLOCK_SIZE) {
-        num_iter /= xferBenchConfig::large_blk_iter_ftr;
+        total_iter /= xferBenchConfig::large_blk_iter_ftr;
+        per_thread_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
     // Targets don't participate in reduction - they have no throughput to contribute
@@ -1135,8 +1137,8 @@ xferBenchUtils::printStats(bool is_target,
 
     double total_duration = stats.total_duration.avg();
 
-    total_data_transferred = ((block_size * batch_size) * num_iter); // In Bytes
-    avg_latency = (total_duration / (num_iter * batch_size)); // In microsec
+    total_data_transferred = ((block_size * batch_size) * total_iter); // In Bytes
+    avg_latency = (total_duration / (per_thread_iter * batch_size)); // In microsec
     if (IS_PAIRWISE_AND_MG() ||
         (IS_PAIRWISE_AND_SG() && xferBenchConfig::num_initiator_dev > 1 && rt->getSize() == 1)) {
         total_data_transferred *= xferBenchConfig::num_initiator_dev; // In Bytes


### PR DESCRIPTION
## What?

Fix incorrect iteration counts in printStats.

Throughput is computed using total iterations (all threads combined).
Latency used total iterations instead of per-thread iterations.

Since wall time covers all threads running in parallel, throughput needs the total count, while latency (per-thread sequential) needs the per-thread count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of benchmark statistics calculation by correctly distinguishing between total and per-thread iteration counts, ensuring latency measurements are properly computed across different block size scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->