### PR TITLE
Limit gRPC NPROC only in wheel CI builds

### DIFF
--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -106,6 +106,7 @@ matrix:
 # Global environment variables for the build process
 env:
   NPROC: 16
+  GRPC_NPROC: 10
   DOCKER_REGISTRY_HOST: 'artifactory.nvidia.com'
   BASE_IMAGE: "${DOCKER_REGISTRY_HOST}/sw-nbu-swx-nixl-docker-local/base/cuda"
   BASE_TAG: '13.0-devel-manylinux--25.09'
@@ -137,6 +138,7 @@ steps:
     run: |
       set -x
       export NPROC=$NPROC
+      export GRPC_NPROC=$GRPC_NPROC
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -116,6 +116,7 @@ RUN git clone https://github.com/abseil/abseil-cpp.git && \
     make install && \
     ldconfig
 
+ARG GRPC_NPROC
 RUN git clone --recurse-submodules -b ${GRPC_TAG} --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
     cd grpc && \
     mkdir -p cmake/build && \
@@ -134,7 +135,7 @@ RUN git clone --recurse-submodules -b ${GRPC_TAG} --depth 1 --shallow-submodules
     -DgRPC_ABSL_PROVIDER=package \
     -DgRPC_PROTOBUF_PROVIDER=module \
     -DgRPC_ZLIB_PROVIDER=package ../.. && \
-    make -j10 && \
+    make -j${GRPC_NPROC:-$(nproc)} && \
     make install && \
     ldconfig
 

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -39,6 +39,7 @@ UCX_REF=${UCX_REF:-v1.21.x}
 BUILD_NIXL_EP="true"
 OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
+GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
 
 get_options() {
@@ -222,6 +223,7 @@ BUILD_ARGS+=" --build-arg ARCH=$ARCH"
 BUILD_ARGS+=" --build-arg UCX_REF=$UCX_REF"
 BUILD_ARGS+=" --build-arg BUILD_NIXL_EP=$BUILD_NIXL_EP"
 BUILD_ARGS+=" --build-arg NPROC=$NPROC"
+BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 


### PR DESCRIPTION
## What?
Set a gRPC process limit only in CI wheel builds

## Why?
Wheel builds are now slow everywhere.

https://github.com/ai-dynamo/nixl/pull/534 added blossom jobs that hardcode -j10, set it to 10 in blossom but use nproc everywhere else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made gRPC compilation parallelism configurable via a build-time parameter exposed to the build environment.
  * The build workflow now sets and exports a new environment variable that is forwarded into container builds.
  * If not set, the parallelism defaults to the system CPU count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->