### PR TITLE
Add Kvbench deepseek v4 Pro Support

### DIFF
--- a/benchmark/kvbench/examples/model_config_deepseek_v4_128k.yaml
+++ b/benchmark/kvbench/examples/model_config_deepseek_v4_128k.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 128K-context profile for DeepSeek-V4-Pro with efficient storage: mixed
+# fp8 (NoPE) + bf16 (RoPE) main KV and fp4 indexer.
+
+strategy:
+  tp_size: 1
+  pp_size: 1
+  model_quant_mode: "fp8"
+  kvcache_quant_mode: "fp8_mixed"
+  index_quant_mode: "fp4"
+
+runtime:
+  isl: 131072
+  osl: 0
+  num_requests: 1
+
+system:
+  hardware: "H100"
+  backend: "SGLANG"
+  access_pattern: "layer"
+  page_size: 256

--- a/benchmark/kvbench/examples/model_config_deepseek_v4_1m.yaml
+++ b/benchmark/kvbench/examples/model_config_deepseek_v4_1m.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1M-context profile for DeepSeek-V4-Pro, pure bf16 storage.
+
+strategy:
+  tp_size: 1
+  pp_size: 1
+  model_quant_mode: "fp8"
+  kvcache_quant_mode: "bf16"
+  index_quant_mode: "bf16"
+
+runtime:
+  isl: 1048576
+  osl: 0
+  num_requests: 1
+
+system:
+  hardware: "H100"
+  backend: "SGLANG"
+  access_pattern: "layer"
+  page_size: 256

--- a/benchmark/kvbench/examples/model_deepseek_v4_pro.yaml
+++ b/benchmark/kvbench/examples/model_deepseek_v4_pro.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DeepSeek-V4-Pro architecture (1.6T total / 49B activated, 1M context).
+
+model_name: 'DEEPSEEK_V4_PRO'
+
+num_hidden_layers: 61
+num_nextn_predict_layers: 1
+
+num_query_heads: 128
+num_key_value_heads: 1
+kv_head_dim: 512
+kv_rope_dim: 64
+embedding_dimension: 7168
+
+# Sliding-window branch size: n_win uncompressed KV entries on every CSA/HCA
+# layer, and the MTP layer itself runs pure sliding window.
+sliding_window: 128
+
+# Hybrid attention interleaving. Length = num_hidden_layers + num_nextn_predict_layers.
+# r=4   → CSA (Compressed Sparse Attention, with lightning indexer)
+# r=128 → HCA (Heavily Compressed Attention, no indexer)
+# r=0   → MTP layer, pure sliding-window
+compress_ratios: [128, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
+                  128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+                  4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4,
+                  128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128, 4, 128,
+                  4, 0]
+
+# DSA lightning indexer. Cached on CSA layers only, compressed at the same
+# m=4 ratio. Storage precision is set via index_quant_mode in the runtime
+# config (StrategyConfig).
+index_head_dim: 128
+index_n_heads: 64
+index_topk: 1024
+
+num_model_params: 1600000000000

--- a/benchmark/kvbench/main.py
+++ b/benchmark/kvbench/main.py
@@ -135,59 +135,63 @@ def plan_command(model, model_config, model_configs, format, **kwargs):
             model_arch.set_model_config(model_configuration)
 
             separator = "=" * 80
-            isl_nixl_bench = NIXLBench(model_arch, model_configuration, **filtered_args)
+            io_sizes = model_arch.get_io_sizes(model_configuration.system.page_size)
 
-            io_size = model_arch.get_io_size(model_configuration.system.page_size)
-            batch_size = get_batch_size(model_arch, model_configuration, io_size)
-            isl_nixl_bench.set_io_size(io_size)
-            isl_nixl_bench.set_batch_size(batch_size)
+            for layer_class, io_size in io_sizes.items():
+                isl_nixl_bench = NIXLBench(model_arch, model_configuration, **filtered_args)
+                batch_size = get_batch_size(model_arch, model_configuration, io_size)
+                isl_nixl_bench.set_io_size(io_size)
+                isl_nixl_bench.set_batch_size(batch_size)
 
-            isl_nixl_bench.configure_scheme(direction="isl")
-            isl_nixl_bench.configure_segment_type(
-                kwargs.get("backend"), kwargs.get("source"), kwargs.get("destination")
-            )
+                isl_nixl_bench.configure_scheme(direction="isl")
+                isl_nixl_bench.configure_segment_type(
+                    kwargs.get("backend"), kwargs.get("source"), kwargs.get("destination")
+                )
 
-            # Generate plan
-            plan = isl_nixl_bench.plan(format=format)
+                # Generate plan
+                plan = isl_nixl_bench.plan(format=format)
 
-            # For JSON format, add config filename to the output
-            if format == "json":
-                plan_with_config = plan.copy() if isinstance(plan, dict) else {}
-                plan_with_config["config_file"] = config_file
-                all_plans.append(plan_with_config)
-            elif format == "csv":
-                plan_data = plan
-                # Add metadata
-                plan_data["config_file"] = config_file
-                plan_data["model"] = model_arch.to_dict().get("model")
+                # For JSON format, add config filename to the output
+                if format == "json":
+                    plan_with_config = plan.copy() if isinstance(plan, dict) else {}
+                    plan_with_config["config_file"] = config_file
+                    plan_with_config["layer_class"] = layer_class
+                    all_plans.append(plan_with_config)
+                elif format == "csv":
+                    plan_data = plan
+                    # Add metadata
+                    plan_data["config_file"] = config_file
+                    plan_data["layer_class"] = layer_class
+                    plan_data["model"] = model_arch.to_dict().get("model")
 
-                # Add all model_config parameters with proper prefixes
-                model_config_dict = model_configuration.to_dict()
+                    # Add all model_config parameters with proper prefixes
+                    model_config_dict = model_configuration.to_dict()
 
-                # Add strategy parameters
-                for key, value in model_config_dict.get("strategy", {}).items():
-                    plan_data[f"model_strategy_{key}"] = value
+                    # Add strategy parameters
+                    for key, value in model_config_dict.get("strategy", {}).items():
+                        plan_data[f"model_strategy_{key}"] = value
 
-                # Add runtime parameters
-                for key, value in model_config_dict.get("runtime", {}).items():
-                    plan_data[f"model_runtime_{key}"] = value
+                    # Add runtime parameters
+                    for key, value in model_config_dict.get("runtime", {}).items():
+                        plan_data[f"model_runtime_{key}"] = value
 
-                # Add system parameters
-                for key, value in model_config_dict.get("system", {}).items():
-                    plan_data[f"model_system_{key}"] = value
+                    # Add system parameters
+                    for key, value in model_config_dict.get("system", {}).items():
+                        plan_data[f"model_system_{key}"] = value
 
-                all_plans.append(plan_data)
-            else:
-                click.echo(separator)
-                click.echo(f"Model Config: {config_file}")
-                click.echo(f"ISL: {model_configuration.runtime.isl} tokens")
-                click.echo(f"Page Size: {model_configuration.system.page_size}")
-                click.echo(f"Requests: {model_configuration.runtime.num_requests}")
-                click.echo(f"TP: {model_configuration.model.tp_size}")
-                click.echo(f"PP: {model_configuration.model.pp_size}")
-                click.echo(separator)
-                click.echo(plan)
-                click.echo()
+                    all_plans.append(plan_data)
+                else:
+                    click.echo(separator)
+                    click.echo(f"Model Config: {config_file}")
+                    click.echo(f"Layer Class: {layer_class}")
+                    click.echo(f"ISL: {model_configuration.runtime.isl} tokens")
+                    click.echo(f"Page Size: {model_configuration.system.page_size}")
+                    click.echo(f"Requests: {model_configuration.runtime.num_requests}")
+                    click.echo(f"TP: {model_configuration.model.tp_size}")
+                    click.echo(f"PP: {model_configuration.model.pp_size}")
+                    click.echo(separator)
+                    click.echo(plan)
+                    click.echo()
         except Exception as e:
             click.echo(f"Error processing config file {config_file}: {str(e)}")
             errors.append((config_file, e))
@@ -238,27 +242,31 @@ def profile_command(model, model_config, **kwargs):
     filtered_args = {
         k: v for k, v in kwargs.items() if k in NIXLBench.defaults() and v is not None
     }
-    nixl_bench = NIXLBench(model_arch, model_configuration, **filtered_args)
-    io_size = model_arch.get_io_size(model_configuration.system.page_size)
-    batch_size = get_batch_size(model_arch, model_configuration, io_size)
-    nixl_bench.set_io_size(io_size)
-    nixl_bench.set_batch_size(batch_size)
-    nixl_bench.configure_buffer_size()
-
-    nixl_bench.configure_scheme(direction="isl")
-    nixl_bench.configure_segment_type(
-        kwargs.get("backend"), kwargs.get("source"), kwargs.get("destination")
-    )
+    io_sizes = model_arch.get_io_sizes(model_configuration.system.page_size)
     separator = "=" * 80
 
-    click.echo(f"Model Config: {model_config}")
-    click.echo(f"ISL: {model_configuration.runtime.isl} tokens")
-    click.echo(f"Page Size: {model_configuration.system.page_size}")
-    click.echo(f"Requests: {model_configuration.runtime.num_requests}")
-    click.echo(f"TP: {model_configuration.model.tp_size}")
-    click.echo(f"PP: {model_configuration.model.pp_size}")
-    click.echo(separator)
-    nixl_bench.profile()
+    for layer_class, io_size in io_sizes.items():
+        nixl_bench = NIXLBench(model_arch, model_configuration, **filtered_args)
+        batch_size = get_batch_size(model_arch, model_configuration, io_size)
+        nixl_bench.set_io_size(io_size)
+        nixl_bench.set_batch_size(batch_size)
+        nixl_bench.configure_buffer_size()
+
+        nixl_bench.configure_scheme(direction="isl")
+        nixl_bench.configure_segment_type(
+            kwargs.get("backend"), kwargs.get("source"), kwargs.get("destination")
+        )
+
+        click.echo(separator)
+        click.echo(f"Model Config: {model_config}")
+        click.echo(f"Layer Class: {layer_class}")
+        click.echo(f"ISL: {model_configuration.runtime.isl} tokens")
+        click.echo(f"Page Size: {model_configuration.system.page_size}")
+        click.echo(f"Requests: {model_configuration.runtime.num_requests}")
+        click.echo(f"TP: {model_configuration.model.tp_size}")
+        click.echo(f"PP: {model_configuration.model.pp_size}")
+        click.echo(separator)
+        nixl_bench.profile()
 
 
 @cli.command("kvcache")
@@ -287,6 +295,7 @@ def kvcache_command(model, model_config, **kwargs):
 
     labels = [
         "Model",
+        "Layer Class",
         "ISL",
         "Num Requests",
         "Batch Size",
@@ -296,23 +305,35 @@ def kvcache_command(model, model_config, **kwargs):
         "Page Size",
         "Access",
     ]
-    io_size = model_arch.get_io_size(model_configuration.system.page_size)
-    batch_size = get_batch_size(model_arch, model_configuration, io_size)
+    io_sizes = model_arch.get_io_sizes(model_configuration.system.page_size)
 
-    data = [
-        [
-            model_arch.model_name,
-            model_configuration.runtime.isl,
-            model_configuration.runtime.num_requests,
-            batch_size,
-            format_bytes(io_size),
-            model_configuration.model.tp_size,
-            model_configuration.model.pp_size,
-            model_configuration.system.page_size,
-            model_configuration.system.access_pattern,
-        ]
-    ]
+    data = []
+    for label, io_size in io_sizes.items():
+        batch_size = get_batch_size(model_arch, model_configuration, io_size)
+        data.append(
+            [
+                model_arch.model_name,
+                label,
+                model_configuration.runtime.isl,
+                model_configuration.runtime.num_requests,
+                batch_size,
+                format_bytes(io_size),
+                model_configuration.model.tp_size,
+                model_configuration.model.pp_size,
+                model_configuration.system.page_size,
+                model_configuration.system.access_pattern,
+            ]
+        )
     click.echo(tabulate(data, headers=labels, floatfmt=".6f"))
+
+    # Surface the aggregate cache size at the configured ISL for models that
+    # support heterogeneous per-layer caches (e.g. V4 hybrid attention).
+    if hasattr(model_arch, "get_total_kv_bytes"):
+        total = model_arch.get_total_kv_bytes(model_configuration.runtime.isl)
+        click.echo(
+            f"\nTotal KV cache @ ISL = {model_configuration.runtime.isl:,} tokens: "
+            f"{format_bytes(total)}"
+        )
 
 
 @cli.command("sequential-ct-perftest")

--- a/benchmark/kvbench/models/deepseek_v4.py
+++ b/benchmark/kvbench/models/deepseek_v4.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from typing import Any, Dict, List, Optional
+
+import yaml  # type: ignore
+from models.model_config import ModelConfig
+from models.models import BaseModelArch
+
+
+_CSA_RATIO = 4
+_HCA_RATIO = 128
+_INDEX_DTYPE_BYTES = {"fp4": 0.5, "fp8": 1.0, "bf16": 2.0, "bfloat16": 2.0, "fp16": 2.0}
+
+
+class DeepSeekV4(BaseModelArch):
+    """DeepSeek-V4 hybrid attention architecture.
+
+    Interleaves Compressed Sparse Attention (CSA, compress_ratio=4) and
+    Heavily Compressed Attention (HCA, compress_ratio=128) with a
+    sliding-window branch on every layer. CSA layers additionally carry a
+    lightning-indexer cache for top-k sparse selection.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        num_hidden_layers: int,
+        num_nextn_predict_layers: int,
+        num_query_heads: int,
+        num_key_value_heads: int,
+        kv_head_dim: int,
+        kv_rope_dim: int,
+        embedding_dimension: int,
+        compress_ratios: List[int],
+        sliding_window: int,
+        index_head_dim: int,
+        index_n_heads: int,
+        index_topk: int,
+        num_model_params: int,
+        model_config: Optional[ModelConfig] = None,
+    ):
+        self.model_name = model_name
+        self.model_config = model_config or ModelConfig()
+        self.num_hidden_layers = num_hidden_layers
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.num_query_heads = num_query_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.kv_head_dim = kv_head_dim
+        self.kv_rope_dim = kv_rope_dim
+        self.embedding_dimension = embedding_dimension
+        self.compress_ratios = list(compress_ratios)
+        self.sliding_window = sliding_window
+        self.index_head_dim = index_head_dim
+        self.index_n_heads = index_n_heads
+        self.index_topk = index_topk
+        self.num_model_params = num_model_params
+
+        self.num_layers = num_hidden_layers + num_nextn_predict_layers
+
+        self._validate()
+
+    def _validate(self) -> None:
+        expected = self.num_hidden_layers + self.num_nextn_predict_layers
+        if len(self.compress_ratios) != expected:
+            raise ValueError(
+                f"compress_ratios length {len(self.compress_ratios)} does not match "
+                f"num_hidden_layers + num_nextn_predict_layers = {expected}"
+            )
+        for i, r in enumerate(self.compress_ratios):
+            if r not in (0, _CSA_RATIO, _HCA_RATIO):
+                raise ValueError(
+                    f"compress_ratios[{i}] = {r}; expected 0 (SWA), "
+                    f"{_CSA_RATIO} (CSA), or {_HCA_RATIO} (HCA)"
+                )
+        if self.num_key_value_heads < 1:
+            raise ValueError(f"num_key_value_heads must be >= 1, got {self.num_key_value_heads}")
+        if any(r == 0 for r in self.compress_ratios) and self.sliding_window < 1:
+            raise ValueError(
+                "sliding_window must be >= 1 when any compress_ratio == 0 (SWA layer present)"
+            )
+
+    def _main_slot_bytes(self) -> int:
+        # Mixed-precision storage: NoPE dims in fp8, RoPE dims in bf16.
+        mode = self.model_config.model.kvcache_quant_mode
+        c, rope = self.kv_head_dim, self.kv_rope_dim
+        if mode == "fp8_mixed":
+            return (c - rope) * 1 + rope * 2
+        if mode in ("fp8", "int8"):
+            return c * 1
+        if mode in ("bf16", "bfloat16", "fp16"):
+            return c * 2
+        raise ValueError(f"Unsupported kvcache_quant_mode for V4: {mode!r}")
+
+    def _index_slot_bytes(self) -> int:
+        mode = self.model_config.model.index_quant_mode
+        if mode not in _INDEX_DTYPE_BYTES:
+            raise ValueError(
+                f"index_quant_mode {mode!r} not in {list(_INDEX_DTYPE_BYTES)}"
+            )
+        return int(self.index_head_dim * _INDEX_DTYPE_BYTES[mode])
+
+    def _csa_count(self) -> int:
+        return sum(1 for r in self.compress_ratios if r == _CSA_RATIO)
+
+    def _hca_count(self) -> int:
+        return sum(1 for r in self.compress_ratios if r == _HCA_RATIO)
+
+    def _swa_layer_count(self) -> int:
+        # SWA buffer exists on every CSA and HCA layer, and the MTP layer
+        # itself runs pure SWA.
+        return self._csa_count() + self._hca_count() + self.num_nextn_predict_layers
+
+    def get_kv_size_per_token(self, token_count: int = 1) -> int:
+        """Amortized bytes per token (for get_batch_size).
+
+        Excludes the sliding-window fixed cost: SWA buffers don't grow with
+        context length past n_win, so their amortized per-token contribution
+        vanishes at the large-L regime where batching matters.
+        """
+        p_main = self._main_slot_bytes()
+        p_idx = self._index_slot_bytes()
+        n_csa = self._csa_count()
+        n_hca = self._hca_count()
+        # Integer multiply-before-divide over LCM(4, 128) = 128 to stay exact.
+        main = p_main * (n_csa * _HCA_RATIO + n_hca * _CSA_RATIO) // (_CSA_RATIO * _HCA_RATIO)
+        idx = p_idx * n_csa // _CSA_RATIO
+        return int((main + idx) * token_count)
+
+    def get_total_kv_bytes(self, seq_len: int) -> int:
+        """Exact total KV cache bytes at sequence length `seq_len`.
+
+        Includes: compressed main KV (CSA+HCA), lightning-indexer cache (CSA
+        only), and sliding-window fixed cost (every layer).
+        """
+        p_main = self._main_slot_bytes()
+        p_idx = self._index_slot_bytes()
+        n_csa = self._csa_count()
+        n_hca = self._hca_count()
+        n_sw_layers = self._swa_layer_count()
+
+        csa_slots = math.ceil(seq_len / _CSA_RATIO)
+        hca_slots = math.ceil(seq_len / _HCA_RATIO)
+
+        main_bytes = p_main * (n_csa * csa_slots + n_hca * hca_slots)
+        indexer_bytes = p_idx * n_csa * csa_slots
+        swa_bytes = n_sw_layers * self.sliding_window * p_main
+        return int(main_bytes + indexer_bytes + swa_bytes)
+
+    def get_io_size(self, page_size: int = 1) -> int:
+        raise NotImplementedError(
+            "DeepSeek V4 has heterogeneous layers; use get_io_sizes() instead"
+        )
+
+    def get_io_sizes(self, page_size: int = 1) -> Dict[str, int]:
+        """Return a label → per-transfer IO bytes map for V4.
+
+        One key per distinct layer class present in `compress_ratios`, plus a
+        per-layer SWA entry when sliding-window layers exist, plus a
+        `block__worst_stage` entry when access_pattern == "block".
+        """
+        p_main = self._main_slot_bytes()
+        p_idx = self._index_slot_bytes()
+        tp = max(self.model_config.model.tp_size, 1)
+        out: Dict[str, int] = {}
+
+        if self._csa_count() > 0:
+            out["layer__csa_main"] = max(p_main * page_size // _CSA_RATIO // tp, 1)
+            out["layer__csa_indexer"] = max(p_idx * page_size // _CSA_RATIO // tp, 1)
+        if self._hca_count() > 0:
+            out["layer__hca_main"] = max(p_main * page_size // _HCA_RATIO // tp, 1)
+        if self._swa_layer_count() > 0:
+            # SWA buffer is fixed at n_win tokens per layer, independent of page_size.
+            out["layer__swa_per_layer"] = max(p_main * self.sliding_window // tp, 1)
+
+        if self.model_config.system.access_pattern == "block":
+            out["block__worst_stage"] = self._block_worst_stage_bytes(page_size, tp)
+        return out
+
+    def _block_worst_stage_bytes(self, page_size: int, tp: int) -> int:
+        """Worst-case sum of per-layer bytes across any single pipeline stage.
+
+        For even pp partitioning, returns the max over stages `s` of the
+        contiguous slice's per-page bytes (main + indexer contributions,
+        amortized per token times page_size). Clamps gracefully when
+        pp_size > num_layers.
+        """
+        pp = max(self.model_config.model.pp_size, 1)
+        total_layers = len(self.compress_ratios)
+        layers_per_stage = max(math.ceil(total_layers / pp), 1)
+        p_main = self._main_slot_bytes()
+        p_idx = self._index_slot_bytes()
+
+        worst = 0
+        for start in range(0, total_layers, layers_per_stage):
+            slice_ratios = self.compress_ratios[start : start + layers_per_stage]
+            stage = 0
+            for r in slice_ratios:
+                if r == _CSA_RATIO:
+                    stage += (p_main + p_idx) * page_size // _CSA_RATIO
+                elif r == _HCA_RATIO:
+                    stage += p_main * page_size // _HCA_RATIO
+                # r == 0: SWA-only layer; its per-page contribution is 0
+                # (the fixed SWA buffer is transferred via layer__swa_per_layer).
+            worst = max(worst, stage)
+        return max(worst // tp, 1)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "model_name": self.model_name.lower(),
+            "num_hidden_layers": self.num_hidden_layers,
+            "num_nextn_predict_layers": self.num_nextn_predict_layers,
+            "num_query_heads": self.num_query_heads,
+            "num_key_value_heads": self.num_key_value_heads,
+            "kv_head_dim": self.kv_head_dim,
+            "kv_rope_dim": self.kv_rope_dim,
+            "embedding_dimension": self.embedding_dimension,
+            "compress_ratios": self.compress_ratios,
+            "sliding_window": self.sliding_window,
+            "index_head_dim": self.index_head_dim,
+            "index_n_heads": self.index_n_heads,
+            "index_topk": self.index_topk,
+            "num_model_params": self.num_model_params,
+        }
+
+    def __str__(self) -> str:
+        return yaml.dump(self.to_dict())

--- a/benchmark/kvbench/models/model_config.py
+++ b/benchmark/kvbench/models/model_config.py
@@ -38,6 +38,7 @@ class StrategyConfig:
     pp_size: int = 1
     model_quant_mode: str = "fp8"
     kvcache_quant_mode: str = "fp8"
+    index_quant_mode: str = "bf16"
 
 
 @dataclass
@@ -187,6 +188,7 @@ class ModelConfig:
                 "pp_size": self.model.pp_size,
                 "model_quant_mode": self.model.model_quant_mode,
                 "kvcache_quant_mode": self.model.kvcache_quant_mode,
+                "index_quant_mode": self.model.index_quant_mode,
             },
             "runtime": {
                 "num_requests": self.runtime.num_requests,

--- a/benchmark/kvbench/models/models.py
+++ b/benchmark/kvbench/models/models.py
@@ -74,6 +74,13 @@ class BaseModelArch(ABC):
     def get_io_size(self, page_size: int = 1) -> int:
         raise NotImplementedError("Subclasses must implement this method")
 
+    def get_io_sizes(self, page_size: int = 1) -> Dict[str, int]:
+        """Return a label → IO bytes map. Default wraps get_io_size() so that
+        homogeneous-layer models (Llama3.1, GPT-OSS, Qwen3, DeepSeek-R1) keep
+        their current single-size contract. Heterogeneous-layer models (V4)
+        override this and raise from get_io_size()."""
+        return {"default": self.get_io_size(page_size)}
+
     @abstractmethod
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/benchmark/kvbench/models/models.py
+++ b/benchmark/kvbench/models/models.py
@@ -127,6 +127,10 @@ class BaseModelArch(ABC):
                 from models.llama3_1 import Llama3_1
 
                 modelc = Llama3_1(**filtered_dict)
+            elif "deepseek_v4" in model_name.lower():
+                from models.deepseek_v4 import DeepSeekV4
+
+                modelc = DeepSeekV4(**filtered_dict)
             elif "deepseek_r1" in model_name.lower():
                 from models.deepseek_r1 import DeepSeekR1
 


### PR DESCRIPTION
## What?                                                                                                                                                                                                                                                       
  Add support for DeepSeek V4-Pro (1.6T params, 1M-context hybrid attention) to kvbench so it can size KV-cache transfers for V4 deployments the same way it already does for DeepSeek-R1, Llama 3.1, Qwen3, and GPT-OSS.                                  
                                                                                                                                                                                                                                                           
  Three logical commits on aranadive/kvbench-deepseek-v4:     
                                                              
  1. kvbench: Add heterogeneous-layer model interface — introduces get_io_sizes() on BaseModelArch and an index_quant_mode field on StrategyConfig. Additive, fully backward-compatible.                                                                   
  2. kvbench: Add DeepSeek V4 hybrid attention model — new DeepSeekV4 class, V4-Pro model YAML, and two runtime profiles (128K efficient, 1M pure-bf16).                                                                                                   
  3. kvbench: Iterate kvcache/plan/profile over heterogeneous layer classes — walks get_io_sizes() in all three CLI subcommands, emitting one row / NIXLBench invocation per layer class.
   
## Why?
V4 replaces V3/R1's uniform MLA with a hybrid attention stack whose per-layer KV footprint is not constant:                
                                          
  - 30 Compressed Sparse Attention layers (m=4) with a lightning-indexer cache for top-k sparse selection.                   
  - 31 Heavily Compressed Attention layers (m=128) with no indexer.
  - 1 MTP layer running pure sliding-window attention.        
  - A 128-token sliding-window buffer on every CSA+HCA+MTP layer, on top of the compressed cache.                            

The existing kvbench model classes all assume one cache shape per layer and encode it in a single scalar get_io_size(). Trying to reuse that contract for V4 would either under-size the IO (if we pick the compressed-128 size) by ~128× on the CSA path, or over-size it (if we pick the uncompressed SWA buffer) by the same factor on the HCA path. Either way, downstream nixlbench benchmark numbers become meaningless for V4-shaped traffic.                                                          

The interface extension is the smallest change that lets kvbench faithfully represent a model whose layers carry different amounts of cache, without touching any existing model class.

## How?
Interface (commit 1). BaseModelArch gains get_io_sizes(page_size) -> Dict[str, int] returning a label→bytes map. The default implementation wraps the existing scalar get_io_size() as {"default": ...}, so every current model class keeps byte-for-byte identical output. StrategyConfig gains index_quant_mode: str = "bf16" so sparse-attention models can quantize their indexer cache independently of the main KV cache.

  Model (commit 2). DeepSeekV4 derives all bytes directly from the model's structural parameters:                                   
  - _main_slot_bytes() handles the three main-KV storage modes: mixed-precision (fp8_mixed: NoPE dims fp8 + RoPE dims bf16), pure fp8, or pure bf16.                                                                                                       
  - _index_slot_bytes() handles fp4/fp8/bf16 indexer precision. 
  - get_kv_size_per_token() returns the amortized per-token cost using integer arithmetic over LCM(4, 128) to stay exact.    
  - get_total_kv_bytes(seq_len) returns the exact total (main + indexer + fixed SWA).                                        
  - get_io_sizes() emits one entry per layer class present in compress_ratios, plus a block__worst_stage entry in block access mode.                                                                                                                       
  - get_io_size() is overridden to raise, forcing callers through the layer-aware API so nobody silently under-sizes a V4 transfer.                                                                                                                        

  Registration happens in BaseModelArch.from_yaml() ordered before the deepseek_r1 substring match so the more-specific name wins.                                                                                                                         

  CLI (commit 3). kvcache_command walks the get_io_sizes() dict and prints one row per layer class, adds a Layer Class column, and appends a Total KV cache @ ISL summary line when the model exposes get_total_kv_bytes(). plan_command and  profile_command instantiate a fresh NIXLBench per layer class and tag each emitted JSON/CSV row with layer_class. Homogeneous models (R1, Llama, Qwen, GPT-OSS) get a single "default" label, preserving their exact existing output shape.

## Verification

V4-Pro kvcache subcommand output:                           
   
  $ python3 main.py kvcache \                                 
      --model examples/model_deepseek_v4_pro.yaml \           
      --model_config examples/model_config_deepseek_v4_128k.yaml

  Model            Layer Class              ISL    Num Requests    Batch Size  IO Size      TP    PP    Page Size  Access
  ---------------  --------------------  ------  --------------  ------------  ---------  ----  ----  -----------  --------  
  DEEPSEEK_V4_PRO  layer__csa_main       131072               1         17561  36.0 KB       1     1          256  layer     
  DEEPSEEK_V4_PRO  layer__csa_indexer    131072               1        158048  4.0 KB        1     1          256  layer     
  DEEPSEEK_V4_PRO  layer__hca_main       131072               1        561949  1.12 KB       1     1          256  layer     
  DEEPSEEK_V4_PRO  layer__swa_per_layer  131072               1          8781  72.0 KB       1     1          256  layer     

  Total KV cache @ ISL = 131,072 tokens: 621.8 MB             


  $ python3 main.py kvcache \                                    
      --model examples/model_deepseek_v4_pro.yaml \
      --model_config examples/model_config_deepseek_v4_1m.yaml
  DEEPSEEK_V4_PRO  layer__swa_per_layer  131072               1          8781  72.0 KB       1     1          256  layer     
                                                                                                                          
  Total KV cache @ ISL = 131,072 tokens: 621.8 MB             


  $ python3 main.py kvcache \                                 
      --model examples/model_deepseek_v4_pro.yaml \           
      --model_config examples/model_config_deepseek_v4_1m.yaml

  Model            Layer Class               ISL    Num Requests    Batch Size  IO Size      TP    PP    Page Size  Access   
  ---------------  --------------------  -------  --------------  ------------  ---------  ----  ----  -----------  -------- 
  DEEPSEEK_V4_PRO  layer__csa_main       1048576               1        157568  64.0 KB       1     1          256  layer
  DEEPSEEK_V4_PRO  layer__csa_indexer    1048576               1        630272  16.0 KB       1     1          256  layer    
  DEEPSEEK_V4_PRO  layer__hca_main       1048576               1       5042176  2.0 KB        1     1          256  layer
  DEEPSEEK_V4_PRO  layer__swa_per_layer  1048576               1         78784  128.0 KB      1     1          256  layer
                                                          
  Total KV cache @ ISL = 1,048,576 tokens: 9.62 GB
