### PR TITLE
Enforce braces on control statements with `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 ---
+# Requires clang-format-15+
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false

--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
@@ -46,6 +46,7 @@ DerivePointerAlignment: false
 IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth: 4
+InsertBraces: true
 IndentWrappedFunctionNames: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: Inner

--- a/docs/CodeStyle.md
+++ b/docs/CodeStyle.md
@@ -179,8 +179,8 @@ limitations under the License.
   }
   ```
 
-* Short if-statements without else can be on single line when appropriate
-* Empty functions/blocks can be on single line: `void empty() {}`
+* Braces are **required** around every control statement (`if`/`else`/`for`/`while`/`do`).
+* Empty functions/blocks can be on single line: `void empty() {}` / `while (poll()) {}`
 
 ### Switch Statements
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -352,6 +352,36 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.syncMode = data->config_.syncMode;
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
 
+    volatile bool cond = false;
+
+    // The code below was added to check if CI would fail these changes:
+    // fail
+    if (cond) NIXL_INFO << "single line without braces";
+
+    // fail
+    if (cond) { NIXL_INFO << "single line with braces"; }
+
+    // fail
+    if (cond)
+        NIXL_INFO << "block without braces";
+
+    // pass
+    if (cond) {
+        NIXL_INFO << "block with braces";
+    }
+
+    // fail
+    for (int i = 0; i < 10; i++) NIXL_INFO << "for loop without braces one line";
+
+    // fail
+    for (int i = 0; i < 10; i++)
+        NIXL_INFO << "for loop without braces";
+
+    // pass
+    for (int i = 0; i < 10; i++) {
+        NIXL_INFO << "for loop with braces";
+    }
+
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
     auto plugin_handle = plugin_manager.loadBackendPlugin(type);

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -352,36 +352,6 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.syncMode = data->config_.syncMode;
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
 
-    volatile bool cond = false;
-
-    // The code below was added to check if CI would fail these changes:
-    // fail
-    if (cond) NIXL_INFO << "single line without braces";
-
-    // fail
-    if (cond) { NIXL_INFO << "single line with braces"; }
-
-    // fail
-    if (cond)
-        NIXL_INFO << "block without braces";
-
-    // pass
-    if (cond) {
-        NIXL_INFO << "block with braces";
-    }
-
-    // fail
-    for (int i = 0; i < 10; i++) NIXL_INFO << "for loop without braces one line";
-
-    // fail
-    for (int i = 0; i < 10; i++)
-        NIXL_INFO << "for loop without braces";
-
-    // pass
-    for (int i = 0; i < 10; i++) {
-        NIXL_INFO << "for loop with braces";
-    }
-
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
     auto plugin_handle = plugin_manager.loadBackendPlugin(type);


### PR DESCRIPTION
## What?
Change `clang-format` rules to enforce brackets on control statements (`if`, `else`, `for`, `do`, `while`)

## Why?
This is a repeated issue in NIXL PRs.
With this change CI will fail if any control statement is missing braces (in new and changed code only)

## Examples
```c++
// fail
if (cond) NIXL_INFO << "single line without braces";

// fail
if (cond) { NIXL_INFO << "single line with braces"; }

// fail
if (cond)
    NIXL_INFO << "block without braces";

// pass
if (cond) {
    NIXL_INFO << "block with braces";
}

// fail
for (int i = 0; i < 10; i++) NIXL_INFO << "for loop without braces one line";

// fail
for (int i = 0; i < 10; i++)
    NIXL_INFO << "for loop without braces";

// pass
for (int i = 0; i < 10; i++) {
    NIXL_INFO << "for loop with braces";
}
 ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code formatting rules to enforce stricter, more consistent formatting across the codebase (automatic brace insertion and no single-line control statements).
* **Documentation**
  * Updated coding style guidance to require braces for control statements and adjusted examples for empty blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->