### PR TITLE
AGENT: Move enum functions etc.

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -55,6 +55,7 @@ endif
 
 nixl_lib = library('nixl',
                    'nixl_agent.cpp',
+                   'nixl_enum_strings.cpp',
                    'nixl_plugin_manager.cpp',
                    'nixl_listener.cpp',
                    'telemetry/telemetry.cpp',

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -33,50 +33,13 @@
 #include "telemetry.h"
 #include "telemetry_event.h"
 
-constexpr char TELEMETRY_ENABLED_VAR[] = "NIXL_TELEMETRY_ENABLE";
-static const std::vector<std::vector<std::string>> illegal_plugin_combinations = {
+namespace {
+
+const std::vector<std::vector<std::string>> illegal_plugin_combinations = {
     {"GDS", "GDS_MT"},
 };
 
-/*** nixlEnumStrings namespace implementation in API ***/
-std::string nixlEnumStrings::memTypeStr(const nixl_mem_t &mem) {
-    static std::array<std::string, FILE_SEG+1> nixl_mem_str = {
-           "DRAM_SEG", "VRAM_SEG", "BLK_SEG", "OBJ_SEG", "FILE_SEG"};
-    if (mem<DRAM_SEG || mem>FILE_SEG)
-        return "BAD_SEG";
-    return nixl_mem_str[mem];
-}
-
-std::string nixlEnumStrings::xferOpStr (const nixl_xfer_op_t &op) {
-    static std::array<std::string, 2> nixl_op_str = {"READ", "WRITE"};
-    if (op<NIXL_READ || op>NIXL_WRITE)
-        return "BAD_OP";
-    return nixl_op_str[op];
-
-}
-
-std::string
-nixlEnumStrings::statusStr(const nixl_status_t &status) {
-    switch (status) {
-        case NIXL_IN_PROG:               return "NIXL_IN_PROG";
-        case NIXL_SUCCESS:               return "NIXL_SUCCESS";
-        case NIXL_ERR_NOT_POSTED:        return "NIXL_ERR_NOT_POSTED";
-        case NIXL_ERR_INVALID_PARAM:     return "NIXL_ERR_INVALID_PARAM";
-        case NIXL_ERR_BACKEND:           return "NIXL_ERR_BACKEND";
-        case NIXL_ERR_NOT_FOUND:         return "NIXL_ERR_NOT_FOUND";
-        case NIXL_ERR_MISMATCH:          return "NIXL_ERR_MISMATCH";
-        case NIXL_ERR_NOT_ALLOWED:       return "NIXL_ERR_NOT_ALLOWED";
-        case NIXL_ERR_REPOST_ACTIVE:     return "NIXL_ERR_REPOST_ACTIVE";
-        case NIXL_ERR_UNKNOWN:           return "NIXL_ERR_UNKNOWN";
-        case NIXL_ERR_NOT_SUPPORTED:     return "NIXL_ERR_NOT_SUPPORTED";
-        case NIXL_ERR_REMOTE_DISCONNECT: return "NIXL_ERR_REMOTE_DISCONNECT";
-        case NIXL_ERR_CANCELED:
-            return "NIXL_ERR_CANCELED";
-        case NIXL_ERR_NO_TELEMETRY:
-            return "NIXL_ERR_NO_TELEMETRY";
-        default:                         return "BAD_STATUS";
-    }
-}
+} // namespace
 
 void
 nixlEngineDeleter::operator()(nixlBackendEngine *engine) const noexcept {
@@ -171,10 +134,11 @@ nixlAgentData::nixlAgentData(const std::string &name, const nixlAgentConfig &con
 #else
     NIXL_DEBUG << "NIXL ETCD is excluded";
 #endif
-    if (name.empty())
-        throw std::invalid_argument("Agent needs a name");
+    if (name.empty()) {
+        throw std::invalid_argument("Agent needs a non-empty name");
+    }
 
-    const auto telemetry_enabled = nixl::config::getValueOptional<bool>(TELEMETRY_ENABLED_VAR);
+    const auto telemetry_enabled = nixl::config::getValueOptional<bool>("NIXL_TELEMETRY_ENABLE");
 
     if (telemetry_enabled) {
         if (*telemetry_enabled) {

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -24,9 +24,7 @@ namespace nixlEnumStrings {
 
 std::string
 memTypeStr(const nixl_mem_t &mem) {
-    static const std::array strings = {
-        "DRAM_SEG", "VRAM_SEG", "BLK_SEG", "OBJ_SEG", "FILE_SEG"
-    };
+    static const std::array strings = {"DRAM_SEG", "VRAM_SEG", "BLK_SEG", "OBJ_SEG", "FILE_SEG"};
 
     if ((mem < 0) || (mem >= strings.size())) {
         return "BAD_SEG";
@@ -36,9 +34,7 @@ memTypeStr(const nixl_mem_t &mem) {
 
 std::string
 xferOpStr(const nixl_xfer_op_t &op) {
-    static const std::array strings = {
-        "READ", "WRITE"
-    };
+    static const std::array strings = {"READ", "WRITE"};
 
     if ((op < 0) || (op >= strings.size())) {
         return "BAD_OP";

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -17,7 +17,6 @@
 
 #include "nixl_types.h"
 
-#include <array>
 #include <string>
 
 namespace nixlEnumStrings {

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -24,22 +24,30 @@ namespace nixlEnumStrings {
 
 std::string
 memTypeStr(const nixl_mem_t &mem) {
-    static const std::array strings = {"DRAM_SEG", "VRAM_SEG", "BLK_SEG", "OBJ_SEG", "FILE_SEG"};
-
-    if ((mem < 0) || (mem >= strings.size())) {
-        return "BAD_SEG";
+    switch (mem) {
+    case DRAM_SEG:
+        return "DRAM_SEG";
+    case VRAM_SEG:
+        return "VRAM_SEG";
+    case BLK_SEG:
+        return "BLK_SEG";
+    case OBJ_SEG:
+        return "OBJ_SEG";
+    case FILE_SEG:
+        return "FILE_SEG";
     }
-    return strings[mem];
+    return "BAD_SEG";
 }
 
 std::string
 xferOpStr(const nixl_xfer_op_t &op) {
-    static const std::array strings = {"READ", "WRITE"};
-
-    if ((op < 0) || (op >= strings.size())) {
-        return "BAD_OP";
+    switch (op) {
+    case NIXL_READ:
+        return "READ";
+    case NIXL_WRITE:
+        return "WRITE";
     }
-    return strings[op];
+    return "BAD_OP";
 }
 
 std::string

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -73,9 +73,8 @@ statusStr(const nixl_status_t &status) {
         return "NIXL_ERR_CANCELED";
     case NIXL_ERR_NO_TELEMETRY:
         return "NIXL_ERR_NO_TELEMETRY";
-    default:
-        return "BAD_STATUS";
     }
+    return "BAD_STATUS";
 }
 
 } // namespace nixlEnumStrings

--- a/src/core/nixl_enum_strings.cpp
+++ b/src/core/nixl_enum_strings.cpp
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nixl_types.h"
+
+#include <array>
+#include <string>
+
+namespace nixlEnumStrings {
+
+std::string
+memTypeStr(const nixl_mem_t &mem) {
+    static const std::array strings = {
+        "DRAM_SEG", "VRAM_SEG", "BLK_SEG", "OBJ_SEG", "FILE_SEG"
+    };
+
+    if ((mem < 0) || (mem >= strings.size())) {
+        return "BAD_SEG";
+    }
+    return strings[mem];
+}
+
+std::string
+xferOpStr(const nixl_xfer_op_t &op) {
+    static const std::array strings = {
+        "READ", "WRITE"
+    };
+
+    if ((op < 0) || (op >= strings.size())) {
+        return "BAD_OP";
+    }
+    return strings[op];
+}
+
+std::string
+statusStr(const nixl_status_t &status) {
+    switch (status) {
+    case NIXL_IN_PROG:
+        return "NIXL_IN_PROG";
+    case NIXL_SUCCESS:
+        return "NIXL_SUCCESS";
+    case NIXL_ERR_NOT_POSTED:
+        return "NIXL_ERR_NOT_POSTED";
+    case NIXL_ERR_INVALID_PARAM:
+        return "NIXL_ERR_INVALID_PARAM";
+    case NIXL_ERR_BACKEND:
+        return "NIXL_ERR_BACKEND";
+    case NIXL_ERR_NOT_FOUND:
+        return "NIXL_ERR_NOT_FOUND";
+    case NIXL_ERR_MISMATCH:
+        return "NIXL_ERR_MISMATCH";
+    case NIXL_ERR_NOT_ALLOWED:
+        return "NIXL_ERR_NOT_ALLOWED";
+    case NIXL_ERR_REPOST_ACTIVE:
+        return "NIXL_ERR_REPOST_ACTIVE";
+    case NIXL_ERR_UNKNOWN:
+        return "NIXL_ERR_UNKNOWN";
+    case NIXL_ERR_NOT_SUPPORTED:
+        return "NIXL_ERR_NOT_SUPPORTED";
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        return "NIXL_ERR_REMOTE_DISCONNECT";
+    case NIXL_ERR_CANCELED:
+        return "NIXL_ERR_CANCELED";
+    case NIXL_ERR_NO_TELEMETRY:
+        return "NIXL_ERR_NO_TELEMETRY";
+    default:
+        return "BAD_STATUS";
+    }
+}
+
+} // namespace nixlEnumStrings


### PR DESCRIPTION
## What?
- Move the enum-to-string functions from `nixl_agent.cpp` to `nixl_enum_strings.cpp`.
- Eliminate a constant in `nixl_agent.cpp` that was only used once.
- Put `illegal_plugin_combinations` in an anonymous namespace.
- Improve a `nixlAgent` exception message.
- Change all moved enum-to-string functions to provoke a compile-time error when the enums are extended (and no new case is added).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved internal enum-to-string utilities into a dedicated module for clearer organization and maintainability.
* **Chore**
  * Build updated to include the new module so its utilities are compiled with the project.
* **Bug Fix**
  * Invalid-name error message clarified to explicitly state that names must be non-empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->