### PR TITLE
fix(plugins): namespace meson variables to prevent cross-plugin leakage.

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -72,4 +72,4 @@ nixl_lib = library('nixl',
                    install: true,
                    install_rpath: join_paths(get_option('prefix'), get_option('libdir')))
 
-nixl_dep = declare_dependency(link_with: nixl_lib, include_directories: nixl_inc_dirs)
+nixl_dep = declare_dependency(link_with: nixl_lib, include_directories: nixl_inc_dirs, dependencies: nixl_lib_deps)

--- a/src/plugins/azure_blob/meson.build
+++ b/src/plugins/azure_blob/meson.build
@@ -43,7 +43,7 @@ if 'AZURE_BLOB' in static_plugins
         'AZURE_BLOB',
         azure_sources,
         dependencies: azure_deps,
-        cpp_args: compile_defs + compile_flags,
+        cpp_args: [],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
@@ -52,7 +52,7 @@ else
         'AZURE_BLOB',
         azure_sources,
         dependencies: azure_deps,
-        cpp_args: compile_defs + ['-fPIC'],
+        cpp_args: ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries

--- a/src/plugins/cuda_gds/meson.build
+++ b/src/plugins/cuda_gds/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@ if 'GDS' in static_plugins
         dependencies: [nixl_infra, nixl_common_dep, cuda_dep, cufile_dep, file_utils_interface],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
-        cpp_args: compile_flags,
+        cpp_args: [],
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     gds_backend_lib = shared_library('GDS',

--- a/src/plugins/gds_mt/meson.build
+++ b/src/plugins/gds_mt/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@ if 'GDS_MT' in static_plugins
         dependencies: [nixl_infra, nixl_common_dep, cuda_dep, cufile_dep, taskflow_proj, file_utils_interface],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
-        cpp_args: compile_flags,
+        cpp_args: [],
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     gds_mt_backend_lib = shared_library('GDS_MT',

--- a/src/plugins/gpunetio/meson.build
+++ b/src/plugins/gpunetio/meson.build
@@ -16,7 +16,7 @@
 plugin_gpunetio_deps = [dependency('libibverbs'), dependency('libmlx5'), dependency('doca-common'), dependency('doca-verbs'), dependency('doca-gpunetio')]
 
 # C++20 for CUDA is set project-wide in the root meson.build.
-compile_flags = ['-D DOCA_ALLOW_EXPERIMENTAL_API']
+gpunetio_compile_flags = ['-D DOCA_ALLOW_EXPERIMENTAL_API']
 
 if 'GPUNETIO' in static_plugins
     gpunetio_backend_lib = static_library('GPUNETIO',
@@ -24,7 +24,7 @@ if 'GPUNETIO' in static_plugins
                dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : compile_flags,
+               cpp_args : gpunetio_compile_flags,
                cuda_args : ['-rdc=true'],
                name_prefix: 'libplugin_',
                install_dir: plugin_install_dir)  # Custom prefix for plugin libraries
@@ -34,7 +34,7 @@ else
                dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : compile_flags + ['-fPIC'],
+               cpp_args : gpunetio_compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir)
 

--- a/src/plugins/gusli/meson.build
+++ b/src/plugins/gusli/meson.build
@@ -24,14 +24,14 @@ if 'GUSLI' in static_plugins
         dependencies: gusli_deps,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
-        cpp_args: compile_defs + compile_flags,
+        cpp_args: [],
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
   gusli_backend_lib = shared_library('GUSLI', cpp_sources,
         dependencies: gusli_deps,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
-        cpp_args: compile_defs + ['-fPIC'],
+        cpp_args: ['-fPIC'],
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
         install_dir: plugin_install_dir,
         install_rpath: '$ORIGIN/..')

--- a/src/plugins/hf3fs/meson.build
+++ b/src/plugins/hf3fs/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ if 'HF3FS' in static_plugins
                     dependencies: [nixl_infra, threefs_dep, nixl_common_dep, file_utils_interface],
                     include_directories: [nixl_inc_dirs, utils_inc_dirs],
                     install: false,
-                    cpp_args : compile_flags,
+                    cpp_args : [],
                     name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
   hf3fs_backend_lib = shared_library('HF3FS',

--- a/src/plugins/libfabric/meson.build
+++ b/src/plugins/libfabric/meson.build
@@ -26,12 +26,12 @@ libfabric_plugin_deps = [
     dependency('dl', required: true)
 ]
 
-compile_flags = ['-DHAVE_LIBFABRIC']
+libfabric_compile_flags = ['-DHAVE_LIBFABRIC']
 
 # Add CUDA support if available
 if cuda_dep.found()
     libfabric_plugin_deps += [cuda_dep]
-    compile_flags += ['-DHAVE_CUDA']
+    libfabric_compile_flags += ['-DHAVE_CUDA']
 endif
 
 # Build as static or shared library based on configuration
@@ -44,7 +44,7 @@ if 'LIBFABRIC' in static_plugins
         dependencies: libfabric_plugin_deps,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
-        cpp_args: compile_flags,
+        cpp_args: libfabric_compile_flags,
         name_prefix: 'libplugin_',
     )
 else
@@ -56,7 +56,7 @@ else
         dependencies: libfabric_plugin_deps,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
-        cpp_args: compile_flags + ['-fPIC'],
+        cpp_args: libfabric_compile_flags + ['-fPIC'],
         name_prefix: 'libplugin_',
         install_dir: plugin_install_dir,
     )

--- a/src/plugins/mooncake/meson.build
+++ b/src/plugins/mooncake/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 cpp = meson.get_compiler('cpp')
 mooncake_lib = cpp.find_library('transfer_engine')
 
-compile_flags = []
+mooncake_compile_flags = []
 
 if 'Mooncake' in static_plugins
     mooncake_backend_lib = static_library('Mooncake',
@@ -24,7 +24,7 @@ if 'Mooncake' in static_plugins
                dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: nixl_inc_dirs,
                install: false,
-               cpp_args : compile_flags,
+               cpp_args : mooncake_compile_flags,
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     mooncake_backend_lib = shared_library('Mooncake',
@@ -32,7 +32,7 @@ else
                dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : compile_flags + ['-fPIC'],
+               cpp_args : mooncake_compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir,
                install_rpath: '$ORIGIN/..')

--- a/src/plugins/mooncake/meson.build
+++ b/src/plugins/mooncake/meson.build
@@ -16,15 +16,13 @@
 cpp = meson.get_compiler('cpp')
 mooncake_lib = cpp.find_library('transfer_engine')
 
-mooncake_compile_flags = []
-
 if 'Mooncake' in static_plugins
     mooncake_backend_lib = static_library('Mooncake',
                'mooncake_backend.cpp', 'mooncake_backend.h', 'mooncake_plugin.cpp',
                dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: nixl_inc_dirs,
                install: false,
-               cpp_args : mooncake_compile_flags,
+               cpp_args : [],
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     mooncake_backend_lib = shared_library('Mooncake',
@@ -32,7 +30,7 @@ else
                dependencies: [nixl_infra, nixl_common_dep, serdes_interface, mooncake_lib, cuda_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : mooncake_compile_flags + ['-fPIC'],
+               cpp_args : ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir,
                install_rpath: '$ORIGIN/..')

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -37,8 +37,6 @@ if not is_variable('obj_utils_interface')
 endif
 
 obj_plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asio', required: true)]
-obj_compile_defs = []
-obj_compile_flags = []
 
 if cuobj_dep.found()
     message('Found CUObjClient Library. Enabling S3 Accelerated engines')
@@ -62,7 +60,7 @@ if 'OBJ' in static_plugins
         'OBJ',
         obj_sources,
         dependencies: obj_plugin_deps,
-        cpp_args: obj_compile_defs + obj_compile_flags,
+        cpp_args: [],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
@@ -71,7 +69,7 @@ else
         'OBJ',
         obj_sources,
         dependencies: obj_plugin_deps,
-        cpp_args: obj_compile_defs + obj_compile_flags + ['-fPIC'],
+        cpp_args: ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -36,9 +36,9 @@ if not is_variable('obj_utils_interface')
     subdir_done()
 endif
 
-plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asio', required: true)]
-compile_defs = []
-compile_flags = []
+obj_plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asio', required: true)]
+obj_compile_defs = []
+obj_compile_flags = []
 
 if cuobj_dep.found()
     message('Found CUObjClient Library. Enabling S3 Accelerated engines')
@@ -52,7 +52,7 @@ if cuobj_dep.found()
         's3_accel/dell/engine_impl.cpp',
         's3_accel/dell/engine_impl.h',
     ]
-    plugin_deps += [ cuobj_dep ]
+    obj_plugin_deps += [ cuobj_dep ]
 else
     message('Could not find CUObjClient Library. Skipping S3 Accelerated engines')
 endif
@@ -61,8 +61,8 @@ if 'OBJ' in static_plugins
     obj_backend_lib = static_library(
         'OBJ',
         obj_sources,
-        dependencies: plugin_deps,
-        cpp_args: compile_defs + compile_flags,
+        dependencies: obj_plugin_deps,
+        cpp_args: obj_compile_defs + obj_compile_flags,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
@@ -70,8 +70,8 @@ else
     obj_backend_lib = shared_library(
         'OBJ',
         obj_sources,
-        dependencies: plugin_deps,
-        cpp_args: compile_defs + compile_flags + ['-fPIC'],
+        dependencies: obj_plugin_deps,
+        cpp_args: obj_compile_defs + obj_compile_flags + ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
@@ -85,8 +85,14 @@ else
     endif
 endif
 
+# obj_backend.h publicly includes <asio.hpp>, so propagate the asio dependency
+# (include dirs) to consumers of this interface, e.g. the plugins gtest.
 if 'OBJ' in static_plugins
-    obj_backend_interface = declare_dependency(link_whole: obj_backend_lib)
+    obj_backend_interface = declare_dependency(
+        link_whole: obj_backend_lib,
+        dependencies: dependency('asio', required: true))
 else
-    obj_backend_interface = declare_dependency(link_with: obj_backend_lib)
+    obj_backend_interface = declare_dependency(
+        link_with: obj_backend_lib,
+        dependencies: dependency('asio', required: true))
 endif

--- a/src/plugins/posix/meson.build
+++ b/src/plugins/posix/meson.build
@@ -18,7 +18,7 @@ if not has_posix_plugin
     subdir_done()
 endif
 
-plugin_deps = [nixl_infra, nixl_common_dep, file_utils_interface]
+posix_plugin_deps = [nixl_infra, nixl_common_dep, file_utils_interface]
 
 # Define base source files
 posix_sources = [
@@ -29,31 +29,31 @@ posix_sources = [
     'io_queue.cpp'
 ]
 
-compile_defs = []
-plugin_link_args = []
+posix_compile_defs = []
+posix_link_args = []
 
 if has_linux_aio
-    compile_defs += ['-DHAVE_LINUXAIO']
+    posix_compile_defs += ['-DHAVE_LINUXAIO']
     posix_sources += ['linux_aio_io_queue.cpp']
-    plugin_deps += [ linux_aio_dep ]
+    posix_plugin_deps += [ linux_aio_dep ]
     message('Linux AIO found, adding Linux AIO support')
 else
     warning('Linux AIO not found')
 endif
 
 if has_io_uring
-    compile_defs += ['-DHAVE_LIBURING']
+    posix_compile_defs += ['-DHAVE_LIBURING']
     posix_sources += ['io_uring_io_queue.cpp']
-    plugin_deps += [ io_uring_dep ]
+    posix_plugin_deps += [ io_uring_dep ]
     message('liburing found, adding io_uring support')
 else
     warning('liburing not found')
 endif
 
 if has_posix_aio
-    compile_defs += ['-DHAVE_POSIXAIO']
+    posix_compile_defs += ['-DHAVE_POSIXAIO']
     posix_sources += ['posix_aio_io_queue.cpp']
-    plugin_deps += [ rt_dep ]
+    posix_plugin_deps += [ rt_dep ]
     message('POSIX AIO found, adding POSIX AIO support')
 else
     message('POSIX AIO not found')
@@ -62,18 +62,18 @@ endif
 if 'POSIX' in static_plugins
     posix_backend_lib = static_library('POSIX',
         posix_sources,
-        dependencies: plugin_deps,
-        link_args: plugin_link_args,
-        cpp_args: compile_defs + compile_flags,
+        dependencies: posix_plugin_deps,
+        link_args: posix_link_args,
+        cpp_args: posix_compile_defs,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     posix_backend_lib = shared_library('POSIX',
         posix_sources,
-        dependencies: plugin_deps,
-        link_args: plugin_link_args,
-        cpp_args: compile_defs + ['-fPIC'],
+        dependencies: posix_plugin_deps,
+        link_args: posix_link_args,
+        cpp_args: posix_compile_defs + ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries

--- a/src/plugins/uccl/meson.build
+++ b/src/plugins/uccl/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 cpp = meson.get_compiler('cpp')
-compile_flags = []
+uccl_compile_flags = []
 
 
 if 'UCCL' in static_plugins
@@ -23,7 +23,7 @@ if 'UCCL' in static_plugins
                dependencies: [nixl_infra, serdes_interface, cuda_dep, libuccl_p2p, nixl_common_dep],
                include_directories: nixl_inc_dirs,
                install: false,
-               cpp_args : compile_flags,
+               cpp_args : uccl_compile_flags,
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     uccl_backend_lib = shared_library('UCCL',
@@ -31,7 +31,7 @@ else
                dependencies: [nixl_infra, serdes_interface, cuda_dep, libuccl_p2p, nixl_common_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : compile_flags + ['-fPIC'],
+               cpp_args : uccl_compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir)
 

--- a/src/plugins/uccl/meson.build
+++ b/src/plugins/uccl/meson.build
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 cpp = meson.get_compiler('cpp')
-uccl_compile_flags = []
-
 
 if 'UCCL' in static_plugins
     uccl_backend_lib = static_library('UCCL',
@@ -23,7 +21,7 @@ if 'UCCL' in static_plugins
                dependencies: [nixl_infra, serdes_interface, cuda_dep, libuccl_p2p, nixl_common_dep],
                include_directories: nixl_inc_dirs,
                install: false,
-               cpp_args : uccl_compile_flags,
+               cpp_args : [],
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     uccl_backend_lib = shared_library('UCCL',
@@ -31,7 +29,7 @@ else
                dependencies: [nixl_infra, serdes_interface, cuda_dep, libuccl_p2p, nixl_common_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
-               cpp_args : uccl_compile_flags + ['-fPIC'],
+               cpp_args : ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir)
 

--- a/test/gtest/plugins/azure_blob/meson.build
+++ b/test/gtest/plugins/azure_blob/meson.build
@@ -40,7 +40,6 @@ azure_blob_test_exe = executable('azure_blob_gtest',
         azure_storage_common,
         azure_storage_blobs,
         azure_identity,
-        plugin_deps,
         azure_blob_backend_interface
     ],
     link_with: [nixl_build_lib],

--- a/test/gtest/plugins/azure_blob/meson.build
+++ b/test/gtest/plugins/azure_blob/meson.build
@@ -34,6 +34,7 @@ azure_blob_test_exe = executable('azure_blob_gtest',
     dependencies : [
         nixl_dep,
         gtest_dep,
+        absl_log_dep,
         absl_strings_dep,
         absl_time_dep,
         azure_core,

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -53,7 +53,7 @@ plugins_test_exe = executable('plugins_gtest',
     sources : plugins_gtest_sources,
     include_directories: [nixl_inc_dirs, utils_inc_dirs, plugins_inc_dirs, '.'],
     cpp_args : plugins_gtest_cpp_flags,
-    dependencies : [nixl_dep, gtest_dep, absl_strings_dep, absl_time_dep, plugin_deps,
+    dependencies : [nixl_dep, gtest_dep, absl_strings_dep, absl_time_dep,
                     obj_backend_interface] + plugins_gtest_cuda_deps,
     link_with: [nixl_build_lib],
     install : true

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -53,7 +53,7 @@ plugins_test_exe = executable('plugins_gtest',
     sources : plugins_gtest_sources,
     include_directories: [nixl_inc_dirs, utils_inc_dirs, plugins_inc_dirs, '.'],
     cpp_args : plugins_gtest_cpp_flags,
-    dependencies : [nixl_dep, gtest_dep, absl_strings_dep, absl_time_dep,
+    dependencies : [nixl_dep, gtest_dep, absl_log_dep, absl_strings_dep, absl_time_dep,
                     obj_backend_interface] + plugins_gtest_cuda_deps,
     link_with: [nixl_build_lib],
     install : true


### PR DESCRIPTION
## What?
Namespace all plugin-local meson variables (`plugin_deps`, `compile_defs`, `compile_flags`, `plugin_link_args`)
with a plugin-specific prefix across all plugin `meson.build` files following the pattern already established by `ucx` and partially by `libfabric`.

## Why?
Meson variables defined in one plugin's `meson.build` are visible to all subsequently-built plugins.
Generic variable names like `plugin_deps`, `compile_defs`, and `compile_flags` were reused across plugins,

causing two classes of bugs:           

1. **Silent cross-contamination:** When multiple plugins are enabled, later plugins inherit dependencies and compile definitions from earlier ones.
For example, enabling both POSIX and OBJ causes OBJ to silently pick up POSIX's `-DHAVE_LINUXAIO` flags and `file_utils_interface` dependency.
2. **Build failures in isolation:** Several plugins (OBJ, Azure Blob, GDS, GDS_MT, Gusli, HF3FS) reference `compile_defs` or `compile_flags` without ever defining them, relying on leakage from a previously-built plugin.                                                                                                                                                       
   
This bug has existed since the initial plugin commits (#479 for OBJ, #234 for POSIX) but was masked because POSIX always ran unconditionally.
Since #1086 introduced the `has_posix_plugin` guard, on systems where POSIX is disabled (either explicitely disabled or no `libaio`, `liburing`, or POSIX AIO), `plugin_deps` is never defined and downstream plugins fail with `Unknown variable "plugin_deps"`.

## How?
- Variables that are only used within a single plugin are prefixed with the plugin name (e.g. `posix_plugin_deps`, `obj_compile_defs`, `libfabric_compile_flags`).
- For plugins that never had compile defs/flags of their own (azure_blob, cuda_gds, gds_mt, gusli, hf3fs), the undefined variable references are replaced with empty lists.
- No functional change to any plugin's actual dependencies or compile flags, only scoping.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized per-plugin build configuration and renamed plugin-specific build variables for clearer isolation.
  * Static plugin builds no longer inherit shared build flags; shared builds consistently include position-independent settings.
  * Updated several plugin build declarations and expanded SPDX year ranges.
  * Core dependency declaration now propagates downstream library dependencies.

* **Tests**
  * Some plugin test targets no longer propagate the broader plugin dependency list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->