### PR TITLE
fix(nixlbench): fix double evaluation in CHECK_NIXL_ERROR macro

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -40,12 +40,14 @@
 #define ROUND_UP(value, granularity) \
     ((((value) + (granularity) - 1) / (granularity)) * (granularity))
 
-#define CHECK_NIXL_ERROR(result, message)                                                       \
-    do {                                                                                        \
-        if (0 != result) {                                                                      \
-            std::cerr << "NIXL: " << message << " (Error code: " << result << ")" << std::endl; \
-            exit(EXIT_FAILURE);                                                                 \
-        }                                                                                       \
+#define CHECK_NIXL_ERROR(result, message)                                                     \
+    do {                                                                                      \
+        const nixl_status_t _r = (result);                                                    \
+        if (0 != _r) {                                                                        \
+            std::cerr << "NIXL: " << message << " (" << nixlEnumStrings::statusStr(_r) << ")" \
+                      << std::endl;                                                           \
+            exit(EXIT_FAILURE);                                                               \
+        }                                                                                     \
     } while (0)
 
 static nixl_mem_t


### PR DESCRIPTION
## What?
Fix the `CHECK_NIXL_ERROR` macro in nixlbench to evaluate its `result` argument only once.

## Why?
The macro expanded its result parameter twice: once in the condition and once in the error message.

When the argument is a function call (e.g. `agent->registerMem()`), the function executes twice on failure.
This can cause double side effects (double registration, double memory allocation, etc.) and the printed error code may differ from the one that actually triggered the error path.

## How?
Capture the `result` argument into a local `nixl_status_t` variable before testing and printing, following the standard C macro hygiene pattern. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal error reporting so error messages display descriptive status names instead of numeric codes.
  * No change to functionality or behavior; error handling outcomes remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->