### PR TITLE
nixlbench: fix README note about using raw block device with POSIX backend

### DIFF
--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -652,6 +652,14 @@ $ host2 > sleep 2 && ./nixlbench --etcd_endpoints http://etcd-server:2379 --back
 ./nixlbench --backend POSIX --filepath /mnt/storage/testfile --posix_api_type URING --storage_enable_direct
 ```
 
+**Note**: To use a raw block device with the POSIX backend, create a symlink to the device using the expected filename pattern:
+
+```bash
+mkdir -p /mnt/block_device_name
+ln -sf /dev/block_device_name /mnt/block_device_name/nixlbench_posix_test_file_initiator_0
+./nixlbench --backend POSIX --filepath /mnt/block_device_name --posix_api_type AIO
+```
+
 **GUSLI Backend (G3+ User Space Access Library):**
 
 GUSLI provides direct user-space access to block storage devices, supporting local files, kernel block devices, and networked GUSLI servers.


### PR DESCRIPTION
## What?
added note in `benchmark/nixlbench/README.md` about using a raw block device with the POSIX backend.

## Why?
The note is meant to help users hook a raw block device up to the POSIX backend by symlinking it into a directory using the expected `nixlbench_posix_test_file_initiator_<rank>` filename pattern. As-is.

No code or behavior changes — README only.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for configuring raw block devices with the POSIX backend, including directory creation and symlink configuration procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->