### PR TITLE
Python: Export missing symbols in the meta package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        args: [--ignore-missing-imports]
         additional_dependencies: [types-PyYAML, types-tabulate]
         files: \.py$
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ authors = [
 
 dependencies = ["torch", "numpy"]
 
+[tool.mypy]
+mypy_path = ["src/bindings/python/nixl-meta"]
+ignore_missing_imports = true
+
 [tool.isort]
 profile = "black"
 

--- a/src/bindings/python/nixl-meta/nixl/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl/__init__.py
@@ -69,6 +69,11 @@ for sub_name in submodules:
 if TYPE_CHECKING:
     from nixl import logging  # noqa: F401
     from nixl._api import (  # type: ignore[attr-defined]  # noqa: F401
+        DEFAULT_COMM_PORT,
         nixl_agent,
         nixl_agent_config,
+        nixl_backend_handle,
+        nixl_prepped_dlist_handle,
+        nixl_thread_sync_t,
+        nixl_xfer_handle,
     )

--- a/src/bindings/python/nixl-meta/nixl/_api.py
+++ b/src/bindings/python/nixl-meta/nixl/_api.py
@@ -21,11 +21,21 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     try:
         from nixl_cu13._api import (  # type: ignore[import]  # noqa: F401
+            DEFAULT_COMM_PORT,
             nixl_agent,
             nixl_agent_config,
+            nixl_backend_handle,
+            nixl_prepped_dlist_handle,
+            nixl_thread_sync_t,
+            nixl_xfer_handle,
         )
     except ImportError:
         from nixl_cu12._api import (  # type: ignore[import]  # noqa: F401
+            DEFAULT_COMM_PORT,
             nixl_agent,
             nixl_agent_config,
+            nixl_backend_handle,
+            nixl_prepped_dlist_handle,
+            nixl_thread_sync_t,
+            nixl_xfer_handle,
         )


### PR DESCRIPTION
## What?

Add all public `_api` symbols to the `TYPE_CHECKING` blocks in `src/bindings/python/nixl-meta/nixl/_api.py` and `__init__.py`.

## Why?

PR #1501 added `nixl_thread_sync_t` to `src/api/python/_api.py` and `__init__.py` but did not update the meta-package type stubs. Since mypy resolves `nixl._api` through the meta-package stub, the pre-commit mypy hook fails with:

```
test/python/test_nixl_api.py:24: error: Module "nixl._api" has no attribute "nixl_thread_sync_t"  [attr-defined]
```

This PR also adds the three other symbols (`DEFAULT_COMM_PORT`, `nixl_backend_handle`, `nixl_prepped_dlist_handle`) that were already missing before #1501 so the stubs match the full public API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved static type-checking support for the Python bindings by expanding the set of type-only imports used for analysis.
  * Added MyPy configuration to the project to locate binding stubs during checks.
  * Updated pre-commit MyPy hook to run with stricter reporting (no longer silently ignoring missing type imports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->