### PR TITLE
fix: multiple evaluation in nixlbench macro

### DIFF
--- a/benchmark/nixlbench/src/utils/neuron.h
+++ b/benchmark/nixlbench/src/utils/neuron.h
@@ -41,12 +41,13 @@ neuronMemcpy(void *dest, const void *src, size_t count, neuronMemcpyKind kind);
 int
 neuronMemset(void *addr, int val, size_t count);
 
-#define CHECK_NEURON_ERROR(result, message)                                                       \
-    do {                                                                                          \
-        if (result != 0) {                                                                        \
-            std::cerr << "NEURON: " << message << " (Error code: " << result << ")" << std::endl; \
-            exit(EXIT_FAILURE);                                                                   \
-        }                                                                                         \
+#define CHECK_NEURON_ERROR(result, message)                                                   \
+    do {                                                                                      \
+        const auto _r = (result);                                                             \
+        if (_r != 0) {                                                                        \
+            std::cerr << "NEURON: " << message << " (Error code: " << _r << ")" << std::endl; \
+            exit(EXIT_FAILURE);                                                               \
+        }                                                                                     \
     } while (0)
 
 

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -35,24 +35,26 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 
-#define CHECK_CUDA_ERROR(result, message)                                           \
-    do {                                                                            \
-        if (result != cudaSuccess) {                                                \
-            std::cerr << "CUDA: " << message << " (Error code: " << result << " - " \
-                      << cudaGetErrorString(result) << ")" << std::endl;            \
-            exit(EXIT_FAILURE);                                                     \
-        }                                                                           \
+#define CHECK_CUDA_ERROR(result, message)                                       \
+    do {                                                                        \
+        const auto _r = (result);                                               \
+        if (_r != cudaSuccess) {                                                \
+            std::cerr << "CUDA: " << message << " (Error code: " << _r << " - " \
+                      << cudaGetErrorString(_r) << ")" << std::endl;            \
+            exit(EXIT_FAILURE);                                                 \
+        }                                                                       \
     } while (0)
 
-#define CHECK_CUDA_DRIVER_ERROR(result, message)                                           \
-    do {                                                                                   \
-        if (result != CUDA_SUCCESS) {                                                      \
-            const char *error_str;                                                         \
-            cuGetErrorString(result, &error_str);                                          \
-            std::cerr << "CUDA Driver: " << message << " (Error code: " << result << " - " \
-                      << error_str << ")" << std::endl;                                    \
-            exit(EXIT_FAILURE);                                                            \
-        }                                                                                  \
+#define CHECK_CUDA_DRIVER_ERROR(result, message)                                       \
+    do {                                                                               \
+        const auto _r = (result);                                                      \
+        if (_r != CUDA_SUCCESS) {                                                      \
+            const char *error_str;                                                     \
+            cuGetErrorString(_r, &error_str);                                          \
+            std::cerr << "CUDA Driver: " << message << " (Error code: " << _r << " - " \
+                      << error_str << ")" << std::endl;                                \
+            exit(EXIT_FAILURE);                                                        \
+        }                                                                              \
     } while (0)
 #endif
 


### PR DESCRIPTION
## What?
I fixed the confirmed double-evaluation bugs in three benchmark macros by storing result in a local temporary and using that value for the check and error message

## Why?
these macros used result more than once inside the macro body. When callers pass a function call as result, that function is
executed multiple times during macro expansion.

## How?
capturing result once avoids repeated execution and makes the macro behave correctly for expressions with side effects.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of benchmark diagnostic error reporting to avoid duplicated evaluations and ensure accurate error codes.
  * Updated GPU/CUDA diagnostic checks for more reliable and consistent error messages during benchmarking and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->