### PR TITLE
CI: triage failed builds with triagebot

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -86,6 +86,15 @@ taskName: "${name}/${arch}/ucx-${ucx_version}/${axis_index}"
 
 
 steps:
+  # TEMP: force nixl-ci-gpu to fail fast so the triagebot catch-block
+  # actually fires on this PR. REVERT BEFORE MERGE.
+  - name: TEMP force-fail to exercise triagebot
+    containerSelector: "{name: 'build_helper'}"
+    parallel: false
+    run: |
+      echo "intentional failure on PR triagebot-ci-integration to exercise the catch-block"
+      exit 1
+
   - name: Compiling NIXL Docker Image
     containerSelector: "{name: 'build_helper'}"
     credentialsId: "nixl_harbor_credentials"

--- a/.ci/jenkins/lib/triagebot-matrix.yaml
+++ b/.ci/jenkins/lib/triagebot-matrix.yaml
@@ -1,0 +1,74 @@
+---
+# Triagebot job — invoked from a parent's catch-block on failure.
+
+job: nixl-ci-triagebot
+
+failFast: true
+# Deep-tournament path can run 15+ min; 30 gives headroom.
+timeout_minutes: 30
+
+# Pull-only: harbor creds, nothing pushed.
+registry_auth: nixl_harbor_credentials
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: "{memory: 4Gi, cpu: 2000m}"
+  requests: "{memory: 2Gi, cpu: 1000m}"
+
+# Bot's full .env — bound per-step via credentialsId.
+credentials:
+  - {credentialsId: 'triagebot_env', type: 'file', variable: 'ENV_FILE'}
+
+env:
+  ANTHROPIC_BASE_URL: "https://inference-api.nvidia.com"  # NV LLM gateway, per company policy
+  TRIAGEBOT_AGENT_MODEL: "azure/anthropic/claude-opus-4-7"
+  TRIAGEBOT_CLASSIFIER_MODEL: "azure/anthropic/claude-haiku-4-5"
+  JENKINS_NIXL_URL: "https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main"
+  JIRA_BASE_URL: "https://jirasw.nvidia.com"
+  CONFLUENCE_BASE_URL: "https://nvidia.atlassian.net/wiki"
+
+matrix:
+  axes:
+    arch:
+      - x86_64
+
+# `url:` alone (no `file:`) skips ci-demo's build path; k8s pulls fresh each run.
+runs_on_dockers:
+  - {
+      url: 'harbor.mellanox.com/nixl/triagebot:latest',
+      name: 'triagebot-runner',
+      arch: x86_64,
+    }
+
+steps:
+  - name: Build complaint
+    containerSelector: "{name: 'triagebot-runner'}"
+    parallel: false
+    run: |
+      set -e
+      {
+        printf 'Parent CI job: %s build #%s\n' "${source_job}" "${source_build}"
+        printf 'Parent URL:    %s\n\n' "${source_url}"
+        printf -- '----- failure excerpt (parent console) -----\n'
+        printf '%s\n' "${failure_excerpt}"
+      } > complaint.txt
+      echo "complaint.txt: $(wc -c < complaint.txt) bytes"
+
+  # Isolated stage — parent's description links here for one-click navigation.
+  - name: Triagebot Output
+    containerSelector: "{name: 'triagebot-runner'}"
+    parallel: false
+    timeout: 25
+    credentialsId: ['triagebot_env']
+    run: |
+      set -e
+      /app/.venv/bin/triagebot-cli --env-file "$ENV_FILE" nixl --ci - < complaint.txt | tee triage.txt
+      test -s triage.txt || { echo "ERROR: triage.txt is empty"; exit 1; }
+
+  - name: Archive
+    parallel: false
+    shell: action
+    module: groovy
+    run: |
+      archiveArtifacts artifacts: 'triage.txt', allowEmptyArchive: false, fingerprint: false

--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -48,15 +48,36 @@ try {
 } catch (Exception ex) {
     currentBuild.result = 'FAILURE'
     println ex
+    // Post FAILURE before bot dispatch — keeps the PR check from sitting
+    // PENDING while the bot thinks.
+    if (params.githubData) {
+        githubHelper.updateCommitStatus(blueOceanUrl, "Test completed", GitHubCommitState.FAILURE, env.JOB_BASE_NAME)
+    }
+    // propagate: false so bot outcome doesn't mask the parent's failure.
+    if (env.JOB_BASE_NAME == 'nixl-ci-gpu') {
+        try {
+            def excerpt = currentBuild.rawBuild.getLog(400).join('\n')
+            def t = build job: 'Devops/nixl-ci-triagebot', parameters: [
+                string(name: 'source_job',      value: env.JOB_NAME),
+                string(name: 'source_build',    value: env.BUILD_NUMBER),
+                string(name: 'source_url',      value: env.BUILD_URL),
+                text(  name: 'failure_excerpt', value: excerpt),
+                string(name: 'sha1',            value: params.sha1 ?: 'main'),
+                string(name: 'githubData',      value: params.githubData ?: ''),
+            ], propagate: false, wait: true
+            echo "Triagebot completed: ${t.absoluteUrl}"
+            currentBuild.description = (currentBuild.description ?: '') +
+                "<br/>Triagebot: <a href='${t.absoluteUrl}'>#${t.number}</a>"
+        } catch (Exception tex) {
+            echo "Triagebot invocation failed: ${tex.message}"
+        }
+    }
     throw ex
 } finally {
     if (params.githubData) {
-        githubHelper.updateCommitStatus(
-            blueOceanUrl,
-            "Test completed",
-            currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE,
-            env.JOB_BASE_NAME
-        )
+        if (currentBuild.result != 'FAILURE') {
+            githubHelper.updateCommitStatus(blueOceanUrl, "Test completed", GitHubCommitState.SUCCESS, env.JOB_BASE_NAME)
+        }
         githubHelper.uploadLogs(this, env.JOB_NAME, env.BUILD_NUMBER, null, null)
     }
 }

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -220,7 +220,10 @@
               jjb_proj={jjb_proj}-gpu
     description: Do NOT edit this job through the Web GUI !
     concurrent: true
-    sandbox: true
+    # sandbox: false so the catch-block can call rawBuild.getLog() for the
+    # triagebot dispatch (rejected under script sandbox). Other nixl-ci-*
+    # keep sandbox: true — their JOB_BASE_NAME guard skips this path.
+    sandbox: false
     # Test job parameters
     parameters:
         - string:
@@ -487,6 +490,55 @@
                     parent-credentials: true
         script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
+# Generic single-matrix pipeline job template. Project entry supplies the
+# full job name (jjb_proj), the matrix yaml (jjb_conf_file), and a
+# description. Prefer this for new conf-driven jobs over per-job templates.
+- job-template:
+    name: "{jjb_proj}"
+    folder: "{jjb_folder}"
+    project-type: pipeline
+    disabled: false
+    properties:
+        - github:
+            url: "{jjb_gh_url}"
+        - build-discarder:
+            days-to-keep: 14
+            num-to-keep: 500
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}
+              conf_file={jjb_conf_file}
+    description: "{jjb_description}"
+    concurrent: true
+    sandbox: true
+    parameters:
+        - string: {name: "sha1",            default: "{jjb_branch}"}
+        - string: {name: "githubData",      default: ""}
+        - string: {name: "source_job",      default: ""}
+        - string: {name: "source_build",    default: ""}
+        - string: {name: "source_url",      default: ""}
+        - text:   {name: "failure_excerpt", default: ""}
+        - bool:   {name: "build_dockers",   default: false}
+        - string: {name: "DEBUG",           default: 0}
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                credentials-id: 'svc-nixl-ssh_key'
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"
+
 # Project definition that instantiates the job templates
 # This section defines the actual jobs that will be created
 - project:
@@ -504,3 +556,19 @@
         - "{jjb_proj}-gpu"        # Create gpu job
         - "{jjb_proj}-dl-gpu"   # Create dl-gpu job for dlcluster.nvidia.com
         - "{jjb_proj}-build-wheel"  # Create build wheel job
+
+# Triagebot: failure-triggered triage job. Invoked from the Jenkinsfile
+# catch-block on nixl-ci-gpu failure; logic lives in the matrix yaml.
+- project:
+    name: nixl-ci-triagebot
+    jjb_proj: 'nixl-ci-triagebot'
+    jjb_folder: 'Devops'
+    jjb_conf_file: '.ci/jenkins/lib/triagebot-matrix.yaml'
+    jjb_description: 'Automated triage of failed NIXL CI runs. Do NOT edit via Web GUI!'
+    jjb_git: 'git@github.com:ai-dynamo/nixl.git'
+    jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'
+    jjb_branch: 'main'
+    jjb_gh_url: 'https://github.com/ai-dynamo/nixl'
+    jjb_gh_refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*'
+    jobs:
+        - "{jjb_proj}"


### PR DESCRIPTION
## What?
On `nixl-ci-gpu` failure, the Jenkinsfile catch-block dispatches a new `nixl-ci-triagebot` job, waits for its analysis, and copies `triage.txt` back into the parent's console. Also flips the GitHub commit status to FAILURE before the bot runs (was leaving the PR check at PENDING for ~30s-6min while the bot thinks).

## Why?
- Triage lands in the same console the engineer is already reading — no jumping between jobs.
- PR check reflects the failure immediately, not after the bot finishes.

## How?
- New `.ci/jenkins/lib/triagebot-matrix.yaml` and JJB template in `proj-jjb.yaml`.
- Triagebot image referenced by URL in `runs_on_dockers` — ci-demo only triggers a build when `file:` is set; with `url:` alone, k8s pulls fresh on every run, so a new `:latest` pushed to harbor is picked up automatically (no per-PR rebuild, no per-PR tag).
- `nixl-ci-gpu` set to `sandbox: false` so the catch-block can use `currentBuild.rawBuild.getLog()` for the failure excerpt; other templates keep `sandbox: true` and skip the rawBuild path via the `JOB_BASE_NAME` guard.