### PR TITLE
nixlbench: Reuse existing client for KeepAlive for rank key

### DIFF
--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -82,10 +82,10 @@ xferBenchEtcdRT::setup() {
     }
 
     // Register the rank key with a lease before bumping "size"; a crash before
-    // registration leaves size unchanged. Standalone KeepAlive uses its own
-    // gRPC channel to avoid races with the main client.
+    // registration leaves size unchanged.
     try {
-        keepalive = std::make_unique<etcd::KeepAlive>(stored_etcd_endpoints, lease_ttl_s);
+        // Reuse client's gRPC channel to avoid slow channel creation under load.
+        keepalive = std::make_unique<etcd::KeepAlive>(*client, lease_ttl_s);
     }
     catch (const std::exception &e) {
         client->unlock(lock_response.lock_key());
@@ -130,6 +130,7 @@ xferBenchEtcdRT::~xferBenchEtcdRT() {
     // rather than expiring after the TTL
     if (keepalive) {
         keepalive->Cancel();
+        keepalive.reset();
     }
     // All ranks delete, as some could be missing if ETCD state is confused
     if (client) {


### PR DESCRIPTION
Today, creating a new channel can take 2-5 seconds under load, consistently redproduced on some aws instance types (e.g. g6). This delay made the background thread creation late. When the scheduled refresh happens (TTL-1) in the background thread, the lease has expired already.


## What?
Reusing the channel eliminates this overhead (leasegrant completes in in milliseconds).

## Why?
gRCP supports multiplexing streams over single channel. So sharing the channel with the main client is probably not a big concern.

## How?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reuse the existing etcd client during benchmark setup to avoid creating duplicate connections and share transport channels.
  * Improve teardown so keepalive is explicitly cancelled and released, reducing resource leaks and making failure-path cleanup more robust.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1615)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->