### PR TITLE
CI: fix build result not set to FAILURE on exception

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -46,6 +46,7 @@ if (params.githubData) {
 try {
     matrix.main()
 } catch (Exception ex) {
+    currentBuild.result = 'FAILURE'
     println ex
     throw ex
 } finally {


### PR DESCRIPTION
## What
Update Jenkinsfile behavior on corner case failures.

## Why?
In some very specific cases, the job may fail to run but will report as succeeded to GH checks.

## How?
Force update the build result on any failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to explicitly mark builds as failed when exceptions occur, improving build failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->