### PR TITLE
UCX: fail on invalid UCX_TLS for GPU support

### DIFF
--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -16,12 +16,96 @@
  */
 #include "config.h"
 
+#include <cctype>
 #include <stdexcept>
+#include <string>
 
 #include "common/configuration.h"
+#include "common/hw_info.h"
 #include "common/nixl_log.h"
+#include "ucx_utils.h"
 
 namespace nixl::ucx {
+namespace {
+
+bool
+hasInvalidDenyListSyntax(std::string_view tls) {
+    bool can_start_deny_list = true;
+
+    for (const char c : tls) {
+        if (std::isspace(static_cast<unsigned char>(c)) && can_start_deny_list) {
+            continue;
+        }
+
+        if (c == '^') {
+            if (!can_start_deny_list) {
+                return true;
+            }
+
+            can_start_deny_list = false;
+            continue;
+        }
+
+        can_start_deny_list = false;
+    }
+
+    return false;
+}
+
+bool
+isDenyList(std::string_view tls) {
+    for (const char c : tls) {
+        if (std::isspace(static_cast<unsigned char>(c))) {
+            continue;
+        }
+
+        return c == '^';
+    }
+
+    return false;
+}
+
+bool
+isCudaSupportToken(std::string_view token) {
+    return (token == "cuda") || (token == "cuda_copy");
+}
+
+bool
+hasCudaSupportToken(std::string_view tls) {
+    size_t pos = isDenyList(tls) ? tls.find('^') + 1 : 0;
+
+    while (pos < tls.size()) {
+        size_t end = tls.find(',', pos);
+        if (end == std::string_view::npos) {
+            end = tls.size();
+        }
+
+        while ((pos < end) && std::isspace(static_cast<unsigned char>(tls[pos]))) {
+            ++pos;
+        }
+
+        while ((end > pos) && std::isspace(static_cast<unsigned char>(tls[end - 1]))) {
+            --end;
+        }
+
+        if (isCudaSupportToken(tls.substr(pos, end - pos))) {
+            return true;
+        }
+
+        pos = end + 1;
+    }
+
+    return false;
+}
+
+bool
+tlsEnablesCudaSupport(std::string_view tls) {
+    const bool has_cuda_support = hasCudaSupportToken(tls);
+    return (!isDenyList(tls) && has_cuda_support) || (isDenyList(tls) && !has_cuda_support);
+}
+
+} // namespace
+
 void
 config::modify(std::string_view key, std::string_view value) const {
     const auto env_val = nixl::config::getValueOptional<std::string>("UCX_" + std::string(key));
@@ -44,6 +128,44 @@ config::modifyAlways(std::string_view key, std::string_view value) const {
     } else {
         NIXL_DEBUG << "Modified UCX config: " << key_str << "=" << value_str;
     }
+}
+
+void
+config::validateTlsEnvironment() const {
+    const auto tls = nixl::config::getValueOptional<std::string>("UCX_TLS");
+    if (!tls) {
+        return;
+    }
+
+    if (hasInvalidDenyListSyntax(*tls)) {
+        const std::string error =
+            "Invalid UCX_TLS=" + *tls +
+            " for NIXL UCX backend: '^' may only appear as the first "
+            "non-space character of UCX_TLS.";
+        NIXL_ERROR << error;
+        throw std::runtime_error(error);
+    }
+}
+
+void
+config::validateTlsCudaSupport(ucp_context_h ctx) const {
+    const auto tls = nixl::config::getValueOptional<std::string>("UCX_TLS");
+    if (!tls || tlsEnablesCudaSupport(*tls) || nixl::hwInfo::instance().numNvidiaGpus == 0) {
+        return;
+    }
+
+    const auto supports_cuda = nixlUcpContextSupportsMemoryType(ctx, UCS_MEMORY_TYPE_CUDA);
+    if (!supports_cuda || *supports_cuda) {
+        return;
+    }
+
+    const std::string error =
+        "Invalid UCX_TLS=" + *tls +
+        " for NIXL UCX backend: NVIDIA GPU(s) are present, "
+        "but this setting does not enable CUDA memory support. Add cuda_copy for "
+        "basic GPU support, or cuda to also include NVLink support.";
+    NIXL_ERROR << error;
+    throw std::runtime_error(error);
 }
 
 ucp_config_t *

--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -36,7 +36,8 @@ namespace {
         const std::string tokens = "," + std::string(tls) + ",";
         const bool has_cuda_support = (tls == "all") ||
             (tokens.find(",cuda,") != std::string::npos) ||
-            (tokens.find(",cuda_copy,") != std::string::npos);
+            (tokens.find(",cuda_copy,") != std::string::npos) ||
+            (tokens.find(",\\cuda_copy,") != std::string::npos);
         return deny_list ? !has_cuda_support : has_cuda_support;
     }
 

--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -25,24 +25,25 @@
 #include "common/hw_info.h"
 #include "common/nixl_log.h"
 
-namespace nixl::ucx {
 namespace {
 
-    bool
-    tlsEnablesCudaSupport(std::string_view tls) {
-        const bool deny_list = !tls.empty() && tls.front() == '^';
-        if (deny_list) {
-            tls.remove_prefix(1);
-        }
-
-        const std::string tokens = "," + std::string(tls) + ",";
-        const auto has_cuda_support = std::ranges::any_of(
-            std::array{",all,", ",cuda,", ",cuda_copy,", ",\\cuda_copy,"},
-            [&](auto token) { return tokens.find(token) != std::string::npos; });
-        return deny_list ? !has_cuda_support : has_cuda_support;
+bool
+tlsEnablesCudaSupport(std::string_view tls) {
+    const bool deny_list = !tls.empty() && tls.front() == '^';
+    if (deny_list) {
+        tls.remove_prefix(1);
     }
 
+    const std::string tokens = "," + std::string(tls) + ",";
+    const bool has_cuda_support =
+        std::ranges::any_of(std::array{",all,", ",cuda,", ",cuda_copy,", ",\\cuda_copy,"},
+                            [&](auto token) { return tokens.find(token) != std::string::npos; });
+    return deny_list ? !has_cuda_support : has_cuda_support;
+}
+
 } // namespace
+
+namespace nixl::ucx {
 
 void
 config::modify(std::string_view key, std::string_view value) const {

--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -16,6 +16,8 @@
  */
 #include "config.h"
 
+#include <algorithm>
+#include <array>
 #include <stdexcept>
 #include <string>
 
@@ -34,10 +36,9 @@ namespace {
         }
 
         const std::string tokens = "," + std::string(tls) + ",";
-        const bool has_cuda_support = (tls == "all") ||
-            (tokens.find(",cuda,") != std::string::npos) ||
-            (tokens.find(",cuda_copy,") != std::string::npos) ||
-            (tokens.find(",\\cuda_copy,") != std::string::npos);
+        const auto has_cuda_support = std::ranges::any_of(
+            std::array{",all,", ",cuda,", ",cuda_copy,", ",\\cuda_copy,"},
+            [&](auto token) { return tokens.find(token) != std::string::npos; });
         return deny_list ? !has_cuda_support : has_cuda_support;
     }
 
@@ -71,7 +72,7 @@ config::modifyAlways(std::string_view key, std::string_view value) const {
 void
 config::validateTlsCudaSupport() const {
     const auto tls = nixl::config::getValueOptional<std::string>("UCX_TLS");
-    if (!tls || tlsEnablesCudaSupport(*tls) || nixl::hwInfo::instance().numNvidiaGpus == 0) {
+    if (nixl::hwInfo::instance().numNvidiaGpus == 0 || !tls || tlsEnablesCudaSupport(*tls)) {
         return;
     }
 

--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -17,11 +17,31 @@
 #include "config.h"
 
 #include <stdexcept>
+#include <string>
 
 #include "common/configuration.h"
+#include "common/hw_info.h"
 #include "common/nixl_log.h"
 
 namespace nixl::ucx {
+namespace {
+
+    bool
+    tlsEnablesCudaSupport(std::string_view tls) {
+        const bool deny_list = !tls.empty() && tls.front() == '^';
+        if (deny_list) {
+            tls.remove_prefix(1);
+        }
+
+        const std::string tokens = "," + std::string(tls) + ",";
+        const bool has_cuda_support = (tls == "all") ||
+            (tokens.find(",cuda,") != std::string::npos) ||
+            (tokens.find(",cuda_copy,") != std::string::npos);
+        return deny_list ? !has_cuda_support : has_cuda_support;
+    }
+
+} // namespace
+
 void
 config::modify(std::string_view key, std::string_view value) const {
     const auto ucx_key = "UCX_" + std::string(key);
@@ -45,6 +65,21 @@ config::modifyAlways(std::string_view key, std::string_view value) const {
     } else {
         NIXL_DEBUG << "Modified UCX config: " << key_str << "=" << value_str;
     }
+}
+
+void
+config::validateTlsCudaSupport() const {
+    const auto tls = nixl::config::getValueOptional<std::string>("UCX_TLS");
+    if (!tls || tlsEnablesCudaSupport(*tls) || nixl::hwInfo::instance().numNvidiaGpus == 0) {
+        return;
+    }
+
+    const std::string error = "Invalid UCX_TLS=" + *tls +
+        " for NIXL UCX backend: NVIDIA GPU(s) are present, "
+        "but this setting does not enable CUDA memory support. Add cuda_copy for "
+        "basic GPU support, or cuda to also include NVLink support.";
+    NIXL_ERROR << error;
+    throw std::runtime_error(error);
 }
 
 ucp_config_t *

--- a/src/plugins/ucx/config.h
+++ b/src/plugins/ucx/config.h
@@ -43,6 +43,12 @@ public:
     void
     modifyAlways(std::string_view key, std::string_view value) const;
 
+    void
+    validateTlsEnvironment() const;
+
+    void
+    validateTlsCudaSupport(ucp_context_h ctx) const;
+
 private:
     [[nodiscard]] static ucp_config_t *
     readUcpConfig();

--- a/src/plugins/ucx/config.h
+++ b/src/plugins/ucx/config.h
@@ -43,6 +43,9 @@ public:
     void
     modifyAlways(std::string_view key, std::string_view value) const;
 
+    void
+    validateTlsCudaSupport() const;
+
 private:
     [[nodiscard]] static ucp_config_t *
     readUcpConfig();

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -364,6 +364,20 @@ nixlUcxMtLevelIsSupported(const nixl::ucx::mt_mode_t mt_type) noexcept {
     std::terminate();
 }
 
+std::optional<bool>
+nixlUcpContextSupportsMemoryType(ucp_context_h ctx, ucs_memory_type_t mem_type) noexcept {
+    ucp_context_attr_t attr = {
+        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
+    };
+    const auto status = ucp_context_query(ctx, &attr);
+    if (status != UCS_OK) {
+        NIXL_DEBUG << "Failed to query UCX context: " << ucs_status_string(status);
+        return std::nullopt;
+    }
+
+    return UCS_BIT_GET(attr.memory_types, mem_type) != 0;
+}
+
 namespace {
 
 [[nodiscard]] unsigned
@@ -452,11 +466,24 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         }
     }
 
-    const auto status = ucp_init(&ucp_params, config.getUcpConfig(), &ctx);
+    config.validateTlsEnvironment();
+
+    ucp_context_h new_ctx = nullptr;
+    const auto status = ucp_init(&ucp_params, config.getUcpConfig(), &new_ctx);
     if (status != UCS_OK) {
         throw std::runtime_error("Failed to create UCX context: " +
                                  std::string(ucs_status_string(status)));
     }
+
+    try {
+        config.validateTlsCudaSupport(new_ctx);
+    }
+    catch (...) {
+        ucp_cleanup(new_ctx);
+        throw;
+    }
+
+    ctx = new_ctx;
 }
 
 nixlUcxContext::~nixlUcxContext() {
@@ -601,26 +628,30 @@ nixlUcxContext::memDereg(nixlUcxMem &mem) {
 
 void
 nixlUcxContext::warnAboutHardwareSupportMismatch() const {
-    ucp_context_attr_t attr = {
-        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
-    };
-    const auto status = ucp_context_query(ctx, &attr);
-    if (status != UCS_OK) {
-        NIXL_WARN << "Failed to query UCX context: " << ucs_status_string(status) << ", "
+    const auto cuda_supported = nixlUcpContextSupportsMemoryType(ctx, UCS_MEMORY_TYPE_CUDA);
+    if (!cuda_supported) {
+        NIXL_WARN << "Failed to query UCX context, "
                   << "hardware support mismatch check will be skipped";
         return;
     }
 
     const auto &hw_info = nixl::hwInfo::instance();
 
-    if (hw_info.numNvidiaGpus > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_CUDA)) {
+    if (hw_info.numNvidiaGpus > 0 && !*cuda_supported) {
         NIXL_WARN << hw_info.numNvidiaGpus
                   << " NVIDIA GPU(s) were detected, but UCX CUDA support was not found! "
                   << "GPU memory is not supported.";
     }
 
     if (ucpVersion_ >= ucp_version_mem_type_rdma) {
-        if (hw_info.numIbDevices > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_RDMA)) {
+        const auto rdma_supported = nixlUcpContextSupportsMemoryType(ctx, UCS_MEMORY_TYPE_RDMA);
+        if (!rdma_supported) {
+            NIXL_WARN << "Failed to query UCX context, "
+                      << "hardware support mismatch check will be skipped";
+            return;
+        }
+
+        if (hw_info.numIbDevices > 0 && !*rdma_supported) {
             NIXL_WARN << hw_info.numIbDevices
                       << " IB device(s) were detected, but accelerated IB support was not found! "
                          "Performance may be degraded.";

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -517,20 +517,35 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         }
     }
 
-    const auto status = ucp_init(&ucp_params, config.getUcpConfig(), &ctx);
+    config.validateTlsCudaSupport();
+
+    ucp_context_h new_ctx = nullptr;
+    const auto status = ucp_init(&ucp_params, config.getUcpConfig(), &new_ctx);
     if (status != UCS_OK) {
         throw std::runtime_error(std::string("Failed to create UCX context ") + name_ + ": " +
                                  std::string(ucs_status_string(status)));
     }
-}
 
-nixlUcxContext::~nixlUcxContext() {
-    ucp_cleanup(ctx);
+    ctx.reset(new_ctx);
 }
 
 std::ostream &
 operator<<(std::ostream &os, const nixlUcxContext &ctx) {
     return os << "nixlUcxContext " << ctx.getName();
+}
+
+bool
+nixlUcxContext::supportsMemoryType(ucs_memory_type_t mem_type) const {
+    ucp_context_attr_t attr = {
+        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
+    };
+    const auto status = ucp_context_query(ctx.get(), &attr);
+    if (status != UCS_OK) {
+        throw std::runtime_error(std::string("Failed to query UCX context ") + name_ + ": " +
+                                 std::string(ucs_status_string(status)));
+    }
+
+    return UCS_BIT_GET(attr.memory_types, mem_type) != 0;
 }
 
 namespace {
@@ -565,7 +580,7 @@ ucp_worker *
 nixlUcxWorker::createUcpWorker(const nixlUcxContext &ctx) const {
     ucp_worker *worker = nullptr;
     const nixlUcpWorkerParams params(ctx.mtType_, name_);
-    const ucs_status_t status = ucp_worker_create(ctx.ctx, &params, &worker);
+    const ucs_status_t status = ucp_worker_create(ctx.ctx.get(), &params, &worker);
     if (status != UCS_OK) {
         throw std::runtime_error(std::string("Failed to create UCX worker ") + name_ + ": " +
                                  ucs_status_string(status));
@@ -635,7 +650,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         .length = mem.size,
     };
 
-    ucs_status_t status = ucp_mem_map(ctx, &mem_params, &mem.memh);
+    ucs_status_t status = ucp_mem_map(ctx.get(), &mem_params, &mem.memh);
     if (status != UCS_OK) {
         NIXL_ERROR << *this << ": failed to ucp_mem_map: " << ucs_status_string(status);
         return -1;
@@ -647,7 +662,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         status = ucp_mem_query(mem.memh, &attr);
         if (status != UCS_OK) {
             NIXL_ERROR << *this << ": failed to ucp_mem_query: " << ucs_status_string(status);
-            ucp_mem_unmap(ctx, mem.memh);
+            ucp_mem_unmap(ctx.get(), mem.memh);
             return -1;
         }
 
@@ -656,7 +671,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
                        << ": VRAM memory is detected as host by UCX. "
                           "UCX is likely not configured with CUDA/ROCm support. "
                           "VRAM registration cannot proceed.";
-            ucp_mem_unmap(ctx, mem.memh);
+            ucp_mem_unmap(ctx.get(), mem.memh);
             return -1;
         }
     }
@@ -671,7 +686,7 @@ nixlUcxContext::packRkey(nixlUcxMem &mem) {
     void *rkey_buf;
     std::size_t size;
 
-    const ucs_status_t status = ucp_rkey_pack(ctx, mem.memh, &rkey_buf, &size);
+    const ucs_status_t status = ucp_rkey_pack(ctx.get(), mem.memh, &rkey_buf, &size);
     if (status != UCS_OK) {
         NIXL_ERROR << *this << ": failed to ucp_rkey_pack: " << ucs_status_string(status);
         return {};
@@ -686,31 +701,25 @@ void
 nixlUcxContext::memDereg(nixlUcxMem &mem) {
     NIXL_DEBUG << *this << ": deregistering " << mem.size << " bytes at " << mem.base << ", memh "
                << mem.memh;
-    ucp_mem_unmap(ctx, mem.memh);
+    ucp_mem_unmap(ctx.get(), mem.memh);
 }
 
 void
 nixlUcxContext::warnAboutHardwareSupportMismatch() const {
-    ucp_context_attr_t attr = {
-        .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
-    };
-    const auto status = ucp_context_query(ctx, &attr);
-    if (status != UCS_OK) {
-        NIXL_WARN << *this << ": failed to query UCX context: " << ucs_status_string(status) << ", "
-                  << "hardware support mismatch check will be skipped";
-        return;
-    }
+    const bool cuda_supported = supportsMemoryType(UCS_MEMORY_TYPE_CUDA);
 
     const auto &hw_info = nixl::hwInfo::instance();
 
-    if (hw_info.numNvidiaGpus > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_CUDA)) {
+    if (hw_info.numNvidiaGpus > 0 && !cuda_supported) {
         NIXL_WARN << *this << ": " << hw_info.numNvidiaGpus
                   << " NVIDIA GPU(s) were detected, but UCX CUDA support was not found! "
                   << "GPU memory is not supported.";
     }
 
     if (ucpVersion_ >= ucp_version_mem_type_rdma) {
-        if (hw_info.numIbDevices > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_RDMA)) {
+        const bool rdma_supported = supportsMemoryType(UCS_MEMORY_TYPE_RDMA);
+
+        if (hw_info.numIbDevices > 0 && !rdma_supported) {
             NIXL_WARN << *this << ": " << hw_info.numIbDevices
                       << " IB device(s) were detected, but accelerated IB support was not found! "
                          "Performance may be degraded.";

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -18,6 +18,7 @@
 #define NIXL_SRC_UTILS_UCX_UCX_UTILS_H
 
 #include <memory>
+#include <optional>
 #include <type_traits>
 
 extern "C" {
@@ -200,6 +201,9 @@ public:
 
 [[nodiscard]] bool
 nixlUcxMtLevelIsSupported(const nixl::ucx::mt_mode_t) noexcept;
+
+[[nodiscard]] std::optional<bool>
+nixlUcpContextSupportsMemoryType(ucp_context_h ctx, ucs_memory_type_t mem_type) noexcept;
 
 class nixlUcxWorker {
 public:

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -155,10 +155,13 @@ public:
 class nixlUcxContext {
 private:
     /* Local UCX stuff */
-    ucp_context_h ctx;
+    std::unique_ptr<ucp_context, void (*)(ucp_context_h)> ctx{nullptr, &ucp_cleanup};
     const nixl::ucx::mt_mode_t mtType_;
     const unsigned ucpVersion_;
     const std::string name_;
+
+    [[nodiscard]] bool
+    supportsMemoryType(ucs_memory_type_t mem_type) const;
 
 public:
     nixlUcxContext(const std::vector<std::string> &devs,
@@ -168,8 +171,6 @@ public:
                    size_t num_device_channels,
                    const std::string &engine_conf = "",
                    const std::string &name = "");
-    ~nixlUcxContext();
-
     nixlUcxContext(nixlUcxContext &&) = delete;
     nixlUcxContext(const nixlUcxContext &) = delete;
 

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -45,6 +45,11 @@ protected:
     }
 };
 
+class UcxTlsValidationTest : public ::testing::Test {
+protected:
+    gtest::ScopedEnv envHelper_;
+};
+
 /**
  * Test that a warning is logged when NVIDIA GPUs are present but UCX
  * CUDA support is not available.
@@ -115,6 +120,43 @@ TEST_F(HardwareWarningTest, NoWarningWhenIbAndCudaSupported) {
     nixlUcxContext ctx(devs, false, 1, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, 0);
 
     ctx.warnAboutHardwareSupportMismatch();
+
+    envHelper_.popVar();
+}
+
+TEST_F(UcxTlsValidationTest, InvalidTlsDenyListSyntaxFails) {
+    envHelper_.addVar("UCX_TLS", "sm,ib,^cuda_ipc");
+
+    const gtest::LogIgnoreGuard lig_tls(
+        "Invalid UCX_TLS=sm,ib,\\^cuda_ipc.*\\^.*first non-space character");
+    const gtest::LogIgnoreGuard lig_backend("backend creation failed for 'UCX'");
+
+    nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
+    nixlBackendH *backend = nullptr;
+    EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_ERR_BACKEND);
+    EXPECT_GE(lig_tls.getIgnoredCount(), 1);
+    EXPECT_EQ(lig_backend.getIgnoredCount(), 1);
+
+    envHelper_.popVar();
+}
+
+TEST_F(UcxTlsValidationTest, MissingCudaTlsFailsWhenCudaIsAvailable) {
+    if (std::getenv("NIXL_CI_NON_GPU") != nullptr) {
+        GTEST_SKIP() << "NIXL_CI_NON_GPU is set, skipping GPU UCX_TLS validation test";
+    }
+
+    envHelper_.addVar("UCX_TLS", "sm");
+
+    const gtest::LogIgnoreGuard lig_tls(
+        "Invalid UCX_TLS=sm.*Add cuda_copy for basic GPU support, or cuda to also include "
+        "NVLink support");
+    const gtest::LogIgnoreGuard lig_backend("backend creation failed for 'UCX'");
+
+    nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
+    nixlBackendH *backend = nullptr;
+    EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_ERR_BACKEND);
+    EXPECT_GE(lig_tls.getIgnoredCount(), 1);
+    EXPECT_EQ(lig_backend.getIgnoredCount(), 1);
 
     envHelper_.popVar();
 }

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -47,8 +47,6 @@ protected:
 
 class UcxTlsValidationTest : public ::testing::Test {
 protected:
-    gtest::ScopedEnv envHelper_;
-
     void
     SetUp() override {
         if (std::getenv("NIXL_CI_NON_GPU") != nullptr ||
@@ -59,7 +57,8 @@ protected:
 
     void
     expectCudaTlsValidationFailure(const std::string &tls) {
-        envHelper_.addVar("UCX_TLS", tls);
+        gtest::ScopedEnv env_helper;
+        env_helper.addVar("UCX_TLS", tls);
 
         const gtest::LogIgnoreGuard lig_tls(
             "Invalid UCX_TLS=.*Add cuda_copy for basic GPU support, or cuda to also include "
@@ -71,19 +70,16 @@ protected:
         EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_ERR_BACKEND);
         EXPECT_GE(lig_tls.getIgnoredCount(), 1);
         EXPECT_EQ(lig_backend.getIgnoredCount(), 1);
-
-        envHelper_.popVar();
     }
 
     void
     expectCudaTlsValidationSuccess(const std::string &tls) {
-        envHelper_.addVar("UCX_TLS", tls);
+        gtest::ScopedEnv env_helper;
+        env_helper.addVar("UCX_TLS", tls);
 
         nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
         nixlBackendH *backend = nullptr;
         EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_SUCCESS);
-
-        envHelper_.popVar();
     }
 };
 

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -61,11 +61,9 @@ protected:
     expectCudaTlsValidationFailure(const std::string &tls) {
         envHelper_.addVar("UCX_TLS", tls);
 
-        const std::string tls_regex = tls.starts_with('^') ? "\\" + tls : tls;
-
         const gtest::LogIgnoreGuard lig_tls(
-            "Invalid UCX_TLS=" + tls_regex +
-            ".*Add cuda_copy for basic GPU support, or cuda to also include NVLink support");
+            "Invalid UCX_TLS=.*Add cuda_copy for basic GPU support, or cuda to also include "
+            "NVLink support");
         const gtest::LogIgnoreGuard lig_backend("backend creation failed for 'UCX'");
 
         nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
@@ -99,19 +97,21 @@ TEST_F(HardwareWarningTest, WarnWhenGpuPresentButCudaNotSupported) {
         GTEST_SKIP() << "No NVIDIA GPUs detected, skipping test";
     }
 
-    // Disable CUDA transport in UCX
-    envHelper_.addVar("UCX_TLS", "^cuda,rc_gda");
-
+    // Configure TLS directly so this test reaches the hardware warning path instead of the
+    // UCX_TLS environment validation path.
     std::vector<std::string> devs;
-    nixlUcxContext ctx(devs, false, 1, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, 0);
+    nixlUcxContext ctx(devs,
+                       false,
+                       1,
+                       nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE,
+                       0,
+                       "TLS=^cuda,rc_gda");
 
     const gtest::LogIgnoreGuard lig(
         "NVIDIA GPU\\(s\\) were detected, but UCX CUDA support was not found");
     ctx.warnAboutHardwareSupportMismatch();
 
     EXPECT_EQ(lig.getIgnoredCount(), 1);
-
-    envHelper_.popVar();
 }
 
 /**
@@ -175,6 +175,8 @@ TEST_F(UcxTlsValidationTest, CudaDenyListFailsWhenCudaIsAvailable) {
 TEST_F(UcxTlsValidationTest, CudaCopyDenyListFailsWhenCudaIsAvailable) {
     expectCudaTlsValidationFailure("^cuda_copy");
     expectCudaTlsValidationFailure("^tcp,cuda_copy");
+    expectCudaTlsValidationFailure("^\\cuda_copy");
+    expectCudaTlsValidationFailure("^tcp,\\cuda_copy");
 }
 
 TEST_F(UcxTlsValidationTest, CudaIpcDenyListSucceedsWhenCudaIsAvailable) {
@@ -183,6 +185,10 @@ TEST_F(UcxTlsValidationTest, CudaIpcDenyListSucceedsWhenCudaIsAvailable) {
 
 TEST_F(UcxTlsValidationTest, AllTlsSucceedsWhenCudaIsAvailable) {
     expectCudaTlsValidationSuccess("all");
+}
+
+TEST_F(UcxTlsValidationTest, EscapedCudaCopyTlsSucceedsWhenCudaIsAvailable) {
+    expectCudaTlsValidationSuccess("tcp,\\cuda_copy");
 }
 
 /**

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -45,6 +45,50 @@ protected:
     }
 };
 
+class UcxTlsValidationTest : public ::testing::Test {
+protected:
+    gtest::ScopedEnv envHelper_;
+
+    void
+    SetUp() override {
+        if (std::getenv("NIXL_CI_NON_GPU") != nullptr ||
+            nixl::hwInfo::instance().numNvidiaGpus == 0) {
+            GTEST_SKIP() << "No available NVIDIA GPUs, skipping GPU UCX_TLS validation test";
+        }
+    }
+
+    void
+    expectCudaTlsValidationFailure(const std::string &tls) {
+        envHelper_.addVar("UCX_TLS", tls);
+
+        const std::string tls_regex = tls.starts_with('^') ? "\\" + tls : tls;
+
+        const gtest::LogIgnoreGuard lig_tls(
+            "Invalid UCX_TLS=" + tls_regex +
+            ".*Add cuda_copy for basic GPU support, or cuda to also include NVLink support");
+        const gtest::LogIgnoreGuard lig_backend("backend creation failed for 'UCX'");
+
+        nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
+        nixlBackendH *backend = nullptr;
+        EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_ERR_BACKEND);
+        EXPECT_GE(lig_tls.getIgnoredCount(), 1);
+        EXPECT_EQ(lig_backend.getIgnoredCount(), 1);
+
+        envHelper_.popVar();
+    }
+
+    void
+    expectCudaTlsValidationSuccess(const std::string &tls) {
+        envHelper_.addVar("UCX_TLS", tls);
+
+        nixlAgent agent("TlsTestAgent", nixlAgentConfig(true));
+        nixlBackendH *backend = nullptr;
+        EXPECT_EQ(agent.createBackend("UCX", {}, backend), NIXL_SUCCESS);
+
+        envHelper_.popVar();
+    }
+};
+
 /**
  * Test that a warning is logged when NVIDIA GPUs are present but UCX
  * CUDA support is not available.
@@ -117,6 +161,28 @@ TEST_F(HardwareWarningTest, NoWarningWhenIbAndCudaSupported) {
     ctx.warnAboutHardwareSupportMismatch();
 
     envHelper_.popVar();
+}
+
+TEST_F(UcxTlsValidationTest, MissingCudaTlsFailsWhenCudaIsAvailable) {
+    expectCudaTlsValidationFailure("sm,tcp");
+}
+
+TEST_F(UcxTlsValidationTest, CudaDenyListFailsWhenCudaIsAvailable) {
+    expectCudaTlsValidationFailure("^cuda");
+    expectCudaTlsValidationFailure("^tcp,cuda");
+}
+
+TEST_F(UcxTlsValidationTest, CudaCopyDenyListFailsWhenCudaIsAvailable) {
+    expectCudaTlsValidationFailure("^cuda_copy");
+    expectCudaTlsValidationFailure("^tcp,cuda_copy");
+}
+
+TEST_F(UcxTlsValidationTest, CudaIpcDenyListSucceedsWhenCudaIsAvailable) {
+    expectCudaTlsValidationSuccess("^cuda_ipc");
+}
+
+TEST_F(UcxTlsValidationTest, AllTlsSucceedsWhenCudaIsAvailable) {
+    expectCudaTlsValidationSuccess("all");
 }
 
 /**

--- a/test/gtest/hw_warning_test.cpp
+++ b/test/gtest/hw_warning_test.cpp
@@ -100,12 +100,8 @@ TEST_F(HardwareWarningTest, WarnWhenGpuPresentButCudaNotSupported) {
     // Configure TLS directly so this test reaches the hardware warning path instead of the
     // UCX_TLS environment validation path.
     std::vector<std::string> devs;
-    nixlUcxContext ctx(devs,
-                       false,
-                       1,
-                       nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE,
-                       0,
-                       "TLS=^cuda,rc_gda");
+    nixlUcxContext ctx(
+        devs, false, 1, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, 0, "TLS=^cuda,rc_gda");
 
     const gtest::LogIgnoreGuard lig(
         "NVIDIA GPU\\(s\\) were detected, but UCX CUDA support was not found");


### PR DESCRIPTION
## What?
This PR adds NIXL-side validation for common invalid `UCX_TLS` settings in the UCX backend.

  What is covered:
   - Fail backend creation when NVIDIA GPU(s) are present, `UCX_TLS` is explicitly set without `cuda` or `cuda_copy`, and the created UCX context does not expose CUDA memory support.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for UCX TLS configurations when NVIDIA GPU support is available.
  - Recognizes supported CUDA transport settings, including `cuda`, `cuda_copy`, escaped `\cuda_copy`, and `all`.
  - Improved detection of CUDA and RDMA hardware capabilities.

- **Bug Fixes**
  - Initialization now fails early with a clear error when required CUDA support is unavailable.
  - Hardware capability query failures are now reported instead of silently ignored.
  - Improved reliability of UCX memory and communication operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->