### PR TITLE
UTILS: Exception throw utility function.

### DIFF
--- a/src/utils/common/configuration.cpp
+++ b/src/utils/common/configuration.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "configuration.h"
+#include "exception.h"
 
 namespace nixl::config {
 
@@ -31,7 +32,7 @@ namespace {
             return toml::parse_file(file.native());
         }
         catch (const std::exception &e) {
-            internal::throwRuntimeError("Error ", e.what(), " reading TOML config file ", file);
+            throwRuntimeError("Error ", e.what(), " reading TOML config file ", file);
         }
     }
 

--- a/src/utils/common/configuration.h
+++ b/src/utils/common/configuration.h
@@ -25,8 +25,6 @@
 #include <filesystem>
 #include <limits>
 #include <optional>
-#include <sstream>
-#include <stdexcept>
 #include <string>
 #include <strings.h>
 #include <type_traits>
@@ -37,6 +35,7 @@
 
 #include <toml++/toml.hpp>
 
+#include "exception.h"
 #include "nixl_log.h"
 #include "nixl_types.h"
 
@@ -49,14 +48,6 @@
 namespace nixl::config {
 
 namespace internal {
-
-    template<typename... Ts>
-    [[noreturn]] void
-    throwRuntimeError(Ts &&...ts) {
-        std::ostringstream oss;
-        (void)(oss << ... << ts);
-        throw std::runtime_error(std::move(oss).str());
-    }
 
     [[nodiscard]] std::optional<std::string>
     getenvOptional(const std::string &name);
@@ -285,7 +276,7 @@ getValue(const std::string &env) {
     if (const auto view = internal::findTomlNode(env)) {
         return traits<type>::convert(view);
     }
-    internal::throwRuntimeError("Missing config entry '", env, "'");
+    throwRuntimeError("Missing config entry '", env, "'");
 }
 
 template<typename type, template<typename...> class traits = internal::convertTraits>
@@ -314,7 +305,7 @@ getNonEmptyString(const std::string &env) {
     const std::string result = getValue<std::string>(env);
 
     if (result.empty()) {
-        internal::throwRuntimeError("Config parameter '", env, "' needs non-empty value");
+        throwRuntimeError("Config parameter '", env, "' needs non-empty value");
     }
     return result;
 }

--- a/src/utils/common/exception.h
+++ b/src/utils/common/exception.h
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_UTILS_COMMON_EXCEPTION_H
+#define NIXL_SRC_UTILS_COMMON_EXCEPTION_H
+
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace nixl {
+
+template<typename... Ts>
+[[noreturn]] void
+throwRuntimeError(Ts &&...ts) {
+    std::ostringstream oss;
+    (void)(oss << ... << ts);
+    throw std::runtime_error(std::move(oss).str());
+}
+
+} // namespace nixl
+
+#endif

--- a/src/utils/common/exception.h
+++ b/src/utils/common/exception.h
@@ -28,7 +28,7 @@ template<typename... Ts>
 [[noreturn]] void
 throwRuntimeError(Ts &&...ts) {
     std::ostringstream oss;
-    (void)(oss << ... << ts);
+    (oss << ... << ts);
     throw std::runtime_error(std::move(oss).str());
 }
 


### PR DESCRIPTION
## What?
Make the utility function `throwRuntimeError` from the config utility generally/separately available.

## Why?
Can and will be used in other places; will not remain the only exception-related utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling for configuration routines, centralizing how runtime errors are produced and ensuring consistent, clearer error messages.
  * No changes to configuration behavior, public interfaces, or loading precedence; end-user functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->