### PR TITLE
PLUGINS/UCX: Revert "Do not allow emulated RMA protocols" - 1.1.0

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -452,9 +452,6 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
     config.modify("RCACHE_MAX_UNRELEASED", "1024");
 
     if (ucpVersion_ >= UCP_VERSION(1, 21)) {
-        config.modify("IB_TX_INLINE_RESP", "0");
-        config.modify("PROTO_EMULATION_ENABLE", "n");
-
         config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
     }
 


### PR DESCRIPTION
## What?
Revert options settings to disable emulated RMA protocols.
