### PR TITLE
CODEOWNERS: Updated owners of /examples/device/ep.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,4 +36,4 @@ CODEOWNERS @ai-dynamo/Devops @ai-dynamo/nixl-maintainers
 /test/unit/utils/libfabric @amitrad-aws @yexiang-aws @akkart-aws @fengjica
 
 # NIXL EP example
-/examples/device/ep @itayalroy @ebarilanM @ofirfarjun7 @ai-dynamo/nixl-maintainers
+/examples/device/ep @itayalroy @ebarilanM @rakhmets @ai-dynamo/nixl-maintainers


### PR DESCRIPTION
## What?
Added `rakhmets` as a code owner of `/examples/device/ep`.
Removed `ofirfarjun7` from code owners of `/examples/device/ep`, as the user is a member of `ai-dynamo/nixl-maintainers`.