### PR TITLE
CI: Rebuild docker images when inputs change, not only on tag bump

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -49,14 +49,17 @@ env:
 runs_on_dockers:
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-25.06-cuda12.9-ubuntu24.04", tag: "${CI_IMAGE_TAG}",
+     deps: ['.gitlab/build.sh', '.ci/scripts/common.sh'],
      build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-25.10-cuda13.0-ubuntu24.04", tag: "${CI_IMAGE_TAG}",
+     deps: ['.gitlab/build.sh', '.ci/scripts/common.sh'],
      build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-13.0.1-ubuntu22.04", tag: "${CI_IMAGE_TAG}",
+     deps: ['.gitlab/build.sh', '.ci/scripts/common.sh'],
      build_args: '--build-arg BASE_IMAGE=dockerhub.nvidia.com/nvidia/cuda:13.0.1-devel-ubuntu22.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
 

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -67,6 +67,7 @@ runs_on_dockers:
      name: 'nixl-ci-dl-gpu-base-25.10-cuda13.0-ubuntu24.04',
      tag: "${CI_IMAGE_TAG}",
      arch: "aarch64",
+     deps: ['.gitlab/build.sh', '.ci/scripts/common.sh'],
      build_args: '--build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04 --build-arg PRE_INSTALLED_UCX_ENV=true --build-arg PRE_INSTALLED_NIXL_ENV=true --build-arg ARCH=${arch} --pull --no-cache'
     }
 

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -65,6 +65,7 @@ runs_on_dockers:
      file: '.ci/dockerfiles/Dockerfile.base',
      name: 'nixl-ci-gpu-base-25.10-cuda13.0-ubuntu24.04',
      tag: "${CI_IMAGE_TAG}",
+     deps: ['.gitlab/build.sh', '.ci/scripts/common.sh'],
      build_args: '--build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR}  --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04 --build-arg PRE_INSTALLED_UCX_ENV=true --build-arg PRE_INSTALLED_NIXL_ENV=true --build-arg ARCH=${arch} --pull --no-cache'
     }
   - {


### PR DESCRIPTION

## What?
Make ci-demo automatically rebuild base CI images when their build inputs change.

## Why?
A follow-up push that edits a tracked CI file without re-bumping CI_IMAGE_TAG silently reuses the stale image already in the registry, so the change never reaches CI. The existing tag-bump check misses this on a squash + amend push.

## How?
Declare the relevant build inputs as ci-demo deps: so the matrix engine rebuilds whenever any of them change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/Jenkins build configurations to improve dependency tracking for Docker build contexts across GPU and non-GPU build matrices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->