### PR TITLE
libfabric: use FI_MORE with EP pinning

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1077,7 +1077,9 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
             [backend_handle]() {
                 backend_handle->increment_completed_requests();
             }, // Completion callback
-            submitted_count);
+            submitted_count,
+            desc_idx,
+            desc_count);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1029,6 +1029,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
     size_t total_submitted = 0;
 
     // Core transfer submission to process each descriptor with direct submission
+    // Reserve base_offset once per transfer so all descriptors see a stable rail assignment
+    const size_t xfer_base_offset = rail_manager.reserveBaseOffset();
     for (int desc_idx = 0; desc_idx < desc_count; ++desc_idx) {
         auto *local_md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
         auto *remote_md = static_cast<nixlLibfabricPublicMetadata *>(remote[desc_idx].metadataP);
@@ -1079,7 +1081,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
             }, // Completion callback
             submitted_count,
             desc_idx,
-            desc_count);
+            desc_count,
+            xfer_base_offset);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1203,8 +1203,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
                             fi_addr_t dest_addr,
                             uint64_t remote_addr,
                             uint64_t remote_key,
-                            nixlLibfabricReq *req,
-                            uint64_t fi_flags) const {
+                            nixlLibfabricReq *req) const {
     // Validation
     if (!req) {
         NIXL_ERROR << "Invalid request for read on rail " << rail_id;
@@ -1220,30 +1219,18 @@ nixlLibfabricRail::postRead(void *local_buffer,
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
-    struct iovec iov{};
-
-    iov.iov_base = local_buffer;
-    iov.iov_len = length;
-
-    struct fi_rma_iov rma_iov{};
-
-    rma_iov.addr = remote_addr;
-    rma_iov.len = length;
-    rma_iov.key = remote_key;
-    struct fi_msg_rma msg = {};
-    msg.msg_iov = &iov;
-    msg.desc = &local_desc;
-    msg.iov_count = 1;
-    msg.addr = dest_addr;
-    msg.rma_iov = &rma_iov;
-    msg.rma_iov_count = 1;
-    msg.context = &req->ctx;
-
     while (true) {
-        // Libfabric fi_readmsg call (supports FI_MORE flag)
+        // Libfabric fi_read call
         {
             const std::lock_guard<std::mutex> ep_lock(ep_mutex_);
-            ret = fi_readmsg(endpoint, &msg, fi_flags);
+            ret = fi_read(endpoint,
+                          local_buffer,
+                          length,
+                          local_desc,
+                          dest_addr,
+                          remote_addr,
+                          remote_key,
+                          &req->ctx);
         }
 
         if (ret == 0) {

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1124,8 +1124,16 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
-    struct iovec iov = {.iov_base = const_cast<void *>(local_buffer), .iov_len = length};
-    struct fi_rma_iov rma_iov = {.addr = remote_addr, .len = length, .key = remote_key};
+    struct iovec iov{};
+
+    iov.iov_base = const_cast<void *>(local_buffer);
+    iov.iov_len = length;
+
+    struct fi_rma_iov rma_iov{};
+
+    rma_iov.addr = remote_addr;
+    rma_iov.len = length;
+    rma_iov.key = remote_key;
     struct fi_msg_rma msg = {};
     msg.msg_iov = &iov;
     msg.desc = &local_desc;
@@ -1212,8 +1220,16 @@ nixlLibfabricRail::postRead(void *local_buffer,
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
-    struct iovec iov = {.iov_base = local_buffer, .iov_len = length};
-    struct fi_rma_iov rma_iov = {.addr = remote_addr, .len = length, .key = remote_key};
+    struct iovec iov{};
+
+    iov.iov_base = local_buffer;
+    iov.iov_len = length;
+
+    struct fi_rma_iov rma_iov{};
+
+    rma_iov.addr = remote_addr;
+    rma_iov.len = length;
+    rma_iov.key = remote_key;
     struct fi_msg_rma msg = {};
     msg.msg_iov = &iov;
     msg.desc = &local_desc;

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1107,7 +1107,8 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                              fi_addr_t dest_addr,
                              uint64_t remote_addr,
                              uint64_t remote_key,
-                             nixlLibfabricReq *req) const {
+                             nixlLibfabricReq *req,
+                             uint64_t fi_flags) const {
     // Validation
     if (!req) {
         NIXL_ERROR << "Invalid request for write on rail " << rail_id;
@@ -1123,19 +1124,23 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
+    struct iovec iov = {.iov_base = const_cast<void *>(local_buffer), .iov_len = length};
+    struct fi_rma_iov rma_iov = {.addr = remote_addr, .len = length, .key = remote_key};
+    struct fi_msg_rma msg = {};
+    msg.msg_iov = &iov;
+    msg.desc = &local_desc;
+    msg.iov_count = 1;
+    msg.addr = dest_addr;
+    msg.rma_iov = &rma_iov;
+    msg.rma_iov_count = 1;
+    msg.context = &req->ctx;
+    msg.data = immediate_data;
+
     while (true) {
-        // Libfabric fi_writedata call
+        // Libfabric fi_writemsg call (supports FI_MORE flag)
         {
             const std::lock_guard<std::mutex> ep_lock(ep_mutex_);
-            ret = fi_writedata(endpoint,
-                               local_buffer,
-                               length,
-                               local_desc,
-                               immediate_data,
-                               dest_addr,
-                               remote_addr,
-                               remote_key,
-                               &req->ctx);
+            ret = fi_writemsg(endpoint, &msg, fi_flags | FI_REMOTE_CQ_DATA);
         }
 
         if (ret == 0) {
@@ -1190,7 +1195,8 @@ nixlLibfabricRail::postRead(void *local_buffer,
                             fi_addr_t dest_addr,
                             uint64_t remote_addr,
                             uint64_t remote_key,
-                            nixlLibfabricReq *req) const {
+                            nixlLibfabricReq *req,
+                            uint64_t fi_flags) const {
     // Validation
     if (!req) {
         NIXL_ERROR << "Invalid request for read on rail " << rail_id;
@@ -1206,18 +1212,22 @@ nixlLibfabricRail::postRead(void *local_buffer,
     int ret = -FI_EAGAIN;
     int attempt = 0;
 
+    struct iovec iov = {.iov_base = local_buffer, .iov_len = length};
+    struct fi_rma_iov rma_iov = {.addr = remote_addr, .len = length, .key = remote_key};
+    struct fi_msg_rma msg = {};
+    msg.msg_iov = &iov;
+    msg.desc = &local_desc;
+    msg.iov_count = 1;
+    msg.addr = dest_addr;
+    msg.rma_iov = &rma_iov;
+    msg.rma_iov_count = 1;
+    msg.context = &req->ctx;
+
     while (true) {
-        // Libfabric fi_read call
+        // Libfabric fi_readmsg call (supports FI_MORE flag)
         {
             const std::lock_guard<std::mutex> ep_lock(ep_mutex_);
-            ret = fi_read(endpoint,
-                          local_buffer,
-                          length,
-                          local_desc,
-                          dest_addr,
-                          remote_addr,
-                          remote_key,
-                          &req->ctx);
+            ret = fi_readmsg(endpoint, &msg, fi_flags);
         }
 
         if (ret == 0) {

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -314,7 +314,8 @@ public:
               fi_addr_t dest_addr,
               uint64_t remote_addr,
               uint64_t remote_key,
-              nixlLibfabricReq *req) const;
+              nixlLibfabricReq *req,
+              uint64_t fi_flags = 0) const;
 
     /** Post RDMA read operation */
     nixl_status_t
@@ -324,7 +325,8 @@ public:
              fi_addr_t dest_addr,
              uint64_t remote_addr,
              uint64_t remote_key,
-             nixlLibfabricReq *req) const;
+             nixlLibfabricReq *req,
+             uint64_t fi_flags = 0) const;
 
     /** Process completion queue with batching support */
     nixl_status_t

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -325,8 +325,7 @@ public:
              fi_addr_t dest_addr,
              uint64_t remote_addr,
              uint64_t remote_key,
-             nixlLibfabricReq *req,
-             uint64_t fi_flags = 0) const;
+             nixlLibfabricReq *req) const;
 
     /** Process completion queue with batching support */
     nixl_status_t

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -394,26 +394,19 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
-        // Round-robin with FI_MORE batching: group 16 consecutive descs to same rail
-        // then rotate. This ensures doorbell flush every 16 ops on the same rail.
-        // Use atomic counter as base offset so concurrent postXfer calls distribute
-        // across rails instead of all starting from rail 0.
+        // WRITE: group 16 consecutive descs to same rail for FI_MORE batching.
+        // READ: per-descriptor round-robin (FI_MORE has no benefit for reads).
         constexpr int FI_MORE_BATCH_SIZE = 16;
-        // base_offset is reserved once per transfer by the caller (postXfer)
-        // and passed in, ensuring all descriptors in a transfer see a stable
-        // value even under concurrent postXfer calls.
-        const size_t group_idx = base_offset + desc_idx / FI_MORE_BATCH_SIZE;
-        const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
-        bool is_last_in_group =
-            (pos_in_group == FI_MORE_BATCH_SIZE - 1) || (desc_idx == desc_count - 1);
-
-        // Use group_idx for rail selection (same rail for 16 consecutive descs)
-        const size_t rail_id = selected_rails[group_idx % selected_rails.size()];
+        const bool batch_write = (op_type == nixlLibfabricReq::WRITE);
+        const size_t rr_idx =
+            batch_write ? (base_offset + desc_idx / FI_MORE_BATCH_SIZE) : (base_offset + desc_idx);
+        const size_t rail_id = selected_rails[rr_idx % selected_rails.size()];
         const size_t remote_ep_id =
-            remote_selected_endpoints[group_idx % remote_selected_endpoints.size()];
-
-        // FI_MORE: defer doorbell for first 15, flush on 16th or last desc
-        uint64_t fi_flags = is_last_in_group ? 0 : FI_MORE;
+            remote_selected_endpoints[rr_idx % remote_selected_endpoints.size()];
+        const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
+        const bool is_last_in_group =
+            (pos_in_group == FI_MORE_BATCH_SIZE - 1) || (desc_idx == desc_count - 1);
+        const uint64_t fi_flags = (batch_write && !is_last_in_group) ? FI_MORE : 0;
         NIXL_DEBUG << "rail " << rail_id << ", remote_ep_id " << remote_ep_id;
         // Allocate request
         nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
@@ -464,8 +457,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                dest_addrs.at(rail_id)[remote_ep_id],
                                                req->remote_addr,
                                                req->remote_key,
-                                               req,
-                                               fi_flags);
+                                               req);
         }
         if (status != NIXL_SUCCESS) {
             // Release the allocated request back to pool on failure
@@ -547,8 +539,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                    dest_addrs.at(rail_id)[remote_ep_id],
                                                    req->remote_addr,
                                                    req->remote_key,
-                                                   req,
-                                                   fi_flags);
+                                                   req);
             }
             if (status != NIXL_SUCCESS) {
                 // This request failed to submit - release it immediately

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -373,7 +373,9 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     uint16_t agent_idx,
     uint16_t xfer_id,
     std::function<void()> completion_callback,
-    size_t &submitted_count_out) {
+    size_t &submitted_count_out,
+    int desc_idx,
+    int desc_count) {
     // Initialize output parameter
     submitted_count_out = 0;
 
@@ -386,11 +388,25 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
-        // Round-robin: use one rail for entire transfer
-        const auto counter_value = round_robin_counter.fetch_add(1);
-        const size_t rail_id = selected_rails[counter_value % selected_rails.size()];
+        // Round-robin with FI_MORE batching: group 16 consecutive descs to same rail
+        // then rotate. This ensures doorbell flush every 16 ops on the same rail.
+        // Use atomic counter as base offset so concurrent postXfer calls distribute
+        // across rails instead of all starting from rail 0.
+        constexpr int FI_MORE_BATCH_SIZE = 16;
+        const size_t base_offset =
+            (desc_idx == 0) ? round_robin_counter.fetch_add(1) : round_robin_counter.load();
+        const size_t group_idx = base_offset + desc_idx / FI_MORE_BATCH_SIZE;
+        const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
+        bool is_last_in_group =
+            (pos_in_group == FI_MORE_BATCH_SIZE - 1) || (desc_idx == desc_count - 1);
+
+        // Use group_idx for rail selection (same rail for 16 consecutive descs)
+        const size_t rail_id = selected_rails[group_idx % selected_rails.size()];
         const size_t remote_ep_id =
-            remote_selected_endpoints[counter_value % remote_selected_endpoints.size()];
+            remote_selected_endpoints[group_idx % remote_selected_endpoints.size()];
+
+        // FI_MORE: defer doorbell for first 15, flush on 16th or last desc
+        uint64_t fi_flags = is_last_in_group ? 0 : FI_MORE;
         NIXL_DEBUG << "rail " << rail_id << ", remote_ep_id " << remote_ep_id;
         // Allocate request
         nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
@@ -432,7 +448,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                 dest_addrs.at(rail_id)[remote_ep_id],
                                                 req->remote_addr,
                                                 req->remote_key,
-                                                req);
+                                                req,
+                                                fi_flags);
         } else {
             status = rails_[rail_id]->postRead(req->local_addr,
                                                req->chunk_size,
@@ -440,7 +457,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                dest_addrs.at(rail_id)[remote_ep_id],
                                                req->remote_addr,
                                                req->remote_key,
-                                               req);
+                                               req,
+                                               fi_flags);
         }
         if (status != NIXL_SUCCESS) {
             // Release the allocated request back to pool on failure
@@ -458,7 +476,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                    << transfer_size << " bytes, XFER_ID=" << req->xfer_id;
 
     } else {
-        // Striping: distribute across multiple rails
+        // Striping: distribute across multiple rails (no FI_MORE for striped transfers)
+        uint64_t fi_flags = 0;
         size_t num_rails = selected_rails.size();
         size_t chunk_size = transfer_size / num_rails;
         size_t remainder = transfer_size % num_rails;
@@ -512,7 +531,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                     dest_addrs.at(rail_id)[remote_ep_id],
                                                     req->remote_addr,
                                                     req->remote_key,
-                                                    req);
+                                                    req,
+                                                    fi_flags);
             } else {
                 status = rails_[rail_id]->postRead(req->local_addr,
                                                    req->chunk_size,
@@ -520,7 +540,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                                                    dest_addrs.at(rail_id)[remote_ep_id],
                                                    req->remote_addr,
                                                    req->remote_key,
-                                                   req);
+                                                   req,
+                                                   fi_flags);
             }
             if (status != NIXL_SUCCESS) {
                 // This request failed to submit - release it immediately

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -358,6 +358,11 @@ nixlLibfabricRailManager::shouldUseStriping(size_t transfer_size) const {
     return transfer_size >= striping_threshold_;
 }
 
+size_t
+nixlLibfabricRailManager::reserveBaseOffset() {
+    return round_robin_counter.fetch_add(1);
+}
+
 nixl_status_t
 nixlLibfabricRailManager::prepareAndSubmitTransfer(
     nixlLibfabricReq::OpType op_type,
@@ -375,7 +380,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     std::function<void()> completion_callback,
     size_t &submitted_count_out,
     int desc_idx,
-    int desc_count) {
+    int desc_count,
+    size_t base_offset) {
     // Initialize output parameter
     submitted_count_out = 0;
 
@@ -393,8 +399,9 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         // Use atomic counter as base offset so concurrent postXfer calls distribute
         // across rails instead of all starting from rail 0.
         constexpr int FI_MORE_BATCH_SIZE = 16;
-        const size_t base_offset =
-            (desc_idx == 0) ? round_robin_counter.fetch_add(1) : round_robin_counter.load();
+        // base_offset is reserved once per transfer by the caller (postXfer)
+        // and passed in, ensuring all descriptors in a transfer see a stable
+        // value even under concurrent postXfer calls.
         const size_t group_idx = base_offset + desc_idx / FI_MORE_BATCH_SIZE;
         const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
         bool is_last_in_group =

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -217,9 +217,9 @@ public:
                              uint16_t xfer_id,
                              std::function<void()> completion_callback,
                              size_t &submitted_count_out,
-                             int desc_idx = 0,
-                             int desc_count = 1,
-                             size_t base_offset = 0);
+                             int desc_idx,
+                             int desc_count,
+                             size_t base_offset);
 
     /** Reserve a base offset for a transfer to ensure stable rail assignment
      *  across all descriptors in the transfer. Call once per postXfer. */

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -197,6 +197,9 @@ public:
      * @param xfer_id Transfer ID for tracking
      * @param completion_callback Callback for completion notification
      * @param submitted_count_out Number of requests successfully submitted
+     * @param desc_idx Index of current descriptor within the transfer
+     * @param desc_count Total number of descriptors in the transfer
+     * @param base_offset Pre-reserved round-robin offset from reserveBaseOffset()
      * @return NIXL_SUCCESS on success, error code on failure
      */
     nixl_status_t
@@ -215,7 +218,13 @@ public:
                              std::function<void()> completion_callback,
                              size_t &submitted_count_out,
                              int desc_idx = 0,
-                             int desc_count = 1);
+                             int desc_count = 1,
+                             size_t base_offset = 0);
+
+    /** Reserve a base offset for a transfer to ensure stable rail assignment
+     *  across all descriptors in the transfer. Call once per postXfer. */
+    size_t
+    reserveBaseOffset();
     /** Determine if striping should be used for given transfer size
      * @param transfer_size Size of the transfer in bytes
      * @return true if striping should be used, false for round-robin

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -213,7 +213,9 @@ public:
                              uint16_t agent_idx,
                              uint16_t xfer_id,
                              std::function<void()> completion_callback,
-                             size_t &submitted_count_out);
+                             size_t &submitted_count_out,
+                             int desc_idx = 0,
+                             int desc_count = 1);
     /** Determine if striping should be used for given transfer size
      * @param transfer_size Size of the transfer in bytes
      * @return true if striping should be used, false for round-robin


### PR DESCRIPTION
Use fi_writemsg()/fi_readmsg() with FI_MORE flag to batch 16 descriptors
before flushing the doorbell to the EFA device. Consecutive descriptors
are pinned to the same rail (EP pinning), ensuring all
FI_MORE ops and the final flush go to the same endpoint.

This reduces PCIe doorbell round trips for small-message
high-descriptor-count transfers while correctly handling any batch size
(including non-16-aligned).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * More consistent rail/endpoint assignment across multi-descriptor transfers for steadier throughput.
  * Descriptor-aware grouping and per-descriptor control flags to improve pipelining and reduce stalls on non-final segments.
  * Switched to message-oriented remote read/write submissions for more efficient and reliable transfer handling.
  * Reduced contention when submitting multi-descriptor transfers for more stable concurrency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1626)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->