### PR TITLE
nixl_ep: remove CUDA_VISIBLE_DEVICES from elastic.py

### DIFF
--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -482,7 +482,7 @@ def worker(torch_rank: int, args: argparse.Namespace):
     # Initialize torch
     torch.set_default_dtype(torch.bfloat16)
     torch.set_default_device("cuda")
-    torch.cuda.set_device(local_rank % 8)
+    torch.cuda.set_device(local_rank % torch.cuda.device_count())
 
     tcp_store = store_group.create_client_store(
         master_addr=server_addr,

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -480,10 +480,9 @@ def worker(torch_rank: int, args: argparse.Namespace):
     )
 
     # Initialize torch
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(local_rank % 8)
     torch.set_default_dtype(torch.bfloat16)
     torch.set_default_device("cuda")
-    torch.cuda.set_device(0)
+    torch.cuda.set_device(local_rank % 8)
 
     tcp_store = store_group.create_client_store(
         master_addr=server_addr,


### PR DESCRIPTION
What?

This PR updates elastic.py to remove CUDA_VISIBLE_DEVICES and to set the CUDA device directly from local_rank.

Why?

Avoid CUDA_VISIBLE_DEVICES so that UCX/DOCA can see all GPUs for GPU-initiated RDMA when needed.

This change avoids that and makes elastic.py match test_ht.py.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Improved GPU selection in distributed testing so each worker binds to an appropriate visible GPU based on its runtime rank, yielding more reliable and balanced device allocation across nodes during test runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1629)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->