### PR TITLE
test(obj): Increase unit test coverage for Dell ObjectScale accelerated engine

### DIFF
--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -13,10 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+obj_test_sources = ['obj.cpp']
+
+if cuobj_dep.found()
+    obj_test_sources += ['obj_cuobj.cpp']
+endif
+
 obj_unit_test_dep = declare_dependency(
-    sources: [
-        'obj.cpp',
-    ],
+    sources: obj_test_sources,
     include_directories: [
         nixl_inc_dirs, utils_inc_dirs,
         '../../../../src/plugins/obj',

--- a/test/gtest/unit/obj/obj_cuobj.cpp
+++ b/test/gtest/unit/obj/obj_cuobj.cpp
@@ -1,0 +1,711 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for all cuobjclient based accelerated engine unit tests.
+ *
+ * This file is only built when the cuobjclient library is available.
+ * It exercises the Dell S3-over-RDMA code path and adds the Accel/Dell
+ * configurations to the common parameterized test suite.
+ */
+#include "obj_test_base.h"
+
+namespace gtest::obj {
+
+// Accel and Dell test configurations for the common parameterized tests
+static const ObjTestConfig accelConfig = {"Accel",
+                                          {{"accelerated", "true"}},
+                                          "test-accel-agent",
+                                          false};
+static const ObjTestConfig dellConfig = {"Dell",
+                                         {{"accelerated", "true"}, {"type", "dell"}},
+                                         "test-dell-agent",
+                                         true};
+
+// Parameterized test fixture is defined in obj.cpp; add Accel/Dell instantiations here
+INSTANTIATE_TEST_SUITE_P(ObjAccelClientTests,
+                         objParamTestFixture,
+                         testing::Values(accelConfig, dellConfig),
+                         [](const testing::TestParamInfo<ObjTestConfig> &info) {
+                             return info.param.name;
+                         });
+
+/**
+ * Dell ObjectScale accelerated engine test fixture.
+ *
+ * Exercises the Dell S3-over-RDMA code path by configuring the OBJ engine
+ * with accelerated=true and type=dell. Uses mockDellS3Client to simulate
+ * RDMA put/get operations via the iDellS3RdmaClient interface without
+ * requiring real cuobjclient or ObjectScale infrastructure.
+ */
+class objDellTestFixture : public objTestBase, public testing::Test {
+protected:
+    void
+    SetUp() override {
+        setupEngine("test-dell-agent", {{"accelerated", "true"}, {"type", "dell"}});
+    }
+};
+
+/** End-to-end RDMA write through the Dell accelerated engine. */
+TEST_F(objDellTestFixture, DellRdmaWriteWithDescriptor) {
+    testTransferWithSize(NIXL_WRITE, 1024, "-dell-rdma");
+}
+
+/** RDMA read at a non-zero object offset; verifies data correctness. */
+TEST_F(objDellTestFixture, DellRdmaReadWithOffset) {
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(256);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "dell-rdma-read-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    const size_t offset = 512;
+    const size_t length = 256;
+    nixlMetaDesc local_meta_desc(local_desc.addr, length, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(offset, length, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(objEngine_->prepXfer(
+                  NIXL_READ, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_SUCCESS);
+
+    nixl_status_t status = objEngine_->postXfer(
+        NIXL_READ, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    mockS3Client_->execAsync();
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_EQ(test_buffer[0], 'A' + (offset % 26));
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** Dell engine advertises VRAM_SEG support and can register VRAM memory. */
+TEST_F(objDellTestFixture, DellVramMemorySupport) {
+    auto supported_mems = objEngine_->getSupportedMems();
+    EXPECT_TRUE(std::find(supported_mems.begin(), supported_mems.end(), VRAM_SEG) !=
+                supported_mems.end());
+
+    std::vector<char> test_buffer1(512);
+    std::fill(test_buffer1.begin(), test_buffer1.end(), 'A');
+    nixlBlobDesc vram_desc;
+
+    vram_desc.addr = reinterpret_cast<uintptr_t>(test_buffer1.data());
+    vram_desc.len = test_buffer1.size();
+    vram_desc.devId = 3;
+    nixlBackendMD *vram_metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(vram_desc, VRAM_SEG, vram_metadata);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(vram_metadata, nullptr);
+
+    objEngine_->deregisterMem(vram_metadata);
+}
+
+/** Multi-descriptor RDMA write with two different buffer sizes. */
+TEST_F(objDellTestFixture, DellMultiDescriptorRdmaOperations) {
+    testMultiDescriptorWithSizes(NIXL_WRITE, 512, 1024, "-dell-multi");
+}
+
+/** prepXfer rejects an invalid (out-of-range) transfer operation enum. */
+TEST_F(objDellTestFixture, DellEngineInvalidOperationType) {
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "invalid-op-test";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+
+    // Test invalid operation type (using a cast to simulate invalid enum)
+    nixl_xfer_op_t invalid_op = static_cast<nixl_xfer_op_t>(999);
+    nixl_status_t status = objEngine_->prepXfer(
+        invalid_op, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail due to invalid operation
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer rejects OBJ_SEG as the local descriptor segment type. */
+TEST_F(objDellTestFixture, DellEngineInvalidLocalMemoryType) {
+    // Test that Dell engine rejects invalid local memory type in prepXfer
+    nixlBlobDesc local_desc, remote_desc;
+    nixlBackendMD *local_metadata = nullptr, *remote_metadata = nullptr;
+
+    // Register both as OBJ_SEG
+    local_desc.devId = 1;
+    local_desc.metaInfo = "local-obj-key";
+    ASSERT_EQ(objEngine_->registerMem(local_desc, OBJ_SEG, local_metadata), NIXL_SUCCESS);
+
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "remote-obj-key";
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(OBJ_SEG); // Invalid - should be DRAM/VRAM
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    char dummy[1024];
+    nixlMetaDesc local_meta_desc(reinterpret_cast<uintptr_t>(dummy), 1024, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail due to invalid local memory type
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer rejects a non-OBJ_SEG remote descriptor segment type. */
+TEST_F(objDellTestFixture, DellEngineInvalidRemoteMemoryType) {
+    // Test that Dell engine rejects non-OBJ_SEG remote memory type in prepXfer
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(DRAM_SEG); // Invalid - should be OBJ_SEG
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, 2);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+}
+
+/** prepXfer rejects mismatched local/remote descriptor list sizes. */
+TEST_F(objDellTestFixture, DellEngineMismatchedDescriptorCounts) {
+    // Test that Dell engine rejects mismatched local/remote descriptor counts
+    std::vector<char> test_buffer1(512);
+    std::vector<char> test_buffer2(512);
+
+    nixlBlobDesc local_desc1, local_desc2;
+    local_desc1.addr = reinterpret_cast<uintptr_t>(test_buffer1.data());
+    local_desc1.len = test_buffer1.size();
+    local_desc1.devId = 1;
+    local_desc2.addr = reinterpret_cast<uintptr_t>(test_buffer2.data());
+    local_desc2.len = test_buffer2.size();
+    local_desc2.devId = 2;
+    nixlBackendMD *local_metadata1 = nullptr, *local_metadata2 = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc1, DRAM_SEG, local_metadata1), NIXL_SUCCESS);
+    ASSERT_EQ(objEngine_->registerMem(local_desc2, DRAM_SEG, local_metadata2), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 3;
+    remote_desc.metaInfo = "mismatch-test-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Add 2 local descriptors but only 1 remote descriptor
+    nixlMetaDesc local_meta_desc1(local_desc1.addr, local_desc1.len, local_desc1.devId);
+    nixlMetaDesc local_meta_desc2(local_desc2.addr, local_desc2.len, local_desc2.devId);
+    nixlMetaDesc remote_meta_desc(0, 512, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc1);
+    local_descs.addDesc(local_meta_desc2);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata1);
+    objEngine_->deregisterMem(local_metadata2);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer fails when the remote devId has no registered OBJ_SEG mapping. */
+TEST_F(objDellTestFixture, DellUnregisteredRemoteDevId) {
+    // Test that Dell engine rejects transfers when remote devId is not registered
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    // Register an OBJ_SEG with devId=2, but use devId=999 in the descriptor
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "registered-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    // Use devId=999 which was never registered
+    nixlMetaDesc remote_meta_desc(0, 1024, 999);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** registerMem rejects unsupported segment types (BLK_SEG, FILE_SEG). */
+TEST_F(objDellTestFixture, DellRegisterMemUnsupportedType) {
+    // Test that Dell engine rejects unsupported memory types
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, BLK_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Also test FILE_SEG
+    status = objEngine_->registerMem(mem_desc, FILE_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** registerMem rejects DRAM/VRAM buffers exceeding CUOBJ_MAX_MEMORY_REG_SIZE (4 GiB). */
+TEST_F(objDellTestFixture, DellRegisterMemExceedsMaxSize) {
+    // Test that registerMem rejects DRAM/VRAM buffers larger than CUOBJ_MAX_MEMORY_REG_SIZE (4
+    // GiB). This constant is defined in cuobjclient.h; keep in sync if it changes.
+    constexpr size_t kMaxMemRegSize = 4ULL * 1024 * 1024 * 1024;
+    std::vector<char> dummy(1);
+
+    nixlBlobDesc mem_desc;
+    mem_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    mem_desc.len = kMaxMemRegSize + 1;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, DRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Same check for VRAM_SEG
+    metadata = nullptr;
+    status = objEngine_->registerMem(mem_desc, VRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** prepXfer handles zero-length descriptors without crashing. */
+TEST_F(objDellTestFixture, DellEngineZeroSizePrep) {
+    // Test that prepXfer accepts zero-size descriptors without crashing.
+    // Note: both putObjectRdmaAsync and getObjectRdmaAsync in client.cpp
+    // reject data_len==0, so a zero-size transfer would fail at postXfer
+    // in production. This test only verifies prepXfer handles the edge case.
+    mockS3Client_->setSimulateSuccess(true);
+
+    nixlBlobDesc local_desc;
+    std::vector<char> dummy(1);
+    local_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    local_desc.len = 1;
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    // registerMem calls into cuMemObjGetDescriptor which requires a non-zero length buffer
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "zero-size-test";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Create meta descriptions with zero size
+    nixlMetaDesc local_meta_desc(local_desc.addr, 0, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 0, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should handle zero size gracefully
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    if (handle) {
+        objEngine_->releaseReqH(handle);
+    }
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** Simulated RDMA write failure propagates error status through checkXfer. */
+TEST_F(objDellTestFixture, DellWriteTransferFailure) {
+    testTransferFailure(NIXL_WRITE, 1024, "-dell-fail-write");
+}
+
+/** Simulated RDMA read failure propagates error status through checkXfer. */
+TEST_F(objDellTestFixture, DellReadTransferFailure) {
+    testTransferFailure(NIXL_READ, 1024, "-dell-fail-read");
+}
+
+/** Multi-descriptor RDMA read with data-content verification. */
+TEST_F(objDellTestFixture, DellMultiDescriptorReadVerifyData) {
+    testMultiDescriptorWithSizes(NIXL_READ, 512, 256, "-dell-multi-read");
+}
+
+/** Agent name mismatch between prepXfer and engine logs a warning but succeeds. */
+TEST_F(objDellTestFixture, DellAgentMismatchWarning) {
+    // Test that agent mismatch produces a warning but does not fail
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "agent-mismatch-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    // Pass a different remote_agent than the engine's localAgent
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, "different-agent", handle, nullptr);
+
+    // Should succeed (mismatch is only a warning, not an error)
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(handle, nullptr);
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** OBJ_SEG registration with empty metaInfo auto-generates a key from devId. */
+TEST_F(objDellTestFixture, DellObjSegAutoKeyGeneration) {
+    // Test that OBJ_SEG with empty metaInfo auto-generates key from devId
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 42;
+    mem_desc.metaInfo = ""; // Empty key - engine will generate from devId
+
+    nixlBackendMD *metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(mem_desc, OBJ_SEG, metadata), NIXL_SUCCESS);
+    ASSERT_NE(metadata, nullptr);
+
+    // Verify the key is used by attempting a transfer
+    std::vector<char> test_buffer(256);
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), mem_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    // The auto-generated key should be "42" (from devId)
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    if (handle) {
+        objEngine_->releaseReqH(handle);
+    }
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(metadata);
+}
+
+/** Deregistering an OBJ_SEG removes its devId-to-key mapping; subsequent transfers fail. */
+TEST_F(objDellTestFixture, DellDeregisterObjSegCleansMapping) {
+    // Test that deregistering OBJ_SEG cleans up the devId-to-key mapping
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 10;
+    remote_desc.metaInfo = "deregister-cleanup-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    // Deregister the OBJ_SEG
+    ASSERT_EQ(objEngine_->deregisterMem(remote_metadata), NIXL_SUCCESS);
+
+    // Now try to use the devId in a transfer - should fail because mapping was cleaned
+    std::vector<char> test_buffer(256);
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 256, 10); // devId=10, no longer registered
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail because devId 10 mapping was removed
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+}
+
+/** checkXfer returns NIXL_IN_PROG before mock callbacks are executed. */
+TEST_F(objDellTestFixture, DellCheckXferBeforeExecAsync) {
+    // Test checkXfer returns NIXL_IN_PROG before callbacks are executed
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "check-before-exec-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(objEngine_->prepXfer(
+                  NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_SUCCESS);
+
+    nixl_status_t status = objEngine_->postXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Check before executing async callbacks - should still be in progress
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Now execute and verify completion
+    mockS3Client_->execAsync();
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** registerMem rejects zero-length DRAM/VRAM buffers with NIXL_ERR_BACKEND. */
+TEST_F(objDellTestFixture, DellRegisterMemZeroLengthBuffer) {
+    // Test that cuMemObjGetDescriptor fails when given a zero-length buffer
+    std::vector<char> dummy(1);
+
+    nixlBlobDesc mem_desc;
+    mem_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    mem_desc.len = 0;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, DRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Same check for VRAM_SEG
+    metadata = nullptr;
+    status = objEngine_->registerMem(mem_desc, VRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** prepXfer fails when the local buffer address was never registered with cuObj. */
+TEST_F(objDellTestFixture, DellPrepXferUnregisteredAddress) {
+    // Test that cuObjPut fails when the local address was never registered with cuObj
+    std::vector<char> registered_buffer(1024);
+    std::vector<char> unregistered_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(registered_buffer.data());
+    local_desc.len = registered_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "unregistered-addr-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Use unregistered_buffer's address - not registered with cuMemObjGetDescriptor
+    nixlMetaDesc local_meta_desc(reinterpret_cast<uintptr_t>(unregistered_buffer.data()),
+                                 unregistered_buffer.size(),
+                                 local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, unregistered_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer fails when the local address exceeds the 16 MiB RDMA descriptor coverage limit. */
+TEST_F(objDellTestFixture, DellPrepXferLargeMemoryOffset) {
+    // Test that cuObjPut fails when the local address is more than 16 MB from the
+    // base address of the registered memory region.
+    // This is a cuObject library constraint on RDMA descriptor coverage.
+    constexpr size_t k16MiB = 16ULL * 1024 * 1024;
+    constexpr size_t kBufSize = k16MiB + 4096;
+    std::vector<char> large_buffer(kBufSize);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(large_buffer.data());
+    local_desc.len = large_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "large-offset-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Use an address > 16 MiB from the registered base
+    uintptr_t offset_addr = reinterpret_cast<uintptr_t>(large_buffer.data()) + k16MiB + 1;
+    nixlMetaDesc local_meta_desc(offset_addr, 1024, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+} // namespace gtest::obj

--- a/test/gtest/unit/obj/obj_test_base.h
+++ b/test/gtest/unit/obj/obj_test_base.h
@@ -1,0 +1,601 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_GTEST_UNIT_OBJ_OBJ_TEST_BASE_H
+#define NIXL_TEST_GTEST_UNIT_OBJ_OBJ_TEST_BASE_H
+
+#include <gtest/gtest.h>
+#include "nixl_descriptors.h"
+#include "nixl_types.h"
+#include <memory>
+#include <string>
+#include <algorithm>
+#include <vector>
+#include <functional>
+#include <chrono>
+#include <thread>
+#include <map>
+#include <set>
+#include <optional>
+
+#include "s3/client.h"
+#include "obj_backend.h"
+#include "obj_executor.h"
+#include "object/engine_utils.h"
+#include "s3_accel/dell/rdma_interface.h"
+
+namespace gtest::obj {
+
+// Test configuration for different S3 client types
+struct ObjTestConfig {
+    std::string name;
+    nixl_b_params_t customParams;
+    std::string agentName;
+    bool supportsVram = false;
+};
+
+class mockS3Client : public iS3Client {
+private:
+    bool simulateSuccess_ = true;
+    bool simulateError_ = false;
+    std::shared_ptr<asioThreadPoolExecutor> executor_;
+    std::vector<std::function<void()>> pendingCallbacks_;
+    std::set<std::string> checkedKeys_;
+    std::map<std::string, bool> keyOutcomes_;
+    std::map<std::string, std::chrono::milliseconds> keyDelays_;
+    std::set<std::string> keyErrors_;
+
+public:
+    mockS3Client() = default;
+
+    mockS3Client([[maybe_unused]] nixl_b_params_t *custom_params,
+                 std::shared_ptr<Aws::Utils::Threading::Executor> executor = nullptr) {
+        if (executor) {
+            executor_ = std::dynamic_pointer_cast<asioThreadPoolExecutor>(executor);
+        }
+    }
+
+    void
+    setSimulateSuccess(bool success) {
+        simulateSuccess_ = success;
+    }
+
+    void
+    setSimulateError(bool error) {
+        simulateError_ = error;
+    }
+
+    void
+    setKeyOutcome(const std::string &key, bool success) {
+        keyOutcomes_[key] = success;
+    }
+
+    void
+    setKeyDelay(const std::string &key, std::chrono::milliseconds delay) {
+        keyDelays_[key] = delay;
+    }
+
+    void
+    setKeyError(const std::string &key) {
+        keyErrors_.insert(key);
+    }
+
+    void
+    setExecutor(std::shared_ptr<Aws::Utils::Threading::Executor> executor) override {
+        executor_ = std::dynamic_pointer_cast<asioThreadPoolExecutor>(executor);
+    }
+
+    void
+    putObjectAsync(std::string_view key,
+                   uintptr_t data_ptr,
+                   size_t data_len,
+                   size_t offset,
+                   put_object_callback_t callback) override {
+        std::string key_str(key);
+
+        // Per-key error overrides global simulateError_
+        bool simulate_error = keyErrors_.count(key_str) > 0 || simulateError_;
+
+        // Per-key outcome overrides global simulateSuccess_
+        bool success = simulateSuccess_;
+        auto outcome_it = keyOutcomes_.find(key_str);
+        if (outcome_it != keyOutcomes_.end()) {
+            success = outcome_it->second;
+        }
+
+        // Per-key delay (defaults to no delay)
+        std::chrono::milliseconds delay{0};
+        auto delay_it = keyDelays_.find(key_str);
+        if (delay_it != keyDelays_.end()) {
+            delay = delay_it->second;
+        }
+
+        pendingCallbacks_.push_back([callback, success, simulate_error, delay]() {
+            if (delay.count() > 0) {
+                std::this_thread::sleep_for(delay);
+            }
+            callback(simulate_error ? false : success);
+        });
+    }
+
+    void
+    getObjectAsync(std::string_view key,
+                   uintptr_t data_ptr,
+                   size_t data_len,
+                   size_t offset,
+                   get_object_callback_t callback) override {
+        std::string key_str(key);
+
+        // Per-key error overrides global simulateError_
+        bool simulate_error = keyErrors_.count(key_str) > 0 || simulateError_;
+
+        // Per-key outcome overrides global simulateSuccess_
+        bool success = simulateSuccess_;
+        auto outcome_it = keyOutcomes_.find(key_str);
+        if (outcome_it != keyOutcomes_.end()) {
+            success = outcome_it->second;
+        }
+
+        // Per-key delay (defaults to no delay)
+        std::chrono::milliseconds delay{0};
+        auto delay_it = keyDelays_.find(key_str);
+        if (delay_it != keyDelays_.end()) {
+            delay = delay_it->second;
+        }
+
+        pendingCallbacks_.push_back(
+            [callback, data_ptr, data_len, offset, success, simulate_error, delay]() {
+                if (delay.count() > 0) {
+                    std::this_thread::sleep_for(delay);
+                }
+                bool final_success = simulate_error ? false : success;
+                if (final_success && data_ptr && data_len > 0) {
+                    char *buffer = reinterpret_cast<char *>(data_ptr);
+                    for (size_t i = 0; i < data_len; ++i) {
+                        buffer[i] = static_cast<char>('A' + ((i + offset) % 26));
+                    }
+                }
+                callback(final_success);
+            });
+    }
+
+    void
+    checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) override {
+        std::string key_str(key);
+        checkedKeys_.insert(key_str);
+
+        // Per-key error overrides global simulateError_
+        bool simulate_error = keyErrors_.count(key_str) > 0 || simulateError_;
+
+        // Per-key outcome overrides global simulateSuccess_
+        auto outcome_it = keyOutcomes_.find(key_str);
+        bool success = (outcome_it != keyOutcomes_.end()) ? outcome_it->second : simulateSuccess_;
+
+        // Per-key delay (defaults to no delay)
+        std::chrono::milliseconds delay{0};
+        auto delay_it = keyDelays_.find(key_str);
+        if (delay_it != keyDelays_.end()) {
+            delay = delay_it->second;
+        }
+
+        if (executor_) {
+            executor_->Submit([callback, success, simulate_error, delay]() {
+                if (delay.count() > 0) {
+                    std::this_thread::sleep_for(delay);
+                }
+                callback(simulate_error ? std::optional<bool>(std::nullopt) :
+                                          std::optional<bool>(success));
+            });
+        } else {
+            if (delay.count() > 0) {
+                std::this_thread::sleep_for(delay);
+            }
+            callback(simulate_error ? std::optional<bool>(std::nullopt) :
+                                      std::optional<bool>(success));
+        }
+    }
+
+    void
+    execAsync() {
+        if (executor_) {
+            for (auto &callback : pendingCallbacks_) {
+                executor_->Submit([callback]() { callback(); });
+            }
+            pendingCallbacks_.clear();
+            executor_->waitUntilIdle();
+        } else {
+            for (auto &callback : pendingCallbacks_) {
+                callback();
+            }
+            pendingCallbacks_.clear();
+        }
+    }
+
+    size_t
+    getPendingCount() const {
+        return pendingCallbacks_.size();
+    }
+
+    const std::set<std::string> &
+    getCheckedKeys() const {
+        return checkedKeys_;
+    }
+
+    bool
+    hasExecutor() const {
+        return executor_ != nullptr;
+    }
+
+protected:
+    // Make pendingCallbacks_ accessible to derived classes
+    std::vector<std::function<void()>> &
+    getPendingCallbacks() {
+        return pendingCallbacks_;
+    }
+
+    // Make simulateSuccess_ accessible to derived classes
+    bool
+    getSimulateSuccess() const {
+        return simulateSuccess_;
+    }
+};
+
+// Dell-specific mock S3 client with RDMA support
+class mockDellS3Client : public mockS3Client, public iDellS3RdmaClient {
+public:
+    mockDellS3Client() = default;
+
+    mockDellS3Client([[maybe_unused]] nixl_b_params_t *custom_params,
+                     std::shared_ptr<Aws::Utils::Threading::Executor> executor = nullptr)
+        : mockS3Client(custom_params, executor) {}
+
+    // Dell-specific RDMA methods
+    void
+    putObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       put_object_callback_t callback) override {
+        if (rdma_desc.empty()) {
+            getPendingCallbacks().push_back([callback]() { callback(false); });
+        } else {
+            getPendingCallbacks().push_back([callback, this]() { callback(getSimulateSuccess()); });
+        }
+    }
+
+    void
+    getObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       get_object_callback_t callback) override {
+        if (rdma_desc.empty()) {
+            getPendingCallbacks().push_back([callback]() { callback(false); });
+        } else {
+            getPendingCallbacks().push_back([callback, data_ptr, data_len, offset, this]() {
+                if (getSimulateSuccess() && data_ptr && data_len > 0) {
+                    char *buffer = reinterpret_cast<char *>(data_ptr);
+                    for (size_t i = 0; i < data_len; ++i) {
+                        buffer[i] = static_cast<char>('A' + ((i + offset) % 26));
+                    }
+                }
+                callback(getSimulateSuccess());
+            });
+        }
+    }
+};
+
+// Mock that invokes the checkObjectExistsAsync callback twice to test
+// the exact-once guard in engine_impl.cpp's queryMem.
+class doubleCallbackMockS3Client : public iS3Client {
+private:
+    std::shared_ptr<asioThreadPoolExecutor> executor_;
+
+public:
+    doubleCallbackMockS3Client() = default;
+
+    void
+    setExecutor(std::shared_ptr<Aws::Utils::Threading::Executor> executor) override {
+        executor_ = std::dynamic_pointer_cast<asioThreadPoolExecutor>(executor);
+    }
+
+    void
+    putObjectAsync(std::string_view, uintptr_t, size_t, size_t, put_object_callback_t callback)
+        override {
+        callback(true);
+    }
+
+    void
+    getObjectAsync(std::string_view, uintptr_t, size_t, size_t, get_object_callback_t callback)
+        override {
+        callback(true);
+    }
+
+    void
+    checkObjectExistsAsync(std::string_view, check_object_callback_t callback) override {
+        if (executor_) {
+            executor_->Submit([callback]() {
+                callback(true); // First invocation
+                callback(true); // Second invocation — should be a no-op
+            });
+        } else {
+            callback(true);
+            callback(true);
+        }
+    }
+};
+
+// Base test fixture with common test helper methods
+class objTestBase {
+protected:
+    std::unique_ptr<nixlObjEngine> objEngine_;
+    std::shared_ptr<mockS3Client> mockS3Client_;
+    nixlBackendInitParams initParams_;
+    nixl_b_params_t customParams_;
+
+    void
+    setupEngine(const std::string &agentName, nixl_b_params_t params = {}) {
+        customParams_ = params;
+        initParams_.localAgent = agentName;
+        initParams_.type = "OBJ";
+        initParams_.customParams = &customParams_;
+        initParams_.enableProgTh = false;
+        initParams_.pthrDelay = 0;
+        initParams_.syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW;
+
+        // Use appropriate mock client based on configuration
+        if (isDellOBSRequested(&customParams_)) {
+            mockS3Client_ = std::make_shared<mockDellS3Client>();
+        } else {
+            mockS3Client_ = std::make_shared<mockS3Client>();
+        }
+        objEngine_ = std::make_unique<nixlObjEngine>(&initParams_, mockS3Client_);
+    }
+
+    void
+    testTransferWithSize(nixl_xfer_op_t operation,
+                         size_t buffer_size,
+                         const std::string &key_suffix = "") {
+        mockS3Client_->setSimulateSuccess(true);
+
+        std::vector<char> test_buffer(buffer_size);
+
+        nixlBlobDesc local_desc = {}, remote_desc = {};
+        local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+        local_desc.len = test_buffer.size();
+        local_desc.devId = 1;
+        remote_desc.devId = 2;
+        remote_desc.metaInfo = (operation == NIXL_READ) ? "test-read-key" : "test-write-key";
+        remote_desc.metaInfo += key_suffix;
+
+        nixlBackendMD *local_metadata = nullptr;
+        nixlBackendMD *remote_metadata = nullptr;
+
+        ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+        ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs(DRAM_SEG);
+        nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+        nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+        local_descs.addDesc(local_meta_desc);
+
+        nixlMetaDesc remote_meta_desc(0, test_buffer.size(), 2);
+        remote_descs.addDesc(remote_meta_desc);
+
+        nixlBackendReqH *handle = nullptr;
+
+        ASSERT_EQ(
+            objEngine_->prepXfer(
+                operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE(handle, nullptr);
+
+        nixl_status_t status = objEngine_->postXfer(
+            operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+        EXPECT_EQ(mockS3Client_->getPendingCount(), 1);
+        status = objEngine_->checkXfer(handle);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+
+        mockS3Client_->execAsync();
+        status = objEngine_->checkXfer(handle);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+
+        if (operation == NIXL_READ) {
+            if (test_buffer.size() > 0) {
+                EXPECT_TRUE(std::all_of(
+                    test_buffer.begin(), test_buffer.end(), [](char c) { return c == 'A'; }));
+            }
+        }
+
+        objEngine_->releaseReqH(handle);
+        objEngine_->deregisterMem(local_metadata);
+        objEngine_->deregisterMem(remote_metadata);
+    }
+
+    void
+    testMultiDescriptorWithSizes(nixl_xfer_op_t operation,
+                                 size_t size0,
+                                 size_t size1,
+                                 const std::string &key_suffix = "") {
+        mockS3Client_->setSimulateSuccess(true);
+
+        std::vector<char> test_buffer0(size0);
+        std::vector<char> test_buffer1(size1);
+        nixlBlobDesc local_desc0 = {}, local_desc1 = {};
+        local_desc0.addr = reinterpret_cast<uintptr_t>(test_buffer0.data());
+        local_desc1.addr = reinterpret_cast<uintptr_t>(test_buffer1.data());
+        local_desc0.len = test_buffer0.size();
+        local_desc1.len = test_buffer1.size();
+        local_desc0.devId = 1;
+        local_desc1.devId = 1;
+        nixlBackendMD *local_metadata0 = nullptr;
+        nixlBackendMD *local_metadata1 = nullptr;
+
+        ASSERT_EQ(objEngine_->registerMem(local_desc0, DRAM_SEG, local_metadata0), NIXL_SUCCESS);
+        ASSERT_EQ(objEngine_->registerMem(local_desc1, DRAM_SEG, local_metadata1), NIXL_SUCCESS);
+
+        nixlBlobDesc remote_desc0 = {}, remote_desc1 = {};
+        remote_desc0.devId = 2;
+        remote_desc1.devId = 3;
+        remote_desc0.metaInfo = (operation == NIXL_READ) ? "test-read-key0" : "test-write-key0";
+        remote_desc0.metaInfo += key_suffix;
+        remote_desc1.metaInfo = (operation == NIXL_READ) ? "test-read-key1" : "test-write-key1";
+        remote_desc1.metaInfo += key_suffix;
+        nixlBackendMD *remote_metadata0 = nullptr;
+        nixlBackendMD *remote_metadata1 = nullptr;
+
+        ASSERT_EQ(objEngine_->registerMem(remote_desc0, OBJ_SEG, remote_metadata0), NIXL_SUCCESS);
+        ASSERT_EQ(objEngine_->registerMem(remote_desc1, OBJ_SEG, remote_metadata1), NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs(DRAM_SEG);
+        nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+        nixlMetaDesc local_meta_desc0(reinterpret_cast<uintptr_t>(test_buffer0.data()),
+                                      test_buffer0.size(),
+                                      local_desc0.devId);
+        nixlMetaDesc local_meta_desc1(reinterpret_cast<uintptr_t>(test_buffer1.data()),
+                                      test_buffer1.size(),
+                                      local_desc1.devId);
+        local_descs.addDesc(local_meta_desc0);
+        local_descs.addDesc(local_meta_desc1);
+
+        nixlMetaDesc remote_meta_desc0(0, test_buffer0.size(), remote_desc0.devId);
+        nixlMetaDesc remote_meta_desc1(0, test_buffer1.size(), remote_desc1.devId);
+        remote_descs.addDesc(remote_meta_desc0);
+        remote_descs.addDesc(remote_meta_desc1);
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ(
+            objEngine_->prepXfer(
+                operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE(handle, nullptr);
+
+        nixl_status_t status = objEngine_->postXfer(
+            operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+        EXPECT_EQ(mockS3Client_->getPendingCount(), 2);
+        status = objEngine_->checkXfer(handle);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+
+        mockS3Client_->execAsync();
+        status = objEngine_->checkXfer(handle);
+        EXPECT_EQ(status, NIXL_SUCCESS);
+
+        if (operation == NIXL_READ) {
+            EXPECT_EQ(test_buffer0[0], 'A');
+            EXPECT_EQ(test_buffer1[0], 'A');
+        }
+
+        objEngine_->releaseReqH(handle);
+        objEngine_->deregisterMem(local_metadata0);
+        objEngine_->deregisterMem(local_metadata1);
+        objEngine_->deregisterMem(remote_metadata0);
+        objEngine_->deregisterMem(remote_metadata1);
+    }
+
+    void
+    testTransferFailure(nixl_xfer_op_t operation,
+                        size_t buffer_size,
+                        const std::string &key_suffix = "") {
+        mockS3Client_->setSimulateSuccess(false);
+
+        std::vector<char> test_buffer(buffer_size, 'Z');
+
+        nixlBlobDesc local_desc = {};
+        local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+        local_desc.len = test_buffer.size();
+        local_desc.devId = 1;
+        nixlBackendMD *local_metadata = nullptr;
+        ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+        nixlBlobDesc remote_desc = {};
+        remote_desc.devId = 2;
+        remote_desc.metaInfo = "test-fail-key" + key_suffix;
+        nixlBackendMD *remote_metadata = nullptr;
+        ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+        nixl_meta_dlist_t local_descs(DRAM_SEG);
+        nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+        nixlMetaDesc local_meta_desc(
+            reinterpret_cast<uintptr_t>(test_buffer.data()), test_buffer.size(), local_desc.devId);
+        nixlMetaDesc remote_meta_desc(0, test_buffer.size(), remote_desc.devId);
+        local_descs.addDesc(local_meta_desc);
+        remote_descs.addDesc(remote_meta_desc);
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ(
+            objEngine_->prepXfer(
+                operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+            NIXL_SUCCESS);
+        ASSERT_NE(handle, nullptr);
+
+        nixl_status_t status = objEngine_->postXfer(
+            operation, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+        EXPECT_EQ(mockS3Client_->getPendingCount(), 1);
+        status = objEngine_->checkXfer(handle);
+        EXPECT_EQ(status, NIXL_IN_PROG);
+
+        mockS3Client_->execAsync();
+        int max_polls = 100;
+        int poll_count = 0;
+        do {
+            status = objEngine_->checkXfer(handle);
+            poll_count++;
+        } while (status == NIXL_IN_PROG && poll_count < max_polls);
+        EXPECT_NE(status, NIXL_IN_PROG) << "Polling timed out waiting for terminal status";
+        EXPECT_NE(status, NIXL_SUCCESS); // Should not succeed
+
+        // Verify failed read did not mutate destination buffer
+        if (operation == NIXL_READ) {
+            EXPECT_TRUE(std::all_of(
+                test_buffer.begin(), test_buffer.end(), [](char c) { return c == 'Z'; }));
+        }
+
+        objEngine_->releaseReqH(handle);
+        objEngine_->deregisterMem(local_metadata);
+        objEngine_->deregisterMem(remote_metadata);
+    }
+};
+
+// Parameterized test fixture for common tests across all client types
+class objParamTestFixture : public objTestBase, public testing::TestWithParam<ObjTestConfig> {
+protected:
+    void
+    SetUp() override {
+        const auto &config = GetParam();
+        setupEngine(config.agentName, config.customParams);
+    }
+};
+
+// Non-parameterized fixture for specialized tests
+class objTestFixture : public objTestBase, public testing::Test {
+protected:
+    void
+    SetUp() override {
+        setupEngine("test-agent");
+    }
+};
+
+} // namespace gtest::obj
+
+#endif // NIXL_TEST_GTEST_UNIT_OBJ_OBJ_TEST_BASE_H


### PR DESCRIPTION
These tests require the cuobjclient library provided by CUDA 13.1 and a cufile.json configuration.

What?
Adds unit test cases

Why?
To increase unit test coverage and protect against regression

How?
Filled gaps in unit test coverage using mocks where necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive cuobj-accelerated unit tests for the object engine covering RDMA transfers, memory registration limits, transfer prep/check behavior, async/failure semantics, OBJ_SEG mapping, and agent mismatch. Introduced shared fixtures, parameterized configs, and multiple mock clients to enable deterministic async and failure scenarios.
* **Chores**
  * Test build now conditionally includes accelerated test sources when the accelerated client is available.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1630)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->