### PR TITLE
fix(rust-bindings): surface register memory error

### DIFF
--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -294,22 +294,27 @@ impl Agent {
         opt_args: Option<&OptArgs>,
     ) -> Result<RegistrationHandle, NixlError> {
         let mut reg_dlist = RegDescList::new(descriptor.mem_type())?;
-        unsafe {
-            reg_dlist.add_storage_desc(descriptor)?;
+        reg_dlist.add_storage_desc(descriptor)?;
 
+        let status = unsafe {
             nixl_capi_register_mem(
                 self.inner.write().unwrap().handle.as_ptr(),
                 reg_dlist.handle(),
                 opt_args.map_or(std::ptr::null_mut(), |args| args.inner.as_ptr()),
-            );
+            )
+        };
+
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(RegistrationHandle {
+                agent: Some(self.inner.clone()),
+                ptr: unsafe { descriptor.as_ptr() } as usize,
+                size: descriptor.size(),
+                dev_id: descriptor.device_id(),
+                mem_type: descriptor.mem_type(),
+            }),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
         }
-        Ok(RegistrationHandle {
-            agent: Some(self.inner.clone()),
-            ptr: unsafe { descriptor.as_ptr() } as usize,
-            size: descriptor.size(),
-            dev_id: descriptor.device_id(),
-            mem_type: descriptor.mem_type(),
-        })
     }
 
     /// Query information about memory/storage

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -435,11 +435,11 @@ fn test_multiple_storage_descriptors() {
 
 #[test]
 fn test_memory_registration() {
-    let agent = Agent::new("test_agent").unwrap();
+    let (agent, opt_args) = create_agent_with_backend("test_agent").unwrap();
     let mut storage = SystemStorage::new(1024).unwrap();
 
     // Register memory
-    storage.register(&agent, None).unwrap();
+    storage.register(&agent, Some(&opt_args)).unwrap();
 
     // Verify we can still access the memory
     storage.memset(0xAA);
@@ -448,29 +448,29 @@ fn test_memory_registration() {
 
 #[test]
 fn test_registration_handle_drop() {
-    let agent = Agent::new("test_agent").unwrap();
+    let (agent, opt_args) = create_agent_with_backend("test_agent").unwrap();
     let mut storage = SystemStorage::new(1024).unwrap();
 
     // Register memory
-    storage.register(&agent, None).unwrap();
+    storage.register(&agent, Some(&opt_args)).unwrap();
 
     // Drop the storage, which should trigger deregistration
     drop(storage);
 
     // Create new storage to verify we can register again
     let mut new_storage = SystemStorage::new(1024).unwrap();
-    new_storage.register(&agent, None).unwrap();
+    new_storage.register(&agent, Some(&opt_args)).unwrap();
 }
 
 #[test]
 fn test_multiple_registrations() {
-    let agent = Agent::new("test_agent").unwrap();
+    let (agent, opt_args) = create_agent_with_backend("test_agent").unwrap();
     let mut storage1 = SystemStorage::new(1024).unwrap();
     let mut storage2 = SystemStorage::new(2048).unwrap();
 
     // Register both storages
-    storage1.register(&agent, None).unwrap();
-    storage2.register(&agent, None).unwrap();
+    storage1.register(&agent, Some(&opt_args)).unwrap();
+    storage2.register(&agent, Some(&opt_args)).unwrap();
 
     // Verify we can still access both memories
     storage1.memset(0xAA);


### PR DESCRIPTION
## What?
surface error from nixl_capi_register_mem in rust bindings.

## Why?
unable to check if registration was successful when using rust bindings. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for memory registration to distinguish invalid parameters from backend failures, providing clearer failure diagnostics and more reliable outcomes.
* **Tests**
  * Updated memory-registration tests to exercise registration with explicit backend options and re-registration scenarios, improving coverage and realism.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1632)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1632)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->