### PR TITLE
mem_section: fix addElement using hardcoded VRAM_SEG lookup

### DIFF
--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -109,7 +109,7 @@ nixl_status_t
 nixlMemSection::addElement(const nixlRemoteDesc &query,
                            nixlBackendEngine *backend,
                            nixl_remote_meta_dlist_t &resp) const {
-    const section_key_t sec_key{VRAM_SEG, backend};
+    const section_key_t sec_key{resp.getType(), backend};
     const auto it = sectionMap.find(sec_key);
     if (it == sectionMap.end()) {
         return NIXL_ERR_NOT_FOUND;

--- a/test/gtest/mocks/gmock_engine.cpp
+++ b/test/gtest/mocks/gmock_engine.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ namespace mocks {
 nixl_b_params_t custom_params;
 const nixlBackendInitParams init_params{.customParams = &custom_params};
 const std::string gmock_engine_key = "gmock_engine_key";
+char gmock_dummy_mvh;
 
 GMockBackendEngine::GMockBackendEngine() : nixlBackendEngine(&init_params) {
     using testing::Return;
@@ -40,6 +41,12 @@ GMockBackendEngine::GMockBackendEngine() : nixlBackendEngine(&init_params) {
     ON_CALL(*this, postXfer(_, _, _, _, _, _)).WillByDefault(Return(NIXL_SUCCESS));
     ON_CALL(*this, checkXfer(_)).WillByDefault(Return(NIXL_SUCCESS));
     ON_CALL(*this, releaseReqH(_)).WillByDefault(Return(NIXL_SUCCESS));
+    ON_CALL(*this, prepMemView(_, _, _))
+        .WillByDefault(
+            [](const nixl_remote_meta_dlist_t &, nixlMemViewH &mvh, const nixl_opt_b_args_t *) {
+                mvh = &gmock_dummy_mvh;
+                return NIXL_SUCCESS;
+            });
     ON_CALL(*this, getPublicData(_, _)).WillByDefault(Return(NIXL_SUCCESS));
     ON_CALL(*this, getConnInfo(_)).WillByDefault([&](std::string &str) {
         str = "mock_backend_plugin_conn_info";

--- a/test/gtest/mocks/gmock_engine.h
+++ b/test/gtest/mocks/gmock_engine.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,12 @@ public:
                 (const, override));
     MOCK_METHOD(nixl_status_t, checkXfer, (nixlBackendReqH * req), (const, override));
     MOCK_METHOD(nixl_status_t, releaseReqH, (nixlBackendReqH * req), (const, override));
+    MOCK_METHOD(nixl_status_t,
+                prepMemView,
+                (const nixl_remote_meta_dlist_t &dlist,
+                 nixlMemViewH &mvh,
+                 const nixl_opt_b_args_t *opt_args),
+                (const, override));
     MOCK_METHOD(nixl_status_t,
                 getPublicData,
                 (const nixlBackendMD *input, std::string &str),

--- a/test/gtest/mocks/mock_backend_engine.h
+++ b/test/gtest/mocks/mock_backend_engine.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -67,7 +67,16 @@ public:
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const override;
   nixl_status_t checkXfer(nixlBackendReqH *handle) const override;
-  nixl_status_t releaseReqH(nixlBackendReqH *handle) const override;
+  nixl_status_t
+  releaseReqH(nixlBackendReqH *handle) const override;
+
+  nixl_status_t
+  prepMemView(const nixl_remote_meta_dlist_t &dlist,
+              nixlMemViewH &mvh,
+              const nixl_opt_b_args_t *opt_args) const override {
+      assert(sharedState > 0);
+      return gmock_backend_engine->prepMemView(dlist, mvh, opt_args);
+  }
   nixl_status_t getPublicData(const nixlBackendMD *meta, std::string &str) const override {
     assert(sharedState > 0);
     return gmock_backend_engine->getPublicData(meta, str);

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -141,6 +141,47 @@ namespace agent {
             local_agent_ = local_agent_helper_->getAgent();
             remote_agent_ = remote_agent_helper_->getAgent();
         }
+
+        struct DualAgentSetup {
+            nixlBackendH *local_backend = nullptr;
+            nixlBackendH *remote_backend = nullptr;
+            blob local_blob;
+            blob remote_blob;
+            nixl_reg_dlist_t local_reg_dlist;
+            nixl_reg_dlist_t remote_reg_dlist;
+            nixl_opt_args_t local_extra_params;
+            nixl_opt_args_t remote_extra_params;
+            nixl_b_params_t local_params;
+            nixl_b_params_t remote_params;
+            std::string remote_agent_name;
+
+            explicit DualAgentSetup(nixl_mem_t mem_type)
+                : local_reg_dlist(mem_type),
+                  remote_reg_dlist(mem_type) {}
+        };
+
+        void
+        setupDualAgent(DualAgentSetup &s, bool register_local = true, bool register_remote = true) {
+            EXPECT_EQ(local_agent_helper_->createBackendWithGMock(s.local_params, s.local_backend),
+                      NIXL_SUCCESS);
+            EXPECT_EQ(
+                remote_agent_helper_->createBackendWithGMock(s.remote_params, s.remote_backend),
+                NIXL_SUCCESS);
+            if (register_local) {
+                EXPECT_EQ(
+                    local_agent_helper_->initAndRegisterMemory(
+                        s.local_blob, s.local_reg_dlist, s.local_extra_params, s.local_backend),
+                    NIXL_SUCCESS);
+            }
+            if (register_remote) {
+                EXPECT_EQ(
+                    remote_agent_helper_->initAndRegisterMemory(
+                        s.remote_blob, s.remote_reg_dlist, s.remote_extra_params, s.remote_backend),
+                    NIXL_SUCCESS);
+            }
+            EXPECT_EQ(local_agent_helper_->getAndLoadRemoteMd(remote_agent_, s.remote_agent_name),
+                      NIXL_SUCCESS);
+        }
     };
 
     class singleAgentWithMemParamFixture : public testing::TestWithParam<nixl_mem_t> {
@@ -390,6 +431,20 @@ namespace agent {
         EXPECT_EQ(notif_map[local_agent_name].front(), msg);
 
         EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
+    }
+
+    TEST_F(dualAgentBridgeFixture, PrepMemViewRemoteDRAM) {
+        DualAgentSetup s(DRAM_SEG);
+        setupDualAgent(s, /*register_local=*/false);
+
+        nixl_remote_dlist_t remote_dlist(DRAM_SEG);
+        remote_dlist.addDesc(nixlRemoteDesc(s.remote_blob.getDesc(), s.remote_agent_name));
+
+        nixlMemViewH mvh = nullptr;
+        EXPECT_EQ(local_agent_->prepMemView(remote_dlist, mvh), NIXL_SUCCESS);
+        EXPECT_NE(mvh, nullptr);
+
+        local_agent_->releaseMemView(mvh);
     }
 
     TEST_F(dualAgentBridgeFixture, XferReqSubFunctionsTest) {


### PR DESCRIPTION
## What?
Fix nixlMemSection::addElement (remote-descriptor variant) using a hardcoded VRAM_SEG when looking up sectionMap. 
Use resp.getType() instead, which the caller (nixlAgent::prepMemView) initializes from the request dlist.

## Why?
nixlAgent::prepMemView is broken for any non-VRAM remote descriptor list — e.g. a DRAM_SEG request always fails the sectionMap.find() and returns NIXL_ERR_NOT_FOUND, even when the matching DRAM section is registered. The local-section sibling at nixl_memory_section.cpp:63 already uses query.getType(); this aligns the remote path with that behavior.

## How?
One-line change at src/infra/nixl_memory_section.cpp:112:
-    const section_key_t sec_key{VRAM_SEG, backend};
+    const section_key_t sec_key{resp.getType(), backend};


Note: this bug went undetected because VRAM-typed prepMemView calls coincidentally matched the hardcoded VRAM_SEG. The regression test added here exercises DRAM specifically, which fails on the buggy code and passes on the fix — see PR #1428's CI for an independent symptom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Memory section lookup now selects the correct segment type based on the response, improving accuracy when adding remote descriptors.

* **Tests**
  * Added an end-to-end unit test validating preparation and release of remote memory views.
  * Enhanced test mocks to simulate memory-view preparation behavior and provide a stable test handle.

* **Chores**
  * Updated SPDX copyright/year headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->