### PR TITLE
file: support path-based file registration in all FILE_SEG backends

### DIFF
--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -73,6 +73,11 @@ Note that loadRemoteConnInfo does not initiate the connection, if the user wants
 
 Each backend inherits from nixlBackendMD base class to store any metadata required per registration. A pointer to an object of this class will be the output of registerMem, and the only input to deregisterMem.
 
+For backends that support `FILE_SEG`, NIXL ships a shared **path-mode**
+helper (`nixl::parsePathMeta()` + `nixlFilePathMD`) that lets callers
+register files by path in `nixlBlobDesc::metaInfo` instead of by
+pre-opened fd; see [`src/utils/file/README.md`](../src/utils/file/README.md#path-mode-file-registration).
+
 ### Metadata Management:
 
 * getPublicData(): Provide a serialized byte array for remote identifier for a registered memory

--- a/src/plugins/cuda_gds/README.md
+++ b/src/plugins/cuda_gds/README.md
@@ -23,6 +23,14 @@ NIXL.
 [NVIDIA GDS](https://docs.nvidia.com/gpudirect-storage/overview-guide/index.html)<br />
 [CUDA GDS Install and Setup](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
 
+## File registration
+
+`FILE_SEG` accepts either fd-in-`devId` (fd-mode) or a
+`"<modes>:<path>"` string in `metaInfo` (path-mode); see
+[`src/utils/file/README.md`](../../utils/file/README.md#path-mode-file-registration).
+Note: `gds_file_map` keys on fd, so two path-mode regs of the same path
+get two cuFile handles (no path-level dedup).
+
 ### cufile.json configuration
 This section provides the recommended configuration for the cufile.json file when using the NIXL GDS plugin in compatibility mode.
 The configuration ensures that sufficient POSIX buffers are available. Only the properties that need to be overridden are included in this cufile.json configuration.

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,11 @@
  */
 #include <cassert>
 #include <cufile.h>
+#include <absl/strings/str_format.h>
 #include "gds_backend.h"
 #include "gds_utils.h"
 #include "common/nixl_log.h"
+#include "file/file_path_mode.h"
 #include "file/file_utils.h"
 #include <unordered_map>
 #include <memory>
@@ -95,67 +97,53 @@ nixl_status_t nixlGdsEngine::registerMem(const nixlBlobDesc &mem,
                                          const nixl_mem_t &nixl_mem,
                                          nixlBackendMD* &out)
 {
-    nixl_status_t status = NIXL_SUCCESS;
-    nixlGdsMetadata *md = new nixlGdsMetadata();
+    if (nixl_mem == FILE_SEG) {
+        std::unique_ptr<nixlGdsMetadata> md;
+        try {
+            md = std::make_unique<nixlGdsMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+        }
+        catch (const std::system_error &e) {
+            NIXL_ERROR << "GDS path-mode open failed: " << e.what();
+            return NIXL_ERR_BACKEND;
+        }
+        int fd = md->file_fd.fd();
+
+        if (auto it = gds_file_map.find(fd); it != gds_file_map.end()) {
+            md->handle = it->second;
+            md->handle.size = mem.len;
+            md->handle.metadata = mem.metaInfo;
+        } else {
+            nixl_status_t s = gds_utils->registerFileHandle(fd, mem.len, mem.metaInfo, md->handle);
+            if (s != NIXL_SUCCESS) {
+                return s; // ~FileFd via unique_ptr drop closes the owned fd
+            }
+            gds_file_map[fd] = md->handle;
+        }
+        out = md.release();
+        return NIXL_SUCCESS;
+    }
+
+    auto md = std::make_unique<nixlGdsMetadata>();
     md->type = nixl_mem;
-    cudaError_t error_id;
 
-    switch (nixl_mem) {
-        case FILE_SEG: {
-            // Check if we already have a file handle for this devId
-            auto it = gds_file_map.find(mem.devId);
-            if (it != gds_file_map.end()) {
-                md->handle = it->second;
-                md->handle.size = mem.len;
-                md->handle.metadata = mem.metaInfo;
-                break;
-            }
-
-            status = gds_utils->registerFileHandle(mem.devId, mem.len,
-                                                   mem.metaInfo, md->handle);
-            if (status == NIXL_SUCCESS) {
-                gds_file_map[mem.devId] = md->handle;
-            }
-            break;
+    if (nixl_mem == VRAM_SEG) {
+        if (cudaError_t e = cudaSetDevice(mem.devId); e != cudaSuccess) {
+            NIXL_ERROR << "cudaSetDevice returned " << cudaGetErrorString(e) << " for device ID "
+                       << mem.devId;
+            return NIXL_ERR_BACKEND;
         }
-
-        case VRAM_SEG: {
-            error_id = cudaSetDevice(mem.devId);
-            if (error_id != cudaSuccess) {
-                NIXL_ERROR << "cudaSetDevice returned " << cudaGetErrorString(error_id)
-                          << " for device ID " << mem.devId;
-                delete md;
-                return NIXL_ERR_BACKEND;
-            }
-            status = gds_utils->registerBufHandle((void *)mem.addr, mem.len, 0);
-            if (status == NIXL_SUCCESS) {
-                md->buf.base = (void *)mem.addr;
-                md->buf.size = mem.len;
-            }
-            break;
-        }
-
-        case DRAM_SEG: {
-            status = gds_utils->registerBufHandle((void *)mem.addr, mem.len, 0);
-            if (status == NIXL_SUCCESS) {
-                md->buf.base = (void *)mem.addr;
-                md->buf.size = mem.len;
-            }
-            break;
-        }
-
-        default:
-            status = NIXL_ERR_BACKEND;
-            break;
+    } else if (nixl_mem != DRAM_SEG) {
+        return NIXL_ERR_BACKEND;
     }
 
-    if (status != NIXL_SUCCESS) {
-        delete md;
-        return status;
+    if (nixl_status_t s = gds_utils->registerBufHandle((void *)mem.addr, mem.len, 0);
+        s != NIXL_SUCCESS) {
+        return s;
     }
-
-    out = (nixlBackendMD*)md;
-    return status;
+    md->buf.base = (void *)mem.addr;
+    md->buf.size = mem.len;
+    out = md.release();
+    return NIXL_SUCCESS;
 }
 
 nixl_status_t nixlGdsEngine::deregisterMem (nixlBackendMD* meta)
@@ -164,11 +152,21 @@ nixl_status_t nixlGdsEngine::deregisterMem (nixlBackendMD* meta)
     if (md->type == FILE_SEG) {
         gds_utils->deregisterFileHandle(md->handle);
         gds_file_map.erase(md->handle.fd);
-        // No need to close fd since we're not opening files
     } else {
         gds_utils->deregisterBufHandle(md->buf.base);
     }
-    delete md;  // Clean up the metadata object
+    delete md;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlGdsEngine::resolveFileHandle(const nixlMetaDesc &d, gdsFileHandle &fh) const {
+    auto *md = static_cast<const nixlGdsMetadata *>(d.metadataP);
+    if (!md || md->type != FILE_SEG) {
+        NIXL_ERROR << "GDS: missing FILE_SEG metadata at xfer time";
+        return NIXL_ERR_NOT_FOUND;
+    }
+    fh = md->handle;
     return NIXL_SUCCESS;
 }
 
@@ -220,13 +218,10 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
             total_size = remote[i].len;
             base_offset = (size_t)local[i].addr;
 
-            auto it = gds_file_map.find(local[i].devId);
-            if (it == gds_file_map.end()) {
-                NIXL_ERROR << "File handle not found";
+            if (resolveFileHandle(local[i], fh) != NIXL_SUCCESS) {
                 delete gds_handle;
                 return NIXL_ERR_NOT_FOUND;
             }
-            fh = it->second;
         } else {
             base_addr = (void*)local[i].addr;
             if (!base_addr) {
@@ -236,13 +231,10 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
             total_size = local[i].len;
             base_offset = (size_t)remote[i].addr;
 
-            auto it = gds_file_map.find(remote[i].devId);
-            if (it == gds_file_map.end()) {
-                NIXL_ERROR << "File handle not found";
+            if (resolveFileHandle(remote[i], fh) != NIXL_SUCCESS) {
                 delete gds_handle;
                 return NIXL_ERR_NOT_FOUND;
             }
-            fh = it->second;
         }
 
         // Split large transfers into multiple requests

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,15 +28,17 @@
 #include <mutex>
 #include "gds_utils.h"
 #include "backend/backend_engine.h"
+#include "file/file_path_mode.h"
 
-class nixlGdsMetadata : public nixlBackendMD {
-    public:
-        gdsFileHandle handle;
-        gdsMemBuf buf;
-        nixl_mem_t type;
+class nixlGdsMetadata : public nixlFilePathMD {
+public:
+    gdsFileHandle handle;
+    gdsMemBuf buf;
+    nixl_mem_t type;
 
-        nixlGdsMetadata() : nixlBackendMD(true) { }
-        ~nixlGdsMetadata() { }
+    nixlGdsMetadata() = default;
+
+    explicit nixlGdsMetadata(nixl::FileFd &&fd) : nixlFilePathMD(std::move(fd)), type(FILE_SEG) {}
 };
 
 class GdsTransferRequestH {
@@ -97,9 +99,13 @@ class nixlGdsEngine : public nixlBackendEngine {
 
         nixlGdsIOBatch* getBatchFromPool(unsigned int size) const;
         void returnBatchToPool(nixlGdsIOBatch* batch) const;
-        nixl_status_t createAndSubmitBatch(const std::vector<GdsTransferRequestH>& requests,
-                                           size_t start_idx, size_t batch_size,
-                                           std::vector<nixlGdsIOBatch*>& batch_list) const;
+        nixl_status_t
+        createAndSubmitBatch(const std::vector<GdsTransferRequestH> &requests,
+                             size_t start_idx,
+                             size_t batch_size,
+                             std::vector<nixlGdsIOBatch *> &batch_list) const;
+        nixl_status_t
+        resolveFileHandle(const nixlMetaDesc &d, gdsFileHandle &fh) const;
         nixl_status_t createBatches(const nixl_xfer_op_t &operation,
                                    const nixl_meta_dlist_t &local,
                                    const nixl_meta_dlist_t &remote,

--- a/src/plugins/gds_mt/gds_mt_backend.cpp
+++ b/src/plugins/gds_mt/gds_mt_backend.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,7 @@
 #include "common/nixl_log.h"
 #include "gds_mt_backend.h"
 #include "gds_mt_utils.h"
+#include "file/file_path_mode.h"
 #include "file/file_utils.h"
 #include <taskflow/taskflow.hpp>
 #include <unordered_map>
@@ -158,7 +159,6 @@ runCuFileOp (GdsMtTransferRequestH *req, std::atomic<nixl_status_t> *overall_sta
 nixl_status_t
 extractTransferParams (const nixlMetaDesc &mem_desc,
                        const nixlMetaDesc &file_desc,
-                       const std::unordered_map<int, std::weak_ptr<gdsMtFileHandle>> &file_map,
                        void *&base_addr,
                        size_t &total_size,
                        size_t &base_offset,
@@ -167,15 +167,17 @@ extractTransferParams (const nixlMetaDesc &mem_desc,
     total_size = mem_desc.len;
     base_offset = (size_t)file_desc.addr;
 
-    auto it = file_map.find (file_desc.devId);
-    if (it == file_map.end()) {
-        NIXL_ERROR << "GDS_MT: error: file metadata not found";
+    const auto *md = static_cast<const nixlGdsMtMetadata *>(file_desc.metadataP);
+    if (!md) {
+        NIXL_ERROR << "GDS_MT: missing FILE_SEG metadata at xfer time";
         return NIXL_ERR_NOT_FOUND;
     }
-
-    auto handle = it->second.lock();
-    NIXL_ASSERT (handle);
-    cu_fhandle = handle->cu_fhandle;
+    auto *file_data = std::get_if<FileSegData>(&md->data_);
+    if (!file_data || !file_data->handle) {
+        NIXL_ERROR << "GDS_MT: file metadata is not a FILE_SEG variant";
+        return NIXL_ERR_NOT_FOUND;
+    }
+    cu_fhandle = file_data->handle->cu_fhandle;
     return NIXL_SUCCESS;
 }
 } // namespace
@@ -200,26 +202,35 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
                               nixlBackendMD *&out) {
     switch (nixl_mem) {
     case FILE_SEG: {
-        auto it = gds_mt_file_map_.find (mem.devId);
-        std::shared_ptr<gdsMtFileHandle> handle;
-        if (it != gds_mt_file_map_.end()) {
-            handle = it->second.lock();
-            if (handle) {
-                out = new nixlGdsMtMetadata (handle);
-                return NIXL_SUCCESS;
-            }
-            gds_mt_file_map_.erase (it);
-        }
-
+        nixl::FileFd file_fd;
         try {
-            handle = std::make_shared<gdsMtFileHandle> (mem.devId);
+            file_fd = nixl::FileFd(mem.devId, mem.metaInfo);
         }
-        catch (const std::exception &e) {
-            NIXL_ERROR << "GDS_MT: failed to create file handle: " << e.what();
+        catch (const std::system_error &e) {
+            NIXL_ERROR << "GDS_MT: path-mode open failed: " << e.what();
             return NIXL_ERR_BACKEND;
         }
-        gds_mt_file_map_[mem.devId] = handle;
-        out = new nixlGdsMtMetadata (handle);
+        int fd = file_fd.fd();
+
+        std::shared_ptr<gdsMtFileHandle> handle;
+        if (auto it = gds_mt_file_map_.find(fd); it != gds_mt_file_map_.end()) {
+            handle = it->second.lock();
+            if (!handle) {
+                gds_mt_file_map_.erase(it);
+            }
+            // Cache hit: drop file_fd (~FileFd closes any duplicate owned fd).
+        }
+        if (!handle) {
+            try {
+                handle = std::make_shared<gdsMtFileHandle>(std::move(file_fd));
+            }
+            catch (const std::exception &e) {
+                NIXL_ERROR << "GDS_MT: failed to create file handle: " << e.what();
+                return NIXL_ERR_BACKEND;
+            }
+            gds_mt_file_map_[fd] = handle;
+        }
+        out = new nixlGdsMtMetadata(std::move(handle));
         return NIXL_SUCCESS;
     }
 
@@ -251,11 +262,11 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
 
 nixl_status_t
 nixlGdsMtEngine::deregisterMem (nixlBackendMD *meta) {
-    std::unique_ptr<nixlGdsMtMetadata> md ((nixlGdsMtMetadata *)meta);
+    std::unique_ptr<nixlGdsMtMetadata> md((nixlGdsMtMetadata *)meta);
 
     if (auto *file_data = std::get_if<FileSegData> (&md->data_)) {
         if (file_data->handle) {
-            int key = file_data->handle->fd;
+            int key = file_data->handle->file_fd.fd();
             md.reset(); // Release metadata first
 
             auto it = gds_mt_file_map_.find (key);
@@ -263,7 +274,7 @@ nixlGdsMtEngine::deregisterMem (nixlBackendMD *meta) {
                 gds_mt_file_map_.erase (it);
             }
 
-            // No need to close fd since we're not opening files
+            // owned fds: closed by ~FileFd (RAII) on last shared_ptr drop.
         }
     }
 
@@ -304,7 +315,6 @@ nixlGdsMtEngine::prepXfer (const nixl_xfer_op_t &operation,
         if (is_local_file) {
             param_status = extractTransferParams (remote[i],
                                                   local[i],
-                                                  gds_mt_file_map_,
                                                   base_addr,
                                                   total_size,
                                                   base_offset,
@@ -312,7 +322,6 @@ nixlGdsMtEngine::prepXfer (const nixl_xfer_op_t &operation,
         } else {
             param_status = extractTransferParams (local[i],
                                                   remote[i],
-                                                  gds_mt_file_map_,
                                                   base_addr,
                                                   total_size,
                                                   base_offset,

--- a/src/plugins/gds_mt/gds_mt_utils.cpp
+++ b/src/plugins/gds_mt/gds_mt_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -52,19 +52,21 @@ gdsMtMemBuf::~gdsMtMemBuf() {
     }
 }
 
-gdsMtFileHandle::gdsMtFileHandle (int file_fd) : fd (file_fd) {
-
+gdsMtFileHandle::gdsMtFileHandle(nixl::FileFd &&fd) : file_fd(std::move(fd)) {
     CUfileDescr_t descr = {};
-    descr.handle.fd = fd;
+    descr.handle.fd = file_fd.fd();
     descr.type = CU_FILE_HANDLE_TYPE_OPAQUE_FD;
 
-    const CUfileError_t status = cuFileHandleRegister (&cu_fhandle, &descr);
+    const CUfileError_t status = cuFileHandleRegister(&cu_fhandle, &descr);
     if (status.err != CU_FILE_SUCCESS) {
-        throw std::runtime_error ("GDS_MT: file register error: error=" +
-                                  std::to_string (status.err) + ", fd=" + std::to_string (fd));
+        // ~FileFd as the exception unwinds closes the owned fd if any.
+        throw std::runtime_error(
+            "GDS_MT: file register error: error=" + std::to_string(status.err) +
+            ", fd=" + std::to_string(file_fd.fd()));
     }
 }
 
 gdsMtFileHandle::~gdsMtFileHandle() {
-    cuFileHandleDeregister (cu_fhandle);
+    cuFileHandleDeregister(cu_fhandle);
+    // ~FileFd closes the fd if path-mode owned it.
 }

--- a/src/plugins/gds_mt/gds_mt_utils.h
+++ b/src/plugins/gds_mt/gds_mt_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,9 +22,11 @@
 #include <nixl.h>
 #include <cufile.h>
 
+#include "file/file_path_mode.h"
+
 class gdsMtFileHandle {
 public:
-    gdsMtFileHandle (int fd);
+    explicit gdsMtFileHandle(nixl::FileFd &&fd);
     ~gdsMtFileHandle();
 
     gdsMtFileHandle (const gdsMtFileHandle &) = delete;
@@ -34,7 +36,7 @@ public:
     gdsMtFileHandle &
     operator= (gdsMtFileHandle &&) = delete;
 
-    int fd{-1};
+    nixl::FileFd file_fd;
     CUfileHandle_t cu_fhandle{nullptr};
 };
 

--- a/src/plugins/hf3fs/README.md
+++ b/src/plugins/hf3fs/README.md
@@ -38,3 +38,9 @@ This plugin will try to shared the user provided memory direcrly with the 3FS ba
 mmap() requires the memory to be page-aligned, and size has to be multiple of page size.
 
 If the user-provided memory could not be shared, the plugin will allocate it's own memory to shared with 3FS backend process and copy the data between user-provided memory and the shared memory.
+
+## File registration
+
+`FILE_SEG` accepts either fd-in-`devId` (fd-mode) or a
+`"<modes>:<path>"` string in `metaInfo` (path-mode); see
+[`src/utils/file/README.md`](../../utils/file/README.md#path-mode-file-registration).

--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -24,6 +24,7 @@
 #include "hf3fs_backend.h"
 #include "hf3fs_log.h"
 #include "common/nixl_log.h"
+#include "file/file_path_mode.h"
 #include "file/file_utils.h"
 
 #define NUM_CQES 1024
@@ -185,11 +186,18 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
         break;
     }
     case FILE_SEG: {
-        int fd = mem.devId;
+        std::unique_ptr<nixlHf3fsFileMetadata> md;
+        try {
+            md = std::make_unique<nixlHf3fsFileMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+        }
+        catch (const std::system_error &e) {
+            HF3FS_LOG_RETURN(NIXL_ERR_BACKEND,
+                             absl::StrFormat("HF3FS path-mode open failed: %s", e.what()));
+        }
+        int fd = md->file_fd.fd();
 
         // if the same file is reused - no need to re-register
-        auto it = hf3fs_file_set.find(fd);
-        if (it == hf3fs_file_set.end()) {
+        if (hf3fs_file_set.find(fd) == hf3fs_file_set.end()) {
             int ret = 0;
             status = hf3fs_utils->registerFileHandle(fd, &ret);
             if (status != NIXL_SUCCESS) {
@@ -199,11 +207,10 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
             hf3fs_file_set.insert(fd);
         }
 
-        nixlHf3fsFileMetadata *md = new nixlHf3fsFileMetadata();
         md->handle.fd = fd;
         md->handle.size = mem.len;
         md->handle.metadata = mem.metaInfo;
-        out = (nixlBackendMD *)md;
+        out = md.release();
         break;
     }
     default:
@@ -299,8 +306,8 @@ nixl_status_t nixlHf3fsEngine::prepXfer (const nixl_xfer_op_t &operation,
     }
 
     for (int i = 0; i < file_cnt; i++) {
-        // Get file descriptor from the proper list
-        int file_descriptor = (*file_list)[i].devId;
+        auto file_md = static_cast<nixlHf3fsFileMetadata *>((*file_list)[i].metadataP);
+        int file_descriptor = file_md->file_fd.fd();
         addr = (void*) (*mem_list)[i].addr;
         size = (*mem_list)[i].len;
         offset = (size_t) (*file_list)[i].addr;  // Offset in file

--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@
 #include <thread>
 #include "hf3fs_utils.h"
 #include "backend/backend_engine.h"
+#include "file/file_path_mode.h"
 
 class nixlHf3fsShmException : public std::runtime_error {
 public:
@@ -56,8 +57,13 @@ class nixlHf3fsMetadata : public nixlBackendMD {
 class nixlHf3fsFileMetadata : public nixlHf3fsMetadata {
 public:
     hf3fsFileHandle handle;
+    nixl::FileFd file_fd;
 
     nixlHf3fsFileMetadata() : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE) {}
+
+    explicit nixlHf3fsFileMetadata(nixl::FileFd &&fd)
+        : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE),
+          file_fd(std::move(fd)) {}
 };
 
 class nixlHf3fsDramMetadata : public nixlHf3fsMetadata {

--- a/src/plugins/posix/README.md
+++ b/src/plugins/posix/README.md
@@ -20,6 +20,12 @@ limitations under the License.
 This backend provides POSIX-compliant I/O operations using either Linux AIO (libaio) by default
 Optionally POSIX plugin can also use liburing.
 
+## File registration
+
+`FILE_SEG` descriptors accept either fd-in-`devId` (fd-mode) or a
+`"<modes>:<path>"` string in `metaInfo` (path-mode, backend owns the
+open/close); see [`src/utils/file/README.md`](../../utils/file/README.md#path-mode-file-registration).
+
 ## Dependencies
 To enable Linux AIO support, you need to install the libaio package:
 

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -18,7 +18,12 @@
 #include <iostream>
 #include <cmath>
 #include <errno.h>
+#include <fcntl.h>
+#include <memory>
+#include <optional>
 #include <stdexcept>
+#include <string>
+#include <unistd.h>
 #include "posix_backend.h"
 #include <absl/log/log.h>
 #include <absl/strings/str_format.h>
@@ -206,7 +211,8 @@ nixlPosixBackendReqH::postXfer() {
     for (auto [local_it, remote_it] = std::make_pair(local.begin(), remote.begin());
          local_it != local.end() && remote_it != remote.end();
          ++local_it, ++remote_it) {
-        nixl_status_t status = io_queue_->enqueue(remote_it->devId,
+        int fd = static_cast<nixlPosixFileMD *>(remote_it->metadataP)->file_fd.fd();
+        nixl_status_t status = io_queue_->enqueue(fd,
                                                   reinterpret_cast<void *>(local_it->addr),
                                                   remote_it->len,
                                                   remote_it->addr,
@@ -249,14 +255,26 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
                              const nixl_mem_t &nixl_mem,
                              nixlBackendMD *&out) {
     auto supported_mems = getSupportedMems();
-    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) != supported_mems.end())
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) != supported_mems.end()) {
+        out = nullptr;
+        if (nixl_mem == FILE_SEG) {
+            try {
+                out = new nixlPosixFileMD(nixl::FileFd(mem.devId, mem.metaInfo));
+            }
+            catch (const std::system_error &e) {
+                NIXL_ERROR << "POSIX path-mode open failed: " << e.what();
+                return NIXL_ERR_BACKEND;
+            }
+        }
         return NIXL_SUCCESS;
+    }
 
     return NIXL_ERR_NOT_SUPPORTED;
 }
 
 nixl_status_t
-nixlPosixEngine::deregisterMem(nixlBackendMD *) {
+nixlPosixEngine::deregisterMem(nixlBackendMD *meta) {
+    delete meta;
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -25,8 +25,12 @@
 #include <vector>
 
 #include "backend/backend_engine.h"
+#include "file/file_path_mode.h"
 #include "io_queue.h"
 #include "sync.h"
+
+// POSIX reuses the shared owned-fd base (no extra per-descriptor state).
+using nixlPosixFileMD = nixlFilePathMD;
 
 class nixlPosixBackendReqH : public nixlBackendReqH {
 private:

--- a/src/utils/file/README.md
+++ b/src/utils/file/README.md
@@ -1,11 +1,15 @@
-# File Utils and QueryMem API Implementation
+# File Utils, QueryMem API, and Path-Mode Registration
 
-This directory contains the implementation of file utilities for NIXL file backends, such as using stat to check for file existence used for the QueryMem API.
+This directory contains shared C++ utilities for NIXL file-aware backends:
 
-## Overview
+- `file_utils.{h,cpp}`: `nixl::queryFileInfo()` / `queryFileInfoList()` helpers
+  for the QueryMem API (file existence + stat).
+- `file_path_mode.{h,cpp}`: `nixl::parsePathMeta()` parser and `nixlFilePathMD`
+  owned-fd RAII base for path-mode FILE_SEG registration; see
+  [Path-Mode File Registration](#path-mode-file-registration).
 
-The implementation provides utility functions for generic file operations, such as file query, implementented in `file_utils.h` and `file_utils.cpp`.
-The goal is to eliminate the need for intermediate layers, such as `file_query_helper`, and hence provide better separation of concerns.
+All file-aware plugins (POSIX, HF3FS, CUDA_GDS, GDS_MT) link
+`file_utils_interface` and consume both sets of helpers.
 
 ## QueryMem API Implementation through queryFileInfoList
 
@@ -76,3 +80,37 @@ Test files are provided:
 - Standard C++ libraries
 - POSIX system calls (`stat`, `open`, `close`)
 - NIXL common library for logging
+
+## Path-Mode File Registration
+
+Path-mode lets a caller declare a `FILE_SEG` descriptor by path in
+`nixlBlobDesc::metaInfo` instead of pre-opening an fd; the backend
+opens in `registerMem` and closes in `deregisterMem`. Motivation:
+collapse N Python `os.open()` GIL crossings into one.
+
+A `metaInfo` string is parsed as path-mode iff it matches:
+
+```text
+metaInfo := <modes>:<path>     # path-mode
+          | <anything else>    # fd-in-devId mode
+modes    := <access>[,<flag>]*
+access   := "ro"               # O_RDONLY
+          | "rw"               # O_RDWR
+flag     := "direct"           # | O_DIRECT
+          | "sync"             # | O_SYNC
+          | "noatime"          # | O_NOATIME
+          | "create"           # | O_CREAT (mode 0644)
+```
+
+Examples: `ro:/var/cache/x.bin`, `rw,direct:/var/cache/x.bin`,
+`rw,create:/var/cache/x.bin`. Unknown/missing tokens yield `nullopt`
+(fail-loud); the design is strictly additive: any non-matching
+`metaInfo` falls through to caller-owned fd in `devId`.
+
+Backends consume the shared helpers `nixl::parsePathMeta()` +
+`nixlFilePathMD` from `file_path_mode.{h,cpp}`. POSIX uses
+`nixlFilePathMD` directly; HF3FS / CUDA_GDS / GDS_MT extend their
+existing per-descriptor MD struct with `owned` (and close the fd in
+`deregisterMem` after the backend-specific teardown). The GDS per-fd
+caches key on the *opened* fd, so two path-mode registrations of the
+same path yield two cuFile handles (no path-level dedup).

--- a/src/utils/file/file_path_mode.cpp
+++ b/src/utils/file/file_path_mode.cpp
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "file_path_mode.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include <absl/strings/str_split.h>
+
+#include "common/nixl_log.h"
+
+namespace nixl {
+
+std::optional<PathSpec>
+parsePathMeta(const std::string &s) {
+    auto colon = s.find(':');
+    if (colon == std::string::npos) {
+        return std::nullopt;
+    }
+    std::string modes = s.substr(0, colon);
+    std::string path = s.substr(colon + 1);
+
+    std::vector<std::string> tokens = absl::StrSplit(modes, ',');
+
+    int flags;
+    if (tokens[0] == "ro") {
+        flags = O_RDONLY;
+    } else if (tokens[0] == "rw") {
+        flags = O_RDWR;
+    } else {
+        return std::nullopt;
+    }
+
+    // From here on: Starts with ro or rw and has colon -> caller intends path-mode -> warn on error
+    if (path.empty()) {
+        NIXL_DEBUG << "path-mode registration ignored: empty path in \"" << s << "\"";
+        return std::nullopt;
+    }
+
+    mode_t mode = 0;
+    for (size_t i = 1; i < tokens.size(); ++i) {
+        if (tokens[i] == "direct") {
+            flags |= O_DIRECT;
+        } else if (tokens[i] == "sync") {
+            flags |= O_SYNC;
+        } else if (tokens[i] == "noatime") {
+            flags |= O_NOATIME;
+        } else if (tokens[i] == "create") {
+            flags |= O_CREAT;
+            mode = 0644;
+        } else {
+            NIXL_DEBUG << "path-mode registration ignored: unknown flag token \"" << tokens[i]
+                       << "\" in \"" << s << "\"";
+            return std::nullopt;
+        }
+    }
+
+    return PathSpec{path, flags, mode};
+}
+
+FileFd::FileFd(int fallback_fd, const std::string &metaInfo) {
+    auto spec = parsePathMeta(metaInfo);
+    if (!spec) {
+        fd_ = fallback_fd;
+        return;
+    }
+    int fd = ::open(spec->path.c_str(), spec->flags, spec->mode);
+    if (fd < 0) {
+        throw std::system_error(
+            errno, std::generic_category(), "nixl::FileFd(\"" + spec->path + "\")");
+    }
+    fd_ = fd;
+    owned_ = true;
+    path_ = std::move(spec->path);
+}
+
+FileFd::FileFd(FileFd &&other) noexcept
+    : fd_(other.fd_),
+      owned_(other.owned_),
+      path_(std::move(other.path_)) {
+    other.fd_ = -1;
+    other.owned_ = false;
+}
+
+FileFd &
+FileFd::operator=(FileFd &&other) noexcept {
+    if (this != &other) {
+        if (owned_ && fd_ >= 0) {
+            ::close(fd_);
+        }
+        fd_ = other.fd_;
+        owned_ = other.owned_;
+        path_ = std::move(other.path_);
+        other.fd_ = -1;
+        other.owned_ = false;
+    }
+    return *this;
+}
+
+FileFd::~FileFd() {
+    if (owned_ && fd_ >= 0) {
+        ::close(fd_);
+    }
+}
+
+} // namespace nixl

--- a/src/utils/file/file_path_mode.h
+++ b/src/utils/file/file_path_mode.h
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __FILE_PATH_MODE_H
+#define __FILE_PATH_MODE_H
+
+#include <sys/types.h>
+
+#include <optional>
+#include <string>
+
+#include "backend/backend_engine.h"
+
+// Path-mode parser for FILE_SEG. Grammar (intentionally verbose: API contract).
+//
+//   metaInfo := <modes>:<path>     # path-mode
+//             | <anything else>    # fd-in-devId mode
+//   modes    := <access>[,<flag>]*
+//   access   := "ro"               # O_RDONLY
+//             | "rw"               # O_RDWR
+//   flag     := "direct"           # | O_DIRECT
+//             | "sync"             # | O_SYNC
+//             | "noatime"          # | O_NOATIME
+//             | "create"           # | O_CREAT (mode 0644)
+//
+// Unknown tokens: parsePathMeta returns std::nullopt (fail-loud).
+
+namespace nixl {
+
+// `mode` is only consumed when O_CREAT is in `flags`.
+struct PathSpec {
+    std::string path;
+    int flags;
+    mode_t mode;
+};
+
+std::optional<PathSpec>
+parsePathMeta(const std::string &s);
+
+// RAII wrapper bundling an fd + ownership flag + (optional) path string.
+// Used by FILE_SEG backends so per-MD bookkeeping (owned/path) lives in
+// one place. One ctor covers both registration modes:
+//
+//   FileFd(fallback_fd, metaInfo)
+//     metaInfo parses as path-mode -> open(spec) and own the fd;
+//                                     throws std::system_error on open() failure.
+//     otherwise                    -> fd = fallback_fd, not owned.
+//
+// Move-only. fd() returns the held fd; dtor closes iff owned.
+class FileFd {
+public:
+    FileFd() = default;
+    FileFd(int fallback_fd, const std::string &metaInfo);
+
+    FileFd(const FileFd &) = delete;
+    FileFd &
+    operator=(const FileFd &) = delete;
+    FileFd(FileFd &&other) noexcept;
+    FileFd &
+    operator=(FileFd &&other) noexcept;
+    ~FileFd();
+
+    int
+    fd() const noexcept {
+        return fd_;
+    }
+
+    const std::string &
+    path() const noexcept {
+        return path_;
+    }
+
+private:
+    int fd_ = -1;
+    bool owned_ = false;
+    std::string path_;
+};
+
+} // namespace nixl
+
+class nixlFilePathMD : public nixlBackendMD {
+public:
+    nixl::FileFd file_fd;
+
+    nixlFilePathMD() : nixlBackendMD(true /*isPrivate*/) {}
+
+    explicit nixlFilePathMD(nixl::FileFd &&fd) : nixlBackendMD(true), file_fd(std::move(fd)) {}
+};
+
+#endif // __FILE_PATH_MODE_H

--- a/src/utils/file/meson.build
+++ b/src/utils/file/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 
 file_utils_lib = library('file_utils',
            'file_utils.cpp', 'file_utils.h',
+           'file_path_mode.cpp', 'file_path_mode.h',
            include_directories: [nixl_inc_dirs, utils_inc_dirs],
            dependencies: [nixl_common_dep],
            install: true)

--- a/test/unit/plugins/cuda_gds/meson.build
+++ b/test/unit/plugins/cuda_gds/meson.build
@@ -19,5 +19,7 @@ endif
 
 nixl_gds_app = executable('nixl_gds_test', 'nixl_gds_test.cpp',
                           dependencies: [nixl_dep, nixl_infra, cuda_dep, nixl_common_dep],
-                          include_directories: [nixl_inc_dirs, utils_inc_dirs],
+                          include_directories: [nixl_inc_dirs, utils_inc_dirs,
+                                                include_directories('..')],
                           install: true)
+test('gds_path_mode_smoke', nixl_gds_app)

--- a/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
+++ b/test/unit/plugins/cuda_gds/nixl_gds_test.cpp
@@ -30,6 +30,7 @@
 #include "nixl_params.h"
 #include "nixl.h"
 #include "common/nixl_time.h"
+#include "path_mode_common.h"
 
 // Default values
 #define DEFAULT_NUM_TRANSFERS 250
@@ -64,23 +65,29 @@ size_t parse_size(const char* size_str) {
 }
 
 void print_usage(const char* program_name) {
-    std::cerr << "Usage: " << program_name << " [options] <directory_path>\n"
-              << "Options:\n"
-              << "  -d, --dram              Use DRAM for memory operations\n"
-              << "  -v, --vram              Use VRAM for memory operations (default)\n"
-              << "  -n, --num-transfers N   Number of transfers to perform (default: " << DEFAULT_NUM_TRANSFERS << ")\n"
-              << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE << " bytes)\n"
-              << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
-              << "  -r, --no-read           Skip read test\n"
-              << "  -w, --no-write          Skip write test\n"
-              << "  -p, --pool-size SIZE    Size of batch pool (default: 8, range: 1-32)\n"
-              << "  -b, --batch-limit SIZE  Maximum requests per batch  (default: 128, Max allowed: 1-128)\n"
-              << "  -m, --max-req-size SIZE Maximum size per request (default: 16M, Max allowed: 16M)\n"
-              << "  -t, --iterations N      Number of iterations for each transfer (default: " << DEFAULT_ITERATIONS << ")\n"
-              << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
-              << "  -h, --help              Show this help message\n"
-              << "\nExample:\n"
-              << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
+    std::cerr
+        << "Usage: " << program_name << " [options] <directory_path>\n"
+        << "Options:\n"
+        << "  -d, --dram              Use DRAM for memory operations\n"
+        << "  -v, --vram              Use VRAM for memory operations (default)\n"
+        << "  -n, --num-transfers N   Number of transfers to perform (default: "
+        << DEFAULT_NUM_TRANSFERS << ")\n"
+        << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE
+        << " bytes)\n"
+        << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
+        << "  -r, --no-read           Skip read test\n"
+        << "  -w, --no-write          Skip write test\n"
+        << "  -p, --pool-size SIZE    Size of batch pool (default: 8, range: 1-32)\n"
+        << "  -b, --batch-limit SIZE  Maximum requests per batch  (default: 128, Max allowed: "
+           "1-128)\n"
+        << "  -m, --max-req-size SIZE Maximum size per request (default: 16M, Max allowed: 16M)\n"
+        << "  -t, --iterations N      Number of iterations for each transfer (default: "
+        << DEFAULT_ITERATIONS << ")\n"
+        << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
+        << "  -P, --no-path-mode-smoke Skip the path-mode smoke (enabled by default)\n"
+        << "  -h, --help              Show this help message\n"
+        << "\nExample:\n"
+        << "  " << program_name << " -d -n 100 -s 2M -p 16 -b 256 -m 32M -t 5 -D /path/to/dir\n";
 }
 
 void printProgress(float progress) {
@@ -195,6 +202,12 @@ std::string format_duration(nixlTime::us_t us) {
     return ss.str();
 }
 
+static int
+runPathModeSmoke() {
+    return nixl_test::runPathModeSmoke(
+        "GDSPathModeSmoke", "GDS", "/tmp/nixl_gds_path_mode_smoke.bin", 4096);
+}
+
 int main(int argc, char *argv[])
 {
     nixl_status_t               ret = NIXL_SUCCESS;
@@ -214,30 +227,30 @@ int main(int argc, char *argv[])
     bool                        skip_write = false;
     unsigned int                pool_size = 8;
     unsigned int                batch_limit = 128;
-    size_t                      max_request_size = 16 * 1024 * 1024;
+    size_t max_request_size = 16 * 1024 * 1024;
     nixlTime::us_t              total_time(0);
     double                      total_data_gb = 0;
     bool                        use_direct = false;
-    unsigned int                iterations = DEFAULT_ITERATIONS;
+    unsigned int iterations = DEFAULT_ITERATIONS;
+    bool run_path_mode_smoke = true;
 
     // Parse command line options
-    static struct option long_options[] = {
-        {"dram",            no_argument,       0, 'd'},
-        {"vram",            no_argument,       0, 'v'},
-        {"num-transfers",   required_argument, 0, 'n'},
-        {"size",           required_argument, 0, 's'},
-        {"no-read",        no_argument,       0, 'r'},
-        {"no-write",       no_argument,       0, 'w'},
-        {"pool-size",      required_argument, 0, 'p'},
-        {"batch-limit",    required_argument, 0, 'b'},
-        {"max-req-size",   required_argument, 0, 'm'},
-        {"iterations",     required_argument, 0, 't'},
-        {"direct",         no_argument,       0, 'D'},
-        {"help",           no_argument,       0, 'h'},
-        {0,                0,                 0,  0}
-    };
+    static struct option long_options[] = {{"dram", no_argument, 0, 'd'},
+                                           {"vram", no_argument, 0, 'v'},
+                                           {"num-transfers", required_argument, 0, 'n'},
+                                           {"size", required_argument, 0, 's'},
+                                           {"no-read", no_argument, 0, 'r'},
+                                           {"no-write", no_argument, 0, 'w'},
+                                           {"pool-size", required_argument, 0, 'p'},
+                                           {"batch-limit", required_argument, 0, 'b'},
+                                           {"max-req-size", required_argument, 0, 'm'},
+                                           {"iterations", required_argument, 0, 't'},
+                                           {"direct", no_argument, 0, 'D'},
+                                           {"no-path-mode-smoke", no_argument, 0, 'P'},
+                                           {"help", no_argument, 0, 'h'},
+                                           {0, 0, 0, 0}};
 
-    while ((opt = getopt_long(argc, argv, "dvn:s:rwp:b:m:t:Dh", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "dvn:s:rwp:b:m:t:DPh", long_options, NULL)) != -1) {
         switch (opt) {
             case 'd':
                 use_dram = true;
@@ -292,6 +305,9 @@ int main(int argc, char *argv[])
             case 'D':
                 use_direct = true;
                 break;
+            case 'P':
+                run_path_mode_smoke = false;
+                break;
             case 'h':
                 print_usage(argv[0]);
                 return 0;
@@ -304,6 +320,12 @@ int main(int argc, char *argv[])
     if (skip_read && skip_write) {
         std::cerr << "Error: Cannot skip both read and write tests\n";
         return 1;
+    }
+
+    if (run_path_mode_smoke) {
+        if (int rc = runPathModeSmoke(); rc != 0) {
+            return rc;
+        }
     }
 
     // Check if directory path is provided

--- a/test/unit/plugins/gds_mt/meson.build
+++ b/test/unit/plugins/gds_mt/meson.build
@@ -19,5 +19,8 @@ endif
 
 nixl_gds_mt_app = executable('nixl_gds_mt_test', 'nixl_gds_mt_test.cpp',
                              dependencies: [nixl_dep, nixl_infra, cuda_dep, nixl_common_dep],
-                             include_directories: [nixl_inc_dirs, utils_inc_dirs],
+                             include_directories: [nixl_inc_dirs, utils_inc_dirs,
+                                                   include_directories('..')],
                              install: true)
+
+test('gds_mt_path_mode_smoke', nixl_gds_mt_app)

--- a/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
+++ b/test/unit/plugins/gds_mt/nixl_gds_mt_test.cpp
@@ -25,11 +25,16 @@
 #include <sstream>
 #include <cerrno>
 #include <cstring>
+#include <cstdio>
+#include <filesystem>
 #include <getopt.h>
 #include "nixl_descriptors.h"
 #include "nixl_params.h"
 #include "nixl.h"
 #include "common/nixl_time.h"
+#include "path_mode_common.h"
+
+namespace fs = std::filesystem;
 
 // Default values
 #define DEFAULT_NUM_TRANSFERS 250
@@ -89,6 +94,7 @@ print_usage (const char *program_name) {
         << "  -t, --iterations N      Number of iterations for each transfer (default: "
         << DEFAULT_ITERATIONS << ")\n"
         << "  -D, --direct            Use O_DIRECT for file operations (bypass page cache)\n"
+        << "  -P, --no-path-mode-smoke Skip the path-mode smoke (enabled by default)\n"
         << "  -G, --num-gpus          Number of GPUs to use (default: " << DEFAULT_NUM_GPUS << ")\n"
         << "  -N, --num-threads N     Number of CPU Threads to use (default: all CPUs detected)\n"
         << "  -h, --help              Show this help message\n"
@@ -219,6 +225,12 @@ format_duration (nixlTime::us_t us) {
     return ss.str();
 }
 
+static int
+runPathModeSmoke() {
+    return nixl_test::runPathModeSmoke(
+        "GDSMTPathModeSmoke", "GDS_MT", "/tmp/nixl_gds_mt_path_mode_smoke.bin", 4096);
+}
+
 int
 main (int argc, char *argv[]) {
     nixl_status_t ret = NIXL_SUCCESS;
@@ -242,6 +254,7 @@ main (int argc, char *argv[]) {
     bool use_direct = false;
     unsigned int iterations = DEFAULT_ITERATIONS;
     unsigned int num_gpus = DEFAULT_NUM_GPUS;
+    bool run_path_mode_smoke = true;
 
     // Parse command line options
     static struct option long_options[] = {{"dram", no_argument, 0, 'd'},
@@ -255,10 +268,11 @@ main (int argc, char *argv[]) {
                                            {"num-threads", required_argument, 0, 'N'},
                                            {"iterations", required_argument, 0, 't'},
                                            {"direct", no_argument, 0, 'D'},
+                                           {"no-path-mode-smoke", no_argument, 0, 'P'},
                                            {"help", no_argument, 0, 'h'},
                                            {0, 0, 0, 0}};
 
-    while ((opt = getopt_long (argc, argv, "dvn:s:rwp:b:t:G:DhN:", long_options, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "dvn:s:rwp:b:t:G:DPhN:", long_options, NULL)) != -1) {
         switch (opt) {
         case 'd':
             use_dram = true;
@@ -310,6 +324,9 @@ main (int argc, char *argv[]) {
         case 'D':
             use_direct = true;
             break;
+        case 'P':
+            run_path_mode_smoke = false;
+            break;
         case 'h':
             print_usage (argv[0]);
             return 0;
@@ -322,6 +339,12 @@ main (int argc, char *argv[]) {
     if (skip_read && skip_write) {
         std::cerr << "Error: Cannot skip both read and write tests\n";
         return 1;
+    }
+
+    if (run_path_mode_smoke) {
+        if (int rc = runPathModeSmoke(); rc != 0) {
+            return rc;
+        }
     }
 
     // Check if directory path is provided

--- a/test/unit/plugins/hf3fs/meson.build
+++ b/test/unit/plugins/hf3fs/meson.build
@@ -15,7 +15,8 @@
 
 nixl_hf3fs_app = executable('nixl_hf3fs_test', 'nixl_hf3fs_test.cpp',
                           dependencies: [nixl_dep, nixl_infra],
-                          include_directories: [nixl_inc_dirs, utils_inc_dirs],
+                          include_directories: [nixl_inc_dirs, utils_inc_dirs,
+                                                include_directories('..')],
                           install: true)
 
 nixl_hf3fs_mt_app = executable('nixl_hf3fs_mt_test', 'nixl_hf3fs_mt_test.cpp',

--- a/test/unit/plugins/hf3fs/nixl_hf3fs_test.cpp
+++ b/test/unit/plugins/hf3fs/nixl_hf3fs_test.cpp
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <getopt.h>
 #include "common/nixl_time.h"
+#include "path_mode_common.h"
 #include "temp_file.h"
 
 namespace {
@@ -138,6 +139,14 @@ namespace {
         }
     };
 
+    int
+    runPathModeSmoke() {
+        const char *probe_path = std::getenv("NIXL_HF3FS_PROBE_PATH");
+        if (!probe_path) {
+            probe_path = "/mnt/3fs/nixl_hf3fs_path_mode_smoke.bin";
+        }
+        return nixl_test::runPathModeSmoke("HF3FSPathModeSmoke", "HF3FS", probe_path, 4096);
+    }
 }
 
 int main(int argc, char *argv[])
@@ -149,10 +158,11 @@ int main(int argc, char *argv[])
     nixlTime::us_t wait_time = default_wait_time;
     int max_waits = default_max_waits;
     bool filled_after_mem_register = false;
+    bool run_path_mode_smoke = true;
 
     // getopt argument parsing
     int opt;
-    while ((opt = getopt(argc, argv, "hn:s:d:w:m:l:")) != -1) {
+    while ((opt = getopt(argc, argv, "hn:s:d:w:m:l:P")) != -1) {
         switch (opt) {
         case 'l':
             if (strcmp(optarg, "before") == 0) {
@@ -202,11 +212,14 @@ int main(int argc, char *argv[])
                 return 1;
             }
             break;
+        case 'P':
+            run_path_mode_smoke = false;
+            break;
         case 'h':
         default:
             std::cout << "Usage: " << argv[0]
                       << " [-n num_transfers] [-s transfer_size] [-d test_files_dir_path] [-w "
-                         "wait_time] [-m max_waits]"
+                         "wait_time] [-m max_waits] [-P]"
                       << std::endl;
             std::cout << "  -n num_transfers      Number of transfers (default: "
                       << default_num_transfers << ")" << std::endl;
@@ -224,6 +237,8 @@ int main(int argc, char *argv[])
             std::cout << "  -l                    Filled memory before or after memory register "
                          "with NIXL: [before, after]"
                       << std::endl;
+            std::cout << "  -P                    Skip path-mode smoke (enabled by default)"
+                      << std::endl;
             std::cout << "  -h                    Show this help message" << std::endl;
             return (opt == 'h') ? 0 : 1;
         }
@@ -232,6 +247,12 @@ int main(int argc, char *argv[])
     if (page_size == 0) {
         std::cerr << "Error: Invalid page size returned by sysconf" << std::endl;
         return 1;
+    }
+
+    if (run_path_mode_smoke) {
+        if (int rc = runPathModeSmoke(); rc != 0) {
+            return rc;
+        }
     }
 
     // Convert directory path to absolute path using std::filesystem

--- a/test/unit/plugins/path_mode_common.h
+++ b/test/unit/plugins/path_mode_common.h
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+// Shared smoke harness: 2-file register -> WRITE/READ/verify -> dereg with fd-leak check.
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#include "nixl.h"
+#include "nixl_descriptors.h"
+#include "nixl_params.h"
+#include "nixl_types.h"
+
+namespace nixl_test {
+
+inline size_t
+countOpenFds() {
+    size_t n = 0;
+    for ([[maybe_unused]] auto &e : std::filesystem::directory_iterator("/proc/self/fd")) {
+        ++n;
+    }
+    return n;
+}
+
+inline void *
+allocDram(size_t s) {
+    void *p = nullptr;
+    return posix_memalign(&p, sysconf(_SC_PAGESIZE), s) == 0 ? p : nullptr;
+}
+
+inline bool
+verifyDram(const void *p, unsigned char v, size_t s) {
+    auto *b = static_cast<const unsigned char *>(p);
+    for (size_t i = 0; i < s; ++i) {
+        if (b[i] != v) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// One register/WRITE/READ/verify/deregister cycle; baseline non-null asserts net-zero fd delta.
+inline bool
+doRoundtrip(nixlAgent &agent,
+            const char *agent_name,
+            const std::string &path_a,
+            const std::string &path_b,
+            size_t size,
+            const size_t *baseline) {
+    constexpr unsigned char kPatternA = 0xA5;
+    constexpr unsigned char kPatternB = 0x5A;
+
+    nixl_reg_dlist_t file_descs(FILE_SEG);
+    uint64_t file_devid = 0;
+    for (const std::string &p : {path_a, path_b}) {
+        nixlBlobDesc fd;
+        fd.addr = 0;
+        fd.len = size;
+        fd.devId = file_devid++; // distinct so xfer-time lookup disambiguates
+        fd.metaInfo = std::string("rw:") + p;
+        file_descs.addDesc(fd);
+    }
+    if (agent.registerMem(file_descs) != NIXL_SUCCESS) {
+        return false;
+    }
+
+    void *buf_a = allocDram(size);
+    void *buf_b = allocDram(size);
+    nixl_reg_dlist_t buf_descs(DRAM_SEG);
+    for (void *b : {buf_a, buf_b}) {
+        nixlBlobDesc bd;
+        bd.addr = reinterpret_cast<uintptr_t>(b);
+        bd.len = size;
+        bd.devId = 0; // buf addrs already disambiguate
+        buf_descs.addDesc(bd);
+    }
+
+    bool ok = false;
+    if (buf_a && buf_b && agent.registerMem(buf_descs) == NIXL_SUCCESS) {
+        std::memset(buf_a, kPatternA, size);
+        std::memset(buf_b, kPatternB, size);
+        nixl_xfer_dlist_t bx = buf_descs.trim();
+        nixl_xfer_dlist_t fx = file_descs.trim();
+        auto xfer = [&](nixl_xfer_op_t op) {
+            nixlXferReqH *req = nullptr;
+            nixl_status_t r = agent.createXferReq(op, bx, fx, agent_name, req);
+            if (r == NIXL_SUCCESS) {
+                r = agent.postXferReq(req);
+                while (r == NIXL_IN_PROG) {
+                    r = agent.getXferStatus(req);
+                }
+                agent.releaseXferReq(req);
+            }
+            return r;
+        };
+        if (xfer(NIXL_WRITE) == NIXL_SUCCESS) {
+            std::memset(buf_a, 0, size);
+            std::memset(buf_b, 0, size);
+            if (xfer(NIXL_READ) == NIXL_SUCCESS && verifyDram(buf_a, kPatternA, size) &&
+                verifyDram(buf_b, kPatternB, size)) {
+                ok = true;
+            }
+        }
+        agent.deregisterMem(buf_descs);
+    }
+    if (buf_a) {
+        free(buf_a);
+    }
+    if (buf_b) {
+        free(buf_b);
+    }
+    if (agent.deregisterMem(file_descs) != NIXL_SUCCESS) {
+        ok = false;
+    }
+    if (baseline && ok && countOpenFds() != *baseline) {
+        ok = false;
+    }
+    return ok;
+}
+
+// A ro: registration of a missing `path` must fail gracefully, not crash.
+inline bool
+checkMissingFileRejected(nixlAgent &agent, const std::string &path) {
+    nixl_reg_dlist_t file_descs(FILE_SEG);
+    nixlBlobDesc fd;
+    fd.addr = 0;
+    fd.len = 4096;
+    fd.devId = 0;
+    fd.metaInfo = std::string("ro:") + path;
+    file_descs.addDesc(fd);
+    if (agent.registerMem(file_descs) == NIXL_SUCCESS) {
+        agent.deregisterMem(file_descs);
+        return false;
+    }
+    return true;
+}
+
+// 0 on success or SKIP (backend unavailable), 1 on hard failure.
+inline int
+runPathModeSmoke(const char *agent_name,
+                 const char *backend_name,
+                 const char *file_path,
+                 size_t size) {
+    const std::string path_a = file_path;
+    const std::string path_b = std::string(file_path) + ".b";
+
+    for (const std::string &p : {path_a, path_b}) {
+        if (auto *f = std::fopen(p.c_str(), "wb")) {
+            std::fseek(f, size - 1, SEEK_SET);
+            std::fputc(0, f);
+            std::fclose(f);
+        } else {
+            return 1;
+        }
+    }
+
+    nixlAgentConfig cfg;
+    nixlAgent agent(agent_name, cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend(backend_name, params, be) != NIXL_SUCCESS || !be) {
+        std::cout << "SKIP: " << backend_name << " createBackend failed" << std::endl;
+        std::remove(path_a.c_str());
+        std::remove(path_b.c_str());
+        return 0;
+    }
+
+    // Warm-up absorbs backends' lazy-init fds (e.g. libhf3fs's hf3fs_iorcreate) into baseline.
+    if (!doRoundtrip(agent, agent_name, path_a, path_b, size, nullptr)) {
+        std::cerr << backend_name << " path-mode warm-up FAILED" << std::endl;
+        std::remove(path_a.c_str());
+        std::remove(path_b.c_str());
+        return 1;
+    }
+
+    const std::string missing = std::string(file_path) + ".missing";
+    std::remove(missing.c_str());
+    if (!checkMissingFileRejected(agent, missing)) {
+        std::cerr << backend_name << " path-mode missing-file check FAILED" << std::endl;
+        std::remove(path_a.c_str());
+        std::remove(path_b.c_str());
+        return 1;
+    }
+
+    const size_t baseline = countOpenFds();
+    bool ok = doRoundtrip(agent, agent_name, path_a, path_b, size, &baseline);
+    std::remove(path_a.c_str());
+    std::remove(path_b.c_str());
+    if (ok) {
+        std::cout << backend_name << " path-mode roundtrip OK (baseline=" << baseline << ")"
+                  << std::endl;
+        return 0;
+    }
+    std::cerr << backend_name << " path-mode roundtrip FAILED" << std::endl;
+    return 1;
+}
+
+} // namespace nixl_test

--- a/test/unit/plugins/posix/meson.build
+++ b/test/unit/plugins/posix/meson.build
@@ -16,10 +16,10 @@
 # Using globally defined has_posix_plugin from the root meson.build
 if has_posix_plugin
     nixl_posix_app = executable('nixl_posix_test', 'nixl_posix_test.cpp',
-                                dependencies: [nixl_dep, nixl_infra, absl_log_dep],
-                                include_directories: [nixl_inc_dirs, utils_inc_dirs],
+                                dependencies: [nixl_dep, nixl_infra,
+                                               file_utils_interface, absl_log_dep],
+                                include_directories: [nixl_inc_dirs, utils_inc_dirs,
+                                                      include_directories('..')],
                                 install: true)
-
-    # Register the test with the test suite
     test('posix_plugin_test', nixl_posix_app)
 endif

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -29,6 +29,8 @@
 #include "nixl_params.h"
 #include "nixl_descriptors.h"
 #include "common/nixl_time.h"
+#include "file/file_path_mode.h"
+#include "path_mode_common.h"
 #include <stdexcept>
 #include <cstdio>
 #include <getopt.h>
@@ -731,6 +733,70 @@ test_posix_repost (std::string test_files_dir_path_abs_path, bool use_uring) {
     return 0;
 }
 
+// Path-mode parser unit checks (POSIX-only since it owns parsePathMeta tests).
+static void
+checkPathModeParser() {
+    using nixl::parsePathMeta;
+    {
+        const auto s = parsePathMeta("ro:/tmp/x");
+        assert(s && s->path == "/tmp/x" && s->flags == O_RDONLY);
+    }
+    {
+        const auto s = parsePathMeta("rw:/tmp/x");
+        assert(s && s->flags == O_RDWR);
+    }
+    {
+        const auto s = parsePathMeta("rw,direct:/tmp/x");
+        assert(s && s->flags == (O_RDWR | O_DIRECT));
+    }
+    {
+        const auto s = parsePathMeta("ro,direct,sync,noatime:/tmp/x");
+        assert(s && s->flags == (O_RDONLY | O_DIRECT | O_SYNC | O_NOATIME));
+    }
+    {
+        const auto s = parsePathMeta("rw,create:/tmp/x");
+        assert(s && s->flags == (O_RDWR | O_CREAT) && s->mode == 0644);
+    }
+    assert(!parsePathMeta("").has_value());
+    assert(!parsePathMeta("no-colon").has_value());
+    assert(!parsePathMeta("ro:").has_value());
+    assert(!parsePathMeta("xx:/tmp/x").has_value());
+    assert(!parsePathMeta("rw,foo:/tmp/x").has_value());
+    assert(!parsePathMeta("kv-0042.bin").has_value());
+    std::cout << "parsePathMeta: OK" << std::endl;
+}
+
+// `rw,create:` should produce a new file at registerMem.
+static int
+runPathModeCreateCheck() {
+    constexpr const char *kCreateFile = "/tmp/nixl_posix_path_mode_create.bin";
+    std::remove(kCreateFile);
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXPathModeCreate", cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend("POSIX", params, be) != NIXL_SUCCESS) {
+        return 1;
+    }
+    nixl_reg_dlist_t d(FILE_SEG);
+    nixlBlobDesc desc;
+    desc.addr = 0;
+    desc.len = 4096;
+    desc.devId = 0;
+    desc.metaInfo = std::string("rw,create:") + kCreateFile;
+    d.addDesc(desc);
+    if (agent.registerMem(d) != NIXL_SUCCESS) {
+        return 1;
+    }
+    if (!std::filesystem::exists(kCreateFile)) {
+        return 1;
+    }
+    agent.deregisterMem(d);
+    std::remove(kCreateFile);
+    std::cout << "O_CREAT path-mode: OK" << std::endl;
+    return 0;
+}
+
 int
 main (int argc, char *argv[]) {
     if (page_size <= 0) {
@@ -746,8 +812,9 @@ main (int argc, char *argv[]) {
     std::string test_files_dir_path = default_test_files_dir_path;
     bool use_direct_io = false;
     bool use_uring = false;
+    bool run_path_mode_smoke = true;
 
-    while ((opt = getopt (argc, argv, "n:s:d:DUh")) != -1) {
+    while ((opt = getopt(argc, argv, "n:s:d:DUPh")) != -1) {
         switch (opt) {
         case 'n':
             num_transfers = std::stoi (optarg);
@@ -764,11 +831,14 @@ main (int argc, char *argv[]) {
         case 'U':
             use_uring = true;
             break;
+        case 'P':
+            run_path_mode_smoke = false;
+            break;
         case 'h':
         default:
-            std::cout << absl::StrFormat ("Usage: %s [-n num_transfers] [-s transfer_size] [-d "
-                                          "test_files_dir_path] [-D] [-U]",
-                                          argv[0])
+            std::cout << absl::StrFormat("Usage: %s [-n num_transfers] [-s transfer_size] [-d "
+                                         "test_files_dir_path] [-D] [-U] [-P]",
+                                         argv[0])
                       << std::endl;
             std::cout << absl::StrFormat (
                              "  -n num_transfers      Number of transfers (default: %d)",
@@ -785,8 +855,22 @@ main (int argc, char *argv[]) {
                       << std::endl;
             std::cout << absl::StrFormat ("  -D Use O_DIRECT for file I/O") << std::endl;
             std::cout << absl::StrFormat ("  -U Use io_uring backend instead of AIO") << std::endl;
+            std::cout << absl::StrFormat("  -P Skip path-mode smoke (enabled by default)")
+                      << std::endl;
             std::cout << absl::StrFormat ("  -h Show this help message") << std::endl;
             return (opt == 'h') ? 0 : 1;
+        }
+    }
+
+    if (run_path_mode_smoke) {
+        checkPathModeParser();
+        if (int rc = runPathModeCreateCheck(); rc != 0) {
+            return rc;
+        }
+        if (int rc = nixl_test::runPathModeSmoke(
+                "POSIXPathModeSmoke", "POSIX", "/tmp/nixl_posix_path_mode_smoke.bin", 4096);
+            rc != 0) {
+            return rc;
         }
     }
 


### PR DESCRIPTION
## What?

Allow callers of the northbound API to declare files by path (string) instead of as file descriptor.

## Why?

SGLang's HiCache issues 128 os.open() calls per flush from Python; GIL contention makes each batch take ~415ms. Moving the opens to C++ gives ~24x batch-open speedup in our mock and ~6-12x end-to-end warm-phase TTFT speedup in hibench against Qwen-32B.

## How?

Allow callers to declare files by path in nixlBlobDesc::metaInfo:

    metaInfo := <modes>:<path>     # path-mode (new)
              | <anything else>    # legacy fd-in-devId
    modes    := <access>[,<flag>]*
    access   := "ro" | "rw"
    flag     := "direct" | "sync" | "noatime" | "create"

Backends open the file in registerMem and close it in deregisterMem. Wired in all four file-aware plugins via a shared helper at src/utils/file/file_path_mode.{h,cpp} (parsePathMeta + nixlFilePathMD owned-fd RAII base):

  - POSIX  
  - HF3FS 
  - CUDA_GDS 
  - GDS_MT

Strictly additive: unknown access/flag tokens fall through to legacy mode, so existing fd-in-devId callers are unaffected.


## Testing 

I ran the smoke test included in this PR on: 

* POSIX : tested
* GDS: tested (on dlcluster, viking-prod machines)
* GDS-MT: tested (on dlcluster, viking-prod machines)
* H3FS : tested against a 3FS cluster. However, #1645 is necessary to compile NIXL with h3fs. 

The smoke test registers some memory then transfers from a file. At the end, it verifies no stale file handles.

## Performance

### Mock 
In a single-file repro that imitates the SGLang access pattern minimally:

- One main thread busy-loops on a non-yielding boolean flag (mimicking the scheduler's CPU usage).
- A "nixl-connector" thread runs 16 iterations of (open 128 files ->  `register_memory` -> `READ` xfer → cleanup) against `/raid/hicache/*.bin` (256 KB each).
- An env var `NIXL_MOCK_MODE=fd|path` switches between the legacy fd-based registration and our proposed path-mode, so the two are directly comparable on the same box and the same workload.

The mock reports per-iteration, per-128-batch, and per-individual-`os.open` timings. The 128-batch number is the one we want to improve.

| Phase            | fd mode (legacy) | path mode (new) | Δ |
|------------------|------------------|-----------------|---|
| Per-128-batch open | ~415 ms        | **~17 ms**      | **24× faster** |
| Per-iteration    | ~684 ms          | **~55 ms**      | **12× faster** |
| Total wall-clock | ~12.0 s          | **~1.9 s**      | **6× faster**  |

With path mode, the 128 sequential Python-level `os.open()` calls collapse into a single `register_memory` call where the opens happen in C++, thus we collapse the 128 GIL re-acquires to just one. Note, this works because the `register_memory` is already batched (takes a list of descriptors), without this batching we would not be able to improve! 

### Integrated in SGLang

PoC integration of the path mode to HiCache NIXL for KV Cache loading from SSD. It leads to significant TTFT improvements with `tp=1` (one GPU). Changes on the SGLang NIXL connector are necessary to use the path mode, just integrating this patched NIXL version will not change anything (it will still use the FD mode).

TTFT with `tp=1`:
<img width="900" height="500" alt="image" src="https://github.com/user-attachments/assets/f34d8951-7d69-425a-bd4e-2f8b43d9ae3d" />

It is a bit less significant in `tp>1` because the worker communication adds more GIL yield points.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Path-mode file registration: register files by path+access-mode (backend opens/closes files) across GPU and POSIX backends.

* **Documentation**
  * Comprehensive docs for path-mode vs fd-mode and backend file-lifecycle expectations.

* **Tests**
  * New path-mode smoke/integration tests exercising registration, write/read roundtrips, and FD lifecycle.

* **Chores**
  * CI updated to gracefully skip path-mode smoke tests when runtime plugins or binaries are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1635)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->