### PR TITLE
PLUGINS/UCX: set UCX_MAX_HCA_PER_GPU to auto

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -427,6 +427,10 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
     }
 
+    if (ucpVersion_ >= UCP_VERSION(1, 21)) {
+        config.modify("MAX_HCA_PER_GPU", "auto");
+    }
+
     const auto &hw_info = nixl::hwInfo::instance();
     if (hw_info.numEfaDevices != 0) {
         config.modify("ADDRESS_VERSION", "v2");

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -425,9 +425,6 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
 
     if (ucpVersion_ >= UCP_VERSION(1, 21)) {
         config.modify("RC_GDA_NUM_CHANNELS", std::to_string(num_device_channels));
-    }
-
-    if (ucpVersion_ >= UCP_VERSION(1, 21)) {
         config.modify("MAX_HCA_PER_GPU", "auto");
     }
 


### PR DESCRIPTION
## What?
Se the default in setting for `UCX_MAX_HCA_PER_GPU` to `auto`. This will cause UCX to register GPU memory only on closest HCAs.

## Why?
Currently UCX was registering every memory buffer on every MD, which is consuming a lot of ICM memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatic GPU resource optimization enabled for systems using UCX 1.21 and later to improve compatibility and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1637)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->