### PR TITLE
Add a meson option for CUDA target selection.

### DIFF
--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --output-dir: Directory to output the wheel to (default: $OUTPUT_DIR)"
             echo "  --ucx-plugins-dir: Directory to find UCX plugins in (default: $UCX_PLUGINS_DIR)"
             echo "  --nixl-plugins-dir: Directory to find NIXL plugins in (default: $NIXL_PLUGINS_DIR)"
-            echo "  --build-nixl-ep: Build wheel with nixl_ep package included (requires CUDA sm90-compatible environment)"
+            echo "  --build-nixl-ep: Build wheel with nixl_ep package included (requires a CUDA sm_90 or newer target environment)"
             echo "  --help: Show this help message"
             echo ""
             echo "Must be executed from the root of the NIXL repository."

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -92,7 +92,6 @@ nixl_ep_cuda_args = [
     '-DHAVE_CUDA',
     '-DTORCH_EXTENSION_NAME=nixl_ep_cpp',
     '--expt-relaxed-constexpr',  # Allow calling constexpr __host__ functions from __device__ functions
-    '-arch=sm_90',  # Only compile for sm90 (overrides global -gencode flags)
     '--ptxas-options=--register-usage-level=10',  # Allow more register usage (matches setup.py)
     '-Xcompiler', '-Wno-deprecated-declarations',
     '-Xcompiler', '-Wno-unused-variable',

--- a/meson.build
+++ b/meson.build
@@ -195,27 +195,52 @@ if cuda_dep.found()
     cuda = import('unstable-cuda')
     nvcc = meson.get_compiler('cuda')
 
-    # Please extend with your arch if not present in the list
-    nvcc_flags = []
-    # nixl ep cannot be built with sm_80
-    if not get_option('build_nixl_ep')
-        nvcc_flags += ['-gencode', 'arch=compute_80,code=sm_80']
+    cuda_arch_list = get_option('nixl_cuda_arch_list').strip()
+    if cuda_arch_list == 'auto'
+        if get_option('build_nixl_ep')
+            cuda_arch_list = '90,100,103,120'
+        else
+            cuda_arch_list = '80,86,89,90,100,103,120'
+        endif
     endif
-    nvcc_flags += ['-gencode', 'arch=compute_90,code=sm_90']
+
+    nvcc_flags = []
+    nvcc_flags_link = []
+    nvcc_ptx_arch = ''
+    selected_cuda_arches = []
+    foreach cuda_arch : cuda_arch_list.split(',')
+        cuda_arch = cuda_arch.strip()
+        if cuda_arch == ''
+            continue
+        endif
+        if cuda_arch.startswith('sm_')
+            cuda_arch = cuda_arch.replace('sm_', '')
+        endif
+
+        cuda_compute_arch = 'compute_' + cuda_arch
+        cuda_sm_arch = 'sm_' + cuda_arch
+        nvcc_flags += ['-gencode', 'arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
+        nvcc_flags_link += ['-gencode=arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
+        nvcc_ptx_arch = cuda_compute_arch
+        selected_cuda_arches += [cuda_sm_arch]
+    endforeach
+
+    if selected_cuda_arches.length() == 0
+        error('No CUDA targets selected')
+    endif
+
+    nvcc_flags += ['-gencode', 'arch=' + nvcc_ptx_arch + ',code=' + nvcc_ptx_arch]
+    nvcc_flags_link += ['-gencode=arch=' + nvcc_ptx_arch + ',code=' + nvcc_ptx_arch]
+
     add_project_arguments(nvcc_flags, language: 'cuda')
 
     # Refer to https://mesonbuild.com/Cuda-module.html
     add_project_arguments('-forward-unknown-to-host-compiler', language: 'cuda')
     add_project_arguments('-rdc=true', language: 'cuda')
 
-    nvcc_flags_link = []
-    # nixl ep cannot be built with sm_80
-    if not get_option('build_nixl_ep')
-        nvcc_flags_link += ['-gencode=arch=compute_80,code=sm_80']
-    endif
-    nvcc_flags_link += ['-gencode=arch=compute_90,code=sm_90']
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
     message('nvcc version: ' + nvcc.version())
+    message('CUDA targets: ' + ', '.join(selected_cuda_arches) + ' + ' + nvcc_ptx_arch)
     if nvcc.version().version_compare('>=12.8')
         doca_gpunetio_dep = dependency('doca-gpunetio', required : false)
     else

--- a/meson.build
+++ b/meson.build
@@ -207,7 +207,7 @@ if cuda_dep.found()
     nvcc_flags = []
     nvcc_flags_link = []
     nvcc_ptx_arch_num = 0
-    selected_cuda_arches = []
+    selected_cuda_archs = []
     foreach cuda_arch : cuda_arch_list.split(',')
         cuda_arch = cuda_arch.strip()
         if cuda_arch == ''
@@ -226,10 +226,10 @@ if cuda_dep.found()
         cuda_sm_arch = 'sm_' + cuda_arch
         nvcc_flags += ['-gencode', 'arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
         nvcc_flags_link += ['-gencode=arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
-        selected_cuda_arches += [cuda_sm_arch]
+        selected_cuda_archs += [cuda_sm_arch]
     endforeach
 
-    if selected_cuda_arches.length() == 0
+    if selected_cuda_archs.length() == 0
         error('No CUDA targets selected')
     endif
 
@@ -245,7 +245,7 @@ if cuda_dep.found()
 
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
     message('nvcc version: ' + nvcc.version())
-    message('CUDA targets: ' + ', '.join(selected_cuda_arches) + ' + ' + nvcc_ptx_arch)
+    message('CUDA targets: ' + ', '.join(selected_cuda_archs) + ' + ' + nvcc_ptx_arch)
     if nvcc.version().version_compare('>=12.8')
         doca_gpunetio_dep = dependency('doca-gpunetio', required : false)
     else

--- a/meson.build
+++ b/meson.build
@@ -206,7 +206,7 @@ if cuda_dep.found()
 
     nvcc_flags = []
     nvcc_flags_link = []
-    nvcc_ptx_arch = ''
+    nvcc_ptx_arch_num = 0
     selected_cuda_arches = []
     foreach cuda_arch : cuda_arch_list.split(',')
         cuda_arch = cuda_arch.strip()
@@ -217,11 +217,15 @@ if cuda_dep.found()
             cuda_arch = cuda_arch.replace('sm_', '')
         endif
 
+        cuda_arch_num = cuda_arch.to_int()
+        if cuda_arch_num > nvcc_ptx_arch_num
+            nvcc_ptx_arch_num = cuda_arch_num
+        endif
+
         cuda_compute_arch = 'compute_' + cuda_arch
         cuda_sm_arch = 'sm_' + cuda_arch
         nvcc_flags += ['-gencode', 'arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
         nvcc_flags_link += ['-gencode=arch=' + cuda_compute_arch + ',code=' + cuda_sm_arch]
-        nvcc_ptx_arch = cuda_compute_arch
         selected_cuda_arches += [cuda_sm_arch]
     endforeach
 
@@ -229,6 +233,7 @@ if cuda_dep.found()
         error('No CUDA targets selected')
     endif
 
+    nvcc_ptx_arch = 'compute_' + nvcc_ptx_arch_num.to_string()
     nvcc_flags += ['-gencode', 'arch=' + nvcc_ptx_arch + ',code=' + nvcc_ptx_arch]
     nvcc_flags_link += ['-gencode=arch=' + nvcc_ptx_arch + ',code=' + nvcc_ptx_arch]
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,6 +24,7 @@ option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
+option('nixl_cuda_arch_list', type: 'string', value: 'auto', description: 'Comma-separated CUDA SM targets, or auto. Example: 90,100. Use 100 for a single-target build.')
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
 option('enable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to build. Default (empty) builds all available plugins.')
 option('disable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to exclude from build. Cannot be used with enable_plugins.')
@@ -35,5 +36,5 @@ option('rust', type: 'boolean', value: false, description: 'Build Rust bindings'
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')
 option('build_examples', type: 'boolean', value: true, description: 'Build all examples')
-option('build_nixl_ep', type: 'boolean', value: false, description: 'Build nixl_ep example (requires sm_90)')
+option('build_nixl_ep', type: 'boolean', value: false, description: 'Build nixl_ep example (requires sm_90 or newer)')
 option('test_all_plugins', type: 'boolean', value: false, description: 'Testing all plugins in addition to the mocks..')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -24,7 +24,7 @@ option('gds_path', type: 'string', value: '/usr/local/cuda/', description: 'Path
 option('cudapath_inc', type: 'string', value: '', description: 'Include path for CUDA')
 option('cudapath_lib', type: 'string', value: '', description: 'Library path for CUDA')
 option('cudapath_stub', type: 'string', value: '', description: 'Extra Stub path for CUDA')
-option('nixl_cuda_arch_list', type: 'string', value: 'auto', description: 'Comma-separated CUDA SM targets, or auto. Example: 90,100. Use 100 for a single-target build.')
+option('nixl_cuda_arch_list', type: 'string', value: 'auto', description: 'Comma-separated CUDA SM targets (e.g. 90,100), or auto to select defaults (sm_80+ normally, sm_90+ when build_nixl_ep is enabled). Use a single target like 100 for faster single-GPU builds.')
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
 option('enable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to build. Default (empty) builds all available plugins.')
 option('disable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to exclude from build. Cannot be used with enable_plugins.')


### PR DESCRIPTION
By default, build common datacenter GPU targets:
sm_80, sm_86, sm_89, sm_90, sm_100, sm_103, and sm_120.

When nixl_ep is enabled, disable sm_8x builds.

Users can pass a smaller list, such as -Dnixl_cuda_arch_list=90, 100
for faster builds / specific architectures that are not listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to specify comma-separated CUDA SM targets with an "auto" mode and improved build output that shows NVCC version and chosen SM/PTX targets.

* **Chores**
  * Updated build guidance to require CUDA sm_90 or newer and removed the prior forced sm_90 compile override so selected targets are respected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1639)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->