### PR TITLE
CORE/AGENT: Tune createXferReq.

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -851,14 +851,6 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    NIXL_SHARED_LOCK_GUARD(data->lock);
-    const auto rem_sec_it = data->remoteSections_.find(remote_agent);
-    if (data->remoteSections_.end() == rem_sec_it) {
-        NIXL_ERROR_FUNC << "metadata for remote agent '" << remote_agent << "' not found";
-        data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
-        return NIXL_ERR_NOT_FOUND;
-    }
-
     size_t total_bytes = 0;
     for (int i = 0; i < local_descs.descCount(); ++i) {
         if (__builtin_expect(local_descs[i].len != remote_descs[i].len, 0)) {
@@ -866,6 +858,14 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             return NIXL_ERR_INVALID_PARAM;
         }
         total_bytes += local_descs[i].len;
+    }
+
+    NIXL_SHARED_LOCK_GUARD(data->lock);
+    const auto rem_sec_it = data->remoteSections_.find(remote_agent);
+    if (data->remoteSections_.end() == rem_sec_it) {
+        NIXL_ERROR_FUNC << "metadata for remote agent '" << remote_agent << "' not found";
+        data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
+        return NIXL_ERR_NOT_FOUND;
     }
 
     if (!extra_params || extra_params->backends.size() == 0) {
@@ -897,8 +897,11 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
     // TODO: merge descriptors back to back in memory (like makeXferReq).
     // TODO [Perf]: Avoid heap allocation on the datapath, maybe use a mem pool
 
-    std::unique_ptr<nixlXferReqH> handle = std::make_unique<nixlXferReqH>(
-        remote_agent, operation, local_descs.getType(), remote_descs.getType());
+    auto handle = std::make_unique<nixlXferReqH>(remote_agent,
+                                                 operation,
+                                                 local_descs.getType(),
+                                                 remote_descs.getType(),
+                                                 local_descs.descCount());
 
     // Currently we loop through and find first local match. Can use a
     // preference list or more exhaustive search.


### PR DESCRIPTION
## What?
Two small improvements to `nixlAgent::createXferReq()`:
 - Move a reentrant code section outside of the lock.
 - Add size to call of `nixlXferReqH` c'tor used for `reserve()` by `nixlDescList`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer request initialization to correctly account for descriptor entries, enhancing the stability and accuracy of transfer operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1641)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->