### PR TITLE
[BUILD] fix doca telemetry dep

### DIFF
--- a/src/plugins/telemetry/doca/meson.build
+++ b/src/plugins/telemetry/doca/meson.build
@@ -38,7 +38,7 @@ if doca_found
         'doca_plugin.cpp',
         'doca_exporter.cpp',
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
-        dependencies: [nixl_infra, absl_log_dep, doca_dep],
+        dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, doca_dep],
         install: true,
         install_dir: plugin_install_dir,
         name_prefix: '',


### PR DESCRIPTION
What?
Add nixl_common_dep to the deps for the DOCA telemetry exporter.

Why?
`doca_exporter.cpp` calls `nixl::config::getValueDefaulted`. The impl needs to be resolved at link time, which lives in libnixl_common. And `nixl_infra` does not provide those symbols.

How?
Align the DOCA telemetry with the same dep pattern already used by the Prometheus telemetry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DOCA telemetry exporter build configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1643)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->