### PR TITLE
PLUGINS/HF3FS: drop dead null check on member address in checkXfer

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -16,6 +16,59 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
 ARG OS
+# 3FS revision to build the client library from.
+ARG HF3FS_REF="22fca04564c7cc230fd8b9523b8b92864e1dad47"
+
+# Builder stage: build the 3FS client library (libhf3fs_api_shared.so + hf3fs_usrbio.h)
+# from source. The artifacts are copied into the final stage so the HF3FS plugin
+# gets compiled and link-checked by CI. The heavy build deps (boost, clang-14,
+# folly transitive prereqs) stay confined to this stage.
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS hf3fs-builder
+ARG HF3FS_REF
+
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      git ca-certificates build-essential cmake ninja-build pkg-config \
+      gcc-12 g++-12 libstdc++-12-dev \
+      clang-14 clang-format-14 clang-tidy-14 lld-14 libclang-rt-14-dev \
+      libuv1-dev liblz4-dev liblzma-dev libdouble-conversion-dev \
+      libdwarf-dev libunwind-dev libaio-dev \
+      libgflags-dev libgoogle-glog-dev libgtest-dev libgmock-dev \
+      libgoogle-perftools-dev google-perftools \
+      libssl-dev libboost-all-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# cuda-dl-base ships libibverbs-dev as dpkg-installed but strips the
+# unversioned `libibverbs.so` dev symlink. 3FS's hf3fs_api_shared link
+# step (`-libverbs`) needs it, and apt --reinstall can't recreate it
+# (the installed 56.0-1 isn't in any configured repo). Recreate it by
+# hand so the hf3fs_api_shared link step succeeds.
+RUN ln -sf libibverbs.so.1 /usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/libibverbs.so
+
+# Ubuntu 24.04 ships gcc-13 as the default toolchain. clang-14 paired with
+# gcc-13's libstdc++ fails on folly's <chrono> users (consteval). Expose a
+# gcc-toolchain dir that only contains gcc-12 so clang-14 selects that one.
+RUN MULTIARCH=$(dpkg-architecture -q DEB_HOST_MULTIARCH) && \
+    mkdir -p /opt/gcc12-only/lib/gcc/${MULTIARCH} && \
+    ln -sfn /usr/lib/gcc/${MULTIARCH}/12 /opt/gcc12-only/lib/gcc/${MULTIARCH}/12
+
+WORKDIR /build
+RUN git clone https://github.com/deepseek-ai/3FS.git && \
+    cd 3FS && \
+    git checkout ${HF3FS_REF} && \
+    git submodule update --init --recursive && \
+    ./patches/apply.sh
+
+RUN cd /build/3FS && \
+    cmake -S . -B build \
+      -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 \
+      -DCMAKE_C_FLAGS=--gcc-toolchain=/opt/gcc12-only \
+      -DCMAKE_CXX_FLAGS=--gcc-toolchain=/opt/gcc12-only \
+      -DCMAKE_EXE_LINKER_FLAGS=--gcc-toolchain=/opt/gcc12-only \
+      -DCMAKE_SHARED_LINKER_FLAGS=--gcc-toolchain=/opt/gcc12-only \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DSHUFFLE_METHOD=stdshuffle && \
+    cmake --build build --target hf3fs_api_shared -j"$(nproc)"
 
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 
@@ -85,6 +138,22 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
     --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
     libnuma-dev librdmacm-dev ibverbs-providers
+
+# Runtime libraries needed by libhf3fs_api_shared.so (copied in below from the
+# hf3fs-builder stage). libnuma/libgflags/libssl/libz are already present via
+# the build-deps apt block above; the rest are HF3FS-specific.
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    libboost-context1.83.0 libboost-filesystem1.83.0 libboost-program-options1.83.0 \
+    libboost-regex1.83.0 libboost-system1.83.0 libboost-thread1.83.0 libboost-atomic1.83.0 \
+    libdouble-conversion3 libgoogle-glog0v6t64 libevent-2.1-7t64 libdwarf1 libgoogle-perftools4t64
+
+# Install the HF3FS client artifacts at the paths NIXL's meson build expects.
+# This must happen before the meson setup step below so the HF3FS plugin is
+# detected. Skipping the install (e.g. if the builder stage is omitted) makes
+# meson silently disable the plugin via cc.find_library(required: false).
+COPY --from=hf3fs-builder /build/3FS/build/src/lib/api/libhf3fs_api_shared.so /usr/lib/
+COPY --from=hf3fs-builder /build/3FS/src/lib/api/hf3fs_usrbio.h /usr/include/hf3fs/hf3fs_usrbio.h
+RUN ldconfig
 
 WORKDIR /workspace
 

--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -487,12 +487,6 @@ nixl_status_t nixlHf3fsEngine::checkXfer(nixlBackendReqH* handle) const
 
     nixlHf3fsBackendReqH *hf3fs_handle = (nixlHf3fsBackendReqH *) handle;
 
-    // Check if IOR is initialized
-    if (&hf3fs_handle->ior == nullptr) {
-        HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
-            "Error: IOR is not initialized in checkXfer");
-    }
-
     if (hf3fs_handle->io_status.thread == nullptr) {
         HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
             "Error: io thread is not initialized in checkXfer");


### PR DESCRIPTION
## Summary

Two commits, fixing the HF3FS plugin build on Ubuntu 24.04 and making sure CI catches future HF3FS regressions:

**1. `PLUGINS/HF3FS: drop dead null check on member address in checkXfer`**

`ior` is declared as a value member of `nixlHf3fsBackendReqH` in `src/plugins/hf3fs/hf3fs_backend.h`:

```cpp
class nixlHf3fsBackendReqH : public nixlBackendReqH {
    public:
        std::list<nixlHf3fsIO *> io_list;
        hf3fs_ior ior;                       // value member, not a pointer
        uint32_t completed_ios = 0;
        ...
};
```

so `&hf3fs_handle->ior` (address-of a value member of a non-null object) can never be `nullptr`, and the `if (&hf3fs_handle->ior == nullptr)` check in `nixlHf3fsEngine::checkXfer` is unreachable. gcc-13 (default on Ubuntu 24.04) flags this under `-Werror=address` and fails the HF3FS plugin build.

**2. `contrib/Dockerfile: build HF3FS client library in a separate stage`**

- CI currently builds NIXL with all plugins enabled, but `libhf3fs_api_shared.so` / `hf3fs_usrbio.h` are not present in the image. `src/plugins/meson.build` uses `cc.find_library('hf3fs_api_shared', required: false)`, so the plugin is silently skipped and HF3FS-only build breakage (like commit 1) reaches `main` without anyone noticing.
- Add a `hf3fs-builder` stage that builds `deepseek-ai/3FS`'s `hf3fs_api_shared` target and copies the resulting `.so` + header into the final image so the plugin is compiled and link-checked by CI.
- 3FS source is clang-only and Ubuntu 24.04's gcc-13 `<chrono>` headers trip a consteval check in folly. The builder pins `clang-14 + gcc-12`'s libstdc++ via a single-version `--gcc-toolchain` symlink. Only `hf3fs_api_shared` is built; the storage server, fuse, and FoundationDB pieces are not needed for the client lib.
- `HF3FS_REF` is pinned to a specific 3FS commit so rebuilds are reproducible. Override at build time if needed.

Marking as **WIP / draft**: I haven't run the full HF3FS test suite against a real 3FS cluster, and I haven't validated the multi-stage Dockerfile end-to-end against the real CI runner yet — only confirmed it builds locally with the same toolchain pins.

## Test plan

- [x] `ninja -C build` succeeds on Ubuntu 24.04 with gcc-13 (`-Denable_plugins=POSIX,OBJ,HF3FS`)
- [x] `libplugin_HF3FS.so` produced; `ldd` shows `libhf3fs_api_shared.so` resolved
- [ ] `docker build -f contrib/Dockerfile .` produces an image where `libplugin_HF3FS.so` is present under `$NIXL_PLUGIN_DIR`
- [ ] Run `test/unit/plugins/hf3fs/nixl_hf3fs_test` against an actual 3FS mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker build now includes a multi-stage HF3FS build with a configurable build reference and HF3FS runtime libraries in the final image.

* **Bug Fixes**
  * HF3FS backend IO transfer handling improved: removed a faulty initialization check, added stricter thread-state validation, and clarified error propagation and cleanup during IO failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->