### PR TITLE
NIXL EP wheels: Add support for multiple CUDA and PyTorch versions

### DIFF
--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -294,11 +294,9 @@ RUN rm -rf $VIRTUAL_ENV && uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Install python dependencies
 RUN uv pip install --upgrade meson meson-python pybind11 patchelf pyYAML click setuptools tabulate auditwheel tomlkit
-# Install PyTorch (default version for meson setup; wheel builds may reinstall other versions)
-ARG TORCH_VERSIONS="2.11,2.12,2.13"
+# Install PyTorch
 RUN export UV_INDEX="https://download.pytorch.org/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .)" && \
-    FIRST_TORCH=$(echo "$TORCH_VERSIONS" | cut -d, -f1) && \
-    uv pip install "torch==${FIRST_TORCH}.*"
+    uv pip install 'torch==2.11.*'
 # Upgrade setuptools to latest version for compatibility with PEP 639 (license format)
 RUN uv pip install --upgrade 'setuptools>=80.9.0'
 
@@ -355,15 +353,12 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 
 # Create the wheel
 # No need to specifically add path to libcuda.so here, meson finds the stubs and links them
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG WHL_PYTHON_VERSIONS="3.10,3.11,3.12,3.13,3.14"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
-    CU_TAG="cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .)" && \
-    export UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/nightly/${CU_TAG}" && \
-    export UV_INDEX="https://download.pytorch.org/whl/${CU_TAG}" && \
-    export UV_INDEX_STRATEGY=unsafe-best-match && \
     if [ "$BUILD_NIXL_EP" = "true" ]; then \
-        EP_BUILD_FLAG="--build-nixl-ep --torch-versions $TORCH_VERSIONS"; \
+        EP_BUILD_FLAG="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
     else \
         EP_BUILD_FLAG=""; \
     fi && \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -353,14 +353,14 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 
 # Create the wheel
 # No need to specifically add path to libcuda.so here, meson finds the stubs and links them
-ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG WHL_PYTHON_VERSIONS="3.10,3.11,3.12,3.13,3.14"
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     if [ "$BUILD_NIXL_EP" = "true" ]; then \
-        EP_BUILD_FLAG="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
+        FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
     else \
-        EP_BUILD_FLAG=""; \
+        FLAGS=""; \
     fi && \
     rm -rf dist && mkdir -p dist && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
@@ -371,7 +371,7 @@ RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
             --ucx-plugins-dir /usr/lib64/ucx \
             --nixl-plugins-dir $NIXL_PLUGIN_DIR \
             --output-dir dist \
-            $EP_BUILD_FLAG ; \
+            $FLAGS ; \
     done
 
 # Copy the meta package wheel to the dist directory, which will be used to push to PyPI.

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -354,7 +354,7 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 # Create the wheel
 # No need to specifically add path to libcuda.so here, meson finds the stubs and links them
 ARG WHL_PYTHON_VERSIONS="3.10,3.11,3.12,3.13,3.14"
-ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
+ARG WHL_TORCH_VERSIONS="2.11,2.12"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     if [ "$BUILD_NIXL_EP" = "true" ]; then \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -294,9 +294,11 @@ RUN rm -rf $VIRTUAL_ENV && uv venv $VIRTUAL_ENV --python $DEFAULT_PYTHON_VERSION
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Install python dependencies
 RUN uv pip install --upgrade meson meson-python pybind11 patchelf pyYAML click setuptools tabulate auditwheel tomlkit
-# Install PyTorch
+# Install PyTorch (default version for meson setup; wheel builds may reinstall other versions)
+ARG TORCH_VERSIONS="2.11,2.12,2.13"
 RUN export UV_INDEX="https://download.pytorch.org/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .)" && \
-    uv pip install 'torch==2.11.*'
+    FIRST_TORCH=$(echo "$TORCH_VERSIONS" | cut -d, -f1) && \
+    uv pip install "torch==${FIRST_TORCH}.*"
 # Upgrade setuptools to latest version for compatibility with PEP 639 (license format)
 RUN uv pip install --upgrade 'setuptools>=80.9.0'
 
@@ -356,9 +358,15 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 ARG WHL_PYTHON_VERSIONS="3.10,3.11,3.12,3.13,3.14"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
-    export UV_INDEX="https://download.pytorch.org/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .)" && \
+    CU_TAG="cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d .)" && \
+    export UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/nightly/${CU_TAG}" && \
+    export UV_INDEX="https://download.pytorch.org/whl/${CU_TAG}" && \
     export UV_INDEX_STRATEGY=unsafe-best-match && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAG="--build-nixl-ep"; else EP_BUILD_FLAG=""; fi && \
+    if [ "$BUILD_NIXL_EP" = "true" ]; then \
+        EP_BUILD_FLAG="--build-nixl-ep --torch-versions $TORCH_VERSIONS"; \
+    else \
+        EP_BUILD_FLAG=""; \
+    fi && \
     rm -rf dist && mkdir -p dist && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
         export PATH=$VIRTUAL_ENV/bin:$PATH && \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -358,9 +358,9 @@ ARG WHL_TORCH_VERSIONS="2.11,2.12"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
     if [ "$BUILD_NIXL_EP" = "true" ]; then \
-        FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
+        EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
     else \
-        FLAGS=""; \
+        EP_BUILD_FLAGS=""; \
     fi && \
     rm -rf dist && mkdir -p dist && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
@@ -371,7 +371,7 @@ RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
             --ucx-plugins-dir /usr/lib64/ucx \
             --nixl-plugins-dir $NIXL_PLUGIN_DIR \
             --output-dir dist \
-            $FLAGS ; \
+            $EP_BUILD_FLAGS ; \
     done
 
 # Copy the meta package wheel to the dist directory, which will be used to push to PyPI.

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Parse arguments
 PYTHON_VERSION="3.12"
 ARCH=$(uname -m)
 WHL_PLATFORM="manylinux_2_39_$ARCH"
@@ -25,7 +24,6 @@ OUTPUT_DIR="dist"
 BUILD_NIXL_EP="false"
 TORCH_VERSIONS=""
 
-# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --python-version)
@@ -85,7 +83,6 @@ done
 set -e
 set -x
 
-# Build the wheel
 TMP_DIR=$(mktemp -d)
 
 CUDA_MAJOR=$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | cut -d'.' -f1)
@@ -100,13 +97,10 @@ PKG_NAME="nixl-cu${CUDA_MAJOR}"
 CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | tr -d .)"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
 
-# Index URLs for the resolved CUDA tag. Stable cu index hosts released
-# wheels; nightly index hosts dev/pre-release wheels.
 TORCH_STABLE_INDEX="https://download.pytorch.org/whl/${CU_TAG}"
 TORCH_NIGHTLY_INDEX="https://download.pytorch.org/whl/nightly/${CU_TAG}"
 
-# Build deps installed into the per-iteration venv (torch is added
-# separately with channel-appropriate constraints).
+# Build deps for the per-iteration venv; torch is installed separately.
 BUILD_DEPS=(
     "meson"
     "meson-python"
@@ -138,14 +132,9 @@ venv_path() {
     fi
 }
 
-# Classify a requested torch version for the target Python: does
-# `torch==${VER}.*` resolve from the stable cu index alone, only from the
-# nightly index (with --pre), or from neither? Echoes one of:
-#   stable       — resolvable from $TORCH_STABLE_INDEX without --pre
-#   nightly      — resolvable from $TORCH_NIGHTLY_INDEX with --pre
-#   unavailable  — not in either index for this Python
-# Result is cached so each (PYTHON_VERSION, VER) probe runs at most once
-# across the script's filter and build phases.
+# Echo "stable", "nightly", or "unavailable" depending on whether
+# torch==${VER}.* resolves from the stable cu index, the nightly cu
+# index (with --pre), or neither. Cached.
 torch_classify() {
     local VER=$1
     if [ -n "${TORCH_CLASS_CACHE[$VER]:-}" ]; then
@@ -175,47 +164,33 @@ torch_classify() {
     echo "$CLASS"
 }
 
-# Echo the torch requirement spec for the given (version, channel). Stable
-# stays as `torch==X.Y.*`; nightly uses an explicit `.dev0` lower bound so
-# pre-release/dev wheels are admissible without --prerelease=allow.
-torch_spec() {
-    local VER=$1
-    local CHANNEL=$2
-    if [ "$CHANNEL" = "nightly" ]; then
-        local MAJOR="${VER%%.*}"
-        local MINOR="${VER##*.}"
-        echo "torch>=${MAJOR}.${MINOR}.0.dev0,<${MAJOR}.$((MINOR + 1))"
-    else
-        echo "torch==${VER}.*"
-    fi
-}
+# Install torch from the cu index, isolated from PyPI: with PyPI as a
+# fallback its plain `torch==X.Y.0` beats cu nightly's `X.Y.0.dev*+cuXX`
+# (PEP 440: final > pre-release).
+install_torch() {
+    local VENV_PATH=$1
+    local VER=$2
+    local CHANNEL=$3
+    local MAJOR="${VER%%.*}"
+    local MINOR="${VER##*.}"
 
-# Echo the uv index/resolution flags appropriate for the given channel,
-# one flag per line. Stable builds use only the stable cu index and no
-# pre-release allowance; nightly builds add the nightly index and
-# --prerelease=allow.
-torch_uv_flags() {
-    local CHANNEL=$1
     if [ "$CHANNEL" = "nightly" ]; then
-        printf '%s\n' \
-            --extra-index-url "$TORCH_STABLE_INDEX" \
-            --extra-index-url "$TORCH_NIGHTLY_INDEX" \
-            --index-strategy unsafe-best-match \
-            --prerelease allow
+        uv pip install \
+            --python "$VENV_PATH/bin/python" \
+            --index-url "$TORCH_NIGHTLY_INDEX" \
+            --pre \
+            "torch>=${MAJOR}.${MINOR}.0.dev0,<${MAJOR}.$((MINOR + 1))"
     else
-        printf '%s\n' \
-            --extra-index-url "$TORCH_STABLE_INDEX" \
-            --index-strategy unsafe-best-match
+        uv pip install \
+            --python "$VENV_PATH/bin/python" \
+            --index-url "$TORCH_STABLE_INDEX" \
+            "torch==${VER}.*"
     fi
 }
 
 # Build the wheel for the current PYTHON_VERSION (and optional torch VER).
-# Creates a fresh venv at venv_path, installs build deps + torch with the
-# channel-appropriate flags, runs `uv build --no-build-isolation`, and
-# tears the venv down so the next iteration starts from a clean slate.
-# Doing it this way instead of `pip install --reinstall torch` avoids
-# orphan packages from the previous torch's transitive footprint
-# (nvidia-* wheels, triton, sympy, …) bleeding across iterations.
+# Each iteration uses a fresh venv so torch's dependencies
+# (nvidia-* wheels, triton, sympy, …) do not leak across iterations.
 build_wheel() {
     local OUT_DIR=$1
     local VER=${2:-}
@@ -225,25 +200,14 @@ build_wheel() {
     local CHANNEL="stable"
     [ -n "$VER" ] && CHANNEL=$(torch_classify "$VER")
 
-    local UV_FLAGS=()
-    while IFS= read -r f; do UV_FLAGS+=("$f"); done < <(torch_uv_flags "$CHANNEL")
-
-    local TORCH_PKG=()
-    [ -n "$VER" ] && TORCH_PKG+=("$(torch_spec "$VER" "$CHANNEL")")
-
     echo "=== Provisioning ${VENV_PATH} (python ${PYTHON_VERSION}${VER:+, torch ${VER} [${CHANNEL}]}) ==="
     rm -rf "$VENV_PATH"
     uv venv "$VENV_PATH" --python "$PYTHON_VERSION"
-    uv pip install \
-        --python "$VENV_PATH/bin/python" \
-        "${UV_FLAGS[@]}" \
-        "${BUILD_DEPS[@]}" \
-        "${TORCH_PKG[@]}"
+    uv pip install --python "$VENV_PATH/bin/python" "${BUILD_DEPS[@]}"
+    [ -n "$VER" ] && install_torch "$VENV_PATH" "$VER" "$CHANNEL"
 
     # Activate so meson's `find_installation('python3')` resolves to this
-    # venv's interpreter (which has the right torch). Deactivate before
-    # returning so the caller's auditwheel keeps using the orchestration
-    # venv on PATH.
+    # venv's interpreter (which has the right torch).
     # shellcheck disable=SC1091
     source "$VENV_PATH/bin/activate"
 
@@ -262,8 +226,8 @@ build_wheel() {
     uv build "${BUILD_ARGS[@]}"
 
     deactivate
-    # Free disk: torch + nvidia-* wheels in a venv add up to several GB;
-    # 3 torches × 5 pythons would otherwise blow the docker layer budget.
+    # torch + nvidia-* in each venv is several GB; tear down so the docker
+    # layer doesnt blow up across the (python, torch) matrix.
     rm -rf "$VENV_PATH"
 }
 
@@ -276,7 +240,8 @@ repair_wheel() {
 }
 
 if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
-    # Multi-torch: build full wheel with first torch, then merge extra .so from others.
+    # Multi-torch: build the full wheel with the first torch, then merge
+    # the per-torch .so from the others into it.
     IFS=',' read -ra TORCH_REQUESTED <<< "$TORCH_VERSIONS"
 
     # Filter to torch versions actually resolvable for this (Python, CUDA) combo.
@@ -311,14 +276,12 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
 
         EP_TMP=$(mktemp -d)
         build_wheel "$EP_TMP" "$TORCH"
-        # Repair so the .so passes auditwheel for the manylinux tag before we extract it
         repair_wheel "$EP_TMP" "$EP_TMP/dist"
 
-        # Merge the torch-versioned .so from the freshly-built wheel into
-        # the base wheel and regenerate RECORD. Both wheels were built
-        # against the same outer C++ build, so the .so's DT_NEEDED entries
-        # (libucp-<hash>.so etc.) match the libs already bundled in
-        # $BASE_WHL by auditwheel.
+        # Merge only the torch-versioned .so. Both wheels were built
+        # against the same outer C++ build, so its DT_NEEDED entries
+        # (libucp-<hash>.so etc.) match what auditwheel already bundled
+        # into $BASE_WHL.
         TORCH_MM=$(echo "$TORCH" | tr -d '.')
         EP_WHL=$(ls "$EP_TMP"/dist/*.whl)
         ./contrib/wheel_merge.py \

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -193,10 +193,12 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
 
         EP_TMP=$(mktemp -d)
         build_wheel "$EP_TMP"
+        # Repair so the .so passes auditwheel for the manylinux tag before we extract it
+        repair_wheel "$EP_TMP" "$EP_TMP/dist"
 
-        # Extract torch-versioned .so from new wheel, inject into base wheel
+        # Extract torch-versioned .so from repaired wheel, inject into base wheel
         EP_EXTRACT=$(mktemp -d)
-        unzip -o "$EP_TMP"/nixl*.whl -d "$EP_EXTRACT"
+        unzip -o "$EP_TMP"/dist/*.whl -d "$EP_EXTRACT"
         BASE_EXTRACT=$(mktemp -d)
         unzip -o "$BASE_WHL" -d "$BASE_EXTRACT"
 

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -100,51 +100,186 @@ PKG_NAME="nixl-cu${CUDA_MAJOR}"
 CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | tr -d .)"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
 
-# Pin the torch build dep in pyproject.toml so uv build's isolated env resolves it.
-pin_torch() {
-    local VER=$1
-    ./contrib/tomlutil.py --torch-version "$VER" pyproject.toml
-}
+# Index URLs for the resolved CUDA tag. Stable cu index hosts released
+# wheels; nightly index hosts dev/pre-release wheels.
+TORCH_STABLE_INDEX="https://download.pytorch.org/whl/${CU_TAG}"
+TORCH_NIGHTLY_INDEX="https://download.pytorch.org/whl/nightly/${CU_TAG}"
 
-# PyPI stays primary (for meson-python etc); PyTorch indexes are extras for torch.
-UV_BUILD_INDEX_FLAGS=(
-    --extra-index-url "https://download.pytorch.org/whl/${CU_TAG}"
-    --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}"
-    --index-strategy unsafe-best-match
-    --prerelease allow
+# Build deps every wheel build needs in its venv. Mirrors pyproject.toml's
+# `build-system.requires` minus torch (which is added per-iteration with
+# channel-appropriate constraints). pytest/build are not strictly needed by
+# meson-python at build time but are kept in sync with pyproject.toml so
+# nothing breaks if a backend hook decides to import them.
+BUILD_DEPS=(
+    "meson"
+    "meson-python"
+    "pybind11"
+    "patchelf"
+    "pyyaml"
+    "types-PyYAML"
+    "setuptools>=80.9.0"
 )
 
-# Check whether torch==${VER}.* is resolvable from the configured indexes
-# for the target Python version. Echoes "yes" on success, nothing otherwise.
+# Channel cache for repeated lookups within a single script run.
+declare -A TORCH_CHANNEL_CACHE
+
+# Slugify a dotted version (e.g. "2.13" -> "213", "3.10" -> "310") so it can
+# be used unambiguously as a path component.
+slug() { echo "${1//./}"; }
+
+# Path for a per-iteration build venv. One venv per (python, torch) tuple
+# so torch's transitive footprint (nvidia-*, triton, sympy, …) never bleeds
+# across torch versions. Lives in /workspace, not /tmp, so it inherits the
+# image's UV_CACHE_DIR layout and is visible to debugging.
+venv_path() {
+    local VER=${1:-}
+    if [ -n "$VER" ]; then
+        echo "/workspace/venv-torch$(slug "$VER")-py$(slug "$PYTHON_VERSION")"
+    else
+        echo "/workspace/venv-py$(slug "$PYTHON_VERSION")"
+    fi
+}
+
+# Determine whether torch==${VER}.* has a stable release on the stable cu
+# index for the target Python version. Echoes "stable" or "nightly".
+# A torch version is treated as stable iff a non-pre-release wheel resolves
+# from the stable cu index alone (no nightly index, no --pre).
+torch_channel() {
+    local VER=$1
+    if [ -n "${TORCH_CHANNEL_CACHE[$VER]:-}" ]; then
+        echo "${TORCH_CHANNEL_CACHE[$VER]}"
+        return
+    fi
+    local CHANNEL="nightly"
+    local CHECK_VENV="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
+    rm -rf "$CHECK_VENV"
+    if uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1; then
+        # Unset UV_*INDEX* env vars (the wheel-build loop in
+        # Dockerfile.manylinux exports them with the nightly index, which
+        # would otherwise let `torch==X.Y.*` resolve from nightly and make
+        # us mis-classify a nightly-only release as stable).
+        if env -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_INDEX_STRATEGY -u UV_DEFAULT_INDEX \
+            uv pip install --dry-run \
+            --python "$CHECK_VENV/bin/python" \
+            --index-url "$TORCH_STABLE_INDEX" \
+            "torch==${VER}.*" >/dev/null 2>&1; then
+            CHANNEL="stable"
+        fi
+    fi
+    rm -rf "$CHECK_VENV"
+    TORCH_CHANNEL_CACHE[$VER]="$CHANNEL"
+    echo "$CHANNEL"
+}
+
+# Echo the torch requirement spec for the given (version, channel). Stable
+# stays as `torch==X.Y.*`; nightly uses an explicit `.dev0` lower bound so
+# pre-release/dev wheels are admissible without --prerelease=allow.
+torch_spec() {
+    local VER=$1
+    local CHANNEL=$2
+    if [ "$CHANNEL" = "nightly" ]; then
+        local MAJOR="${VER%%.*}"
+        local MINOR="${VER##*.}"
+        echo "torch>=${MAJOR}.${MINOR}.0.dev0,<${MAJOR}.$((MINOR + 1))"
+    else
+        echo "torch==${VER}.*"
+    fi
+}
+
+# Echo the uv index/resolution flags appropriate for the given channel,
+# one flag per line. Stable builds use only the stable cu index and no
+# pre-release allowance; nightly builds add the nightly index and
+# --prerelease=allow.
+torch_uv_flags() {
+    local CHANNEL=$1
+    if [ "$CHANNEL" = "nightly" ]; then
+        printf '%s\n' \
+            --extra-index-url "$TORCH_STABLE_INDEX" \
+            --extra-index-url "$TORCH_NIGHTLY_INDEX" \
+            --index-strategy unsafe-best-match \
+            --prerelease allow
+    else
+        printf '%s\n' \
+            --extra-index-url "$TORCH_STABLE_INDEX" \
+            --index-strategy unsafe-best-match
+    fi
+}
+
+# Check whether torch==${VER}.* is resolvable from any configured index
+# (stable or nightly) for the target Python version. Echoes "yes" on
+# success, nothing otherwise.
 torch_available() {
     local VER=$1
-    local CHECK_VENV
-    CHECK_VENV=$(mktemp -d)/venv
+    local CHECK_VENV="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
+    rm -rf "$CHECK_VENV"
     uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1 || return
-    # shellcheck disable=SC1090
-    source "$CHECK_VENV/bin/activate"
     if uv pip install --dry-run --pre \
-        --extra-index-url "https://download.pytorch.org/whl/${CU_TAG}" \
-        --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}" \
+        --python "$CHECK_VENV/bin/python" \
+        --extra-index-url "$TORCH_STABLE_INDEX" \
+        --extra-index-url "$TORCH_NIGHTLY_INDEX" \
         --index-strategy unsafe-best-match \
         "torch==${VER}.*" >/dev/null 2>&1; then
         echo "yes"
     fi
-    deactivate
-    rm -rf "$(dirname "$CHECK_VENV")"
+    rm -rf "$CHECK_VENV"
 }
 
+# Build the wheel for the current PYTHON_VERSION (and optional torch VER).
+# Creates a fresh venv at venv_path, installs build deps + torch with the
+# channel-appropriate flags, runs `uv build --no-build-isolation`, and
+# tears the venv down so the next iteration starts from a clean slate.
+# Doing it this way instead of `pip install --reinstall torch` avoids
+# orphan packages from the previous torch's transitive footprint
+# (nvidia-* wheels, triton, sympy, …) bleeding across iterations.
 build_wheel() {
     local OUT_DIR=$1
+    local VER=${2:-}
+
+    local VENV_PATH
+    VENV_PATH=$(venv_path "$VER")
+    local CHANNEL="stable"
+    [ -n "$VER" ] && CHANNEL=$(torch_channel "$VER")
+
+    local UV_FLAGS=()
+    while IFS= read -r f; do UV_FLAGS+=("$f"); done < <(torch_uv_flags "$CHANNEL")
+
+    local TORCH_PKG=()
+    [ -n "$VER" ] && TORCH_PKG+=("$(torch_spec "$VER" "$CHANNEL")")
+
+    echo "=== Provisioning ${VENV_PATH} (python ${PYTHON_VERSION}${VER:+, torch ${VER} [${CHANNEL}]}) ==="
+    rm -rf "$VENV_PATH"
+    uv venv "$VENV_PATH" --python "$PYTHON_VERSION"
+    uv pip install \
+        --python "$VENV_PATH/bin/python" \
+        "${UV_FLAGS[@]}" \
+        "${BUILD_DEPS[@]}" \
+        "${TORCH_PKG[@]}"
+
+    # Activate so meson's `find_installation('python3')` resolves to this
+    # venv's interpreter (which has the right torch). Deactivate before
+    # returning so the caller's auditwheel keeps using the orchestration
+    # venv on PATH.
+    # shellcheck disable=SC1091
+    source "$VENV_PATH/bin/activate"
+
+    local BUILD_ARGS=(
+        --wheel
+        --no-build-isolation
+        --out-dir "$OUT_DIR"
+        --python "$VENV_PATH/bin/python"
+    )
     if [ "$BUILD_NIXL_EP" = "true" ]; then
-        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION \
-            "${UV_BUILD_INDEX_FLAGS[@]}" \
-            -Csetup-args=-Dbuild_nixl_ep=true \
+        BUILD_ARGS+=(
+            -Csetup-args=-Dbuild_nixl_ep=true
             -Csetup-args=-Dbuild_examples=true
-    else
-        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION \
-            "${UV_BUILD_INDEX_FLAGS[@]}"
+        )
     fi
+    uv build "${BUILD_ARGS[@]}"
+
+    deactivate
+    # Free disk: torch + nvidia-* wheels in a venv add up to several GB;
+    # 3 torches × 5 pythons would otherwise blow the docker layer budget.
+    rm -rf "$VENV_PATH"
 }
 
 repair_wheel() {
@@ -181,18 +316,16 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
 
     FIRST_TORCH="${TV_ARRAY[0]}"
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="
-    pin_torch "$FIRST_TORCH"
-    build_wheel "$TMP_DIR"
+    build_wheel "$TMP_DIR" "$FIRST_TORCH"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
     BASE_WHL=$(ls "$TMP_DIR"/dist/*.whl)
 
     for ((i=1; i<${#TV_ARRAY[@]}; i++)); do
         TV="${TV_ARRAY[$i]}"
         echo "=== Building nixl_ep .so for torch ${TV} ==="
-        pin_torch "$TV"
 
         EP_TMP=$(mktemp -d)
-        build_wheel "$EP_TMP"
+        build_wheel "$EP_TMP" "$TV"
         # Repair so the .so passes auditwheel for the manylinux tag before we extract it
         repair_wheel "$EP_TMP" "$EP_TMP/dist"
 

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -23,6 +23,7 @@ UCX_PLUGINS_DIR="/usr/lib64/ucx"
 NIXL_PLUGINS_DIR="/usr/local/nixl/lib/$ARCH-linux-gnu/plugins"
 OUTPUT_DIR="dist"
 BUILD_NIXL_EP="false"
+TORCH_VERSIONS=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -69,6 +70,11 @@ while [[ $# -gt 0 ]]; do
             BUILD_NIXL_EP="true"
             shift
             ;;
+        --torch-versions)
+            TORCH_VERSIONS=$2
+            shift
+            shift
+            ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -88,21 +94,83 @@ if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then
     echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'"
     exit 1
 fi
+AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca*"
+
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
-if [ "$BUILD_NIXL_EP" = "true" ]; then
-    uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION \
-        -Csetup-args=-Dbuild_nixl_ep=true \
-        -Csetup-args=-Dbuild_examples=true
-else
-    uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
-fi
 
-# Bundle libraries
-mkdir $TMP_DIR/dist
-auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
-./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $TMP_DIR/dist/*.whl
-cp $TMP_DIR/dist/*.whl $OUTPUT_DIR
+install_torch() {
+    local VER=$1
+    uv pip install --pre "torch==${VER}.*"
+}
+
+build_wheel() {
+    local OUT_DIR=$1
+    if [ "$BUILD_NIXL_EP" = "true" ]; then
+        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION \
+            -Csetup-args=-Dbuild_nixl_ep=true \
+            -Csetup-args=-Dbuild_examples=true
+    else
+        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION
+    fi
+}
+
+repair_wheel() {
+    local IN_DIR=$1
+    local OUT_DIR=$2
+    mkdir -p "$OUT_DIR"
+    auditwheel repair $AUDITWHEEL_EXCLUDES "$IN_DIR"/nixl*.whl --plat $WHL_PLATFORM --wheel-dir "$OUT_DIR"
+    ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR "$OUT_DIR"/*.whl
+}
+
+if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
+    # Multi-torch: build full wheel with first torch, then merge extra .so from others.
+    IFS=',' read -ra TV_ARRAY <<< "$TORCH_VERSIONS"
+
+    FIRST_TORCH="${TV_ARRAY[0]}"
+    echo "=== Building wheel with torch ${FIRST_TORCH} ==="
+    install_torch "$FIRST_TORCH"
+    build_wheel "$TMP_DIR"
+    repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
+    BASE_WHL=$(ls "$TMP_DIR"/dist/*.whl)
+
+    for ((i=1; i<${#TV_ARRAY[@]}; i++)); do
+        TV="${TV_ARRAY[$i]}"
+        echo "=== Building nixl_ep .so for torch ${TV} ==="
+        install_torch "$TV"
+
+        EP_TMP=$(mktemp -d)
+        build_wheel "$EP_TMP"
+
+        # Extract torch-versioned .so from new wheel, inject into base wheel
+        EP_EXTRACT=$(mktemp -d)
+        unzip -o "$EP_TMP"/nixl*.whl -d "$EP_EXTRACT"
+        BASE_EXTRACT=$(mktemp -d)
+        unzip -o "$BASE_WHL" -d "$BASE_EXTRACT"
+
+        TORCH_MM=$(echo "$TV" | tr -d '.')
+        find "$EP_EXTRACT" -name "nixl_ep_cpp_torch${TORCH_MM}*" -exec cp {} "$BASE_EXTRACT"/nixl_ep_cu${CUDA_MAJOR}/ \;
+
+        # Regenerate RECORD
+        DIST_INFO=$(ls -d "$BASE_EXTRACT"/*.dist-info)
+        (cd "$BASE_EXTRACT" && find . -type f ! -name RECORD -printf '%P\n' | while read f; do
+            hash=$(python3 -c "import hashlib,base64; d=open('$f','rb').read(); print('sha256=' + base64.urlsafe_b64encode(hashlib.sha256(d).digest()).rstrip(b'=').decode())")
+            size=$(stat -c%s "$f")
+            echo "$f,$hash,$size"
+        done > "$DIST_INFO/RECORD"
+        echo "$(basename $DIST_INFO)/RECORD,," >> "$DIST_INFO/RECORD")
+
+        rm -f "$BASE_WHL"
+        (cd "$BASE_EXTRACT" && zip -r "$BASE_WHL" .)
+        rm -rf "$EP_TMP" "$EP_EXTRACT" "$BASE_EXTRACT"
+    done
+
+    cp "$BASE_WHL" "$OUTPUT_DIR"
+else
+    build_wheel "$TMP_DIR"
+    repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
+    cp "$TMP_DIR"/dist/*.whl "$OUTPUT_DIR"
+fi
 
 # Clean up
 rm -rf "$TMP_DIR"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -97,21 +97,33 @@ fi
 AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca*"
 
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
+CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | tr -d .)"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
 
-install_torch() {
+# Pin the torch build dep in pyproject.toml so uv build's isolated env resolves it.
+pin_torch() {
     local VER=$1
-    uv pip install --pre "torch==${VER}.*"
+    ./contrib/tomlutil.py --torch-version "$VER" pyproject.toml
 }
+
+# uv build's isolated build env needs access to the nightly index too.
+UV_BUILD_INDEX_FLAGS=(
+    --index-url "https://download.pytorch.org/whl/${CU_TAG}"
+    --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}"
+    --index-strategy unsafe-best-match
+    --prerelease allow
+)
 
 build_wheel() {
     local OUT_DIR=$1
     if [ "$BUILD_NIXL_EP" = "true" ]; then
         uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION \
+            "${UV_BUILD_INDEX_FLAGS[@]}" \
             -Csetup-args=-Dbuild_nixl_ep=true \
             -Csetup-args=-Dbuild_examples=true
     else
-        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION
+        uv build --wheel --out-dir "$OUT_DIR" --python $PYTHON_VERSION \
+            "${UV_BUILD_INDEX_FLAGS[@]}"
     fi
 }
 
@@ -129,7 +141,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
 
     FIRST_TORCH="${TV_ARRAY[0]}"
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="
-    install_torch "$FIRST_TORCH"
+    pin_torch "$FIRST_TORCH"
     build_wheel "$TMP_DIR"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
     BASE_WHL=$(ls "$TMP_DIR"/dist/*.whl)
@@ -137,7 +149,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     for ((i=1; i<${#TV_ARRAY[@]}; i++)); do
         TV="${TV_ARRAY[$i]}"
         echo "=== Building nixl_ep .so for torch ${TV} ==="
-        install_torch "$TV"
+        pin_torch "$TV"
 
         EP_TMP=$(mktemp -d)
         build_wheel "$EP_TMP"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -321,27 +321,20 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         # Repair so the .so passes auditwheel for the manylinux tag before we extract it
         repair_wheel "$EP_TMP" "$EP_TMP/dist"
 
-        # Extract torch-versioned .so from repaired wheel, inject into base wheel
-        EP_EXTRACT=$(mktemp -d)
-        unzip -o "$EP_TMP"/dist/*.whl -d "$EP_EXTRACT"
-        BASE_EXTRACT=$(mktemp -d)
-        unzip -o "$BASE_WHL" -d "$BASE_EXTRACT"
-
+        # Merge the torch-versioned .so from the freshly-built wheel into
+        # the base wheel and regenerate RECORD. Both wheels were built
+        # against the same outer C++ build, so the .so's DT_NEEDED entries
+        # (libucp-<hash>.so etc.) match the libs already bundled in
+        # $BASE_WHL by auditwheel.
         TORCH_MM=$(echo "$TORCH" | tr -d '.')
-        find "$EP_EXTRACT" -name "nixl_ep_cpp_torch${TORCH_MM}*" -exec cp {} "$BASE_EXTRACT"/nixl_ep_cu${CUDA_MAJOR}/ \;
+        EP_WHL=$(ls "$EP_TMP"/dist/*.whl)
+        ./contrib/wheel_merge.py \
+            --base-wheel "$BASE_WHL" \
+            --source-wheel "$EP_WHL" \
+            --pattern "nixl_ep_cpp_torch${TORCH_MM}.*" \
+            --target-dir "nixl_ep_cu${CUDA_MAJOR}"
 
-        # Regenerate RECORD
-        DIST_INFO=$(ls -d "$BASE_EXTRACT"/*.dist-info)
-        (cd "$BASE_EXTRACT" && find . -type f ! -name RECORD -printf '%P\n' | while read f; do
-            hash=$(python3 -c "import hashlib,base64; d=open('$f','rb').read(); print('sha256=' + base64.urlsafe_b64encode(hashlib.sha256(d).digest()).rstrip(b'=').decode())")
-            size=$(stat -c%s "$f")
-            echo "$f,$hash,$size"
-        done > "$DIST_INFO/RECORD"
-        echo "$(basename $DIST_INFO)/RECORD,," >> "$DIST_INFO/RECORD")
-
-        rm -f "$BASE_WHL"
-        (cd "$BASE_EXTRACT" && zip -r "$BASE_WHL" .)
-        rm -rf "$EP_TMP" "$EP_EXTRACT" "$BASE_EXTRACT"
+        rm -rf "$EP_TMP"
     done
 
     cp "$BASE_WHL" "$OUTPUT_DIR"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -240,6 +240,19 @@ repair_wheel() {
     ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR "$OUT_DIR"/*.whl
 }
 
+# Echo the path of the single .whl in $1, or exit if the count is not 1.
+single_wheel() {
+    local dir=$1 wheels
+    shopt -s nullglob
+    wheels=("$dir"/*.whl)
+    shopt -u nullglob
+    if [ ${#wheels[@]} -ne 1 ]; then
+        echo "expected 1 wheel in $dir, got ${#wheels[@]}: ${wheels[*]}" >&2
+        exit 1
+    fi
+    echo "${wheels[0]}"
+}
+
 if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     # Multi-torch: build the full wheel with the first torch, then merge
     # the per-torch .so from the others into it.
@@ -269,7 +282,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="
     build_wheel "$TMP_DIR" "$FIRST_TORCH"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
-    BASE_WHL=$(ls "$TMP_DIR"/dist/*.whl)
+    BASE_WHL=$(single_wheel "$TMP_DIR/dist")
 
     for ((i=1; i<${#TORCH_ARRAY[@]}; i++)); do
         TORCH="${TORCH_ARRAY[$i]}"
@@ -284,7 +297,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         # (libucp-<hash>.so etc.) match what auditwheel already bundled
         # into $BASE_WHL.
         TORCH_MM=$(echo "$TORCH" | tr -d '.')
-        EP_WHL=$(ls "$EP_TMP"/dist/*.whl)
+        EP_WHL=$(single_wheel "$EP_TMP/dist")
         ./contrib/wheel_merge.py \
             --base-wheel "$BASE_WHL" \
             --source-wheel "$EP_WHL" \

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -105,11 +105,8 @@ CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 |
 TORCH_STABLE_INDEX="https://download.pytorch.org/whl/${CU_TAG}"
 TORCH_NIGHTLY_INDEX="https://download.pytorch.org/whl/nightly/${CU_TAG}"
 
-# Build deps every wheel build needs in its venv. Mirrors pyproject.toml's
-# `build-system.requires` minus torch (which is added per-iteration with
-# channel-appropriate constraints). pytest/build are not strictly needed by
-# meson-python at build time but are kept in sync with pyproject.toml so
-# nothing breaks if a backend hook decides to import them.
+# Build deps installed into the per-iteration venv (torch is added
+# separately with channel-appropriate constraints).
 BUILD_DEPS=(
     "meson"
     "meson-python"
@@ -154,12 +151,7 @@ torch_channel() {
     local CHECK_VENV="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
     rm -rf "$CHECK_VENV"
     if uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1; then
-        # Unset UV_*INDEX* env vars (the wheel-build loop in
-        # Dockerfile.manylinux exports them with the nightly index, which
-        # would otherwise let `torch==X.Y.*` resolve from nightly and make
-        # us mis-classify a nightly-only release as stable).
-        if env -u UV_INDEX -u UV_EXTRA_INDEX_URL -u UV_INDEX_STRATEGY -u UV_DEFAULT_INDEX \
-            uv pip install --dry-run \
+        if uv pip install --dry-run \
             --python "$CHECK_VENV/bin/python" \
             --index-url "$TORCH_STABLE_INDEX" \
             "torch==${VER}.*" >/dev/null 2>&1; then
@@ -292,40 +284,40 @@ repair_wheel() {
 
 if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     # Multi-torch: build full wheel with first torch, then merge extra .so from others.
-    IFS=',' read -ra TV_REQUESTED <<< "$TORCH_VERSIONS"
+    IFS=',' read -ra TORCH_REQUESTED <<< "$TORCH_VERSIONS"
 
     # Filter to torch versions actually resolvable for this (Python, CUDA) combo.
-    TV_ARRAY=()
+    TORCH_ARRAY=()
     SKIPPED=()
-    for TV in "${TV_REQUESTED[@]}"; do
-        if [ -n "$(torch_available "$TV")" ]; then
-            TV_ARRAY+=("$TV")
+    for TORCH in "${TORCH_REQUESTED[@]}"; do
+        if [ -n "$(torch_available "$TORCH")" ]; then
+            TORCH_ARRAY+=("$TORCH")
         else
-            SKIPPED+=("$TV")
+            SKIPPED+=("$TORCH")
         fi
     done
 
     if [ ${#SKIPPED[@]} -gt 0 ]; then
         echo "=== Skipping torch versions (no wheel on index for Python ${PYTHON_VERSION} + ${CU_TAG}): ${SKIPPED[*]} ==="
     fi
-    if [ ${#TV_ARRAY[@]} -eq 0 ]; then
-        echo "ERROR: none of the requested torch versions (${TV_REQUESTED[*]}) are available for Python ${PYTHON_VERSION} + ${CU_TAG}"
+    if [ ${#TORCH_ARRAY[@]} -eq 0 ]; then
+        echo "ERROR: none of the requested torch versions (${TORCH_REQUESTED[*]}) are available for Python ${PYTHON_VERSION} + ${CU_TAG}"
         exit 1
     fi
-    echo "=== Building for torch versions: ${TV_ARRAY[*]} ==="
+    echo "=== Building for torch versions: ${TORCH_ARRAY[*]} ==="
 
-    FIRST_TORCH="${TV_ARRAY[0]}"
+    FIRST_TORCH="${TORCH_ARRAY[0]}"
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="
     build_wheel "$TMP_DIR" "$FIRST_TORCH"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
     BASE_WHL=$(ls "$TMP_DIR"/dist/*.whl)
 
-    for ((i=1; i<${#TV_ARRAY[@]}; i++)); do
-        TV="${TV_ARRAY[$i]}"
-        echo "=== Building nixl_ep .so for torch ${TV} ==="
+    for ((i=1; i<${#TORCH_ARRAY[@]}; i++)); do
+        TORCH="${TORCH_ARRAY[$i]}"
+        echo "=== Building nixl_ep .so for torch ${TORCH} ==="
 
         EP_TMP=$(mktemp -d)
-        build_wheel "$EP_TMP" "$TV"
+        build_wheel "$EP_TMP" "$TORCH"
         # Repair so the .so passes auditwheel for the manylinux tag before we extract it
         repair_wheel "$EP_TMP" "$EP_TMP/dist"
 
@@ -335,7 +327,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         BASE_EXTRACT=$(mktemp -d)
         unzip -o "$BASE_WHL" -d "$BASE_EXTRACT"
 
-        TORCH_MM=$(echo "$TV" | tr -d '.')
+        TORCH_MM=$(echo "$TORCH" | tr -d '.')
         find "$EP_EXTRACT" -name "nixl_ep_cpp_torch${TORCH_MM}*" -exec cp {} "$BASE_EXTRACT"/nixl_ep_cu${CUDA_MAJOR}/ \;
 
         # Regenerate RECORD

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -81,6 +81,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [ "$BUILD_NIXL_EP" = "true" ] && [ -z "$TORCH_VERSIONS" ]; then
+    echo "ERROR: --build-nixl-ep requires --torch-versions (e.g. --torch-versions 2.11,2.12)" >&2
+    exit 1
+fi
+
 set -e
 set -x
 
@@ -112,10 +117,6 @@ BUILD_DEPS=(
     "setuptools>=80.9.0"
 )
 
-# Classification cache for repeated lookups within a single script run.
-# Values: "stable" | "nightly" | "unavailable".
-declare -A TORCH_CLASS_CACHE
-
 # Slugify a dotted version (e.g. "2.13" -> "213", "3.10" -> "310") so it can
 # be used unambiguously as a path component.
 slug() { echo "${1//./}"; }
@@ -135,13 +136,9 @@ venv_path() {
 
 # Echo "stable", "nightly", or "unavailable" depending on whether
 # torch==${VER}.* resolves from the stable cu index, the nightly cu
-# index (with --pre), or neither. Cached.
+# index (with --pre), or neither.
 torch_classify() {
     local VER=$1
-    if [ -n "${TORCH_CLASS_CACHE[$VER]:-}" ]; then
-        echo "${TORCH_CLASS_CACHE[$VER]}"
-        return
-    fi
     local CLASS="unavailable"
     local PROBE="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
     rm -rf "$PROBE"
@@ -161,7 +158,6 @@ torch_classify() {
         fi
     fi
     rm -rf "$PROBE"
-    TORCH_CLASS_CACHE[$VER]="$CLASS"
     echo "$CLASS"
 }
 

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -117,8 +117,9 @@ BUILD_DEPS=(
     "setuptools>=80.9.0"
 )
 
-# Channel cache for repeated lookups within a single script run.
-declare -A TORCH_CHANNEL_CACHE
+# Classification cache for repeated lookups within a single script run.
+# Values: "stable" | "nightly" | "unavailable".
+declare -A TORCH_CLASS_CACHE
 
 # Slugify a dotted version (e.g. "2.13" -> "213", "3.10" -> "310") so it can
 # be used unambiguously as a path component.
@@ -137,30 +138,41 @@ venv_path() {
     fi
 }
 
-# Determine whether torch==${VER}.* has a stable release on the stable cu
-# index for the target Python version. Echoes "stable" or "nightly".
-# A torch version is treated as stable iff a non-pre-release wheel resolves
-# from the stable cu index alone (no nightly index, no --pre).
-torch_channel() {
+# Classify a requested torch version for the target Python: does
+# `torch==${VER}.*` resolve from the stable cu index alone, only from the
+# nightly index (with --pre), or from neither? Echoes one of:
+#   stable       — resolvable from $TORCH_STABLE_INDEX without --pre
+#   nightly      — resolvable from $TORCH_NIGHTLY_INDEX with --pre
+#   unavailable  — not in either index for this Python
+# Result is cached so each (PYTHON_VERSION, VER) probe runs at most once
+# across the script's filter and build phases.
+torch_classify() {
     local VER=$1
-    if [ -n "${TORCH_CHANNEL_CACHE[$VER]:-}" ]; then
-        echo "${TORCH_CHANNEL_CACHE[$VER]}"
+    if [ -n "${TORCH_CLASS_CACHE[$VER]:-}" ]; then
+        echo "${TORCH_CLASS_CACHE[$VER]}"
         return
     fi
-    local CHANNEL="nightly"
-    local CHECK_VENV="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
-    rm -rf "$CHECK_VENV"
-    if uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1; then
+    local CLASS="unavailable"
+    local PROBE="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
+    rm -rf "$PROBE"
+    if uv venv "$PROBE" --python "$PYTHON_VERSION" >/dev/null 2>&1; then
         if uv pip install --dry-run \
-            --python "$CHECK_VENV/bin/python" \
+            --python "$PROBE/bin/python" \
             --index-url "$TORCH_STABLE_INDEX" \
             "torch==${VER}.*" >/dev/null 2>&1; then
-            CHANNEL="stable"
+            CLASS="stable"
+        elif uv pip install --dry-run --pre \
+            --python "$PROBE/bin/python" \
+            --extra-index-url "$TORCH_STABLE_INDEX" \
+            --extra-index-url "$TORCH_NIGHTLY_INDEX" \
+            --index-strategy unsafe-best-match \
+            "torch==${VER}.*" >/dev/null 2>&1; then
+            CLASS="nightly"
         fi
     fi
-    rm -rf "$CHECK_VENV"
-    TORCH_CHANNEL_CACHE[$VER]="$CHANNEL"
-    echo "$CHANNEL"
+    rm -rf "$PROBE"
+    TORCH_CLASS_CACHE[$VER]="$CLASS"
+    echo "$CLASS"
 }
 
 # Echo the torch requirement spec for the given (version, channel). Stable
@@ -197,25 +209,6 @@ torch_uv_flags() {
     fi
 }
 
-# Check whether torch==${VER}.* is resolvable from any configured index
-# (stable or nightly) for the target Python version. Echoes "yes" on
-# success, nothing otherwise.
-torch_available() {
-    local VER=$1
-    local CHECK_VENV="/workspace/venv-probe-py$(slug "$PYTHON_VERSION")"
-    rm -rf "$CHECK_VENV"
-    uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1 || return
-    if uv pip install --dry-run --pre \
-        --python "$CHECK_VENV/bin/python" \
-        --extra-index-url "$TORCH_STABLE_INDEX" \
-        --extra-index-url "$TORCH_NIGHTLY_INDEX" \
-        --index-strategy unsafe-best-match \
-        "torch==${VER}.*" >/dev/null 2>&1; then
-        echo "yes"
-    fi
-    rm -rf "$CHECK_VENV"
-}
-
 # Build the wheel for the current PYTHON_VERSION (and optional torch VER).
 # Creates a fresh venv at venv_path, installs build deps + torch with the
 # channel-appropriate flags, runs `uv build --no-build-isolation`, and
@@ -230,7 +223,7 @@ build_wheel() {
     local VENV_PATH
     VENV_PATH=$(venv_path "$VER")
     local CHANNEL="stable"
-    [ -n "$VER" ] && CHANNEL=$(torch_channel "$VER")
+    [ -n "$VER" ] && CHANNEL=$(torch_classify "$VER")
 
     local UV_FLAGS=()
     while IFS= read -r f; do UV_FLAGS+=("$f"); done < <(torch_uv_flags "$CHANNEL")
@@ -290,10 +283,10 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     TORCH_ARRAY=()
     SKIPPED=()
     for TORCH in "${TORCH_REQUESTED[@]}"; do
-        if [ -n "$(torch_available "$TORCH")" ]; then
-            TORCH_ARRAY+=("$TORCH")
-        else
+        if [ "$(torch_classify "$TORCH")" = "unavailable" ]; then
             SKIPPED+=("$TORCH")
+        else
+            TORCH_ARRAY+=("$TORCH")
         fi
     done
 

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -106,13 +106,33 @@ pin_torch() {
     ./contrib/tomlutil.py --torch-version "$VER" pyproject.toml
 }
 
-# uv build's isolated build env needs access to the nightly index too.
+# PyPI stays primary (for meson-python etc); PyTorch indexes are extras for torch.
 UV_BUILD_INDEX_FLAGS=(
-    --index-url "https://download.pytorch.org/whl/${CU_TAG}"
+    --extra-index-url "https://download.pytorch.org/whl/${CU_TAG}"
     --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}"
     --index-strategy unsafe-best-match
     --prerelease allow
 )
+
+# Check whether torch==${VER}.* is resolvable from the configured indexes
+# for the target Python version. Echoes "yes" on success, nothing otherwise.
+torch_available() {
+    local VER=$1
+    local CHECK_VENV
+    CHECK_VENV=$(mktemp -d)/venv
+    uv venv "$CHECK_VENV" --python "$PYTHON_VERSION" >/dev/null 2>&1 || return
+    # shellcheck disable=SC1090
+    source "$CHECK_VENV/bin/activate"
+    if uv pip install --dry-run --pre \
+        --extra-index-url "https://download.pytorch.org/whl/${CU_TAG}" \
+        --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}" \
+        --index-strategy unsafe-best-match \
+        "torch==${VER}.*" >/dev/null 2>&1; then
+        echo "yes"
+    fi
+    deactivate
+    rm -rf "$(dirname "$CHECK_VENV")"
+}
 
 build_wheel() {
     local OUT_DIR=$1
@@ -137,7 +157,27 @@ repair_wheel() {
 
 if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     # Multi-torch: build full wheel with first torch, then merge extra .so from others.
-    IFS=',' read -ra TV_ARRAY <<< "$TORCH_VERSIONS"
+    IFS=',' read -ra TV_REQUESTED <<< "$TORCH_VERSIONS"
+
+    # Filter to torch versions actually resolvable for this (Python, CUDA) combo.
+    TV_ARRAY=()
+    SKIPPED=()
+    for TV in "${TV_REQUESTED[@]}"; do
+        if [ -n "$(torch_available "$TV")" ]; then
+            TV_ARRAY+=("$TV")
+        else
+            SKIPPED+=("$TV")
+        fi
+    done
+
+    if [ ${#SKIPPED[@]} -gt 0 ]; then
+        echo "=== Skipping torch versions (no wheel on index for Python ${PYTHON_VERSION} + ${CU_TAG}): ${SKIPPED[*]} ==="
+    fi
+    if [ ${#TV_ARRAY[@]} -eq 0 ]; then
+        echo "ERROR: none of the requested torch versions (${TV_REQUESTED[*]}) are available for Python ${PYTHON_VERSION} + ${CU_TAG}"
+        exit 1
+    fi
+    echo "=== Building for torch versions: ${TV_ARRAY[*]} ==="
 
     FIRST_TORCH="${TV_ARRAY[0]}"
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -236,12 +236,12 @@ repair_wheel() {
     local IN_DIR=$1
     local OUT_DIR=$2
     mkdir -p "$OUT_DIR"
-    auditwheel repair $AUDITWHEEL_EXCLUDES "$IN_DIR"/nixl*.whl --plat $WHL_PLATFORM --wheel-dir "$OUT_DIR"
-    ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR "$OUT_DIR"/*.whl
+    auditwheel repair $AUDITWHEEL_EXCLUDES "$IN_DIR"/nixl*.whl --plat "$WHL_PLATFORM" --wheel-dir "$OUT_DIR"
+    ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir "$UCX_PLUGINS_DIR" --nixl-plugins-dir "$NIXL_PLUGINS_DIR" "$OUT_DIR"/*.whl
 }
 
 # Echo the path of the single .whl in $1, or exit if the count is not 1.
-single_wheel() {
+get_wheel_path() {
     local dir=$1 wheels
     shopt -s nullglob
     wheels=("$dir"/*.whl)
@@ -282,7 +282,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     echo "=== Building wheel with torch ${FIRST_TORCH} ==="
     build_wheel "$TMP_DIR" "$FIRST_TORCH"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
-    BASE_WHL=$(single_wheel "$TMP_DIR/dist")
+    BASE_WHL=$(get_wheel_path "$TMP_DIR/dist")
 
     for ((i=1; i<${#TORCH_ARRAY[@]}; i++)); do
         TORCH="${TORCH_ARRAY[$i]}"
@@ -297,7 +297,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         # (libucp-<hash>.so etc.) match what auditwheel already bundled
         # into $BASE_WHL.
         TORCH_MM=$(echo "$TORCH" | tr -d '.')
-        EP_WHL=$(single_wheel "$EP_TMP/dist")
+        EP_WHL=$(get_wheel_path "$EP_TMP/dist")
         ./contrib/wheel_merge.py \
             --base-wheel "$BASE_WHL" \
             --source-wheel "$EP_WHL" \
@@ -311,7 +311,7 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
 else
     build_wheel "$TMP_DIR"
     repair_wheel "$TMP_DIR" "$TMP_DIR/dist"
-    cp "$TMP_DIR"/dist/*.whl "$OUTPUT_DIR"
+    cp "$(get_wheel_path "$TMP_DIR/dist")" "$OUTPUT_DIR"
 fi
 
 # Clean up

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -59,6 +59,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --ucx-plugins-dir: Directory to find UCX plugins in (default: $UCX_PLUGINS_DIR)"
             echo "  --nixl-plugins-dir: Directory to find NIXL plugins in (default: $NIXL_PLUGINS_DIR)"
             echo "  --build-nixl-ep: Build wheel with nixl_ep package included (requires CUDA sm90-compatible environment)"
+            echo "  --torch-versions: Comma-separated list of torch versions to build the wheel for (default: $TORCH_VERSIONS)"
             echo "  --help: Show this help message"
             echo ""
             echo "Must be executed from the root of the NIXL repository."
@@ -227,7 +228,7 @@ build_wheel() {
 
     deactivate
     # torch + nvidia-* in each venv is several GB; tear down so the docker
-    # layer doesnt blow up across the (python, torch) matrix.
+    # layer does not get too large across the (python, torch) matrix.
     rm -rf "$VENV_PATH"
 }
 

--- a/contrib/tomlutil.py
+++ b/contrib/tomlutil.py
@@ -21,6 +21,11 @@ import tomlkit
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--wheel-name", type=str, help="Set the project name")
+parser.add_argument(
+    "--torch-version",
+    type=str,
+    help="Pin the torch build dep to this major.minor (e.g. '2.13')",
+)
 parser.add_argument("file", type=str, help="The toml file to modify")
 args = parser.parse_args()
 
@@ -28,13 +33,14 @@ with open(args.file) as f:
     doc = tomlkit.parse(f.read())
 
 if args.wheel_name:
-    # Set the wheel name
-    # Example:
-    # ```toml
-    # [project]
-    # name = "<wheel_name>"
-    # ```
     doc["project"]["name"] = args.wheel_name
+
+if args.torch_version:
+    # Replace any existing "torch" or "torch==X.*" entry in build requires
+    requires = doc["build-system"]["requires"]
+    new_requires = [r for r in requires if not r.split("==")[0].strip() == "torch"]
+    new_requires.append(f"torch=={args.torch_version}.*")
+    doc["build-system"]["requires"] = new_requires
 
 with open(args.file, "w") as f:
     f.write(tomlkit.dumps(doc))

--- a/contrib/tomlutil.py
+++ b/contrib/tomlutil.py
@@ -21,11 +21,6 @@ import tomlkit
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--wheel-name", type=str, help="Set the project name")
-parser.add_argument(
-    "--torch-version",
-    type=str,
-    help="Pin the torch build dep to this major.minor (e.g. '2.13')",
-)
 parser.add_argument("file", type=str, help="The toml file to modify")
 args = parser.parse_args()
 
@@ -33,14 +28,13 @@ with open(args.file) as f:
     doc = tomlkit.parse(f.read())
 
 if args.wheel_name:
+    # Set the wheel name
+    # Example:
+    # ```toml
+    # [project]
+    # name = "<wheel_name>"
+    # ```
     doc["project"]["name"] = args.wheel_name
-
-if args.torch_version:
-    # Replace any existing "torch" or "torch==X.*" entry in build requires
-    requires = doc["build-system"]["requires"]
-    new_requires = [r for r in requires if not r.split("==")[0].strip() == "torch"]
-    new_requires.append(f"torch=={args.torch_version}.*")
-    doc["build-system"]["requires"] = new_requires
 
 with open(args.file, "w") as f:
     f.write(tomlkit.dumps(doc))

--- a/contrib/wheel_merge.py
+++ b/contrib/wheel_merge.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/contrib/wheel_merge.py
+++ b/contrib/wheel_merge.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Merge file(s) from one wheel into another, regenerating RECORD."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import fnmatch
+import hashlib
+import io
+import os
+import sys
+import zipfile
+
+
+def _sha256_b64(data: bytes) -> str:
+    digest = hashlib.sha256(data).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def _record_bytes(entries: list[tuple[str, bytes]], record_path: str) -> bytes:
+    rows = [
+        [name, f"sha256={_sha256_b64(data)}", str(len(data))]
+        for name, data in entries
+        if name != record_path
+    ]
+    rows.append([record_path, "", ""])
+    buf = io.StringIO()
+    csv.writer(buf).writerows(rows)
+    return buf.getvalue().encode("utf-8")
+
+
+def merge(
+    base_wheel: str,
+    source_wheel: str,
+    pattern: str,
+    target_dir: str,
+) -> list[str]:
+    """Merge files matching `pattern` from `source_wheel` into `base_wheel`.
+
+    `pattern` is a fnmatch glob applied to the basename of each entry in
+    the source wheel; matches are placed under `target_dir/` inside the
+    base wheel. `base_wheel` is rewritten atomically with a regenerated
+    RECORD. Returns the list of merged entry names (relative to the
+    wheel root).
+    """
+    target_dir = target_dir.rstrip("/")
+
+    # Pull matching files out of the source wheel, rewriting their path so
+    # they land under target_dir/.
+    merged: dict[str, tuple[zipfile.ZipInfo, bytes]] = {}
+    with zipfile.ZipFile(source_wheel, "r") as zsrc:
+        for info in zsrc.infolist():
+            name = os.path.basename(info.filename)
+            if not fnmatch.fnmatch(name, pattern):
+                continue
+            new_name = f"{target_dir}/{name}"
+            new_info = zipfile.ZipInfo(filename=new_name)
+            new_info.compress_type = info.compress_type
+            new_info.external_attr = info.external_attr
+            new_info.date_time = info.date_time
+            merged[new_name] = (new_info, zsrc.read(info))
+
+    if not merged:
+        raise SystemExit(
+            f"no files matched {pattern!r} in {source_wheel}"
+        )
+
+    # Read base wheel; pull out RECORD path so we can regenerate it.
+    by_name: dict[str, tuple[zipfile.ZipInfo, bytes]] = {}
+    record_path: str | None = None
+    with zipfile.ZipFile(base_wheel, "r") as zin:
+        for info in zin.infolist():
+            if info.filename.endswith(".dist-info/RECORD"):
+                record_path = info.filename
+                continue
+            by_name[info.filename] = (info, zin.read(info))
+    if record_path is None:
+        raise SystemExit(f"no .dist-info/RECORD found in {base_wheel}")
+
+    # Apply merge (source overrides base if a name collides).
+    by_name.update(merged)
+
+    # Sort for stable output; nice for diffing two wheels.
+    ordered = sorted(by_name)
+    record = _record_bytes([(n, by_name[n][1]) for n in ordered], record_path)
+
+    record_info = zipfile.ZipInfo(filename=record_path)
+    record_info.compress_type = zipfile.ZIP_DEFLATED
+
+    tmp_path = f"{base_wheel}.tmp"
+    with zipfile.ZipFile(
+        tmp_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as zout:
+        for name in ordered:
+            info, data = by_name[name]
+            zout.writestr(info, data)
+        zout.writestr(record_info, record)
+    os.replace(tmp_path, base_wheel)
+
+    return sorted(merged)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-wheel",
+        required=True,
+        help="wheel to merge into (rewritten in place)",
+    )
+    parser.add_argument(
+        "--source-wheel",
+        required=True,
+        help="wheel to extract files from",
+    )
+    parser.add_argument(
+        "--pattern",
+        required=True,
+        help="basename glob of files to merge (e.g. 'nixl_ep_cpp_torch212.*')",
+    )
+    parser.add_argument(
+        "--target-dir",
+        required=True,
+        help="directory inside the base wheel for the merged files "
+        "(e.g. 'nixl_ep_cu13')",
+    )
+    args = parser.parse_args()
+
+    merged = merge(
+        base_wheel=args.base_wheel,
+        source_wheel=args.source_wheel,
+        pattern=args.pattern,
+        target_dir=args.target_dir,
+    )
+    print(f"merged {len(merged)} file(s) into {args.base_wheel}:")
+    for name in merged:
+        print(f"  {name}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/wheel_merge.py
+++ b/contrib/wheel_merge.py
@@ -79,9 +79,7 @@ def merge(
             merged[new_name] = (new_info, zsrc.read(info))
 
     if not merged:
-        raise SystemExit(
-            f"no files matched {pattern!r} in {source_wheel}"
-        )
+        raise SystemExit(f"no files matched {pattern!r} in {source_wheel}")
 
     # Read base wheel; pull out RECORD path so we can regenerate it.
     by_name: dict[str, tuple[zipfile.ZipInfo, bytes]] = {}

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -135,9 +135,18 @@ nixl_ep_install_rpath = join_paths(get_option('prefix'), get_option('libdir'))
 nixl_ep_install_rpath += ':' + join_paths(get_option('prefix'), get_option('libdir'), 'plugins')
 nixl_ep_install_rpath += ':' + torch_lib_dir
 
-nixl_ep_ext = py.extension_module('nixl_ep_cpp',
+# CUDA-versioned install dir so cu12 and cu13 wheels don't collide.
+nixl_ep_install_dir = 'nixl_ep_' + cuda_wheel_dir.split('_')[-1]  # nixl_ep_cu12 or nixl_ep_cu13
+
+# Torch-versioned .so name so multiple torch ABIs coexist in a single wheel.
+torch_ver = run_command(py, '-c',
+    'import torch; print("".join(torch.__version__.split(".")[:2]))',
+    check: true).stdout().strip()
+nixl_ep_ext_name = 'nixl_ep_cpp_torch' + torch_ver
+
+nixl_ep_ext = py.extension_module(nixl_ep_ext_name,
     nixl_ep_sources,
-    subdir: 'nixl_ep',
+    subdir: nixl_ep_install_dir,
     dependencies: [
         nixl_dep,
         pybind_dep,
@@ -165,11 +174,12 @@ custom_target('nixl_ep_py_copy',
     input: nixl_ep_py_files,
     command: [
         'bash', '-c',
-        'cp -r @0@/nixl_ep @1@/ && cp @2@ @1@/nixl_ep/ && touch @3@'.format(
+        'mkdir -p @1@/@4@ && cp @0@/nixl_ep/*.py @1@/@4@/ && cp @2@ @1@/@4@/ && touch @3@'.format(
             meson.current_source_dir(),
             meson.current_build_dir(),
             nixl_ep_ext.full_path(),
-            join_paths(meson.current_build_dir(), 'nixl_ep_py.stamp')
+            join_paths(meson.current_build_dir(), 'nixl_ep_py.stamp'),
+            nixl_ep_install_dir,
         )
     ],
     depends: nixl_ep_ext,
@@ -180,6 +190,6 @@ py.install_sources(
     'nixl_ep/__init__.py',
     'nixl_ep/buffer.py',
     'nixl_ep/utils.py',
-    subdir: 'nixl_ep',
+    subdir: nixl_ep_install_dir,
     pure: false,
 )

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -118,15 +118,10 @@ nixl_ep_rpath += ':' + nixl_lib_dir
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'core')
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'plugins')
 
-# Torch >=2.13 ships public C10 headers (e.g. c10/core/AutogradState.h)
-# that use C++20 features (default member initializers for bit-fields), so
-# the nixl_ep extension must be compiled as C++20. C++20 is backwards-
-# compatible with the project's default cpp_std=c++17, so older torch
-# versions keep building.
-nixl_ep_override_options = ['cpp_std=c++20', 'cuda_std=c++20']
 # For now, nixl ep cannot be built with -G due to register usage limits
+nixl_ep_override_options = []
 if get_option('buildtype') == 'debug'
-    nixl_ep_override_options += ['optimization=3']
+    nixl_ep_override_options = ['optimization=3']
     nixl_ep_cpp_args += ['-g']
 endif
 

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -78,9 +78,19 @@ nixl_ep_inc_dirs = [
     torch_inc_dirs,
 ]
 
+# Torch-versioned .so name so multiple torch ABIs coexist in a single
+# wheel. Defined up here because TORCH_EXTENSION_NAME (consumed by
+# pybind11's PYBIND11_MODULE macro to generate the PyInit_<name> symbol)
+# must match the .so filename Python loads, otherwise import fails with
+# "dynamic module does not define module export function".
+torch_ver = run_command(py, '-c',
+    'import torch; print("".join(torch.__version__.split(".")[:2]))',
+    check: true).stdout().strip()
+nixl_ep_ext_name = 'nixl_ep_cpp_torch' + torch_ver
+
 nixl_ep_cpp_args = [
     '-DHAVE_CUDA',
-    '-DTORCH_EXTENSION_NAME=nixl_ep_cpp',
+    '-DTORCH_EXTENSION_NAME=' + nixl_ep_ext_name,
     '-Wno-deprecated-declarations',
     '-Wno-unused-variable',
     '-Wno-sign-compare',
@@ -90,7 +100,7 @@ nixl_ep_cpp_args = [
 
 nixl_ep_cuda_args = [
     '-DHAVE_CUDA',
-    '-DTORCH_EXTENSION_NAME=nixl_ep_cpp',
+    '-DTORCH_EXTENSION_NAME=' + nixl_ep_ext_name,
     '--expt-relaxed-constexpr',  # Allow calling constexpr __host__ functions from __device__ functions
     '-arch=sm_90',  # Only compile for sm90 (overrides global -gencode flags)
     '--ptxas-options=--register-usage-level=10',  # Allow more register usage (matches setup.py)
@@ -137,12 +147,6 @@ nixl_ep_install_rpath += ':' + torch_lib_dir
 
 # CUDA-versioned install dir so cu12 and cu13 wheels don't collide.
 nixl_ep_install_dir = 'nixl_ep_' + cuda_wheel_dir.split('_')[-1]  # nixl_ep_cu12 or nixl_ep_cu13
-
-# Torch-versioned .so name so multiple torch ABIs coexist in a single wheel.
-torch_ver = run_command(py, '-c',
-    'import torch; print("".join(torch.__version__.split(".")[:2]))',
-    check: true).stdout().strip()
-nixl_ep_ext_name = 'nixl_ep_cpp_torch' + torch_ver
 
 nixl_ep_ext = py.extension_module(nixl_ep_ext_name,
     nixl_ep_sources,

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -118,10 +118,15 @@ nixl_ep_rpath += ':' + nixl_lib_dir
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'core')
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'plugins')
 
+# Torch >=2.13 ships public C10 headers (e.g. c10/core/AutogradState.h)
+# that use C++20 features (default member initializers for bit-fields), so
+# the nixl_ep extension must be compiled as C++20. C++20 is backwards-
+# compatible with the project's default cpp_std=c++17, so older torch
+# versions keep building.
+nixl_ep_override_options = ['cpp_std=c++20', 'cuda_std=c++20']
 # For now, nixl ep cannot be built with -G due to register usage limits
-nixl_ep_override_options = []
 if get_option('buildtype') == 'debug'
-    nixl_ep_override_options = ['optimization=3']
+    nixl_ep_override_options += ['optimization=3']
     nixl_ep_cpp_args += ['-g']
 endif
 

--- a/examples/device/ep/nixl_ep/__init__.py
+++ b/examples/device/ep/nixl_ep/__init__.py
@@ -25,8 +25,10 @@ import torch
 _torch_mm = "".join(torch.__version__.split(".")[:2])
 _nixl_ep_cpp = importlib.import_module(f".nixl_ep_cpp_torch{_torch_mm}", __package__)
 
-from .buffer import Buffer
-from .utils import EventOverlap
+# The submodules below import names from `_nixl_ep_cpp`, so the dynamic
+# import above must run first; that's why these aren't at the top.
+from .buffer import Buffer  # noqa: E402
+from .utils import EventOverlap  # noqa: E402
 
 topk_idx_t = getattr(_nixl_ep_cpp, "topk_idx_t", torch.int64)
 Config = _nixl_ep_cpp.Config

--- a/examples/device/ep/nixl_ep/__init__.py
+++ b/examples/device/ep/nixl_ep/__init__.py
@@ -18,9 +18,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+
 import torch
 
-from . import nixl_ep_cpp as _nixl_ep_cpp
+_torch_mm = "".join(torch.__version__.split(".")[:2])
+_nixl_ep_cpp = importlib.import_module(f".nixl_ep_cpp_torch{_torch_mm}", __package__)
+
 from .buffer import Buffer
 from .utils import EventOverlap
 

--- a/examples/device/ep/nixl_ep/__init__.py
+++ b/examples/device/ep/nixl_ep/__init__.py
@@ -19,13 +19,17 @@
 # limitations under the License.
 
 import importlib
+import sys
 
 import torch
 
 _torch_mm = "".join(torch.__version__.split(".")[:2])
 _nixl_ep_cpp = importlib.import_module(f".nixl_ep_cpp_torch{_torch_mm}", __package__)
+# Alias the torch-versioned extension as `nixl_ep_cpp` so the static
+# `from .nixl_ep_cpp import ...` imports in buffer.py / utils.py resolve.
+sys.modules[f"{__package__}.nixl_ep_cpp"] = _nixl_ep_cpp
 
-# The submodules below import names from `_nixl_ep_cpp`, so the dynamic
+# The submodules below import names from `nixl_ep_cpp`, so the dynamic
 # import above must run first; that's why these aren't at the top.
 from .buffer import Buffer  # noqa: E402
 from .utils import EventOverlap  # noqa: E402

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = ["torch", "numpy"]
 [tool.mypy]
 mypy_path = ["src/bindings/python/nixl-meta"]
 ignore_missing_imports = true
+# Two `nixl_ep/__init__.py` files coexist legitimately: the meta-dispatcher
+# under `src/bindings/python/nixl-meta/nixl_ep/` and the actual EP source
+# under `examples/device/ep/nixl_ep/`. Without explicit_package_bases mypy
+# refuses to resolve them and errors with "Duplicate module named nixl_ep".
+explicit_package_bases = true
 
 [tool.isort]
 profile = "black"

--- a/src/bindings/python/nixl-meta/meson.build
+++ b/src/bindings/python/nixl-meta/meson.build
@@ -34,16 +34,27 @@ source_root = meson.project_source_root()
 root_license_path = join_paths(source_root, 'LICENSE')
 license_path = fs.copyfile(root_license_path)
 
-nixl_sources = files('nixl/__init__.py')
-
 subdir('nixl')
+subdir('nixl_ep')
 
 uv = find_program('uv', required: false)
 if uv.found()
   wheel_name = 'nixl-@0@-py3-none-any.whl'.format(meson.project_version())
+  # Inputs intentionally point at the build-dir COPIES (return values of
+  # fs.copyfile() captured in the subdirs), not the source files. This way
+  # ninja runs the copies before `uv build` and incremental rebuilds pick
+  # up edits to the source __init__.py files.
   meta_wheel = custom_target(
     'build_nixl_meta',
-    input: [pyproject_toml, readme_md, license_path] + nixl_sources,
+    input: [
+      pyproject_toml,
+      readme_md,
+      license_path,
+      nixl_init_copy,
+      nixl_api_copy,
+      nixl_logging_copy,
+      nixl_ep_init_copy,
+    ],
     output: [wheel_name],
     command: [uv, 'build', '--wheel', '--out-dir', build_dir, build_dir],
     install: false,

--- a/src/bindings/python/nixl-meta/nixl/meson.build
+++ b/src/bindings/python/nixl-meta/nixl/meson.build
@@ -17,3 +17,18 @@ fs = import('fs')
 fs.copyfile('__init__.py')
 fs.copyfile('_api.py')
 fs.copyfile('logging.py')
+
+# nixl_ep meta-dispatcher: copy into build dir so the meta wheel picks it up
+nixl_ep_meta_dir = join_paths(meson.current_build_dir(), '..', 'nixl_ep')
+nixl_ep_meta_src = join_paths(meson.current_source_dir(), '..', 'nixl_ep', '__init__.py')
+custom_target('nixl_ep_meta_copy',
+    output: 'nixl_ep_meta.stamp',
+    command: ['bash', '-c',
+        'mkdir -p @0@ && cp @1@ @0@/__init__.py && touch @2@'.format(
+            nixl_ep_meta_dir,
+            nixl_ep_meta_src,
+            join_paths(meson.current_build_dir(), 'nixl_ep_meta.stamp'),
+        )
+    ],
+    build_by_default: true,
+)

--- a/src/bindings/python/nixl-meta/nixl/meson.build
+++ b/src/bindings/python/nixl-meta/nixl/meson.build
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 fs = import('fs')
-# Return values are captured so the meta-wheel custom_target in the parent
-# meson.build can depend on them and ninja runs the copies before `uv build`.
 nixl_init_copy = fs.copyfile('__init__.py')
 nixl_api_copy = fs.copyfile('_api.py')
 nixl_logging_copy = fs.copyfile('logging.py')

--- a/src/bindings/python/nixl-meta/nixl_ep/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl_ep/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bindings/python/nixl-meta/nixl_ep/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl_ep/__init__.py
@@ -27,7 +27,7 @@ def _get_torch_cuda_major() -> int | None:
     return int(_torch_cuda_ver.split(".")[0]) if _torch_cuda_ver else None
 
 
-def _load_ep_backend() -> str:
+def _load_ep_module() -> str:
     cuda_major = _get_torch_cuda_major()
     if cuda_major is not None:
         pip_name = f"nixl-cu{cuda_major}"
@@ -51,7 +51,7 @@ def _load_ep_backend() -> str:
     raise ImportError("No nixl_ep CUDA backend found")
 
 
-_pkg = sys.modules[_load_ep_backend()]
+_pkg = sys.modules[_load_ep_module()]
 
 submodules = ["buffer", "utils"]
 for sub_name in submodules:

--- a/src/bindings/python/nixl-meta/nixl_ep/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl_ep/__init__.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""nixl_ep meta-dispatcher: selects the correct CUDA and torch ABI backend."""
+
+import importlib
+import sys
+from typing import TYPE_CHECKING
+
+
+def _get_torch_cuda_major() -> int | None:
+    """Return the CUDA major version that torch was built for, or None."""
+    from torch.version import cuda as _torch_cuda_ver
+
+    return int(_torch_cuda_ver.split(".")[0]) if _torch_cuda_ver else None
+
+
+def _load_ep_backend() -> str:
+    cuda_major = _get_torch_cuda_major()
+    if cuda_major is not None:
+        pip_name = f"nixl-cu{cuda_major}"
+        mod_name = f"nixl_ep_cu{cuda_major}"
+        try:
+            return importlib.import_module(mod_name).__name__
+        except ModuleNotFoundError as e:
+            if e.name != mod_name:
+                raise
+            raise ImportError(
+                f"torch reports CUDA {cuda_major} but {pip_name} is not installed"
+            ) from e
+    # CPU-only torch — use whatever backend is installed
+    for mod_name in ("nixl_ep_cu13", "nixl_ep_cu12"):
+        try:
+            return importlib.import_module(mod_name).__name__
+        except ModuleNotFoundError as e:
+            if e.name != mod_name:
+                raise
+            continue
+    raise ImportError("No nixl_ep CUDA backend found")
+
+
+_pkg = sys.modules[_load_ep_backend()]
+
+submodules = ["buffer", "utils"]
+for sub_name in submodules:
+    # Import submodule from actual wheel
+    module = importlib.import_module(f"{_pkg.__name__}.{sub_name}")
+    # Make it accessible as nixl_ep.buffer, nixl_ep.utils
+    sys.modules[f"nixl_ep.{sub_name}"] = module
+    # Also add the submodule itself to the nixl_ep namespace
+    setattr(sys.modules[__name__], sub_name, module)
+
+    # Expose all public symbols from the submodule under the nixl_ep namespace
+    for attr in dir(module):
+        if not attr.startswith("_"):
+            setattr(sys.modules[__name__], attr, getattr(module, attr))
+
+# Expose public symbols from the backend __init__ (Config, topk_idx_t, etc.)
+for attr in dir(_pkg):
+    if not attr.startswith("_"):
+        setattr(sys.modules[__name__], attr, getattr(_pkg, attr))
+
+if TYPE_CHECKING:
+    from nixl_ep.buffer import Buffer  # noqa: F401
+    from nixl_ep.utils import EventOverlap  # noqa: F401

--- a/src/bindings/python/nixl-meta/nixl_ep/meson.build
+++ b/src/bindings/python/nixl-meta/nixl_ep/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bindings/python/nixl-meta/nixl_ep/meson.build
+++ b/src/bindings/python/nixl-meta/nixl_ep/meson.build
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 fs = import('fs')
-# Return values are captured so the meta-wheel custom_target in the parent
-# meson.build can depend on them and ninja runs the copies before `uv build`.
-nixl_init_copy = fs.copyfile('__init__.py')
-nixl_api_copy = fs.copyfile('_api.py')
-nixl_logging_copy = fs.copyfile('logging.py')
+# Return value is captured so the meta-wheel custom_target in the parent
+# meson.build can depend on it and ninja runs the copy before `uv build`.
+nixl_ep_init_copy = fs.copyfile('__init__.py')

--- a/src/bindings/python/nixl-meta/nixl_ep/meson.build
+++ b/src/bindings/python/nixl-meta/nixl_ep/meson.build
@@ -14,6 +14,4 @@
 # limitations under the License.
 
 fs = import('fs')
-# Return value is captured so the meta-wheel custom_target in the parent
-# meson.build can depend on it and ninja runs the copy before `uv build`.
 nixl_ep_init_copy = fs.copyfile('__init__.py')

--- a/src/bindings/python/nixl-meta/pyproject.toml.in
+++ b/src/bindings/python/nixl-meta/pyproject.toml.in
@@ -36,4 +36,4 @@ cu12 = ["nixl-cu12==@VERSION@"]
 cu13 = ["nixl-cu13==@VERSION@"]
 
 [tool.setuptools]
-packages = ["nixl"]
+packages = ["nixl", "nixl_ep"]


### PR DESCRIPTION
## What?

Adds a `nixl_ep` Python dispatch layer that ships in the **meta wheel** and routes `import nixl_ep` to the correct backend at runtime, picked from two axes:

1. **CUDA major** (cu12 vs cu13) — selected from `torch.version.cuda`.
2. **torch minor ABI** (e.g. 2.11 vs 2.12) — selected from `torch.__version__`.

Each `nixl-cu12` / `nixl-cu13` backend wheel ships *all* supported torch ABIs as separate compiled extensions in the same package, so a single backend wheel works against any installed torch in the supported range without reinstalling.

## Why?

vLLM is working on upgrading torch from 2.11 to 2.12. Currently NIXL EP wheel ships binary with ABI compatibility only with 2.11, by the time we release this may be obsolete.

Also, there may be a transition period where vLLM will ship a mix of images, some requiring PyTorch 2.11 (stable) and some 2.12 (nightly) so it is best if we can support both.

vLLM PR: https://github.com/vllm-project/vllm/pull/40077

Also fixes https://github.com/vllm-project/vllm/issues/42525

## How?

The full import flow works like this:

1. `import nixl_ep` lands in the **meta dispatcher**, `src/bindings/python/nixl-meta/nixl_ep/__init__.py`. It reads `torch.version.cuda` and picks `nixl_ep_cu12` or `nixl_ep_cu13`:

   ```30:42:src/bindings/python/nixl-meta/nixl_ep/__init__.py
   def _load_ep_backend() -> str:
       cuda_major = _get_torch_cuda_major()
       if cuda_major is not None:
           pip_name = f"nixl-cu{cuda_major}"
           mod_name = f"nixl_ep_cu{cuda_major}"
           try:
               return importlib.import_module(mod_name).__name__
           except ModuleNotFoundError as e:
               if e.name != mod_name:
                   raise
               raise ImportError(
                   f"torch reports CUDA {cuda_major} but {pip_name} is not installed"
               ) from e
   ```

   On CPU-only torch it falls through to a `cu13`→`cu12` probe order so that something gets loaded and the import does not fail, since vLLM imports unconditionally, but it will not be used. This is the same as `import nixl` works.

2. The selected backend (e.g. `nixl_ep_cu13/__init__.py`, shipped in the `nixl-cu13` wheel) reads `torch.__version__` and loads the matching ABI extension bindings through a second dispatch:

   ```25:26:examples/device/ep/nixl_ep/__init__.py
   _torch_mm = "".join(torch.__version__.split(".")[:2])
   _nixl_ep_cpp = importlib.import_module(f".nixl_ep_cpp_torch{_torch_mm}", __package__)
   ```

   With torch 2.12 installed, this resolves to `nixl_ep_cu13.nixl_ep_cpp_torch212`.

3. The meta dispatcher then re-exposes the backend's public symbols and submodules under the top-level `nixl_ep` namespace so that the import is fully pass-through:

   ```56:73:src/bindings/python/nixl-meta/nixl_ep/__init__.py
   submodules = ["buffer", "utils"]
   for sub_name in submodules:
       module = importlib.import_module(f"{_pkg.__name__}.{sub_name}")
       sys.modules[f"nixl_ep.{sub_name}"] = module
       setattr(sys.modules[__name__], sub_name, module)
       for attr in dir(module):
           if not attr.startswith("_"):
               setattr(sys.modules[__name__], attr, getattr(module, attr))

   for attr in dir(_pkg):
       if not attr.startswith("_"):
           setattr(sys.modules[__name__], attr, getattr(_pkg, attr))
   ```

   So `nixl_ep.Buffer`, `nixl_ep.EventOverlap`, `nixl_ep.Config`, `nixl_ep.utils`, `nixl_ep.buffer` all work regardless of which (CUDA, torch) backend was selected.

If torch reports a CUDA major for which no backend wheel is installed, the meta dispatcher raises `ImportError` with a clear message (e.g. `"torch reports CUDA 13 but nixl-cu13 is not installed"`).

### Wheel layout

Supported PyTorch versions: 2.11,2.12.

**PyTorch 2.13 is intentionally excluded** since it is a nightly package that is not built for all platforms at the moment, and also requires C++20. Out of scope of this PR.

**Meta wheel** — `nixl-1.1.0-py3-none-any.whl` (~12 KB, pure-Python, dispatch only):

```
   2933  nixl/__init__.py               ← NIXL dispatcher
   1593  nixl/_api.py
   1166  nixl/logging.py
   2916  nixl_ep/__init__.py            ← NIXL EP dispatcher
```

**Backend wheel** — `nixl_cu13-1.1.0-cp312-cp312-manylinux_2_28_x86_64.whl`:

```
        0  nixl_cu13/
     1099  nixl_cu13/__init__.py
    45009  nixl_cu13/_api.py
  1122345  nixl_cu13/_bindings.cpython-312-x86_64-linux-gnu.so
   187232  nixl_cu13/_utils.cpython-312-x86_64-linux-gnu.so
     3640  nixl_cu13/logging.py
        0  nixl_cu13/py.typed
        0  nixl_ep_cu13/
     1474  nixl_ep_cu13/__init__.py
    36336  nixl_ep_cu13/buffer.py
     2985  nixl_ep_cu13/utils.py
  9447553  nixl_ep_cu13/nixl_ep_cpp_torch211.cpython-312-x86_64-linux-gnu.so    <-- PyTorch 2.11 bindings
  9555257  nixl_ep_cu13/nixl_ep_cpp_torch212.cpython-312-x86_64-linux-gnu.so    <-- PyTorch 2.12 bindings
```

The `cu12` backend wheel mirrors this, with `nixl_cu12/` + `nixl_ep_cu12/` and the same per-torch `.so` set.

### Testing

#### Test matrix

| run | torch resolved | dispatched backend | loaded `.so` | `libcudart.so.X` |
|---|---|---|---|---|
| CUDA 12 PyTorch 2.11 | `2.11.0+cu129` (stable) | `nixl_ep_cu12` | `nixl_ep_cpp_torch211` | `12` ✓ |
| CUDA 12 PyTorch 2.12 | `2.12.0.dev20260401+cu129` (nightly) | `nixl_ep_cu12` | `nixl_ep_cpp_torch212` | `12` ✓ |
| CUDA 13 PyTorch 2.11 | `2.11.0+cu130` (stable) | `nixl_ep_cu13` | `nixl_ep_cpp_torch211` | `13` ✓ |
| CUDA 13 PyTorch 2.12 | `2.12.0+cu130` (stable) | `nixl_ep_cu13` | `nixl_ep_cpp_torch212` | `13` ✓ |

For each case, we check that:

- CUDA-major assertion passes (`torch.version.cuda` matches the requested cuda-major).
- Meta `nixl_ep` dispatcher routed to the correct `nixl_ep_cu{12,13}` backend based on `torch.version.cuda`.
- Backend selected the correct `nixl_ep_cpp_torch{211,212}.so` based on `torch.__version__`.
- `Buffer`, `Config`, `EventOverlap` all resolve through both layers (the `nixl_ep_cpp` alias trick is working in `buffer.py`/`utils.py`).
- `ldd` shows the wheel-bundled `libucp-…/libucs-…` from `nixl_cu{12,13}.libs/`, the right `libcudart.so.{12,13}` for the cu-major, and `libtorch*.so` from the resolved torch in the venv. No `not found`.
- `import nixl` (non-EP meta) also imports clean.

End-to-end: dispatch contract from `nixl_ep/__init__.py` (cuda-major from `torch.version.cuda`) and `nixl_ep_cu{N}/__init__.py` (torch ABI slug from `torch.__version__`) is verified across the full {cu12, cu13} × {2.11, 2.12} matrix.

#### Testing strategy

```bash
# install uv
apt-get update -qq && apt-get install -y curl ca-certificates
curl -LsSf https://astral.sh/uv/install.sh | sh
export PATH=$HOME/.local/bin:$PATH

# venv
uv venv --python 3.12 /venv
source /venv/bin/activate

# install torch — pick ONE line based on your image:
uv pip install --index-url https://download.pytorch.org/whl/cu129 'torch==2.11.*'    # cu12 + 2.11
uv pip install --index-url https://download.pytorch.org/whl/cu129 --extra-index-url https://download.pytorch.org/whl/nightly/cu129 --index-strategy unsafe-best-match --pre 'torch==2.12.*'    # cu12 + 2.12
uv pip install --index-url https://download.pytorch.org/whl/cu130 'torch==2.11.*'    # cu13 + 2.11
uv pip install --index-url https://download.pytorch.org/whl/cu130 'torch==2.12.*'    # cu13 + 2.12

# install nixl
uv pip install --find-links /wheels nixl

# test
python -c 'import nixl_ep; print(nixl_ep.Buffer, nixl_ep.Config)'
```

#### Smoke test script

```bash
#!/usr/bin/env bash
set -euo pipefail

if [ "$#" -lt 2 ]; then
    echo "usage: $0 <cuda-major: 12|13> <torch-version: 2.11|2.12>" >&2
    exit 2
fi

CUDA_MAJOR="$1"
TORCH_VER="$2"
WHEEL_DIR="${WHEEL_DIR:-$(dirname "$(readlink -f "$0")")}"

case "$CUDA_MAJOR" in
    12) IMAGE="nvidia/cuda:12.9.0-runtime-ubuntu22.04"; CU_TAG="cu129" ;;
    13) IMAGE="nvidia/cuda:13.0.0-runtime-ubuntu22.04"; CU_TAG="cu130" ;;
    *) echo "cuda-major must be 12 or 13" >&2; exit 2 ;;
esac

case "$TORCH_VER" in
    2.11|2.12) ;;
    *) echo "torch-version must be 2.11 or 2.12" >&2; exit 2 ;;
esac

echo ">>> image     : $IMAGE"
echo ">>> cu-tag    : $CU_TAG"
echo ">>> torch     : $TORCH_VER"
echo ">>> wheel dir : $WHEEL_DIR"

docker run --rm --gpus all \
    -v "$WHEEL_DIR":/wheels:ro \
    -e CUDA_MAJOR="$CUDA_MAJOR" -e TORCH_VER="$TORCH_VER" -e CU_TAG="$CU_TAG" \
    "$IMAGE" bash -exc '
        set -euo pipefail

        apt-get update -qq
        apt-get install -y -qq --no-install-recommends curl ca-certificates >/dev/null
        curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null
        export PATH="$HOME/.local/bin:$PATH"

        uv venv --python 3.12 /venv
        # shellcheck disable=SC1091
        . /venv/bin/activate

        # Only torch==2.12 on cu129 is nightly-only today; everything else
        # is on the stable cu index. Add --pre + nightly index iff needed.
        TORCH_FLAGS=( --index-url "https://download.pytorch.org/whl/${CU_TAG}" )
        if [ "$CU_TAG" = "cu129" ] && [ "$TORCH_VER" = "2.12" ]; then
            TORCH_FLAGS+=(
                --extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}"
                --pre
                --index-strategy unsafe-best-match
            )
        fi
        uv pip install "${TORCH_FLAGS[@]}" "torch==${TORCH_VER}.*"

        # nixl + transitive deps (numpy, etc.) — torch already satisfied;
        # local wheel dir provides the meta + nixl-cu{12,13}.
        uv pip install --find-links /wheels nixl

        echo "=== environment ==="
        python -c "
import torch
print(f\"torch={torch.__version__}  cuda={torch.version.cuda}\")
expected = ${CUDA_MAJOR}
got = int(torch.version.cuda.split(\".\")[0]) if torch.version.cuda else None
assert got == expected, f\"expected torch built for cuda{expected}, got cuda{got}\"
"

        echo "=== nixl_ep dispatch ==="
        python - <<PY
import nixl_ep, sys
print("nixl_ep loaded from:", nixl_ep.__file__)
backend = next(m for n, m in sys.modules.items()
               if n.startswith("nixl_ep_cu") and "." not in n)
print("dispatched backend :", backend.__name__, "->", backend.__file__)
print("loaded torch-abi .so:", backend._nixl_ep_cpp.__file__)
print("Buffer       :", nixl_ep.Buffer)
print("Config       :", nixl_ep.Config)
print("EventOverlap :", nixl_ep.EventOverlap)
PY

        echo "=== resolved deps of active .so ==="
        python - <<PY
import os, subprocess, sys, torch
import nixl_ep
backend = next(m for n, m in sys.modules.items()
               if n.startswith("nixl_ep_cu") and "." not in n)
so = backend._nixl_ep_cpp.__file__
torch_libdir = os.path.join(os.path.dirname(torch.__file__), "lib")
env = {**os.environ, "LD_LIBRARY_PATH": torch_libdir + ":" + os.environ.get("LD_LIBRARY_PATH", "")}
print(so)
out = subprocess.check_output(["ldd", so], env=env, text=True)
for line in out.splitlines():
    if any(x in line for x in ("libcudart", "libtorch", "libcuda.", "libucp", "libucs", "not found")):
        print(line)
PY

        echo "=== nixl dispatch ==="
        python -c "import nixl; print(\"nixl OK\", nixl.__file__)"
    '

```

Test log:

<details>

```bash
./smoke 12 2.11
./smoke 12 2.12
./smoke 13 2.11
./smoke 13 2.12
>>> image     : nvidia/cuda:12.9.0-runtime-ubuntu22.04
>>> cu-tag    : cu129
>>> torch     : 2.11
>>> wheel dir : /.autodirect/mtrswgwork/ovidium/wheels/nixl-ep-wheel-dispatch-20260515

==========
== CUDA ==
==========

CUDA Version 12.9.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

+ set -euo pipefail
+ apt-get update -qq
+ apt-get install -y -qq --no-install-recommends curl ca-certificates
debconf: delaying package configuration, since apt-utils is not installed
+ curl -LsSf https://astral.sh/uv/install.sh
+ sh
downloading uv 0.11.14 x86_64-unknown-linux-gnu
+ export PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ uv venv --python 3.12 /venv
Downloading cpython-3.12.13-linux-x86_64-gnu (download) (32.5MiB)
 Downloaded cpython-3.12.13-linux-x86_64-gnu (download)
Using CPython 3.12.13
Creating virtual environment at: /venv
Activate with: source venv/bin/activate
+ . /venv/bin/activate
++ '[' -z '' ']'
++ '[' -n x ']'
++ SCRIPT_PATH=/venv/bin/activate
++ '[' /venv/bin/activate = bash ']'
++ deactivate nondestructive
++ unset -f pydoc
++ '[' -z '' ']'
++ '[' -z '' ']'
++ hash -r
++ '[' -z '' ']'
++ unset VIRTUAL_ENV
++ unset VIRTUAL_ENV_PROMPT
++ '[' '!' nondestructive = nondestructive ']'
++ VIRTUAL_ENV=/venv
++ '[' linux-gnu = cygwin ']'
++ '[' linux-gnu = msys ']'
++ export VIRTUAL_ENV
++ '[' -z '' ']'
++ unset SCRIPT_PATH
++ _OLD_VIRTUAL_PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/venv/bin:/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ export PATH
++ '[' x '!=' x ']'
+++ basename /venv
++ VIRTUAL_ENV_PROMPT=venv
++ export VIRTUAL_ENV_PROMPT
++ '[' -z '' ']'
++ '[' -z '' ']'
++ _OLD_VIRTUAL_PS1=
++ PS1='(venv) '
++ export PS1
++ alias pydoc
++ true
++ hash -r
+ TORCH_FLAGS=(--index-url "https://download.pytorch.org/whl/${CU_TAG}")
+ '[' cu129 = cu129 ']'
+ '[' 2.11 = 2.12 ']'
+ uv pip install --index-url https://download.pytorch.org/whl/cu129 'torch==2.11.*'
Using Python 3.12.13 environment at: /venv
Resolved 29 packages in 1.95s
Downloading nvidia-curand-cu12 (65.1MiB)
Downloading torch (1.1GiB)
Downloading cuda-bindings (11.6MiB)
Downloading triton (179.6MiB)
Downloading nvidia-cuda-nvrtc-cu12 (85.4MiB)
Downloading nvidia-nccl-cu12 (283.0MiB)
Downloading nvidia-cusparse-cu12 (349.5MiB)
Downloading nvidia-cuda-runtime-cu12 (3.3MiB)
Downloading nvidia-cublas-cu12 (554.3MiB)
Downloading nvidia-cufile-cu12 (1.2MiB)
Downloading nvidia-nvjitlink-cu12 (37.9MiB)
Downloading nvidia-cudnn-cu12 (617.8MiB)
Downloading nvidia-cusparselt-cu12 (273.9MiB)
Downloading nvidia-cufft-cu12 (191.6MiB)
Downloading nvidia-nvshmem-cu12 (132.7MiB)
Downloading nvidia-cuda-cupti-cu12 (10.3MiB)
Downloading nvidia-cusolver-cu12 (322.5MiB)
Downloading networkx (2.0MiB)
Downloading sympy (6.0MiB)
 Downloaded nvidia-cufile-cu12
 Downloaded nvidia-cuda-runtime-cu12
 Downloaded cuda-bindings
 Downloaded nvidia-cuda-cupti-cu12
 Downloaded nvidia-curand-cu12
 Downloaded networkx
 Downloaded triton
 Downloaded nvidia-nvjitlink-cu12
 Downloaded nvidia-cuda-nvrtc-cu12
 Downloaded sympy
 Downloaded nvidia-nccl-cu12
 Downloaded nvidia-nvshmem-cu12
 Downloaded nvidia-cusparse-cu12
 Downloaded nvidia-cufft-cu12
 Downloaded nvidia-cusparselt-cu12
 Downloaded nvidia-cublas-cu12
 Downloaded nvidia-cusolver-cu12
 Downloaded nvidia-cudnn-cu12
 Downloaded torch
Prepared 29 packages in 34.86s
Installed 29 packages in 318ms
 + cuda-bindings==12.9.4
 + cuda-pathfinder==1.2.2
 + cuda-toolkit==12.9.1
 + filelock==3.29.0
 + fsspec==2026.4.0
 + jinja2==3.1.6
 + markupsafe==3.0.3
 + mpmath==1.3.0
 + networkx==3.6.1
 + nvidia-cublas-cu12==12.9.1.4
 + nvidia-cuda-cupti-cu12==12.9.79
 + nvidia-cuda-nvrtc-cu12==12.9.86
 + nvidia-cuda-runtime-cu12==12.9.79
 + nvidia-cudnn-cu12==9.17.1.4
 + nvidia-cufft-cu12==11.4.1.4
 + nvidia-cufile-cu12==1.14.1.1
 + nvidia-curand-cu12==10.3.10.19
 + nvidia-cusolver-cu12==11.7.5.82
 + nvidia-cusparse-cu12==12.5.10.65
 + nvidia-cusparselt-cu12==0.7.1
 + nvidia-nccl-cu12==2.28.9
 + nvidia-nvjitlink-cu12==12.9.86
 + nvidia-nvshmem-cu12==3.4.5
 + nvidia-nvtx-cu12==12.9.79
 + setuptools==70.2.0
 + sympy==1.14.0
 + torch==2.11.0+cu129
 + triton==3.6.0
 + typing-extensions==4.15.0
+ uv pip install --find-links /wheels nixl
Using Python 3.12.13 environment at: /venv
Resolved 33 packages in 1.04s
Downloading numpy (15.9MiB)
 Downloaded numpy
Prepared 4 packages in 962ms
Installed 4 packages in 64ms
 + nixl==1.1.0
 + nixl-cu12==1.1.0
 + nixl-cu13==1.1.0
 + numpy==2.4.4
+ echo '=== environment ==='
=== environment ===
+ python -c '
import torch
print(f"torch={torch.__version__}  cuda={torch.version.cuda}")
expected = 12
got = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else None
assert got == expected, f"expected torch built for cuda{expected}, got cuda{got}"
'
torch=2.11.0+cu129  cuda=12.9
=== nixl_ep dispatch ===
+ echo '=== nixl_ep dispatch ==='
+ python -
nixl_ep loaded from: /venv/lib/python3.12/site-packages/nixl_ep/__init__.py
dispatched backend : nixl_ep_cu12 -> /venv/lib/python3.12/site-packages/nixl_ep_cu12/__init__.py
loaded torch-abi .so: /venv/lib/python3.12/site-packages/nixl_ep_cu12/nixl_ep_cpp_torch211.cpython-312-x86_64-linux-gnu.so
Buffer       : <class 'nixl_ep_cu12.buffer.Buffer'>
Config       : <class 'nixl_ep_cu12.nixl_ep_cpp_torch211.Config'>
EventOverlap : <class 'nixl_ep_cu12.utils.EventOverlap'>
=== resolved deps of active .so ===
+ echo '=== resolved deps of active .so ==='
+ python -
/venv/lib/python3.12/site-packages/nixl_ep_cu12/nixl_ep_cpp_torch211.cpython-312-x86_64-linux-gnu.so
        libcuda.so.1 => /lib/x86_64-linux-gnu/libcuda.so.1 (0x00007ffff1618000)
        libucp-14aa4f8d.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu12/../nixl_cu12.libs/libucp-14aa4f8d.so.0.0.0 (0x00007ffff1507000)
        libucs-f64e0bb0.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu12/../nixl_cu12.libs/libucs-f64e0bb0.so.0.0.0 (0x00007ffff1435000)
        libtorch.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch.so (0x00007ffff13d0000)
        libtorch_python.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so (0x00007fffefd77000)
        libtorch_cuda.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so (0x00007fff9ffd1000)
        libcudart.so.12 => /usr/local/cuda/lib64/libcudart.so.12 (0x00007fff9fa00000)
        libtorch_cpu.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so (0x00007fff89bc5000)
        libtorch_nvshmem.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_nvshmem.so (0x00007fff6da25000)
=== nixl dispatch ===
+ echo '=== nixl dispatch ==='
+ python -c 'import nixl; print("nixl OK", nixl.__file__)'
nixl OK /venv/lib/python3.12/site-packages/nixl/__init__.py
>>> image     : nvidia/cuda:12.9.0-runtime-ubuntu22.04
>>> cu-tag    : cu129
>>> torch     : 2.12
>>> wheel dir : /.autodirect/mtrswgwork/ovidium/wheels/nixl-ep-wheel-dispatch-20260515

==========
== CUDA ==
==========

CUDA Version 12.9.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

+ set -euo pipefail
+ apt-get update -qq
+ apt-get install -y -qq --no-install-recommends curl ca-certificates
debconf: delaying package configuration, since apt-utils is not installed
+ curl -LsSf https://astral.sh/uv/install.sh
+ sh
downloading uv 0.11.14 x86_64-unknown-linux-gnu
+ export PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ uv venv --python 3.12 /venv
Downloading cpython-3.12.13-linux-x86_64-gnu (download) (32.5MiB)
 Downloaded cpython-3.12.13-linux-x86_64-gnu (download)
Using CPython 3.12.13
Creating virtual environment at: /venv
Activate with: source venv/bin/activate
+ . /venv/bin/activate
++ '[' -z '' ']'
++ '[' -n x ']'
++ SCRIPT_PATH=/venv/bin/activate
++ '[' /venv/bin/activate = bash ']'
++ deactivate nondestructive
++ unset -f pydoc
++ '[' -z '' ']'
++ '[' -z '' ']'
++ hash -r
++ '[' -z '' ']'
++ unset VIRTUAL_ENV
++ unset VIRTUAL_ENV_PROMPT
++ '[' '!' nondestructive = nondestructive ']'
++ VIRTUAL_ENV=/venv
++ '[' linux-gnu = cygwin ']'
++ '[' linux-gnu = msys ']'
++ export VIRTUAL_ENV
++ '[' -z '' ']'
++ unset SCRIPT_PATH
++ _OLD_VIRTUAL_PATH=/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/venv/bin:/root/.local/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ export PATH
++ '[' x '!=' x ']'
+++ basename /venv
++ VIRTUAL_ENV_PROMPT=venv
++ export VIRTUAL_ENV_PROMPT
++ '[' -z '' ']'
++ '[' -z '' ']'
++ _OLD_VIRTUAL_PS1=
++ PS1='(venv) '
++ export PS1
++ alias pydoc
++ true
++ hash -r
+ TORCH_FLAGS=(--index-url "https://download.pytorch.org/whl/${CU_TAG}")
+ '[' cu129 = cu129 ']'
+ '[' 2.12 = 2.12 ']'
+ TORCH_FLAGS+=(--extra-index-url "https://download.pytorch.org/whl/nightly/${CU_TAG}" --pre --index-strategy unsafe-best-match)
+ uv pip install --index-url https://download.pytorch.org/whl/cu129 --extra-index-url https://download.pytorch.org/whl/nightly/cu129 --pre --index-strategy unsafe-best-match 'torch==2.12.*'
Using Python 3.12.13 environment at: /venv
Resolved 29 packages in 2.47s
Downloading nvidia-cuda-runtime-cu12 (3.3MiB)
Downloading nvidia-cublas-cu12 (554.3MiB)
Downloading nvidia-cusparse-cu12 (349.5MiB)
Downloading nvidia-cufile-cu12 (1.2MiB)
Downloading nvidia-nvjitlink-cu12 (37.9MiB)
Downloading nvidia-cufft-cu12 (191.6MiB)
Downloading nvidia-nvshmem-cu12 (132.7MiB)
Downloading nvidia-cuda-cupti-cu12 (10.3MiB)
Downloading nvidia-cusolver-cu12 (322.5MiB)
Downloading nvidia-curand-cu12 (65.1MiB)
Downloading nvidia-nccl-cu12 (280.0MiB)
Downloading nvidia-cuda-nvrtc-cu12 (85.4MiB)
Downloading nvidia-cusparselt-cu12 (228.2MiB)
Downloading nvidia-cudnn-cu12 (627.4MiB)
Downloading setuptools (1.2MiB)
Downloading networkx (2.0MiB)
Downloading sympy (6.0MiB)
Downloading cuda-bindings (11.6MiB)
Downloading triton (278.6MiB)
Downloading torch (1.1GiB)
 Downloaded nvidia-cufile-cu12
 Downloaded nvidia-cuda-runtime-cu12
 Downloaded cuda-bindings
 Downloaded nvidia-cuda-cupti-cu12
 Downloaded setuptools
 Downloaded networkx
 Downloaded nvidia-nvjitlink-cu12
 Downloaded triton
 Downloaded sympy
 Downloaded nvidia-curand-cu12
 Downloaded nvidia-cuda-nvrtc-cu12
 Downloaded nvidia-cusparse-cu12
 Downloaded nvidia-nvshmem-cu12
 Downloaded nvidia-cublas-cu12
 Downloaded nvidia-cufft-cu12
 Downloaded nvidia-cusolver-cu12
 Downloaded nvidia-nccl-cu12
 Downloaded nvidia-cudnn-cu12
 Downloaded nvidia-cusparselt-cu12
 Downloaded torch
Prepared 29 packages in 36.00s
Installed 29 packages in 315ms
 + cuda-bindings==12.9.4
 + cuda-pathfinder==1.2.2
 + cuda-toolkit==12.9.1
 + filelock==3.29.0
 + fsspec==2026.4.0
 + jinja2==3.1.6
 + markupsafe==3.0.3
 + mpmath==1.3.0
 + networkx==3.6.1
 + nvidia-cublas-cu12==12.9.1.4
 + nvidia-cuda-cupti-cu12==12.9.79
 + nvidia-cuda-nvrtc-cu12==12.9.86
 + nvidia-cuda-runtime-cu12==12.9.79
 + nvidia-cudnn-cu12==9.20.0.48
 + nvidia-cufft-cu12==11.4.1.4
 + nvidia-cufile-cu12==1.14.1.1
 + nvidia-curand-cu12==10.3.10.19
 + nvidia-cusolver-cu12==11.7.5.82
 + nvidia-cusparse-cu12==12.5.10.65
 + nvidia-cusparselt-cu12==0.8.1
 + nvidia-nccl-cu12==2.29.7
 + nvidia-nvjitlink-cu12==12.9.86
 + nvidia-nvshmem-cu12==3.4.5
 + nvidia-nvtx-cu12==12.9.79
 + setuptools==78.1.0
 + sympy==1.14.0
 + torch==2.12.0.dev20260401+cu129
 + triton==3.7.0+git9c288bc5
 + typing-extensions==4.15.0
+ uv pip install --find-links /wheels nixl
Using Python 3.12.13 environment at: /venv
Resolved 33 packages in 921ms
Downloading numpy (15.9MiB)
 Downloaded numpy
Prepared 4 packages in 1.01s
Installed 4 packages in 61ms
 + nixl==1.1.0
 + nixl-cu12==1.1.0
 + nixl-cu13==1.1.0
 + numpy==2.4.4
+ echo '=== environment ==='
=== environment ===
+ python -c '
import torch
print(f"torch={torch.__version__}  cuda={torch.version.cuda}")
expected = 12
got = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else None
assert got == expected, f"expected torch built for cuda{expected}, got cuda{got}"
'
torch=2.12.0.dev20260401+cu129  cuda=12.9
=== nixl_ep dispatch ===
+ echo '=== nixl_ep dispatch ==='
+ python -
nixl_ep loaded from: /venv/lib/python3.12/site-packages/nixl_ep/__init__.py
dispatched backend : nixl_ep_cu12 -> /venv/lib/python3.12/site-packages/nixl_ep_cu12/__init__.py
loaded torch-abi .so: /venv/lib/python3.12/site-packages/nixl_ep_cu12/nixl_ep_cpp_torch212.cpython-312-x86_64-linux-gnu.so
Buffer       : <class 'nixl_ep_cu12.buffer.Buffer'>
Config       : <class 'nixl_ep_cu12.nixl_ep_cpp_torch212.Config'>
EventOverlap : <class 'nixl_ep_cu12.utils.EventOverlap'>
=== resolved deps of active .so ===
+ echo '=== resolved deps of active .so ==='
+ python -
/venv/lib/python3.12/site-packages/nixl_ep_cu12/nixl_ep_cpp_torch212.cpython-312-x86_64-linux-gnu.so
        libcuda.so.1 => /lib/x86_64-linux-gnu/libcuda.so.1 (0x00007ffff15ff000)
        libucp-14aa4f8d.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu12/../nixl_cu12.libs/libucp-14aa4f8d.so.0.0.0 (0x00007ffff14ee000)
        libucs-f64e0bb0.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu12/../nixl_cu12.libs/libucs-f64e0bb0.so.0.0.0 (0x00007ffff141c000)
        libtorch.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch.so (0x00007ffff13e9000)
        libtorch_python.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so (0x00007fffefd99000)
        libtorch_cuda.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so (0x00007fff9d8af000)
        libcudart.so.12 => /usr/local/cuda/lib64/libcudart.so.12 (0x00007fff9d200000)
        libtorch_cpu.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so (0x00007fff87748000)
        libtorch_nvshmem.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_nvshmem.so (0x00007fff867a3000)
=== nixl dispatch ===
+ echo '=== nixl dispatch ==='
+ python -c 'import nixl; print("nixl OK", nixl.__file__)'
nixl OK /venv/lib/python3.12/site-packages/nixl/__init__.py
>>> image     : nvidia/cuda:13.0.0-runtime-ubuntu22.04
>>> cu-tag    : cu130
>>> torch     : 2.11
>>> wheel dir : /.autodirect/mtrswgwork/ovidium/wheels/nixl-ep-wheel-dispatch-20260515

==========
== CUDA ==
==========

CUDA Version 13.0.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

+ set -euo pipefail
+ apt-get update -qq
+ apt-get install -y -qq --no-install-recommends curl ca-certificates
debconf: delaying package configuration, since apt-utils is not installed
+ curl -LsSf https://astral.sh/uv/install.sh
+ sh
downloading uv 0.11.14 x86_64-unknown-linux-gnu
+ export PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ uv venv --python 3.12 /venv
Downloading cpython-3.12.13-linux-x86_64-gnu (download) (32.5MiB)
 Downloaded cpython-3.12.13-linux-x86_64-gnu (download)
Using CPython 3.12.13
Creating virtual environment at: /venv
Activate with: source venv/bin/activate
+ . /venv/bin/activate
++ '[' -z '' ']'
++ '[' -n x ']'
++ SCRIPT_PATH=/venv/bin/activate
++ '[' /venv/bin/activate = bash ']'
++ deactivate nondestructive
++ unset -f pydoc
++ '[' -z '' ']'
++ '[' -z '' ']'
++ hash -r
++ '[' -z '' ']'
++ unset VIRTUAL_ENV
++ unset VIRTUAL_ENV_PROMPT
++ '[' '!' nondestructive = nondestructive ']'
++ VIRTUAL_ENV=/venv
++ '[' linux-gnu = cygwin ']'
++ '[' linux-gnu = msys ']'
++ export VIRTUAL_ENV
++ '[' -z '' ']'
++ unset SCRIPT_PATH
++ _OLD_VIRTUAL_PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/venv/bin:/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ export PATH
++ '[' x '!=' x ']'
+++ basename /venv
++ VIRTUAL_ENV_PROMPT=venv
++ export VIRTUAL_ENV_PROMPT
++ '[' -z '' ']'
++ '[' -z '' ']'
++ _OLD_VIRTUAL_PS1=
++ PS1='(venv) '
++ export PS1
++ alias pydoc
++ true
++ hash -r
+ TORCH_FLAGS=(--index-url "https://download.pytorch.org/whl/${CU_TAG}")
+ '[' cu130 = cu129 ']'
+ uv pip install --index-url https://download.pytorch.org/whl/cu130 'torch==2.11.*'
Using Python 3.12.13 environment at: /venv
Resolved 29 packages in 1.86s
Downloading nvidia-cufft (204.2MiB)
Downloading triton (179.6MiB)
Downloading nvidia-cusolver (191.6MiB)
Downloading nvidia-cuda-runtime (2.1MiB)
Downloading nvidia-nvjitlink (38.8MiB)
Downloading nvidia-cufile (1.2MiB)
Downloading nvidia-curand (56.8MiB)
Downloading nvidia-cudnn-cu13 (349.1MiB)
Downloading nvidia-cusparse (139.2MiB)
Downloading nvidia-nvshmem-cu13 (57.6MiB)
Downloading nvidia-cublas (403.5MiB)
Downloading nvidia-cuda-nvrtc (86.0MiB)
Downloading nvidia-cusparselt-cu13 (162.0MiB)
Downloading nvidia-nccl-cu13 (187.4MiB)
Downloading nvidia-cuda-cupti (10.2MiB)
Downloading networkx (2.0MiB)
Downloading sympy (6.0MiB)
Downloading torch (506.5MiB)
Downloading cuda-bindings (11.6MiB)
 Downloaded nvidia-cufile
 Downloaded nvidia-cuda-runtime
 Downloaded cuda-bindings
 Downloaded nvidia-cuda-cupti
 Downloaded nvidia-nvjitlink
 Downloaded networkx
 Downloaded triton
 Downloaded nvidia-curand
 Downloaded sympy
 Downloaded nvidia-nvshmem-cu13
 Downloaded nvidia-cufft
 Downloaded nvidia-cusolver
 Downloaded nvidia-cuda-nvrtc
 Downloaded nvidia-cusparse
 Downloaded nvidia-cusparselt-cu13
 Downloaded nvidia-nccl-cu13
 Downloaded nvidia-cudnn-cu13
 Downloaded nvidia-cublas
 Downloaded torch
Prepared 29 packages in 14.47s
Installed 29 packages in 318ms
 + cuda-bindings==13.0.3
 + cuda-pathfinder==1.2.2
 + cuda-toolkit==13.0.2
 + filelock==3.29.0
 + fsspec==2026.4.0
 + jinja2==3.1.6
 + markupsafe==3.0.3
 + mpmath==1.3.0
 + networkx==3.6.1
 + nvidia-cublas==13.1.0.3
 + nvidia-cuda-cupti==13.0.85
 + nvidia-cuda-nvrtc==13.0.88
 + nvidia-cuda-runtime==13.0.96
 + nvidia-cudnn-cu13==9.19.0.56
 + nvidia-cufft==12.0.0.61
 + nvidia-cufile==1.15.1.6
 + nvidia-curand==10.4.0.35
 + nvidia-cusolver==12.0.4.66
 + nvidia-cusparse==12.6.3.3
 + nvidia-cusparselt-cu13==0.8.0
 + nvidia-nccl-cu13==2.28.9
 + nvidia-nvjitlink==13.0.88
 + nvidia-nvshmem-cu13==3.4.5
 + nvidia-nvtx==13.0.85
 + setuptools==70.2.0
 + sympy==1.14.0
 + torch==2.11.0+cu130
 + triton==3.6.0
 + typing-extensions==4.15.0
+ uv pip install --find-links /wheels nixl
Using Python 3.12.13 environment at: /venv
Resolved 33 packages in 933ms
Downloading numpy (15.9MiB)
 Downloaded numpy
Prepared 4 packages in 1.17s
Installed 4 packages in 64ms
 + nixl==1.1.0
 + nixl-cu12==1.1.0
 + nixl-cu13==1.1.0
 + numpy==2.4.4
+ echo '=== environment ==='
=== environment ===
+ python -c '
import torch
print(f"torch={torch.__version__}  cuda={torch.version.cuda}")
expected = 13
got = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else None
assert got == expected, f"expected torch built for cuda{expected}, got cuda{got}"
'
torch=2.11.0+cu130  cuda=13.0
=== nixl_ep dispatch ===
+ echo '=== nixl_ep dispatch ==='
+ python -
nixl_ep loaded from: /venv/lib/python3.12/site-packages/nixl_ep/__init__.py
dispatched backend : nixl_ep_cu13 -> /venv/lib/python3.12/site-packages/nixl_ep_cu13/__init__.py
loaded torch-abi .so: /venv/lib/python3.12/site-packages/nixl_ep_cu13/nixl_ep_cpp_torch211.cpython-312-x86_64-linux-gnu.so
Buffer       : <class 'nixl_ep_cu13.buffer.Buffer'>
Config       : <class 'nixl_ep_cu13.nixl_ep_cpp_torch211.Config'>
EventOverlap : <class 'nixl_ep_cu13.utils.EventOverlap'>
=== resolved deps of active .so ===
+ echo '=== resolved deps of active .so ==='
+ python -
/venv/lib/python3.12/site-packages/nixl_ep_cu13/nixl_ep_cpp_torch211.cpython-312-x86_64-linux-gnu.so
        libcuda.so.1 => /lib/x86_64-linux-gnu/libcuda.so.1 (0x00007ffff1983000)
        libucp-14aa4f8d.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu13/../nixl_cu13.libs/libucp-14aa4f8d.so.0.0.0 (0x00007ffff1872000)
        libucs-f64e0bb0.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu13/../nixl_cu13.libs/libucs-f64e0bb0.so.0.0.0 (0x00007ffff17a0000)
        libtorch.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch.so (0x00007ffff173b000)
        libtorch_python.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so (0x00007ffff00e2000)
        libtorch_cuda.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so (0x00007fffd845e000)
        libcudart.so.13 => /usr/local/cuda/lib64/libcudart.so.13 (0x00007fffd7e00000)
        libtorch_cpu.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so (0x00007fffc2024000)
        libtorch_nvshmem.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_nvshmem.so (0x00007fffc1347000)
=== nixl dispatch ===
+ echo '=== nixl dispatch ==='
+ python -c 'import nixl; print("nixl OK", nixl.__file__)'
nixl OK /venv/lib/python3.12/site-packages/nixl/__init__.py
>>> image     : nvidia/cuda:13.0.0-runtime-ubuntu22.04
>>> cu-tag    : cu130
>>> torch     : 2.12
>>> wheel dir : /.autodirect/mtrswgwork/ovidium/wheels/nixl-ep-wheel-dispatch-20260515

==========
== CUDA ==
==========

CUDA Version 13.0.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

+ set -euo pipefail
+ apt-get update -qq
+ apt-get install -y -qq --no-install-recommends curl ca-certificates
debconf: delaying package configuration, since apt-utils is not installed
+ curl -LsSf https://astral.sh/uv/install.sh
+ sh
downloading uv 0.11.14 x86_64-unknown-linux-gnu
+ export PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ uv venv --python 3.12 /venv
Downloading cpython-3.12.13-linux-x86_64-gnu (download) (32.5MiB)
 Downloaded cpython-3.12.13-linux-x86_64-gnu (download)
Using CPython 3.12.13
Creating virtual environment at: /venv
Activate with: source venv/bin/activate
+ . /venv/bin/activate
++ '[' -z '' ']'
++ '[' -n x ']'
++ SCRIPT_PATH=/venv/bin/activate
++ '[' /venv/bin/activate = bash ']'
++ deactivate nondestructive
++ unset -f pydoc
++ '[' -z '' ']'
++ '[' -z '' ']'
++ hash -r
++ '[' -z '' ']'
++ unset VIRTUAL_ENV
++ unset VIRTUAL_ENV_PROMPT
++ '[' '!' nondestructive = nondestructive ']'
++ VIRTUAL_ENV=/venv
++ '[' linux-gnu = cygwin ']'
++ '[' linux-gnu = msys ']'
++ export VIRTUAL_ENV
++ '[' -z '' ']'
++ unset SCRIPT_PATH
++ _OLD_VIRTUAL_PATH=/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ PATH=/venv/bin:/root/.local/bin:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++ export PATH
++ '[' x '!=' x ']'
+++ basename /venv
++ VIRTUAL_ENV_PROMPT=venv
++ export VIRTUAL_ENV_PROMPT
++ '[' -z '' ']'
++ '[' -z '' ']'
++ _OLD_VIRTUAL_PS1=
++ PS1='(venv) '
++ export PS1
++ alias pydoc
++ true
++ hash -r
+ TORCH_FLAGS=(--index-url "https://download.pytorch.org/whl/${CU_TAG}")
+ '[' cu130 = cu129 ']'
+ uv pip install --index-url https://download.pytorch.org/whl/cu130 'torch==2.12.*'
Using Python 3.12.13 environment at: /venv
Resolved 29 packages in 2.32s
Downloading nvidia-cuda-runtime (2.1MiB)
Downloading torch (508.0MiB)
Downloading nvidia-cusolver (191.6MiB)
Downloading nvidia-cufft (204.2MiB)
Downloading nvidia-cufile (1.2MiB)
Downloading nvidia-nvjitlink (38.8MiB)
Downloading nvidia-cuda-cupti (10.2MiB)
Downloading nvidia-curand (56.8MiB)
Downloading nvidia-cudnn-cu13 (349.2MiB)
Downloading nvidia-cusparse (139.2MiB)
Downloading nvidia-nvshmem-cu13 (57.6MiB)
Downloading nvidia-cublas (403.5MiB)
Downloading nvidia-cusparselt-cu13 (162.3MiB)
Downloading nvidia-cuda-nvrtc (86.0MiB)
Downloading nvidia-nccl-cu13 (196.4MiB)
Downloading sympy (6.0MiB)
Downloading networkx (2.0MiB)
Downloading cuda-bindings (11.6MiB)
Downloading triton (192.1MiB)
 Downloaded nvidia-cufile
 Downloaded nvidia-cuda-runtime
 Downloaded nvidia-cuda-cupti
 Downloaded cuda-bindings
 Downloaded nvidia-nvjitlink
 Downloaded networkx
 Downloaded triton
 Downloaded sympy
 Downloaded nvidia-curand
 Downloaded nvidia-cusolver
 Downloaded nvidia-nvshmem-cu13
 Downloaded nvidia-cufft
 Downloaded nvidia-cuda-nvrtc
 Downloaded nvidia-cusparse
 Downloaded nvidia-cusparselt-cu13
 Downloaded nvidia-cudnn-cu13
 Downloaded nvidia-nccl-cu13
 Downloaded nvidia-cublas
 Downloaded torch
Prepared 29 packages in 15.06s
Installed 29 packages in 310ms
 + cuda-bindings==13.0.3
 + cuda-pathfinder==1.2.2
 + cuda-toolkit==13.0.2
 + filelock==3.29.0
 + fsspec==2026.4.0
 + jinja2==3.1.6
 + markupsafe==3.0.3
 + mpmath==1.3.0
 + networkx==3.6.1
 + nvidia-cublas==13.1.1.3
 + nvidia-cuda-cupti==13.0.85
 + nvidia-cuda-nvrtc==13.0.88
 + nvidia-cuda-runtime==13.0.96
 + nvidia-cudnn-cu13==9.20.0.48
 + nvidia-cufft==12.0.0.61
 + nvidia-cufile==1.15.1.6
 + nvidia-curand==10.4.0.35
 + nvidia-cusolver==12.0.4.66
 + nvidia-cusparse==12.6.3.3
 + nvidia-cusparselt-cu13==0.8.1
 + nvidia-nccl-cu13==2.29.7
 + nvidia-nvjitlink==13.0.88
 + nvidia-nvshmem-cu13==3.4.5
 + nvidia-nvtx==13.0.85
 + setuptools==70.2.0
 + sympy==1.14.0
 + torch==2.12.0+cu130
 + triton==3.7.0
 + typing-extensions==4.15.0
+ uv pip install --find-links /wheels nixl
Using Python 3.12.13 environment at: /venv
Resolved 33 packages in 827ms
Downloading numpy (15.9MiB)
 Downloaded numpy
Prepared 4 packages in 900ms
Installed 4 packages in 61ms
 + nixl==1.1.0
 + nixl-cu12==1.1.0
 + nixl-cu13==1.1.0
 + numpy==2.4.4
+ echo '=== environment ==='
=== environment ===
+ python -c '
import torch
print(f"torch={torch.__version__}  cuda={torch.version.cuda}")
expected = 13
got = int(torch.version.cuda.split(".")[0]) if torch.version.cuda else None
assert got == expected, f"expected torch built for cuda{expected}, got cuda{got}"
'
torch=2.12.0+cu130  cuda=13.0
=== nixl_ep dispatch ===
+ echo '=== nixl_ep dispatch ==='
+ python -
nixl_ep loaded from: /venv/lib/python3.12/site-packages/nixl_ep/__init__.py
dispatched backend : nixl_ep_cu13 -> /venv/lib/python3.12/site-packages/nixl_ep_cu13/__init__.py
loaded torch-abi .so: /venv/lib/python3.12/site-packages/nixl_ep_cu13/nixl_ep_cpp_torch212.cpython-312-x86_64-linux-gnu.so
Buffer       : <class 'nixl_ep_cu13.buffer.Buffer'>
Config       : <class 'nixl_ep_cu13.nixl_ep_cpp_torch212.Config'>
EventOverlap : <class 'nixl_ep_cu13.utils.EventOverlap'>
=== resolved deps of active .so ===
+ echo '=== resolved deps of active .so ==='
+ python -
/venv/lib/python3.12/site-packages/nixl_ep_cu13/nixl_ep_cpp_torch212.cpython-312-x86_64-linux-gnu.so
        libcuda.so.1 => /lib/x86_64-linux-gnu/libcuda.so.1 (0x00007ffff196d000)
        libucp-14aa4f8d.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu13/../nixl_cu13.libs/libucp-14aa4f8d.so.0.0.0 (0x00007ffff185c000)
        libucs-f64e0bb0.so.0.0.0 => /venv/lib/python3.12/site-packages/nixl_ep_cu13/../nixl_cu13.libs/libucs-f64e0bb0.so.0.0.0 (0x00007ffff178a000)
        libtorch.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch.so (0x00007ffff1757000)
        libtorch_python.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_python.so (0x00007ffff00fb000)
        libtorch_cuda.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cuda.so (0x00007fffd7edd000)
        libcudart.so.13 => /usr/local/cuda/lib64/libcudart.so.13 (0x00007fffd7a00000)
        libtorch_cpu.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_cpu.so (0x00007fffc1db8000)
        libtorch_nvshmem.so => /venv/lib/python3.12/site-packages/torch/lib/libtorch_nvshmem.so (0x00007fffc1242000)
=== nixl dispatch ===
+ echo '=== nixl dispatch ==='
+ python -c 'import nixl; print("nixl OK", nixl.__file__)'
nixl OK /venv/lib/python3.12/site-packages/nixl/__init__.py
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build can produce wheels for multiple PyTorch versions in one run.
  * Runtime auto-selects and loads the appropriate Torch/CUDA-versioned extension.

* **Chores**
  * Wheel pipeline reorganized to build, repair, and merge per-PyTorch artifacts and inject plugins.
  * Added a utility to merge extension artifacts between wheels.
  * Packaging updated to include the EP package alongside the core distribution.

* **Style**
  * Type-checker config adjusted to avoid duplicate-package resolution errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->