### PR TITLE
Use backend mask instead of backend set

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -53,6 +53,7 @@ class nixlBackendInitParams {
         nixlTime::us_t    pthrDelay;
         nixl_thread_sync_t syncMode;
         bool enableTelemetry_;
+        uint64_t backendId_ = 0;
 };
 
 // Pure virtual class to have a common pointer type

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -35,7 +35,7 @@ class nixlBackendEngine {
         // Members that cannot be modified by a child backend and parent bookkeep
         nixl_backend_t  backendType;
         nixl_b_params_t customParams;
-        const uint64_t  backendId_;
+        const uint64_t backendId_;
         std::vector<nixlTelemetryEvent> telemetryEvents_;
         std::mutex telemetryEventsMutex_;
 
@@ -93,10 +93,14 @@ class nixlBackendEngine {
             return std::move(telemetryEvents_);
         }
 
+        uint64_t
+        getBackendId() const noexcept {
+            return backendId_;
+        }
+
         bool getInitErr() const noexcept { return initErr; }
         const nixl_backend_t& getType() const noexcept { return backendType; }
         const nixl_b_params_t& getCustomParams() const noexcept { return customParams; }
-        uint64_t getBackendId() const noexcept { return backendId_; }
 
         // The support function determine which methods are necessary by the child backend, and
         // if they're called by mistake, they will return error if not implemented by backend.

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -35,6 +35,7 @@ class nixlBackendEngine {
         // Members that cannot be modified by a child backend and parent bookkeep
         nixl_backend_t  backendType;
         nixl_b_params_t customParams;
+        const uint64_t  backendId_;
         std::vector<nixlTelemetryEvent> telemetryEvents_;
         std::mutex telemetryEventsMutex_;
 
@@ -74,6 +75,7 @@ class nixlBackendEngine {
         explicit nixlBackendEngine(const nixlBackendInitParams *init_params)
             : backendType(init_params->type),
               customParams(*init_params->customParams),
+              backendId_(init_params->backendId_),
               localAgent(init_params->localAgent),
               enableTelemetry_(init_params->enableTelemetry_) {}
 
@@ -94,6 +96,7 @@ class nixlBackendEngine {
         bool getInitErr() const noexcept { return initErr; }
         const nixl_backend_t& getType() const noexcept { return backendType; }
         const nixl_b_params_t& getCustomParams() const noexcept { return customParams; }
+        uint64_t getBackendId() const noexcept { return backendId_; }
 
         // The support function determine which methods are necessary by the child backend, and
         // if they're called by mistake, they will return error if not implemented by backend.

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -97,7 +97,7 @@ class nixlAgentData {
         // The order of the following data members is crucial for destruction.
         // Bookkeeping for local connection metadata and user handles per backend
         std::unordered_map<nixl_backend_t, std::unique_ptr<nixlBackendH>> backendHandles_;
-        std::vector<nixlBackendEngine*> backendsById_;
+        std::vector<nixlBackendEngine *> backendsById_;
         std::unordered_map<nixl_backend_t, nixl_blob_t> connMd_;
         backend_map_t backendEngines_;
         std::unordered_map<std::string, nixlRemoteSection> remoteSections_;

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -97,6 +97,7 @@ class nixlAgentData {
         // The order of the following data members is crucial for destruction.
         // Bookkeeping for local connection metadata and user handles per backend
         std::unordered_map<nixl_backend_t, std::unique_ptr<nixlBackendH>> backendHandles_;
+        std::vector<nixlBackendEngine*> backendsById_;
         std::unordered_map<nixl_backend_t, nixl_blob_t> connMd_;
         backend_map_t backendEngines_;
         std::unordered_map<std::string, nixlRemoteSection> remoteSections_;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -499,7 +499,8 @@ nixlAgent::deregisterMem(const nixl_reg_dlist_t &descs,
     }
 
     // Doing best effort, and returning err if any
-    for (auto &backend : backend_set) {
+    for (size_t id : backend_set) {
+        nixlBackendEngine *backend = data->backendsById_[id];
         if (backend->supportsLocal()) {
             const auto it = data->remoteSections_.find(data->name_);
             if (it != data->remoteSections_.end()) {
@@ -586,8 +587,7 @@ nixlAgent::prepXferDlist (const std::string &agent_name,
                           nixlDlistH* &dlist_hndl,
                           const nixl_opt_args_t* extra_params) const {
 
-    // Using a set as order is not important to revert the operation
-    backend_set_t *backend_set;
+    backend_set_t backend_set;
     const bool init_side = (agent_name == NIXL_INIT_AGENT);
 
     NIXL_LOCK_GUARD(data->lock);
@@ -604,17 +604,16 @@ nixlAgent::prepXferDlist (const std::string &agent_name,
                                           static_cast<nixlMemSection &>(rem_sec_it->second);
 
     if (!extra_params || (extra_params->backends.size() == 0)) {
-        backend_set = section.queryBackends(descs.getType());
-
-        if (!backend_set || backend_set->empty()) {
+        const backend_set_t *avail = section.queryBackends(descs.getType());
+        if (!avail || avail->empty()) {
             NIXL_ERROR_FUNC << "no available backends for mem type '" << descs.getType() << "'";
             data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
             return NIXL_ERR_NOT_FOUND;
         }
+        backend_set = *avail;
     } else {
-        backend_set = new backend_set_t();
         for (auto &elm : extra_params->backends) {
-            backend_set->insert(elm->engine);
+            backend_set.insert(elm->engine);
         }
     }
 
@@ -622,15 +621,12 @@ nixlAgent::prepXferDlist (const std::string &agent_name,
 
     std::unordered_map<nixlBackendEngine *, std::unique_ptr<nixl_meta_dlist_t>> dlists;
 
-    for (const auto &backend : *backend_set) {
+    for (size_t id : backend_set) {
+        nixlBackendEngine *backend = data->backendsById_[id];
         nixl_meta_dlist_t dlist(descs.getType());
         if (section.populate(descs, backend, dlist) == NIXL_SUCCESS) {
             dlists.try_emplace(backend, std::make_unique<nixl_meta_dlist_t>(std::move(dlist)));
         }
-    }
-
-    if (extra_params && (extra_params->backends.size() > 0)) {
-        delete backend_set;
     }
 
     if (dlists.empty()) {
@@ -886,10 +882,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
             return NIXL_ERR_NOT_FOUND;
         }
 
-        for (auto & elm : *local_set)
-            if (remote_set->count(elm) != 0) {
-                backend_set.insert(elm);
-            }
+        backend_set = *local_set & *remote_set;
 
         if (backend_set.empty()) {
             NIXL_ERROR_FUNC << "no potential backend found to be able to do the transfer";
@@ -909,7 +902,8 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     // Currently we loop through and find first local match. Can use a
     // preference list or more exhaustive search.
-    for (auto &backend : backend_set) {
+    for (size_t id : backend_set) {
+        nixlBackendEngine *backend = data->backendsById_[id];
         // If populate fails, it clears the resp before return
         ret1 = data->localSection_.populate(local_descs, backend, handle->initiatorDescs);
         ret2 = rem_sec_it->second.populate(remote_descs, backend, handle->targetDescs);
@@ -1429,7 +1423,7 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
         selected_engines.insert(backend);
     }
 
-    if (selected_engines.size() == 0 && descs.descCount() > 0) {
+    if (selected_engines.empty() && descs.descCount() > 0) {
         NIXL_ERROR_FUNC << "no backends support the requested descriptors";
         return NIXL_ERR_BACKEND;
     }
@@ -1767,7 +1761,8 @@ nixlAgent::prepMemView(const nixl_remote_dlist_t &dlist,
         // Engine has not been selected yet, try to find a backend that can add an element to the
         // remote metadata
         const auto backends = data->getBackends(extra_params, it->second, mem_type);
-        for (const auto &backend : backends) {
+        for (size_t id : backends) {
+            nixlBackendEngine *backend = data->backendsById_[id];
             const auto status = it->second.addElement(desc, backend, remote_meta_dlist);
             if (status == NIXL_SUCCESS) {
                 NIXL_DEBUG << "Selected backend: " << backend->getType();
@@ -1811,7 +1806,8 @@ nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
 
     NIXL_SHARED_LOCK_GUARD(data->lock);
     const auto backends = data->getBackends(extra_params, data->localSection_, mem_type);
-    for (const auto &backend : backends) {
+    for (size_t id : backends) {
+        nixlBackendEngine *backend = data->backendsById_[id];
         const auto status = data->localSection_.populate(dlist, backend, meta_dlist);
         if (status == NIXL_SUCCESS) {
             NIXL_DEBUG << "Selected backend: " << backend->getType();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -291,6 +291,11 @@ nixlAgent::createBackend(const nixl_backend_t &type,
         return NIXL_ERR_INVALID_PARAM;
     }
 
+    if (data->backendsById_.size() >= nixlBackendMask::MAX_BACKENDS) {
+        NIXL_ERROR_FUNC << "maximum number of backends reached";
+        return NIXL_ERR_BACKEND;
+    }
+
     // Check if the plugin is in an illegal combination with another plugin backend already created
     for (const auto &combination : illegal_plugin_combinations) {
         if (std::find(combination.begin(), combination.end(), type) != combination.end()) {
@@ -313,6 +318,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
+    init_params.backendId_ = data->backendsById_.size();
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
@@ -381,6 +387,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     bknd_hndl = it->second.get();
 
     data->backendEngines_.try_emplace(type, std::move(backend));
+    data->backendsById_.push_back(data->backendEngines_[type].get());
 
     // TODO: Check if backend supports ProgThread
     //       when threading is in agent

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -32,6 +32,32 @@
 using section_key_t = std::pair<nixl_mem_t, nixlBackendEngine*>;
 using backend_set_t = std::set<nixlBackendEngine*>;
 
+// Compact set of backend engines, addressed by each engine's id (bit position).
+class nixlBackendMask {
+public:
+    static constexpr unsigned MAX_BACKENDS = 64;
+
+    void
+    insert(const nixlBackendEngine *be) noexcept {
+        bits_ |= uint64_t{1} << be->getBackendId();
+    }
+
+    bool
+    contains(const nixlBackendEngine *be) const noexcept {
+        return (bits_ & (uint64_t{1} << be->getBackendId())) != 0;
+    }
+
+    bool
+    empty() const noexcept {
+        return bits_ == 0;
+    }
+
+private:
+    uint64_t bits_ = 0;
+};
+
+using nixl_backend_mask_t = nixlBackendMask;
+
 struct nixlEngineDeleter {
     void
     operator()(nixlBackendEngine *) const noexcept;

--- a/src/infra/mem_section.h
+++ b/src/infra/mem_section.h
@@ -30,16 +30,45 @@
 #include "backend/backend_engine.h"
 
 using section_key_t = std::pair<nixl_mem_t, nixlBackendEngine*>;
-using backend_set_t = std::set<nixlBackendEngine*>;
 
 // Compact set of backend engines, addressed by each engine's id (bit position).
+// Range-iteration yields ids (i.e. positions) of the contained engines.
 class nixlBackendMask {
 public:
     static constexpr unsigned MAX_BACKENDS = 64;
 
+    class iterator {
+    public:
+        explicit iterator(uint64_t bits) noexcept : bits_(bits) {}
+
+        size_t
+        operator*() const noexcept {
+            return __builtin_ctzll(bits_);
+        }
+
+        iterator &
+        operator++() noexcept {
+            bits_ &= bits_ - 1;
+            return *this;
+        }
+
+        bool
+        operator!=(iterator other) const noexcept {
+            return bits_ != other.bits_;
+        }
+
+    private:
+        uint64_t bits_;
+    };
+
     void
     insert(const nixlBackendEngine *be) noexcept {
         bits_ |= uint64_t{1} << be->getBackendId();
+    }
+
+    void
+    erase(const nixlBackendEngine *be) noexcept {
+        bits_ &= ~(uint64_t{1} << be->getBackendId());
     }
 
     bool
@@ -52,11 +81,33 @@ public:
         return bits_ == 0;
     }
 
+    iterator
+    begin() const noexcept {
+        return iterator(bits_);
+    }
+
+    iterator
+    end() const noexcept {
+        return iterator(0);
+    }
+
+    nixlBackendMask &
+    operator&=(nixlBackendMask other) noexcept {
+        bits_ &= other.bits_;
+        return *this;
+    }
+
+    friend nixlBackendMask
+    operator&(nixlBackendMask lhs, nixlBackendMask rhs) noexcept {
+        return lhs &= rhs;
+    }
+
 private:
     uint64_t bits_ = 0;
 };
 
 using nixl_backend_mask_t = nixlBackendMask;
+using backend_set_t = nixlBackendMask;
 
 struct nixlEngineDeleter {
     void

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -31,7 +31,7 @@ nixlMemSection::emplace(const nixl_mem_t nixl_mem, nixlBackendEngine *backend) {
     const section_key_t sec_key(nixl_mem, backend);
     const auto [it, inserted] = sectionMap.try_emplace(sec_key, sec_key.first);
     if (inserted) {
-        memToBackend[sec_key.first].emplace(sec_key.second);
+        memToBackend[sec_key.first].insert(sec_key.second);
     }
     return it->second;
 }
@@ -303,14 +303,11 @@ nixl_status_t nixlLocalSection::serializePartial(nixlSerDes* serializer,
     }
 
     // TODO: consider concatenating 2 serializers instead of using mem_elms_to_serialize
-    for (const auto &backend : backends) {
-        const section_key_t sec_key(nixl_mem, backend);
-        const auto it = sectionMap.find(sec_key);
-        if (it == sectionMap.end()) {
+    for (const auto &[sec_key, base] : sectionMap) {
+        if (sec_key.first != nixl_mem || !backends.contains(sec_key.second)) {
             continue;
         }
 
-        const nixlSecDescList &base = it->second;
         std::vector<nixlSectionDesc> descs;
         descs.reserve(mem_elms.descCount());
         for (const auto &desc : mem_elms) {


### PR DESCRIPTION
## What?
Use bitmask of backends instead of a set

## Why?
To avoid heap allocation/deallocation in the hot path, and also simplify backend lookup functionality

## How?

This gives around 1% of BW increase on small messages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented enhanced backend identification and tracking infrastructure to improve system management and backend organization throughout the platform.
  * Optimized backend selection mechanisms and set operations for better performance in memory management, transfer requests, and descriptor processing.
  * Refactored memory section handling and iteration patterns using more efficient data structure implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->