### PR TITLE
nixlbench: derive storage taxonomy from supported mem types

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -35,6 +35,7 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <gflags/gflags.h>
+#include <nixl.h>
 
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/neuron.h"
@@ -312,6 +313,28 @@ int xferBenchConfig::gusli_max_simultaneous_requests = 0;
 std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
+nixl_mem_list_t xferBenchConfig::backend_mems = {};
+
+namespace {
+// Discover the memory segment types supported by the configured backend plugin.
+// Uses a transient nixlAgent to call getPluginParams; the plugin manager is a
+// singleton so this is cheap and does not affect the real agent created later
+// by the worker.
+nixl_mem_list_t
+discoverPluginMems(const std::string &backend) {
+    nixl_mem_list_t mems;
+    if (backend.empty()) {
+        return mems;
+    }
+    nixlAgent discovery_agent("nixlbench_discovery_" + std::to_string(::getpid()),
+                              nixlAgentConfig());
+    nixl_b_params_t params;
+    if (discovery_agent.getPluginParams(backend, mems, params) != NIXL_SUCCESS) {
+        mems.clear();
+    }
+    return mems;
+}
+} // namespace
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -378,6 +401,9 @@ xferBenchConfig::loadParams(void) {
     // Only load NIXL-specific configurations if using NIXL worker
     if (worker_type == XFERBENCH_WORKER_NIXL) {
         backend = NB_ARG(backend);
+        // Discover supported memory types so the storage/object/block predicates work
+        // before the real agent is created (the worker later refreshes from the engine).
+        backend_mems = discoverPluginMems(backend);
         enable_pt = NB_ARG(enable_pt);
         progress_threads = NB_ARG(progress_threads);
         device_list = NB_ARG(device_list);
@@ -818,22 +844,22 @@ xferBenchConfig::parseDeviceList() {
 
 bool
 xferBenchConfig::isStorageBackend() {
-    return (XFERBENCH_BACKEND_GDS == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_GDS_MT == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_HF3FS == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_POSIX == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+    return std::any_of(backend_mems.begin(), backend_mems.end(), [](nixl_mem_t m) {
+        return m == FILE_SEG || m == BLK_SEG || m == OBJ_SEG;
+    });
 }
 
 bool
 xferBenchConfig::isObjStorageBackend() {
-    return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
-};
+    return std::any_of(
+        backend_mems.begin(), backend_mems.end(), [](nixl_mem_t m) { return m == OBJ_SEG; });
+}
+
+bool
+xferBenchConfig::isBlkStorageBackend() {
+    return std::any_of(
+        backend_mems.begin(), backend_mems.end(), [](nixl_mem_t m) { return m == BLK_SEG; });
+}
 
 
 /**********
@@ -1006,8 +1032,7 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
 
             len = iov.len;
 
-            if (xferBenchConfig::isStorageBackend() ||
-                xferBenchConfig::backend == XFERBENCH_BACKEND_GPUNETIO) {
+            if (xferBenchConfig::isStorageBackend()) {
                 if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
                     if (xferBenchConfig::initiator_seg_type == XFERBENCH_SEG_TYPE_VRAM) {
                         if (posix_memalign(&addr, xferBenchConfig::page_size, len) != 0) {

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -27,6 +27,7 @@
 #include <variant>
 #include <vector>
 #include <optional>
+#include <nixl_types.h>
 #include <toml++/toml.hpp>
 #include <utils/common/nixl_time.h>
 #include "runtime/runtime.h"
@@ -220,6 +221,12 @@ public:
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
 
+    // Cached set of memory segment types reported by the selected backend.
+    // Populated pre-instantiation in loadParams via getPluginParams, then refreshed
+    // post-instantiation by the worker via getBackendParams (so LIBFABRIC's runtime-added
+    // VRAM_SEG is picked up). The storage/object/block predicates derive from this list.
+    static nixl_mem_list_t backend_mems;
+
     static int
     parseConfig(int argc, char *argv[]);
     static void
@@ -230,10 +237,16 @@ public:
     printSeparator(const char sep = '-');
     static std::vector<std::string>
     parseDeviceList();
+    // Storage taxonomy predicates. All three derive from backend_mems and are safe to
+    // call before the backend is instantiated (using plugin-reported mems) and after
+    // (using engine-reported mems). They return false when backend_mems is empty,
+    // which covers the nvshmem worker case.
     static bool
     isStorageBackend();
     static bool
     isObjStorageBackend();
+    static bool
+    isBlkStorageBackend();
 
 protected:
     static int

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -123,15 +123,10 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
 
     agent->getAvailPlugins(plugins);
 
-    if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCX) ||
-        0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_LIBFABRIC) ||
-        0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GPUNETIO) ||
-        0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE) ||
-        0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCCL) ||
-        xferBenchConfig::isStorageBackend()) {
-        backend_name = xferBenchConfig::backend;
-    } else {
-        std::cerr << "Unsupported NIXLBench backend: " << xferBenchConfig::backend << std::endl;
+    backend_name = xferBenchConfig::backend;
+    if (xferBenchConfig::backend_mems.empty()) {
+        std::cerr << "NIXLBench backend '" << backend_name
+                  << "' is not available or reports no supported memory types" << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -327,6 +322,18 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
 
     CHECK_NIXL_ERROR(agent->createBackend(backend_name, backend_params, backend_engine),
                      "createBackend failed!");
+
+    // Refresh the cached mem list from the instantiated engine. Plugins like LIBFABRIC
+    // only report VRAM_SEG after runtime feature detection (e.g. CUDA HMEM), so the
+    // post-instantiation list can be a strict superset of the plugin-reported one.
+    {
+        nixl_mem_list_t engine_mems;
+        nixl_b_params_t engine_params;
+        if (agent->getBackendParams(backend_engine, engine_mems, engine_params) == NIXL_SUCCESS &&
+            !engine_mems.empty()) {
+            xferBenchConfig::backend_mems = engine_mems;
+        }
+    }
 }
 
 xferBenchNixlWorker::~xferBenchNixlWorker() {
@@ -1310,10 +1317,10 @@ prepareTransferDescriptors(nixl_xfer_dlist_t &local_desc,
                            nixl_xfer_dlist_t &remote_desc,
                            const std::vector<xferBenchIOV> &local_iov,
                            const std::vector<xferBenchIOV> &remote_iov) {
-    // Set remote descriptor type based on backend
+    // Pick the remote descriptor mem type from the storage taxonomy of the active backend.
     if (xferBenchConfig::isObjStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(OBJ_SEG);
-    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+    } else if (xferBenchConfig::isBlkStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(BLK_SEG);
     } else if (xferBenchConfig::isStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(FILE_SEG);


### PR DESCRIPTION
## What?
Re-implement isStorageBackend() and isObjStorageBackend() by querying supported memory types rather than a hard coded list of backend names.

## Why?
Long term, we'd like to not require nixlbench changes each time a new backend is added. This is one small piece of that puzzle.

## How?
isStorageBackend() and isObjStorageBackend() compared the configured backend string against a hardcoded set of names, and nixl_worker.cpp maintained a separate allowlist of "supported" backend strings. Adding a new backend or registering an existing plugin under a different name required touching both lists in the bench.

Cache nixl_mem_list_t for the configured backend in xferBenchConfig. Populate it pre-instantiation via a transient discovery nixlAgent and getPluginParams (so the predicate works before the worker exists, for the runtime / role / metadata-exchange gates), then refresh it from getBackendParams after createBackend so plugins that add mem types at runtime (LIBFABRIC adds VRAM_SEG when CUDA HMEM is detected) are reflected. Rewrite the predicates against the cached mem set and add isBlkStorageBackend().


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added runtime discovery and caching of backend memory-segment capabilities (via NIXL plugin discovery) so supported storage segment types are detected automatically.
  * Backend capability checks now rely on discovered segment types instead of hard-coded backend identifiers.
  * Initialization validates discovered capabilities and fails early if none are found; capabilities are refreshed after backend creation.
  * Added explicit block-storage detection and tightened readback/consistency logic to only treat true storage-capable backends as storage-backed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->