### PR TITLE
nixlbench: OBJ generic set up and verification

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -127,7 +127,8 @@ static int processBatchSizes(xferBenchWorker &worker,
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
 
-            if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
+            if (!xferBenchUtils::validateTransfer(
+                    worker, false, local_trans_lists, local_trans_lists)) {
                 return EXIT_FAILURE;
             }
             if (IS_PAIRWISE_AND_SG()) {
@@ -144,7 +145,8 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return 1;
             }
 
-            if (!xferBenchUtils::validateTransfer(true, local_trans_lists, remote_trans_lists)) {
+            if (!xferBenchUtils::validateTransfer(
+                    worker, true, local_trans_lists, remote_trans_lists)) {
                 return EXIT_FAILURE;
             }
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -39,6 +39,7 @@
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/neuron.h"
 #include "utils/utils.h"
+#include "worker/worker.h"
 
 // Define command line parameters
 #define NB_ARG_STRING(param_name, def_val, help_text) DEFINE_string(param_name, def_val, help_text)
@@ -984,7 +985,8 @@ parseGusliDeviceList(const std::string &device_list,
 }
 
 bool
-xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lists) {
+xferBenchUtils::checkConsistency(xferBenchWorker &worker,
+                                 std::vector<std::vector<xferBenchIOV>> &iov_lists) {
     int i = 0, j = 0;
     static bool gusli_devmap_init = false;
     static std::vector<GusliDeviceConfig> gusli_devs;
@@ -1028,23 +1030,14 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
                     }
                     is_allocated = true;
                     if (xferBenchConfig::isObjStorageBackend()) {
-                        if (!xferBenchUtils::getObj(iov.metaInfo)) {
-                            std::cerr << "Failed to get object: " << iov.metaInfo << std::endl;
-                            exit(EXIT_FAILURE);
+                        if (!worker.readObjForVerify(iov, addr, len)) {
+                            std::cerr << "Failed to read object for verify: " << iov.metaInfo
+                                      << std::endl;
+                            if (is_allocated) {
+                                free(addr);
+                            }
+                            return false;
                         }
-                        int fd = open(iov.metaInfo.c_str(), O_RDONLY);
-                        if (fd < 0) {
-                            std::cerr << "Failed to open downloaded file: " << iov.metaInfo
-                                      << " with error: " << strerror(errno) << std::endl;
-                            exit(EXIT_FAILURE);
-                        }
-                        ssize_t rc = pread(fd, addr, len, 0);
-                        if (rc < 0) {
-                            std::cerr << "Failed to read from file: " << iov.metaInfo
-                                      << " with error: " << strerror(errno) << std::endl;
-                        }
-                        close(fd);
-                        unlink(iov.metaInfo.c_str());
                     } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_GUSLI) {
                         // Map device id -> path via device_list and read from the bdev at LBA
                         // offset
@@ -1130,7 +1123,8 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
 }
 
 bool
-xferBenchUtils::validateTransfer(bool is_initiator,
+xferBenchUtils::validateTransfer(xferBenchWorker &worker,
+                                 bool is_initiator,
                                  std::vector<std::vector<xferBenchIOV>> &local_lists,
                                  std::vector<std::vector<xferBenchIOV>> &remote_lists) {
     if (!xferBenchConfig::check_consistency) {
@@ -1139,16 +1133,16 @@ xferBenchUtils::validateTransfer(bool is_initiator,
 
     if (is_initiator) {
         if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
-            return checkConsistency(local_lists);
+            return checkConsistency(worker, local_lists);
         } else if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
             if (xferBenchConfig::isStorageBackend()) {
-                return checkConsistency(remote_lists);
+                return checkConsistency(worker, remote_lists);
             }
         }
     } else {
         // Target
         if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
-            return checkConsistency(local_lists);
+            return checkConsistency(worker, local_lists);
         }
     }
 
@@ -1304,23 +1298,6 @@ xferBenchUtils::buildAwsCredentials() {
 }
 
 bool
-xferBenchUtils::getObj(const std::string &name) {
-    if (xferBenchConfig::backend == XFERBENCH_BACKEND_INFINIA) {
-        // INFINIA backends don't need external CLI get
-        return true;
-    }
-    if (xferBenchConfig::backend == XFERBENCH_BACKEND_OBJ) {
-        return getObjS3(name);
-    } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_AZURE_BLOB) {
-        return getObjAzure(name);
-    } else {
-        std::cerr << "Error: getObj called with unsupported object storage backend: "
-                  << xferBenchConfig::backend << std::endl;
-        return false;
-    }
-}
-
-bool
 xferBenchUtils::rmObj(const std::string &name) {
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_INFINIA) {
         return true;
@@ -1334,31 +1311,6 @@ xferBenchUtils::rmObj(const std::string &name) {
                   << xferBenchConfig::backend << std::endl;
         return false;
     }
-}
-
-bool
-xferBenchUtils::getObjS3(const std::string &name) {
-    std::string bucket_name = xferBenchConfig::obj_bucket_name;
-    if (bucket_name.empty()) {
-        std::cerr << "Error: Invalid bucket name for S3 object get" << std::endl;
-        return false;
-    }
-    std::string aws_cmd = "aws s3 cp s3://" + bucket_name + "/" + name + " " + name;
-    if (!xferBenchConfig::obj_endpoint_override.empty()) {
-        aws_cmd += " --endpoint-url " + xferBenchConfig::obj_endpoint_override;
-    }
-
-    std::string full_cmd = buildAwsCredentials() + aws_cmd;
-    std::cout << "Getting S3 object: " << name << " from bucket: " << bucket_name << std::endl;
-
-    int result = system(full_cmd.c_str());
-    if (result != 0) {
-        std::cerr << "Failed to get S3 object " << name << " from bucket " << bucket_name
-                  << " (exit code: " << result << ")" << std::endl;
-        return false;
-    }
-
-    return true;
 }
 
 bool
@@ -1418,24 +1370,6 @@ void
 xferBenchUtils::cleanupFile(const int fd, const std::string &filename) {
     close(fd);
     unlink(filename.c_str());
-}
-
-bool
-xferBenchUtils::getObjAzure(const std::string &name) {
-    std::string az_cli_params = buildCommonAzCliBlobParams(name);
-    if (az_cli_params.empty()) {
-        return false;
-    }
-    std::string full_cmd = "az storage blob download " + az_cli_params + " -f " + name;
-    std::cout << "Getting Azure blob: " << name << std::endl;
-
-    int result = system(full_cmd.c_str());
-    if (result != 0) {
-        std::cerr << "Warning: Failed to get Azure blob " << name << " (exit code: " << result
-                  << ")" << std::endl;
-        return false;
-    }
-    return true;
 }
 
 bool

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -1304,23 +1304,6 @@ xferBenchUtils::buildAwsCredentials() {
 }
 
 bool
-xferBenchUtils::putObj(size_t buffer_size, const std::string &name) {
-    if (xferBenchConfig::backend == XFERBENCH_BACKEND_INFINIA) {
-        // INFINIA backends don't need external CLI put
-        return true;
-    }
-    if (xferBenchConfig::backend == XFERBENCH_BACKEND_OBJ) {
-        return putObjS3(buffer_size, name);
-    } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_AZURE_BLOB) {
-        return putObjAzure(buffer_size, name);
-    } else {
-        std::cerr << "Error: putObj called with unsupported object storage backend: "
-                  << xferBenchConfig::backend << std::endl;
-        return false;
-    }
-}
-
-bool
 xferBenchUtils::getObj(const std::string &name) {
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_INFINIA) {
         // INFINIA backends don't need external CLI get
@@ -1351,43 +1334,6 @@ xferBenchUtils::rmObj(const std::string &name) {
                   << xferBenchConfig::backend << std::endl;
         return false;
     }
-}
-
-bool
-xferBenchUtils::putObjS3(size_t buffer_size, const std::string &name) {
-    std::string filename = "/tmp/" + name;
-    int fd = createFile(buffer_size, filename);
-    if (fd < 0) {
-        return false;
-    }
-
-    std::string bucket_name = xferBenchConfig::obj_bucket_name;
-    if (bucket_name.empty()) {
-        std::cerr << "Error: Invalid bucket name for S3 object put" << std::endl;
-        close(fd);
-        unlink(filename.c_str());
-        return false;
-    }
-    std::string aws_cmd = "aws s3 cp " + filename + " s3://" + bucket_name;
-    if (!xferBenchConfig::obj_endpoint_override.empty()) {
-        aws_cmd +=
-            " --checksum-algorithm SHA256 --endpoint-url " + xferBenchConfig::obj_endpoint_override;
-    }
-
-    std::string full_cmd = buildAwsCredentials() + aws_cmd;
-    std::cout << "Putting S3 object: " << name << " in bucket: " << bucket_name
-              << " (size: " << buffer_size << " bytes)" << std::endl;
-
-    int result = system(full_cmd.c_str());
-    if (result != 0) {
-        std::cerr << "Failed to put S3 object " << name << " in bucket " << bucket_name
-                  << " (exit code: " << result << ")" << std::endl;
-        cleanupFile(fd, filename);
-        return false;
-    }
-
-    cleanupFile(fd, filename);
-    return true;
 }
 
 bool
@@ -1472,33 +1418,6 @@ void
 xferBenchUtils::cleanupFile(const int fd, const std::string &filename) {
     close(fd);
     unlink(filename.c_str());
-}
-
-bool
-xferBenchUtils::putObjAzure(size_t buffer_size, const std::string &name) {
-    std::string filename = "/tmp/" + name;
-    int fd = createFile(buffer_size, filename);
-    if (fd < 0) {
-        return false;
-    }
-
-    std::string az_cli_params = buildCommonAzCliBlobParams(name);
-    if (az_cli_params.empty()) {
-        return false;
-    }
-    std::string full_cmd = "az storage blob upload " + az_cli_params + " -f " + filename;
-    std::cout << "Putting Azure blob: " << name << std::endl;
-
-    int result = system(full_cmd.c_str());
-    if (result != 0) {
-        std::cerr << "Warning: Failed to put Azure blob " << name << " (exit code: " << result
-                  << ")" << std::endl;
-        cleanupFile(fd, filename);
-        return false;
-    }
-
-    cleanupFile(fd, filename);
-    return true;
 }
 
 bool

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -356,8 +356,6 @@ private:
     static void
     cleanupFile(const int fd, const std::string &filename);
     static bool
-    putObjAzure(size_t buffer_size, const std::string &name);
-    static bool
     getObjAzure(const std::string &name);
     static bool
     rmObjAzure(const std::string &name);
@@ -374,13 +372,9 @@ public:
     static std::string
     buildAwsCredentials();
     static bool
-    putObj(size_t buffer_size, const std::string &name);
-    static bool
     getObj(const std::string &name);
     static bool
     rmObj(const std::string &name);
-    static bool
-    putObjS3(size_t buffer_size, const std::string &name);
     static bool
     getObjS3(const std::string &name);
     static bool

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -347,6 +347,8 @@ public:
           metaInfo(m) {}
 };
 
+class xferBenchWorker;
+
 class xferBenchUtils {
 private:
     static xferBenchRT *rt;
@@ -355,8 +357,6 @@ private:
     createFile(size_t buffer_size, const std::string &filename);
     static void
     cleanupFile(const int fd, const std::string &filename);
-    static bool
-    getObjAzure(const std::string &name);
     static bool
     rmObjAzure(const std::string &name);
     static std::string
@@ -372,18 +372,15 @@ public:
     static std::string
     buildAwsCredentials();
     static bool
-    getObj(const std::string &name);
-    static bool
     rmObj(const std::string &name);
-    static bool
-    getObjS3(const std::string &name);
     static bool
     rmObjS3(const std::string &name);
 
     static bool
-    checkConsistency(std::vector<std::vector<xferBenchIOV>> &desc_lists);
+    checkConsistency(xferBenchWorker &worker, std::vector<std::vector<xferBenchIOV>> &desc_lists);
     static bool
-    validateTransfer(bool is_initiator,
+    validateTransfer(xferBenchWorker &worker,
+                     bool is_initiator,
                      std::vector<std::vector<xferBenchIOV>> &local_lists,
                      std::vector<std::vector<xferBenchIOV>> &remote_lists);
     static void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -850,6 +850,64 @@ cleanupIov(nixl_mem_t seg_type, xferBenchIOV &iov) {
     }
 }
 
+bool
+xferBenchNixlWorker::seedObjectLoopback(const xferBenchIOV &remote_iov, size_t len) {
+    void *scratch = nullptr;
+    if (!allocateXferMemory(len, &scratch)) {
+        std::cerr << "seedObjectLoopback: failed to allocate " << len << " bytes" << std::endl;
+        return false;
+    }
+    memset(scratch, XFERBENCH_TARGET_BUFFER_ELEMENT, len);
+
+    nixl_reg_dlist_t scratch_reg(DRAM_SEG);
+    nixlBlobDesc reg_desc;
+    reg_desc.addr = (uintptr_t)scratch;
+    reg_desc.len = len;
+    reg_desc.devId = 0;
+    scratch_reg.addDesc(reg_desc);
+
+    nixl_opt_args_t opt_args;
+    opt_args.backends.push_back(backend_engine);
+
+    nixl_status_t rc = agent->registerMem(scratch_reg, &opt_args);
+    if (NIXL_SUCCESS != rc) {
+        std::cerr << "seedObjectLoopback: registerMem failed: "
+                  << nixlEnumStrings::statusStr(rc) << std::endl;
+        free(scratch);
+        return false;
+    }
+
+    std::vector<xferBenchIOV> local_iov{xferBenchIOV((uintptr_t)scratch, len, 0)};
+    std::vector<xferBenchIOV> remote_iov_vec{remote_iov};
+    nixl_xfer_dlist_t local_desc(DRAM_SEG);
+    nixl_xfer_dlist_t remote_desc(OBJ_SEG);
+    iovListToNixlXferDlist(local_iov, local_desc);
+    iovListToNixlXferDlist(remote_iov_vec, remote_desc);
+
+    bool ok = false;
+    nixlXferReqH *req = nullptr;
+    rc = agent->createXferReq(NIXL_WRITE, local_desc, remote_desc, name, req, &opt_args);
+    if (NIXL_SUCCESS == rc) {
+        rc = agent->postXferReq(req);
+        while (NIXL_IN_PROG == rc) {
+            rc = agent->getXferStatus(req);
+        }
+        ok = (NIXL_SUCCESS == rc);
+        if (!ok) {
+            std::cerr << "seedObjectLoopback: transfer failed: "
+                      << nixlEnumStrings::statusStr(rc) << std::endl;
+        }
+        agent->releaseXferReq(req);
+    } else {
+        std::cerr << "seedObjectLoopback: createXferReq failed: "
+                  << nixlEnumStrings::statusStr(rc) << std::endl;
+    }
+
+    agent->deregisterMem(scratch_reg, &opt_args);
+    free(scratch);
+    return ok;
+}
+
 std::optional<xferBenchIOV>
 xferBenchNixlWorker::initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t dev_offset) {
     // The dev_offset represents the LBA (Logical Block Address) offset in the block device
@@ -965,19 +1023,11 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         for (int list_idx = 0; list_idx < num_threads; list_idx++) {
             std::vector<xferBenchIOV> iov_list;
             for (i = 0; i < num_devices; i++) {
-                std::optional<xferBenchIOV> basic_desc;
                 std::string unique_name = "nixlbench_obj" + std::to_string(list_idx) + "_" +
                     std::to_string(i) + "_" + std::to_string(timestamp);
 
-                if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
-                    if (!xferBenchUtils::putObj(buffer_size, unique_name)) {
-                        std::cerr << "Failed to put object: " << unique_name << std::endl;
-                        continue;
-                    }
-                }
-
                 int obj_dev_id = list_idx * num_devices + i;
-                basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);
+                auto basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);
                 if (basic_desc) {
                     std::cout << "Creating obj: " << unique_name << std::endl;
                     iov_list.push_back(basic_desc.value());
@@ -985,6 +1035,16 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
             nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, OBJ_SEG);
             CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
+
+            if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
+                for (const auto &iov : iov_list) {
+                    if (!seedObjectLoopback(iov, buffer_size)) {
+                        std::cerr << "Failed to seed object: " << iov.metaInfo << std::endl;
+                        exit(EXIT_FAILURE);
+                    }
+                }
+            }
+
             remote_regs_.emplace_back(*agent, backend_engine, OBJ_SEG, std::move(iov_list));
         }
     } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -851,33 +851,28 @@ cleanupIov(nixl_mem_t seg_type, xferBenchIOV &iov) {
 }
 
 bool
-xferBenchNixlWorker::seedObjectLoopback(const xferBenchIOV &remote_iov, size_t len) {
-    void *scratch = nullptr;
-    if (!allocateXferMemory(len, &scratch)) {
-        std::cerr << "seedObjectLoopback: failed to allocate " << len << " bytes" << std::endl;
-        return false;
-    }
-    memset(scratch, XFERBENCH_TARGET_BUFFER_ELEMENT, len);
-
-    nixl_reg_dlist_t scratch_reg(DRAM_SEG);
+xferBenchNixlWorker::objLoopback(const xferBenchIOV &remote_iov,
+                                 void *local_buf,
+                                 size_t len,
+                                 nixl_xfer_op_t op) {
+    nixl_reg_dlist_t local_reg(DRAM_SEG);
     nixlBlobDesc reg_desc;
-    reg_desc.addr = (uintptr_t)scratch;
+    reg_desc.addr = (uintptr_t)local_buf;
     reg_desc.len = len;
     reg_desc.devId = 0;
-    scratch_reg.addDesc(reg_desc);
+    local_reg.addDesc(reg_desc);
 
     nixl_opt_args_t opt_args;
     opt_args.backends.push_back(backend_engine);
 
-    nixl_status_t rc = agent->registerMem(scratch_reg, &opt_args);
+    nixl_status_t rc = agent->registerMem(local_reg, &opt_args);
     if (NIXL_SUCCESS != rc) {
-        std::cerr << "seedObjectLoopback: registerMem failed: "
-                  << nixlEnumStrings::statusStr(rc) << std::endl;
-        free(scratch);
+        std::cerr << "objLoopback: registerMem failed: " << nixlEnumStrings::statusStr(rc)
+                  << std::endl;
         return false;
     }
 
-    std::vector<xferBenchIOV> local_iov{xferBenchIOV((uintptr_t)scratch, len, 0)};
+    std::vector<xferBenchIOV> local_iov{xferBenchIOV((uintptr_t)local_buf, len, 0)};
     std::vector<xferBenchIOV> remote_iov_vec{remote_iov};
     nixl_xfer_dlist_t local_desc(DRAM_SEG);
     nixl_xfer_dlist_t remote_desc(OBJ_SEG);
@@ -886,26 +881,56 @@ xferBenchNixlWorker::seedObjectLoopback(const xferBenchIOV &remote_iov, size_t l
 
     bool ok = false;
     nixlXferReqH *req = nullptr;
-    rc = agent->createXferReq(NIXL_WRITE, local_desc, remote_desc, name, req, &opt_args);
+    rc = agent->createXferReq(op, local_desc, remote_desc, name, req, &opt_args);
     if (NIXL_SUCCESS == rc) {
+        // Once posted, the backend may DMA into local_buf until the request reaches a
+        // terminal state. On signal we stop reporting progress but must keep polling
+        // getXferStatus until the backend is done before releasing the request and
+        // deregistering local_buf, otherwise the caller's free() races with the backend.
+        bool aborted = false;
         rc = agent->postXferReq(req);
         while (NIXL_IN_PROG == rc) {
+            if (!aborted && signaled()) {
+                std::cerr << "objLoopback: aborted by signal, draining transfer" << std::endl;
+                aborted = true;
+            }
             rc = agent->getXferStatus(req);
         }
-        ok = (NIXL_SUCCESS == rc);
-        if (!ok) {
-            std::cerr << "seedObjectLoopback: transfer failed: "
-                      << nixlEnumStrings::statusStr(rc) << std::endl;
+        ok = !aborted && (NIXL_SUCCESS == rc);
+        if (!aborted && !ok) {
+            std::cerr << "objLoopback: transfer failed: " << nixlEnumStrings::statusStr(rc)
+                      << std::endl;
         }
         agent->releaseXferReq(req);
     } else {
-        std::cerr << "seedObjectLoopback: createXferReq failed: "
-                  << nixlEnumStrings::statusStr(rc) << std::endl;
+        std::cerr << "objLoopback: createXferReq failed: " << nixlEnumStrings::statusStr(rc)
+                  << std::endl;
     }
 
-    agent->deregisterMem(scratch_reg, &opt_args);
-    free(scratch);
+    agent->deregisterMem(local_reg, &opt_args);
     return ok;
+}
+
+bool
+xferBenchNixlWorker::seedObjectLoopback(const xferBenchIOV &remote_iov, size_t len) {
+    auto scratch = nixlAlloc::make(len);
+    if (!scratch) {
+        std::cerr << "seedObjectLoopback: failed to allocate " << len << " bytes" << std::endl;
+        return false;
+    }
+    memset(scratch->addr(), XFERBENCH_TARGET_BUFFER_ELEMENT, len);
+
+    return objLoopback(remote_iov, scratch->addr(), len, NIXL_WRITE);
+}
+
+bool
+xferBenchNixlWorker::readObjForVerify(const xferBenchIOV &remote_iov, void *dst, size_t len) {
+    if (!dst || len == 0) {
+        std::cerr << "readObjForVerify: invalid arguments (dst=" << dst << ", len=" << len << ")"
+                  << std::endl;
+        return false;
+    }
+    return objLoopback(remote_iov, dst, len, NIXL_READ);
 }
 
 std::optional<xferBenchIOV>
@@ -1019,12 +1044,16 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         struct timeval tv;
         gettimeofday(&tv, nullptr);
         uint64_t timestamp = tv.tv_sec * 1000000ULL + tv.tv_usec;
+        const std::string benchmark_group =
+            xferBenchConfig::benchmark_group.empty() ? "default" : xferBenchConfig::benchmark_group;
 
         for (int list_idx = 0; list_idx < num_threads; list_idx++) {
             std::vector<xferBenchIOV> iov_list;
             for (i = 0; i < num_devices; i++) {
-                std::string unique_name = "nixlbench_obj" + std::to_string(list_idx) + "_" +
-                    std::to_string(i) + "_" + std::to_string(timestamp);
+                std::string unique_name = "nixlbench_obj_" + benchmark_group + "_rank" +
+                    std::to_string(rt->getRank()) + "_pid" + std::to_string(getpid()) + "_" +
+                    std::to_string(list_idx) + "_" + std::to_string(i) + "_" +
+                    std::to_string(timestamp);
 
                 int obj_dev_id = list_idx * num_devices + i;
                 auto basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);
@@ -1278,12 +1307,24 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             for (size_t devidx = 0; devidx < num_devices; devidx++) {
                 const auto &iov = iov_list[devidx];
                 if (xferBenchConfig::isObjStorageBackend()) {
-                    std::optional<xferBenchIOV> basic_desc;
-                    int obj_dev_id = list_idx * num_devices + devidx;
-                    basic_desc = initBasicDescObj(iov.len, obj_dev_id, iov.metaInfo);
-                    if (basic_desc) {
-                        remote_iov_list.push_back(basic_desc.value());
+                    const auto &local_base_iovs = local_regs_[list_idx].iovs();
+                    const auto &object_iovs = remote_regs_[list_idx].iovs();
+                    auto local_it = std::find_if(
+                        local_base_iovs.begin(), local_base_iovs.end(), [&](const auto &base_iov) {
+                            return iov.addr >= base_iov.addr &&
+                                iov.addr < base_iov.addr + base_iov.len;
+                        });
+                    if (local_it == local_base_iovs.end()) {
+                        std::cerr << "Failed to resolve OBJ transfer offset for local address "
+                                  << iov.addr << std::endl;
+                        exit(EXIT_FAILURE);
                     }
+                    size_t obj_idx = std::distance(local_base_iovs.begin(), local_it);
+                    const auto &object_iov = object_iovs[obj_idx];
+                    xferBenchIOV iov_remote(
+                        iov.addr - local_it->addr, block_size, object_iov.devId);
+                    iov_remote.metaInfo = object_iov.metaInfo;
+                    remote_iov_list.push_back(iov_remote);
                 } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
                     xferBenchIOV iov_remote(iov);
                     iov_remote.addr = gusli_devices[devidx].dev_offset + file_offset;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -68,6 +68,9 @@ class xferBenchNixlWorker: public xferBenchWorker {
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
+        bool
+        readObjForVerify(const xferBenchIOV &iov, void *dst, size_t len) override;
+
     private:
         std::optional<xferBenchIOV>
         initBasicDescDram(size_t buffer_size, int mem_dev_id);
@@ -81,6 +84,12 @@ class xferBenchNixlWorker: public xferBenchWorker {
         // Used to pre-populate object-storage backends before a READ benchmark.
         bool
         seedObjectLoopback(const xferBenchIOV &remote_iov, size_t len);
+        // Register local_buf as DRAM_SEG, issue op against a single OBJ_SEG remote_iov
+        // through the bench's own agent, poll the request to a terminal state, then
+        // release the request and deregister. A signal stops further status reporting
+        // but the poll continues draining until the backend is done with local_buf.
+        bool
+        objLoopback(const xferBenchIOV &remote_iov, void *local_buf, size_t len, nixl_xfer_op_t op);
         std::optional<xferBenchIOV>
         initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t dev_offset);
         bool

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -77,6 +77,10 @@ class xferBenchNixlWorker: public xferBenchWorker {
         initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);
         std::optional<xferBenchIOV>
         initBasicDescObj(size_t buffer_size, int mem_dev_id, std::string name);
+        // Issue a NIXL_WRITE loopback from a TARGET-pattern DRAM buffer to remote_iov.
+        // Used to pre-populate object-storage backends before a READ benchmark.
+        bool
+        seedObjectLoopback(const xferBenchIOV &remote_iov, size_t len);
         std::optional<xferBenchIOV>
         initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t dev_offset);
         bool

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -21,6 +21,7 @@
 #include "runtime/runtime.h"
 #include "utils/utils.h"
 #include <atomic>
+#include <iostream>
 #include <string>
 #include <vector>
 #include <variant>
@@ -63,6 +64,20 @@ class xferBenchWorker {
         transfer(size_t block_size,
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) = 0;
+
+        // Read an OBJ_SEG buffer back from the backend into a verify buffer.
+        // Used by the consistency check for object-storage backends. Default
+        // implementation reports the operation as unsupported; concrete workers
+        // override to issue a backend-native read.
+        virtual bool
+        readObjForVerify(const xferBenchIOV &iov, void *dst, size_t len) {
+            (void)iov;
+            (void)dst;
+            (void)len;
+            std::cerr << "readObjForVerify: not implemented for this worker; "
+                      << "OBJ_SEG consistency check requires the NIXL worker" << std::endl;
+            return false;
+        }
 };
 
 #endif // NIXL_BENCHMARK_NIXLBENCH_SRC_WORKER_WORKER_H


### PR DESCRIPTION
## What?
nixlbench was delegating to CLI tools for AWS and Azure to set up objects and verify them. Instead, use a standard nixl agent and do read/write operations.

## Why?
This is a step toward making nixlbench generic for all OBJ backends, rather than having specific code for each command line tool.

## How?
We create an agent and do regular read/write operations via the NIXL API instead of invoking command line tools.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transfer validation now runs through the active worker, consolidating consistency checks and removing redundant local object PUT/GET helpers.
* **New Features**
  * Workers can seed and loop back remote objects and perform read-for-verify operations to enable end-to-end object-storage transfer validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->