### PR TITLE
Log AM error

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -200,6 +200,10 @@ using nixl_ucx_am_cb_ctx_ptr_t = std::unique_ptr<nixl_ucx_am_cb_ctx_t>;
 
 void
 nixlUcxEp::sendAmCallback(void *request, ucs_status_t status, void *user_data) {
+    if (status != UCS_OK) {
+        NIXL_ERROR << "UCX AM send failed with status " << status << " ("
+                   << ucs_status_string(status) << ")";
+    }
     auto ctx = static_cast<nixl_ucx_am_cb_ctx_t *>(user_data);
     ctx->second(request, ctx->first);
     delete ctx;


### PR DESCRIPTION
## What?
https://nvbugspro.nvidia.com/bug/6114610
Log error when AM fails

nixlUcxEngine::genNotif is a fire-and-forget API by construction

Making nixlUcxEngine::genNotif synchronous would require blocking the calling thread on UCX worker progress until the active message completes, which is not acceptable on the notification fast path and would also need a non-trivial refactor of the engine's threading model. Since genNotif returns no caller-visible request handle, there is no channel left to propagate an asynchronous send failure back to the caller after the function returns NIXL_SUCCESS. As a best-effort first fix, we can log the failure status in the AM completion callback, so transport errors such as UCS_ERR_ENDPOINT_TIMEOUT become visible in NIXL logs instead of being silently dropped. This does not prevent the hang on the CTX side, but it gives operators a clear signal of which notifications were lost and why.

## Why?
Improve diagnostics on the caller side


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error reporting for network communication failures with detailed diagnostic information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->