### PR TITLE
ci: add LLM container build pipeline for vllm/sglang images

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -1,0 +1,401 @@
+# NIXL LLM Container Build Configuration
+#
+# Builds and pushes vLLM-NIXL and SGLang-NIXL inference containers from a
+# pre-built NIXL wheel set.
+#
+#   - vllm-nixl-<ver>         : Dockerfile.vllm   + vllm/vllm-openai:latest
+#   - sglang-nixl-<ver>       : Dockerfile.sglang + lmsysorg/sglang:latest
+#   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
+#
+# For RC0 builds the upstream defaults are used. For subsequent RCs (or
+# re-spins) BASE_IMAGE_* parameters pin each variant to the RC0 image so the
+# verification stays isolated to the NIXL change.
+#
+# Wheels are pulled from Artifactory at:
+#   sw-dynamo-nixl-pypi-local/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/<arch>/
+#
+# Runtime: podman (no docker). Cross-arch aarch64 builds on x86_64 hosts use
+# `podman build --platform linux/arm64` with QEMU registered via
+# multiarch/qemu-user-static. Multi-arch manifests are assembled with
+# `podman manifest` (the README's `docker buildx imagetools create` is a
+# docker-only command and is not available here).
+
+---
+job: nixl-ci-build-llm-container
+
+# Build settings
+failFast: false
+timeout_minutes: 240
+
+# Infrastructure
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: "{memory: 32Gi, cpu: 16000m}"
+  requests: "{memory: 16Gi, cpu: 8000m}"
+
+pvc_volumes:
+  - {claimName: nbu-swx-nixl-pvc, mountPath: /mnt/pvc, readOnly: false}
+
+empty_volumes:
+  - {mountPath: /var/lib/containers/storage, memory: false}
+
+runs_on_dockers:
+  - { name: "podman", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+
+# Build matrix - one run per architecture; each run sequentially builds the
+# enabled target(s) so wheel download is shared.
+matrix:
+  axes:
+    arch:
+      - x86_64
+      - aarch64
+
+# Configuration
+env:
+  REGISTRY_HOST_NAME: "artifactory.nvidia.com"
+  REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
+  REGISTRY_REPO_PATH: "verification/llm"
+  ARTIFACTORY_REGISTRY_URL: "${REGISTRY_HOST_NAME}/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}"
+  ARTIFACTORY_CLEANUP_AGE: '3m' # 3 months
+  WHEELS_REPO_NAME: "sw-dynamo-nixl-pypi-local"
+  WHEELS_ARTIFACTORY_URL: "https://${REGISTRY_HOST_NAME}/artifactory/${WHEELS_REPO_NAME}"
+  WHEELS_DIR: "${WORKSPACE}/llm-wheels"
+  MAIL_FROM: "jenkins@nvidia.com"
+  # Build pods save image tarballs here; pipeline_stop loads them and runs the
+  # registry pushes in one shot, so an arch failure leaves the registry clean.
+  PVC_STAGING_ROOT: "/mnt/pvc/nixl-llm-build"
+
+taskName: "${arch}"
+
+credentials:
+  - credentialsId: 'svc-nixl-new-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_USERNAME'
+    passwordVariable: 'ARTIFACTORY_PASSWORD'
+
+pipeline_start:
+  shell: action
+  module: groovy
+  run: |
+    def suffix = params.TAG_SUFFIX ? "-${params.TAG_SUFFIX}" : ""
+    def tag = "${params.NIXL_VERSION}-${params.RC}${suffix}"
+    env.IMAGE_TAG = tag
+    currentBuild.displayName += "-${params.BUILD_TARGET}-${tag}"
+
+    def target = params.BUILD_TARGET
+    env.ENABLE_VLLM = (target == 'vllm'        || target == 'all') ? 'true' : 'false'
+    env.ENABLE_SGLANG = (target == 'sglang'      || target == 'all') ? 'true' : 'false'
+    env.ENABLE_SGLANG_CU13 = (target == 'sglang-cu13' || target == 'all') ? 'true' : 'false'
+
+    echo "BUILD_TARGET:       ${target}"
+    echo "IMAGE_TAG:          ${tag}"
+    echo "NIXL_VERSION:       ${params.NIXL_VERSION}"
+    echo "RC:                 ${params.RC}"
+    echo "WHEEL_BUILD_ID:     ${params.WHEEL_BUILD_ID}"
+    echo "BASE_IMAGE_VLLM:        ${params.BASE_IMAGE_VLLM}"
+    echo "BASE_IMAGE_SGLANG:      ${params.BASE_IMAGE_SGLANG}"
+    echo "BASE_IMAGE_SGLANG_CU13: ${params.BASE_IMAGE_SGLANG_CU13}"
+    echo "ENABLE_VLLM:        ${env.ENABLE_VLLM}"
+    echo "ENABLE_SGLANG:      ${env.ENABLE_SGLANG}"
+    echo "ENABLE_SGLANG_CU13: ${env.ENABLE_SGLANG_CU13}"
+
+steps:
+  - name: Prepare
+    containerSelector: "{name: 'podman'}"
+    credentialsId: 'svc-nixl-new-artifactory-token'
+    run: |
+      set -e
+      rm -f /etc/containers/storage.conf /usr/share/containers/storage.conf
+      podman system reset -f || true
+      podman info
+
+      echo "$ARTIFACTORY_PASSWORD" | podman login "${REGISTRY_HOST_NAME}" \
+        -u "$ARTIFACTORY_USERNAME" --password-stdin
+
+      # Pre-flight: refuse to build if any destination tag already exists in
+      # the registry, to avoid silently overwriting a published image.
+      # Override with ALLOW_OVERWRITE=true.
+      if [[ "${ALLOW_OVERWRITE}" == "true" ]]; then
+        echo "ALLOW_OVERWRITE=true — skipping tag existence check."
+      else
+        check_tag_free() {
+          local img="$1"
+          if podman manifest inspect "${img}" >/dev/null 2>&1; then
+            echo "ERROR: image ${img} already exists in the registry."
+            echo "       Bump TAG_SUFFIX / RC, or rerun with ALLOW_OVERWRITE=true."
+            exit 1
+          fi
+          echo "OK: ${img} is free."
+        }
+        # Check the multi-arch manifest tag (the canonical published artifact),
+        # not the per-arch tag. Both matrix arches run the same check, but the
+        # multi-arch tag is what consumers pull and what we ultimately publish.
+        [[ "${ENABLE_VLLM}"        == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}"
+        [[ "${ENABLE_SGLANG}"      == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}"
+        [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}"
+        true
+      fi
+
+  - name: Download Wheels
+    containerSelector: "{name: 'podman'}"
+    credentialsId: 'svc-nixl-new-artifactory-token'
+    run: |
+      set -eu
+      DEST="${WHEELS_DIR}/${arch}"
+      rm -rf "${DEST}"
+      mkdir -p "${DEST}"
+
+      BASE="${WHEELS_ARTIFACTORY_URL}/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/${arch}"
+      WHEELS=(
+        "nixl-${NIXL_VERSION}-py3-none-any.whl"
+        "nixl_cu12-${NIXL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
+        "nixl_cu13-${NIXL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
+      )
+      for whl in "${WHEELS[@]}"; do
+        curl -fL --retry 3 --retry-delay 2 \
+          -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" \
+          -o "${DEST}/${whl}" \
+          "${BASE}/${whl}"
+      done
+      ls -lah "${DEST}"
+
+  - name: Build vLLM
+    enable: ${ENABLE_VLLM}
+    containerSelector: "{name: 'podman'}"
+    parallel: true
+    run: |
+      set -eu
+      export TMPDIR=/var/tmp/vllm
+      mkdir -p "${TMPDIR}"
+      case "${arch}" in
+        x86_64)  PLATFORM="linux/amd64" ;;
+        aarch64) PLATFORM="linux/arm64" ;;
+        *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
+      esac
+      IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}-${arch}"
+      # Podman enforces short-name resolution, so always pass a fully-qualified
+      # BASE_IMAGE. Falls back to the upstream docker.io image when no override.
+      BASE="${BASE_IMAGE_VLLM:-docker.io/vllm/vllm-openai:latest}"
+      podman build \
+        --platform "${PLATFORM}" \
+        --build-arg "BASE_IMAGE=${BASE}" \
+        -f contrib/Dockerfile.vllm \
+        -t "${IMAGE}" \
+        "${WHEELS_DIR}/${arch}/"
+      # Stash to PVC instead of pushing — pipeline_stop publishes after all
+      # arches succeed, so a failed arch leaves the registry clean.
+      STAGE_DIR="${PVC_STAGING_ROOT}/${BUILD_NUMBER}/${arch}"
+      mkdir -p "${STAGE_DIR}"
+      podman save --format oci-archive -o "${STAGE_DIR}/vllm-nixl.tar" "${IMAGE}"
+      ls -lh "${STAGE_DIR}/vllm-nixl.tar"
+
+  - name: Build SGLang
+    enable: ${ENABLE_SGLANG}
+    containerSelector: "{name: 'podman'}"
+    parallel: true
+    run: |
+      set -eu
+      export TMPDIR=/var/tmp/sglang
+      mkdir -p "${TMPDIR}"
+      case "${arch}" in
+        x86_64)  PLATFORM="linux/amd64" ;;
+        aarch64) PLATFORM="linux/arm64" ;;
+        *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
+      esac
+      IMAGE="${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"
+      BASE="${BASE_IMAGE_SGLANG:-docker.io/lmsysorg/sglang:latest}"
+      podman build \
+        --platform "${PLATFORM}" \
+        --build-arg "BASE_IMAGE=${BASE}" \
+        -f contrib/Dockerfile.sglang \
+        -t "${IMAGE}" \
+        "${WHEELS_DIR}/${arch}/"
+      STAGE_DIR="${PVC_STAGING_ROOT}/${BUILD_NUMBER}/${arch}"
+      mkdir -p "${STAGE_DIR}"
+      podman save --format oci-archive -o "${STAGE_DIR}/sglang-nixl.tar" "${IMAGE}"
+      ls -lh "${STAGE_DIR}/sglang-nixl.tar"
+
+  - name: Build SGLang CU13
+    enable: ${ENABLE_SGLANG_CU13}
+    containerSelector: "{name: 'podman'}"
+    parallel: true
+    run: |
+      set -eu
+      export TMPDIR=/var/tmp/sglang-cu13
+      mkdir -p "${TMPDIR}"
+      case "${arch}" in
+        x86_64)  PLATFORM="linux/amd64" ;;
+        aarch64) PLATFORM="linux/arm64" ;;
+        *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
+      esac
+      IMAGE="${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}-${arch}"
+      # Default to the upstream cu130 runtime tag for RC0 builds; subsequent
+      # RCs override via BASE_IMAGE_SGLANG_CU13 to pin the rc0 image.
+      # Fully-qualified docker.io name required by podman's short-name policy.
+      BASE="${BASE_IMAGE_SGLANG_CU13:-docker.io/lmsysorg/sglang:latest-cu130-runtime}"
+      podman build \
+        --platform "${PLATFORM}" \
+        --build-arg "BASE_IMAGE=${BASE}" \
+        -f contrib/Dockerfile.sglang \
+        -t "${IMAGE}" \
+        "${WHEELS_DIR}/${arch}/"
+      STAGE_DIR="${PVC_STAGING_ROOT}/${BUILD_NUMBER}/${arch}"
+      mkdir -p "${STAGE_DIR}"
+      podman save --format oci-archive -o "${STAGE_DIR}/sglang-cu13-nixl.tar" "${IMAGE}"
+      ls -lh "${STAGE_DIR}/sglang-cu13-nixl.tar"
+
+  - name: Smoke Test
+    enable: ${RUN_SMOKE_TEST}
+    containerSelector: "{name: 'podman'}"
+    run: |
+      set -eu
+      # Smoke test runs natively only - skip for cross-arch builds because QEMU
+      # emulation of full LLM image startup is too slow to be useful here.
+      if [[ "${arch}" != "$(uname -m)" ]]; then
+        echo "Skipping smoke test for cross-arch build (${arch} on $(uname -m))"
+        exit 0
+      fi
+
+      check_image() {
+        local image="$1" framework="$2"
+        echo "=== Smoke test: ${image} ==="
+        podman run --rm --entrypoint python3 "${image}" -c \
+          "from importlib.metadata import version; \
+           print('${framework}', version('${framework}'), 'nixl', version('nixl'))"
+      }
+
+      [[ "${ENABLE_VLLM}"        == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}-${arch}"       vllm
+      [[ "${ENABLE_SGLANG}"      == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"     sglang
+      [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}-${arch}" sglang
+      true
+
+pipeline_stop:
+  shell: action
+  module: groovy
+  containerSelector: "{name: 'podman'}"
+  run: |
+    // Multi-arch manifests can only be created after both architectures have
+    // been pushed, so this runs once at the end of the matrix.
+    def suffix = params.TAG_SUFFIX ? "-${params.TAG_SUFFIX}" : ""
+    def tag = "${params.NIXL_VERSION}-${params.RC}${suffix}"
+    def reg = "${env.ARTIFACTORY_REGISTRY_URL}"
+    def target = params.BUILD_TARGET
+
+    def variants = []
+    if (target == 'vllm'        || target == 'all') variants << 'vllm-nixl'
+    if (target == 'sglang'      || target == 'all') variants << 'sglang-nixl'
+    if (target == 'sglang-cu13' || target == 'all') variants << 'sglang-cu13-nixl'
+
+    // Flipped to true only after every variant publishes AND the properties
+    // artifact is archived; the email below uses it to decide whether to
+    // advertise the image URLs.
+    def publishSucceeded = false
+
+    withCredentials([usernamePassword(
+        credentialsId: 'svc-nixl-new-artifactory-token',
+        usernameVariable: 'ARTIFACTORY_USER',
+        passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+
+      sh """
+        echo "\$ARTIFACTORY_TOKEN" | podman login "${env.REGISTRY_HOST_NAME}" \
+          -u "\$ARTIFACTORY_USER" --password-stdin
+      """
+
+      def stageDir = "${env.PVC_STAGING_ROOT}/${env.BUILD_NUMBER}"
+
+      try {
+        if (currentBuild.currentResult == null || currentBuild.currentResult == 'SUCCESS') {
+          for (variant in variants) {
+            def manifest = "${reg}/${variant}:${tag}"
+            def amd64Img = "${manifest}-x86_64"
+            def arm64Img = "${manifest}-aarch64"
+            echo "Publishing ${manifest} from ${stageDir}"
+            sh """
+              # Load the per-arch images that the matrix runs stashed on the
+              # shared PVC, then push the per-arch tags and assemble the
+              # multi-arch manifest list.
+              podman load -i "${stageDir}/x86_64/${variant}.tar"
+              podman load -i "${stageDir}/aarch64/${variant}.tar"
+
+              podman manifest rm "${manifest}" 2>/dev/null || true
+              podman manifest create "${manifest}" \
+                "${amd64Img}" \
+                "${arm64Img}"
+              podman manifest push --all "${manifest}" "docker://${manifest}"
+            """
+            if (params.UPDATE_LATEST) {
+              def latest = "${reg}/${variant}:latest"
+              sh """
+                podman manifest rm "${latest}" 2>/dev/null || true
+                podman manifest create "${latest}" \
+                  "${amd64Img}" \
+                  "${arm64Img}"
+                podman manifest push --all "${latest}" "docker://${latest}"
+              """
+            }
+          }
+
+          // Record the published multi-arch manifest URLs in a Jenkins-archived
+          // properties file so downstream jobs / humans can consume them.
+          def keyByVariant = [
+            'vllm-nixl'       : 'vLLM',
+            'sglang-nixl'     : 'SGLang',
+            'sglang-cu13-nixl': 'SGLangCU13',
+          ]
+          def propsLines = variants.collect { "${keyByVariant[it]}=${reg}/${it}:${tag}" }
+          def propsBody = propsLines.join('\n') + '\n'
+          writeFile file: 'artifact.property', text: propsBody
+          archiveArtifacts artifacts: 'artifact.property', fingerprint: true
+          echo "Archived artifact.property:\n${propsBody}"
+          publishSucceeded = true
+        } else {
+          echo "Skipping manifest creation - build status is ${currentBuild.currentResult}"
+        }
+      } finally {
+        // Always clean up the staging directory, even if publish threw —
+        // successful runs already published everything to the registry; failed
+        // runs leave nothing to resume from (rebuilds re-stash) so retaining
+        // the multi-GB tarballs on PVC just accumulates dead bytes.
+        sh """rm -rf "${stageDir}" || true"""
+      }
+
+    }
+
+    if (params.MAIL_TO) {
+      def jobStatus = currentBuild.currentResult ?: 'SUCCESS'
+      def statusColor = jobStatus == 'SUCCESS' ? 'green' : 'red'
+      def userName = currentBuild.rawBuild.getCause(hudson.model.Cause.UserIdCause)?.userName ?: 'schedule'
+
+      // Only advertise the image URLs in the email when publish actually
+      // succeeded — otherwise the recipient sees URLs that don't resolve.
+      def imagesSection = ''
+      if (publishSucceeded) {
+        def imageList = variants.collect { "<li>${env.ARTIFACTORY_REGISTRY_URL}/${it}:${tag}</li>" }.join('')
+        imagesSection = "<p>Images:</p><ul>${imageList}</ul>"
+      }
+
+      mail(
+        from: env.MAIL_FROM,
+        to: params.MAIL_TO,
+        subject: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' - ${jobStatus}",
+        mimeType: 'text/html',
+        body: """
+          <p>Started by: <b>${userName}</b></p>
+          <p>Status: <span style="color: ${statusColor};"><b>${jobStatus}</b></span></p>
+          <p>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a></p>
+          <p>Build: <a href='${env.BUILD_URL}'>#${env.BUILD_NUMBER}</a></p>
+          <p>Console Output: <a href='${env.BUILD_URL}console'>Full Log</a></p>
+          <p>Build Target: <b>${params.BUILD_TARGET}</b></p>
+          <p>NIXL Version: <b>${params.NIXL_VERSION}</b></p>
+          <p>RC: <b>${params.RC}</b></p>
+          <p>Wheel Build ID: <b>${params.WHEEL_BUILD_ID}</b></p>
+          <p>Image Tag: <b>${tag}</b></p>
+          <p>Architectures: <b>x86_64, aarch64</b></p>
+          ${imagesSection}
+          ${publishSucceeded && params.UPDATE_LATEST ? '<p>Latest tag updated: <b>Yes</b></p>' : ''}
+        """
+      )
+    }
+    withCredentials([usernamePassword(credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
+      sh "yum install -y jq > /dev/null && .ci/scripts/artifactory-cleanup-by-time.sh --path ${REGISTRY_REPO_PATH} ${REGISTRY_REPO_NAME} ${ARTIFACTORY_CLEANUP_AGE}"
+    }

--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -4,7 +4,7 @@
 # pre-built NIXL wheel set.
 #
 #   - vllm-nixl-<ver>         : Dockerfile.vllm   + vllm/vllm-openai:latest
-#   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:v0.22.1-cu129
+#   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu129
 #   - sglang-nixl-<ver>       : Dockerfile.sglang + lmsysorg/sglang:latest
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
@@ -208,7 +208,7 @@ steps:
         *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
       esac
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}-${arch}"
-      BASE="${BASE_IMAGE_VLLM_CU12:-docker.io/vllm/vllm-openai:v0.22.1-cu129}"
+      BASE="${BASE_IMAGE_VLLM_CU12:-docker.io/vllm/vllm-openai:latest-cu129}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \
@@ -393,6 +393,30 @@ pipeline_stop:
         sh """rm -rf "${stageDir}" || true"""
       }
 
+    }
+
+    // Optionally fan out to the downstream LLM container test job, one run per
+    // published variant. Passes the canonical multi-arch manifest tag (not a
+    // per-arch tag — only `manifest push --all` runs above, which does not
+    // create `-<arch>` tags); the manifest resolves to the x86_64 image when
+    // pulled on the x86_64-only mizu SLURM nodes.
+    // Fired asynchronously (wait:false) so the build pod is not held for the
+    // multi-hour SLURM test, and propagate:false so a test failure does not
+    // retroactively fail this build.
+    if (publishSucceeded && params.RUN_TEST) {
+      for (variant in variants) {
+        def imageUrl = "${reg}/${variant}:${tag}"
+        echo "Triggering nixl-ci-test-llm-container for ${imageUrl}"
+        build job: 'nixl-ci-test-llm-container',
+          parameters: [
+            string(name: 'IMAGE_URL', value: imageUrl),
+            booleanParam(name: 'RUN_SMOKE', value: params.TEST_RUN_SMOKE),
+            booleanParam(name: 'RUN_PERF', value: params.TEST_RUN_PERF),
+            booleanParam(name: 'RUN_ACCURACY', value: params.TEST_RUN_ACCURACY),
+            string(name: 'ci_refspec', value: params.ci_refspec)
+          ],
+          wait: false, propagate: false
+      }
     }
 
     if (params.MAIL_TO) {

--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -4,6 +4,7 @@
 # pre-built NIXL wheel set.
 #
 #   - vllm-nixl-<ver>         : Dockerfile.vllm   + vllm/vllm-openai:latest
+#   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:v0.22.1-cu129
 #   - sglang-nixl-<ver>       : Dockerfile.sglang + lmsysorg/sglang:latest
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
@@ -84,6 +85,7 @@ pipeline_start:
 
     def target = params.BUILD_TARGET
     env.ENABLE_VLLM = (target == 'vllm'        || target == 'all') ? 'true' : 'false'
+    env.ENABLE_VLLM_CU12 = (target == 'vllm-cu12'   || target == 'all') ? 'true' : 'false'
     env.ENABLE_SGLANG = (target == 'sglang'      || target == 'all') ? 'true' : 'false'
     env.ENABLE_SGLANG_CU13 = (target == 'sglang-cu13' || target == 'all') ? 'true' : 'false'
 
@@ -93,9 +95,11 @@ pipeline_start:
     echo "RC:                 ${params.RC}"
     echo "WHEEL_BUILD_ID:     ${params.WHEEL_BUILD_ID}"
     echo "BASE_IMAGE_VLLM:        ${params.BASE_IMAGE_VLLM}"
+    echo "BASE_IMAGE_VLLM_CU12:   ${params.BASE_IMAGE_VLLM_CU12}"
     echo "BASE_IMAGE_SGLANG:      ${params.BASE_IMAGE_SGLANG}"
     echo "BASE_IMAGE_SGLANG_CU13: ${params.BASE_IMAGE_SGLANG_CU13}"
     echo "ENABLE_VLLM:        ${env.ENABLE_VLLM}"
+    echo "ENABLE_VLLM_CU12:   ${env.ENABLE_VLLM_CU12}"
     echo "ENABLE_SGLANG:      ${env.ENABLE_SGLANG}"
     echo "ENABLE_SGLANG_CU13: ${env.ENABLE_SGLANG_CU13}"
 
@@ -131,6 +135,7 @@ steps:
         # not the per-arch tag. Both matrix arches run the same check, but the
         # multi-arch tag is what consumers pull and what we ultimately publish.
         [[ "${ENABLE_VLLM}"        == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}"
+        [[ "${ENABLE_VLLM_CU12}"   == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}"
         [[ "${ENABLE_SGLANG}"      == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}"
         [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}"
         true
@@ -188,6 +193,32 @@ steps:
       mkdir -p "${STAGE_DIR}"
       podman save --format oci-archive -o "${STAGE_DIR}/vllm-nixl.tar" "${IMAGE}"
       ls -lh "${STAGE_DIR}/vllm-nixl.tar"
+
+  - name: Build vLLM CU12
+    enable: ${ENABLE_VLLM_CU12}
+    containerSelector: "{name: 'podman'}"
+    parallel: true
+    run: |
+      set -eu
+      export TMPDIR=/var/tmp/vllm-cu12
+      mkdir -p "${TMPDIR}"
+      case "${arch}" in
+        x86_64)  PLATFORM="linux/amd64" ;;
+        aarch64) PLATFORM="linux/arm64" ;;
+        *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
+      esac
+      IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}-${arch}"
+      BASE="${BASE_IMAGE_VLLM_CU12:-docker.io/vllm/vllm-openai:v0.22.1-cu129}"
+      podman build \
+        --platform "${PLATFORM}" \
+        --build-arg "BASE_IMAGE=${BASE}" \
+        -f contrib/Dockerfile.vllm \
+        -t "${IMAGE}" \
+        "${WHEELS_DIR}/${arch}/"
+      STAGE_DIR="${PVC_STAGING_ROOT}/${BUILD_NUMBER}/${arch}"
+      mkdir -p "${STAGE_DIR}"
+      podman save --format oci-archive -o "${STAGE_DIR}/vllm-cu12-nixl.tar" "${IMAGE}"
+      ls -lh "${STAGE_DIR}/vllm-cu12-nixl.tar"
 
   - name: Build SGLang
     enable: ${ENABLE_SGLANG}
@@ -265,6 +296,7 @@ steps:
       }
 
       [[ "${ENABLE_VLLM}"        == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}-${arch}"       vllm
+      [[ "${ENABLE_VLLM_CU12}"   == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}-${arch}"  vllm
       [[ "${ENABLE_SGLANG}"      == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"     sglang
       [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}-${arch}" sglang
       true
@@ -283,6 +315,7 @@ pipeline_stop:
 
     def variants = []
     if (target == 'vllm'        || target == 'all') variants << 'vllm-nixl'
+    if (target == 'vllm-cu12'   || target == 'all') variants << 'vllm-cu12-nixl'
     if (target == 'sglang'      || target == 'all') variants << 'sglang-nixl'
     if (target == 'sglang-cu13' || target == 'all') variants << 'sglang-cu13-nixl'
 
@@ -339,6 +372,7 @@ pipeline_stop:
           // properties file so downstream jobs / humans can consume them.
           def keyByVariant = [
             'vllm-nixl'       : 'vLLM',
+            'vllm-cu12-nixl'  : 'vLLMCU12',
             'sglang-nixl'     : 'SGLang',
             'sglang-cu13-nixl': 'SGLangCU13',
           ]

--- a/.ci/jenkins/lib/test-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/test-llm-container-matrix.yaml
@@ -1,0 +1,231 @@
+# NIXL LLM Container Test Configuration
+#
+# Smoke- / perf- / accuracy-tests a single published LLM inference container
+# (vllm-nixl, sglang-nixl, or sglang-cu13-nixl) on the mizu SLURM partition.
+# The job allocates ONE 2-GPU node and runs each enabled phase sequentially.
+#
+# Image selection: a single IMAGE_URL parameter. The framework (vllm vs sglang)
+# is auto-detected from the URL — "vllm" → test_vllm.sh, "sglang" → test_sglang.sh.
+# vllm has no built-in accuracy harness, so the accuracy phase no-ops for vllm.
+#
+# Test scripts live at .ci/scripts/llm-tests/{test_vllm.sh,test_sglang.sh}.
+# The slurmCI module mounts the workspace into the running container, so these
+# scripts are reachable from inside the LLM image at runtime.
+
+---
+job: nixl-ci-test-llm-container
+
+failFast: false
+timeout_minutes: 240
+
+# Harbor is only used for the build_helper_llm container that drives SLURM —
+# the LLM image under test is pulled directly by SLURM from artifactory.
+registry_host: nbu-harbor.gtm.nvidia.com
+registry_auth: nixl_harbor_credentials
+registry_path: /nixl/base
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: "{memory: 8Gi, cpu: 4000m}"
+  requests: "{memory: 4Gi, cpu: 2000m}"
+  privileged: true
+
+credentials:
+  - {credentialsId: 'nixl_harbor_credentials', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
+  - {credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USERNAME', passwordVariable: 'ARTIFACTORY_PASSWORD'}
+  - {credentialsId: 'svc-nixl-scctl', usernameVariable: 'SERVICE_USER_USERNAME', passwordVariable: 'SERVICE_USER_PASSWORD'}
+
+env:
+  SLURM_NODES: 1
+  SLURM_PARTITION: mizu
+  SLURM_HEAD_NODE: scctl
+  SLURM_GRES: gpu:2
+  SLURM_MEM: 128G
+  SLURM_MINCPUS: 24
+  SLURM_JOB_TIMEOUT: '01:30:00'
+  SLURM_IMMEDIATE_TIMEOUT: "3600"
+  SLURM_EXCLUDE: mizu01
+  SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
+  JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
+  IMAGE_REGISTRY_HOST: "nbu-harbor.gtm.nvidia.com"
+  IMAGE_REGISTRY_PATH: "nixl/base"
+  CONFIG_PATH: /labhome/svc-nixl/.config/enroot
+  CI_IMAGE_TAG: "20260518-1"
+
+empty_volumes:
+  - {mountPath: /root, memory: false}
+  - {mountPath: /var/lib/containers/storage, memory: false}
+
+pvc_volumes:
+  - {claimName: nbu-swx-nixl-pvc, mountPath: /mnt/pvc, readOnly: false}
+
+runs_on_dockers:
+  - {
+     file: '.ci/dockerfiles/Dockerfile.build_helper',
+     name: 'build_helper_llm',
+     tag: "${CI_IMAGE_TAG}",
+     build_args: '--build-arg BASE_IMAGE=dockerhub.nvidia.com/ubuntu:24.04'
+    }
+
+# Matrix kept to a single arch axis because the framework requires `arch` to
+# be defined when `runs_on_dockers` is set (it scopes the per-arch build_helper
+# image build). Mizu SLURM nodes are x86_64-only.
+matrix:
+  axes:
+    arch:
+      - x86_64
+
+taskName: "${arch}"
+
+# Per-phase gating computed up front. The framework's `enable:` field only
+# supports literal env-var refs (no $(...) command sub, no conditional logic),
+# so disabled phases run /bin/true inside the sentinel image as a fast no-op.
+pipeline_start:
+  shell: action
+  module: groovy
+  run: |
+    def url = (params.IMAGE_URL ?: '').trim()
+    if (!url) {
+      error("IMAGE_URL is required.")
+    }
+
+    // Test scripts are pulled fresh from the nixl repo at ci_refspec on the
+    // SLURM node (see Copy Tests step), so a rerun against a different ref
+    // does not require rebuilding the LLM image.
+    env.CI_REFSPEC = (params.ci_refspec ?: 'main').trim()
+
+    // Convert "registry/path:tag" → "registry#path:tag" for the slurmCI module.
+    def slash = url.indexOf('/')
+    def dockerImage = slash < 0 ? url : url.substring(0, slash) + '#' + url.substring(slash + 1)
+    env.DOCKER_IMAGE = dockerImage
+
+    // Auto-detect framework from the image URL. The published images are named
+    // vllm-nixl / sglang-nixl / sglang-cu13-nixl, so a substring match suffices.
+    def lower = url.toLowerCase()
+    def framework
+    if (lower.contains('vllm')) {
+      framework = 'vllm'
+    } else if (lower.contains('sglang')) {
+      framework = 'sglang'
+    } else {
+      error("Cannot detect framework from IMAGE_URL: ${url} (expected 'vllm' or 'sglang' in the URL).")
+    }
+    env.FRAMEWORK = framework
+
+    def testScript = "/llm-tests/test_${framework}.sh"
+    def SENTINEL_SCRIPT = "/bin/true"
+
+    env.SMOKE_SCRIPT = params.RUN_SMOKE ? "${testScript} smoke" : SENTINEL_SCRIPT
+    env.PERF_SCRIPT  = params.RUN_PERF  ? "${testScript} perf"  : SENTINEL_SCRIPT
+    // vllm has no built-in accuracy harness, so accuracy always no-ops for vllm.
+    env.ACCURACY_SCRIPT = (params.RUN_ACCURACY && framework == 'sglang') ?
+        "${testScript} accuracy" : SENTINEL_SCRIPT
+
+    currentBuild.displayName += "-${framework}"
+
+    echo "IMAGE_URL:       ${url}"
+    echo "DOCKER_IMAGE:    ${env.DOCKER_IMAGE}"
+    echo "FRAMEWORK:       ${framework}"
+    echo "CI_REFSPEC:      ${env.CI_REFSPEC}"
+    echo "SMOKE_SCRIPT:    ${env.SMOKE_SCRIPT}"
+    echo "PERF_SCRIPT:     ${env.PERF_SCRIPT}"
+    echo "ACCURACY_SCRIPT: ${env.ACCURACY_SCRIPT}"
+
+steps:
+
+  - name: Allocate Environment
+    containerSelector: "{name: 'build_helper_llm'}"
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: allocation
+    args:
+      partition: "${SLURM_PARTITION}"
+      headNode: "${SLURM_HEAD_NODE}"
+      nodes: "${SLURM_NODES}"
+      jobTimeout: "${SLURM_JOB_TIMEOUT}"
+      immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
+      jobName: "nixl-llm-${BUILD_NUMBER}"
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      credentialsId: "${SCCTL_CREDENTIALS_ID}"
+      extraArgs: [
+        "--gres=${SLURM_GRES}",
+        "--mincpus=${SLURM_MINCPUS}",
+        "--mem=${SLURM_MEM}",
+        "--exclude=${SLURM_EXCLUDE}"
+      ]
+
+  - name: Copy Tests
+    containerSelector: "{name: 'build_helper_llm'}"
+    timeout: 30
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: "rm -rf /llm-tests /nixl-src && git clone https://github.com/ai-dynamo/nixl.git /nixl-src && git -C /nixl-src fetch origin '+refs/pull/*:refs/pull/*' && git -C /nixl-src checkout ${CI_REFSPEC} && cp -r /nixl-src/.ci/scripts/llm-tests /llm-tests && rm -rf /nixl-src"
+      headNode: "${SLURM_HEAD_NODE}"
+      dockerImage: "${DOCKER_IMAGE}"
+      credentialsId: "${SCCTL_CREDENTIALS_ID}"
+      containerName: "nixl-llm-${FRAMEWORK}-${BUILD_NUMBER}"
+      extraArgs: [
+        "--container-mount-home"
+      ]
+
+  - name: Smoke
+    containerSelector: "{name: 'build_helper_llm'}"
+    timeout: 30
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: "${SMOKE_SCRIPT}"
+      headNode: "${SLURM_HEAD_NODE}"
+      dockerImage: "${DOCKER_IMAGE}"
+      credentialsId: "${SCCTL_CREDENTIALS_ID}"
+      containerName: "nixl-llm-${FRAMEWORK}-${BUILD_NUMBER}"
+
+  - name: Perf
+    containerSelector: "{name: 'build_helper_llm'}"
+    timeout: 40
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: "${PERF_SCRIPT}"
+      headNode: "${SLURM_HEAD_NODE}"
+      dockerImage: "${DOCKER_IMAGE}"
+      credentialsId: "${SCCTL_CREDENTIALS_ID}"
+      containerName: "nixl-llm-${FRAMEWORK}-${BUILD_NUMBER}"
+
+  - name: Accuracy
+    containerSelector: "{name: 'build_helper_llm'}"
+    timeout: 50
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: "${ACCURACY_SCRIPT}"
+      headNode: "${SLURM_HEAD_NODE}"
+      dockerImage: "${DOCKER_IMAGE}"
+      credentialsId: "${SCCTL_CREDENTIALS_ID}"
+      containerName: "nixl-llm-${FRAMEWORK}-${BUILD_NUMBER}"
+
+pipeline_stop:
+  containerSelector: "{name: 'build_helper_llm'}"
+  parallel: false
+  shell: action
+  module: slurmCI
+  run: stopAllForBuild
+  args:
+    credentialsId: "${SCCTL_CREDENTIALS_ID}"
+    headNode: "${SLURM_HEAD_NODE}"
+    jobIdDir: "${JOB_ID_FILE_ROOT}"

--- a/.ci/jenkins/lib/test-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/test-llm-container-matrix.yaml
@@ -45,7 +45,6 @@ env:
   SLURM_MINCPUS: 24
   SLURM_JOB_TIMEOUT: '01:30:00'
   SLURM_IMMEDIATE_TIMEOUT: "3600"
-  SLURM_EXCLUDE: mizu01
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   IMAGE_REGISTRY_HOST: "nbu-harbor.gtm.nvidia.com"

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -545,7 +545,7 @@
         script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
 # Job template for the LLM (vLLM / SGLang) container build pipeline.
-# Builds 3 image variants (vllm-nixl, sglang-nixl, sglang-cu13-nixl) from a
+# Builds 4 image variants (vllm-nixl, vllm-cu12-nixl, sglang-nixl, sglang-cu13-nixl) from a
 # published NIXL wheel set, for x86_64 and aarch64, and publishes multi-arch
 # manifests. Mirrors the manual procedure documented at
 # README.md
@@ -564,11 +564,11 @@
             conf_file=.ci/jenkins/lib/build-llm-container-matrix.yaml
     description: >
       <b>NIXL LLM container build</b><br/>
-      • Builds 3 inference container variants per release: <b>vllm-nixl</b>, <b>sglang-nixl</b>, <b>sglang-cu13-nixl</b><br/>
+      • Builds 4 inference container variants per release: <b>vllm-nixl</b>, <b>vllm-cu12-nixl</b>, <b>sglang-nixl</b>, <b>sglang-cu13-nixl</b><br/>
       • Builds for x86_64 and aarch64 (aarch64 via podman with QEMU)<br/>
       • Publishes multi-arch manifests after both arches succeed<br/>
       • Wheels pulled from <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/</code><br/>
-      • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ under <code>llm/{{vllm-nixl,sglang-nixl,sglang-cu13-nixl}}</code><br/>
+      • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ under <code>llm/{{vllm-nixl,vllm-cu12-nixl,sglang-nixl,sglang-cu13-nixl}}</code><br/>
       • For <b>rc0</b> leave the <code>BASE_IMAGE_*</code> params empty to use upstream defaults<br/>
       • For <b>rcN, N&gt;0</b> set each <code>BASE_IMAGE_*</code> to the matching rc0 image to isolate the verification to the NIXL change<br/>
       <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
@@ -580,12 +580,14 @@
           choices:
             - "all"
             - "vllm"
+            - "vllm-cu12"
             - "sglang"
             - "sglang-cu13"
           description: >
             Which image variants to build:<br/>
-            • <b>all</b>: build all 3 variants (default)<br/>
+            • <b>all</b>: build all 4 variants (default)<br/>
             • <b>vllm</b>: only vllm-nixl<br/>
+            • <b>vllm-cu12</b>: only vllm-cu12-nixl<br/>
             • <b>sglang</b>: only sglang-nixl (cu12)<br/>
             • <b>sglang-cu13</b>: only sglang-cu13-nixl
       - string:
@@ -618,6 +620,13 @@
             Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/vllm/vllm-openai:latest</code>).<br/>
             For <b>rcN, N&gt;0</b> set to the corresponding rc0 image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/llm/vllm-nixl:1.1.0-rc0</code>
+      - string:
+          name: "BASE_IMAGE_VLLM_CU12"
+          default: ""
+          description: >
+            Optional override for the vllm-cu12 base image build-arg.<br/>
+            Leave empty to use upstream <code>docker.io/vllm/vllm-openai:v0.22.1-cu129</code> (rc0 default).<br/>
+            For <b>rcN, N&gt;0</b> pin to the rc0 vllm-cu12 image.
       - string:
           name: "BASE_IMAGE_SGLANG"
           default: ""

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -544,6 +544,229 @@
                     parent-credentials: true
         script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
+# Job template for the LLM (vLLM / SGLang) container build pipeline.
+# Builds 3 image variants (vllm-nixl, sglang-nixl, sglang-cu13-nixl) from a
+# published NIXL wheel set, for x86_64 and aarch64, and publishes multi-arch
+# manifests. Mirrors the manual procedure documented at
+# README.md
+- job-template:
+    name: "{jjb_proj}-build-llm-container"
+    project-type: pipeline
+    disabled: false
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 30
+      - inject:
+          keep-system-variables: true
+          properties-content: |
+            jjb_proj={jjb_proj}-build-llm-container
+            conf_file=.ci/jenkins/lib/build-llm-container-matrix.yaml
+    description: >
+      <b>NIXL LLM container build</b><br/>
+      • Builds 3 inference container variants per release: <b>vllm-nixl</b>, <b>sglang-nixl</b>, <b>sglang-cu13-nixl</b><br/>
+      • Builds for x86_64 and aarch64 (aarch64 via podman with QEMU)<br/>
+      • Publishes multi-arch manifests after both arches succeed<br/>
+      • Wheels pulled from <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/</code><br/>
+      • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ under <code>llm/{{vllm-nixl,sglang-nixl,sglang-cu13-nixl}}</code><br/>
+      • For <b>rc0</b> leave the <code>BASE_IMAGE_*</code> params empty to use upstream defaults<br/>
+      • For <b>rcN, N&gt;0</b> set each <code>BASE_IMAGE_*</code> to the matching rc0 image to isolate the verification to the NIXL change<br/>
+      <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
+    concurrent: true
+    sandbox: true
+    parameters:
+      - choice:
+          name: "BUILD_TARGET"
+          choices:
+            - "all"
+            - "vllm"
+            - "sglang"
+            - "sglang-cu13"
+          description: >
+            Which image variants to build:<br/>
+            • <b>all</b>: build all 3 variants (default)<br/>
+            • <b>vllm</b>: only vllm-nixl<br/>
+            • <b>sglang</b>: only sglang-nixl (cu12)<br/>
+            • <b>sglang-cu13</b>: only sglang-cu13-nixl
+      - string:
+          name: "NIXL_VERSION"
+          default: "1.1.0"
+          description: "NIXL version (e.g. 1.1.0). Used in image tag and wheel path."
+      - string:
+          name: "RC"
+          default: "rc0"
+          description: "Release candidate label (e.g. rc0, rc1, rc4). Used in image tag."
+      - string:
+          name: "WHEEL_BUILD_ID"
+          default: ""
+          description: >
+            Artifactory build id for the wheel set (e.g. <code>48633863</code>).<br/>
+            Full wheel URL: <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/nixl*.whl</code>
+      - string:
+          name: "PYTHON_TAG"
+          default: "cp312"
+          description: "CPython ABI tag used in wheel filename (e.g. cp312)."
+      - string:
+          name: "MANYLINUX_TAG"
+          default: "2_28"
+          description: "manylinux platform tag used in wheel filename (e.g. 2_28)."
+      - string:
+          name: "BASE_IMAGE_VLLM"
+          default: ""
+          description: >
+            Optional override for the vllm base image build-arg.<br/>
+            Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/vllm/vllm-openai:latest</code>).<br/>
+            For <b>rcN, N&gt;0</b> set to the corresponding rc0 image, e.g.<br/>
+            <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/llm/vllm-nixl:1.1.0-rc0</code>
+      - string:
+          name: "BASE_IMAGE_SGLANG"
+          default: ""
+          description: >
+            Optional override for the sglang (cu12) base image build-arg.<br/>
+            Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/lmsysorg/sglang:latest</code>).<br/>
+            For <b>rcN, N&gt;0</b> pin to the rc0 image.
+      - string:
+          name: "BASE_IMAGE_SGLANG_CU13"
+          default: ""
+          description: >
+            Optional override for the sglang-cu13 base image build-arg.<br/>
+            Leave empty to use upstream <code>docker.io/lmsysorg/sglang:latest-cu130-runtime</code> (rc0 default).<br/>
+            For <b>rcN, N&gt;0</b> pin to the rc0 sglang-cu13 image.
+      - string:
+          name: "TAG_SUFFIX"
+          default: ""
+          description: >
+            Optional tag suffix for re-spins (e.g. <code>v2</code>, <code>v3</code>).<br/>
+            Final tag format: <code>&lt;NIXL_VERSION&gt;-&lt;RC&gt;[-&lt;TAG_SUFFIX&gt;]</code>
+      - bool:
+          name: "RUN_SMOKE_TEST"
+          default: true
+          description: "Run `python3 -c 'importlib.metadata.version(...)'` on the built images (native-arch runs only)."
+      - bool:
+          name: "UPDATE_LATEST"
+          default: false
+          description: >
+            Also tag the resulting multi-arch manifests as <code>:latest</code> for each variant.
+      - bool:
+          name: "ALLOW_OVERWRITE"
+          default: false
+          description: >
+            By default the job aborts in <b>Prepare</b> if the canonical
+            multi-arch destination tag
+            (<code>&lt;variant&gt;:&lt;NIXL_VERSION&gt;-&lt;RC&gt;[-&lt;TAG_SUFFIX&gt;]</code>)
+            already exists in the registry, to avoid silently overwriting a
+            published RC. Per-architecture tags are not checked.<br/>
+            Tick to skip the check and overwrite the existing tag(s).
+      - string:
+          name: "MAIL_TO"
+          default: ""
+          description: "Email address to send build results to (optional)."
+      - string:
+          name: "ci_refspec"
+          default: "{jjb_branch}"
+          description: >
+            Git ref of <b>this</b> nixl repo to check out for the Dockerfiles
+            and CI scripts (separate from NIXL_VERSION, which is the wheel
+            version embedded in image tags).<br/>
+            Examples: <code>main</code>, <code>release/1.1.0</code>,
+            <code>refs/tags/v1.1.0-rc4</code>, a commit SHA, or
+            <code>refs/pull/1234/head</code>.
+    pipeline-scm:
+      scm:
+        - git:
+            url: "{jjb_git}"
+            credentials-id: "svc-nixl-ssh_key"
+            branches: ['${{ci_refspec}}']
+            shallow-clone: false
+            do-not-fetch-tags: false
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +refs/pull/*/head:refs/pull/*/head"
+            browser: githubweb
+            browser-url: "{jjb_git}"
+            submodule:
+              disable: false
+              recursive: true
+              tracking: true
+              parent-credentials: true
+      script-path: "{jjb_jenkinsfile}"
+
+# Job template for the LLM (vLLM / SGLang) container test pipeline.
+# Tests the three published LLM inference container variants on mizu SLURM:
+# spins up prefill + decode + proxy/router inside the LLM image on a 2-GPU
+# node and runs smoke / perf / accuracy phases.
+- job-template:
+    name: "{jjb_proj}-test-llm-container"
+    project-type: pipeline
+    disabled: false
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 30
+      - inject:
+          keep-system-variables: true
+          properties-content: |
+            jjb_proj={jjb_proj}-test-llm-container
+            conf_file=.ci/jenkins/lib/test-llm-container-matrix.yaml
+    description: >
+      <b>NIXL LLM container test</b><br/>
+      • Tests one inference container image on the <b>mizu</b> SLURM partition (single 2-GPU node)<br/>
+      • Brings up prefill + decode + proxy/router and runs smoke / perf / accuracy phases<br/>
+      • Framework (vllm vs sglang) is auto-detected from the image URL<br/>
+      • The URL must point to the per-arch image (mizu nodes are x86_64), e.g.<br/>
+      &nbsp;&nbsp;<code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/llm/vllm-nixl:1.1.0-rc0-x86_64</code><br/>
+      <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
+    concurrent: true
+    sandbox: true
+    parameters:
+      - string:
+          name: "IMAGE_URL"
+          default: ""
+          description: >
+            Full URL of the LLM image to test (per-arch, e.g.
+            <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/llm/vllm-nixl:1.1.0-rc0-x86_64</code>).<br/>
+            Framework is auto-detected: URL containing <code>vllm</code> runs
+            <code>test_vllm.sh</code>; URL containing <code>sglang</code> runs <code>test_sglang.sh</code>.
+      - bool:
+          name: "RUN_SMOKE"
+          default: true
+          description: "Run the smoke test (prefill+decode+proxy/router, one completion request)."
+      - bool:
+          name: "RUN_PERF"
+          default: false
+          description: "Run the perf bench (vllm bench serve / sglang.bench_serving). Adds ~15 min."
+      - bool:
+          name: "RUN_ACCURACY"
+          default: false
+          description: >
+            Run the accuracy test (<code>sglang.test.run_eval --eval-name gsm8k</code>, 200 examples, threshold 0.85).<br/>
+            SGLang only — no-ops for vllm (no equivalent built-in harness).
+      - bool:
+          name: "build_dockers"
+          default: false
+          description: "Force rebuild docker containers"
+      - string:
+          name: "ci_refspec"
+          default: "{jjb_branch}"
+          description: >
+            Git ref of <b>this</b> nixl repo to check out for the test scripts and CI helpers.<br/>
+            Examples: <code>main</code>, <code>release/1.1.0</code>, <code>refs/tags/v1.1.0-rc4</code>, a commit SHA, or <code>refs/pull/1234/head</code>.
+    pipeline-scm:
+      scm:
+        - git:
+            url: "{jjb_git}"
+            credentials-id: "svc-nixl-ssh_key"
+            branches: ['${{ci_refspec}}']
+            shallow-clone: false
+            do-not-fetch-tags: false
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +refs/pull/*/head:refs/pull/*/head"
+            browser: githubweb
+            browser-url: "{jjb_git}"
+            submodule:
+              disable: false
+              recursive: true
+              tracking: true
+              parent-credentials: true
+      script-path: "{jjb_jenkinsfile}"
+
 # Project definition that instantiates the job templates
 # This section defines the actual jobs that will be created
 - project:
@@ -559,6 +782,8 @@
         - "{jjb_proj}-non-gpu"       # Create non-gpu job
         - "{jjb_proj}-test-sanitizers"  # Create sanitizer test job
         - "{jjb_proj}-build-container"  # Create container builder job
+        - "{jjb_proj}-build-llm-container"  # Create LLM (vllm/sglang) container builder job
+        - "{jjb_proj}-test-llm-container"   # Create LLM container test job (SLURM)
         - "{jjb_proj}-gpu"        # Create gpu job
         - "{jjb_proj}-dl-gpu"   # Create dl-gpu job for dlcluster.nvidia.com
         - "{jjb_proj}-build-wheel"  # Create build wheel job

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -625,7 +625,7 @@
           default: ""
           description: >
             Optional override for the vllm-cu12 base image build-arg.<br/>
-            Leave empty to use upstream <code>docker.io/vllm/vllm-openai:v0.22.1-cu129</code> (rc0 default).<br/>
+            Leave empty to use upstream <code>docker.io/vllm/vllm-openai:latest-cu129</code> (rc0 default).<br/>
             For <b>rcN, N&gt;0</b> pin to the rc0 vllm-cu12 image.
       - string:
           name: "BASE_IMAGE_SGLANG"
@@ -661,11 +661,37 @@
           default: false
           description: >
             By default the job aborts in <b>Prepare</b> if the canonical
-            multi-arch destination tag
-            (<code>&lt;variant&gt;:&lt;NIXL_VERSION&gt;-&lt;RC&gt;[-&lt;TAG_SUFFIX&gt;]</code>)
+            multi-arch destination tag<br/>
+            (<code>&lt;variant&gt;:&lt;NIXL_VERSION&gt;-&lt;RC&gt;[-&lt;TAG_SUFFIX&gt;]</code>)<br/>
             already exists in the registry, to avoid silently overwriting a
             published RC. Per-architecture tags are not checked.<br/>
-            Tick to skip the check and overwrite the existing tag(s).
+            Tick to skip the check and overwrite the existing tag(s).<br/>
+      - bool:
+          name: "RUN_TEST"
+          default: false
+          description: >
+            After a successful publish, trigger the downstream
+            <code>nixl-ci-test-llm-container</code> job once per built variant on
+            the <b>mizu</b> SLURM partition.<br/>
+            Each downstream run is passed the canonical multi-arch manifest tag
+            (<code>&lt;variant&gt;:&lt;NIXL_VERSION&gt;-&lt;RC&gt;[-&lt;TAG_SUFFIX&gt;]</code>),
+            which resolves to the x86_64 image on mizu.<br/>
+            The test is fired asynchronously (this build does not wait for it) and
+            a test failure does not retroactively fail this build.
+      - bool:
+          name: "TEST_RUN_SMOKE"
+          default: true
+          description: "Downstream test: run the smoke phase (only used when RUN_TEST is set)."
+      - bool:
+          name: "TEST_RUN_PERF"
+          default: false
+          description: "Downstream test: run the perf phase (only used when RUN_TEST is set)."
+      - bool:
+          name: "TEST_RUN_ACCURACY"
+          default: false
+          description: >
+            Downstream test: run the accuracy phase &mdash; sglang only, no-ops for
+            vllm (only used when RUN_TEST is set).
       - string:
           name: "MAIL_TO"
           default: ""
@@ -746,7 +772,7 @@
           name: "RUN_ACCURACY"
           default: false
           description: >
-            Run the accuracy test (<code>sglang.test.run_eval --eval-name gsm8k</code>, 200 examples, threshold 0.85).<br/>
+            Run the accuracy test (<code>sglang.test.run_eval --eval-name gsm8k</code>, 200 examples, threshold 0.9, served on <code>Qwen/Qwen3-8B</code>).<br/>
             SGLang only — no-ops for vllm (no equivalent built-in harness).
       - bool:
           name: "build_dockers"

--- a/.ci/scripts/llm-tests/common.sh
+++ b/.ci/scripts/llm-tests/common.sh
@@ -127,3 +127,7 @@ EOF
 }
 
 MODEL="${MODEL:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
+# Accuracy (gsm8k) needs a model that can actually clear the >0.9 bar;
+# TinyLlama-1.1B tops out well below that. Qwen3-8B clears it with margin.
+# Smoke/perf keep the lightweight default for fast startup.
+ACCURACY_MODEL="${ACCURACY_MODEL:-Qwen/Qwen3-8B}"

--- a/.ci/scripts/llm-tests/common.sh
+++ b/.ci/scripts/llm-tests/common.sh
@@ -131,3 +131,18 @@ MODEL="${MODEL:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"
 # TinyLlama-1.1B tops out well below that. Qwen3-8B clears it with margin.
 # Smoke/perf keep the lightweight default for fast startup.
 ACCURACY_MODEL="${ACCURACY_MODEL:-Qwen/Qwen3-8B}"
+
+# Download model weights to the HuggingFace cache before launching servers.
+# sglang/vllm spend several minutes discovering a cache miss inside their own
+# startup path, which burns the health-check timeout; an explicit download step
+# fails fast and clearly instead.
+prefetch_model() {
+    local model="$1"
+    echo "=== pre-fetching model weights: ${model} ==="
+    if command -v huggingface-cli >/dev/null 2>&1; then
+        huggingface-cli download "${model}"
+    else
+        python3 -c "from huggingface_hub import snapshot_download; snapshot_download('${model}')"
+    fi
+    echo "=== model weights ready ==="
+}

--- a/.ci/scripts/llm-tests/common.sh
+++ b/.ci/scripts/llm-tests/common.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Helpers shared between test_vllm.sh and test_sglang.sh.
+# Sourced, not executed.
+
+# Poll an HTTP endpoint until it returns 2xx or timeout. Used to gate test
+# execution on prefill/decode/proxy servers being actually ready (model load
+# can take 60–120s for TinyLlama).
+wait_for_endpoint() {
+    local url="$1" timeout="${2:-300}" what="${3:-endpoint}"
+    local deadline=$(( $(date +%s) + timeout ))
+    echo "Waiting up to ${timeout}s for ${what}: ${url}"
+    while [[ $(date +%s) -lt ${deadline} ]]; do
+        if curl -fsS -o /dev/null -m 5 "${url}"; then
+            echo "READY: ${what}"
+            return 0
+        fi
+        sleep 5
+    done
+    echo "ERROR: ${what} did not become ready within ${timeout}s"
+    return 1
+}
+
+# Dump every *.log in the given directory to stdout, banner-delimited so it's
+# easy to find each server's output in a SLURM job log. Files inside the
+# container are gone once the job ends, so without this you have no clue why
+# prefill/decode failed to come up.
+dump_logs() {
+    local dir="$1"
+    [[ -d "${dir}" ]] || return 0
+    shopt -s nullglob
+    local f
+    for f in "${dir}"/*.log "${dir}"/*.out; do
+        echo
+        echo "===== ${f} ====="
+        cat "${f}"
+        echo "===== end ${f} ====="
+    done
+    shopt -u nullglob
+}
+
+# Print a one-shot snapshot of what the container sees for RDMA/UCX/GPU
+# topology. Cheap, always-on; rendered once before the servers launch so any
+# subsequent NIXL transport failure is debuggable from the Jenkins log alone.
+# Every probe is best-effort: a missing tool or denied permission must not
+# abort the test run.
+dump_env_diagnostics() {
+    echo "===== env diagnostics ====="
+    echo "--- /dev/infiniband ---"
+    ls -la /dev/infiniband 2>&1 || true
+    # Some LLM containers ship UCX as a library only, without the CLI tools.
+    # Fall back to /sys/class/infiniband so we still get HCA names + ports.
+    if command -v ibv_devinfo >/dev/null 2>&1; then
+        echo "--- ibv_devinfo -l ---"
+        ibv_devinfo -l 2>&1 || true
+    else
+        echo "--- /sys/class/infiniband (ibv_devinfo not installed) ---"
+        for d in /sys/class/infiniband/*; do
+            [[ -e "${d}" ]] || continue
+            hca=$(basename "${d}")
+            state=$(cat "${d}/ports/1/state" 2>/dev/null || echo "?")
+            ltype=$(cat "${d}/ports/1/link_layer" 2>/dev/null || echo "?")
+            rate=$(cat "${d}/ports/1/rate" 2>/dev/null || echo "?")
+            echo "  ${hca}: state=${state} link=${ltype} rate=${rate}"
+        done
+    fi
+    if command -v ucx_info >/dev/null 2>&1; then
+        echo "--- ucx_info -d (head) ---"
+        ucx_info -d 2>&1 | head -40 || true
+    else
+        echo "--- ucx_info not installed ---"
+    fi
+    echo "--- nvidia-smi topo -m ---"
+    nvidia-smi topo -m 2>&1 || true
+    echo "--- nvidia-smi nvlink --status (head) ---"
+    nvidia-smi nvlink --status 2>&1 | head -40 || true
+    echo "===== end env diagnostics ====="
+}
+
+# Kill a process tree by PID, swallowing failures (best-effort cleanup).
+kill_tree() {
+    local pid="$1"
+    [[ -z "${pid}" ]] && return 0
+    if kill -0 "${pid}" 2>/dev/null; then
+        echo "Stopping pid ${pid} (and children)"
+        pkill -P "${pid}" 2>/dev/null || true
+        kill "${pid}" 2>/dev/null || true
+        sleep 2
+        kill -9 "${pid}" 2>/dev/null || true
+    fi
+}
+
+# Send the standard smoke-test prompt and verify the response is non-empty.
+# Retries on curl failure / 5xx to absorb router worker-activation races
+# (sglang_router's /v1/models returns 200 as soon as ONE worker registers,
+# but /v1/completions needs both prefill+decode healthy).
+# Args: <completions-url> <model> [timeout-seconds]
+smoke_request() {
+    local url="$1" model="$2" timeout="${3:-120}"
+    local body resp deadline
+    body=$(cat <<EOF
+{"model":"${model}","prompt":"San Francisco is a","max_tokens":10,"temperature":0}
+EOF
+)
+    echo "POST ${url} with body: ${body}"
+    deadline=$(( $(date +%s) + timeout ))
+    while [[ $(date +%s) -lt ${deadline} ]]; do
+        # --max-time bounds each attempt: 10 tokens on TinyLlama should
+        # finish in seconds; anything past 30s is a server-side hang (e.g.
+        # NIXL KV transfer wedged) and we want to fail-and-dump-logs
+        # rather than block the CI job for hours.
+        if resp=$(curl -fsS --max-time 30 -H 'Content-Type: application/json' -d "${body}" "${url}" 2>&1); then
+            echo "Response: ${resp}"
+            # Bare-minimum sanity check: response must contain a "text" field
+            # with something non-empty in it.
+            if echo "${resp}" | python3 -c "import sys, json; r=json.load(sys.stdin); t=r['choices'][0]['text']; sys.exit(0 if t else 1)"; then
+                echo "SMOKE OK"
+                return 0
+            fi
+            echo "smoke retry: empty or malformed completion"
+        else
+            echo "smoke retry: curl failed: ${resp}"
+        fi
+        sleep 3
+    done
+    echo "SMOKE FAILED: did not succeed within ${timeout}s"
+    return 1
+}
+
+MODEL="${MODEL:-TinyLlama/TinyLlama-1.1B-Chat-v1.0}"

--- a/.ci/scripts/llm-tests/test_sglang.sh
+++ b/.ci/scripts/llm-tests/test_sglang.sh
@@ -20,6 +20,7 @@ if [[ "${PHASE}" == "accuracy" ]]; then
     MODEL="${ACCURACY_MODEL}"
 fi
 echo "Using model: ${MODEL}"
+prefetch_model "${MODEL}"
 
 PREFILL_PORT=30000
 DECODE_PORT=30001

--- a/.ci/scripts/llm-tests/test_sglang.sh
+++ b/.ci/scripts/llm-tests/test_sglang.sh
@@ -13,6 +13,14 @@ source "${SCRIPT_DIR}/common.sh"
 
 PHASE="${1:-smoke}"
 
+# The accuracy phase serves a stronger model (see ACCURACY_MODEL in common.sh)
+# so gsm8k can clear the >0.9 threshold; the prefill/decode servers below are
+# launched with whatever MODEL ends up being for this phase.
+if [[ "${PHASE}" == "accuracy" ]]; then
+    MODEL="${ACCURACY_MODEL}"
+fi
+echo "Using model: ${MODEL}"
+
 PREFILL_PORT=30000
 DECODE_PORT=30001
 ROUTER_PORT=8000
@@ -110,31 +118,33 @@ case "${PHASE}" in
         ;;
 
     accuracy)
-        echo "=== sglang gsm8k (200 examples) ==="
+        echo "=== sglang gsm8k (200 examples) on ${MODEL} ==="
         # Run gsm8k and capture stdout; parse the "Accuracy:" line and fail
-        # if it's below the threshold. Threshold of 0.85 leaves headroom on
-        # the manual EOS baseline of 0.945 to absorb run-to-run variance.
+        # if it's below the threshold. Qwen3-8B comfortably exceeds 0.9 on
+        # gsm8k, so 0.9 is the gate with headroom for run-to-run variance.
         OUT=/tmp/sglang-logs/gsm8k.out
-        # --max-tokens 512: run_eval's ChatCompletionSampler defaults to 2048,
-        # which busts TinyLlama's 2048-token context once the 5-shot prompt
-        # (~1k tokens) is added. 512 is more than any gsm8k CoT answer needs.
+        # --max-tokens 2048: Qwen3-8B has a 32k+ context, so the 5-shot prompt
+        # plus a full chain-of-thought answer fits easily; 2048 leaves ample
+        # room for the CoT to finish without truncating the final answer.
         python3 -m sglang.test.run_eval \
             --eval-name gsm8k \
             --num-examples 200 \
-            --max-tokens 512 \
+            --max-tokens 2048 \
             --host 127.0.0.1 \
             --port "${ROUTER_PORT}" \
             | tee "${OUT}"
-        ACC=$(grep -E '^Accuracy:' "${OUT}" | awk '{print $2}')
+        # run_eval prints "Score: 0.935" (older builds printed "Accuracy:");
+        # accept either so the gate survives the harness's output rename.
+        ACC=$(grep -E '^(Score|Accuracy):' "${OUT}" | head -1 | awk '{print $2}')
         if [[ -z "${ACC}" ]]; then
-            echo "ERROR: could not parse Accuracy from gsm8k output"
+            echo "ERROR: could not parse Score/Accuracy from gsm8k output"
             exit 1
         fi
         # Numeric compare in awk; bash doesn't do floats.
-        if awk -v a="${ACC}" 'BEGIN { exit !(a+0 >= 0.85) }'; then
-            echo "ACCURACY OK: ${ACC} (>= 0.85)"
+        if awk -v a="${ACC}" 'BEGIN { exit !(a+0 >= 0.9) }'; then
+            echo "ACCURACY OK: ${ACC} (>= 0.9)"
         else
-            echo "ACCURACY FAILED: ${ACC} (< 0.85)"
+            echo "ACCURACY FAILED: ${ACC} (< 0.9)"
             exit 1
         fi
         ;;

--- a/.ci/scripts/llm-tests/test_sglang.sh
+++ b/.ci/scripts/llm-tests/test_sglang.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Test the sglang-nixl (and sglang-cu13-nixl) container: prefill + decode +
+# sglang_router, then run the requested test phase against the router.
+#
+# Usage: test_sglang.sh <phase>
+#   phase = smoke | perf | accuracy
+#
+# Runs inside the sglang LLM container on a SLURM-allocated 2-GPU node.
+
+set -eo pipefail
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+source "${SCRIPT_DIR}/common.sh"
+
+PHASE="${1:-smoke}"
+
+PREFILL_PORT=30000
+DECODE_PORT=30001
+ROUTER_PORT=8000
+
+PREFILL_PID=""
+DECODE_PID=""
+ROUTER_PID=""
+
+cleanup() {
+    local rc=$?
+    set +e
+    echo "=== cleanup ==="
+    kill_tree "${ROUTER_PID}"
+    kill_tree "${DECODE_PID}"
+    kill_tree "${PREFILL_PID}"
+    if (( rc != 0 )); then
+        echo "=== server logs (exit ${rc}) ==="
+        dump_logs /tmp/sglang-logs
+    fi
+}
+trap cleanup EXIT
+
+mkdir -p /tmp/sglang-logs
+
+dump_env_diagnostics
+
+# --sampling-defaults openai forces deterministic defaults instead of the
+# newer sglang default 'model', which inherits TinyLlama-Chat's stochastic
+# generation_config (temperature/top_p > 0) and collapses gsm8k accuracy
+# under the harness's parallel-request load.
+echo "=== launching sglang prefill on GPU 0 ==="
+CUDA_VISIBLE_DEVICES=0 \
+python3 -m sglang.launch_server \
+    --model-path "${MODEL}" \
+    --host 0.0.0.0 \
+    --port "${PREFILL_PORT}" \
+    --disaggregation-mode prefill \
+    --disaggregation-transfer-backend nixl \
+    --sampling-defaults openai \
+    --tp 1 \
+    >/tmp/sglang-logs/prefill.log 2>&1 &
+PREFILL_PID=$!
+echo "prefill pid=${PREFILL_PID}"
+
+echo "=== launching sglang decode on GPU 1 ==="
+CUDA_VISIBLE_DEVICES=1 \
+python3 -m sglang.launch_server \
+    --model-path "${MODEL}" \
+    --host 0.0.0.0 \
+    --port "${DECODE_PORT}" \
+    --disaggregation-mode decode \
+    --disaggregation-transfer-backend nixl \
+    --sampling-defaults openai \
+    --tp 1 \
+    >/tmp/sglang-logs/decode.log 2>&1 &
+DECODE_PID=$!
+echo "decode pid=${DECODE_PID}"
+
+# SGLang exposes /v1/models once the server is fully up.
+wait_for_endpoint "http://127.0.0.1:${PREFILL_PORT}/health" 300 "sglang prefill"
+wait_for_endpoint "http://127.0.0.1:${DECODE_PORT}/health"  300 "sglang decode"
+
+echo "=== launching sglang router on :${ROUTER_PORT} ==="
+python3 -m sglang_router.launch_router \
+    --pd-disaggregation \
+    --prefill "http://127.0.0.1:${PREFILL_PORT}" \
+    --decode  "http://127.0.0.1:${DECODE_PORT}" \
+    --host 0.0.0.0 \
+    --port "${ROUTER_PORT}" \
+    >/tmp/sglang-logs/router.log 2>&1 &
+ROUTER_PID=$!
+echo "router pid=${ROUTER_PID}"
+
+wait_for_endpoint "http://127.0.0.1:${ROUTER_PORT}/v1/models" 120 "sglang router"
+
+case "${PHASE}" in
+    smoke)
+        smoke_request "http://127.0.0.1:${ROUTER_PORT}/v1/completions" "${MODEL}"
+        ;;
+
+    perf)
+        echo "=== sglang.bench_serving ==="
+        python3 -m sglang.bench_serving \
+            --backend sglang \
+            --base-url "http://127.0.0.1:${ROUTER_PORT}" \
+            --model "${MODEL}" \
+            --dataset-name random \
+            --num-prompts 100 \
+            --max-concurrency 10 \
+            --random-input 1024 \
+            --random-output 1024 \
+            --warmup-requests 100 \
+            --output-details \
+            --random-range-ratio 1
+        ;;
+
+    accuracy)
+        echo "=== sglang gsm8k (200 examples) ==="
+        # Run gsm8k and capture stdout; parse the "Accuracy:" line and fail
+        # if it's below the threshold. Threshold of 0.85 leaves headroom on
+        # the manual EOS baseline of 0.945 to absorb run-to-run variance.
+        OUT=/tmp/sglang-logs/gsm8k.out
+        # --max-tokens 512: run_eval's ChatCompletionSampler defaults to 2048,
+        # which busts TinyLlama's 2048-token context once the 5-shot prompt
+        # (~1k tokens) is added. 512 is more than any gsm8k CoT answer needs.
+        python3 -m sglang.test.run_eval \
+            --eval-name gsm8k \
+            --num-examples 200 \
+            --max-tokens 512 \
+            --host 127.0.0.1 \
+            --port "${ROUTER_PORT}" \
+            | tee "${OUT}"
+        ACC=$(grep -E '^Accuracy:' "${OUT}" | awk '{print $2}')
+        if [[ -z "${ACC}" ]]; then
+            echo "ERROR: could not parse Accuracy from gsm8k output"
+            exit 1
+        fi
+        # Numeric compare in awk; bash doesn't do floats.
+        if awk -v a="${ACC}" 'BEGIN { exit !(a+0 >= 0.85) }'; then
+            echo "ACCURACY OK: ${ACC} (>= 0.85)"
+        else
+            echo "ACCURACY FAILED: ${ACC} (< 0.85)"
+            exit 1
+        fi
+        ;;
+
+    *)
+        echo "ERROR: unknown phase '${PHASE}'"
+        exit 1
+        ;;
+esac
+
+echo "=== ${PHASE} OK ==="

--- a/.ci/scripts/llm-tests/test_vllm.sh
+++ b/.ci/scripts/llm-tests/test_vllm.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Test the vllm-nixl container: prefill + decode + toy_proxy_server, then run
+# the requested test phase against the proxy.
+#
+# Usage: test_vllm.sh <phase>
+#   phase = smoke | perf | accuracy
+#
+# Runs inside the vllm-nixl LLM container on a SLURM-allocated 2-GPU node.
+# Mirrors the manual EOS procedure (prefill on GPU 0, decode on GPU 1, toy
+# proxy on host, single-prompt completion request).
+
+set -eo pipefail
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+source "${SCRIPT_DIR}/common.sh"
+
+PHASE="${1:-smoke}"
+
+PREFILL_PORT=8100
+DECODE_PORT=8200
+PROXY_PORT=8192
+SIDE_CHANNEL_HOST="127.0.0.1"
+
+PREFILL_PID=""
+DECODE_PID=""
+PROXY_PID=""
+
+cleanup() {
+    local rc=$?
+    set +e
+    echo "=== cleanup ==="
+    kill_tree "${PROXY_PID}"
+    kill_tree "${DECODE_PID}"
+    kill_tree "${PREFILL_PID}"
+    if (( rc != 0 )); then
+        echo "=== server logs (exit ${rc}) ==="
+        dump_logs /tmp/vllm-logs
+    fi
+}
+trap cleanup EXIT
+
+mkdir -p /tmp/vllm-logs
+
+echo "=== launching prefill on GPU 0 ==="
+CUDA_VISIBLE_DEVICES=0 \
+UCX_PROTO_INFO=used \
+VLLM_NIXL_SIDE_CHANNEL_HOST="${SIDE_CHANNEL_HOST}" \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5600 \
+vllm serve "${MODEL}" \
+    --port "${PREFILL_PORT}" \
+    --enforce-eager \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+    >/tmp/vllm-logs/prefill.log 2>&1 &
+PREFILL_PID=$!
+echo "prefill pid=${PREFILL_PID}"
+
+echo "=== launching decode on GPU 1 ==="
+CUDA_VISIBLE_DEVICES=1 \
+UCX_PROTO_INFO=used \
+VLLM_NIXL_SIDE_CHANNEL_HOST="${SIDE_CHANNEL_HOST}" \
+VLLM_NIXL_SIDE_CHANNEL_PORT=5601 \
+vllm serve "${MODEL}" \
+    --port "${DECODE_PORT}" \
+    --enforce-eager \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+    >/tmp/vllm-logs/decode.log 2>&1 &
+DECODE_PID=$!
+echo "decode pid=${DECODE_PID}"
+
+wait_for_endpoint "http://127.0.0.1:${PREFILL_PORT}/v1/models" 180 "vllm prefill"
+wait_for_endpoint "http://127.0.0.1:${DECODE_PORT}/v1/models"  180 "vllm decode"
+
+# The Dockerfile.vllm baked in toy_proxy_server.py at /toy_proxy_server.py.
+# Fall back to fetching it if it's missing (older RC images).
+PROXY=/toy_proxy_server.py
+if [[ ! -f "${PROXY}" ]]; then
+    echo "toy_proxy_server.py not in image; fetching from upstream"
+    PROXY=/tmp/toy_proxy_server.py
+    curl -fL --retry 3 --retry-delay 2 \
+        https://raw.githubusercontent.com/vllm-project/vllm/b73b5b06290c0d1439b09db71eef15fe59bc1fbb/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
+        -o "${PROXY}"
+fi
+
+echo "=== launching toy proxy on :${PROXY_PORT} ==="
+python3 "${PROXY}" \
+    --port "${PROXY_PORT}" \
+    --prefiller-hosts 127.0.0.1 \
+    --prefiller-ports "${PREFILL_PORT}" \
+    --decoder-hosts   127.0.0.1 \
+    --decoder-ports   "${DECODE_PORT}" \
+    >/tmp/vllm-logs/proxy.log 2>&1 &
+PROXY_PID=$!
+echo "proxy pid=${PROXY_PID}"
+
+# /v1/models won't necessarily be implemented by the toy proxy — instead poll
+# the underlying decoder via the proxy with a HEAD to /v1/completions.
+sleep 5  # give the proxy a moment to bind
+wait_for_endpoint "http://127.0.0.1:${PREFILL_PORT}/v1/models" 60 "proxy upstream sanity"
+
+case "${PHASE}" in
+    smoke)
+        smoke_request "http://127.0.0.1:${PROXY_PORT}/v1/completions" "${MODEL}"
+        ;;
+
+    perf)
+        echo "=== vllm bench serve ==="
+        # `vllm bench serve` is the canonical perf tool; needs a prompt
+        # dataset. The sonnet dataset ships with the vllm install under
+        # benchmarks/; fall back to a generated synthetic prompt set if not.
+        DATASET=""
+        for p in /workspace/vllm/benchmarks/sonnet.txt /usr/local/lib/python*/dist-packages/vllm/benchmarks/sonnet.txt; do
+            if compgen -G "${p}" > /dev/null; then DATASET=$(ls ${p} | head -1); break; fi
+        done
+        if [[ -z "${DATASET}" ]]; then
+            echo "WARN: sonnet.txt not found; using random dataset instead"
+            BENCH_ARGS=(--dataset-name random --random-input-len 256 --random-output-len 64)
+        else
+            BENCH_ARGS=(--dataset-name sonnet --dataset-path "${DATASET}")
+        fi
+        vllm bench serve \
+            --backend vllm \
+            --model "${MODEL}" \
+            --host 127.0.0.1 \
+            --port "${PROXY_PORT}" \
+            --endpoint /v1/completions \
+            --num-prompts 50 \
+            --max-concurrency 10 \
+            "${BENCH_ARGS[@]}"
+        ;;
+
+    accuracy)
+        # vLLM has no built-in equivalent to sglang.test.few_shot_gsm8k;
+        # treated as a no-op for this variant.
+        echo "Accuracy phase not implemented for vllm — skipping."
+        ;;
+
+    *)
+        echo "ERROR: unknown phase '${PHASE}'"
+        exit 1
+        ;;
+esac
+
+echo "=== ${PHASE} OK ==="

--- a/.ci/scripts/llm-tests/test_vllm.sh
+++ b/.ci/scripts/llm-tests/test_vllm.sh
@@ -40,6 +40,8 @@ trap cleanup EXIT
 
 mkdir -p /tmp/vllm-logs
 
+prefetch_model "${MODEL}"
+
 echo "=== launching prefill on GPU 0 ==="
 CUDA_VISIBLE_DEVICES=0 \
 UCX_PROTO_INFO=used \

--- a/contrib/Dockerfile.vllm
+++ b/contrib/Dockerfile.vllm
@@ -19,6 +19,11 @@ FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 # Build context is expected to contain only wheel files for one architecture.
 COPY . /tmp/nixl-wheels
 
+RUN apt update && \
+    apt install -y curl git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN set -eux; \
     ls /tmp/nixl-wheels/*.whl >/dev/null; \
     uv pip install --system --no-deps --force-reinstall /tmp/nixl-wheels/*.whl; \


### PR DESCRIPTION
## What?
Adds a new Jenkins matrix pipeline that builds the three NIXL inference
container variants (vllm-nixl, sglang-nixl, sglang-cu13-nixl) from a
published NIXL wheel set, for x86_64 and aarch64, and publishes
multi-arch manifests. 

## Why?
Mirrors the manual procedure documented at
README.md so
that release-candidate inference images can be cut without running the
build steps by hand.

## How?
Uses native podman for build/push/manifest operations (no docker on the
build pod). Cross-arch aarch64 builds run on x86_64 hosts via QEMU.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated multi-architecture container builds for NIXL LLM inference (x86_64 and aarch64).
  * Builds up to three optional variants: vLLM-NIXL, SGLang-NIXL, and SGLang-CU13-NIXL.
  * Per-architecture staging with post-build creation and publishing of multi-arch manifests; optional update of :latest tags.
  * Optional pre-publish overwrite checks, native-arch smoke tests, and HTML email notifications containing published image URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->