### PR TITLE
PLUGINS/UCX: Fix config handling.

### DIFF
--- a/src/plugins/ucx/config.cpp
+++ b/src/plugins/ucx/config.cpp
@@ -24,10 +24,11 @@
 namespace nixl::ucx {
 void
 config::modify(std::string_view key, std::string_view value) const {
-    const auto env_val = nixl::config::getValueOptional<std::string>("UCX_" + std::string(key));
+    const auto ucx_key = "UCX_" + std::string(key);
+    const auto env_val = nixl::config::internal::getenvOptional(ucx_key);
 
     if (env_val) {
-        NIXL_DEBUG << "UCX env var has already been set: " << key << "=" << *env_val;
+        NIXL_DEBUG << "UCX env var already set: " << ucx_key << "=" << *env_val;
     } else {
         modifyAlways(key, value);
     }


### PR DESCRIPTION
## What?
Don't let a config file entry prevent an update to the UCX environment.

## Why?
UCX reads config values from the environment and not the NIXL config file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved UCX environment variable detection mechanism and enhanced diagnostic logging for configuration status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->