### PR TITLE
TEST/GTEST: Disable ReadConfigFile gtest.

### DIFF
--- a/test/gtest/configuration.cpp
+++ b/test/gtest/configuration.cpp
@@ -216,6 +216,12 @@ TEST(Config, ConvertUnsigned) {
     testUnsigned<std::uint64_t>();
 }
 
+#if 0
+
+  // ReadConfigFile is temporarily disabled because it always fails when it is
+  // not the first or only test to run. TODO: Enable again with more robust
+  // file handling.
+
 namespace {
 
     const std::string pid = std::to_string(::getpid());
@@ -267,5 +273,7 @@ TEST(Config, ReadConfigFile) {
         EXPECT_THROW((void)nixl::config::getValue<int>(env2name), std::runtime_error);
     }
 }
+
+#endif
 
 } // namespace nixl::config


### PR DESCRIPTION
## What?
Disable the ReadConfigFile gtest.

## Why?
The test only succeeds when it runs as first or only test (as `.gitlab/test_cpp.sh` does with `gtest-parallel`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * A test case has been temporarily disabled to prevent it from being built and executed during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->