### PR TITLE
fix(nixlbench): Eliminate Local Memory Registration Leak via Symmetrical Error Rollback

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1375,6 +1375,7 @@ registerIterationMem(nixlAgent *agent,
     iovListToNixlRegDlist(remote_iov, remote_reg);
     rc = agent->registerMem(remote_reg, &reg_args);
     if (rc != NIXL_SUCCESS) {
+        agent->deregisterMem(local_reg, &reg_args);
         return rc;
     }
 


### PR DESCRIPTION
## What?
Eliminate Local Memory Registration Leak via Symmetrical Error Rollback

## Why?

The error handling path in registerIterationMem was asymmetric. When remote memory registration failed, the function returned the  error code immediately without deregistering the already successful local memory registration.


## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory registration error handling to ensure proper resource cleanup when registration operations fail unexpectedly, enhancing system stability and preventing incomplete state conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->