### PR TITLE
ci: Switch git URL to HTTPS and reduce fetch size

### DIFF
--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -186,7 +186,6 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'svc-nixl-ssh_key'
                 branches: ['$sha1']
                 shallow-clone: false
                 do-not-fetch-tags: false
@@ -248,7 +247,6 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'svc-nixl-ssh_key'
                 branches: ['$sha1']
                 shallow-clone: false
                 do-not-fetch-tags: false
@@ -310,7 +308,6 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'svc-nixl-ssh_key'
                 branches: ['$sha1']
                 shallow-clone: false
                 do-not-fetch-tags: false
@@ -414,7 +411,6 @@
       scm:
         - git:
             url: "{jjb_git}"
-            credentials-id: "svc-nixl-ssh_key"
             branches: ['$NIXL_VERSION']
             shallow-clone: false
             do-not-fetch-tags: false
@@ -471,7 +467,6 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: false
                 do-not-fetch-tags: false
@@ -492,7 +487,7 @@
 - project:
     name: nixl
     jjb_proj: 'nixl-ci'           # Project prefix for job names
-    jjb_git: 'git@github.com:ai-dynamo/nixl.git'  # Repository URL
+    jjb_git: 'https://github.com/ai-dynamo/nixl.git'  # Repository URL
     jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'  # Main pipeline definition
     jjb_branch: 'main'            # Default branch
     jjb_gh_url: 'https://github.com/ai-dynamo/nixl'  # GitHub web URL

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -414,7 +414,7 @@
             branches: ['$NIXL_VERSION']
             shallow-clone: false
             do-not-fetch-tags: false
-            refspec: "{jjb_gh_refspec}"
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/remotes/origin/tags/* +$NIXL_VERSION:refs/remotes/origin/$NIXL_VERSION"
             browser: githubweb
             browser-url: "{jjb_git}"
             submodule:
@@ -491,7 +491,7 @@
     jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'  # Main pipeline definition
     jjb_branch: 'main'            # Default branch
     jjb_gh_url: 'https://github.com/ai-dynamo/nixl'  # GitHub web URL
-    jjb_gh_refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*:refs/remotes/origin/pr/* +refs/tags/*:refs/remotes/origin/tags/*'
+    jjb_gh_refspec: '+refs/heads/*:refs/remotes/origin/* +$sha1:refs/remotes/origin/$sha1'
     jobs:
         - "{jjb_proj}-dispatcher"  # Create dispatcher job
         - "{jjb_proj}-non-gpu"       # Create non-gpu job


### PR DESCRIPTION

## What?
Switch the SCM URL to HTTPS to fix 'Permission denied (publickey)' from 'git ls-remote'. 
SSH requires an SSH key, while HTTPS allows anonymous reads of public repos like nixl.

Fetch only the commit via +$sha1:refs/remotes/origin/$sha1
 instead of +refs/pull/* which fetch every PR.

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched pipeline repository access from SSH to HTTPS.
  * Removed per-job stored credentials so jobs inherit repository-level access.
  * Simplified and standardized branch/tag fetch behavior across build jobs.
  * Added an explicit SHA-based fetch mapping and a targeted fetch configuration for container builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->