### PR TITLE
CI: cap port pool below kernel ephemeral range

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -45,7 +45,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260709-1"
+  CI_IMAGE_TAG: "20260712-1"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -45,7 +45,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260712-1"
+  CI_IMAGE_TAG: "20260712-2"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -60,7 +60,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260712-1"
+  CI_IMAGE_TAG: "20260712-2"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -60,7 +60,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260709-1"
+  CI_IMAGE_TAG: "20260712-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -54,7 +54,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260712-1"
+  CI_IMAGE_TAG: "20260712-2"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -54,7 +54,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260709-1"
+  CI_IMAGE_TAG: "20260712-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -52,7 +52,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260709-1"
+  CI_IMAGE_TAG: "20260712-1"
   ENROOT_MOUNT_PATH: "/enroot_images"  # NFS mount on mizu nodes; on failure the container is exported here as <containerName>.sqsh
   ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"  # svc-nixl user on mizu nodes
 

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -52,7 +52,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260712-1"
+  CI_IMAGE_TAG: "20260712-2"
   ENROOT_MOUNT_PATH: "/enroot_images"  # NFS mount on mizu nodes; on failure the container is exported here as <containerName>.sqsh
   ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"  # svc-nixl user on mizu nodes
 

--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -42,7 +42,7 @@ env:
   TEST_TIMEOUT: 40
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260712-1"
+  CI_IMAGE_TAG: "20260712-2"
 
 runs_on_dockers:
   # TSan-instrumented dependency image for the tsan build (DEPS_SANITIZE=thread

--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -42,7 +42,7 @@ env:
   TEST_TIMEOUT: 40
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260709-1"
+  CI_IMAGE_TAG: "20260712-1"
 
 runs_on_dockers:
   # TSan-instrumented dependency image for the tsan build (DEPS_SANITIZE=thread

--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -22,7 +22,7 @@
 # Set initial port number for client/server applications to be updated with
 # function below
 #
-tcp_port_range=1000
+tcp_port_range=300
 min_port_number=10500
 max_port_number=32500
 

--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -24,18 +24,10 @@
 #
 tcp_port_range=1000
 min_port_number=10500
-max_port_number=65535
+max_port_number=32500
 
-# GITLAB CI
-if [ -n "$CI_CONCURRENT_ID" ]; then
-    nixl_concurrent_id=$CI_CONCURRENT_ID
-# Jenkins CI
-elif [ -n "$EXECUTOR_NUMBER" ]; then
-    nixl_concurrent_id=$EXECUTOR_NUMBER
-else
-    # Fallback to random number if both CI_CONCURRENT_ID and EXECUTOR_NUMBER are not set
-    nixl_concurrent_id=$((RANDOM % $(((max_port_number - min_port_number) / tcp_port_range))))
-fi
+tcp_port_slots=$(((max_port_number - min_port_number) / tcp_port_range))
+nixl_concurrent_id=$(( ${CI_CONCURRENT_ID:-${EXECUTOR_NUMBER:-$RANDOM}} % tcp_port_slots ))
 
 echo nixl_concurrent_id="$nixl_concurrent_id"
 


### PR DESCRIPTION
## What?
Cap the CI port pool below Linux ephemeral range, and modulo the concurrent-id sources by the available slot count.

## Why?
NIXL CI flakes with `Failed to bind metadata listener socket` on both platforms:
- Jenkins: https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/blue/organizations/jenkins/nixl-ci-gpu/detail/nixl-ci-gpu/1850/pipeline/261/
- GitHub Actions (AWS EFA): https://github.com/ai-dynamo/nixl/actions/runs/26509466812/attempts/2?pr=1658

The CI port pool overlaps Linux default `ip_local_port_range` (32768-60999), so the kernel ephemeral allocator can grab a port in our pool between the listener probe in `get_next_tcp_port` and the test's `bind()`.

## How?
Capping at 32500 keeps every bucket below the ephemeral floor. Modulo on the id sources prevents high values (observed 20, 27, 46, 53 on Jenkins) from landing above the cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced the TCP port allocation range used by CI to limit available ports and adjust concurrency-based port selection.
  * Revised CI concurrency handling so concurrent IDs are normalized before selecting ports to avoid collisions.
  * Updated CI pipeline image tags used for build and test jobs to newer versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->