### PR TITLE
CI: fetch DDN Infinia libraries from GCS in non-GPU pipeline

### DIFF
--- a/.ci/dockerfiles/Dockerfile.base
+++ b/.ci/dockerfiles/Dockerfile.base
@@ -7,6 +7,11 @@
 #
 
 ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04
+ARG INFINIA_LIBS_IMAGE=harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1
+
+# Stage that just holds the pre-fetched DDN Infinia libraries.
+# See .ci/dockerfiles/Dockerfile.infinia-libs for how this image is produced.
+FROM ${INFINIA_LIBS_IMAGE} AS infinia
 
 FROM ${BASE_IMAGE}
 
@@ -31,6 +36,10 @@ LABEL version="1.0"
 RUN apt-get update && \
     apt-get install -y sudo python3 python3-pip kmod && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Drop the pre-fetched DDN Infinia libs (for the current ARCH) into ${INFINIA_DEST}.
+ARG INFINIA_DEST=/opt/ddn/red
+COPY --from=infinia /infinia/${ARCH}/ ${INFINIA_DEST}/
 
 # Create group and user in one RUN command to reduce layers
 RUN if ! getent group "${_GID}" > /dev/null 2>&1; then \

--- a/.ci/dockerfiles/Dockerfile.infinia-libs
+++ b/.ci/dockerfiles/Dockerfile.infinia-libs
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.4
+#
+# DDN Infinia closed-source libraries baked into a tiny "data" image. The
+# main CI base image (Dockerfile.base) pulls libs out of this with
+# `COPY --from=infinia`, so no per-PR GCS auth or download is needed.
+#
+# This Dockerfile is built and pushed manually by a maintainer who holds
+# the GCP service-account JSON key, NOT by CI. The service-account key is
+# mounted by BuildKit as a secret only for the gcloud auth+rsync RUN, so
+# it never ends up in any image layer.
+#
+# Build + push:
+#
+#   DOCKER_BUILDKIT=1 docker build \
+#       --secret id=gcs-key,src=/path/to/service-account.json \
+#       --build-arg INFINIA_VERSION=v2.4.0-beta.1 \
+#       -f .ci/dockerfiles/Dockerfile.infinia-libs \
+#       -t harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1 .
+#   docker push harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1
+#
+# To roll Infinia versions: rebuild with a new INFINIA_VERSION and matching
+# tag, then bump INFINIA_LIBS_IMAGE in Dockerfile.base.
+
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+
+ARG INFINIA_GCS_PROJECT=infinia-solutions-436513
+ARG INFINIA_GCS_BUCKET=gs://ddn-sdk
+ARG INFINIA_VERSION=v2.4.0-beta.1
+
+RUN --mount=type=secret,id=gcs-key \
+    gcloud auth activate-service-account --key-file=/run/secrets/gcs-key && \
+    gcloud config set project "${INFINIA_GCS_PROJECT}" && \
+    mkdir -p /infinia/x86_64 /infinia/aarch64 && \
+    gsutil -m rsync -r "${INFINIA_GCS_BUCKET}/${INFINIA_VERSION}/x86/"   /infinia/x86_64/ && \
+    gsutil -m rsync -r "${INFINIA_GCS_BUCKET}/${INFINIA_VERSION}/arm64/" /infinia/aarch64/ && \
+    gcloud auth revoke --all > /dev/null 2>&1 || true

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -43,21 +43,20 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260601-1"
-
+  CI_IMAGE_TAG: "20260603-1"
 
 runs_on_dockers:
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-25.06-cuda12.9-ubuntu24.04", tag: "${CI_IMAGE_TAG}",
-     build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
+     build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --build-arg ARCH=${arch} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-25.10-cuda13.0-ubuntu24.04", tag: "${CI_IMAGE_TAG}",
-     build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
+     build_args: '--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.10-cuda13.0-devel-ubuntu24.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --build-arg ARCH=${arch} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
   - {
      file: '.ci/dockerfiles/Dockerfile.base', name: "nixl-base-13.0.1-ubuntu22.04", tag: "${CI_IMAGE_TAG}",
-     build_args: '--build-arg BASE_IMAGE=dockerhub.nvidia.com/nvidia/cuda:13.0.1-devel-ubuntu22.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
+     build_args: '--build-arg BASE_IMAGE=dockerhub.nvidia.com/nvidia/cuda:13.0.1-devel-ubuntu22.04 --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --build-arg ARCH=${arch} --pull --no-cache --build-arg PRE_INSTALLED_NIXL_ENV=true'
     }
 
 matrix:

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -52,7 +52,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260601-1"
+  CI_IMAGE_TAG: "20260602-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -50,7 +50,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260601-1"
+  CI_IMAGE_TAG: "20260602-1"
 
 empty_volumes:
   - {mountPath: /root, memory: false}


### PR DESCRIPTION
## What?
Add a CI step that pulls DDN's closed-source Infinia SDK from a private Google Cloud Storage bucket into ${NIXL_INSTALL_DIR}/infinia/ so the upcoming Infinia plugin can be built against it. No meson/plugin wiring yet - this only stages the libraries on disk.

  - .gitlab/fetch_infinia.sh: new helper. Authenticates with the service-account JSON exposed via INFINIA_GCS_KEY_FILE (provided by ci-demo's withCredentials wrapper) and `gsutil rsync`s the per-arch tree under gs://ddn-sdk/v2.4.0-beta.1/{x86,arm64}/. Soft-skips with a clear message when the key is unset so contributors who don't touch Infinia aren't blocked. Set NIXL_CI_INFINIA_REQUIRED=1 to flip soft-skip into a hard failure once the plugin lands.

  - .ci/dockerfiles/Dockerfile.base: install google-cloud-cli (gcloud + gsutil) from the Google apt repo so the SDK is baked into the prebuilt CI base image rather than reinstalled every run.

  - .ci/jenkins/lib/build-matrix.yaml: declare the nixl_ddn_infinia_gcs_key file credential, add a `Fetch Infinia libs` step before Build that references it, and bump CI_IMAGE_TAG to 202606021 to force a base-image rebuild (build.sh changed).

The Jenkins admin needs to provision the nixl_ddn_infinia_gcs_key secret-file credential with the DDN-supplied JSON key before the fetch becomes active.

## Why?
[HPCINFRA-4433](https://jirasw.nvidia.com/browse/HPCINFRA-4433)

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI image tags across build and test pipelines to a new release.
  * Added Google Cloud SDK to CI images to enable GCS access during runs.
  * Added a non-parallel CI step to fetch proprietary Infinia libraries during builds.
  * Introduced a file-based CI credential for accessing cloud-stored Infinia artifacts.
  * Added a helper script used by CI to perform the Infinia fetch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->