### PR TITLE
nixl_ep: Refactor rank and expert semantics

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -222,7 +222,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               const void* x, const topk_idx_t* topk_idx,
               uint64_t* next_clean, int num_next_clean_int,
               int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
-              int num_topk, int num_experts, int rank, int num_ranks,
+              int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
               bool use_fp8, bool round_scale, bool use_ue8m0,
               uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
@@ -236,7 +236,7 @@ void combine(void* combined_x,
              int64_t* combine_wait_recv_cost_stats,
              uint64_t* next_clean, int num_next_clean_int,
              int num_combined_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
-             int num_topk, int num_experts, int rank, int num_ranks,
+             int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
              bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx);
@@ -246,8 +246,6 @@ void barrier(gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycl
 void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
 
 void update_mask_buffer(int* mask_buffer_ptr, int rank_to_mask, bool mask, cudaStream_t stream);
-
-void clean_mask_buffer(int* mask_buffer_ptr, int num_ranks, cudaStream_t stream);
 
 } // namespace ep_kernels
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -81,8 +81,8 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     const auto warp_id = thread_id / 32, lane_id = get_lane_id();
     const auto num_sms = static_cast<int>(gridDim.x);
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    const auto num_local_experts = num_experts_per_rank;
-    const auto active_expert_bound = active_rank_bound * num_local_experts;
+    const int num_local_experts = num_experts_per_rank;
+    const int active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;
     const auto responsible_expert_idx = sm_id * num_warp_groups + warp_group_id;
@@ -628,8 +628,8 @@ combine(void* combined_x,
     const auto thread_id = static_cast<int>(threadIdx.x);
     const auto num_threads = __shfl_sync(0xffffffff, static_cast<int>(blockDim.x), 0);
     const auto warp_id = __shfl_sync(0xffffffff, thread_id / 32, 0), lane_id = get_lane_id();
-    const auto num_local_experts = num_experts_per_rank;
-    const auto active_expert_bound = active_rank_bound * num_local_experts;
+    const int num_local_experts = num_experts_per_rank;
+    const int active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;
     const auto responsible_expert_idx = sm_id * num_warp_groups + warp_group_id;

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -72,7 +72,7 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
          int* atomic_counter_per_expert, int* atomic_finish_counter_per_expert,
          uint64_t* next_clean, int num_next_clean_int,
          int num_tokens, int num_max_dispatch_tokens_per_rank,
-         int num_topk, int num_experts, int rank, int num_ranks,
+         int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
          int num_warp_groups, int num_warps_per_group,
          bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
@@ -81,7 +81,8 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     const auto warp_id = thread_id / 32, lane_id = get_lane_id();
     const auto num_sms = static_cast<int>(gridDim.x);
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    const auto num_local_experts = num_experts / num_ranks;
+    const auto num_local_experts = num_experts_per_rank;
+    const auto active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;
     const auto responsible_expert_idx = sm_id * num_warp_groups + warp_group_id;
@@ -175,13 +176,14 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
 
             // Issue NIXL sends
             if (dst_expert_idx >= 0) {
+                EP_DEVICE_ASSERT(dst_expert_idx < active_expert_bound);
                 int slot_idx = lane_id == 0 ? atomicAdd(atomic_counter_per_expert + dst_expert_idx, 1) : 0;
                 slot_idx = __shfl_sync(0xffffffff, slot_idx, 0);
                 const auto dst_rank = dst_expert_idx / num_local_experts;
                 const auto dst_expert_local_idx = dst_expert_idx % num_local_experts;
                 const auto src_ptr = reinterpret_cast<uint64_t>(rdma_x_src_idx);
                 const auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_x) +
-                                     dst_expert_local_idx * num_ranks * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+                                     dst_expert_local_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                                      rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                                      slot_idx * num_bytes_per_msg;
                 if (not is_rank_masked<true>(mask_buffer_ptr, dst_rank)) {
@@ -215,14 +217,14 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
             // Notify before executing `int_p`
             __syncwarp();
             #pragma unroll
-            for (int i = lane_id; i < num_experts; i += 32)
+            for (int i = lane_id; i < active_expert_bound; i += 32)
                 atomic_add_release_global(atomic_finish_counter_per_expert + i, FINISHED_SUM_TAG);
         }
 
         // This SM should be responsible for some destination experts, read `topk_idx` for them
         int expert_count[kNumMaxWarpGroups] = {0};
         const auto expert_begin_idx = sm_id * num_warp_groups;
-        const auto expert_end_idx = min(expert_begin_idx + num_warp_groups, num_experts);
+        const auto expert_end_idx = min(expert_begin_idx + num_warp_groups, active_expert_bound);
 
         // Per lane count
         #pragma unroll 8
@@ -245,14 +247,14 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     __syncthreads();
 
     // Issue count sends
-    if (responsible_expert_idx < num_experts and sub_warp_id == 0 and lane_id == 0) {
+    if (responsible_expert_idx < active_expert_bound and sub_warp_id == 0 and lane_id == 0) {
         const auto dst_rank = responsible_expert_idx / num_local_experts;
         const auto dst_expert_local_idx = responsible_expert_idx % num_local_experts;
         const auto num_tokens_sent = shared_num_tokens_sent_per_expert[responsible_expert_idx - sm_id * num_warp_groups];
 
         // Wait local sends issued and send expert counts
         while (ld_acquire_global(atomic_finish_counter_per_expert + responsible_expert_idx) != FINISHED_SUM_TAG * 2);
-        auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_count + dst_expert_local_idx * num_ranks + rank);
+        auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_count + dst_expert_local_idx * active_rank_bound + rank);
         if (not is_rank_masked(mask_buffer_ptr, dst_rank)) {
             void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
             if (dst_p2p_ptr == 0) {
@@ -283,18 +285,18 @@ DISPATCH_RECV:
         cg::this_grid().sync();
 
     // Receiving and packing
-    if (responsible_expert_idx < num_experts) {
+    if (responsible_expert_idx < active_expert_bound) {
         const auto src_rank = responsible_expert_idx / num_local_experts;
         const auto local_expert_idx = responsible_expert_idx % num_local_experts;
         const auto rdma_recv_x_uint8 = static_cast<uint8_t*>(rdma_recv_x) +
-                local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
+                local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                 src_rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg;
         const auto recv_x_int4 = static_cast<int4*>(packed_recv_x) +
-                local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank * hidden_int4;
-        const auto recv_src_info = packed_recv_src_info + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank;
-        const auto recv_range = packed_recv_layout_range + local_expert_idx * num_ranks;
+                local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * hidden_int4;
+        const auto recv_src_info = packed_recv_src_info + local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank;
+        const auto recv_range = packed_recv_layout_range + local_expert_idx * active_rank_bound;
         const auto num_aligned_scales = align_up<int>(num_scales, sizeof(float) / sizeof(scale_t));
-        const auto recv_x_scales = static_cast<scale_t*>(packed_recv_x_scales) + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank * num_aligned_scales;
+        const auto recv_x_scales = static_cast<scale_t*>(packed_recv_x_scales) + local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * num_aligned_scales;
 
         // Shared between sub-warps in warp groups
         __shared__ int shared_num_recv_tokens[kNumMaxWarpGroups], shared_recv_token_begin_idx[kNumMaxWarpGroups];
@@ -307,7 +309,7 @@ DISPATCH_RECV:
             auto start_time = clock64();
             uint64_t wait_recv_cost = 0;
             if (not is_rank_masked(mask_buffer_ptr, src_rank)) {
-                while ((num_recv_tokens = ld_acquire_sys_global(rdma_recv_count + local_expert_idx * num_ranks + src_rank)) ==
+                while ((num_recv_tokens = ld_acquire_sys_global(rdma_recv_count + local_expert_idx * active_rank_bound + src_rank)) ==
                            0                                                               // data not arrived
                        && (wait_recv_cost = clock64() - start_time) <= timeout_cycles       // not timeout
                 )
@@ -366,7 +368,7 @@ DISPATCH_RECV:
                 const auto num_elems_per_pack = static_cast<int>(sizeof(packed_t) / sizeof(scale_t));
                 const auto token_idx = recv_token_begin_idx + i;
                 const auto token_stride = num_elems_per_pack;
-                const auto pack_stride = num_ranks * num_max_dispatch_tokens_per_rank * num_elems_per_pack;
+                const auto pack_stride = active_rank_bound * num_max_dispatch_tokens_per_rank * num_elems_per_pack;
                 if (lane_id < num_scales) {
                     const auto pack_idx = lane_id / num_elems_per_pack;
                     const auto elem_idx = lane_id % num_elems_per_pack;
@@ -394,25 +396,26 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               const void* x, const topk_idx_t* topk_idx,
               uint64_t* next_clean, int num_next_clean_int,
               int num_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
-              int num_topk, int num_experts, int rank, int num_ranks,
+              int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
               bool use_fp8, bool round_scale, bool use_ue8m0,
               uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
               cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
     constexpr int kNumMaxTopK = 11;
-    const int num_warp_groups = ceil_div(num_experts, num_device_sms);
+    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
+    const int num_warp_groups = ceil_div(active_expert_bound, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
     EP_HOST_ASSERT(num_warp_groups > 0 and num_warps_per_group > 0);
     EP_HOST_ASSERT(kNumMaxTopK + 1 <= num_warp_groups * num_warps_per_group);
 
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    const auto num_sms = ceil_div(num_experts, num_warp_groups);
+    const auto num_sms = ceil_div(active_expert_bound, num_warp_groups);
     EP_HOST_ASSERT(num_topk <= kNumMaxTopK);
 
     // Workspace checks
     auto atomic_counter_per_expert = static_cast<int*>(workspace);
-    auto atomic_finish_counter_per_expert = atomic_counter_per_expert + num_experts;
-    EP_HOST_ASSERT(num_experts * sizeof(int) * 2 <= NUM_WORKSPACE_BYTES);
+    auto atomic_finish_counter_per_expert = atomic_counter_per_expert + active_expert_bound;
+    EP_HOST_ASSERT(active_expert_bound * sizeof(int) * 2 <= NUM_WORKSPACE_BYTES);
 
     // FP8 checks
     if (use_ue8m0)
@@ -436,7 +439,7 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
               atomic_counter_per_expert, atomic_finish_counter_per_expert, \
               next_clean, num_next_clean_int, \
               num_tokens, num_max_dispatch_tokens_per_rank, \
-              num_topk, num_experts, rank, num_ranks, \
+              num_topk, active_rank_bound, num_experts_per_rank, rank, \
               num_warp_groups, num_warps_per_group, \
               round_scale, timeout_cycles, phases, nixl_ctx); } break
 
@@ -616,7 +619,7 @@ combine(void* combined_x,
         int* atomic_clean_flag,
         int num_combined_tokens, int hidden, int num_topk,
         int num_max_dispatch_tokens_per_rank,
-        int num_experts, int rank, int num_ranks,
+        int active_rank_bound, int num_experts_per_rank, int rank,
         int num_warp_groups, int num_warps_per_group,
         uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
@@ -625,7 +628,8 @@ combine(void* combined_x,
     const auto thread_id = static_cast<int>(threadIdx.x);
     const auto num_threads = __shfl_sync(0xffffffff, static_cast<int>(blockDim.x), 0);
     const auto warp_id = __shfl_sync(0xffffffff, thread_id / 32, 0), lane_id = get_lane_id();
-    const auto num_local_experts = num_experts / num_ranks;
+    const auto num_local_experts = num_experts_per_rank;
+    const auto active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;
     const auto responsible_expert_idx = sm_id * num_warp_groups + warp_group_id;
@@ -665,20 +669,20 @@ combine(void* combined_x,
         // Notify before executing `int_p`
         __syncwarp();
         if (lane_id == 0)
-            atomic_add_release_global(atomic_clean_flag, num_experts);
+            atomic_add_release_global(atomic_clean_flag, active_expert_bound);
     }
 
     // Issue NIXL sends
-    if (responsible_expert_idx < num_experts) {
+    if (responsible_expert_idx < active_expert_bound) {
         const auto dst_rank = responsible_expert_idx / num_local_experts;
         const auto local_expert_idx = responsible_expert_idx % num_local_experts;
         const auto global_expert_idx = rank * num_local_experts + local_expert_idx;
-        const auto layout = __ldg(layout_range + local_expert_idx * num_ranks + dst_rank);
+        const auto layout = __ldg(layout_range + local_expert_idx * active_rank_bound + dst_rank);
         const auto local_x = static_cast<const int4*>(x) +
-                local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank * hidden_bf16_int4;
-        const auto local_src_info = src_info + local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank;
+                local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * hidden_bf16_int4;
+        const auto local_src_info = src_info + local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank;
         const auto rdma_send_x_vec = static_cast<uint8_t*>(rdma_send_x) +
-                local_expert_idx * num_ranks * num_max_dispatch_tokens_per_rank * num_bytes_per_slot;
+                local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * num_bytes_per_slot;
 
         // Unpack layout
         int offset, num_tokens_to_send;
@@ -831,7 +835,7 @@ COMBINE_RECV:
         return;
 
     // Wait all ranks to arrive
-    if (responsible_expert_idx < num_experts) {
+    if (responsible_expert_idx < active_expert_bound) {
         EP_DEVICE_ASSERT(num_warps_per_group > 1);
         if (sub_warp_id == 0 and lane_id == 0) {
             const auto src_rank = responsible_expert_idx / num_local_experts;
@@ -915,6 +919,7 @@ COMBINE_RECV:
                     int topk_idx_reg = __shfl_sync(0xffffffff, topk_idx_by_lane, i);
                     if (topk_idx_reg < 0)
                         continue;
+                    EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
                     if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
                         continue;
 
@@ -955,6 +960,7 @@ COMBINE_RECV:
                     int topk_idx_reg = __shfl_sync(0xffffffff, topk_idx_by_lane, i);
                     if (topk_idx_reg < 0)
                         continue;
+                    EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
                     if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
                         continue;
                     const auto& topk_weight = __shfl_sync(0xffffffff, topk_weights_by_lane, i);
@@ -1009,18 +1015,19 @@ void combine(void* combined_x,
              int64_t* combine_wait_recv_cost_stats,
              uint64_t* next_clean, int num_next_clean_int,
              int num_combined_tokens, int hidden, int num_max_dispatch_tokens_per_rank,
-             int num_topk, int num_experts, int rank, int num_ranks,
+             int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
              bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
     constexpr int kNumMaxTopk = 11;
-    const int num_warp_groups = ceil_div(num_experts, num_device_sms);
+    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
+    const int num_warp_groups = ceil_div(active_expert_bound, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
     const int num_recv_per_sm = ceil_div(num_combined_tokens, num_device_sms);
     EP_HOST_ASSERT(num_warp_groups > 0 and num_warps_per_group > 0 and num_recv_per_sm >= 0);
 
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    const auto num_sms = max(ceil_div(num_experts, num_warp_groups),
+    const auto num_sms = max(ceil_div(active_expert_bound, num_warp_groups),
                              num_recv_per_sm == 0 ? 1 : ceil_div(num_combined_tokens, num_recv_per_sm));
 
     // Check workspace
@@ -1062,7 +1069,7 @@ LAUNCH_KERNEL(&cfg, combine_func, \
               atomic_clean_flag, \
               num_combined_tokens, hidden, num_topk, \
               num_max_dispatch_tokens_per_rank, \
-              num_experts, rank, num_ranks, \
+              active_rank_bound, num_experts_per_rank, rank, \
               num_warp_groups, num_warps_per_group, \
               timeout_cycles, phases, zero_copy, nixl_ctx); } break
 
@@ -1106,21 +1113,6 @@ void update_mask_buffer(int* mask_buffer_ptr, int rank, bool mask, cudaStream_t 
     LAUNCH_KERNEL(&cfg, update_mask_buffer<kNumThreads>, mask_buffer_ptr, rank, mask);
 }
 
-
-template <int kNumThreads> __launch_bounds__(kNumThreads, 1)
-__global__ void clean_mask_buffer(int* mask_buffer_ptr, int num_ranks) {
-    auto thread_id = static_cast<int>(threadIdx.x);
-    #pragma unroll
-    for (int i = thread_id; i < num_ranks; i += kNumThreads)
-    mask_buffer_ptr[i] = 0;
-}
-
-void clean_mask_buffer(int* mask_buffer_ptr, int num_ranks, cudaStream_t stream) {
-    constexpr int num_sms = 1;
-    constexpr int kNumThreads = 32;
-    SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
-    LAUNCH_KERNEL(&cfg, clean_mask_buffer<kNumThreads>, mask_buffer_ptr, num_ranks);
-}
 
 template <int kNumThreads>
 __forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mask_buffer_ptr, int thread_id, uint64_t timeout_cycles) {

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -72,7 +72,7 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
          int* atomic_counter_per_expert, int* atomic_finish_counter_per_expert,
          uint64_t* next_clean, int num_next_clean_int,
          int num_tokens, int num_max_dispatch_tokens_per_rank,
-         int num_topk, int active_rank_bound, int num_experts_per_rank, int rank,
+         int num_topk, int active_rank_bound, int num_local_experts, int rank,
          int num_warp_groups, int num_warps_per_group,
          bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
@@ -81,7 +81,6 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     const auto warp_id = thread_id / 32, lane_id = get_lane_id();
     const auto num_sms = static_cast<int>(gridDim.x);
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    const int num_local_experts = num_experts_per_rank;
     const int active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;
@@ -619,7 +618,7 @@ combine(void* combined_x,
         int* atomic_clean_flag,
         int num_combined_tokens, int hidden, int num_topk,
         int num_max_dispatch_tokens_per_rank,
-        int active_rank_bound, int num_experts_per_rank, int rank,
+        int active_rank_bound, int num_local_experts, int rank,
         int num_warp_groups, int num_warps_per_group,
         uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
@@ -628,7 +627,6 @@ combine(void* combined_x,
     const auto thread_id = static_cast<int>(threadIdx.x);
     const auto num_threads = __shfl_sync(0xffffffff, static_cast<int>(blockDim.x), 0);
     const auto warp_id = __shfl_sync(0xffffffff, thread_id / 32, 0), lane_id = get_lane_id();
-    const int num_local_experts = num_experts_per_rank;
     const int active_expert_bound = active_rank_bound * num_local_experts;
     const auto warp_group_id = warp_id / num_warps_per_group;
     const auto sub_warp_id = warp_id % num_warps_per_group;

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -88,7 +88,6 @@ Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int tim
         comm_stream(at::cuda::getStreamFromPool(true)) {}
 
 bool Buffer::_is_rank_connected(int rank_id) const {
-    EP_HOST_ASSERT(rank_id >= 0 and rank_id < max_num_ranks);
     return rank_id == rank or std::find(remote_ranks.begin(), remote_ranks.end(), rank_id) != remote_ranks.end();
 }
 
@@ -104,6 +103,9 @@ void Buffer::_refresh_active_rank_bound() {
 
 void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes, int64_t num_rdma_bytes)
 {
+    EP_HOST_ASSERT(num_ranks > 0);
+    EP_HOST_ASSERT(num_experts_per_rank > 0);
+
     // Update buffer attributes
     this->max_num_ranks = num_ranks;
     this->num_experts_per_rank = num_experts_per_rank;
@@ -175,7 +177,6 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
         *moe_recv_rdma_counter = -1;
     }
 
-    EP_HOST_ASSERT(num_experts_per_rank > 0);
     m_rdma_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_rdma_bytes));
     rdma_buffer_ptr = m_rdma_alloc->ptr();
     CUDA_CHECK(cudaMemset(rdma_buffer_ptr, 0, num_rdma_bytes));
@@ -188,7 +189,7 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     CUDA_CHECK(cudaMemset(mask_buffer_ptr + rank, 0, sizeof(int)));
     active_ranks.assign(max_num_ranks, false);
     active_ranks[rank] = true;
-    _refresh_active_rank_bound();
+    active_rank_bound = rank + 1;
 
     int num_sync_buffer_bytes = max_num_ranks * sizeof(int);
     m_sync_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_sync_buffer_bytes));
@@ -565,7 +566,6 @@ Buffer::get_dispatch_layout(const torch::Tensor& topk_idx, int num_experts,
 
     auto num_tokens = static_cast<int>(topk_idx.size(0)), num_topk = static_cast<int>(topk_idx.size(1));
     const int num_ranks = max_num_ranks;
-    EP_HOST_ASSERT(num_ranks > 0);
     auto num_tokens_per_rank = torch::empty({num_ranks}, dtype(torch::kInt32).device(torch::kCUDA));
     auto num_tokens_per_rdma_rank = std::optional<torch::Tensor>();
     auto num_tokens_per_expert = torch::empty({num_experts}, dtype(torch::kInt32).device(torch::kCUDA));
@@ -617,7 +617,6 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
                            int expert_alignment, const Config& config, std::optional<EventHandle>& previous_event, bool async, bool allocate_on_comm_stream) {
     EP_HOST_ASSERT(!low_latency_mode && "ht_dispatch() requires high-throughput mode (low_latency_mode=false)");
     const int num_ranks = max_num_ranks;
-    EP_HOST_ASSERT(num_ranks > 0);
     // In dispatch, CPU will busy-wait until GPU receive tensor size metadata from other ranks, which can be quite long.
     // If users of DeepEP need to execute other Python code on other threads, such as KV transfer, their code will get stuck due to GIL
     // unless we release GIL here.
@@ -900,7 +899,6 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
                           const Config& config, std::optional<EventHandle>& previous_event, bool async, bool allocate_on_comm_stream) {
     EP_HOST_ASSERT(!low_latency_mode && "ht_combine() requires high-throughput mode (low_latency_mode=false)");
     const int num_ranks = max_num_ranks;
-    EP_HOST_ASSERT(num_ranks > 0);
     const int num_channels = config.num_sms / 2;
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
 

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -83,15 +83,30 @@ Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int tim
             EP_HOST_ASSERT(timeout_ms >= 0);
             return static_cast<uint64_t>(timeout_ms);
         }()),
-        rank(rank), num_ranks(1),
+        rank(rank),
         explicitly_destroy(explicitly_destroy),
         comm_stream(at::cuda::getStreamFromPool(true)) {}
+
+bool Buffer::_is_rank_connected(int rank_id) const {
+    EP_HOST_ASSERT(rank_id >= 0 and rank_id < max_num_ranks);
+    return rank_id == rank or std::find(remote_ranks.begin(), remote_ranks.end(), rank_id) != remote_ranks.end();
+}
+
+void Buffer::_refresh_active_rank_bound() {
+    active_rank_bound = 0;
+    for (int rank_id = max_num_ranks - 1; rank_id >= 0; --rank_id) {
+        if (active_ranks[rank_id]) {
+            active_rank_bound = rank_id + 1;
+            break;
+        }
+    }
+}
 
 void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes, int64_t num_rdma_bytes)
 {
     // Update buffer attributes
     this->max_num_ranks = num_ranks;
-    this->max_experts_per_rank = num_experts_per_rank;
+    this->num_experts_per_rank = num_experts_per_rank;
     this->num_nvl_bytes = num_nvl_bytes;
     this->num_rdma_bytes = num_rdma_bytes;
 
@@ -160,7 +175,7 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
         *moe_recv_rdma_counter = -1;
     }
 
-    EP_HOST_ASSERT(max_experts_per_rank > 0);
+    EP_HOST_ASSERT(num_experts_per_rank > 0);
     m_rdma_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_rdma_bytes));
     rdma_buffer_ptr = m_rdma_alloc->ptr();
     CUDA_CHECK(cudaMemset(rdma_buffer_ptr, 0, num_rdma_bytes));
@@ -171,6 +186,9 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     mask_buffer_ptr = static_cast<int *>(m_mask_alloc->ptr());
     CUDA_CHECK(cudaMemset(mask_buffer_ptr, 0xff, num_mask_buffer_bytes));
     CUDA_CHECK(cudaMemset(mask_buffer_ptr + rank, 0, sizeof(int)));
+    active_ranks.assign(max_num_ranks, false);
+    active_ranks[rank] = true;
+    _refresh_active_rank_bound();
 
     int num_sync_buffer_bytes = max_num_ranks * sizeof(int);
     m_sync_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_sync_buffer_bytes));
@@ -217,7 +235,7 @@ bool Buffer::is_available() const {
 }
 
 bool Buffer::is_ht_available() const {
-    return is_available() and num_ranks > NUM_MAX_NVL_PEERS;
+    return is_available() and max_num_ranks > NUM_MAX_NVL_PEERS;
 }
 
 int Buffer::get_num_rdma_ranks() const {
@@ -451,21 +469,18 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
 
     std::vector<int> new_ranks;
     std::vector<nixl_blob_t> new_ranks_mds;
-    int max_added_rank = std::max(rank, *std::max_element(remote_ranks_list.begin(), remote_ranks_list.end()));
-    num_ranks = std::max(num_ranks, max_added_rank + 1);
 
     if (all_gathered_handles.size() > 0)
         _ipc_handles_sync(all_gathered_handles);
 
     for (size_t i = 0; i < remote_ranks_list.size(); i++) {
         int remote_rank = remote_ranks_list[i];
+        EP_HOST_ASSERT(remote_rank >= 0 and remote_rank < max_num_ranks);
         // Skip self and ranks we are already connected to
-        if (remote_rank == rank or std::find(remote_ranks.begin(), remote_ranks.end(), remote_rank) != remote_ranks.end())
+        if (remote_rank == rank or _is_rank_connected(remote_rank))
             continue;
 
         new_ranks.push_back(remote_rank);
-        int mask = activate ? 0 : 1;
-        CUDA_CHECK(cudaMemcpy(mask_buffer_ptr + remote_rank, &mask, sizeof(int), cudaMemcpyHostToDevice));
         CUDA_CHECK(cudaMemset(sync_count_ptr + remote_rank, 0, sizeof(int)));
         CUDA_CHECK(cudaMemset(sync_buffer_ptr + remote_rank, 0, sizeof(int)));
 
@@ -473,18 +488,24 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
             new_ranks_mds.push_back((*remote_mds)[i]);
     }
 
-    if (new_ranks.empty())
-        return;
+    if (!new_ranks.empty()) {
+        _nixl_agents_connect(new_ranks, new_ranks_mds);
 
-    _nixl_agents_connect(new_ranks, new_ranks_mds);
+        _nixl_agents_peer_info_gather(new_ranks);
 
-    _nixl_agents_peer_info_gather(new_ranks);
+        _nixl_ep_memory_views_destroy();
 
-    _nixl_ep_memory_views_destroy();
+        _nixl_ep_memory_views_create();
 
-    _nixl_ep_memory_views_create();
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
 
-    CUDA_CHECK(cudaDeviceSynchronize());
+    if (activate) {
+        for (int remote_rank : remote_ranks_list) {
+            if (remote_rank != rank)
+                update_mask_buffer(remote_rank, false);
+        }
+    }
 
     // Ready to use
     available = true;
@@ -498,6 +519,8 @@ void Buffer::disconnect_ranks(const std::vector<int>& remote_ranks_list) {
 
     // Update mask buffer to mark ranks as inactive
     for (int removed_rank : remote_ranks_list) {
+        EP_HOST_ASSERT(removed_rank != rank);
+        EP_HOST_ASSERT(_is_rank_connected(removed_rank));
         update_mask_buffer(removed_rank, true);  // mask=true
     }
 
@@ -514,13 +537,6 @@ void Buffer::disconnect_ranks(const std::vector<int>& remote_ranks_list) {
             remote_ranks.end()
         );
     }
-
-    int max_rank = rank;  // Include self
-    if (!remote_ranks.empty()) {
-        max_rank = std::max(max_rank,
-                           *std::max_element(remote_ranks.begin(), remote_ranks.end()));
-    }
-    num_ranks = max_rank + 1;  // Sparse indexing maintained
 
     _nixl_ep_memory_views_create();
 }
@@ -548,6 +564,8 @@ Buffer::get_dispatch_layout(const torch::Tensor& topk_idx, int num_experts,
     }
 
     auto num_tokens = static_cast<int>(topk_idx.size(0)), num_topk = static_cast<int>(topk_idx.size(1));
+    const int num_ranks = max_num_ranks;
+    EP_HOST_ASSERT(num_ranks > 0);
     auto num_tokens_per_rank = torch::empty({num_ranks}, dtype(torch::kInt32).device(torch::kCUDA));
     auto num_tokens_per_rdma_rank = std::optional<torch::Tensor>();
     auto num_tokens_per_expert = torch::empty({num_experts}, dtype(torch::kInt32).device(torch::kCUDA));
@@ -598,6 +616,8 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
                            const std::optional<torch::Tensor>& cached_gbl_channel_prefix_matrix, const std::optional<torch::Tensor>& cached_recv_gbl_rank_prefix_sum,
                            int expert_alignment, const Config& config, std::optional<EventHandle>& previous_event, bool async, bool allocate_on_comm_stream) {
     EP_HOST_ASSERT(!low_latency_mode && "ht_dispatch() requires high-throughput mode (low_latency_mode=false)");
+    const int num_ranks = max_num_ranks;
+    EP_HOST_ASSERT(num_ranks > 0);
     // In dispatch, CPU will busy-wait until GPU receive tensor size metadata from other ranks, which can be quite long.
     // If users of DeepEP need to execute other Python code on other threads, such as KV transfer, their code will get stuck due to GIL
     // unless we release GIL here.
@@ -879,6 +899,8 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
                           const torch::Tensor& combined_rdma_head, const torch::Tensor& combined_nvl_head,
                           const Config& config, std::optional<EventHandle>& previous_event, bool async, bool allocate_on_comm_stream) {
     EP_HOST_ASSERT(!low_latency_mode && "ht_combine() requires high-throughput mode (low_latency_mode=false)");
+    const int num_ranks = max_num_ranks;
+    EP_HOST_ASSERT(num_ranks > 0);
     const int num_channels = config.num_sms / 2;
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
 
@@ -1015,26 +1037,27 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
     EP_HOST_ASSERT(topk_idx.dim() == 2 and topk_idx.is_contiguous());
     EP_HOST_ASSERT(x.size(0) == topk_idx.size(0) and x.size(0) <= num_max_dispatch_tokens_per_rank);
     EP_HOST_ASSERT(topk_idx.scalar_type() == c10::CppTypeToScalarType<topk_idx_t>::value);
-    EP_HOST_ASSERT(num_experts % num_ranks == 0);
+    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
+    EP_HOST_ASSERT(active_rank_bound > 0);
+    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     // Diagnosis tensors
     if (cumulative_local_expert_recv_stats.has_value()) {
         EP_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
         EP_HOST_ASSERT(cumulative_local_expert_recv_stats->dim() == 1 and cumulative_local_expert_recv_stats->is_contiguous());
-        EP_HOST_ASSERT(cumulative_local_expert_recv_stats->size(0) == num_experts / num_ranks);
+        EP_HOST_ASSERT(cumulative_local_expert_recv_stats->size(0) == num_experts_per_rank);
     }
     if (dispatch_wait_recv_cost_stats.has_value()) {
         EP_HOST_ASSERT(dispatch_wait_recv_cost_stats->scalar_type() == torch::kInt64);
         EP_HOST_ASSERT(dispatch_wait_recv_cost_stats->dim() == 1 and dispatch_wait_recv_cost_stats->is_contiguous());
-        EP_HOST_ASSERT(dispatch_wait_recv_cost_stats->size(0) == num_ranks);
+        EP_HOST_ASSERT(dispatch_wait_recv_cost_stats->size(0) == active_rank_bound);
     }
 
     auto num_tokens = static_cast<int>(x.size(0)), hidden = static_cast<int>(x.size(1));
     auto num_topk = static_cast<int>(topk_idx.size(1));
-    int num_local_experts = num_experts / num_ranks;
 
     // Buffer control
-    int max_num_experts = max_num_ranks * max_experts_per_rank;
+    int max_num_experts = max_num_ranks * num_experts_per_rank;
     EPLayout layout(rdma_buffer_ptr, num_max_dispatch_tokens_per_rank, hidden, max_num_ranks, max_num_experts);
     EP_HOST_ASSERT(layout.total_bytes <= num_rdma_bytes);
     auto buffer = layout.buffers[buffer_idx];
@@ -1049,26 +1072,26 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
         stream_wait(launch_stream, compute_stream);
 
     // Allocate packed tensors
-    auto packed_recv_x = torch::empty({num_local_experts, num_ranks * num_max_dispatch_tokens_per_rank, hidden},
+    auto packed_recv_x = torch::empty({num_experts_per_rank, active_rank_bound * num_max_dispatch_tokens_per_rank, hidden},
                                       x.options().dtype(use_fp8 ? torch::kFloat8_e4m3fn: torch::kBFloat16));
-    auto packed_recv_src_info = torch::empty({num_local_experts, num_ranks * num_max_dispatch_tokens_per_rank}, torch::dtype(torch::kInt32).device(torch::kCUDA));
-    auto packed_recv_layout_range = torch::empty({num_local_experts, num_ranks}, torch::dtype(torch::kInt64).device(torch::kCUDA));
-    auto packed_recv_count = torch::empty({num_local_experts}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+    auto packed_recv_src_info = torch::empty({num_experts_per_rank, active_rank_bound * num_max_dispatch_tokens_per_rank}, torch::dtype(torch::kInt32).device(torch::kCUDA));
+    auto packed_recv_layout_range = torch::empty({num_experts_per_rank, active_rank_bound}, torch::dtype(torch::kInt64).device(torch::kCUDA));
+    auto packed_recv_count = torch::empty({num_experts_per_rank}, torch::dtype(torch::kInt32).device(torch::kCUDA));
 
     // Allocate column-majored scales
     auto packed_recv_x_scales = std::optional<torch::Tensor>();
     void* packed_recv_x_scales_ptr = nullptr;
-    EP_HOST_ASSERT((num_ranks * num_max_dispatch_tokens_per_rank) % 4 == 0 and "TMA requires the number of tokens to be multiple of 4");
+    EP_HOST_ASSERT((active_rank_bound * num_max_dispatch_tokens_per_rank) % 4 == 0 and "TMA requires the number of tokens to be multiple of 4");
 
     if (use_fp8) {
         // TODO: support unaligned cases
         EP_HOST_ASSERT(hidden % 512 == 0);
         if (not use_ue8m0) {
-            packed_recv_x_scales = torch::empty({num_local_experts, hidden / 128, num_ranks * num_max_dispatch_tokens_per_rank},
+            packed_recv_x_scales = torch::empty({num_experts_per_rank, hidden / 128, active_rank_bound * num_max_dispatch_tokens_per_rank},
                                                 torch::dtype(torch::kFloat32).device(torch::kCUDA));
         } else {
             EP_HOST_ASSERT(round_scale);
-            packed_recv_x_scales = torch::empty({num_local_experts, hidden / 512, num_ranks * num_max_dispatch_tokens_per_rank},
+            packed_recv_x_scales = torch::empty({num_experts_per_rank, hidden / 512, active_rank_bound * num_max_dispatch_tokens_per_rank},
                                                 torch::dtype(torch::kInt).device(torch::kCUDA));
         }
         packed_recv_x_scales = torch::transpose(packed_recv_x_scales.value(), 1, 2);
@@ -1089,7 +1112,7 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                               x.data_ptr(), topk_idx.data_ptr<topk_idx_t>(),
                                next_clean_meta.first, next_clean_meta.second,
                                num_tokens, hidden, num_max_dispatch_tokens_per_rank,
-                               num_topk, num_experts, rank, num_ranks,
+                               num_topk, active_rank_bound, num_experts_per_rank, rank,
                                use_fp8, round_scale, use_ue8m0,
                                timeout_cycles,
                                workspace, num_device_sms,
@@ -1124,10 +1147,14 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
                             bool use_logfmt, bool zero_copy, bool async, bool return_recv_hook,
                             const std::optional<torch::Tensor>& out) {
     EP_HOST_ASSERT(low_latency_mode && "combine() requires low-latency mode (low_latency_mode=true)");
+    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
+    EP_HOST_ASSERT(active_rank_bound > 0);
+    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
+
     // Tensor checks
     EP_HOST_ASSERT(x.dim() == 3 and x.is_contiguous() and x.scalar_type() == torch::kBFloat16);
-    EP_HOST_ASSERT(x.size(0) == num_experts / num_ranks);
-    EP_HOST_ASSERT(x.size(1) == num_ranks * num_max_dispatch_tokens_per_rank);
+    EP_HOST_ASSERT(x.size(0) == num_experts_per_rank);
+    EP_HOST_ASSERT(x.size(1) == active_rank_bound * num_max_dispatch_tokens_per_rank);
     EP_HOST_ASSERT(x.size(2) % sizeof(int4) == 0 and x.size(2) % 128 == 0);
     EP_HOST_ASSERT(topk_idx.dim() == 2 and topk_idx.is_contiguous());
     EP_HOST_ASSERT(topk_idx.size(0) == topk_weights.size(0) and topk_idx.size(1) == topk_weights.size(1));
@@ -1137,14 +1164,15 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
     EP_HOST_ASSERT(topk_weights.scalar_type() == torch::kFloat32);
     EP_HOST_ASSERT(src_info.dim() == 2 and src_info.is_contiguous());
     EP_HOST_ASSERT(src_info.scalar_type() == torch::kInt32 and x.size(0) == src_info.size(0));
+    EP_HOST_ASSERT(src_info.size(1) == active_rank_bound * num_max_dispatch_tokens_per_rank);
     EP_HOST_ASSERT(layout_range.dim() == 2 and layout_range.is_contiguous());
     EP_HOST_ASSERT(layout_range.scalar_type() == torch::kInt64);
-    EP_HOST_ASSERT(layout_range.size(0) == num_experts / num_ranks and layout_range.size(1) == num_ranks);
+    EP_HOST_ASSERT(layout_range.size(0) == num_experts_per_rank and layout_range.size(1) == active_rank_bound);
 
     if (combine_wait_recv_cost_stats.has_value()) {
         EP_HOST_ASSERT(combine_wait_recv_cost_stats->scalar_type() == torch::kInt64);
         EP_HOST_ASSERT(combine_wait_recv_cost_stats->dim() == 1 and combine_wait_recv_cost_stats->is_contiguous());
-        EP_HOST_ASSERT(combine_wait_recv_cost_stats->size(0) == num_ranks);
+        EP_HOST_ASSERT(combine_wait_recv_cost_stats->size(0) == active_rank_bound);
     }
 
     auto hidden = static_cast<int>(x.size(2));
@@ -1152,7 +1180,7 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
     auto num_combined_tokens = static_cast<int>(topk_weights.size(0));
 
     // Buffer control
-    int max_num_experts = max_num_ranks * max_experts_per_rank;
+    int max_num_experts = max_num_ranks * num_experts_per_rank;
     EPLayout layout(rdma_buffer_ptr, num_max_dispatch_tokens_per_rank, hidden, max_num_ranks, max_num_experts);
     EP_HOST_ASSERT(layout.total_bytes <= num_rdma_bytes);
     auto buffer = layout.buffers[buffer_idx];
@@ -1189,7 +1217,7 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
                               combine_wait_recv_cost_stats.has_value() ? combine_wait_recv_cost_stats->data_ptr<int64_t>() : nullptr,
                               next_clean_meta.first, next_clean_meta.second,
                               num_combined_tokens, hidden, num_max_dispatch_tokens_per_rank,
-                              num_topk, num_experts, rank, num_ranks,
+                              num_topk, active_rank_bound, num_experts_per_rank, rank,
                              use_logfmt, timeout_cycles,
                               workspace, num_device_sms,
                               launch_stream, phases, zero_copy, gpu_ctx_ptr);
@@ -1217,7 +1245,11 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
 
 torch::Tensor
 Buffer::get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden, int num_experts) const {
-    int max_num_experts = max_num_ranks * max_experts_per_rank;
+    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
+    EP_HOST_ASSERT(active_rank_bound > 0);
+    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
+
+    int max_num_experts = max_num_ranks * num_experts_per_rank;
     EPLayout layout(rdma_buffer_ptr, num_max_dispatch_tokens_per_rank, hidden, max_num_ranks, max_num_experts);
 
     auto buffer = layout.buffers[buffer_idx];
@@ -1226,8 +1258,8 @@ Buffer::get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden
 
     EP_HOST_ASSERT(buffer.num_bytes_per_combine_msg % elementSize(torch::kBFloat16) == 0);
     return torch::from_blob(buffer.combine_rdma_send_buffer_data_start,
-                            {num_experts / num_ranks, num_ranks * num_max_dispatch_tokens_per_rank, hidden},
-                            {num_ranks * num_max_dispatch_tokens_per_rank * num_msg_elems, num_msg_elems, 1},
+                            {num_experts_per_rank, active_rank_bound * num_max_dispatch_tokens_per_rank, hidden},
+                            {active_rank_bound * num_max_dispatch_tokens_per_rank * num_msg_elems, num_msg_elems, 1},
                             torch::TensorOptions().dtype(dtype).device(torch::kCUDA));
 }
 
@@ -1242,6 +1274,11 @@ bool is_sm90_compiled() {
 void Buffer::update_mask_buffer(int rank_to_mask, bool mask) {
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
     EP_HOST_ASSERT(rank_to_mask >= 0 and rank_to_mask < max_num_ranks);
+    EP_HOST_ASSERT((rank_to_mask != rank or !mask) && "cannot mask the local rank");
+    if (!mask)
+        EP_HOST_ASSERT(_is_rank_connected(rank_to_mask) && "cannot unmask an unconnected rank");
+    active_ranks[rank_to_mask] = !mask;
+    _refresh_active_rank_bound();
     ep_kernels::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, at::cuda::getCurrentCUDAStream());
 }
 
@@ -1256,7 +1293,16 @@ void Buffer::query_mask_buffer(const torch::Tensor& mask_status) {
 
 void Buffer::clean_mask_buffer() {
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
-    ep_kernels::clean_mask_buffer(mask_buffer_ptr, max_num_ranks, at::cuda::getCurrentCUDAStream());
+    std::vector<int> mask(max_num_ranks, 1);
+    for (int rank_id = 0; rank_id < max_num_ranks; ++rank_id) {
+        const bool active = _is_rank_connected(rank_id);
+        active_ranks[rank_id] = active;
+        mask[rank_id] = !active;
+    }
+    _refresh_active_rank_bound();
+    CUDA_CHECK(cudaMemcpyAsync(mask_buffer_ptr, mask.data(),
+                               max_num_ranks * sizeof(int), cudaMemcpyHostToDevice,
+                               at::cuda::getCurrentCUDAStream()));
 }
 
 std::string Buffer::get_local_metadata() const {
@@ -1289,7 +1335,7 @@ void Buffer::_nixl_ep_memory_views_create(void) {
         EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(remote_descs, gpu_ctx.remote_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
         EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(barrier_descs, gpu_ctx.barrier_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
 
-        if (!low_latency_mode && num_ranks > NUM_MAX_NVL_PEERS) {
+        if (!low_latency_mode && max_num_ranks > NUM_MAX_NVL_PEERS) {
             nixl_remote_dlist_t ht_barrier_descs(VRAM_SEG);
             for (int r = 0; r < max_num_ranks; r++) {
                 std::string remote_agent_name = remote_set.count(r) ? nixl_agent_info->remote_agent_names[r] : nixl_null_agent;
@@ -1404,7 +1450,7 @@ void Buffer::_nixl_agent_init() {
 void Buffer::_nixl_agents_disconnect(const std::vector<int>& ranks) {
     for (int remote_rank : ranks) {
         EP_HOST_ASSERT(remote_rank != rank);
-        EP_HOST_ASSERT(remote_rank < num_ranks);
+        EP_HOST_ASSERT(remote_rank >= 0 and remote_rank < max_num_ranks);
         nixl_xfer_dlist_t empty_descs(VRAM_SEG);
         if(nixl_agent_info->agent->checkRemoteMD(nixl_agent_info->remote_agent_names[remote_rank], empty_descs) == NIXL_SUCCESS) {
             nixl_status_t status = nixl_agent_info->agent->invalidateRemoteMD(nixl_agent_info->remote_agent_names[remote_rank]);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1030,7 +1030,7 @@ std::tuple<torch::Tensor, std::optional<torch::Tensor>, torch::Tensor, torch::Te
 Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                              const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
                              const std::optional<torch::Tensor>& dispatch_wait_recv_cost_stats,
-                             int num_max_dispatch_tokens_per_rank, int num_experts,
+                             int num_max_dispatch_tokens_per_rank,
                              bool use_fp8, bool round_scale, bool use_ue8m0,
                              bool async, bool return_recv_hook) {
     EP_HOST_ASSERT(low_latency_mode && "dispatch() requires low-latency mode (low_latency_mode=true)");
@@ -1041,8 +1041,6 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
     EP_HOST_ASSERT(topk_idx.dim() == 2 and topk_idx.is_contiguous());
     EP_HOST_ASSERT(x.size(0) == topk_idx.size(0) and x.size(0) <= num_max_dispatch_tokens_per_rank);
     EP_HOST_ASSERT(topk_idx.scalar_type() == c10::CppTypeToScalarType<topk_idx_t>::value);
-    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     // Diagnosis tensors
     if (cumulative_local_expert_recv_stats.has_value()) {
@@ -1146,12 +1144,10 @@ std::tuple<torch::Tensor, std::optional<EventHandle>, std::optional<std::functio
 Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
                             const torch::Tensor& src_info, const torch::Tensor& layout_range,
                             const std::optional<torch::Tensor>& combine_wait_recv_cost_stats,
-                            int num_max_dispatch_tokens_per_rank, int num_experts,
+                            int num_max_dispatch_tokens_per_rank,
                             bool use_logfmt, bool zero_copy, bool async, bool return_recv_hook,
                             const std::optional<torch::Tensor>& out) {
     EP_HOST_ASSERT(low_latency_mode && "combine() requires low-latency mode (low_latency_mode=true)");
-    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     // Tensor checks
     EP_HOST_ASSERT(x.dim() == 3 and x.is_contiguous() and x.scalar_type() == torch::kBFloat16);
@@ -1246,10 +1242,7 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
 }
 
 torch::Tensor
-Buffer::get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden, int num_experts) const {
-    const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
-
+Buffer::get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden) const {
     int max_num_experts = max_num_ranks * num_experts_per_rank;
     EPLayout layout(rdma_buffer_ptr, num_max_dispatch_tokens_per_rank, hidden, max_num_ranks, max_num_experts);
 

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -91,14 +91,20 @@ bool Buffer::_is_rank_connected(int rank_id) const {
     return rank_id == rank or std::find(remote_ranks.begin(), remote_ranks.end(), rank_id) != remote_ranks.end();
 }
 
+void Buffer::set_active_rank_bound(int bound) {
+    EP_HOST_ASSERT(bound > 0 && "active_rank_bound must be positive");
+    active_rank_bound = bound;
+}
+
 void Buffer::_refresh_active_rank_bound() {
-    active_rank_bound = 0;
+    int bound = 0;
     for (int rank_id = max_num_ranks - 1; rank_id >= 0; --rank_id) {
         if (active_ranks[rank_id]) {
-            active_rank_bound = rank_id + 1;
+            bound = rank_id + 1;
             break;
         }
     }
+    set_active_rank_bound(bound);
 }
 
 void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes, int64_t num_rdma_bytes)
@@ -189,7 +195,7 @@ void Buffer::init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes
     CUDA_CHECK(cudaMemset(mask_buffer_ptr + rank, 0, sizeof(int)));
     active_ranks.assign(max_num_ranks, false);
     active_ranks[rank] = true;
-    active_rank_bound = rank + 1;
+    set_active_rank_bound(rank + 1);
 
     int num_sync_buffer_bytes = max_num_ranks * sizeof(int);
     m_sync_alloc = std::make_unique<vmm_region>(static_cast<size_t>(num_sync_buffer_bytes));
@@ -1036,7 +1042,6 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
     EP_HOST_ASSERT(x.size(0) == topk_idx.size(0) and x.size(0) <= num_max_dispatch_tokens_per_rank);
     EP_HOST_ASSERT(topk_idx.scalar_type() == c10::CppTypeToScalarType<topk_idx_t>::value);
     const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(active_rank_bound > 0);
     EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     // Diagnosis tensors
@@ -1146,7 +1151,6 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
                             const std::optional<torch::Tensor>& out) {
     EP_HOST_ASSERT(low_latency_mode && "combine() requires low-latency mode (low_latency_mode=true)");
     const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(active_rank_bound > 0);
     EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     // Tensor checks
@@ -1244,7 +1248,6 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
 torch::Tensor
 Buffer::get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden, int num_experts) const {
     const int active_expert_bound = active_rank_bound * num_experts_per_rank;
-    EP_HOST_ASSERT(active_rank_bound > 0);
     EP_HOST_ASSERT(num_experts == active_expert_bound && "num_experts must equal active_rank_bound * num_experts_per_rank");
 
     int max_num_experts = max_num_ranks * num_experts_per_rank;

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -173,6 +173,7 @@ private:
     void _nixl_ep_memory_views_destroy(void);
     void _nixl_ep_destroy(void);
     bool _is_rank_connected(int rank_id) const;
+    void set_active_rank_bound(int bound);
     void _refresh_active_rank_bound();
 
     /* high-throughput mode private funcs */

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -110,8 +110,17 @@ private:
     int num_device_sms;
     uint64_t timeout_cycles = 0;
     int rank, rdma_rank, nvl_rank;
-    int num_ranks, num_rdma_ranks, num_nvl_ranks;
+    int max_num_ranks;
     std::vector<int> remote_ranks; /* global ranks */
+    // Host-side active rank state over max_num_ranks. This can differ from
+    // the runtime device mask, which kernels may update on faults/timeouts.
+    // Host state changes only through explicit control APIs.
+    std::vector<bool> active_ranks;
+    // Upper bound for active rank ids. Ranks may be sparse;
+    // masked holes inside [0, active_rank_bound) are skipped by LL kernels.
+    int active_rank_bound = 0;
+    int num_rdma_ranks = 0, num_nvl_ranks = 0;
+    int num_experts_per_rank = 0;
     cudaIpcMemHandle_t ipc_handles[NUM_MAX_NVL_PEERS];
 
     // Stream for communication
@@ -147,8 +156,6 @@ private:
     std::unique_ptr<NixlAgentInfo> nixl_agent_info;
     std::vector<NixlPeerInfo> nixl_peer_info;
     NixlPeerInfo my_peer_info;
-    int max_num_ranks;
-    int max_experts_per_rank;
     nixl_ep::gpu_nixl_ctx gpu_ctx;
     nixl_ep::gpu_nixl_ctx* gpu_ctx_ptr = nullptr;
     uint64_t* last_ht_barrier_counter = nullptr;
@@ -165,6 +172,8 @@ private:
     void _nixl_ep_memory_views_create(void);
     void _nixl_ep_memory_views_destroy(void);
     void _nixl_ep_destroy(void);
+    bool _is_rank_connected(int rank_id) const;
+    void _refresh_active_rank_bound();
 
     /* high-throughput mode private funcs */
     void _ipc_handles_sync(const std::vector<std::optional<pybind11::bytearray>> &all_gathered_handles);
@@ -172,13 +181,13 @@ private:
 public:
     Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int timeout_ms);
 
-    void update_memory_buffers(int num_ranks, int max_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes = 0);
+    void update_memory_buffers(int num_ranks, int num_experts_per_rank, int64_t num_rdma_bytes, int64_t num_nvl_bytes = 0);
 
     void connect_ranks(const std::vector<int>& remote_ranks_list, const std::optional<std::vector<nixl_blob_t>>& remote_mds = std::nullopt, const std::vector<std::optional<pybind11::bytearray>>& all_gathered_handles = {}, bool activate = true);
 
     void disconnect_ranks(const std::vector<int>& remote_ranks_list);
 
-    void init(int num_ranks, int max_experts_per_rank, int64_t num_nvl_bytes, int64_t num_rdma_bytes);
+    void init(int num_ranks, int num_experts_per_rank, int64_t num_nvl_bytes, int64_t num_rdma_bytes);
 
     ~Buffer() noexcept;
 

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -239,7 +239,7 @@ public:
     dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
                          const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
                          const std::optional<torch::Tensor>& dispatch_wait_recv_cost_stats,
-                         int num_max_dispatch_tokens_per_rank, int num_experts,
+                         int num_max_dispatch_tokens_per_rank,
                          bool use_fp8, bool round_scale, bool use_ue8m0,
                          bool async, bool return_recv_hook);
 
@@ -247,14 +247,14 @@ public:
     combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const torch::Tensor& topk_weights,
                         const torch::Tensor& src_info, const torch::Tensor& layout_range,
                         const std::optional<torch::Tensor>& combine_wait_recv_cost_stats,
-                        int num_max_dispatch_tokens_per_rank, int num_experts,
+                        int num_max_dispatch_tokens_per_rank,
                         bool use_logfmt, bool zero_copy, bool async, bool return_recv_hook,
                         const std::optional<torch::Tensor>& out = std::nullopt);
 
     void barrier();
 
     torch::Tensor
-    get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden, int num_experts) const;
+    get_next_combine_buffer(int num_max_dispatch_tokens_per_rank, int hidden) const;
 
     void update_mask_buffer(int rank_to_mask, bool mask);
 

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -148,8 +148,8 @@ class Buffer:
         Arguments:
             num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
             hidden: the hidden dimension of each token.
-            num_ranks: the number of EP group ranks.
-            num_experts: the number of all experts.
+            num_ranks: rank capacity used to size the low-latency buffers.
+            num_experts: expert capacity, normally num_ranks * num_experts_per_rank.
 
         Returns:
             size: the RDMA buffer size recommended.
@@ -290,7 +290,7 @@ class Buffer:
         Arguments:
             topk_idx: `[num_tokens, num_topk]`, dtype must be `torch.int64`, the expert indices selected by each token,
                 `-1` means no selections.
-            num_experts: the number of experts.
+            num_experts: active expert bound for the active rank set.
             previous_event: the event to wait before actually executing the kernel.
             async_finish: the current stream will not wait for the communication kernels to be finished if set.
             allocate_on_comm_stream: control whether all the allocated tensors' ownership to be on the communication stream.
@@ -353,7 +353,7 @@ class Buffer:
             topk_idx: `torch.Tensor` with `nixl_ep.topk_idx_t`, shaped as `[num_tokens, num_topk]`, only several top-k shapes
                 are supported. `-1` indices (not selecting any expert) are supported.
             num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
-            num_experts: the number of all experts.
+            num_experts: active expert bound for the active rank set.
             cumulative_local_expert_recv_stats: a cumulative expert count tensor for statistics, which should have shape
                 `[num_local_experts]` and be typed as `torch.int`. This is useful for online service EP load balance
                 monitoring.
@@ -714,17 +714,18 @@ class Buffer:
 
     def update_mask_buffer(self, rank_to_mask: int, mask: bool = False):
         """
-        Mask (unmask) a rank during communication (dispatch, combine, and clean)
+        Mask or unmask a rank during low-latency communication.
 
         Arguments:
             rank: the rank to mask (unmask).
             mask: if True, will mask the rank (do not recvfrom/sendto the rank), otherwise will unmask the rank.
+                The local rank cannot be masked.
         """
         self.runtime.update_mask_buffer(rank_to_mask, mask)
 
     def query_mask_buffer(self, mask_status: torch.Tensor):
         """
-        Query the mask status of all ranks
+        Query the runtime device mask status of all ranks.
 
         Arguments:
             mask_status: `[num_ranks]` with `torch.int`, the mask status of each rank. `1` means mask and `0` means unmasked.
@@ -733,8 +734,7 @@ class Buffer:
 
     def clean_mask_buffer(self):
         """
-        Clean the mask buffer
-
+        Unmask connected ranks plus the local rank, and mask unconnected ranks.
         """
         self.runtime.clean_mask_buffer()
 
@@ -774,7 +774,7 @@ class Buffer:
         Allocate remote memory for the communication buffer.
 
         Arguments:
-            num_ranks: the number of ranks.
+            num_ranks: rank capacity used to size the communication buffers.
             num_experts_per_rank: the number of experts per rank.
             num_rdma_bytes: the buffer size for RDMA communication.
             num_nvl_bytes: the buffer size for intranode NVLink communication (default: 0).

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -330,7 +330,7 @@ class Buffer:
         x: torch.Tensor,
         topk_idx: torch.Tensor,
         num_max_dispatch_tokens_per_rank: int,
-        num_experts: int,
+        num_experts: Optional[int] = None,
         cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
         dispatch_wait_recv_cost_stats: Optional[torch.Tensor] = None,
         use_fp8: bool = True,
@@ -353,7 +353,9 @@ class Buffer:
             topk_idx: `torch.Tensor` with `nixl_ep.topk_idx_t`, shaped as `[num_tokens, num_topk]`, only several top-k shapes
                 are supported. `-1` indices (not selecting any expert) are supported.
             num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
-            num_experts: active expert bound for the active rank set.
+            num_experts: deprecated optional parameter. This value is ignored by low-latency
+                dispatch; the number of experts is determined from the `num_experts_per_rank`
+                passed to `update_memory_buffers()` and the currently active ranks.
             cumulative_local_expert_recv_stats: a cumulative expert count tensor for statistics, which should have shape
                 `[num_local_experts]` and be typed as `torch.int`. This is useful for online service EP load balance
                 monitoring.
@@ -401,7 +403,6 @@ class Buffer:
             cumulative_local_expert_recv_stats,
             dispatch_wait_recv_cost_stats,
             num_max_dispatch_tokens_per_rank,
-            num_experts,
             use_fp8,
             round_scale,
             use_ue8m0,
@@ -413,7 +414,6 @@ class Buffer:
             packed_recv_layout_range,
             num_max_dispatch_tokens_per_rank,
             x.size(1),
-            num_experts,
         )
         tensors_to_record = (
             x,
@@ -487,7 +487,6 @@ class Buffer:
             layout_range,
             num_max_dispatch_tokens_per_rank,
             hidden,
-            num_experts,
         ) = handle
         combined_x, event, hook = self.runtime.combine(
             x,
@@ -497,7 +496,6 @@ class Buffer:
             layout_range,
             combine_wait_recv_cost_stats,
             num_max_dispatch_tokens_per_rank,
-            num_experts,
             use_logfmt,
             zero_copy,
             async_finish,
@@ -740,7 +738,7 @@ class Buffer:
         self.runtime.clean_mask_buffer()
 
     def get_next_combine_buffer(
-        self, handle: Tuple[torch.Tensor, torch.Tensor, int, int, int]
+        self, handle: Tuple[torch.Tensor, torch.Tensor, int, int]
     ):
         """
         Get the raw registered RDMA buffer tensor for next combine, so that the next combine kernel can skip the copying.
@@ -758,10 +756,9 @@ class Buffer:
             layout_range,
             num_max_dispatch_tokens_per_rank,
             hidden,
-            num_experts,
         ) = handle
         return self.runtime.get_next_combine_buffer(
-            num_max_dispatch_tokens_per_rank, hidden, num_experts
+            num_max_dispatch_tokens_per_rank, hidden
         )
 
     def update_memory_buffers(

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -717,9 +717,10 @@ class Buffer:
         Mask or unmask a rank during low-latency communication.
 
         Arguments:
-            rank: the rank to mask (unmask).
-            mask: if True, will mask the rank (do not recvfrom/sendto the rank), otherwise will unmask the rank.
-                The local rank cannot be masked.
+            rank_to_mask: the rank to mask or unmask.
+            mask: if True, will mask the rank (do not recvfrom/sendto the
+                rank), otherwise will unmask the rank. The local rank cannot
+                be masked, and unmasking requires an already-connected rank.
         """
         self.runtime.update_mask_buffer(rank_to_mask, mask)
 


### PR DESCRIPTION
num_ranks/num_experts had mixed meanings across different contexts. Replace them with explicit fields that have well-defined meanings:
  - `max_num_ranks`: Preallocated rank capacity
  - `remote_ranks`: Array of connected ranks
  - `active_ranks`: Array of explicitly activated ranks (via `connect_ranks(..., activate=True)` or `update_mask_buffer`)
  - `active_rank_bound`: max(active_ranks) + 1
  - `num_experts_per_rank`: static number of physical experts per rank

Additionally, make `connect_ranks(..., activate=False)` establish connections without changing `active_ranks` or `active_rank_bound` (instead of wrongly modifying `num_ranks` earlier)

Tested thoroughly with both `elastic.py` and vLLM EEP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public mask-update capability and host-side tracking of active ranks for elastic rank handling.

* **API Changes**
  * Dispatch/combine now accept an active-rank bound + experts-per-rank parameterization; internal buffer/layouts updated to use the active-range model.

* **Deprecations**
  * Removed the legacy mask-clean API.

* **Documentation**
  * Clarified buffer sizing, rank-capacity semantics, and mask behavior in docstrings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->