### PR TITLE
fix(posix): surface and recover from short writes in all io queues

### DIFF
--- a/src/plugins/posix/io_queue.h
+++ b/src/plugins/posix/io_queue.h
@@ -51,6 +51,10 @@ public:
     post(void) = 0;
     virtual nixl_status_t
     poll(void) = 0;
+    // Abort the ios owned by ctx without waiting on the kernel. Scoped to ctx so
+    // other transfers sharing this queue keep running.
+    virtual nixl_status_t
+    cancel(void *ctx) = 0;
 
     static std::unique_ptr<nixlPosixIOQueue>
     instantiate(std::string_view io_queue_type, uint32_t ios_pool_size, uint32_t kernel_queue_size);
@@ -86,6 +90,25 @@ public:
         for (uint32_t i = 0; i < ios_pool_size; i++) {
             free_ios_.push_back(&ios_[i]);
         }
+    }
+
+    // Drop ctx's un-submitted ios (firing their callback with an error so the owner
+    // still accounts for them). io_uring overrides to also abort in-flight ios.
+    nixl_status_t
+    cancel(void *ctx) override {
+        for (auto it = ios_to_submit_.begin(); it != ios_to_submit_.end();) {
+            Entry *io = *it;
+            if (io->ctx_ == ctx) {
+                if (io->clb_) {
+                    io->clb_(io->ctx_, 0, 1);
+                }
+                it = ios_to_submit_.erase(it);
+                free_ios_.push_back(io);
+            } else {
+                ++it;
+            }
+        }
+        return NIXL_SUCCESS;
     }
 
 protected:

--- a/src/plugins/posix/io_uring_io_queue.cpp
+++ b/src/plugins/posix/io_uring_io_queue.cpp
@@ -117,14 +117,15 @@ nixlPosixIOQueueUring::doCheckCompleted(void) {
     io_uring_for_each_cqe(&uring, head, cqe) {
         int res = cqe->res;
         nixlPosixIoUringIO *io = reinterpret_cast<nixlPosixIoUringIO *>(io_uring_cqe_get_data(cqe));
+        int error = (res < 0 || static_cast<size_t>(res) != io->len_);
+        if (error) {
+            NIXL_ERROR << absl::StrFormat(
+                "IO operation incomplete: result %d, expected %zu", res, io->len_);
+        }
         if (io->clb_) {
-            io->clb_(io->ctx_, res, 0);
+            io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(res), error);
         }
         free_ios_.push_back(io);
-        if (res < 0) {
-            NIXL_ERROR << absl::StrFormat("IO operation failed: %s", nixl_strerror(-res));
-            return NIXL_ERR_BACKEND;
-        }
         count++;
         if (count == MAX_IO_CHECK_COMPLETED_BATCH_SIZE) {
             break;

--- a/src/plugins/posix/io_uring_io_queue.cpp
+++ b/src/plugins/posix/io_uring_io_queue.cpp
@@ -33,6 +33,7 @@ public:
     nixlPosixIOQueueDoneCb clb_;
     void *ctx_;
     struct io_uring_sqe *sqe_;
+    bool in_flight_; // submitted to the kernel, not yet reaped (scopes cancel)
 };
 
 class nixlPosixIOQueueUring : public nixlPosixIOQueueImpl<nixlPosixIoUringIO> {
@@ -51,6 +52,8 @@ public:
             void *ctx) override;
     virtual nixl_status_t
     poll(void) override;
+    virtual nixl_status_t
+    cancel(void *ctx) override;
     virtual ~nixlPosixIOQueueUring() override;
 
 protected:
@@ -98,6 +101,7 @@ nixlPosixIOQueueUring::post(void) {
         }
 
         io_uring_sqe_set_data(sqe, io);
+        io->in_flight_ = true;
     }
 
     int ret = io_uring_submit(&uring);
@@ -117,14 +121,24 @@ nixlPosixIOQueueUring::doCheckCompleted(void) {
     io_uring_for_each_cqe(&uring, head, cqe) {
         int res = cqe->res;
         nixlPosixIoUringIO *io = reinterpret_cast<nixlPosixIoUringIO *>(io_uring_cqe_get_data(cqe));
+        // cancel SQEs carry a null sentinel user_data; reap the completion but
+        // do not treat it as an io.
+        if (!io) {
+            count++;
+            if (count == MAX_IO_CHECK_COMPLETED_BATCH_SIZE) {
+                break;
+            }
+            continue;
+        }
         int error = (res < 0 || static_cast<size_t>(res) != io->len_);
         if (error) {
-            NIXL_ERROR << absl::StrFormat(
+            NIXL_DEBUG << absl::StrFormat(
                 "IO operation incomplete: result %d, expected %zu", res, io->len_);
         }
         if (io->clb_) {
             io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(res), error);
         }
+        io->in_flight_ = false;
         free_ios_.push_back(io);
         count++;
         if (count == MAX_IO_CHECK_COMPLETED_BATCH_SIZE) {
@@ -164,6 +178,7 @@ nixlPosixIOQueueUring::enqueue(int fd,
     io->read_ = read;
     io->clb_ = clb;
     io->ctx_ = ctx;
+    io->in_flight_ = false;
 
     ios_to_submit_.push_back(io);
 
@@ -178,6 +193,31 @@ nixlPosixIOQueueUring::poll(void) {
     }
 
     return doCheckCompleted();
+}
+
+nixl_status_t
+nixlPosixIOQueueUring::cancel(void *ctx) {
+    // drop this transfer's un-submitted ios
+    nixlPosixIOQueueImpl<nixlPosixIoUringIO>::cancel(ctx);
+
+    // best-effort: cancel this transfer's in-flight ios. The cancel SQE carries a null
+    // sentinel (skipped in doCheckCompleted); the target io completes and is reaped normally.
+    bool submit_cancels = false;
+    for (auto &io : ios_) {
+        if (io.in_flight_ && io.ctx_ == ctx) {
+            struct io_uring_sqe *sqe = io_uring_get_sqe(&uring);
+            if (!sqe) {
+                break; // SQ full; the remaining in-flight ios drain on their own
+            }
+            io_uring_prep_cancel(sqe, &io, 0);
+            io_uring_sqe_set_data(sqe, nullptr);
+            submit_cancels = true;
+        }
+    }
+    if (submit_cancels) {
+        io_uring_submit(&uring);
+    }
+    return NIXL_SUCCESS;
 }
 
 nixlPosixIOQueueUring::~nixlPosixIOQueueUring() {

--- a/src/plugins/posix/linux_aio_io_queue.cpp
+++ b/src/plugins/posix/linux_aio_io_queue.cpp
@@ -160,15 +160,17 @@ nixlPosixIOQueueLinuxAIO::doCheckCompleted(void) {
         struct iocb *iocb = events[i].obj;
         nixlPosixLinuxAioIO *io = (nixlPosixLinuxAioIO *)iocb->data;
 
-        if (events[i].res < 0) {
-            NIXL_ERROR << "AIO operation failed: " << events[i].res;
-            return NIXL_ERR_BACKEND;
+        // io_event.res is unsigned long: read as signed to catch a negative errno;
+        // a short completion (res != len) is a fault too.
+        long res = static_cast<long>(events[i].res);
+        const int error = (res < 0 || static_cast<unsigned long>(res) != iocb->u.c.nbytes);
+        if (error) {
+            NIXL_ERROR << absl::StrFormat(
+                "AIO operation incomplete: result %ld, expected %lu", res, iocb->u.c.nbytes);
         }
-
         if (io->clb_) {
-            io->clb_(io->ctx_, events[i].res, 0);
+            io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(res), error);
         }
-
         completed_ios.push_back(io);
     }
 

--- a/src/plugins/posix/linux_aio_io_queue.cpp
+++ b/src/plugins/posix/linux_aio_io_queue.cpp
@@ -165,7 +165,7 @@ nixlPosixIOQueueLinuxAIO::doCheckCompleted(void) {
         long res = static_cast<long>(events[i].res);
         const int error = (res < 0 || static_cast<unsigned long>(res) != iocb->u.c.nbytes);
         if (error) {
-            NIXL_ERROR << absl::StrFormat(
+            NIXL_DEBUG << absl::StrFormat(
                 "AIO operation incomplete: result %ld, expected %lu", res, iocb->u.c.nbytes);
         }
         if (io->clb_) {

--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -131,35 +131,33 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
     }
 
     int num_ios = std::min(MAX_IO_CHECK_COMPLETED_BATCH_SIZE, (int)ios_in_flight_.size());
-    for (auto it = ios_in_flight_.begin(); it != ios_in_flight_.end();) {
+    for (auto it = ios_in_flight_.begin(); it != ios_in_flight_.end() && num_ios > 0;) {
         nixlPosixAioIO *io = *it;
         int status = aio_error(&io->aio_);
-        if (status == 0) {
-            ssize_t ret = aio_return(&io->aio_);
-            if (ret < 0 || ret != static_cast<ssize_t>(io->aio_.aio_nbytes)) {
-                NIXL_ERROR << "aio_return failed: " << nixl_strerror(-ret);
-                ios_in_flight_.push_front(io);
-                return NIXL_ERR_BACKEND;
-            }
-            if (io->clb_) {
-                io->clb_(io->ctx_, ret, 0);
-            }
-            it = ios_in_flight_.erase(it);
-            free_ios_.push_back(io);
-        } else if (status == EINPROGRESS) {
-            return NIXL_IN_PROG;
-        } else {
+        if (status == EINPROGRESS) {
+            ++it; // still pending; check the rest of the batch
+            continue;
+        }
+
+        int error;
+        ssize_t ret = 0;
+        if (status != 0) {
             NIXL_ERROR << "aio_error failed: " << nixl_strerror(-status);
-            ios_in_flight_.push_front(io);
-            return NIXL_ERR_BACKEND;
+            error = 1;
+        } else {
+            ret = aio_return(&io->aio_);
+            error = (ret < 0 || ret != static_cast<ssize_t>(io->aio_.aio_nbytes));
+            if (error) {
+                NIXL_ERROR << "aio_return incomplete: " << ret << " expected "
+                           << io->aio_.aio_nbytes;
+            }
         }
-
-        it++;
-
+        if (io->clb_) {
+            io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(ret), error);
+        }
+        it = ios_in_flight_.erase(it);
+        free_ios_.push_back(io);
         num_ios--;
-        if (num_ios == 0) {
-            break;
-        }
     }
 
     return ios_in_flight_.empty() ? NIXL_SUCCESS : NIXL_IN_PROG;

--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -142,13 +142,13 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
         int error;
         ssize_t ret = 0;
         if (status != 0) {
-            NIXL_ERROR << "aio_error failed: " << nixl_strerror(-status);
+            NIXL_DEBUG << "aio_error failed: " << nixl_strerror(-status);
             error = 1;
         } else {
             ret = aio_return(&io->aio_);
             error = (ret < 0 || ret != static_cast<ssize_t>(io->aio_.aio_nbytes));
             if (error) {
-                NIXL_ERROR << "aio_return incomplete: " << ret << " expected "
+                NIXL_DEBUG << "aio_return incomplete: " << ret << " expected "
                            << io->aio_.aio_nbytes;
             }
         }

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -130,6 +130,7 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
       remote(rem),
       queue_depth_(loc.descCount()),
       num_confirmed_ios_(queue_depth_),
+      any_failed_(false),
       io_queue_(io_queue) {
     NIXL_ASSERT(local.descCount());
     NIXL_ASSERT(remote.descCount());
@@ -138,6 +139,9 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
 void
 nixlPosixBackendReqH::ioDone(uint32_t data_size, int error) {
     num_confirmed_ios_++;
+    if (error) {
+        any_failed_ = true;
+    }
     logOnPercentStep(num_confirmed_ios_, queue_depth_);
 }
 
@@ -154,8 +158,9 @@ nixlPosixBackendReqH::prepXfer() {
 
 nixl_status_t
 nixlPosixBackendReqH::checkXfer() {
+    // report the verdict only after all ios drain, so a partial fault leaves no stale state
     if (num_confirmed_ios_ == queue_depth_) {
-        return NIXL_SUCCESS;
+        return any_failed_ ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
     }
 
     nixl_status_t status = io_queue_->poll();
@@ -174,6 +179,7 @@ nixlPosixBackendReqH::postXfer() {
     }
 
     num_confirmed_ios_ = 0;
+    any_failed_ = false;
 
     for (auto [local_it, remote_it] = std::make_pair(local.begin(), remote.begin());
          local_it != local.end() && remote_it != remote.end();

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -131,6 +131,7 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
       queue_depth_(loc.descCount()),
       num_confirmed_ios_(queue_depth_),
       any_failed_(false),
+      cancel_requested_(false),
       io_queue_(io_queue) {
     NIXL_ASSERT(local.descCount());
     NIXL_ASSERT(remote.descCount());
@@ -139,7 +140,8 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
 void
 nixlPosixBackendReqH::ioDone(uint32_t data_size, int error) {
     num_confirmed_ios_++;
-    if (error) {
+    if (error && !any_failed_) {
+        NIXL_ERROR << "POSIX transfer failed: an io completed short or with an error";
         any_failed_ = true;
     }
     logOnPercentStep(num_confirmed_ios_, queue_depth_);
@@ -158,7 +160,8 @@ nixlPosixBackendReqH::prepXfer() {
 
 nixl_status_t
 nixlPosixBackendReqH::checkXfer() {
-    // report the verdict only after all ios drain, so a partial fault leaves no stale state
+    // report the verdict only after all ios drain, so terminal status means the
+    // kernel is done with the buffers/fds (safe for reads and writes)
     if (num_confirmed_ios_ == queue_depth_) {
         return any_failed_ ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
     }
@@ -166,6 +169,17 @@ nixlPosixBackendReqH::checkXfer() {
     nixl_status_t status = io_queue_->poll();
     if (status < 0) {
         return status;
+    }
+
+    // on the first failure, abort without waiting: drop un-submitted ios and cancel
+    // in-flight ios where the backend supports it. Done once per transfer.
+    if (any_failed_ && !cancel_requested_) {
+        cancel_requested_ = true;
+        io_queue_->cancel(this);
+    }
+
+    if (num_confirmed_ios_ == queue_depth_) {
+        return any_failed_ ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
     }
 
     return NIXL_IN_PROG;
@@ -180,6 +194,7 @@ nixlPosixBackendReqH::postXfer() {
 
     num_confirmed_ios_ = 0;
     any_failed_ = false;
+    cancel_requested_ = false;
 
     for (auto [local_it, remote_it] = std::make_pair(local.begin(), remote.begin());
          local_it != local.end() && remote_it != remote.end();

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -39,6 +39,7 @@ private:
     const nixl_meta_dlist_t &remote; // Remote memory descriptor list
     const int queue_depth_; // Queue depth for async I/O
     int num_confirmed_ios_; // Number of confirmed IOs
+    bool any_failed_; // Set if any io of the current transfer failed
     std::unique_ptr<nixlPosixIOQueue> &io_queue_; // Async I/O queue instance
 
     void

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -40,6 +40,7 @@ private:
     const int queue_depth_; // Queue depth for async I/O
     int num_confirmed_ios_; // Number of confirmed IOs
     bool any_failed_; // Set if any io of the current transfer failed
+    bool cancel_requested_; // Set once cancel() has been issued for this transfer
     std::unique_ptr<nixlPosixIOQueue> &io_queue_; // Async I/O queue instance
 
     void

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -35,6 +35,8 @@
 #include <cstdio>
 #include <getopt.h>
 #include <csignal>
+#include <chrono>
+#include <thread>
 #include <sys/resource.h>
 
 namespace {
@@ -1127,6 +1129,195 @@ short_write_case(const std::string &test_files_dir_path_abs_path,
     return rc;
 }
 
+// Two transfers share one backend's io queue. A (ios exceed the file-size cap) must
+// fail; B (a large, valid write) must still succeed. A scoped cancel of A's ios must
+// not disturb B's un-submitted ios.
+int
+concurrent_cancel_scoping_case(const std::string &dir,
+                               const std::string &queue,
+                               const std::string &param_key) {
+    print_segment_title(phase_title(absl::StrFormat("Cancel scoping: %s", queue)));
+
+    // paired with the 20us poll_pause below: ~3s backstop before declaring a stall
+    constexpr int max_poll_iters = 150000;
+    const size_t cap = 2 * page_size;
+    const size_t a_size = 4 * page_size; // > cap -> short write, A fails
+    const size_t b_size = page_size; // <= cap -> B succeeds
+    const int a_desc = 4;
+    const int b_desc = 512; // large: leaves un-submitted ios when A's cancel fires
+
+    nixl_b_params_t params;
+    params[param_key] = "true";
+
+    nixlAgentConfig cfg(false);
+    nixlAgent agent("POSIXScopingTester", cfg);
+    nixlBackendH *posix = nullptr;
+    if (agent.createBackend("POSIX", params, posix) != NIXL_SUCCESS) {
+        std::cout << queue << ": backend unavailable, skipping" << std::endl;
+        return -1;
+    }
+
+    tempFile fd_a(dir + "/scope_a_" + queue + "_" + test_file_name, O_RDWR | O_CREAT | O_TRUNC);
+    tempFile fd_b(dir + "/scope_b_" + queue + "_" + test_file_name, O_RDWR | O_CREAT | O_TRUNC);
+
+    nixl_reg_dlist_t dram_reg(DRAM_SEG);
+    nixl_reg_dlist_t file_reg(FILE_SEG);
+    nixl_xfer_dlist_t dram_a(DRAM_SEG), file_a(FILE_SEG);
+    nixl_xfer_dlist_t dram_b(DRAM_SEG), file_b(FILE_SEG);
+
+    std::vector<std::unique_ptr<void, PosixMemalignDeleter>> bufs;
+    auto add =
+        [&](int n, size_t sz, int fd, nixl_xfer_dlist_t &dram_x, nixl_xfer_dlist_t &file_x) -> int {
+        for (int i = 0; i < n; i++) {
+            void *ptr;
+            if (posix_memalign(&ptr, page_size, sz) != 0) {
+                std::cerr << "DRAM allocation failed" << std::endl;
+                return 1;
+            }
+            bufs.emplace_back(ptr);
+            fill_test_pattern(ptr, read_write_test_phrase, sz);
+
+            nixlBlobDesc dram_desc;
+            dram_desc.addr = (uintptr_t)ptr;
+            dram_desc.len = sz;
+            dram_desc.devId = 0;
+            dram_reg.addDesc(dram_desc);
+            dram_x.addDesc(dram_desc);
+
+            nixlBlobDesc file_desc;
+            file_desc.addr = 0;
+            file_desc.len = sz;
+            file_desc.devId = fd;
+            file_reg.addDesc(file_desc);
+            file_x.addDesc(file_desc);
+        }
+        return 0;
+    };
+
+    if (add(a_desc, a_size, fd_a, dram_a, file_a) != 0) {
+        return 1;
+    }
+    if (add(b_desc, b_size, fd_b, dram_b, file_b) != 0) {
+        return 1;
+    }
+
+    if (agent.registerMem(dram_reg) != NIXL_SUCCESS ||
+        agent.registerMem(file_reg) != NIXL_SUCCESS) {
+        std::cerr << "Failed to register memory" << std::endl;
+        return 1;
+    }
+
+    nixlXferReqH *req_a = nullptr;
+    nixlXferReqH *req_b = nullptr;
+    if (agent.createXferReq(NIXL_WRITE, dram_a, file_a, "POSIXScopingTester", req_a) !=
+            NIXL_SUCCESS ||
+        agent.createXferReq(NIXL_WRITE, dram_b, file_b, "POSIXScopingTester", req_b) !=
+            NIXL_SUCCESS) {
+        std::cerr << "Failed to create transfer requests" << std::endl;
+        return 1;
+    }
+
+    signal(SIGXFSZ, SIG_IGN);
+    struct rlimit saved{};
+    getrlimit(RLIMIT_FSIZE, &saved);
+    struct rlimit rl{cap, saved.rlim_max};
+    if (setrlimit(RLIMIT_FSIZE, &rl) != 0) {
+        std::cerr << "setrlimit(RLIMIT_FSIZE) failed" << std::endl;
+        agent.releaseXferReq(req_a);
+        agent.releaseXferReq(req_b);
+        return 1;
+    }
+
+    nixl_status_t st_a = agent.postXferReq(req_a);
+    nixl_status_t st_b = agent.postXferReq(req_b);
+
+    // drive A (the failing transfer) to terminal first -- this fires cancel(A)
+    // while B still has outstanding ios on the shared queue
+    // yield each iteration: a busy-spin here starves the kernel io completion
+    // workers, so B's buffered writes never drain before max_poll_iters
+    constexpr auto poll_pause = std::chrono::microseconds(20);
+    int iters = 0;
+    while (st_a == NIXL_IN_PROG && iters++ < max_poll_iters) {
+        st_a = agent.getXferStatus(req_a);
+        std::this_thread::sleep_for(poll_pause);
+    }
+    iters = 0;
+    while (st_b == NIXL_IN_PROG && iters++ < max_poll_iters) {
+        st_b = agent.getXferStatus(req_b);
+        std::this_thread::sleep_for(poll_pause);
+    }
+
+    setrlimit(RLIMIT_FSIZE, &saved);
+
+    std::cout << queue << ": A=" << nixlEnumStrings::statusStr(st_a)
+              << " B=" << nixlEnumStrings::statusStr(st_b) << std::endl;
+
+    int rc = 0;
+    if (st_a >= 0) {
+        std::cerr << queue << ": failing transfer A was not reported as error" << std::endl;
+        rc = 1;
+    }
+    if (st_b != NIXL_SUCCESS) {
+        std::cerr << queue << ": concurrent transfer B disturbed by A's cancel (status "
+                  << nixlEnumStrings::statusStr(st_b) << ")" << std::endl;
+        rc = 1;
+    } else if (lseek(fd_b, 0, SEEK_END) != (off_t)b_size) {
+        std::cerr << queue << ": transfer B did not fully write its data" << std::endl;
+        rc = 1;
+    }
+
+    agent.releaseXferReq(req_a);
+    agent.releaseXferReq(req_b);
+    {
+        nixl_reg_dlist_t fa(FILE_SEG), fb(FILE_SEG);
+        nixlBlobDesc da;
+        da.addr = 0;
+        da.len = a_size;
+        da.devId = fd_a;
+        fa.addDesc(da);
+        nixlBlobDesc db;
+        db.addr = 0;
+        db.len = b_size;
+        db.devId = fd_b;
+        fb.addDesc(db);
+        for (int i = 0; i < a_desc; i++) {
+            agent.deregisterMem(fa);
+        }
+        for (int i = 0; i < b_desc; i++) {
+            agent.deregisterMem(fb);
+        }
+    }
+    agent.deregisterMem(dram_reg);
+    return rc;
+}
+
+int
+test_concurrent_cancel_scoping(std::string dir) {
+    const std::pair<const char *, const char *> queues[] = {
+        {"AIO", "use_aio"},
+        {"io_uring", "use_uring"},
+        {"POSIXAIO", "use_posix_aio"},
+    };
+
+    int failures = 0;
+    int ran = 0;
+    for (const auto &[queue, param_key] : queues) {
+        int rc = concurrent_cancel_scoping_case(dir, queue, param_key);
+        if (rc >= 0) {
+            ran++;
+        }
+        if (rc == 1) {
+            failures++;
+        }
+    }
+
+    if (ran == 0) {
+        std::cerr << "No POSIX io queue backend available to test" << std::endl;
+        return 1;
+    }
+    return failures == 0 ? 0 : 1;
+}
+
 int
 test_short_write_enospc(std::string test_files_dir_path_abs_path) {
     const std::pair<const char *, const char *> queues[] = {
@@ -1137,8 +1328,9 @@ test_short_write_enospc(std::string test_files_dir_path_abs_path) {
 
     int failures = 0;
     int ran = 0;
-    // 1 = single-io path; 8 = multi-io batch that must fully drain on fault
-    for (int n_desc : {1, 8}) {
+    // 1 = single-io path; 8 = multi-io batch; 200 = >64 batch with an un-submitted
+    // remainder that the cancel path must clear and recover
+    for (int n_desc : {1, 8, 200}) {
         for (const auto &[queue, param_key] : queues) {
             int rc = short_write_case(test_files_dir_path_abs_path, queue, param_key, n_desc);
             if (rc >= 0) {
@@ -1273,6 +1465,14 @@ main (int argc, char *argv[]) {
     ret = test_short_write_enospc(test_files_dir_path_abs_path);
     if (ret != 0) {
         std::cerr << "Short-write/ENOSPC Test failed" << std::endl;
+        return 1;
+    }
+
+    phase_num = 1;
+
+    ret = test_concurrent_cancel_scoping(test_files_dir_path_abs_path);
+    if (ret != 0) {
+        std::cerr << "Concurrent cancel scoping Test failed" << std::endl;
         return 1;
     }
 

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -34,6 +34,8 @@
 #include <stdexcept>
 #include <cstdio>
 #include <getopt.h>
+#include <csignal>
+#include <sys/resource.h>
 
 namespace {
     const size_t page_size = sysconf(_SC_PAGESIZE);
@@ -991,6 +993,170 @@ runFdModeReuseCheck() {
     return 0;
 }
 
+// Force a short write (RLIMIT_FSIZE) on a queue; expect an error + recovery; -1 if absent.
+int
+short_write_case(const std::string &test_files_dir_path_abs_path,
+                 const std::string &queue,
+                 const std::string &param_key,
+                 int n_desc) {
+    print_segment_title(
+        phase_title(absl::StrFormat("Short-write / ENOSPC: %s x%d", queue, n_desc)));
+
+    const size_t cap = page_size;
+    const size_t transfer_size = 4 * page_size;
+
+    nixl_b_params_t params;
+    params[param_key] = "true";
+
+    nixlAgentConfig cfg(false);
+    nixlAgent agent("POSIXEnospcTester", cfg);
+    nixlBackendH *posix = nullptr;
+    if (agent.createBackend("POSIX", params, posix) != NIXL_SUCCESS) {
+        std::cout << queue << ": backend unavailable, skipping" << std::endl;
+        return -1;
+    }
+
+    tempFile fd(test_files_dir_path_abs_path + "/enospc_" + queue + "_" + test_file_name,
+                O_RDWR | O_CREAT | O_TRUNC);
+
+    nixl_reg_dlist_t dram_for_posix(DRAM_SEG);
+    nixl_reg_dlist_t file_for_posix(FILE_SEG);
+    nixl_xfer_dlist_t dram_xfer(DRAM_SEG);
+    nixl_xfer_dlist_t file_xfer(FILE_SEG);
+
+    std::vector<std::unique_ptr<void, PosixMemalignDeleter>> bufs;
+    for (int i = 0; i < n_desc; i++) {
+        void *ptr;
+        if (posix_memalign(&ptr, page_size, transfer_size) != 0) {
+            std::cerr << "DRAM allocation failed" << std::endl;
+            return 1;
+        }
+        bufs.emplace_back(ptr);
+        fill_test_pattern(ptr, read_write_test_phrase, transfer_size);
+
+        nixlBlobDesc dram_desc;
+        dram_desc.addr = (uintptr_t)ptr;
+        dram_desc.len = transfer_size;
+        dram_desc.devId = 0;
+        dram_for_posix.addDesc(dram_desc);
+        dram_xfer.addDesc(dram_desc);
+
+        nixlBlobDesc file_desc;
+        file_desc.addr = 0;
+        file_desc.len = transfer_size;
+        file_desc.devId = fd;
+        file_for_posix.addDesc(file_desc);
+        file_xfer.addDesc(file_desc);
+    }
+
+    if (agent.registerMem(dram_for_posix) != NIXL_SUCCESS ||
+        agent.registerMem(file_for_posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to register memory" << std::endl;
+        return 1;
+    }
+
+    nixlXferReqH *treq = nullptr;
+    if (agent.createXferReq(NIXL_WRITE, dram_xfer, file_xfer, "POSIXEnospcTester", treq) !=
+        NIXL_SUCCESS) {
+        std::cerr << "Failed to create transfer request" << std::endl;
+        return 1;
+    }
+
+    // cap file size to force a short write; ignore SIGXFSZ defensively
+    signal(SIGXFSZ, SIG_IGN);
+    struct rlimit saved{};
+    getrlimit(RLIMIT_FSIZE, &saved);
+    struct rlimit rl{cap, saved.rlim_max};
+    if (setrlimit(RLIMIT_FSIZE, &rl) != 0) {
+        std::cerr << "setrlimit(RLIMIT_FSIZE) failed" << std::endl;
+        agent.releaseXferReq(treq);
+        return 1;
+    }
+
+    nixl_status_t status = agent.postXferReq(treq);
+    while (status == NIXL_IN_PROG) {
+        status = agent.getXferStatus(treq);
+    }
+    setrlimit(RLIMIT_FSIZE, &saved);
+
+    std::cout << queue << ": " << n_desc << " desc, status " << nixlEnumStrings::statusStr(status)
+              << std::endl;
+
+    agent.releaseXferReq(treq);
+
+    int rc = 0;
+    if (status >= 0) {
+        std::cerr << queue << ": short write reported as success -- ENOSPC not propagated"
+                  << std::endl;
+        rc = 1;
+    } else {
+        std::cout << queue << ": short write correctly surfaced as error" << std::endl;
+        // a normal write reusing the same queue must still succeed after the failure
+        nixlXferReqH *treq2 = nullptr;
+        if (agent.createXferReq(NIXL_WRITE, dram_xfer, file_xfer, "POSIXEnospcTester", treq2) !=
+                NIXL_SUCCESS ||
+            treq2 == nullptr) {
+            std::cerr << queue << ": failed to create follow-up transfer request" << std::endl;
+            rc = 1;
+        } else {
+            nixl_status_t status2 = agent.postXferReq(treq2);
+            while (status2 == NIXL_IN_PROG) {
+                status2 = agent.getXferStatus(treq2);
+            }
+            agent.releaseXferReq(treq2);
+            if (status2 != NIXL_SUCCESS || lseek(fd, 0, SEEK_END) != (off_t)transfer_size) {
+                std::cerr << queue << ": transfer after a failed one did not cleanly succeed"
+                          << std::endl;
+                rc = 1;
+            }
+        }
+    }
+
+    {
+        nixl_reg_dlist_t one(FILE_SEG);
+        nixlBlobDesc fd_desc;
+        fd_desc.addr = 0;
+        fd_desc.len = transfer_size;
+        fd_desc.devId = fd;
+        one.addDesc(fd_desc);
+        for (int i = 0; i < n_desc; i++) {
+            agent.deregisterMem(one);
+        }
+    }
+    agent.deregisterMem(dram_for_posix);
+    return rc;
+}
+
+int
+test_short_write_enospc(std::string test_files_dir_path_abs_path) {
+    const std::pair<const char *, const char *> queues[] = {
+        {"AIO", "use_aio"},
+        {"io_uring", "use_uring"},
+        {"POSIXAIO", "use_posix_aio"},
+    };
+
+    int failures = 0;
+    int ran = 0;
+    // 1 = single-io path; 8 = multi-io batch that must fully drain on fault
+    for (int n_desc : {1, 8}) {
+        for (const auto &[queue, param_key] : queues) {
+            int rc = short_write_case(test_files_dir_path_abs_path, queue, param_key, n_desc);
+            if (rc >= 0) {
+                ran++;
+            }
+            if (rc == 1) {
+                failures++;
+            }
+        }
+    }
+
+    if (ran == 0) {
+        std::cerr << "No POSIX io queue backend available to test" << std::endl;
+        return 1;
+    }
+    return failures == 0 ? 0 : 1;
+}
+
 int
 main (int argc, char *argv[]) {
     if (page_size <= 0) {
@@ -1099,6 +1265,14 @@ main (int argc, char *argv[]) {
     ret = test_posix_repost (test_files_dir_path_abs_path, use_uring);
     if (ret != 0) {
         std::cerr << "Repost Test failed" << std::endl;
+        return 1;
+    }
+
+    phase_num = 1;
+
+    ret = test_short_write_enospc(test_files_dir_path_abs_path);
+    if (ret != 0) {
+        std::cerr << "Short-write/ENOSPC Test failed" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
## What

The POSIX backend's libaio (`AIO`, the Linux default) and io_uring (`URING`) I/O queues treated any **non-negative** AIO completion result as a fully successful transfer. When a write runs out of space, the kernel commonly reports a **short write** -- a positive byte count smaller than the requested length -- rather than a negative errno. That short count slipped past the error check, so the transfer was reported as `DONE` while only part of the buffer reached disk: silent data loss with no error surfaced to the caller.

For libaio there was an additional latent bug: `io_event.res` is an `unsigned long`, so the existing `events[i].res < 0` check is always false -- even a fully failed write was never detected.

This PR makes the POSIX backend both **detect** short/failed writes and **cleanly recover** from them across all three io queues.

Fixes #1696.

Note, unlike previous versions of this PR the current version does not include the fix for double dereg anymore. We have separate tracking bugs now for these issues: #1749 and #1792

## Detect

Treat a completion as a fault when its result doesn't equal the requested length (covers both a negative errno and a short write):

- `linux_aio_io_queue.cpp` -- read `events[i].res` as signed (`long`) and compare to `iocb->u.c.nbytes`.
- `io_uring_io_queue.cpp` -- compare `cqe->res` to the requested `len`.
- `posix_aio_io_queue.cpp` already did this (`ret != aio_nbytes`).

## Recover (drain to completion)

The io queue is a **single instance shared across all transfers on an engine**, so the previous "early-return `NIXL_ERR_BACKEND` on the first bad completion" left the queue dirty -- un-reaped in-flight ios and stale completions that the *next* transfer would misattribute (and, since the failed request handle had been released, could reference freed state).

The error path now mirrors the success path instead of short-circuiting:

- A per-io fault is **reported through the completion callback** (a non-zero `error` argument), and the io is recycled exactly like a successful one. `doCheckCompleted` keeps draining; it never early-returns for a per-io fault.
- The request handle records the fault (`any_failed_`), and **`checkXfer()` only renders the verdict once every io of the transfer has terminated** -- returning `NIXL_ERR_BACKEND` if any faulted, else `NIXL_SUCCESS`. (A queue `poll()` returning negative is now reserved for submission / `io_getevents`-level failures.)

This guarantees that after a partial fault the shared queue is fully drained and clean for the next transfer -- no leaked pool entries, no stale completions, no freed-handle references. It also covers all completion-time failures uniformly, not just short writes (a negative `-EIO` recovers identically).

## Behavior change on reads

This PR makes a completion whose transferred byte count differs from the requested length a hard failure (`NIXL_ERR_BACKEND`) in the `libaio` and `io_uring` queues, matching what the POSIX-aio queue already did. Previously these two queues only flagged a negative result (and for `libaio` that check was effectively dead code, since `io_event.res` is an unsigned long), so a short read, for example a READ whose `(offset, len)` extends to or past end-of-file and returns fewer than `len` bytes, was silently reported as DONE. With this change such a short read now surfaces as an error. This is intentional and consistent across all three queues, but callers that rely on partial/short reads (reading a region beyond EOF) will now see an error instead of a truncated-but-successful transfer; transfers are treated as exact-length, all-or-nothing.

## Test

Adds `test_short_write_enospc` to `test/unit/plugins/posix/nixl_posix_test.cpp`. It loops over every available io queue (`use_aio`, `use_uring`, `use_posix_aio`), skipping any the build/runtime doesn't provide, and over **both single- and multi-descriptor (8) transfers**, and for each:

1. forces a short write deterministically by lowering the **soft** `RLIMIT_FSIZE` below the transfer size (no special filesystem or privileges; hard limit preserved so it can be restored),
2. asserts the transfer surfaces an error rather than `DONE`, and
3. asserts a subsequent **normal** transfer on the **same agent** still succeeds.

The multi-descriptor case is what exercises the drain path: every io in the batch faults, so the queue must reap and recycle all of them and stay usable. All queues pass detect + recover for both 1 and 8 descriptors; the existing read/write + repost test is unaffected.
