### PR TITLE
CI: change partition to gb200

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -42,10 +42,10 @@ env:
   NIXL_INSTALL_DIR: /opt/nixl
   NIXL_BUILD_DIR: nixl_build
   SLURM_NODES: 1
-  SLURM_PARTITION: gb300nvl72_ci
+  SLURM_PARTITION: gb200nvl72_ci
   SLURM_HEAD_NODE: dlcluster.nvidia.com
   SLURM_HEAD_USER: svc-nixl
-  SLURM_ACCOUNT: 'blackwell-ci'
+  SLURM_ACCOUNT: 'oberon-gb-ci'
   SLURM_JOB_TIMEOUT: '01:30:00'
   SLURM_IMMEDIATE_TIMEOUT: 3600
   SSH_CREDENTIALS_ID: 'svc-nixl-ssh_key'


### PR DESCRIPTION
gb300 partition does not have available resources changing to partition with more available resources to allow ci to run.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates with no user-facing changes. The modifications adjust backend testing environment configurations to optimize development and CI/CD workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->