### PR TITLE
kvbench: add storage backend abstraction and etcd helpers

### DIFF
--- a/benchmark/kvbench/runtime/etcd_rt.py
+++ b/benchmark/kvbench/runtime/etcd_rt.py
@@ -48,9 +48,9 @@ class _EtcdDistUtils(_RTUtils):
         self,
         etcd_endpoints: str = "http://localhost:2379",
         prefix: str = "/nixl/kvbench",
+        namespace_explicit: bool = False,
     ):
         super().__init__()
-        self.prefix = prefix
         self.ops_counter: dict[str, dict[Any, int]] = defaultdict(
             lambda: defaultdict(int)
         )
@@ -69,6 +69,27 @@ class _EtcdDistUtils(_RTUtils):
             raise ValueError(
                 "Rank and world size not found in environment variables SLURM_PROCID/SLURM_NTASKS or RANK/WORLD_SIZE"
             )
+
+        # If the caller did not pin NIXL_ETCD_NAMESPACE explicitly, append a
+        # shared per-run token derived from the job scheduler so two
+        # concurrent runs on the same etcd don't wipe each other's keys
+        # during rank 0's delete_prefix(). All ranks of the same job must
+        # resolve the same token, so we only consult env vars that are
+        # broadcast across the whole job (not the rank-local ones).
+        if not namespace_explicit:
+            for env_var in ("SLURM_JOB_ID", "SLURM_JOBID", "PMIX_NAMESPACE"):
+                token = os.environ.get(env_var)
+                if token:
+                    prefix = f"{prefix.rstrip('/')}/run-{token}"
+                    logger.info(
+                        "NIXL_ETCD_NAMESPACE not set; auto-namespacing with "
+                        "%s=%s → prefix=%s",
+                        env_var,
+                        token,
+                        prefix,
+                    )
+                    break
+        self.prefix = prefix
 
         # Parse endpoint host & port
         url_pattern = r"^(https?://)?([^:]+)(?::(\d+))?$"
@@ -191,7 +212,7 @@ class _EtcdDistUtils(_RTUtils):
     def get_world_size(self) -> int:
         return self.world_size
 
-    def allgather_obj(self, obj: Any, timeout_sec: float = 120) -> List[Any]:
+    def allgather_obj(self, obj: Any, timeout_sec: float = 600) -> List[Any]:
         allgather_ix = self.ops_counter["allgather"]["world"]
         self.ops_counter["allgather"]["world"] += 1
 
@@ -221,7 +242,7 @@ class _EtcdDistUtils(_RTUtils):
 
         return result
 
-    def alltoall_obj(self, send_objs: List[Any], timeout_sec: float = 120) -> List[Any]:
+    def alltoall_obj(self, send_objs: List[Any], timeout_sec: float = 600) -> List[Any]:
         alltoall_ix = self.ops_counter["alltoall"]["world"]
         self.ops_counter["alltoall"]["world"] += 1
 
@@ -257,7 +278,7 @@ class _EtcdDistUtils(_RTUtils):
         vals: List[float | int],
         op: ReduceOp,
         root: int = 0,
-        timeout_sec: float = 120,
+        timeout_sec: float = 600,
     ) -> List[float | int]:
         self.barrier(timeout_sec=timeout_sec)
         self.client.put(f"{self.prefix}/all_reduce/{self.rank}", pickle.dumps(vals))
@@ -318,16 +339,18 @@ class _EtcdDistUtils(_RTUtils):
         return hash(key)
 
 
-if not os.environ.get("NIXL_ETCD_NAMESPACE"):
+_namespace_explicit = bool(os.environ.get("NIXL_ETCD_NAMESPACE"))
+if not _namespace_explicit:
     logger.warning(
-        "Environment variable NIXL_ETCD_NAMESPACE is not set, using default prefix /nixl/kvbench. "
-        "Note that it can lead to conflicts if multiple instances of KVBench are running. "
-        "To avoid this, set NIXL_ETCD_NAMESPACE to a unique value for each instance of KVBench. "
-        'For example, export NIXL_ETCD_NAMESPACE="/nixl/kvbench/$(uuidgen)"'
+        "Environment variable NIXL_ETCD_NAMESPACE is not set; will try to "
+        "auto-namespace using SLURM_JOB_ID/PMIX_NAMESPACE. If none are set "
+        'either, export NIXL_ETCD_NAMESPACE="/nixl/kvbench/$(uuidgen)" to '
+        "avoid conflicts with other concurrent KVBench runs."
     )
 
 
 etcd_dist_utils = _EtcdDistUtils(
     etcd_endpoints=os.environ.get("NIXL_ETCD_ENDPOINTS", "http://localhost:2379"),
     prefix=os.environ.get("NIXL_ETCD_NAMESPACE", "/nixl/kvbench"),
+    namespace_explicit=_namespace_explicit,
 )

--- a/benchmark/kvbench/runtime/etcd_rt.py
+++ b/benchmark/kvbench/runtime/etcd_rt.py
@@ -28,6 +28,14 @@ from .rt_base import ReduceOp, _RTUtils
 
 logger = get_logger(__name__)
 
+# Poll interval for the wait-until-key-present loops below. The value is a
+# trade-off: too low and we hammer etcd between retries; too high and we add
+# latency to every barrier/allgather/alltoall/all_reduce. 50ms keeps the QPS
+# per waiter well below etcd's per-client default while staying small enough
+# that a typical world-size of <=1024 ranks adds only a few seconds of
+# slack on the slowest path. Not aimed at context-switching — pure backoff.
+_POLL_INTERVAL_SEC = 0.05
+
 
 def int_to_bytes(val: int) -> bytes:
     return val.to_bytes(length=4, byteorder="big")
@@ -105,7 +113,7 @@ class _EtcdDistUtils(_RTUtils):
                     raise TimeoutError(
                         f"[Rank {self.rank}] Timeout waiting for rank 0 init after {init_timeout_sec}s"
                     )
-                time.sleep(0.05)
+                time.sleep(_POLL_INTERVAL_SEC)
             logger.info("Rank %d: rank 0 ready, proceeding", self.rank)
 
     def destroy_dist(self):
@@ -168,7 +176,7 @@ class _EtcdDistUtils(_RTUtils):
                         f"Waiting for rank {waiting_for_rank} to enter barrier."
                     )
             # Fan out - wait for root to set 0 again
-            while not self._get_int_val(key) == 0:
+            while self._get_int_val(key) != 0:
                 if timeout_sec and time.time() - start_time > timeout_sec:
                     current_val = self._get_int_val(key) or 0
                     missing_ranks = (
@@ -211,7 +219,7 @@ class _EtcdDistUtils(_RTUtils):
                     raise TimeoutError(
                         f"[Rank {self.rank}] allgather_obj timeout waiting for rank {dest_rank} after {timeout_sec}s"
                     )
-                time.sleep(0.05)
+                time.sleep(_POLL_INTERVAL_SEC)
                 val = self.client.get(key)[0]
             result[dest_rank] = pickle.loads(val)
 
@@ -242,7 +250,7 @@ class _EtcdDistUtils(_RTUtils):
                     raise TimeoutError(
                         f"[Rank {self.rank}] alltoall_obj timeout waiting for rank {src_rank} after {timeout_sec}s"
                     )
-                time.sleep(0.05)
+                time.sleep(_POLL_INTERVAL_SEC)
                 val = self.client.get(key)[0]
             result[src_rank] = pickle.loads(val)
 
@@ -271,19 +279,23 @@ class _EtcdDistUtils(_RTUtils):
                         raise TimeoutError(
                             f"[Rank {self.rank}] all_reduce timeout waiting for rank {dest_rank} after {timeout_sec}s"
                         )
-                    time.sleep(0.05)
+                    time.sleep(_POLL_INTERVAL_SEC)
                     val = self.client.get(f"{self.prefix}/all_reduce/{dest_rank}")[0]
                 all_vals.append(pickle.loads(val))
 
             logger.debug("All reduce values: %s", all_vals)
+            # strict=True so a per-rank list-length mismatch fails loudly
+            # instead of silently truncating.
             if op == ReduceOp.SUM:
-                final_val = [sum(col) for col in zip(*all_vals)]
+                final_val = [sum(col) for col in zip(*all_vals, strict=True)]
             elif op == ReduceOp.AVG:
-                final_val = [sum(col) / self.world_size for col in zip(*all_vals)]
+                final_val = [
+                    sum(col) / self.world_size for col in zip(*all_vals, strict=True)
+                ]
             elif op == ReduceOp.MIN:
-                final_val = [min(col) for col in zip(*all_vals)]
+                final_val = [min(col) for col in zip(*all_vals, strict=True)]
             elif op == ReduceOp.MAX:
-                final_val = [max(col) for col in zip(*all_vals)]
+                final_val = [max(col) for col in zip(*all_vals, strict=True)]
             else:
                 raise ValueError(f"Unsupported reduce operation: {op}")
 
@@ -298,7 +310,7 @@ class _EtcdDistUtils(_RTUtils):
                 raise TimeoutError(
                     f"[Rank {self.rank}] all_reduce timeout waiting for result after {timeout_sec}s"
                 )
-            time.sleep(0.05)
+            time.sleep(_POLL_INTERVAL_SEC)
             val = self.client.get(f"{self.prefix}/all_reduce/result")[0]
         final_val = pickle.loads(val)
 

--- a/benchmark/kvbench/runtime/etcd_rt.py
+++ b/benchmark/kvbench/runtime/etcd_rt.py
@@ -179,6 +179,7 @@ class _EtcdDistUtils(_RTUtils):
                         f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
                         f"Missing ranks: {missing_ranks[:10]}{'...' if len(missing_ranks) > 10 else ''}"
                     )
+                time.sleep(_POLL_INTERVAL_SEC)
         else:
             my_index = ranks.index(self.rank)
             # Fan in - count from 1 to len(ranks)
@@ -194,6 +195,7 @@ class _EtcdDistUtils(_RTUtils):
                         f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
                         f"Waiting for rank {waiting_for_rank} to enter barrier."
                     )
+                time.sleep(_POLL_INTERVAL_SEC)
             # Fan out - wait for root to set 0 again
             while self._get_int_val(key) != 0:
                 if timeout_sec and time.time() - start_time > timeout_sec:
@@ -205,6 +207,7 @@ class _EtcdDistUtils(_RTUtils):
                         f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
                         f"Missing ranks: {missing_ranks[:10]}{'...' if len(missing_ranks) > 10 else ''}"
                     )
+                time.sleep(_POLL_INTERVAL_SEC)
 
     def get_rank(self) -> int:
         return self.rank

--- a/benchmark/kvbench/runtime/etcd_rt.py
+++ b/benchmark/kvbench/runtime/etcd_rt.py
@@ -95,7 +95,7 @@ class _EtcdDistUtils(_RTUtils):
         try:
             self.client = etcd3.client(host=host, port=port)
         except Exception as e:
-            raise ValueError(f"Failed to initialize ETCD client: {e}")
+            raise ValueError(f"Failed to initialize ETCD client: {e}") from e
 
         # Rank 0 wipes prefix, then signals ready. Others wait for signal.
         init_key = f"{self.prefix}/__init_ready__"
@@ -153,9 +153,7 @@ class _EtcdDistUtils(_RTUtils):
             ):
                 current_val = self._get_int_val(key)
                 if timeout_sec and time.time() - start_time > timeout_sec:
-                    missing_ranks = (
-                        [r for r in ranks[current_val:]] if current_val else ranks[1:]
-                    )
+                    missing_ranks = ranks[current_val:] if current_val else ranks[1:]
                     raise TimeoutError(
                         f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
                         f"Missing ranks: {missing_ranks[:10]}{'...' if len(missing_ranks) > 10 else ''}"
@@ -180,9 +178,7 @@ class _EtcdDistUtils(_RTUtils):
                 if timeout_sec and time.time() - start_time > timeout_sec:
                     current_val = self._get_int_val(key) or 0
                     missing_ranks = (
-                        [r for r in ranks[current_val:]]
-                        if current_val < len(ranks)
-                        else []
+                        ranks[current_val:] if current_val < len(ranks) else []
                     )
                     raise TimeoutError(
                         f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "

--- a/benchmark/kvbench/runtime/etcd_rt.py
+++ b/benchmark/kvbench/runtime/etcd_rt.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ logger = get_logger(__name__)
 
 
 def int_to_bytes(val: int) -> bytes:
-    return int.to_bytes(val, length=4)
+    return val.to_bytes(length=4, byteorder="big")
 
 
 class _EtcdDistUtils(_RTUtils):
@@ -76,16 +76,37 @@ class _EtcdDistUtils(_RTUtils):
                 f"Invalid etcd endpoint format: {etcd_endpoints}, expected format is [http://]host[:port]"
             )
 
-        logger.info("ETCD client initialized with host %s & port %d", host, port)
+        logger.info(
+            "ETCD client initialized with host %s & port %d, rank=%d, world_size=%d",
+            host,
+            port,
+            self.rank,
+            self.world_size,
+        )
 
         try:
             self.client = etcd3.client(host=host, port=port)
         except Exception as e:
             raise ValueError(f"Failed to initialize ETCD client: {e}")
 
+        # Rank 0 wipes prefix, then signals ready. Others wait for signal.
+        init_key = f"{self.prefix}/__init_ready__"
+        init_timeout_sec = 120
         if self.rank == 0:
             logger.info("Wiping ETCD prefix %s", self.prefix)
             self.client.delete_prefix(self.prefix)
+            self.client.put(init_key, b"1")
+            logger.info("Rank 0 init complete, signaled ready")
+        else:
+            logger.info("Rank %d waiting for rank 0 init...", self.rank)
+            start_time = time.time()
+            while self.client.get(init_key)[0] is None:
+                if time.time() - start_time > init_timeout_sec:
+                    raise TimeoutError(
+                        f"[Rank {self.rank}] Timeout waiting for rank 0 init after {init_timeout_sec}s"
+                    )
+                time.sleep(0.05)
+            logger.info("Rank %d: rank 0 ready, proceeding", self.rank)
 
     def destroy_dist(self):
         self.client.delete_prefix(self.prefix)
@@ -94,7 +115,7 @@ class _EtcdDistUtils(_RTUtils):
         val = self.client.get(key)[0]
         if val is None:
             return None
-        return int.from_bytes(val)
+        return int.from_bytes(val, byteorder="big")
 
     def barrier(self, ranks: Optional[List[int]] = None, timeout_sec=600):
         """Barrier for a group of ranks using etcd barrier"""
@@ -108,7 +129,6 @@ class _EtcdDistUtils(_RTUtils):
         root = ranks[0]
         # Create barrier for specific group of ranks
         group_id = self._get_group_id(ranks)
-        group_size = len(ranks)
         barrier_ix = self.ops_counter["barrier"][group_id]
         self.ops_counter["barrier"][group_id] += 1
 
@@ -123,15 +143,14 @@ class _EtcdDistUtils(_RTUtils):
             while not self.client.replace(
                 key, int_to_bytes(len(ranks)), int_to_bytes(0)
             ):
+                current_val = self._get_int_val(key)
                 if timeout_sec and time.time() - start_time > timeout_sec:
+                    missing_ranks = (
+                        [r for r in ranks[current_val:]] if current_val else ranks[1:]
+                    )
                     raise TimeoutError(
-                        "[Rank %d] ROOT - Barrier %s timed out after %.3f seconds, current value: %s, waiting for val=%d (i.e all the ranks have entered the barrier), (ranks: %s)",
-                        self.rank,
-                        key,
-                        timeout_sec,
-                        self.client.get(key),
-                        len(ranks),
-                        ranks,
+                        f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
+                        f"Missing ranks: {missing_ranks[:10]}{'...' if len(missing_ranks) > 10 else ''}"
                     )
         else:
             my_index = ranks.index(self.rank)
@@ -140,14 +159,26 @@ class _EtcdDistUtils(_RTUtils):
                 key, int_to_bytes(my_index), int_to_bytes(my_index + 1)
             ):
                 if timeout_sec and time.time() - start_time > timeout_sec:
+                    current_val = self._get_int_val(key) or 0
+                    waiting_for_rank = (
+                        ranks[my_index - 1] if my_index > 0 else "unknown"
+                    )
                     raise TimeoutError(
-                        f"[Rank {self.rank}] Barrier {key} timed out after {timeout_sec} seconds, current value: {self.client.get(key)}, waiting for val={my_index} (i.e rank {ranks[my_index - 1]} entered barrier), (ranks: {ranks})"
+                        f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
+                        f"Waiting for rank {waiting_for_rank} to enter barrier."
                     )
             # Fan out - wait for root to set 0 again
             while not self._get_int_val(key) == 0:
                 if timeout_sec and time.time() - start_time > timeout_sec:
+                    current_val = self._get_int_val(key) or 0
+                    missing_ranks = (
+                        [r for r in ranks[current_val:]]
+                        if current_val < len(ranks)
+                        else []
+                    )
                     raise TimeoutError(
-                        f"[Rank {self.rank}] Barrier {key} timed out after {timeout_sec} seconds, current value: {self.client.get(key)}, waiting for val={group_size} (i.e all the ranks have entered the barrier), (ranks: {ranks})"
+                        f"[Rank {self.rank}] Barrier timed out after {timeout_sec:.0f}s: {current_val}/{len(ranks)} ranks arrived. "
+                        f"Missing ranks: {missing_ranks[:10]}{'...' if len(missing_ranks) > 10 else ''}"
                     )
 
     def get_rank(self) -> int:
@@ -156,7 +187,7 @@ class _EtcdDistUtils(_RTUtils):
     def get_world_size(self) -> int:
         return self.world_size
 
-    def allgather_obj(self, obj: Any) -> List[Any]:
+    def allgather_obj(self, obj: Any, timeout_sec: float = 120) -> List[Any]:
         allgather_ix = self.ops_counter["allgather"]["world"]
         self.ops_counter["allgather"]["world"] += 1
 
@@ -168,70 +199,108 @@ class _EtcdDistUtils(_RTUtils):
             f"{self.prefix}/allgather/{allgather_ix}/{self.rank}", serialized_obj
         )
 
-        for dest_rank in range(self.world_size):
-            val = None
-            while val is None:
-                val = self.client.get(
-                    f"{self.prefix}/allgather/{allgather_ix}/{dest_rank}"
-                )[0]
+        self.barrier(timeout_sec=timeout_sec)
 
+        for dest_rank in range(self.world_size):
+            key = f"{self.prefix}/allgather/{allgather_ix}/{dest_rank}"
+            val = self.client.get(key)[0]
+            # Retry if value is None (etcd consistency delay)
+            start_time = time.time()
+            while val is None:
+                if time.time() - start_time > timeout_sec:
+                    raise TimeoutError(
+                        f"[Rank {self.rank}] allgather_obj timeout waiting for rank {dest_rank} after {timeout_sec}s"
+                    )
+                time.sleep(0.05)
+                val = self.client.get(key)[0]
             result[dest_rank] = pickle.loads(val)
 
         return result
 
-    def alltoall_obj(self, send_objs: List[Any]) -> List[Any]:
+    def alltoall_obj(self, send_objs: List[Any], timeout_sec: float = 120) -> List[Any]:
+        alltoall_ix = self.ops_counter["alltoall"]["world"]
+        self.ops_counter["alltoall"]["world"] += 1
+
         result = [None for _ in range(self.world_size)]
         serialized_objs = [pickle.dumps(obj) for obj in send_objs]
 
-        self.barrier()
+        self.barrier(timeout_sec=timeout_sec)
         for dest_rank in range(self.world_size):
             self.client.put(
-                f"{self.prefix}/alltoall/{self.rank}_to_{dest_rank}",
+                f"{self.prefix}/alltoall/{alltoall_ix}/{self.rank}_to_{dest_rank}",
                 serialized_objs[dest_rank],
             )
 
-        self.barrier()
+        self.barrier(timeout_sec=timeout_sec)
         for src_rank in range(self.world_size):
-            val = self.client.get(f"{self.prefix}/alltoall/{src_rank}_to_{self.rank}")[
-                0
-            ]
+            key = f"{self.prefix}/alltoall/{alltoall_ix}/{src_rank}_to_{self.rank}"
+            val = self.client.get(key)[0]
+            # Retry if value is None (etcd consistency delay)
+            start_time = time.time()
+            while val is None:
+                if time.time() - start_time > timeout_sec:
+                    raise TimeoutError(
+                        f"[Rank {self.rank}] alltoall_obj timeout waiting for rank {src_rank} after {timeout_sec}s"
+                    )
+                time.sleep(0.05)
+                val = self.client.get(key)[0]
             result[src_rank] = pickle.loads(val)
 
         return result
 
     def all_reduce(
-        self, vals: List[float | int], op: ReduceOp, root: int = 0
+        self,
+        vals: List[float | int],
+        op: ReduceOp,
+        root: int = 0,
+        timeout_sec: float = 120,
     ) -> List[float | int]:
-        self.barrier()
+        self.barrier(timeout_sec=timeout_sec)
         self.client.put(f"{self.prefix}/all_reduce/{self.rank}", pickle.dumps(vals))
         if self.rank == root:
             self.client.delete(f"{self.prefix}/all_reduce/result")
-        self.barrier()
+        self.barrier(timeout_sec=timeout_sec)
 
         if self.rank == root:
-            vals = []
+            all_vals = []
+            start_time = time.time()
             for dest_rank in range(self.world_size):
                 val = self.client.get(f"{self.prefix}/all_reduce/{dest_rank}")[0]
-                vals.append(pickle.loads(val))
+                while val is None:
+                    if time.time() - start_time > timeout_sec:
+                        raise TimeoutError(
+                            f"[Rank {self.rank}] all_reduce timeout waiting for rank {dest_rank} after {timeout_sec}s"
+                        )
+                    time.sleep(0.05)
+                    val = self.client.get(f"{self.prefix}/all_reduce/{dest_rank}")[0]
+                all_vals.append(pickle.loads(val))
 
-            logger.debug("All reduce values: %s", vals)
+            logger.debug("All reduce values: %s", all_vals)
             if op == ReduceOp.SUM:
-                final_val = [sum(col) for col in zip(*vals)]
+                final_val = [sum(col) for col in zip(*all_vals)]
             elif op == ReduceOp.AVG:
-                final_val = [sum(col) / self.world_size for col in zip(*vals)]
+                final_val = [sum(col) / self.world_size for col in zip(*all_vals)]
             elif op == ReduceOp.MIN:
-                final_val = [min(col) for col in zip(*vals)]
+                final_val = [min(col) for col in zip(*all_vals)]
             elif op == ReduceOp.MAX:
-                final_val = [max(col) for col in zip(*vals)]
+                final_val = [max(col) for col in zip(*all_vals)]
             else:
                 raise ValueError(f"Unsupported reduce operation: {op}")
 
             self.client.put(f"{self.prefix}/all_reduce/result", pickle.dumps(final_val))
-        else:
-            while self.client.get(f"{self.prefix}/all_reduce/result")[0] is None:
-                pass
+
+        self.barrier(timeout_sec=timeout_sec)
+
+        val = self.client.get(f"{self.prefix}/all_reduce/result")[0]
+        start_time = time.time()
+        while val is None:
+            if time.time() - start_time > timeout_sec:
+                raise TimeoutError(
+                    f"[Rank {self.rank}] all_reduce timeout waiting for result after {timeout_sec}s"
+                )
+            time.sleep(0.05)
             val = self.client.get(f"{self.prefix}/all_reduce/result")[0]
-            final_val = pickle.loads(val)
+        final_val = pickle.loads(val)
 
         return final_val
 

--- a/benchmark/kvbench/test/storage_backend.py
+++ b/benchmark/kvbench/test/storage_backend.py
@@ -1,0 +1,570 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Storage backend abstraction for KV cache I/O benchmarking.
+
+Provides an abstract interface for storage operations, allowing different
+backend implementations (filesystem, Redis, block devices, etc.).
+
+Current implementations:
+- FilesystemBackend: Uses NIXL POSIX/GDS for file I/O
+"""
+
+import os
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from nixl._api import nixl_agent
+from nixl.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class StorageHandle:
+    """Handle returned by storage backend for a prepared region.
+
+    Attributes:
+        tp_idx: Traffic pattern index
+        rank: Rank this handle belongs to
+        read_size: Size of read region in bytes
+        write_size: Size of write region in bytes
+        backend_data: Backend-specific data (fd, connection, etc.)
+    """
+
+    tp_idx: int
+    rank: int
+    read_size: int
+    write_size: int
+    backend_data: (
+        Any  # Backend-specific (fd for filesystem, connection for redis, etc.)
+    )
+
+
+class StorageBackend(ABC):
+    """Abstract base class for storage backends.
+
+    Implementations must provide methods to:
+    - Prepare storage regions (create files, connect to Redis, etc.)
+    - Get NIXL-compatible transfer handles for read/write operations
+    - Clean up resources
+
+    Example usage:
+        backend = FilesystemBackend(nixl_agent, base_path="/mnt/storage")
+
+        # Prepare storage for a rank
+        handle = backend.prepare(tp_idx=0, rank=0, read_size=1000, write_size=500)
+
+        # Get NIXL transfer handles
+        read_handle = backend.get_read_handle(handle, gpu_buffer)
+        write_handle = backend.get_write_handle(handle, gpu_buffer)
+
+        # Execute transfers via NIXL
+        nixl_agent.transfer(read_handle)
+        nixl_agent.transfer(write_handle)
+
+        # Cleanup
+        backend.close()
+    """
+
+    @abstractmethod
+    def prepare(
+        self,
+        tp_idx: int,
+        rank: int,
+        read_size: int,
+        write_size: int,
+    ) -> StorageHandle:
+        """Prepare storage region for a rank.
+
+        Creates/opens the storage region and returns a handle for later use.
+        For filesystem: creates file, prefills read region
+        For Redis: creates key, populates with initial data
+
+        Args:
+            tp_idx: Traffic pattern index
+            rank: Rank number
+            read_size: Size of read region in bytes
+            write_size: Size of write region in bytes
+
+        Returns:
+            StorageHandle for use with get_read_handle/get_write_handle
+        """
+        pass
+
+    @abstractmethod
+    def get_read_handle(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+    ) -> Any:
+        """Get NIXL transfer handle for reading from storage.
+
+        Args:
+            handle: StorageHandle from prepare()
+            buffer: GPU/CPU buffer to read into
+
+        Returns:
+            NIXL transfer handle (ready for nixl_agent.transfer())
+        """
+        pass
+
+    @abstractmethod
+    def get_write_handle(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+    ) -> Any:
+        """Get NIXL transfer handle for writing to storage.
+
+        Args:
+            handle: StorageHandle from prepare()
+            buffer: GPU/CPU buffer to write from
+
+        Returns:
+            NIXL transfer handle (ready for nixl_agent.transfer())
+        """
+        pass
+
+    @abstractmethod
+    def close(self):
+        """Close all storage handles and release resources."""
+        pass
+
+
+class FilesystemBackend(StorageBackend):
+    """Filesystem-based storage backend using NIXL POSIX/GDS.
+
+    File layout per rank:
+        <base_path>/tp_<idx>/rank_<rank>.bin
+
+    File structure:
+        [read_region (prefilled)][write_region (empty)]
+        offset=0                  offset=read_size
+    """
+
+    def __init__(
+        self,
+        agent: nixl_agent,
+        base_path: Path,
+        nixl_backend: str = "POSIX",
+        use_direct_io: bool = False,
+        block_size: int = 0,
+        backend_params: Optional[Dict[str, str]] = None,
+    ):
+        """Initialize filesystem backend.
+
+        Args:
+            agent: NIXL agent for transfers
+            base_path: Base directory for storage files
+            nixl_backend: NIXL backend to use ("POSIX", "GDS", or "GDS_MT")
+            use_direct_io: Use O_DIRECT for file I/O (recommended for GDS)
+            block_size: Split I/O into blocks of this size for higher queue depth.
+                        0 = no splitting (legacy single-descriptor mode).
+                        Recommended: 1048576 (1MB) to match NFS rsize and maximize
+                        I/O concurrency across nconnect sessions.
+            backend_params: Optional dict of backend-specific params (e.g.,
+                           {"use_uring": "true"} for io_uring).
+        """
+        self._agent = agent
+        self._base_path = Path(base_path)
+        self._nixl_backend = nixl_backend
+        self._use_direct_io = use_direct_io
+        self._block_size = block_size
+        self._num_handles = 1  # Set by caller; controls file sharding
+        self._handles: Dict[str, StorageHandle] = {}  # key -> handle
+        self._file_descriptors: Dict[str, int] = {}  # file_path -> fd
+        self._file_reg_descs: Dict[str, Any] = {}  # file_path -> nixl reg_descs
+
+        # Ensure backend is created
+        try:
+            self._agent.create_backend(nixl_backend, backend_params or {})
+        except Exception as e:
+            logger.debug(
+                "create_backend(%s) returned: %s (may already exist)", nixl_backend, e
+            )
+
+        logger.info(
+            "FilesystemBackend: path=%s backend=%s direct_io=%s block_size=%d params=%s",
+            base_path,
+            nixl_backend,
+            use_direct_io,
+            block_size,
+            backend_params,
+        )
+
+    def _get_file_path(self, tp_idx: int, rank: int, shard: int = -1) -> Path:
+        """Get file path for a rank, optionally sharded."""
+        if shard >= 0:
+            return self._base_path / f"tp_{tp_idx}" / f"rank_{rank}_shard_{shard}.bin"
+        return self._base_path / f"tp_{tp_idx}" / f"rank_{rank}.bin"
+
+    def _create_file(self, file_path: Path, file_size: int, read_size: int, rank: int):
+        """Create and prefill storage file."""
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        logger.debug(
+            "Creating storage file: %s (size=%d, read_region=%d)",
+            file_path,
+            file_size,
+            read_size,
+        )
+
+        with open(file_path, "wb") as f:
+            if read_size > 0:
+                chunk_size = min(8 * 1024 * 1024, read_size)
+                chunk = bytes([rank % 256]) * chunk_size
+                written = 0
+                while written < read_size:
+                    to_write = min(chunk_size, read_size - written)
+                    f.write(chunk[:to_write])
+                    written += to_write
+
+            if file_size > read_size:
+                try:
+                    os.posix_fallocate(f.fileno(), read_size, file_size - read_size)
+                except OSError:
+                    f.seek(file_size - 1)
+                    f.write(b"\0")
+            f.flush()
+            os.fsync(f.fileno())
+
+    def _open_and_register_file(self, file_path: Path, file_size: int) -> int:
+        """Open a file and register it with NIXL. Returns fd."""
+        flags = os.O_RDWR
+        if self._use_direct_io:
+            flags |= os.O_DIRECT
+        fd = os.open(str(file_path), flags)
+        self._file_descriptors[str(file_path)] = fd
+
+        reg_list = [(0, file_size, fd, str(file_path))]
+        reg_descs = self._agent.register_memory(
+            reg_list, "FILE", backends=[self._nixl_backend]
+        )
+        self._file_reg_descs[str(file_path)] = reg_descs
+        return fd
+
+    @property
+    def _num_shards(self):
+        """Number of file shards per rank. Matches num_handles for parallel I/O."""
+        return self._num_handles if self._num_handles > 1 else 1
+
+    def prepare(
+        self,
+        tp_idx: int,
+        rank: int,
+        read_size: int,
+        write_size: int,
+    ) -> StorageHandle:
+        """Prepare storage file(s) for a rank.
+
+        When num_handles > 1, creates N shard files (one per handle) so each
+        gets its own fd. The NFS client can then parallelize I/O across files.
+        This is the key to matching nixlbench's 45 GB/s per node.
+        """
+        file_size = read_size + write_size
+        key = f"{tp_idx}:{rank}"
+        n_shards = self._num_shards
+
+        if n_shards <= 1:
+            # Legacy: single file
+            file_path = self._get_file_path(tp_idx, rank)
+            if not file_path.exists():
+                self._create_file(file_path, file_size, read_size, rank)
+            fd = self._open_and_register_file(file_path, file_size)
+
+            handle = StorageHandle(
+                tp_idx=tp_idx,
+                rank=rank,
+                read_size=read_size,
+                write_size=write_size,
+                backend_data={"file_path": str(file_path), "fd": fd},
+            )
+        else:
+            # Multi-file: N shards, each with size/N
+            align = max(self._block_size, 4096) if self._block_size > 0 else 4096
+            shard_read = ((read_size // n_shards + align - 1) // align) * align
+            shard_write = (
+                ((write_size // n_shards + align - 1) // align) * align
+                if write_size > 0
+                else 0
+            )
+            shard_size = shard_read + shard_write
+
+            shard_fds = []
+            shard_paths = []
+            for s in range(n_shards):
+                fpath = self._get_file_path(tp_idx, rank, shard=s)
+                actual_read = min(shard_read, read_size - s * shard_read)
+                actual_read = max(actual_read, 0)
+                actual_size = actual_read + shard_write
+                if actual_size <= 0:
+                    break
+                if not fpath.exists():
+                    self._create_file(fpath, actual_size, actual_read, rank)
+                fd = self._open_and_register_file(fpath, actual_size)
+                shard_fds.append(fd)
+                shard_paths.append(str(fpath))
+
+            handle = StorageHandle(
+                tp_idx=tp_idx,
+                rank=rank,
+                read_size=read_size,
+                write_size=write_size,
+                backend_data={
+                    "file_path": shard_paths[0],
+                    "fd": shard_fds[0],
+                    "shard_fds": shard_fds,
+                    "shard_paths": shard_paths,
+                    "shard_read_size": shard_read,
+                    "shard_write_size": shard_write,
+                },
+            )
+
+            logger.debug(
+                "Prepared sharded storage: tp=%d, rank=%d, %d shards x %d bytes",
+                tp_idx,
+                rank,
+                len(shard_fds),
+                shard_size,
+            )
+
+        self._handles[key] = handle
+        return handle
+
+    def _create_chunked_descs(self, fd, file_offset, total_size, buffer):
+        """Create file and local memory descriptors, optionally chunked for high queue depth.
+
+        When block_size > 0, splits the transfer into multiple small descriptors.
+        This increases the async I/O queue depth in the POSIX/GDS backend, allowing
+        the NFS client to pipeline requests across nconnect sessions.
+
+        Both local and file descriptor lists must have matching entry counts
+        (required by the POSIX backend: posix_backend.cpp line 57).
+
+        Args:
+            fd: File descriptor
+            file_offset: Starting offset in file
+            total_size: Total bytes to transfer
+            buffer: Memory buffer (torch tensor)
+
+        Returns:
+            (local_descs, file_descs) tuple of NIXL descriptor lists
+        """
+        bs = self._block_size
+        if bs <= 0 or total_size <= bs:
+            # Legacy: single descriptor (queue_depth = 1)
+            file_descs = self._agent.get_xfer_descs(
+                [(file_offset, total_size, fd)], "FILE"
+            )
+            local_descs = self._agent.get_xfer_descs(buffer)
+            return local_descs, file_descs
+
+        # Chunked: N descriptors of block_size each (queue_depth = N)
+        # This mimics nixlbench's approach: 64 x 1MB = 64 outstanding I/Os
+        buf_addr = buffer.data_ptr()
+        dev_id = buffer.device.index if buffer.is_cuda else 0
+
+        file_tuples = []
+        local_tuples = []
+        for off in range(0, total_size, bs):
+            chunk = min(bs, total_size - off)
+            file_tuples.append((file_offset + off, chunk, fd))
+            local_tuples.append((buf_addr + off, chunk, dev_id or 0))
+
+        file_descs = self._agent.get_xfer_descs(file_tuples, "FILE")
+        local_mem_type = "VRAM" if buffer.is_cuda else "DRAM"
+        local_descs = self._agent.get_xfer_descs(local_tuples, local_mem_type)
+
+        logger.debug(
+            "Chunked I/O: %d descs x %d bytes (total %d, queue_depth=%d)",
+            len(file_tuples),
+            bs,
+            total_size,
+            len(file_tuples),
+        )
+
+        return local_descs, file_descs
+
+    def _create_handle(self, op, fd, file_offset, size, buffer):
+        """Create a single NIXL transfer handle for a file region."""
+        local_descs, file_descs = self._create_chunked_descs(
+            fd, file_offset, size, buffer
+        )
+        return self._agent.initialize_xfer(
+            op,
+            local_descs,
+            file_descs,
+            self._agent.name,
+            backends=[self._nixl_backend],
+        )
+
+    def get_read_handle(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+    ) -> Any:
+        """Get NIXL transfer handle for reading from file."""
+        if handle.read_size == 0:
+            return None
+        return self._create_handle(
+            "READ", handle.backend_data["fd"], 0, handle.read_size, buffer
+        )
+
+    def get_write_handle(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+    ) -> Any:
+        """Get NIXL transfer handle for writing to file."""
+        if handle.write_size == 0:
+            return None
+        fd = handle.backend_data["fd"]
+        write_offset = handle.read_size
+        return self._create_handle("WRITE", fd, write_offset, handle.write_size, buffer)
+
+    def get_read_handles(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+        num_handles: int = 8,
+    ) -> list:
+        """Create multiple concurrent transfer handles for high-throughput reads.
+
+        When sharded files exist (prepare() created N files), each handle uses
+        a separate fd. The NFS client parallelizes I/O across different fds,
+        enabling ~10 GB/s per handle = N*10 GB/s total.
+
+        Args:
+            handle: StorageHandle from prepare()
+            buffer: Memory buffer (full size)
+            num_handles: Number of concurrent handles (default: 8, matching nixlbench)
+
+        Returns:
+            List of NIXL transfer handles
+        """
+        if handle.read_size == 0:
+            return []
+
+        if num_handles <= 1:
+            h = self.get_read_handle(handle, buffer)
+            return [h] if h else []
+
+        total = handle.read_size
+        shard_fds = handle.backend_data.get("shard_fds")
+
+        if shard_fds and len(shard_fds) > 1:
+            # Sharded: each handle reads from its own file/fd
+            shard_read = handle.backend_data["shard_read_size"]
+            handles = []
+            for i, fd in enumerate(shard_fds):
+                offset_in_buf = i * shard_read
+                size = min(shard_read, total - offset_in_buf)
+                if size <= 0:
+                    break
+                buf_slice = buffer[offset_in_buf : offset_in_buf + size]
+                # Each shard file starts at offset 0
+                xfer = self._create_handle("READ", fd, 0, size, buf_slice)
+                handles.append(xfer)
+            return handles
+        else:
+            # Single file: split into regions (same fd, limited by NFS)
+            fd = handle.backend_data["fd"]
+            align = max(self._block_size, 4096) if self._block_size > 0 else 4096
+            chunk_per_handle = ((total // num_handles + align - 1) // align) * align
+
+            handles = []
+            for i in range(num_handles):
+                offset = i * chunk_per_handle
+                size = min(chunk_per_handle, total - offset)
+                if size <= 0:
+                    break
+                buf_slice = buffer[offset : offset + size]
+                xfer = self._create_handle("READ", fd, offset, size, buf_slice)
+                handles.append(xfer)
+            return handles
+
+    def get_write_handles(
+        self,
+        handle: StorageHandle,
+        buffer: Any,
+        num_handles: int = 8,
+    ) -> list:
+        """Create multiple concurrent transfer handles for high-throughput writes."""
+        if handle.write_size == 0:
+            return []
+
+        if num_handles <= 1:
+            h = self.get_write_handle(handle, buffer)
+            return [h] if h else []
+
+        total = handle.write_size
+        shard_fds = handle.backend_data.get("shard_fds")
+
+        if shard_fds and len(shard_fds) > 1:
+            shard_read = handle.backend_data["shard_read_size"]
+            shard_write = handle.backend_data["shard_write_size"]
+            handles = []
+            for i, fd in enumerate(shard_fds):
+                offset_in_buf = i * shard_write
+                size = min(shard_write, total - offset_in_buf)
+                if size <= 0:
+                    break
+                buf_slice = buffer[offset_in_buf : offset_in_buf + size]
+                xfer = self._create_handle("WRITE", fd, shard_read, size, buf_slice)
+                handles.append(xfer)
+            return handles
+        else:
+            fd = handle.backend_data["fd"]
+            write_offset = handle.read_size
+            align = max(self._block_size, 4096) if self._block_size > 0 else 4096
+            chunk_per_handle = ((total // num_handles + align - 1) // align) * align
+
+            handles = []
+            for i in range(num_handles):
+                offset = i * chunk_per_handle
+                size = min(chunk_per_handle, total - offset)
+                if size <= 0:
+                    break
+                buf_slice = buffer[offset : offset + size]
+                xfer = self._create_handle(
+                    "WRITE", fd, write_offset + offset, size, buf_slice
+                )
+                handles.append(xfer)
+            return handles
+
+    def close(self):
+        """Close all files and deregister from NIXL."""
+        # Deregister from NIXL
+        for file_path, reg_descs in self._file_reg_descs.items():
+            try:
+                self._agent.deregister_memory(reg_descs, backends=[self._nixl_backend])
+            except Exception:
+                pass
+
+        # Close file descriptors
+        for file_path, fd in self._file_descriptors.items():
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+
+        self._handles.clear()
+        self._file_descriptors.clear()
+        self._file_reg_descs.clear()
+
+        logger.debug("FilesystemBackend closed")

--- a/benchmark/kvbench/test/storage_backend.py
+++ b/benchmark/kvbench/test/storage_backend.py
@@ -307,9 +307,10 @@ class FilesystemBackend(StorageBackend):
 
             shard_fds = []
             shard_paths = []
-            for s in range(n_shards):
-                fpath = self._get_file_path(tp_idx, rank, shard=s)
-                actual_read = min(shard_read, read_size - s * shard_read)
+            shard_actual_reads = []
+            for shard in range(n_shards):
+                fpath = self._get_file_path(tp_idx, rank, shard=shard)
+                actual_read = min(shard_read, read_size - shard * shard_read)
                 actual_read = max(actual_read, 0)
                 actual_size = actual_read + shard_write
                 if actual_size <= 0:
@@ -319,6 +320,7 @@ class FilesystemBackend(StorageBackend):
                 fd = self._open_and_register_file(fpath, actual_size)
                 shard_fds.append(fd)
                 shard_paths.append(str(fpath))
+                shard_actual_reads.append(actual_read)
 
             handle = StorageHandle(
                 tp_idx=tp_idx,
@@ -332,6 +334,12 @@ class FilesystemBackend(StorageBackend):
                     "shard_paths": shard_paths,
                     "shard_read_size": shard_read,
                     "shard_write_size": shard_write,
+                    # Per-shard actual read region size. The trailing shard's
+                    # read region may be shorter than shard_read when read_size
+                    # is not divisible by n_shards; writes for that shard must
+                    # start at this actual offset, not at shard_read, or they
+                    # would land past EOF of the (smaller) shard file.
+                    "shard_actual_reads": shard_actual_reads,
                 },
             )
 
@@ -516,8 +524,8 @@ class FilesystemBackend(StorageBackend):
         shard_fds = handle.backend_data.get("shard_fds")
 
         if shard_fds and len(shard_fds) > 1:
-            shard_read = handle.backend_data["shard_read_size"]
             shard_write = handle.backend_data["shard_write_size"]
+            shard_actual_reads = handle.backend_data["shard_actual_reads"]
             handles = []
             for i, fd in enumerate(shard_fds):
                 offset_in_buf = i * shard_write
@@ -525,7 +533,11 @@ class FilesystemBackend(StorageBackend):
                 if size <= 0:
                     break
                 buf_slice = buffer[offset_in_buf : offset_in_buf + size]
-                xfer = self._create_handle("WRITE", fd, shard_read, size, buf_slice)
+                # Write goes immediately after this shard's read region. For
+                # the trailing shard that region may be shorter than
+                # shard_read_size, so use the per-shard value.
+                write_offset = shard_actual_reads[i]
+                xfer = self._create_handle("WRITE", fd, write_offset, size, buf_slice)
                 handles.append(xfer)
             return handles
         else:

--- a/benchmark/kvbench/test/storage_backend.py
+++ b/benchmark/kvbench/test/storage_backend.py
@@ -549,19 +549,21 @@ class FilesystemBackend(StorageBackend):
 
     def close(self):
         """Close all files and deregister from NIXL."""
-        # Deregister from NIXL
-        for file_path, reg_descs in self._file_reg_descs.items():
+        # Deregister from NIXL. Failures here are not fatal — we still need
+        # to release the file descriptors below — but we log them at debug
+        # level so they're recoverable when investigating a cleanup issue.
+        for reg_descs in self._file_reg_descs.values():
             try:
                 self._agent.deregister_memory(reg_descs, backends=[self._nixl_backend])
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("deregister_memory failed during close: %s", exc)
 
         # Close file descriptors
-        for file_path, fd in self._file_descriptors.items():
+        for fd in self._file_descriptors.values():
             try:
                 os.close(fd)
-            except Exception:
-                pass
+            except OSError as exc:
+                logger.debug("os.close(fd=%d) failed during close: %s", fd, exc)
 
         self._handles.clear()
         self._file_descriptors.clear()

--- a/benchmark/kvbench/test/storage_backend.py
+++ b/benchmark/kvbench/test/storage_backend.py
@@ -244,19 +244,48 @@ class FilesystemBackend(StorageBackend):
             os.fsync(f.fileno())
 
     def _open_and_register_file(self, file_path: Path, file_size: int) -> int:
-        """Open a file and register it with NIXL. Returns fd."""
+        """Open a file and register it with NIXL. Returns fd.
+
+        If register_memory() raises, closes the fd and drops the bookkeeping
+        entry so the failure doesn't leak descriptors or leave stale state.
+        """
         flags = os.O_RDWR
         if self._use_direct_io:
             flags |= os.O_DIRECT
         fd = os.open(str(file_path), flags)
         self._file_descriptors[str(file_path)] = fd
 
-        reg_list = [(0, file_size, fd, str(file_path))]
-        reg_descs = self._agent.register_memory(
-            reg_list, "FILE", backends=[self._nixl_backend]
-        )
+        try:
+            reg_list = [(0, file_size, fd, str(file_path))]
+            reg_descs = self._agent.register_memory(
+                reg_list, "FILE", backends=[self._nixl_backend]
+            )
+        except Exception:
+            self._file_descriptors.pop(str(file_path), None)
+            try:
+                os.close(fd)
+            except OSError as exc:
+                logger.debug(
+                    "os.close(fd=%d) failed during register rollback: %s", fd, exc
+                )
+            raise
         self._file_reg_descs[str(file_path)] = reg_descs
         return fd
+
+    def _release_file(self, file_path: str) -> None:
+        """Deregister and close one file. Safe to call on partial state."""
+        reg_descs = self._file_reg_descs.pop(file_path, None)
+        if reg_descs is not None:
+            try:
+                self._agent.deregister_memory(reg_descs, backends=[self._nixl_backend])
+            except Exception as exc:
+                logger.debug("deregister_memory(%s) failed: %s", file_path, exc)
+        fd = self._file_descriptors.pop(file_path, None)
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError as exc:
+                logger.debug("os.close(fd=%d) failed: %s", fd, exc)
 
     @property
     def _num_shards(self):
@@ -295,32 +324,44 @@ class FilesystemBackend(StorageBackend):
                 backend_data={"file_path": str(file_path), "fd": fd},
             )
         else:
-            # Multi-file: N shards, each with size/N
+            # Multi-file: N shards, each with ceil(size/N) bytes (then
+            # aligned up). Floor division here would yield 0 whenever
+            # read_size < n_shards and silently produce no shards.
             align = max(self._block_size, 4096) if self._block_size > 0 else 4096
-            shard_read = ((read_size // n_shards + align - 1) // align) * align
-            shard_write = (
-                ((write_size // n_shards + align - 1) // align) * align
-                if write_size > 0
-                else 0
-            )
+
+            def _ceil_align(total: int, n: int) -> int:
+                if total <= 0:
+                    return 0
+                per_shard = (total + n - 1) // n
+                return ((per_shard + align - 1) // align) * align
+
+            shard_read = _ceil_align(read_size, n_shards)
+            shard_write = _ceil_align(write_size, n_shards)
             shard_size = shard_read + shard_write
 
             shard_fds = []
             shard_paths = []
             shard_actual_reads = []
-            for shard in range(n_shards):
-                fpath = self._get_file_path(tp_idx, rank, shard=shard)
-                actual_read = min(shard_read, read_size - shard * shard_read)
-                actual_read = max(actual_read, 0)
-                actual_size = actual_read + shard_write
-                if actual_size <= 0:
-                    break
-                if not fpath.exists():
-                    self._create_file(fpath, actual_size, actual_read, rank)
-                fd = self._open_and_register_file(fpath, actual_size)
-                shard_fds.append(fd)
-                shard_paths.append(str(fpath))
-                shard_actual_reads.append(actual_read)
+            try:
+                for shard in range(n_shards):
+                    fpath = self._get_file_path(tp_idx, rank, shard=shard)
+                    actual_read = min(shard_read, read_size - shard * shard_read)
+                    actual_read = max(actual_read, 0)
+                    actual_size = actual_read + shard_write
+                    if actual_size <= 0:
+                        break
+                    if not fpath.exists():
+                        self._create_file(fpath, actual_size, actual_read, rank)
+                    fd = self._open_and_register_file(fpath, actual_size)
+                    shard_fds.append(fd)
+                    shard_paths.append(str(fpath))
+                    shard_actual_reads.append(actual_read)
+            except Exception:
+                # Roll back any shards opened so far; otherwise the caller's
+                # except handler would inherit half-registered files.
+                for path in shard_paths:
+                    self._release_file(path)
+                raise
 
             handle = StorageHandle(
                 tp_idx=tp_idx,

--- a/benchmark/kvbench/test/storage_backend.py
+++ b/benchmark/kvbench/test/storage_backend.py
@@ -421,14 +421,29 @@ class FilesystemBackend(StorageBackend):
             backends=[self._nixl_backend],
         )
 
+    @staticmethod
+    def _is_sharded(handle: StorageHandle) -> bool:
+        shard_fds = handle.backend_data.get("shard_fds")
+        return bool(shard_fds) and len(shard_fds) > 1
+
     def get_read_handle(
         self,
         handle: StorageHandle,
         buffer: Any,
     ) -> Any:
-        """Get NIXL transfer handle for reading from file."""
+        """Get a single NIXL transfer handle that covers the whole read region.
+
+        Not supported for sharded backends (multiple shard files per rank) —
+        a single handle would only touch the first shard. Use
+        get_read_handles() instead, which returns one handle per shard.
+        """
         if handle.read_size == 0:
             return None
+        if self._is_sharded(handle):
+            raise ValueError(
+                "get_read_handle() does not support sharded storage "
+                "(rank has multiple shard files). Use get_read_handles() instead."
+            )
         return self._create_handle(
             "READ", handle.backend_data["fd"], 0, handle.read_size, buffer
         )
@@ -438,9 +453,17 @@ class FilesystemBackend(StorageBackend):
         handle: StorageHandle,
         buffer: Any,
     ) -> Any:
-        """Get NIXL transfer handle for writing to file."""
+        """Get a single NIXL transfer handle that covers the whole write region.
+
+        Not supported for sharded backends — see get_read_handle().
+        """
         if handle.write_size == 0:
             return None
+        if self._is_sharded(handle):
+            raise ValueError(
+                "get_write_handle() does not support sharded storage "
+                "(rank has multiple shard files). Use get_write_handles() instead."
+            )
         fd = handle.backend_data["fd"]
         write_offset = handle.read_size
         return self._create_handle("WRITE", fd, write_offset, handle.write_size, buffer)
@@ -468,18 +491,16 @@ class FilesystemBackend(StorageBackend):
         if handle.read_size == 0:
             return []
 
-        if num_handles <= 1:
-            h = self.get_read_handle(handle, buffer)
-            return [h] if h else []
-
         total = handle.read_size
-        shard_fds = handle.backend_data.get("shard_fds")
 
-        if shard_fds and len(shard_fds) > 1:
-            # Sharded: each handle reads from its own file/fd
+        # Sharded mode always uses one handle per shard; num_handles is
+        # ignored because mixing fds within a shard buys nothing on NFS.
+        # Check this BEFORE the num_handles<=1 singular fallback, since
+        # get_read_handle() can't represent a sharded read.
+        if self._is_sharded(handle):
             shard_read = handle.backend_data["shard_read_size"]
             handles = []
-            for i, fd in enumerate(shard_fds):
+            for i, fd in enumerate(handle.backend_data["shard_fds"]):
                 offset_in_buf = i * shard_read
                 size = min(shard_read, total - offset_in_buf)
                 if size <= 0:
@@ -489,22 +510,26 @@ class FilesystemBackend(StorageBackend):
                 xfer = self._create_handle("READ", fd, 0, size, buf_slice)
                 handles.append(xfer)
             return handles
-        else:
-            # Single file: split into regions (same fd, limited by NFS)
-            fd = handle.backend_data["fd"]
-            align = max(self._block_size, 4096) if self._block_size > 0 else 4096
-            chunk_per_handle = ((total // num_handles + align - 1) // align) * align
 
-            handles = []
-            for i in range(num_handles):
-                offset = i * chunk_per_handle
-                size = min(chunk_per_handle, total - offset)
-                if size <= 0:
-                    break
-                buf_slice = buffer[offset : offset + size]
-                xfer = self._create_handle("READ", fd, offset, size, buf_slice)
-                handles.append(xfer)
-            return handles
+        if num_handles <= 1:
+            h = self.get_read_handle(handle, buffer)
+            return [h] if h else []
+
+        # Single file: split into regions (same fd, limited by NFS)
+        fd = handle.backend_data["fd"]
+        align = max(self._block_size, 4096) if self._block_size > 0 else 4096
+        chunk_per_handle = ((total // num_handles + align - 1) // align) * align
+
+        handles = []
+        for i in range(num_handles):
+            offset = i * chunk_per_handle
+            size = min(chunk_per_handle, total - offset)
+            if size <= 0:
+                break
+            buf_slice = buffer[offset : offset + size]
+            xfer = self._create_handle("READ", fd, offset, size, buf_slice)
+            handles.append(xfer)
+        return handles
 
     def get_write_handles(
         self,
@@ -516,18 +541,15 @@ class FilesystemBackend(StorageBackend):
         if handle.write_size == 0:
             return []
 
-        if num_handles <= 1:
-            h = self.get_write_handle(handle, buffer)
-            return [h] if h else []
-
         total = handle.write_size
-        shard_fds = handle.backend_data.get("shard_fds")
 
-        if shard_fds and len(shard_fds) > 1:
+        # Sharded mode: one handle per shard regardless of num_handles.
+        # See the symmetric note in get_read_handles().
+        if self._is_sharded(handle):
             shard_write = handle.backend_data["shard_write_size"]
             shard_actual_reads = handle.backend_data["shard_actual_reads"]
             handles = []
-            for i, fd in enumerate(shard_fds):
+            for i, fd in enumerate(handle.backend_data["shard_fds"]):
                 offset_in_buf = i * shard_write
                 size = min(shard_write, total - offset_in_buf)
                 if size <= 0:
@@ -540,24 +562,28 @@ class FilesystemBackend(StorageBackend):
                 xfer = self._create_handle("WRITE", fd, write_offset, size, buf_slice)
                 handles.append(xfer)
             return handles
-        else:
-            fd = handle.backend_data["fd"]
-            write_offset = handle.read_size
-            align = max(self._block_size, 4096) if self._block_size > 0 else 4096
-            chunk_per_handle = ((total // num_handles + align - 1) // align) * align
 
-            handles = []
-            for i in range(num_handles):
-                offset = i * chunk_per_handle
-                size = min(chunk_per_handle, total - offset)
-                if size <= 0:
-                    break
-                buf_slice = buffer[offset : offset + size]
-                xfer = self._create_handle(
-                    "WRITE", fd, write_offset + offset, size, buf_slice
-                )
-                handles.append(xfer)
-            return handles
+        if num_handles <= 1:
+            h = self.get_write_handle(handle, buffer)
+            return [h] if h else []
+
+        fd = handle.backend_data["fd"]
+        write_offset = handle.read_size
+        align = max(self._block_size, 4096) if self._block_size > 0 else 4096
+        chunk_per_handle = ((total // num_handles + align - 1) // align) * align
+
+        handles = []
+        for i in range(num_handles):
+            offset = i * chunk_per_handle
+            size = min(chunk_per_handle, total - offset)
+            if size <= 0:
+                break
+            buf_slice = buffer[offset : offset + size]
+            xfer = self._create_handle(
+                "WRITE", fd, write_offset + offset, size, buf_slice
+            )
+            handles.append(xfer)
+        return handles
 
     def close(self):
         """Close all files and deregister from NIXL."""

--- a/benchmark/kvbench/test/traffic_pattern.py
+++ b/benchmark/kvbench/test/traffic_pattern.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass, field
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Dict, Literal, Optional
 
 import numpy as np
 import torch
+
+
+@dataclass
+class StorageOp:
+    """Storage operation configuration for a single rank."""
+
+    file_path: str
+    file_size: int
+    read_offset: int
+    read_size: int
+    write_offset: int
+    write_size: int
 
 
 @dataclass
@@ -24,26 +36,33 @@ class TrafficPattern:
     """Represents a communication pattern between distributed processes.
 
     Attributes:
-        matrix: Communication matrix as numpy array
+        matrix: Communication matrix as numpy array (optional, None for storage-only)
         mem_type: Type of memory to use
         xfer_op: Transfer operation type
         shards: Number of shards for distributed processing
         dtype: PyTorch data type for the buffers
         sleep_before_launch_sec: Number of seconds to sleep before launch
-        sleep_after_launch_sec: Number of seconds to sleep after launch
+        sleep_after_launch_sec: Number of seconds to sleep after RDMA
+        storage_ops: Per-rank storage operations (loaded from external config)
         id: Unique identifier for this traffic pattern
     """
 
-    matrix: np.ndarray
     mem_type: Literal["cuda", "vram", "cpu", "dram"]
+    matrix: Optional[np.ndarray] = None  # None for storage-only patterns
     xfer_op: Literal["WRITE", "READ"] = "WRITE"
     shards: int = 1
     dtype: torch.dtype = torch.int8
-    sleep_before_launch_sec: Optional[int] = None
-    sleep_after_launch_sec: Optional[int] = None
+    sleep_before_launch_sec: Optional[float] = None
+    sleep_after_launch_sec: Optional[float] = None
+    storage_ops: Optional[Dict[int, StorageOp]] = None  # rank -> StorageOp
 
     id: int = field(default_factory=lambda: TrafficPattern._get_next_id())
     _id_counter: ClassVar[int] = 0
+
+    # Cached rank lists (computed once in __post_init__, matrix is immutable)
+    _senders: list = field(default_factory=list, init=False, repr=False)
+    _receivers: list = field(default_factory=list, init=False, repr=False)
+    _all_participating: list = field(default_factory=list, init=False, repr=False)
 
     @classmethod
     def _get_next_id(cls) -> int:
@@ -52,45 +71,85 @@ class TrafficPattern:
         cls._id_counter += 1
         return current_id
 
+    def __post_init__(self):
+        """Pre-compute and cache rank lists from the immutable matrix."""
+        if self.matrix is not None:
+            senders = set()
+            receivers = set()
+            for i in range(self.matrix.shape[0]):
+                for j in range(self.matrix.shape[1]):
+                    if self.matrix[i, j] > 0:
+                        senders.add(i)
+                        receivers.add(j)
+            self._senders = sorted(senders)
+            self._receivers = sorted(receivers)
+        else:
+            self._senders = []
+            self._receivers = []
+
+        # All participating ranks: senders + receivers + storage ranks
+        all_ranks = set(self._senders + self._receivers)
+        if self.storage_ops:
+            all_ranks.update(self.storage_ops.keys())
+        self._all_participating = sorted(all_ranks)
+
+    def has_rdma(self) -> bool:
+        """Check if this traffic pattern has any RDMA traffic."""
+        return len(self._senders) > 0
+
     def senders_ranks(self):
-        """Return the ranks that send messages"""
-        senders_ranks = []
-        for i in range(self.matrix.shape[0]):
-            for j in range(self.matrix.shape[1]):
-                if self.matrix[i, j] > 0:
-                    senders_ranks.append(i)
-                    break
-        return list(set(senders_ranks))
+        """Return the ranks (process indices) that send messages."""
+        return self._senders
 
     def receivers_ranks(self, from_ranks: Optional[list[int]] = None):
-        """Return the ranks that receive messages"""
+        """Return the ranks (process indices) that receive messages."""
         if from_ranks is None:
-            from_ranks = list(range(self.matrix.shape[0]))
-        receivers_ranks = []
+            return self._receivers
+        # Filtered case: only receivers that receive from specified senders
+        if self.matrix is None:
+            return []
+        result = set()
         for i in from_ranks:
             for j in range(self.matrix.shape[1]):
                 if self.matrix[i, j] > 0:
-                    receivers_ranks.append(j)
-                    break
-        return list(set(receivers_ranks))
+                    result.add(j)
+        return sorted(result)
 
     def ranks(self):
-        """Return all ranks that are involved in the traffic pattern"""
-        return list(set(self.senders_ranks() + self.receivers_ranks()))
+        """Return all ranks that are involved in RDMA traffic"""
+        return sorted(set(self._senders + self._receivers))
+
+    def all_participating_ranks(self):
+        """Return all ranks that actively participate in this TP.
+
+        Includes:
+        - RDMA senders (they initiate transfers)
+        - RDMA receivers (they wait for notifications and participate in barriers)
+        - Storage ranks (they do read/write ops)
+        """
+        return self._all_participating
 
     def buf_size(self, src, dst):
+        if self.matrix is None:
+            return 0
         return self.matrix[src, dst]
 
     def total_src_size(self, rank):
-        """Return the sum of the sizes received by <rank>"""
+        """Return the total size sent by <rank> across all destinations."""
+        if self.matrix is None:
+            return 0
         total_src_size = 0
-        for other_rank in range(self.matrix.shape[0]):
-            total_src_size += self.matrix[rank][other_rank]
+        # iterate over columns (destinations)
+        for dst in range(self.matrix.shape[1]):
+            total_src_size += self.matrix[rank][dst]
         return total_src_size
 
     def total_dst_size(self, rank):
-        """Return the sum of the sizes received by <rank>"""
+        """Return the total size received by <rank> across all sources."""
+        if self.matrix is None:
+            return 0
         total_dst_size = 0
-        for other_rank in range(self.matrix.shape[0]):
-            total_dst_size += self.matrix[other_rank][rank]
+        # iterate over rows (sources)
+        for src in range(self.matrix.shape[0]):
+            total_dst_size += self.matrix[src][rank]
         return total_dst_size

--- a/benchmark/kvbench/test/traffic_pattern.py
+++ b/benchmark/kvbench/test/traffic_pattern.py
@@ -99,12 +99,14 @@ class TrafficPattern:
 
     def senders_ranks(self):
         """Return the ranks (process indices) that send messages."""
-        return self._senders
+        # Return a copy: callers mutate downstream and the cached list
+        # must stay pristine.
+        return list(self._senders)
 
     def receivers_ranks(self, from_ranks: Optional[list[int]] = None):
         """Return the ranks (process indices) that receive messages."""
         if from_ranks is None:
-            return self._receivers
+            return list(self._receivers)
         # Filtered case: only receivers that receive from specified senders
         if self.matrix is None:
             return []
@@ -127,7 +129,7 @@ class TrafficPattern:
         - RDMA receivers (they wait for notifications and participate in barriers)
         - Storage ranks (they do read/write ops)
         """
-        return self._all_participating
+        return list(self._all_participating)
 
     def buf_size(self, src, dst):
         if self.matrix is None:


### PR DESCRIPTION
Foundation for storage-target benchmarking in kvbench. Adds:

- test/storage_backend.py: StorageBackend abstraction with a FilesystemBackend implementation. Manages per-rank shard files, read/write handle preparation, block-size chunking for high io_uring queue depth, and cleanup.
- test/traffic_pattern.py: extends TrafficPattern with StorageOp (READ/WRITE) and storage-specific descriptor sizing.
- runtime/etcd_rt.py: pass-through `timeout_sec` for allgather_obj, alltoall_obj, and all_reduce so callers can override the 600s default; add per-call operation counter to alltoall_obj to avoid in-flight key collisions across consecutive calls.

The benchmark runner that consumes this infrastructure (sequential_custom_traffic_perftest.py and CLI wiring) lands in a follow-up PR stacked on this one.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a storage backend abstraction with a filesystem-backed implementation for benchmarks.
  * Traffic pattern model now supports storage-only workloads and per-rank storage operations.

* **Improvements**
  * ETCD-based coordination is more resilient to eventual-consistency delays via an initialization barrier and bounded retries.
  * Collective operations now accept timeouts, use timeout-bounded polling, and report clearer diagnostics for missing/arrived participants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->