### PR TITLE
fix(ci): derive build NPROC from container CPU quota

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -12,8 +12,8 @@ timeout_minutes: 240
 kubernetes:
   cloud: il-ipp-blossom-prod
   namespace: nbu-swx-nixl
-  limits: "{memory: 16Gi, cpu: 8000m}"
-  requests: "{memory: 8Gi, cpu: 4000m}"
+  limits: "{memory: 24Gi, cpu: 12000m}"
+  requests: "{memory: 24Gi, cpu: 12000m}"
 
 runs_on_dockers:
   - { name: "podman", url: "quay.io/podman/stable:v5.7.1", privileged: true }
@@ -27,6 +27,8 @@ matrix:
 
 # Configuration
 env:
+  NPROC: 24
+  GRPC_NPROC: 24
   REGISTRY_HOST_NAME: "artifactory.nvidia.com"
   REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
   REGISTRY_REPO_PATH: "verification"


### PR DESCRIPTION
## What?
build-container.sh defaults NPROC to $(nproc), which inside the privileged podman runner reports the host node's full core count rather than the pod's cpu limit. The resulting over-parallel make exhausted the pod memory limit and OOM-killed the build unless NPROC was passed explicitly as a pipeline parameter.

Set NPROC and GRPC_NPROC in the build-container job env (sized to the pod's 24Gi memory) and bump the job resources to 24Gi/12 cores.

## Why?
[HPCINFRA-4446](https://jirasw.nvidia.com/browse/HPCINFRA-4446)

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build infrastructure configuration with increased resource allocation and enhanced parallelization settings to support more efficient build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->