### PR TITLE
Run DL tests across multiple SLURM partitions

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -115,7 +115,14 @@ steps:
     module: slurmCI
     run: allocation
     args:
-      partition: "${SLURM_PARTITION}"
+      partition: [
+        "gb300nvl72_ci",
+        "gb200nvl72_ci"
+      ]
+      account: [
+        'blackwell-ci',
+        'oberon-gb-ci'
+      ]
       headNode: "${SLURM_HEAD_NODE}"
       headUser: "${SLURM_HEAD_USER}"
       nodes: "${SLURM_NODES}"
@@ -124,9 +131,6 @@ steps:
       jobName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       credentialsId: "${SSH_CREDENTIALS_ID}"
-      extraArgs: [
-        "--account=${SLURM_ACCOUNT}"
-      ]
 
   - name: Run DL Python tests
     containerSelector: "{name: 'build_helper_dl'}"

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -123,7 +123,9 @@ steps:
       extraArgs: [
         "--gres=${SLURM_GRES}",
         "--mincpus=${SLURM_MINCPUS}",
-        "--mem=${SLURM_MEM}"
+        "--mem=${SLURM_MEM}",
+        "--nodelist=mizu03",
+        "--reservation=BF3_tests"
       ]
 
   - name: Run CPP tests


### PR DESCRIPTION
The DL test allocation step previously targeted a single partition via ${SLURM_PARTITION} with the account passed through extraArgs. This made the job dependent on one cluster's availability.

Switch partition and account to parallel lists
(gb300nvl72_ci/blackwell-ci and gb200nvl72_ci/oberon-gb-ci) so the allocation can fall back across Blackwell clusters, and pin the slurmCI module to the slurm-multi-partition ref that supports list-based scheduling. The extraArgs account override is no longer needed and is commented out.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
