### PR TITLE
Release GIL lock during makeXferReq

### DIFF
--- a/src/bindings/python/nixl_bindings.cpp
+++ b/src/bindings/python/nixl_bindings.cpp
@@ -632,13 +632,16 @@ PYBIND11_MODULE(_bindings, m) {
                 local_indices_vec = init_indices_lambda(local_indices);
                 remote_indices_vec = init_indices_lambda(remote_indices);
 
-                throw_nixl_exception(agent.makeXferReq(operation,
-                                                       (nixlDlistH *)local_side,
-                                                       local_indices_vec,
-                                                       (nixlDlistH *)remote_side,
-                                                       remote_indices_vec,
-                                                       handle,
-                                                       &extra_params));
+                {
+                    py::gil_scoped_release release;
+                    throw_nixl_exception(agent.makeXferReq(operation,
+                                                           (nixlDlistH *)local_side,
+                                                           local_indices_vec,
+                                                           (nixlDlistH *)remote_side,
+                                                           remote_indices_vec,
+                                                           handle,
+                                                           &extra_params));
+                }
 
                 return (uintptr_t)handle;
             },


### PR DESCRIPTION
## What?
NIXL does not release GIL lock during `make_prepped_xfer` which leads to GIL lock contention when xfer is made from multiple threads concurrently.

## Why?
High contention on GIL lock causes higher latency

## Testing
This change improves TTFT by ~2-3% when running on large dimensions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved performance efficiency for Python transfer request operations through internal optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->