### PR TITLE
Use C++20 likely/unlikely instead of __builtin_expect

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1548,20 +1548,20 @@ execTransferLoop(nixlAgent *agent,
     int completed = 0;
 
     for (int s = 0; s < depth; s++) {
-        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+        if (terminate_ptr && terminate_ptr->load()) [[unlikely]] {
             cleanupSlots(agent, backend_engine, slots);
             return -1;
         }
         nixl_status_t rc =
             prepareSlot(agent, backend_engine, op, target, params, thread_stats, slots[s]);
-        if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+        if (rc != NIXL_SUCCESS) [[unlikely]] {
             std::cerr << "prepareSlot failed for slot " << s << ": "
                       << nixlEnumStrings::statusStr(rc) << std::endl;
             cleanupSlots(agent, backend_engine, slots);
             return -1;
         }
         rc = postSlot(agent, thread_stats, slots[s]);
-        if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+        if (rc != NIXL_SUCCESS) [[unlikely]] {
             std::cerr << "postSlot failed for slot " << s << ": " << nixlEnumStrings::statusStr(rc)
                       << std::endl;
             cleanupSlots(agent, backend_engine, slots);
@@ -1571,7 +1571,7 @@ execTransferLoop(nixlAgent *agent,
     }
 
     while (completed < num_iter) {
-        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+        if (terminate_ptr && terminate_ptr->load()) [[unlikely]] {
             cleanupSlots(agent, backend_engine, slots);
             return -1;
         }
@@ -1585,7 +1585,7 @@ execTransferLoop(nixlAgent *agent,
                 continue;
             }
 
-            if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+            if (rc != NIXL_SUCCESS) [[unlikely]] {
                 std::cerr << "Transfer failed on slot " << s << ": "
                           << nixlEnumStrings::statusStr(rc) << std::endl;
                 cleanupSlots(agent, backend_engine, slots);
@@ -1600,21 +1600,21 @@ execTransferLoop(nixlAgent *agent,
                 continue;
             }
 
-            if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            if (terminate_ptr && terminate_ptr->load()) [[unlikely]] {
                 cleanupSlots(agent, backend_engine, slots);
                 return -1;
             }
 
             if (recreate) {
                 rc = recycleSlot(agent, backend_engine, slots[s]);
-                if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                if (rc != NIXL_SUCCESS) [[unlikely]] {
                     std::cerr << "recycleSlot failed for slot " << s << ": "
                               << nixlEnumStrings::statusStr(rc) << std::endl;
                     cleanupSlots(agent, backend_engine, slots);
                     return -1;
                 }
                 rc = prepareSlot(agent, backend_engine, op, target, params, thread_stats, slots[s]);
-                if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                if (rc != NIXL_SUCCESS) [[unlikely]] {
                     std::cerr << "prepareSlot failed on resubmit for slot " << s << ": "
                               << nixlEnumStrings::statusStr(rc) << std::endl;
                     cleanupSlots(agent, backend_engine, slots);
@@ -1623,7 +1623,7 @@ execTransferLoop(nixlAgent *agent,
             }
 
             rc = postSlot(agent, thread_stats, slots[s]);
-            if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+            if (rc != NIXL_SUCCESS) [[unlikely]] {
                 std::cerr << "postSlot failed on resubmit for slot " << s << ": "
                           << nixlEnumStrings::statusStr(rc) << std::endl;
                 cleanupSlots(agent, backend_engine, slots);
@@ -1677,7 +1677,7 @@ execTransfer(nixlAgent *agent,
                                       remote_iov,
                                       terminate_ptr);
 
-        if (__builtin_expect(result != 0, 0)) {
+        if (result != 0) [[unlikely]] {
             ret = result;
         }
 

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -853,7 +853,7 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
 
     size_t total_bytes = 0;
     for (int i = 0; i < local_descs.descCount(); ++i) {
-        if (__builtin_expect(local_descs[i].len != remote_descs[i].len, 0)) {
+        if (local_descs[i].len != remote_descs[i].len) [[unlikely]] {
             NIXL_ERROR_FUNC << "length mismatch at index " << i;
             return NIXL_ERR_INVALID_PARAM;
         }

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -83,17 +83,17 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
 
     // Walk forward for non-decreasing elements; logN search on temporal disorder
     for (int i = 1; i < query.descCount(); ++i) {
-        if (__builtin_expect(query[i] < query[i - 1], 0)) {
+        if (query[i] < query[i - 1]) [[unlikely]] {
             // Disorder in the list, resolve this element using logN search
             s_index = base.getCoveringIndex(query[i]);
-            if (__builtin_expect(s_index < 0, 0)) {
+            if (s_index < 0) [[unlikely]] {
                 resp.clear();
                 return NIXL_ERR_UNKNOWN;
             }
         } else {
             while (s_index < size && !base[s_index].covers(query[i]))
                 ++s_index;
-            if (__builtin_expect(s_index == size, 0)) {
+            if (s_index == size) [[unlikely]] {
                 resp.clear();
                 return NIXL_ERR_UNKNOWN;
             }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -155,7 +155,7 @@ public:
         nixl_status_t out_ret = NIXL_SUCCESS;
         for (nixlUcxReq req : requests_) {
             const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
-            if (__builtin_expect(ret == NIXL_SUCCESS, 0)) {
+            if (ret == NIXL_SUCCESS) [[unlikely]] {
                 worker_->reqRelease(req);
             } else if (ret == NIXL_IN_PROG) {
                 if (out_ret == NIXL_SUCCESS) {
@@ -1168,7 +1168,7 @@ nixlUcxEngine::sendXferRangeBatch(nixlUcxEp &ep,
         const auto lmd = static_cast<nixlUcxPrivateMetadata *>(local[i].metadataP);
         const auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[i].metadataP);
         auto &rmd_ep = rmd->conn->getEp(worker_id);
-        if (__builtin_expect(rmd_ep.get() != &ep, 0)) {
+        if (rmd_ep.get() != &ep) [[unlikely]] {
             break;
         }
 
@@ -1179,7 +1179,7 @@ nixlUcxEngine::sendXferRangeBatch(nixlUcxEp &ep,
             ep.write(laddr, lmd->mem, raddr, rmd->getRkey(worker_id), lsize, req);
 
         if (ret == NIXL_IN_PROG) {
-            if (__builtin_expect(result.req != nullptr, 1)) {
+            if (result.req != nullptr) [[likely]] {
                 ucp_request_free(result.req);
             }
             result.req = req;
@@ -1310,12 +1310,12 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
     const nixlUcxBackendReqH::Notif notif(std::move(int_handle->notif).value());
     int_handle->notif.reset();
 
-    if (__builtin_expect(handle_status != NIXL_SUCCESS, 0)) {
+    if (handle_status != NIXL_SUCCESS) [[unlikely]] {
         return handle_status;
     }
 
     const ucx_connection_ptr_t conn = getConnection(notif.agent);
-    if (__builtin_expect(!conn, 0)) {
+    if (!conn) [[unlikely]] {
         return NIXL_ERR_NOT_FOUND;
     }
 

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -155,7 +155,7 @@ public:
         nixl_status_t out_ret = NIXL_SUCCESS;
         for (nixlUcxReq req : requests_) {
             const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
-            if (ret == NIXL_SUCCESS) [[unlikely]] {
+            if (ret == NIXL_SUCCESS) [[likely]] {
                 worker_->reqRelease(req);
             } else if (ret == NIXL_IN_PROG) {
                 if (out_ret == NIXL_SUCCESS) {

--- a/src/plugins/ucx/ucx_enums.cpp
+++ b/src/plugins/ucx/ucx_enums.cpp
@@ -41,8 +41,8 @@ operator<<(std::ostream &os, const am_cb_op_t t) {
 
 nixl_status_t
 ucsToNixlStatus(const ucs_status_t t) {
-    switch (__builtin_expect(t, UCS_OK)) {
-    case UCS_OK:
+    switch (t) {
+    [[likely]] case UCS_OK:
         return NIXL_SUCCESS;
     case UCS_INPROGRESS:
     case UCS_ERR_BUSY:


### PR DESCRIPTION
## What?
Use C++20 likely/unlikely instead of __builtin_expect

## Why?
Prefer C++20 standard constructs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized internal branch annotations across core and backend components. No functional or API changes; error handling and behavior are unchanged. No end‑user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->