### PR TITLE
DOCA MEMOS Backend

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -58,7 +58,7 @@ NB_ARG_STRING(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem
 NB_ARG_STRING(backend,
               XFERBENCH_BACKEND_UCX,
               "Name of NIXL backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ, "
-              "GUSLI, AZURE_BLOB] (only used with nixl worker)");
+              "GUSLI, AZURE_BLOB, DOCA_MEMOS] (only used with nixl worker)");
 NB_ARG_STRING(initiator_seg_type,
               XFERBENCH_SEG_TYPE_DRAM,
               "Type of memory segment for initiator [DRAM, VRAM]. Note: Storage backends always "
@@ -69,7 +69,7 @@ NB_ARG_STRING(target_seg_type,
               "remote type automatically.");
 NB_ARG_STRING(scheme, XFERBENCH_SCHEME_PAIRWISE, "Scheme: pairwise, manytoone, onetomany, tp");
 NB_ARG_STRING(mode, XFERBENCH_MODE_SG, "MODE: SG (Single GPU per proc), MG (Multi GPU per proc)");
-NB_ARG_STRING(op_type, XFERBENCH_OP_WRITE, "Op type: READ, WRITE");
+NB_ARG_STRING(op_type, XFERBENCH_OP_WRITE, "Op type: READ, WRITE, QUERY");
 NB_ARG_BOOL(check_consistency, false, "Enable Consistency Check");
 NB_ARG_UINT64(total_buffer_size,
               8LL * 1024 * (1 << 20),
@@ -241,6 +241,16 @@ NB_ARG_BOOL(gusli_try_use_uring,
             false,
             "Try to use io_uring engine in GUSLI backend (default: false)");
 
+// DOCA_MEMOS options - only used when backend is DOCA_MEMOS
+NB_ARG_STRING(doca_memos_device_name, "/dev/nvme0n1", "DOCA_MEMOS device name");
+NB_ARG_INT32(doca_memos_num_tasks, 8192, "DOCA_MEMOS number of tasks");
+NB_ARG_STRING(doca_memos_query_mem_mode,
+              "assume_success",
+              "DOCA_MEMOS queryMem mode [assume_success, actual]");
+NB_ARG_STRING(doca_memos_nguid, "", "DOCA_MEMOS namespace GUID (32 hex chars, optional)");
+NB_ARG_BOOL(doca_memos_ignore_read_not_found,
+            false,
+            "DOCA_MEMOS: treat key-not-found on read as success");
 
 #undef NB_ARG_INT32
 #undef NB_ARG_UINT32
@@ -321,6 +331,11 @@ std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
 bool xferBenchConfig::gusli_try_use_uring = false;
+std::string xferBenchConfig::doca_memos_device_name = "/dev/nvme0n1";
+int xferBenchConfig::doca_memos_num_tasks = 8192;
+std::string xferBenchConfig::doca_memos_query_mem_mode = "assume_success";
+std::string xferBenchConfig::doca_memos_nguid = "";
+bool xferBenchConfig::doca_memos_ignore_read_not_found = false;
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -446,6 +461,23 @@ xferBenchConfig::loadParams(void) {
             gusli_device_byte_offsets = NB_ARG(gusli_device_byte_offsets);
             gusli_device_security = NB_ARG(gusli_device_security);
             gusli_try_use_uring = NB_ARG(gusli_try_use_uring);
+        }
+
+        // Load DOCA_MEMOS-specific configurations if backend is DOCA_MEMOS
+        if (backend == XFERBENCH_BACKEND_DOCA_MEMOS) {
+            doca_memos_device_name = NB_ARG(doca_memos_device_name);
+            doca_memos_num_tasks = NB_ARG(doca_memos_num_tasks);
+            doca_memos_query_mem_mode = NB_ARG(doca_memos_query_mem_mode);
+            doca_memos_nguid = NB_ARG(doca_memos_nguid);
+            doca_memos_ignore_read_not_found = NB_ARG(doca_memos_ignore_read_not_found);
+
+            // The generic consistency check reads written data back through the
+            // S3/Azure object helpers, which DOCA_MEMOS does not implement. The
+            // plugin verifies retrieved data internally on READ instead.
+            if (NB_ARG(check_consistency)) {
+                std::cerr << "DOCA_MEMOS backend does not support --check_consistency" << std::endl;
+                return -1;
+            }
         }
 
         // Load OBJ-specific configurations if backend is OBJ
@@ -729,8 +761,9 @@ xferBenchConfig::printConfig() {
     }
     printOption("Worker type (--worker_type=[nixl,nvshmem])", worker_type);
     if (worker_type == XFERBENCH_WORKER_NIXL) {
-        printOption("Backend (--backend=[UCX,GDS,GDS_MT,POSIX,Mooncake,HF3FS,OBJ,AZURE_BLOB])",
-                    backend);
+        printOption(
+            "Backend (--backend=[UCX,GDS,GDS_MT,POSIX,Mooncake,HF3FS,OBJ,AZURE_BLOB,DOCA_MEMOS])",
+            backend);
         printOption("Enable pt (--enable_pt=[0,1])", std::to_string(enable_pt));
         printOption("Progress threads (--progress_threads=N)", std::to_string(progress_threads));
         printOption("Device list (--device_list=dev1,dev2,...)", device_list);
@@ -828,7 +861,7 @@ xferBenchConfig::printConfig() {
     printOption("Target seg type (--target_seg_type=[DRAM,VRAM])", target_seg_type);
     printOption("Scheme (--scheme=[pairwise,manytoone,onetomany,tp])", scheme);
     printOption("Mode (--mode=[SG,MG])", mode);
-    printOption("Op type (--op_type=[READ,WRITE])", op_type);
+    printOption("Op type (--op_type=[READ,WRITE,QUERY])", op_type);
     printOption("Check consistency (--check_consistency=[0,1])", std::to_string(check_consistency));
     printOption("Total buffer size (--total_buffer_size=N)", std::to_string(total_buffer_size));
     printOption("Num initiator dev (--num_initiator_dev=N)", std::to_string(num_initiator_dev));
@@ -882,14 +915,22 @@ xferBenchConfig::isStorageBackend() {
             XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend ||
+            XFERBENCH_BACKEND_DOCA_MEMOS == xferBenchConfig::backend);
 }
 
 bool
 xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend ||
+            XFERBENCH_BACKEND_DOCA_MEMOS == xferBenchConfig::backend);
+};
+
+bool
+xferBenchConfig::hasObjectStorageHelpers() {
+    return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
+            XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend);
 };
 
 
@@ -1084,7 +1125,7 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
                         exit(EXIT_FAILURE);
                     }
                     is_allocated = true;
-                    if (xferBenchConfig::isObjStorageBackend()) {
+                    if (xferBenchConfig::hasObjectStorageHelpers()) {
                         if (!xferBenchUtils::getObj(iov.metaInfo)) {
                             std::cerr << "Failed to get object: " << iov.metaInfo << std::endl;
                             exit(EXIT_FAILURE);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -98,6 +98,7 @@
 #define XFERBENCH_BACKEND_UCCL "UCCL"
 #define XFERBENCH_BACKEND_AZURE_BLOB "AZURE_BLOB"
 #define XFERBENCH_BACKEND_INFINIA "INFINIA"
+#define XFERBENCH_BACKEND_DOCA_MEMOS "DOCA_MEMOS"
 
 // POSIX API types
 #define XFERBENCH_POSIX_API_AIO "AIO"
@@ -127,6 +128,7 @@
 // Operation types
 #define XFERBENCH_OP_READ "READ"
 #define XFERBENCH_OP_WRITE "WRITE"
+#define XFERBENCH_OP_QUERY "QUERY"
 
 // Mode types
 #define XFERBENCH_MODE_SG "SG"
@@ -227,6 +229,11 @@ public:
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
     static bool gusli_try_use_uring;
+    static std::string doca_memos_device_name;
+    static int doca_memos_num_tasks;
+    static std::string doca_memos_query_mem_mode;
+    static std::string doca_memos_nguid;
+    static bool doca_memos_ignore_read_not_found;
 
     static int
     parseConfig(int argc, char *argv[]);
@@ -242,6 +249,11 @@ public:
     isStorageBackend();
     static bool
     isObjStorageBackend();
+    // True only for backends that expose S3/Azure-style object CRUD helpers
+    // (putObj/getObj/rmObj). DOCA_MEMOS uses OBJ_SEG but has no such helpers,
+    // so it is intentionally excluded.
+    static bool
+    hasObjectStorageHelpers();
 
 protected:
     static int

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -316,6 +316,29 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
                       << "]: " << dev.device_path << " (" << dev.security_flags << ")"
                       << ", offset = " << dev.dev_offset << std::endl;
         }
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_DOCA_MEMOS)) {
+        // Set DOCA_MEMOS backend parameters
+        backend_params["device_name"] = xferBenchConfig::doca_memos_device_name;
+        backend_params["num_tasks"] = std::to_string(xferBenchConfig::doca_memos_num_tasks);
+        backend_params["query_mem_mode"] = xferBenchConfig::doca_memos_query_mem_mode;
+        if (!xferBenchConfig::doca_memos_nguid.empty()) {
+            backend_params["nguid"] = xferBenchConfig::doca_memos_nguid;
+        }
+        if (xferBenchConfig::doca_memos_ignore_read_not_found) {
+            backend_params["ignore_read_not_found"] = "true";
+        }
+
+        std::cout << "DOCA_MEMOS backend initialized:" << std::endl;
+        std::cout << "  Device: " << xferBenchConfig::doca_memos_device_name << std::endl;
+        std::cout << "  Num tasks: " << xferBenchConfig::doca_memos_num_tasks << std::endl;
+        std::cout << "  Query mem mode: " << xferBenchConfig::doca_memos_query_mem_mode
+                  << std::endl;
+        if (!xferBenchConfig::doca_memos_nguid.empty()) {
+            std::cout << "  Namespace GUID: " << xferBenchConfig::doca_memos_nguid << std::endl;
+        }
+        if (xferBenchConfig::doca_memos_ignore_read_not_found) {
+            std::cout << "  Ignore read not found: true" << std::endl;
+        }
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCCL)) {
         std::cout << "UCCL backend" << std::endl;
         backend_params["in_python"] = "0";
@@ -992,7 +1015,30 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
 
     opt_args.backends.push_back(backend_engine);
 
-    if (xferBenchConfig::isObjStorageBackend()) {
+    if (xferBenchConfig::backend == XFERBENCH_BACKEND_DOCA_MEMOS) {
+        size_t max_batch = xferBenchConfig::max_batch_size;
+        size_t total_keys = 0;
+        for (int list_idx = 0; list_idx < num_threads; list_idx++) {
+            std::vector<xferBenchIOV> iov_list;
+            for (i = 0; i < num_devices; i++) {
+                for (size_t b = 0; b < max_batch; b++) {
+                    int dev_id =
+                        static_cast<int>(list_idx * num_devices * max_batch + i * max_batch + b);
+                    auto basic_desc = initBasicDescObj(buffer_size, dev_id, "");
+                    if (basic_desc) {
+                        iov_list.push_back(basic_desc.value());
+                    }
+                }
+            }
+            nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, OBJ_SEG);
+            CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
+            total_keys += iov_list.size();
+            remote_iovs.push_back(iov_list);
+        }
+        std::cout << "DOCA_MEMOS: Registered " << total_keys << " keys across " << num_threads
+                  << " threads x " << num_devices << " devices x " << max_batch << " batch"
+                  << std::endl;
+    } else if (xferBenchConfig::isObjStorageBackend()) {
         buffer_size = xferBenchConfig::max_block_size;
 
         struct timeval tv;
@@ -1002,7 +1048,6 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         for (int list_idx = 0; list_idx < num_threads; list_idx++) {
             std::vector<xferBenchIOV> iov_list;
             for (i = 0; i < num_devices; i++) {
-                std::optional<xferBenchIOV> basic_desc;
                 std::string unique_name = "nixlbench_obj" + std::to_string(list_idx) + "_" +
                     std::to_string(i) + "_" + std::to_string(timestamp);
 
@@ -1014,7 +1059,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
                 }
 
                 int obj_dev_id = list_idx * num_devices + i;
-                basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);
+                auto basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);
                 if (basic_desc) {
                     std::cout << "Creating obj: " << unique_name << std::endl;
                     iov_list.push_back(basic_desc.value());
@@ -1132,7 +1177,8 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
 
             if (basic_desc) {
-                if (!remote_regs_.empty()) {
+                if (!remote_regs_.empty() &&
+                    xferBenchConfig::backend != XFERBENCH_BACKEND_DOCA_MEMOS) {
                     basic_desc.value().metaInfo = remote_regs_[list_idx].iovs()[i].metaInfo;
                 }
                 iov_list.push_back(basic_desc.value());
@@ -1169,9 +1215,22 @@ void
 xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &iov_lists) {
     // Ordering: deregister remote regions before local ones
     // (remote registrations may reference local buffers).
-    // NixlMemRegion::release() handles deregisterMem + per-IOV cleanup.
+
+    // DOCA_MEMOS remote IOVs are stored separately from NixlMemRegion because
+    // the generic OBJ_SEG cleanup path calls rmObj, which DOCA_MEMOS doesn't support.
+    if (!remote_iovs.empty()) {
+        nixl_opt_args_t opt_args;
+        opt_args.backends.push_back(backend_engine);
+        for (auto &iov_list : remote_iovs) {
+            nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, OBJ_SEG);
+            CHECK_NIXL_ERROR(agent->deregisterMem(desc_list, &opt_args), "deregisterMem failed");
+        }
+        remote_iovs.clear();
+    }
+
+    // NixlMemRegion::release() handles deregisterMem + per-IOV cleanup for all
+    // other backends. xferFileState RAII closes backing fds after deregistrations.
     remote_regs_.clear();
-    // xferFileState RAII closes backing fds after deregistrations complete.
     remote_fds.clear();
     local_regs_.clear();
     iov_lists.clear();
@@ -1254,6 +1313,25 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             const auto &iov_list = local_iovs[list_idx];
             std::vector<xferBenchIOV> remote_iov_list;
             size_t num_devices = iov_list.size();
+
+            if (XFERBENCH_BACKEND_DOCA_MEMOS == xferBenchConfig::backend) {
+                const size_t remote_size = remote_iovs[list_idx].size();
+                if (remote_size == 0 || iov_list.size() % remote_size != 0) {
+                    std::cerr << "DOCA_MEMOS: local IOV count " << iov_list.size()
+                              << " is not a positive multiple of remote IOV count " << remote_size
+                              << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+                const size_t entries_per_key = iov_list.size() / remote_size;
+                for (size_t idx = 0; idx < iov_list.size(); idx++) {
+                    xferBenchIOV remote_iov(remote_iovs[list_idx][idx / entries_per_key]);
+                    remote_iov.len = iov_list[idx].len;
+                    remote_iov_list.push_back(remote_iov);
+                }
+                res.push_back(remote_iov_list);
+                continue;
+            }
+
             for (size_t devidx = 0; devidx < num_devices; devidx++) {
                 const auto &iov = iov_list[devidx];
                 if (xferBenchConfig::isObjStorageBackend()) {
@@ -1766,6 +1844,62 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
+// Execute queryMem iterations across threads, measuring latency
+static int
+execQuery(nixlAgent *agent,
+          nixlBackendH *backend,
+          const std::vector<std::vector<xferBenchIOV>> &remote_iovs,
+          const int num_iter,
+          const int num_threads,
+          xferBenchStats &stats,
+          const std::atomic<int> *terminate_ptr = nullptr) {
+    int ret = 0;
+    stats.clear();
+
+    xferBenchTimer total_timer;
+#pragma omp parallel num_threads(num_threads)
+    {
+        xferBenchStats thread_stats;
+        thread_stats.reserve(num_iter);
+        xferBenchTimer timer;
+        const int tid = omp_get_thread_num();
+        const auto &remote_iov = remote_iovs[tid];
+
+        nixl_opt_args_t opt_args;
+        opt_args.backends.push_back(backend);
+
+        thread_stats.prepare_duration.add(timer.lap());
+
+        for (int i = 0; i < num_iter; ++i) {
+            if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+                break;
+            }
+
+            nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
+
+            std::vector<nixl_query_resp_t> resp;
+            nixl_status_t rc = agent->queryMem(desc_list, resp, &opt_args);
+            // queryMem is synchronous so the full latency lands in
+            // transfer_duration; prepare_/post_duration stay zero.
+            thread_stats.transfer_duration.add(timer.lap());
+
+            if (__builtin_expect(rc != NIXL_SUCCESS, 0)) {
+                std::cerr << "queryMem failed: " << nixlEnumStrings::statusStr(rc) << std::endl;
+#pragma omp atomic write
+                ret = -1;
+                break;
+            }
+        }
+
+#pragma omp critical
+        { stats.add(thread_stats); }
+    }
+
+    const nixlTime::us_t total_duration = total_timer.lap();
+    stats.total_duration.add(total_duration);
+    return ret;
+}
+
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1774,11 +1908,119 @@ xferBenchNixlWorker::transfer(size_t block_size,
     int skip = xferBenchConfig::warmup_iter / xferBenchConfig::num_threads;
     xferBenchStats stats;
     int ret = 0;
+
+    // QUERY op_type: benchmark queryMem instead of read/write transfers
+    if (xferBenchConfig::op_type == XFERBENCH_OP_QUERY) {
+        // For DOCA_MEMOS: pre-populate keys so EXIST operations can find them (actual mode)
+        if (xferBenchConfig::backend == XFERBENCH_BACKEND_DOCA_MEMOS) {
+            xferBenchStats prepop_stats;
+            std::cout << "DOCA_MEMOS: Pre-populating keys with " << block_size
+                      << " byte values before QUERY test..." << std::endl;
+
+            ret = execTransfer(agent,
+                               backend_engine,
+                               local_iovs,
+                               remote_iovs,
+                               NIXL_WRITE,
+                               1,
+                               xferBenchConfig::num_threads,
+                               prepop_stats);
+            if (ret < 0) {
+                std::cerr << "DOCA_MEMOS: Failed to pre-populate keys for QUERY (block_size="
+                          << block_size << ")" << std::endl;
+                return std::variant<xferBenchStats, int>(ret);
+            }
+            std::cout << "DOCA_MEMOS: Key pre-population complete" << std::endl;
+        }
+
+        // Reduce iterations for large block sizes
+        if (block_size > LARGE_BLOCK_SIZE) {
+            skip /= xferBenchConfig::large_blk_iter_ftr;
+            num_iter /= xferBenchConfig::large_blk_iter_ftr;
+        }
+
+        if (skip > 0) {
+            ret = execQuery(agent,
+                            backend_engine,
+                            remote_iovs,
+                            skip,
+                            xferBenchConfig::num_threads,
+                            stats,
+                            &terminate);
+            if (ret < 0) {
+                return std::variant<xferBenchStats, int>(ret);
+            }
+        }
+
+        synchronize();
+        stats.clear();
+
+        ret = execQuery(agent,
+                        backend_engine,
+                        remote_iovs,
+                        num_iter,
+                        xferBenchConfig::num_threads,
+                        stats,
+                        &terminate);
+        if (ret < 0) {
+            return std::variant<xferBenchStats, int>(ret);
+        }
+
+        synchronize();
+        return std::variant<xferBenchStats, int>(stats);
+    }
+
     nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;
 
     if (!rt->checkKeepAlive()) { // also refreshes the lease internally.
         std::cerr << "nixlbench: keepalive failed before transfer — aborting" << std::endl;
         return std::variant<xferBenchStats, int>(-1);
+    }
+
+    // For DOCA_MEMOS READ: pre-populate keys by writing them first with the correct block_size.
+    // DOCA_MEMOS stores exact key-value pairs; a retrieve fails with IO_FAILED if the stored
+    // value length doesn't match the read buffer length. This mirrors fio's approach of
+    // running a write job before the read job.
+    if (xferBenchConfig::backend == XFERBENCH_BACKEND_DOCA_MEMOS &&
+        xferBenchConfig::op_type == XFERBENCH_OP_READ) {
+        xferBenchStats prepop_stats;
+        std::cout << "DOCA_MEMOS: Pre-populating keys with " << block_size
+                  << " byte values before READ test..." << std::endl;
+
+        ret = execTransfer(agent,
+                           backend_engine,
+                           local_iovs,
+                           remote_iovs,
+                           NIXL_WRITE,
+                           1,
+                           xferBenchConfig::num_threads,
+                           prepop_stats);
+        if (ret < 0) {
+            std::cerr << "DOCA_MEMOS: Failed to pre-populate keys for READ (block_size="
+                      << block_size << ")" << std::endl;
+            return std::variant<xferBenchStats, int>(ret);
+        }
+        std::cout << "DOCA_MEMOS: Key pre-population complete" << std::endl;
+
+        // Verify pre-population by retrieving each object
+        std::cout << "DOCA_MEMOS: Verifying pre-populated keys..." << std::endl;
+        xferBenchStats verify_stats;
+        ret = execTransfer(agent,
+                           backend_engine,
+                           local_iovs,
+                           remote_iovs,
+                           NIXL_READ,
+                           1,
+                           xferBenchConfig::num_threads,
+                           verify_stats);
+        if (ret < 0) {
+            std::cerr << "DOCA_MEMOS: Verification failed - retrieve operations failed after "
+                         "pre-population (block_size="
+                      << block_size << ")" << std::endl;
+            return std::variant<xferBenchStats, int>(ret);
+        }
+        std::cout << "DOCA_MEMOS: Verification complete - all keys verified successfully"
+                  << std::endl;
     }
 
     // Reduce skip by 10x for large block sizes

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -43,6 +43,9 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::vector<xferFileState> remote_fds;
         std::vector<NixlMemRegion> remote_regs_;
         std::vector<NixlMemRegion> local_regs_;
+        // DOCA_MEMOS uses raw IOV lists (not NixlMemRegion) because the OBJ_SEG
+        // cleanup path would call rmObj, which DOCA_MEMOS does not support.
+        std::vector<std::vector<xferBenchIOV>> remote_iovs;
         std::vector<GusliDeviceConfig> gusli_devices;
 
     public:

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ if enable_plugins_opt != '' and disable_plugins_opt != ''
     error('Cannot specify both enable_plugins and disable_plugins options')
 endif
 
-all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA']
+all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA', 'DOCA_MEMOS']
 
 enabled_plugins = {}
 
@@ -392,6 +392,12 @@ if libfabric_path != ''
 else
   libfabric_dep = dependency('libfabric', required: false)
 endif
+
+# DOCA KV (used by the DOCA_MEMOS plugin). These pkg-config files live in
+# /opt/mellanox/doca/lib64/pkgconfig, which is normally added to PKG_CONFIG_PATH
+# by /etc/profile.d when the DOCA SDK is installed.
+doca_kv_dep = dependency('doca-kv', required: false)
+doca_common_dep = dependency('doca-common', required: false)
 
 # UCX GPU device API detection
 nvcc_prog = find_program('nvcc', required: false)

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -858,6 +858,9 @@ void nixlPluginManager::registerBuiltinPlugins() {
 #ifdef STATIC_PLUGIN_INFINIA
     NIXL_REGISTER_STATIC_PLUGIN(Backend, INFINIA)
 #endif
+#ifdef STATIC_PLUGIN_DOCA_MEMOS
+    NIXL_REGISTER_STATIC_PLUGIN(Backend, DOCA_MEMOS)
+#endif
 
     NIXL_REGISTER_STATIC_PLUGIN(Telemetry, BUFFER)
     NIXL_REGISTER_STATIC_PLUGIN(Telemetry, NOP)

--- a/src/plugins/doca_memos/README.md
+++ b/src/plugins/doca_memos/README.md
@@ -1,0 +1,289 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL DOCA_MEMOS Plugin
+
+A NIXL backend plugin that provides hardware-accelerated key-value storage operations using NVIDIA's DOCA KV library (`libdoca_kv`, headers `doca_kvdev.h`, `doca_kvdev_io.h`, `doca_nvme_kernel_kvdev.h`, `doca_nvme_kernel_kvdev_io.h`) for BlueField devices. The NIXL backend name is **DOCA_MEMOS**; the underlying DOCA package may be renamed in the future.
+
+## Overview
+
+The DOCA_MEMOS plugin enables high-performance key-value operations (store, retrieve, exist) on BlueField devices through NVIDIA's DOCA framework.
+
+## Requirements
+
+- **DOCA SDK**: Version 4.4 or later
+- **Hardware**: NVIDIA BlueField-3 DPU or newer
+- **Libraries**:
+  - `libdoca_kv` - DOCA Key-Value library
+  - `libdoca_common` - DOCA Core library
+  - `libdoca_nvme_kernel_kvdev` - DOCA NVMe kernel device support
+
+## Configuration
+
+### Required Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `device_name` | Path to the NVMe KV device | `/dev/nvme0n1` |
+
+### Optional Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `num_tasks` | Maximum number of concurrent tasks in the DOCA task pool (clamped to `doca_kvdev_get_max_tasks()`) | `8192` |
+| `nguid` | 32-character hex NVMe namespace NGUID passed to `doca_kvdev_set_nguid()` | all zeros |
+| `query_mem_mode` | Controls `queryMem()` behavior: `assume_success` returns success for every descriptor without querying the device; `actual` issues real DOCA EXIST operations | `assume_success` |
+| `ignore_read_not_found` | When `true`, retrieve operations on missing keys complete successfully (buffer contents are undefined) instead of failing with `NIXL_ERR_BACKEND` | `false` |
+
+### Example Configuration
+
+```cpp
+#include "nixl.h"
+
+// Create DOCA_MEMOS backend with required device_name
+nixl_b_params_t params = {
+    {"device_name", "/dev/nvme0n1"},  // Required
+    {"num_tasks", "256"}               // Optional
+};
+agent.createBackend("DOCA_MEMOS", params);
+```
+
+## Supported Operations
+
+### Memory Registration
+
+- **DRAM_SEG**: Local system memory buffers for data transfer
+- **OBJ_SEG**: Key-value pairs stored on the NVMe KV device
+  - If `metaInfo` is a valid hex string of up to `2 * DOCA_MEMOS_MAX_OBJECT_KEY_LEN` (32) characters, it is decoded into the object key
+  - Otherwise, if `metaInfo` is non-empty and at most `DOCA_MEMOS_MAX_OBJECT_KEY_LEN` (16) bytes, it is used as the raw key
+  - If `metaInfo` is empty, the raw bytes of `devId` (`sizeof(uint64_t)`) are used as the key
+
+### Transfer Operations
+
+- **NIXL_WRITE**: Store data to a key (DOCA STORE operation)
+- **NIXL_READ**: Retrieve data from a key (DOCA RETRIEVE operation)
+
+### Query Operations
+
+- **queryMem()**: Check if a key exists
+  - In `assume_success` mode (default): immediately returns success for every descriptor without contacting the device
+  - In `actual` mode: issues real DOCA EXIST operations; returns success if the key exists, nullopt if not found or on error
+
+## Architecture
+
+### DOCA Resources
+
+The plugin manages the following DOCA resources:
+
+- **Progress Engine (PE)**: Handles task submission and completion polling
+- **NVMe Kernel KV Device (nvmeKvdev)**: Backend-specific NVMe-kernel KV device (path + NGUID configured before start)
+- **Generic KV Device (kvdev)**: View of the NVMe kernel KV device through the `doca_kvdev` API for capability queries
+- **NVMe Kernel KV IO Context (kkvIo) / Generic KV IO Context (kvIo)**: Per-engine I/O context; configured via `doca_kvdev_io_set_num_tasks()`, `doca_kvdev_io_set_task_completion_cb()`, and `doca_kvdev_io_set_task_error_cb()` before start
+- **Context (ctx)**: DOCA context connected to the progress engine
+
+All DOCA resources are initialized in the constructor and cleaned up in the destructor following RAII principles.
+
+### Threading Model
+
+The plugin selects one of two progress-engine implementations based on `enableProgTh`:
+
+#### With Progress Thread (`enableProgTh = true`)
+
+A dedicated background thread is the sole caller of DOCA APIs. Other threads submit transfers, cancel requests, and post queries by pushing entries into a producer queue guarded by a short-lived mutex held only for a pointer/vector swap. The progress thread drains the queue and submits tasks to DOCA outside the lock, keeping the caller-facing hot path effectively lock-free.
+
+#### Without Progress Thread (`enableProgTh = false`)
+
+No background thread is created. Progress is driven by the caller inside `checkXfer()` and `queryMem()`. A single mutex serializes all DOCA calls (submission, progress polling, cancellation) so the engine remains safe under concurrent callers; callers that can tolerate a dedicated thread should prefer the threaded mode for lower contention.
+
+### Request Handling
+
+Each NIXL transfer or query is represented by an opaque `nixlDocaMemosBackendReqH`. The handle aggregates the status of every DOCA task it spawned: callers observe completion through `checkXfer()`, which returns `NIXL_IN_PROG` until every submitted task has reported a result, then returns either `NIXL_SUCCESS` or the first non-success status seen. Completion is published with release ordering, so the caller does not need any external locking to read it.
+
+Failures are sticky: once any task reports a hard error, the request stays in that error state until released, even if later tasks succeed.
+
+### Error Handling
+
+The plugin uses fail-fast error handling for batch operations:
+
+- **On first error**: Stops submitting new tasks immediately
+- **In-flight tasks**: Waits for already-submitted tasks to complete
+- **Overall status**: The entire batch operation is marked as failed
+- **Rationale**: NIXL has no API to report per-task status, so partial success cannot be conveyed
+
+## API Behavior
+
+### registerMem()
+
+Registers memory with the plugin. For OBJ_SEG memory the resolved key (see [Memory Registration](#memory-registration)) is stored in the returned metadata object and retrieved by `postXfer()`. No DOCA call is made.
+
+### prepXfer()
+
+Creates a request handle with the expected number of tasks. No DOCA operations are performed.
+
+### postXfer()
+
+Submits DOCA tasks for the transfer operation. In threaded mode, `postXfer()` pushes an entry onto the producer queue and returns immediately; the progress thread performs the allocation and submission. In no-thread mode, `postXfer()` holds the engine mutex and drives submission inline. If the DOCA task pool is full, the remaining descriptors are queued internally and retried — by the progress thread in threaded mode, or by the next caller-driven `checkXfer()` / `queryMem()` in no-thread mode.
+
+If any descriptor hits a non-recoverable error during submission, no further descriptors are submitted for that request and the overall status is set to `NIXL_ERR_BACKEND` once the in-flight tasks drain.
+
+Each task's `task_user_data` is a per-descriptor `docaMemosTaskContext` pointing back at the request handle.
+
+### checkXfer()
+
+Reports whether a transfer has completed. In no-thread mode it also polls the DOCA progress engine and retries any submissions that were previously queued because the task pool was full. Returns `NIXL_IN_PROG` while tasks remain outstanding, `NIXL_SUCCESS` once every task has completed without error, or the first error status observed otherwise.
+
+### queryMem()
+
+Behavior depends on the `query_mem_mode` configuration parameter:
+
+**`assume_success` mode (default):**
+Returns success for every descriptor immediately, without contacting the device. Useful when the caller already knows that keys exist (e.g., because it just wrote them) and wants to avoid the latency of actual EXIST operations.
+
+**`actual` mode:**
+Synchronously checks if keys exist on the device by submitting EXIST tasks for each key and busy-polling (`std::this_thread::yield()`) until completion. Returns a vector with success (key exists) or nullopt (key missing or error).
+
+### releaseReqH()
+
+Releases the request handle. If any tasks are still in flight, the handle is marked cancelled and deletion is deferred until the last callback fires. It is safe to call regardless of whether the transfer has completed.
+
+### deregisterMem()
+
+Releases the metadata object returned by `registerMem()`. Does not delete data from the device.
+
+## Usage Example
+
+```cpp
+#include "nixl.h"
+
+// Create agent
+nixl_agent_config config;
+config.enable_prog_thread = true;  // Enable progress thread
+nixl_agent agent("kv_agent", config);
+
+// Create DOCA KV backend
+nixl_b_params_t params = {{"device_name", "/dev/nvme0n1"}};
+agent.createBackend("DOCA_MEMOS", params);
+
+// Register OBJ_SEG memory with a key (metaInfo must be <= 16 raw bytes or
+// a hex string of <= 32 chars; see "Memory Registration" above)
+nixlBlobDesc remote_desc;
+remote_desc.devId = 100;
+remote_desc.metaInfo = "ckpt_0001";
+agent.registerMem(remote_desc, OBJ_SEG);
+
+// Register DRAM_SEG memory for local buffer
+char buffer[4096] = "checkpoint data";
+nixlBlobDesc local_desc;
+local_desc.devId = 0;
+local_desc.baseAddr = reinterpret_cast<uint64_t>(buffer);
+local_desc.length = 4096;
+agent.registerMem(local_desc, DRAM_SEG);
+
+// Create descriptor lists
+auto local_dlist = agent.createDlist({local_desc}, DRAM_SEG);
+auto remote_dlist = agent.createDlist({remote_desc}, OBJ_SEG);
+
+// Write data to key
+auto write_handle = agent.postXfer(NIXL_WRITE, local_dlist, remote_dlist, "kv_agent");
+while (agent.checkXfer(write_handle) == NIXL_IN_PROG) {
+    // Wait for completion
+}
+agent.releaseReqH(write_handle);
+
+// Check if key exists
+std::vector<nixl_query_resp_t> query_results;
+auto query_dlist = agent.createDlist({remote_desc}, OBJ_SEG);
+nixl_status_t status = agent.queryMem(query_dlist, query_results);
+if (status == NIXL_SUCCESS && query_results[0].has_value()) {
+    std::cout << "Key exists!" << std::endl;
+}
+
+// Read data from key
+char read_buffer[4096] = {0};
+local_desc.baseAddr = reinterpret_cast<uint64_t>(read_buffer);
+local_dlist = agent.createDlist({local_desc}, DRAM_SEG);
+
+auto read_handle = agent.postXfer(NIXL_READ, local_dlist, remote_dlist, "kv_agent");
+while (agent.checkXfer(read_handle) == NIXL_IN_PROG) {
+    // Wait for completion
+}
+agent.releaseReqH(read_handle);
+
+// Cleanup
+agent.deregisterMem(remote_desc);
+agent.deregisterMem(local_desc);
+```
+
+## Performance Considerations
+
+### Task Pool Size
+
+The `num_tasks` parameter controls the DOCA task pool size:
+- Larger values support more concurrent operations
+- Smaller values reduce memory overhead
+- Default of 8192 is suitable for most workloads
+- Set based on expected maximum in-flight operations
+
+### Progress Thread vs. Manual Polling
+
+**Use progress thread when:**
+- Running a multi-threaded application
+- Submitting operations from multiple threads
+- Need low-latency completions without explicit polling
+
+**Disable progress thread when:**
+- Running a single-threaded application
+- Want explicit control over when I/O progresses
+- Building an async runtime with custom event loop
+- Minimizing thread count and lock contention
+
+### Key Naming
+
+- Keys are at most 16 bytes (`DOCA_MEMOS_MAX_OBJECT_KEY_LEN`)
+- Pass hex strings for explicit binary keys, or short ASCII strings to use the raw-bytes path
+
+## Limitations
+
+- **No notifications**: The plugin does not support NIXL's notification mechanism
+- **Single progress engine**: All operations share one progress engine, which may limit scalability under extreme concurrency
+
+## Thread Safety
+
+- All public API methods are thread-safe in both progress-engine modes
+- With progress thread: DOCA calls run only on the progress thread; other threads communicate through a queue guarded by a short-held mutex
+- Without progress thread: DOCA calls are serialized by a mutex held across submission, progress, and cancellation
+- Request-handle completion state uses atomic operations, allowing `checkXfer()` to poll without acquiring the engine mutex
+
+## Troubleshooting
+
+### "Failed to create DOCA NVMe kernel KV device"
+
+- Verify the device path is correct (`ls /dev/nvme*`)
+- Ensure the device supports KV operations (BlueField-3 or newer)
+- Check device permissions
+
+### "Failed to allocate DOCA KV task"
+
+- Task pool is exhausted (all tasks in use)
+- Increase `num_tasks` parameter
+- Ensure tasks are being completed and handles released
+
+### Timeout in queryMem
+
+- Progress engine is not being polled (if no progress thread)
+- Device is unresponsive or overloaded
+- Check DOCA logs for hardware issues

--- a/src/plugins/doca_memos/doca_memos_backend.cpp
+++ b/src/plugins/doca_memos/doca_memos_backend.cpp
@@ -1,0 +1,579 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "doca_memos_backend.h"
+
+#include "common/nixl_log.h"
+#include "nixl_types.h"
+
+#include <absl/strings/str_format.h>
+#include <charconv>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+// DOCA headers
+#include <doca_kvdev.h>
+#include <doca_nvme_kernel_kvdev.h>
+#include <doca_pe.h>
+#include <doca_ctx.h>
+#include <doca_error.h>
+
+namespace {
+
+// Metadata for OBJ_SEG memory
+class nixlDocaMemosMetadata : public nixlBackendMD {
+public:
+    nixlDocaMemosMetadata(nixl_mem_t nixl_mem, uint64_t dev_id, const docaMemosKey &key)
+        : nixlBackendMD(true),
+          nixlMem(nixl_mem),
+          devId(dev_id),
+          objKey(key) {}
+
+    ~nixlDocaMemosMetadata() = default;
+
+    nixl_mem_t nixlMem;
+    uint64_t devId;
+    docaMemosKey objKey;
+};
+
+[[nodiscard]] bool
+isValidPrepXferParams(const nixl_xfer_op_t &operation,
+                      const nixl_meta_dlist_t &local,
+                      const nixl_meta_dlist_t &remote,
+                      const std::string &remote_agent,
+                      const std::string &local_agent) {
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << absl::StrFormat("Invalid operation type: %d", operation);
+        return false;
+    }
+
+    if (remote_agent != local_agent) {
+        NIXL_WARN << absl::StrFormat("Remote agent doesn't match the requesting agent (%s). Got %s",
+                                     local_agent,
+                                     remote_agent);
+    }
+
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat("Local memory type must be DRAM_SEG, got %d",
+                                      local.getType());
+        return false;
+    }
+
+    if (remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << absl::StrFormat("Remote memory type must be OBJ_SEG, got %d",
+                                      remote.getType());
+        return false;
+    }
+
+    return true;
+}
+
+} // anonymous namespace
+
+std::ostream &
+operator<<(std::ostream &os, const docaMemosKey &k) {
+    NIXL_ASSERT(k.keyLen <= DOCA_MEMOS_MAX_OBJECT_KEY_LEN);
+    std::ios::fmtflags flags(os.flags());
+    char fill = os.fill();
+    os << std::hex << std::setfill('0');
+    for (uint32_t i = 0; i < k.keyLen; ++i) {
+        os << std::setw(2) << static_cast<unsigned>(k.key[i]);
+    }
+    os.flags(flags);
+    os.fill(fill);
+    return os;
+}
+
+void
+nixlDocaMemosEngine::NvmeKvdevDeleter::operator()(doca_nvme_kernel_kvdev *dev) const noexcept {
+    if (!dev) {
+        return;
+    }
+    // doca_kvdev_stop() is only valid on a started device. _set_nguid() /
+    // _set_path() failures during init leave the device in the unstarted
+    // state, so guard with a started check rather than blindly stopping.
+    doca_kvdev *kv = doca_nvme_kernel_kvdev_as_kvdev(dev);
+    if (kv) {
+        uint8_t started = 0;
+        if (doca_kvdev_is_started(kv, &started) == DOCA_SUCCESS && started) {
+            doca_error_t result = doca_kvdev_stop(kv);
+            if (result != DOCA_SUCCESS) {
+                NIXL_WARN << "Failed to stop DOCA KV device: " << doca_error_get_descr(result);
+            }
+        }
+    }
+    doca_error_t result = doca_nvme_kernel_kvdev_destroy(dev);
+    if (result != DOCA_SUCCESS) {
+        NIXL_WARN << "Failed to destroy NVMe kernel KV device: " << doca_error_get_descr(result);
+    }
+}
+
+void
+nixlDocaMemosEngine::cleanupDocaResources() {
+    kvdev_ = nullptr;
+    nvmeKvdev_.reset();
+}
+
+nixl_status_t
+nixlDocaMemosEngine::parseInitParams(const nixl_b_params_t *params) {
+    if (!params) {
+        return NIXL_SUCCESS;
+    }
+
+    auto it = params->find("device_name");
+    if (it != params->end()) {
+        deviceName_ = it->second;
+    }
+
+    it = params->find("num_tasks");
+    if (it != params->end()) {
+        try {
+            const unsigned long long parsed = std::stoull(it->second);
+            if (parsed == 0 || parsed > std::numeric_limits<uint32_t>::max()) {
+                NIXL_ERROR << "num_tasks '" << it->second << "' out of range (1.."
+                           << std::numeric_limits<uint32_t>::max() << ")";
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            numTasks_ = static_cast<uint32_t>(parsed);
+        }
+        catch (...) {
+            NIXL_ERROR << "Failed to parse num_tasks parameter";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+
+    it = params->find("nguid");
+    if (it != params->end()) {
+        nguid_ = it->second;
+    }
+
+    it = params->find("ignore_read_not_found");
+    if (it != params->end()) {
+        if (it->second == "true") {
+            ignoreReadNotFound_ = true;
+        } else if (it->second == "false") {
+            ignoreReadNotFound_ = false;
+        } else {
+            NIXL_ERROR << "Invalid ignore_read_not_found '" << it->second
+                       << "', expected 'true' or 'false'";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+
+    it = params->find("query_mem_mode");
+    if (it != params->end()) {
+        if (it->second == "actual") {
+            queryMemAssumeSuccess_ = false;
+        } else if (it->second == "assume_success") {
+            queryMemAssumeSuccess_ = true;
+        } else {
+            NIXL_ERROR << "Invalid query_mem_mode '" << it->second
+                       << "', expected 'assume_success' or 'actual'";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+
+    if (!params->count("nguid")) {
+        NIXL_WARN << "Using default nguid (all zeros); set 'nguid' to override";
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::initDocaDevice() {
+    uint32_t max_path_len = 0;
+    doca_error_t result = doca_nvme_kernel_kvdev_cap_get_max_path_len(&max_path_len);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "doca_nvme_kernel_kvdev_cap_get_max_path_len failed: "
+                   << doca_error_get_descr(result);
+        return NIXL_ERR_BACKEND;
+    }
+    if (deviceName_.size() + 1 > max_path_len) {
+        NIXL_ERROR << "device_name length " << deviceName_.size() << " exceeds device-reported max "
+                   << (max_path_len - 1);
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    uint8_t nguid_bytes[DOCA_KVDEV_NGUID_LEN] = {0};
+    if (!nguid_.empty()) {
+        if (nguid_.length() != DOCA_KVDEV_NGUID_LEN * 2) {
+            NIXL_ERROR << "Invalid nguid '" << nguid_ << "' (expected 32 hex chars)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        for (size_t i = 0; i < DOCA_KVDEV_NGUID_LEN; i++) {
+            unsigned val = 0;
+            const char *first = nguid_.data() + i * 2;
+            auto [ptr, ec] = std::from_chars(first, first + 2, val, 16);
+            if (ec != std::errc{} || ptr != first + 2) {
+                NIXL_ERROR << "Invalid nguid '" << nguid_ << "' (expected 32 hex chars)";
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            nguid_bytes[i] = static_cast<uint8_t>(val);
+        }
+    }
+
+    doca_nvme_kernel_kvdev *raw_nvme_kvdev = nullptr;
+    result = doca_nvme_kernel_kvdev_create(&raw_nvme_kvdev);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to create DOCA NVMe kernel KV device: "
+                   << doca_error_get_descr(result);
+        return NIXL_ERR_BACKEND;
+    }
+    nvmeKvdev_.reset(raw_nvme_kvdev);
+
+    result = doca_nvme_kernel_kvdev_set_path(nvmeKvdev_.get(), deviceName_.c_str());
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to set NVMe kernel KV device path: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+
+    kvdev_ = doca_nvme_kernel_kvdev_as_kvdev(nvmeKvdev_.get());
+    if (!kvdev_) {
+        NIXL_ERROR << "Failed to convert NVMe kernel KV device to generic KV device";
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+
+    result = doca_kvdev_set_nguid(kvdev_, nguid_bytes);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to set DOCA KV device NGUID: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+
+    result = doca_kvdev_start(kvdev_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to start DOCA KV device: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+
+    NIXL_INFO << "DOCA KV device initialized successfully";
+
+    uint32_t dev_max_tasks = 0;
+    result = doca_kvdev_get_max_tasks(kvdev_, &dev_max_tasks);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "doca_kvdev_get_max_tasks failed: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+    if (dev_max_tasks > 0 && numTasks_ > dev_max_tasks) {
+        NIXL_INFO << "Clamping num_tasks from " << numTasks_ << " to device max " << dev_max_tasks;
+        numTasks_ = dev_max_tasks;
+    }
+
+    // Plugin stores keys inline in a fixed-size array sized to the current
+    // DOCA spec (DOCA_MEMOS_MAX_OBJECT_KEY_LEN). If the device ever reports a
+    // larger maximum, that capacity must be revisited.
+    uint16_t dev_max_key_len = 0;
+    result = doca_kvdev_get_max_key_len(kvdev_, &dev_max_key_len);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "doca_kvdev_get_max_key_len failed: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+    if (dev_max_key_len > DOCA_MEMOS_MAX_OBJECT_KEY_LEN) {
+        NIXL_ERROR << "Device max key length " << dev_max_key_len << " exceeds plugin capacity "
+                   << DOCA_MEMOS_MAX_OBJECT_KEY_LEN;
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+
+    result = doca_kvdev_get_max_value_len(kvdev_, &maxValueLen_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "doca_kvdev_get_max_value_len failed: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        return NIXL_ERR_BACKEND;
+    }
+    NIXL_INFO << "Device max value length: " << maxValueLen_ << " bytes";
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::createProgressEngine(const nixlBackendInitParams *init_params) {
+    try {
+        if (init_params->enableProgTh) {
+            if (init_params->pthrDelay == 0) {
+                NIXL_WARN << "Progress-thread delay is 0us; thread will busy-spin";
+            }
+            progressEngine_ = std::make_unique<nixlThreadedProgressEngine>(
+                nvmeKvdev_.get(),
+                numTasks_,
+                maxValueLen_,
+                std::chrono::microseconds(init_params->pthrDelay));
+        } else {
+            progressEngine_ = std::make_unique<nixlNoThreadProgressEngine>(
+                nvmeKvdev_.get(), numTasks_, maxValueLen_);
+        }
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to create progress engine: " << e.what();
+        return NIXL_ERR_BACKEND;
+    }
+
+    if (progressEngine_->hasInitError()) {
+        NIXL_ERROR << "Progress engine initialization failed";
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixlDocaMemosEngine::nixlDocaMemosEngine(const nixlBackendInitParams *init_params)
+    : nixlBackendEngine(init_params) {
+
+    NIXL_INFO << "Initializing DOCA KV backend";
+
+    if (parseInitParams(init_params->customParams) != NIXL_SUCCESS) {
+        throw std::runtime_error("DOCA_MEMOS: failed to parse init params");
+    }
+
+    if (deviceName_.empty()) {
+        NIXL_ERROR << "DOCA KV backend requires 'device_name' parameter to be set";
+        NIXL_ERROR << "Example: params[\"device_name\"] = \"/dev/nvme0n1\"";
+        throw std::runtime_error("DOCA_MEMOS: device_name is required");
+    }
+
+    NIXL_INFO << "Initializing DOCA KV with device_name=" << deviceName_
+              << ", num_tasks=" << numTasks_ << ", nguid=" << nguid_
+              << ", query_mem_mode=" << (queryMemAssumeSuccess_ ? "assume_success" : "actual")
+              << ", ignore_read_not_found=" << (ignoreReadNotFound_ ? "true" : "false");
+
+    if (initDocaDevice() != NIXL_SUCCESS) {
+        throw std::runtime_error("DOCA_MEMOS: failed to initialize DOCA device");
+    }
+
+    NIXL_INFO << "Creating progress engine";
+    if (createProgressEngine(init_params) != NIXL_SUCCESS) {
+        throw std::runtime_error("DOCA_MEMOS: failed to create progress engine");
+    }
+
+    NIXL_INFO << "DOCA KV backend initialized successfully";
+}
+
+nixlDocaMemosEngine::~nixlDocaMemosEngine() {
+    NIXL_INFO << "Destroying DOCA KV backend";
+
+    progressEngine_.reset();
+
+    cleanupDocaResources();
+
+    NIXL_INFO << "DOCA KV backend destroyed";
+}
+
+bool
+nixlDocaMemosEngine::convertToMemosKey(const std::string &meta_info, docaMemosKey &key) {
+    if (meta_info.empty()) {
+        return false;
+    }
+    if (meta_info.size() > DOCA_MEMOS_MAX_OBJECT_KEY_LEN * 2) {
+        return false;
+    }
+    if (meta_info.size() & 1) {
+        return false;
+    }
+    auto minfo = meta_info.data();
+    key.keyLen = meta_info.size() / 2;
+    for (uint32_t i = 0; i < key.keyLen; i++) {
+        unsigned val = 0;
+        auto [ptr, ec] = std::from_chars(minfo + i * 2, minfo + i * 2 + 2, val, 16);
+        if (ec != std::errc{} || ptr != minfo + i * 2 + 2) {
+            return false;
+        }
+        key.key[i] = static_cast<uint8_t>(val);
+    }
+    return true;
+}
+
+// Resolves meta_info to a device key via one of three paths. The hex-first /
+// raw-fallback behaviour means the same meta_info string may take different
+// paths depending on its contents, so log the chosen path at DEBUG level.
+bool
+nixlDocaMemosEngine::resolveMemosKey(uint64_t dev_id,
+                                     const std::string &meta_info,
+                                     docaMemosKey &key) {
+    if (meta_info.empty()) {
+        key.keyLen = sizeof(dev_id);
+        memcpy(key.key, &dev_id, key.keyLen);
+        NIXL_DEBUG << "resolveMemosKey: empty meta_info, using dev_id bytes";
+        return true;
+    }
+    if (convertToMemosKey(meta_info, key)) {
+        NIXL_DEBUG << "resolveMemosKey: parsed meta_info as hex (" << key.keyLen << " bytes)";
+        return true;
+    }
+    if (meta_info.size() <= DOCA_MEMOS_MAX_OBJECT_KEY_LEN) {
+        key.keyLen = meta_info.size();
+        memcpy(key.key, meta_info.data(), key.keyLen);
+        NIXL_DEBUG << "resolveMemosKey: using meta_info as raw bytes (" << key.keyLen << " bytes)";
+        return true;
+    }
+    return false;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::registerMem(const nixlBlobDesc &mem,
+                                 const nixl_mem_t &nixl_mem,
+                                 nixlBackendMD *&out) {
+    auto supported_mems = getSupportedMems();
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end()) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    if (nixl_mem == OBJ_SEG) {
+        docaMemosKey key;
+        if (!resolveMemosKey(mem.devId, mem.metaInfo, key)) {
+            NIXL_ERROR << "Failed to convert metaInfo to docaMemosKey: " << mem.metaInfo;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        auto kv_md = std::make_unique<nixlDocaMemosMetadata>(nixl_mem, mem.devId, key);
+
+        NIXL_DEBUG << "Registered OBJ_SEG memory with devId: " << mem.devId;
+        out = kv_md.release();
+    } else {
+        out = nullptr;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::deregisterMem(nixlBackendMD *meta) {
+    nixlDocaMemosMetadata *kv_md = static_cast<nixlDocaMemosMetadata *>(meta);
+    if (kv_md) {
+        NIXL_DEBUG << "Deregistered memory with devId: " << kv_md->devId;
+    }
+    delete kv_md;
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::queryMem(const nixl_reg_dlist_t &descs,
+                              std::vector<nixl_query_resp_t> &resp) const {
+    if (queryMemAssumeSuccess_) {
+        resp.reserve(descs.descCount());
+        for (int i = 0; i < descs.descCount(); i++) {
+            resp.emplace_back(nixl_b_params_t{});
+        }
+        return NIXL_SUCCESS;
+    }
+
+    return progressEngine_->queryMem(descs, resp);
+}
+
+nixl_status_t
+nixlDocaMemosEngine::prepXfer(const nixl_xfer_op_t &operation,
+                              const nixl_meta_dlist_t &local,
+                              const nixl_meta_dlist_t &remote,
+                              const std::string &remote_agent,
+                              nixlBackendReqH *&handle,
+                              const nixl_opt_b_args_t *opt_args) const {
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, localAgent)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    int desc_count = local.descCount();
+    if (desc_count == 0) {
+        NIXL_ERROR << "Empty descriptor lists";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (remote.descCount() != desc_count) {
+        NIXL_ERROR << "Descriptor count mismatch: local=" << desc_count
+                   << " remote=" << remote.descCount();
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto req_h = std::make_unique<nixlDocaMemosBackendReqH>(desc_count);
+    req_h->valueIovecs_.resize(desc_count);
+    req_h->taskContexts_.resize(desc_count);
+    if (operation == NIXL_READ) {
+        req_h->ignoreNotFound_ = ignoreReadNotFound_;
+    }
+
+    for (int i = 0; i < desc_count; i++) {
+        const auto &local_desc = local[i];
+        req_h->valueIovecs_[i] = {reinterpret_cast<void *>(local_desc.addr), local_desc.len};
+    }
+
+    req_h->objectKeys_.clear();
+    req_h->objectKeys_.reserve(desc_count);
+
+    for (int i = 0; i < desc_count; i++) {
+        const auto &remote_desc = remote[i];
+        auto *kv_md = static_cast<nixlDocaMemosMetadata *>(remote_desc.metadataP);
+        if (!kv_md) {
+            NIXL_ERROR << "No metadata for remote descriptor at index " << i;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        req_h->objectKeys_.push_back(kv_md->objKey);
+    }
+
+    handle = req_h.release();
+
+    NIXL_DEBUG << "Prepared transfer: operation=" << operation << ", " << desc_count << " tasks";
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlDocaMemosEngine::postXfer(const nixl_xfer_op_t &operation,
+                              const nixl_meta_dlist_t &local,
+                              const nixl_meta_dlist_t &remote,
+                              const std::string &remote_agent,
+                              nixlBackendReqH *&handle,
+                              const nixl_opt_b_args_t *opt_args) const {
+    auto req_h = static_cast<nixlDocaMemosBackendReqH *>(handle);
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << "Unsupported operation type: " << operation;
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    return progressEngine_->postXfer(req_h, operation, local, remote);
+}
+
+nixl_status_t
+nixlDocaMemosEngine::checkXfer(nixlBackendReqH *handle) const {
+    auto req_h = static_cast<nixlDocaMemosBackendReqH *>(handle);
+    return progressEngine_->checkXfer(req_h);
+}
+
+nixl_status_t
+nixlDocaMemosEngine::releaseReqH(nixlBackendReqH *handle) const {
+    auto req_h = static_cast<nixlDocaMemosBackendReqH *>(handle);
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    NIXL_DEBUG << "Releasing request handle with " << req_h->totalTasks_ << " tasks";
+
+    progressEngine_->cancelRequest(req_h);
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/doca_memos/doca_memos_backend.h
+++ b/src/plugins/doca_memos/doca_memos_backend.h
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_BACKEND_H
+#define NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_BACKEND_H
+
+#include <ostream>
+#include <string>
+#include <atomic>
+#include <vector>
+#include <memory>
+#include <sys/uio.h> // for struct iovec
+#include "backend/backend_engine.h"
+#include "doca_memos_progress_engine.h"
+
+// Forward declarations for DOCA types
+struct doca_kvdev;
+struct doca_nvme_kernel_kvdev;
+
+// Static cap on object-key size. DOCA does not expose a compile-time maximum,
+// so this is set to the current spec value (128-bit) and verified at runtime
+// via doca_kvdev_get_max_key_len() during engine init.
+inline constexpr size_t DOCA_MEMOS_MAX_OBJECT_KEY_LEN = 16;
+
+// Forward declaration for backend init params
+class nixlBackendInitParams;
+
+// Default-constructed instances have keyLen = 0, which DOCA will reject at
+// submit time. Callers must populate via nixlDocaMemosEngine::resolveMemosKey()
+// (or convertToMemosKey()) before handing the key to any DOCA API.
+struct docaMemosKey {
+    uint8_t key[DOCA_MEMOS_MAX_OBJECT_KEY_LEN] = {};
+    uint16_t keyLen = 0;
+};
+
+std::ostream &
+operator<<(std::ostream &os, const docaMemosKey &k);
+
+// Per-task scratch passed to DOCA via task_user_data and handed back to the
+// completion / error callbacks. Lifetime invariants:
+//   - reqH is a non-owning pointer; the engine guarantees the request handle
+//     outlives every task it submitted (see nixlDocaMemosBackendReqH and the
+//     destructors in nixlNoThreadProgressEngine / nixlThreadedProgressEngine).
+//   - Instances live inside reqH->taskContexts_, so the address published to
+//     DOCA stays valid as long as that vector is not resized after submit.
+struct docaMemosTaskContext {
+    class nixlDocaMemosBackendReqH *reqH;
+    int taskIndex;
+    bool isRetrieve = false;
+    size_t expectedValueLen = 0;
+};
+
+class nixlDocaMemosBackendReqH : public nixlBackendReqH {
+public:
+    explicit nixlDocaMemosBackendReqH(int num_tasks) : totalTasks_(num_tasks) {}
+
+    ~nixlDocaMemosBackendReqH() = default;
+
+    // Move construction is needed so this type satisfies MoveInsertable for
+    // std::vector (callers reserve() then emplace_back()). Move assignment is
+    // deleted because reassigning an in-flight request handle is never valid.
+    nixlDocaMemosBackendReqH(nixlDocaMemosBackendReqH &&other) noexcept
+        : totalTasks_(other.totalTasks_),
+          submittedTasks_(other.submittedTasks_),
+          completedTasks_(other.completedTasks_),
+          allTasksCompleted_(other.allTasksCompleted_.load(std::memory_order_relaxed)),
+          cancelled_(other.cancelled_.load(std::memory_order_relaxed)),
+          overallStatus_(other.overallStatus_),
+          taskResult_(other.taskResult_.load(std::memory_order_relaxed)),
+          isExistQuery_(other.isExistQuery_),
+          ignoreNotFound_(other.ignoreNotFound_),
+          nextDescriptorIndex_(other.nextDescriptorIndex_),
+          isPending_(other.isPending_),
+          storedOperation_(other.storedOperation_),
+          storedLocal_(std::move(other.storedLocal_)),
+          storedRemote_(std::move(other.storedRemote_)),
+          valueIovecs_(std::move(other.valueIovecs_)),
+          objectKeys_(std::move(other.objectKeys_)),
+          taskContexts_(std::move(other.taskContexts_)) {}
+
+    nixlDocaMemosBackendReqH(const nixlDocaMemosBackendReqH &) = delete;
+    nixlDocaMemosBackendReqH &
+    operator=(const nixlDocaMemosBackendReqH &) = delete;
+    nixlDocaMemosBackendReqH &
+    operator=(nixlDocaMemosBackendReqH &&) = delete;
+
+    [[nodiscard]] bool
+    allTasksCompleted() const noexcept {
+        return allTasksCompleted_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] nixl_status_t
+    getOverallStatus() const noexcept {
+        return overallStatus_;
+    }
+
+private:
+    // Engines and their static helpers are the sole owners of the bookkeeping
+    // below. Keeping these private prevents accidental external mutation while
+    // letting the engines manipulate request state directly.
+    friend class nixlDocaMemosEngine;
+    friend class nixlDocaMemosProgressEngine;
+    friend class nixlNoThreadProgressEngine;
+    friend class nixlThreadedProgressEngine;
+
+    int totalTasks_ = 0;
+    int submittedTasks_ = 0;
+    int completedTasks_ = 0;
+    std::atomic<bool> allTasksCompleted_{false};
+    std::atomic<bool> cancelled_{false};
+    nixl_status_t overallStatus_ = NIXL_IN_PROG;
+    std::atomic<int> taskResult_{0};
+    bool isExistQuery_ = false;
+    bool ignoreNotFound_ = false;
+
+    int nextDescriptorIndex_ = 0;
+    bool isPending_ = false;
+
+    nixl_xfer_op_t storedOperation_ = NIXL_WRITE;
+    std::unique_ptr<nixl_meta_dlist_t> storedLocal_;
+    std::unique_ptr<nixl_meta_dlist_t> storedRemote_;
+
+    std::vector<struct iovec> valueIovecs_;
+    std::vector<docaMemosKey> objectKeys_;
+    std::vector<docaMemosTaskContext> taskContexts_;
+};
+
+class nixlDocaMemosEngine : public nixlBackendEngine {
+public:
+    nixlDocaMemosEngine(const nixlBackendInitParams *init_params);
+    ~nixlDocaMemosEngine() override;
+
+    bool
+    supportsRemote() const override {
+        return false;
+    }
+
+    bool
+    supportsLocal() const override {
+        return true;
+    }
+
+    bool
+    supportsNotif() const override {
+        return false;
+    }
+
+    nixl_mem_list_t
+    getSupportedMems() const override {
+        return {OBJ_SEG, DRAM_SEG};
+    }
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    connect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    disconnect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    unloadMD(nixlBackendMD *input) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        output = input;
+        return NIXL_SUCCESS;
+    }
+
+    // Stateless helpers used by both the engine and the progress engine to turn
+    // a registration's metaInfo blob into a docaMemosKey. Exposed as static
+    // methods (rather than free functions) to keep them out of the plugin's
+    // exported global namespace.
+    static bool
+    convertToMemosKey(const std::string &meta_info, docaMemosKey &key);
+    static bool
+    resolveMemosKey(uint64_t dev_id, const std::string &meta_info, docaMemosKey &key);
+
+private:
+    // Custom deleter for nvmeKvdev_: stops the generic kvdev view, then
+    // destroys the NVMe kernel handle that owns it. kvdev_ is a non-owning
+    // alias derived from nvmeKvdev_ and is cleared before nvmeKvdev_.reset().
+    struct NvmeKvdevDeleter {
+        void
+        operator()(doca_nvme_kernel_kvdev *dev) const noexcept;
+    };
+
+    doca_kvdev *kvdev_ = nullptr;
+    std::unique_ptr<doca_nvme_kernel_kvdev, NvmeKvdevDeleter> nvmeKvdev_;
+    std::unique_ptr<nixlDocaMemosProgressEngine> progressEngine_;
+
+    static constexpr const char *kDefaultNguid = "00000000000000000000000000000000";
+    static constexpr uint32_t kDefaultNumTasks = 8192;
+
+    std::string deviceName_;
+    uint32_t numTasks_ = kDefaultNumTasks;
+    uint32_t maxValueLen_ = 0;
+    std::string nguid_ = kDefaultNguid;
+    bool queryMemAssumeSuccess_ = true;
+    bool ignoreReadNotFound_ = false;
+
+    nixl_status_t
+    parseInitParams(const nixl_b_params_t *params);
+
+    nixl_status_t
+    initDocaDevice();
+
+    nixl_status_t
+    createProgressEngine(const nixlBackendInitParams *init_params);
+
+    void
+    cleanupDocaResources();
+};
+
+#endif // NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_BACKEND_H

--- a/src/plugins/doca_memos/doca_memos_plugin.cpp
+++ b/src/plugins/doca_memos/doca_memos_plugin.cpp
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nixl_types.h"
+#include "doca_memos_backend.h"
+#include "backend/backend_plugin.h"
+
+using doca_memos_plugin_t = nixlBackendPluginCreator<nixlDocaMemosEngine>;
+
+namespace {
+constexpr const char *kPluginName = "DOCA_MEMOS";
+constexpr const char *kPluginVersion = "0.1.0";
+} // namespace
+
+// Custom backend parameters accepted by this plugin:
+//   device_name           - Path to the NVMe KV device (e.g. "/dev/nvme0n1"). Required.
+//   num_tasks             - Max in-flight DOCA tasks (default 8192, clamped to device max).
+//   nguid                 - 32 hex-char namespace GUID for key scoping (default all-zeros).
+//   ignore_read_not_found - "true" to treat key-not-found on retrieve as success (default false).
+//   query_mem_mode        - "assume_success" (default) or "actual" (issues EXIST tasks).
+
+#ifdef STATIC_PLUGIN_DOCA_MEMOS
+nixlBackendPlugin *
+createStaticDOCAMemosPlugin() {
+    return doca_memos_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, kPluginName, kPluginVersion, {}, {DRAM_SEG, OBJ_SEG});
+}
+#else
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
+nixl_plugin_init() {
+    return doca_memos_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, kPluginName, kPluginVersion, {}, {DRAM_SEG, OBJ_SEG});
+}
+
+extern "C" NIXL_PLUGIN_EXPORT void
+nixl_plugin_fini() {}
+#endif

--- a/src/plugins/doca_memos/doca_memos_progress_engine.cpp
+++ b/src/plugins/doca_memos/doca_memos_progress_engine.cpp
@@ -1,0 +1,1039 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "doca_memos_progress_engine.h"
+#include "doca_memos_backend.h" // For nixlDocaMemosBackendReqH
+#include "common/nixl_log.h"
+
+#include <algorithm>
+#include <thread>
+#include <chrono>
+
+// DOCA includes
+#include <doca_pe.h>
+#include <doca_kvdev.h>
+#include <doca_kvdev_io.h>
+#include <doca_nvme_kernel_kvdev.h>
+#include <doca_nvme_kernel_kvdev_io.h>
+#include <doca_ctx.h>
+#include <doca_error.h>
+
+namespace {
+
+// doca_pe_progress() reaps at most one completion per call, so reaping once per
+// checkXfer() costs a full poll-loop round trip per completed task. Drain a
+// bounded burst instead; the bound keeps a saturating device from starving the
+// caller (and, in the no-thread engine, from holding lock_ indefinitely).
+constexpr int kProgressBurst = 64;
+
+} // anonymous namespace
+
+void
+nixlDocaMemosProgressEngine::handleSubmissionFailure(nixlDocaMemosBackendReqH *req_h,
+                                                     nixl_status_t status) {
+    if (req_h->overallStatus_ == NIXL_IN_PROG) {
+        req_h->overallStatus_ = status;
+    }
+
+    // Tasks beyond this point were never submitted and will never generate
+    // callbacks. Adjust totalTasks_ so the in-flight tasks plus this failure
+    // can reach the completion threshold.
+    req_h->totalTasks_ = req_h->submittedTasks_ + 1;
+
+    if (++req_h->completedTasks_ >= req_h->totalTasks_) {
+        req_h->allTasksCompleted_.store(true, std::memory_order_release);
+    }
+}
+
+void
+nixlDocaMemosProgressEngine::taskCompletionCallback(struct doca_task *task,
+                                                    union doca_data task_user_data,
+                                                    union doca_data ctx_user_data) {
+    (void)ctx_user_data;
+
+    auto *task_ctx = static_cast<docaMemosTaskContext *>(task_user_data.ptr);
+    if (task_ctx && task_ctx->reqH) {
+        auto *req_h = task_ctx->reqH;
+        int task_index = task_ctx->taskIndex;
+        // Relaxed load: missing a recent cancel is harmless because
+        // processCancellations reconciles totalTasks_ afterwards. Anything
+        // that changes how cancellations are reaped must preserve that.
+        bool is_cancelled = req_h->cancelled_.load(std::memory_order_relaxed);
+
+        if (!is_cancelled) {
+            if (req_h->isExistQuery_) {
+                req_h->taskResult_.store(static_cast<int>(DOCA_SUCCESS), std::memory_order_release);
+                NIXL_DEBUG << "EXIST query completed - key exists (task " << task_index << ")";
+            } else if (task_ctx->isRetrieve) {
+                const struct doca_kvdev_io_task_retrieve *retrieve_task =
+                    doca_kvdev_io_task_retrieve_from_task(task);
+                uint32_t result_len =
+                    doca_kvdev_io_task_retrieve_get_result_value_len(retrieve_task);
+                if (result_len != task_ctx->expectedValueLen) {
+                    NIXL_WARN << "Task " << task_index << " retrieved " << result_len
+                              << " bytes, expected " << task_ctx->expectedValueLen;
+                }
+                NIXL_DEBUG << "Task " << task_index << " completed successfully (" << result_len
+                           << " bytes)";
+            } else {
+                NIXL_DEBUG << "Task " << task_index << " completed successfully";
+            }
+        }
+
+        if (++req_h->completedTasks_ >= req_h->totalTasks_) {
+            if (!is_cancelled && req_h->overallStatus_ == NIXL_IN_PROG) {
+                req_h->overallStatus_ = NIXL_SUCCESS;
+            }
+            req_h->allTasksCompleted_.store(true, std::memory_order_release);
+        }
+    }
+    doca_task_free(task);
+}
+
+void
+nixlDocaMemosProgressEngine::taskErrorCallback(struct doca_task *task,
+                                               union doca_data task_user_data,
+                                               union doca_data ctx_user_data) {
+    (void)ctx_user_data;
+
+    auto *task_ctx = static_cast<docaMemosTaskContext *>(task_user_data.ptr);
+    if (task_ctx && task_ctx->reqH) {
+        auto *req_h = task_ctx->reqH;
+        int task_index = task_ctx->taskIndex;
+        // See taskCompletionCallback for why relaxed is sufficient here.
+        bool is_cancelled = req_h->cancelled_.load(std::memory_order_relaxed);
+
+        if (!is_cancelled) {
+            doca_error_t task_err = doca_task_get_status(task);
+
+            if (req_h->isExistQuery_) {
+                // The DOCA EXIST task always completes via the error callback:
+                // ALREADY_EXIST = key found, NOT_FOUND = key absent. Any other
+                // status is a real failure.
+                if (task_err == DOCA_ERROR_ALREADY_EXIST) {
+                    req_h->taskResult_.store(static_cast<int>(DOCA_SUCCESS),
+                                             std::memory_order_release);
+                    NIXL_DEBUG << "EXIST query completed - key exists (task " << task_index << ")";
+                } else if (task_err == DOCA_ERROR_NOT_FOUND) {
+                    req_h->taskResult_.store(static_cast<int>(DOCA_ERROR_NOT_FOUND),
+                                             std::memory_order_release);
+                    NIXL_DEBUG << "EXIST query completed - key does not exist (task " << task_index
+                               << ")";
+                } else {
+                    NIXL_ERROR << "EXIST task " << task_index
+                               << " failed: " << doca_error_get_descr(task_err) << " ("
+                               << static_cast<int>(task_err) << ")";
+                    if (req_h->overallStatus_ == NIXL_IN_PROG) {
+                        req_h->overallStatus_ = NIXL_ERR_BACKEND;
+                    }
+                }
+            } else if (task_err == DOCA_ERROR_NOT_FOUND && req_h->ignoreNotFound_) {
+                NIXL_DEBUG << "Task " << task_index
+                           << " got key-not-found on retrieve, ignoring per configuration";
+            } else {
+                NIXL_ERROR << "Task " << task_index
+                           << " failed (non-EXIST operation): " << doca_error_get_descr(task_err)
+                           << " (" << static_cast<int>(task_err) << ")";
+
+                if (req_h->overallStatus_ == NIXL_IN_PROG) {
+                    req_h->overallStatus_ = NIXL_ERR_BACKEND;
+                }
+            }
+        }
+
+        if (++req_h->completedTasks_ >= req_h->totalTasks_) {
+            if (!is_cancelled && req_h->overallStatus_ == NIXL_IN_PROG) {
+                req_h->overallStatus_ = NIXL_SUCCESS;
+            }
+            req_h->allTasksCompleted_.store(true, std::memory_order_release);
+        }
+    }
+    doca_task_free(task);
+}
+
+nixlDocaMemosProgressEngine::nixlDocaMemosProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                                                         uint32_t num_tasks,
+                                                         uint32_t max_value_len)
+    : maxValueLen_(max_value_len) {
+    doca_error_t result;
+
+    result = doca_pe_create(&pe_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to create DOCA progress engine: " << doca_error_get_descr(result);
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_nvme_kernel_kvdev_io_create(nvme_kvdev, &kkvIo_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to create DOCA NVMe kernel KV IO context: "
+                   << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    kvIo_ = doca_nvme_kernel_kvdev_io_as_kvdev_io(kkvIo_);
+    if (!kvIo_) {
+        NIXL_ERROR << "Failed to convert NVMe kernel KV IO context to generic KV IO context";
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_kvdev_io_set_num_tasks(kvIo_, num_tasks);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to set DOCA KV IO task count: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_kvdev_io_set_task_completion_cb(kvIo_, taskCompletionCallback);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to set DOCA KV IO completion callback: "
+                   << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_kvdev_io_set_task_error_cb(kvIo_, taskErrorCallback);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to set DOCA KV IO error callback: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    ctx_ = doca_kvdev_io_as_ctx(kvIo_);
+    if (!ctx_) {
+        NIXL_ERROR << "Failed to convert KV IO context to DOCA context";
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_pe_connect_ctx(pe_, ctx_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to connect context to progress engine: "
+                   << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    result = doca_ctx_start(ctx_);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to start DOCA context: " << doca_error_get_descr(result);
+        cleanupDocaResources();
+        initErr_ = true;
+        return;
+    }
+
+    NIXL_DEBUG << "Progress engine base initialization complete";
+}
+
+void
+nixlDocaMemosProgressEngine::cleanupDocaResources() {
+    doca_error_t result;
+    if (ctx_) {
+        result = doca_ctx_stop(ctx_);
+        if (result != DOCA_SUCCESS) {
+            NIXL_WARN << "Failed to stop DOCA context: " << doca_error_get_descr(result);
+        }
+        ctx_ = nullptr;
+    }
+
+    if (kkvIo_) {
+        result = doca_nvme_kernel_kvdev_io_destroy(kkvIo_);
+        if (result != DOCA_SUCCESS) {
+            NIXL_WARN << "Failed to destroy DOCA NVMe kernel KV IO context: "
+                      << doca_error_get_descr(result);
+        }
+        kkvIo_ = nullptr;
+        kvIo_ = nullptr;
+    }
+
+    if (pe_) {
+        result = doca_pe_destroy(pe_);
+        if (result != DOCA_SUCCESS) {
+            NIXL_WARN << "Failed to destroy DOCA progress engine: " << doca_error_get_descr(result);
+        }
+        pe_ = nullptr;
+    }
+}
+
+nixl_status_t
+nixlDocaMemosProgressEngine::checkXfer(nixlDocaMemosBackendReqH *req_h) const {
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (req_h->allTasksCompleted()) {
+        return req_h->getOverallStatus();
+    }
+
+    return NIXL_IN_PROG;
+}
+
+bool
+nixlDocaMemosProgressEngine::trySubmitRequest(nixlDocaMemosBackendReqH *req_h,
+                                              const nixl_xfer_op_t &operation,
+                                              const nixl_meta_dlist_t &local,
+                                              const nixl_meta_dlist_t &remote) const {
+    if (!pendingRequests_.empty() && !req_h->isPending_) {
+        NIXL_DEBUG << "Pending queue not empty - queuing new request without submission";
+        req_h->nextDescriptorIndex_ = 0;
+        return false;
+    }
+
+    for (int i = req_h->nextDescriptorIndex_; i < local.descCount(); i++) {
+        const docaMemosKey &object_key = req_h->objectKeys_[i];
+
+        auto *task_ctx = &req_h->taskContexts_[i];
+        task_ctx->reqH = req_h;
+        task_ctx->taskIndex = i;
+        task_ctx->isRetrieve = (operation == NIXL_READ);
+        task_ctx->expectedValueLen = req_h->valueIovecs_[i].iov_len;
+        union doca_data task_user_data = {.ptr = task_ctx};
+
+        struct doca_task *doca_task = nullptr;
+        doca_error_t result;
+
+        const size_t iov_len = req_h->valueIovecs_[i].iov_len;
+        if (iov_len > UINT32_MAX) {
+            NIXL_ERROR << "Buffer length " << iov_len << " exceeds DOCA KV max (UINT32_MAX)";
+            handleSubmissionFailure(req_h, NIXL_ERR_INVALID_PARAM);
+            return true;
+        }
+        const uint32_t value_len = static_cast<uint32_t>(iov_len);
+        if (maxValueLen_ > 0 && value_len > maxValueLen_) {
+            NIXL_ERROR << "Buffer length " << value_len << " exceeds device max value length "
+                       << maxValueLen_;
+            handleSubmissionFailure(req_h, NIXL_ERR_INVALID_PARAM);
+            return true;
+        }
+
+        if (operation == NIXL_WRITE) {
+            struct doca_kvdev_io_task_store *store_task = nullptr;
+            result = doca_kvdev_io_task_store_alloc_init(kvIo_, task_user_data, &store_task);
+            if (result != DOCA_SUCCESS) {
+                if (result == DOCA_ERROR_FULL || result == DOCA_ERROR_NO_MEMORY) {
+                    req_h->nextDescriptorIndex_ = i;
+                    NIXL_DEBUG << "Task pool exhausted at descriptor " << i
+                               << ", queueing for retry";
+                    return false;
+                }
+                NIXL_ERROR << "Failed to allocate DOCA KV store task: "
+                           << doca_error_get_descr(result);
+                handleSubmissionFailure(req_h, NIXL_ERR_BACKEND);
+                return true;
+            }
+            doca_kvdev_io_task_store_set_key_value_conf(store_task,
+                                                        object_key.key,
+                                                        object_key.keyLen,
+                                                        &req_h->valueIovecs_[i],
+                                                        1,
+                                                        value_len);
+            doca_task = doca_kvdev_io_task_store_as_task(store_task);
+        } else { // NIXL_READ
+            struct doca_kvdev_io_task_retrieve *retrieve_task = nullptr;
+            result = doca_kvdev_io_task_retrieve_alloc_init(kvIo_, task_user_data, &retrieve_task);
+            if (result != DOCA_SUCCESS) {
+                if (result == DOCA_ERROR_FULL || result == DOCA_ERROR_NO_MEMORY) {
+                    req_h->nextDescriptorIndex_ = i;
+                    NIXL_DEBUG << "Task pool exhausted at descriptor " << i
+                               << ", queueing for retry";
+                    return false;
+                }
+                NIXL_ERROR << "Failed to allocate DOCA KV retrieve task: "
+                           << doca_error_get_descr(result);
+                handleSubmissionFailure(req_h, NIXL_ERR_BACKEND);
+                return true;
+            }
+            doca_kvdev_io_task_retrieve_set_key_value_conf(retrieve_task,
+                                                           object_key.key,
+                                                           object_key.keyLen,
+                                                           &req_h->valueIovecs_[i],
+                                                           1,
+                                                           value_len);
+            doca_task = doca_kvdev_io_task_retrieve_as_task(retrieve_task);
+        }
+
+        // Bump submittedTasks_ only after a successful submit, so the count
+        // stays authoritative even if doca_task_submit invokes the callback
+        // synchronously on failure.
+        result = doca_task_submit(doca_task);
+        if (result != DOCA_SUCCESS) {
+            if (result == DOCA_ERROR_FULL) {
+                doca_task_free(doca_task);
+                req_h->nextDescriptorIndex_ = i;
+                NIXL_DEBUG << "Task queue full at descriptor " << i << ", queueing for retry";
+                return false;
+            }
+            NIXL_ERROR << "Failed to submit task: " << doca_error_get_descr(result);
+            doca_task_free(doca_task);
+            handleSubmissionFailure(req_h, NIXL_ERR_BACKEND);
+            return true;
+        }
+        req_h->submittedTasks_++;
+        req_h->nextDescriptorIndex_ = i + 1;
+    }
+
+    return true;
+}
+
+nixl_status_t
+nixlNoThreadProgressEngine::postXfer(nixlDocaMemosBackendReqH *req_h,
+                                     const nixl_xfer_op_t &operation,
+                                     const nixl_meta_dlist_t &local,
+                                     const nixl_meta_dlist_t &remote) const {
+    const std::lock_guard<std::mutex> guard(lock_);
+
+    req_h->totalTasks_ = local.descCount();
+    req_h->submittedTasks_ = 0;
+    req_h->completedTasks_ = 0;
+    req_h->nextDescriptorIndex_ = 0;
+    req_h->allTasksCompleted_.store(false, std::memory_order_release);
+    req_h->overallStatus_ = NIXL_IN_PROG;
+
+    NIXL_DEBUG << "Posting transfer with " << req_h->totalTasks_ << " tasks";
+
+    bool fully_submitted = trySubmitRequest(req_h, operation, local, remote);
+
+    if (!fully_submitted) {
+        req_h->storedOperation_ = operation;
+        req_h->storedLocal_ = std::make_unique<nixl_meta_dlist_t>(local);
+        req_h->storedRemote_ = std::make_unique<nixl_meta_dlist_t>(remote);
+        req_h->isPending_ = true;
+        pendingRequests_.push_back(req_h);
+
+        NIXL_DEBUG << "Request partially submitted (" << req_h->submittedTasks_ << "/"
+                   << req_h->totalTasks_ << "), queued for retry";
+    }
+
+    // Only reachable when trySubmitRequest hit a synchronous failure and
+    // called handleSubmissionFailure, which caps totalTasks_ to the in-flight
+    // count plus one. In-flight callbacks cannot race here because lock_ is
+    // held and doca_pe_progress runs only under the same lock.
+    if (req_h->allTasksCompleted()) {
+        return req_h->getOverallStatus();
+    }
+
+    NIXL_DEBUG << "Transfer posted (" << req_h->submittedTasks_ << " tasks submitted)";
+    return NIXL_IN_PROG;
+}
+
+void
+nixlNoThreadProgressEngine::tryResumePendingRequests() const {
+    const std::lock_guard<std::mutex> guard(lock_);
+
+    while (!pendingRequests_.empty()) {
+        auto *req_h = pendingRequests_.front();
+
+        bool completed;
+        if (req_h->isExistQuery_) {
+            completed = trySubmitExistTask(req_h);
+        } else {
+            completed = trySubmitRequest(
+                req_h, req_h->storedOperation_, *req_h->storedLocal_, *req_h->storedRemote_);
+        }
+
+        if (!completed) {
+            break;
+        }
+
+        pendingRequests_.pop_front();
+        req_h->isPending_ = false;
+    }
+}
+
+void
+nixlNoThreadProgressEngine::cancelRequest(nixlDocaMemosBackendReqH *req_h) const {
+    const std::lock_guard<std::mutex> guard(lock_);
+
+    if (req_h->isPending_) {
+        auto it = std::find(pendingRequests_.begin(), pendingRequests_.end(), req_h);
+        if (it != pendingRequests_.end()) {
+            pendingRequests_.erase(it);
+        }
+        req_h->isPending_ = false;
+        req_h->totalTasks_ = req_h->submittedTasks_;
+    }
+
+    if (req_h->completedTasks_ >= req_h->totalTasks_) {
+        delete req_h;
+        return;
+    }
+
+    req_h->cancelled_.store(true, std::memory_order_release);
+    cancelledRequests_.push_back(req_h);
+}
+
+int
+nixlNoThreadProgressEngine::progress() const {
+    const std::lock_guard<std::mutex> guard(lock_);
+    if (!pe_) {
+        return 0;
+    }
+    int ret = 0;
+    while (ret < kProgressBurst && doca_pe_progress(pe_) != 0) {
+        ret++;
+    }
+
+    for (auto it = cancelledRequests_.begin(); it != cancelledRequests_.end();) {
+        if ((*it)->allTasksCompleted_.load(std::memory_order_acquire)) {
+            delete *it;
+            it = cancelledRequests_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    return ret;
+}
+
+void
+nixlDocaMemosProgressEngine::prepareQueryHandles(
+    const nixl_reg_dlist_t &descs,
+    std::vector<nixlDocaMemosBackendReqH> &query_handles) const {
+    size_t count = static_cast<size_t>(descs.descCount());
+    // reserve() is load-bearing: callers stash &query_handles[i] in DOCA's
+    // task_user_data, so the vector must not reallocate during emplace_back.
+    query_handles.reserve(count);
+
+    for (size_t i = 0; i < count; i++) {
+        query_handles.emplace_back(1);
+        auto &req_h = query_handles.back();
+        req_h.isExistQuery_ = true;
+        req_h.taskContexts_.resize(1);
+        req_h.objectKeys_.resize(1);
+
+        const auto &desc = descs[i];
+        if (!nixlDocaMemosEngine::resolveMemosKey(
+                desc.devId, desc.metaInfo, req_h.objectKeys_[0])) {
+            NIXL_ERROR << "Failed to resolve key for descriptor " << i;
+            handleSubmissionFailure(&req_h, NIXL_ERR_INVALID_PARAM);
+        }
+    }
+}
+
+void
+nixlDocaMemosProgressEngine::waitForQueryCompletion(
+    const std::vector<nixlDocaMemosBackendReqH> &query_handles,
+    const std::function<void()> &poll) const {
+    while (true) {
+        if (poll) {
+            poll();
+        }
+
+        bool all_completed = true;
+        for (const auto &req_h : query_handles) {
+            if (!req_h.allTasksCompleted()) {
+                all_completed = false;
+                break;
+            }
+        }
+        if (all_completed) {
+            break;
+        }
+
+        std::this_thread::yield();
+    }
+}
+
+size_t
+nixlDocaMemosProgressEngine::collectQueryResults(
+    const std::vector<nixlDocaMemosBackendReqH> &query_handles,
+    std::vector<nixl_query_resp_t> &resp) const {
+    size_t successful_queries = 0;
+
+    for (const auto &req_h : query_handles) {
+        if (req_h.getOverallStatus() == NIXL_SUCCESS) {
+            doca_error_t task_result =
+                static_cast<doca_error_t>(req_h.taskResult_.load(std::memory_order_acquire));
+            if (task_result == DOCA_SUCCESS) {
+                resp.emplace_back(nixl_query_resp_t{nixl_b_params_t{}});
+                successful_queries++;
+                NIXL_DEBUG << "Key exists";
+            } else if (task_result == DOCA_ERROR_NOT_FOUND) {
+                resp.emplace_back(std::nullopt);
+                successful_queries++;
+                NIXL_DEBUG << "Key does not exist";
+            } else {
+                resp.emplace_back(std::nullopt);
+                NIXL_DEBUG << "Unexpected task result: " << task_result;
+            }
+        } else {
+            resp.emplace_back(std::nullopt);
+            NIXL_DEBUG << "Query failed with error";
+        }
+    }
+
+    return successful_queries;
+}
+
+nixlNoThreadProgressEngine::nixlNoThreadProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                                                       uint32_t num_tasks,
+                                                       uint32_t max_value_len)
+    : nixlDocaMemosProgressEngine(nvme_kvdev, num_tasks, max_value_len) {
+    if (initErr_) {
+        return;
+    }
+
+    NIXL_DEBUG << "Created no-thread progress engine";
+}
+
+namespace {
+
+constexpr auto kDestructorDrainBudget = std::chrono::seconds(10);
+
+} // anonymous namespace
+
+nixlNoThreadProgressEngine::~nixlNoThreadProgressEngine() {
+    // Drain in-flight tasks so DOCA doesn't see them still owned by ctx_
+    // when cleanupDocaResources stops the context.
+    auto deadline = std::chrono::steady_clock::now() + kDestructorDrainBudget;
+    while (pe_ && std::chrono::steady_clock::now() < deadline) {
+        int did = doca_pe_progress(pe_);
+        for (auto it = cancelledRequests_.begin(); it != cancelledRequests_.end();) {
+            if ((*it)->allTasksCompleted_.load(std::memory_order_acquire)) {
+                delete *it;
+                it = cancelledRequests_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        if (did == 0 && cancelledRequests_.empty()) {
+            break;
+        }
+    }
+    if (!cancelledRequests_.empty()) {
+        NIXL_WARN << "no-thread engine destructor: " << cancelledRequests_.size()
+                  << " cancelled request(s) did not drain within " << kDestructorDrainBudget.count()
+                  << "s";
+    }
+    cleanupDocaResources();
+}
+
+nixl_status_t
+nixlNoThreadProgressEngine::checkXfer(nixlDocaMemosBackendReqH *req_h) const {
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    progress();
+    tryResumePendingRequests();
+    return nixlDocaMemosProgressEngine::checkXfer(req_h);
+}
+
+nixl_status_t
+nixlNoThreadProgressEngine::queryMem(const nixl_reg_dlist_t &descs,
+                                     std::vector<nixl_query_resp_t> &resp) const {
+    resp.reserve(descs.descCount());
+
+    std::vector<nixlDocaMemosBackendReqH> query_handles;
+    prepareQueryHandles(descs, query_handles);
+
+    // See nixlThreadedProgressEngine::queryMem for the lifetime contract:
+    // &query_handles[i] is published into pendingRequests_ and into DOCA's
+    // task_user_data, so query_handles must not reallocate (prepareQueryHandles
+    // reserves) and waitForQueryCompletion must drain every callback before
+    // we return.
+    {
+        const std::lock_guard<std::mutex> guard(lock_);
+        for (auto &req_h : query_handles) {
+            if (req_h.allTasksCompleted()) {
+                continue;
+            }
+            if (!trySubmitExistTask(&req_h)) {
+                req_h.isPending_ = true;
+                pendingRequests_.push_back(&req_h);
+            }
+        }
+    }
+
+    waitForQueryCompletion(query_handles, [this] {
+        progress();
+        tryResumePendingRequests();
+    });
+
+    size_t successful_queries = collectQueryResults(query_handles, resp);
+    size_t total = query_handles.size();
+    if (successful_queries < total) {
+        NIXL_ERROR << (total - successful_queries) << " of " << total << " query task(s) failed";
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlThreadedProgressEngine::postXfer(nixlDocaMemosBackendReqH *req_h,
+                                     const nixl_xfer_op_t &operation,
+                                     const nixl_meta_dlist_t &local,
+                                     const nixl_meta_dlist_t &remote) const {
+    req_h->totalTasks_ = local.descCount();
+    req_h->submittedTasks_ = 0;
+    req_h->completedTasks_ = 0;
+    req_h->nextDescriptorIndex_ = 0;
+    req_h->allTasksCompleted_.store(false, std::memory_order_release);
+    req_h->overallStatus_ = NIXL_IN_PROG;
+
+    NIXL_DEBUG << "Posting transfer with " << req_h->totalTasks_ << " tasks (queued)";
+
+    {
+        const std::lock_guard<std::mutex> g(queueMutex_);
+        producerVec_->push_back({req_h,
+                                 operation,
+                                 std::make_unique<nixl_meta_dlist_t>(local),
+                                 std::make_unique<nixl_meta_dlist_t>(remote)});
+        hasNewWork_.store(true, std::memory_order_release);
+    }
+    wakeup_.notify_one();
+
+    return NIXL_IN_PROG;
+}
+
+void
+nixlThreadedProgressEngine::cancelRequest(nixlDocaMemosBackendReqH *req_h) const {
+    // If the request is still in the producer queue it can be deleted
+    // immediately. Otherwise mark it cancelled here (not in
+    // processCancellations) so any callbacks firing in the window before the
+    // progress thread observes the cancel see cancelled=true and skip their
+    // status bookkeeping.
+    {
+        const std::lock_guard<std::mutex> g(queueMutex_);
+
+        auto it = std::find_if(producerVec_->begin(),
+                               producerVec_->end(),
+                               [req_h](const pendingEntry &e) { return e.reqH == req_h; });
+        if (it != producerVec_->end()) {
+            producerVec_->erase(it);
+            delete req_h;
+            return;
+        }
+
+        req_h->cancelled_.store(true, std::memory_order_release);
+        cancelledRequests_.push_back(req_h);
+        hasNewWork_.store(true, std::memory_order_release);
+    }
+    wakeup_.notify_one();
+}
+
+nixlThreadedProgressEngine::nixlThreadedProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                                                       uint32_t num_tasks,
+                                                       uint32_t max_value_len,
+                                                       std::chrono::microseconds thread_delay)
+    : nixlDocaMemosProgressEngine(nvme_kvdev, num_tasks, max_value_len),
+      threadDelay_(thread_delay) {
+    if (initErr_) {
+        return;
+    }
+
+    NIXL_INFO << "Starting threaded progress engine with delay " << threadDelay_.count() << "us";
+
+    // std::thread's constructor throws std::system_error on pthread_create
+    // failure; nothing else to check.
+    progressThread_ = std::thread(&nixlThreadedProgressEngine::progressThreadFunc, this);
+}
+
+nixlThreadedProgressEngine::~nixlThreadedProgressEngine() {
+    NIXL_INFO << "Stopping threaded progress engine";
+
+    threadStop_.store(true, std::memory_order_release);
+    wakeup_.notify_all();
+
+    if (progressThread_.joinable()) {
+        progressThread_.join();
+    }
+
+    auto deadline = std::chrono::steady_clock::now() + kDestructorDrainBudget;
+    while (pe_ && std::chrono::steady_clock::now() < deadline) {
+        if (doca_pe_progress(pe_) == 0) {
+            break;
+        }
+    }
+    if (pe_ && std::chrono::steady_clock::now() >= deadline) {
+        NIXL_WARN << "threaded engine destructor: doca_pe drain timed out after "
+                  << kDestructorDrainBudget.count() << "s";
+    }
+
+    for (auto *req_h : pendingDeletes_) {
+        delete req_h;
+    }
+    pendingDeletes_.clear();
+
+    // Producer queues may still hold handles the progress thread never popped.
+    // No DOCA submit ever happened for these, so deleting them is safe.
+    for (auto &entry : vecA_) {
+        delete entry.reqH;
+    }
+    vecA_.clear();
+    for (auto &entry : vecB_) {
+        delete entry.reqH;
+    }
+    vecB_.clear();
+
+    for (auto *req_h : cancelledRequests_) {
+        delete req_h;
+    }
+    cancelledRequests_.clear();
+
+    // Anything still in pendingRequests_ has tasks that were submitted to DOCA
+    // but did not complete within the drain budget; deleting them now would
+    // race with any callback DOCA might still fire. Leak with a warning.
+    if (!pendingRequests_.empty()) {
+        NIXL_WARN << "threaded engine destructor: " << pendingRequests_.size()
+                  << " request(s) with in-flight tasks did not drain; leaking to avoid UAF";
+    }
+
+    cleanupDocaResources();
+}
+
+bool
+nixlDocaMemosProgressEngine::trySubmitExistTask(nixlDocaMemosBackendReqH *req_h) const {
+    if (!pendingRequests_.empty() && !req_h->isPending_) {
+        return false;
+    }
+
+    const docaMemosKey &key = req_h->objectKeys_[0];
+
+    auto *task_ctx = &req_h->taskContexts_[0];
+    task_ctx->reqH = req_h;
+    task_ctx->taskIndex = 0;
+    union doca_data task_user_data = {.ptr = task_ctx};
+
+    struct doca_kvdev_io_task_exist *exist_task = nullptr;
+    doca_error_t result = doca_kvdev_io_task_exist_alloc_init(kvIo_, task_user_data, &exist_task);
+    if (result != DOCA_SUCCESS) {
+        if (result == DOCA_ERROR_FULL || result == DOCA_ERROR_NO_MEMORY) {
+            return false;
+        }
+        NIXL_ERROR << "Failed to allocate DOCA KV exist task: " << doca_error_get_descr(result);
+        handleSubmissionFailure(req_h, NIXL_ERR_BACKEND);
+        return true;
+    }
+
+    doca_kvdev_io_task_exist_set_key_conf(exist_task, key.key, key.keyLen);
+    struct doca_task *doca_task = doca_kvdev_io_task_exist_as_task(exist_task);
+
+    result = doca_task_submit(doca_task);
+    if (result != DOCA_SUCCESS) {
+        if (result == DOCA_ERROR_FULL) {
+            doca_task_free(doca_task);
+            return false;
+        }
+        NIXL_ERROR << "Failed to submit EXIST task: " << doca_error_get_descr(result);
+        doca_task_free(doca_task);
+        handleSubmissionFailure(req_h, NIXL_ERR_BACKEND);
+        return true;
+    }
+    req_h->submittedTasks_++;
+
+    return true;
+}
+
+void
+nixlThreadedProgressEngine::processCancellations(
+    std::vector<nixlDocaMemosBackendReqH *> &cancels) const {
+    // cancelled flag is already set by cancelRequest; here we reconcile queue
+    // state and schedule deferred deletion once in-flight callbacks drain.
+    for (auto *req_h : cancels) {
+        if (req_h->isPending_) {
+            auto it = std::find(pendingRequests_.begin(), pendingRequests_.end(), req_h);
+            if (it != pendingRequests_.end()) {
+                pendingRequests_.erase(it);
+            }
+            req_h->totalTasks_ = req_h->submittedTasks_;
+        }
+        req_h->isPending_ = false;
+        if (req_h->completedTasks_ >= req_h->totalTasks_) {
+            delete req_h;
+        } else {
+            pendingDeletes_.push_back(req_h);
+        }
+    }
+    cancels.clear();
+}
+
+void
+nixlThreadedProgressEngine::progressThreadFunc() {
+    NIXL_INFO << "Progress thread running";
+
+    while (!threadStop_.load(std::memory_order_acquire)) {
+        bool made_progress = false;
+
+        if (pe_) {
+            for (int n = 0; n < kProgressBurst && doca_pe_progress(pe_) != 0; n++) {
+                made_progress = true;
+            }
+        }
+
+        for (auto it = pendingDeletes_.begin(); it != pendingDeletes_.end();) {
+            if ((*it)->allTasksCompleted_.load(std::memory_order_acquire)) {
+                delete *it;
+                it = pendingDeletes_.erase(it);
+                made_progress = true;
+            } else {
+                ++it;
+            }
+        }
+
+        while (!pendingRequests_.empty()) {
+            auto *req_h = pendingRequests_.front();
+            bool completed;
+            if (req_h->isExistQuery_) {
+                completed = trySubmitExistTask(req_h);
+            } else {
+                completed = trySubmitRequest(
+                    req_h, req_h->storedOperation_, *req_h->storedLocal_, *req_h->storedRemote_);
+            }
+            if (!completed) {
+                break;
+            }
+            pendingRequests_.pop_front();
+            req_h->isPending_ = false;
+            made_progress = true;
+        }
+
+        if (hasNewWork_.load(std::memory_order_acquire)) {
+            std::vector<pendingEntry> *drain_vec;
+            std::vector<nixlDocaMemosBackendReqH *> cancels;
+            {
+                const std::lock_guard<std::mutex> g(queueMutex_);
+                drain_vec = producerVec_;
+                producerVec_ = (producerVec_ == &vecA_) ? &vecB_ : &vecA_;
+                cancels.swap(cancelledRequests_);
+                hasNewWork_.store(false, std::memory_order_release);
+            }
+
+            if (!cancels.empty()) {
+                processCancellations(cancels);
+                made_progress = true;
+            }
+
+            for (auto &entry : *drain_vec) {
+                // A cancel that lands after this vector was swapped out cannot
+                // be found in the producer queue, so cancelRequest() only sets
+                // the flag and defers reclamation. Honor it here so a cancelled
+                // request is never submitted to DOCA. Collapsing totalTasks_ to
+                // submittedTasks_ lets the deferred processCancellations() free
+                // it (nothing was submitted, so it completes immediately).
+                if (entry.reqH->cancelled_.load(std::memory_order_acquire)) {
+                    entry.reqH->totalTasks_ = entry.reqH->submittedTasks_;
+                    made_progress = true;
+                    continue;
+                }
+
+                bool fully_submitted;
+                if (entry.reqH->isExistQuery_) {
+                    fully_submitted = trySubmitExistTask(entry.reqH);
+                } else {
+                    fully_submitted =
+                        trySubmitRequest(entry.reqH, entry.operation, *entry.local, *entry.remote);
+                }
+
+                if (!fully_submitted) {
+                    if (!entry.reqH->isExistQuery_) {
+                        entry.reqH->storedOperation_ = entry.operation;
+                        entry.reqH->storedLocal_ = std::move(entry.local);
+                        entry.reqH->storedRemote_ = std::move(entry.remote);
+                    }
+                    entry.reqH->isPending_ = true;
+                    pendingRequests_.push_back(entry.reqH);
+                }
+                made_progress = true;
+            }
+            drain_vec->clear();
+        }
+
+        if (made_progress) {
+            if (threadDelay_.count() > 0) {
+                std::this_thread::sleep_for(threadDelay_);
+            }
+            continue;
+        }
+
+        // delay_us = 0 means "busy-spin" (the user opted in, see the warning
+        // in createProgressEngine). Skip the condvar entirely so we keep
+        // polling doca_pe_progress at full rate.
+        if (threadDelay_.count() == 0) {
+            continue;
+        }
+
+        // Idle path: wait on the condvar to amortise the cost of polling
+        // doca_pe_progress. Producers notify after setting hasNewWork_; the
+        // predicate is also checked on spurious wakeups.
+        std::unique_lock<std::mutex> lk(wakeupMutex_);
+        wakeup_.wait_for(lk, threadDelay_, [this] {
+            return threadStop_.load(std::memory_order_acquire) ||
+                hasNewWork_.load(std::memory_order_acquire);
+        });
+    }
+
+    NIXL_INFO << "Progress thread exiting";
+}
+
+nixl_status_t
+nixlThreadedProgressEngine::queryMem(const nixl_reg_dlist_t &descs,
+                                     std::vector<nixl_query_resp_t> &resp) const {
+    size_t count = static_cast<size_t>(descs.descCount());
+    resp.reserve(count);
+
+    std::vector<nixlDocaMemosBackendReqH> query_handles;
+    prepareQueryHandles(descs, query_handles);
+
+    // Lifetime contract: we hand &query_handles[i] to the progress thread via
+    // producerVec_. Two invariants must hold for this to stay safe:
+    //   1. prepareQueryHandles() reserved capacity, so query_handles never
+    //      reallocates and the addresses we publish stay valid.
+    //   2. waitForQueryCompletion() below blocks until every callback has
+    //      fired, so query_handles outlives all in-flight DOCA tasks. Adding
+    //      a timeout to the wait would silently introduce a use-after-free.
+    size_t enqueued = 0;
+    {
+        const std::lock_guard<std::mutex> g(queueMutex_);
+        for (auto &req_h : query_handles) {
+            if (!req_h.allTasksCompleted()) {
+                // operation/local/remote are unused for exist queries; the
+                // progress thread dispatches on req_h->isExistQuery_.
+                producerVec_->push_back({&req_h, {}, nullptr, nullptr});
+                enqueued++;
+            }
+        }
+        if (enqueued > 0) {
+            hasNewWork_.store(true, std::memory_order_release);
+        }
+    }
+    if (enqueued > 0) {
+        wakeup_.notify_one();
+        // Nothing to wait for when every handle already completed (e.g. an
+        // empty batch or the assume_success fast-path); fall through to collect
+        // the results that are already in place, matching the no-thread engine.
+        waitForQueryCompletion(query_handles, nullptr);
+    }
+
+    size_t successful_queries = collectQueryResults(query_handles, resp);
+    if (successful_queries < count) {
+        NIXL_ERROR << (count - successful_queries) << " of " << count << " query task(s) failed";
+        return NIXL_ERR_BACKEND;
+    }
+
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/doca_memos/doca_memos_progress_engine.h
+++ b/src/plugins/doca_memos/doca_memos_progress_engine.h
@@ -1,0 +1,226 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_PROGRESS_ENGINE_H
+#define NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_PROGRESS_ENGINE_H
+
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include "nixl_types.h"
+#include "backend/backend_aux.h" // For nixl_meta_dlist_t
+
+// Forward declaration suffices for the static callback declarations below
+// (function declarations only need an incomplete type for value parameters).
+// The full definition is pulled in by the .cpp via the real DOCA headers (or
+// by the mock headers in unit tests).
+union doca_data;
+
+// Forward declarations for DOCA types
+struct doca_pe;
+struct doca_kvdev;
+struct doca_kvdev_io;
+struct doca_nvme_kernel_kvdev;
+struct doca_nvme_kernel_kvdev_io;
+struct doca_ctx;
+struct doca_task;
+// Forward declaration for request handle
+class nixlDocaMemosBackendReqH;
+
+/**
+ * @brief Base class for DOCA KV progress engine management.
+ *
+ * Owns the DOCA progress-engine, KV-IO context, and the shared submission
+ * helpers (trySubmitRequest, trySubmitExistTask, collectQueryResults).
+ *
+ * pendingRequests_ is the only piece of mutable state that lives in the base
+ * because both subclasses share the helpers that consult / mutate it.
+ * Synchronisation around it is the subclass's responsibility:
+ *   - nixlNoThreadProgressEngine guards every access with its own lock_.
+ *   - nixlThreadedProgressEngine touches it only from the progress thread.
+ *
+ * Per-subclass state (cancellation queues, mutexes, double-buffers, etc.)
+ * lives in the subclasses, not here.
+ */
+class nixlDocaMemosProgressEngine {
+public:
+    virtual ~nixlDocaMemosProgressEngine() = default;
+
+    bool
+    hasInitError() const {
+        return initErr_;
+    }
+
+    virtual nixl_status_t
+    checkXfer(nixlDocaMemosBackendReqH *req_h) const;
+    virtual nixl_status_t
+    postXfer(nixlDocaMemosBackendReqH *req_h,
+             const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote) const = 0;
+    virtual void
+    cancelRequest(nixlDocaMemosBackendReqH *req_h) const = 0;
+    virtual nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const = 0;
+
+protected:
+    nixlDocaMemosProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                                uint32_t num_tasks,
+                                uint32_t max_value_len);
+    void
+    cleanupDocaResources();
+    bool
+    trySubmitRequest(nixlDocaMemosBackendReqH *req_h,
+                     const nixl_xfer_op_t &operation,
+                     const nixl_meta_dlist_t &local,
+                     const nixl_meta_dlist_t &remote) const;
+    bool
+    trySubmitExistTask(nixlDocaMemosBackendReqH *req_h) const;
+    void
+    prepareQueryHandles(const nixl_reg_dlist_t &descs,
+                        std::vector<nixlDocaMemosBackendReqH> &query_handles) const;
+    void
+    waitForQueryCompletion(const std::vector<nixlDocaMemosBackendReqH> &query_handles,
+                           const std::function<void()> &poll) const;
+    size_t
+    collectQueryResults(const std::vector<nixlDocaMemosBackendReqH> &query_handles,
+                        std::vector<nixl_query_resp_t> &resp) const;
+
+    // DOCA task callbacks and submission-failure helper. They live as static
+    // members so they can touch nixlDocaMemosBackendReqH's private bookkeeping
+    // through the friendship granted to nixlDocaMemosProgressEngine.
+    static void
+    taskCompletionCallback(struct doca_task *task,
+                           union doca_data task_user_data,
+                           union doca_data ctx_user_data);
+    static void
+    taskErrorCallback(struct doca_task *task,
+                      union doca_data task_user_data,
+                      union doca_data ctx_user_data);
+    static void
+    handleSubmissionFailure(nixlDocaMemosBackendReqH *req_h, nixl_status_t status);
+
+    struct doca_pe *pe_ = nullptr;
+    struct doca_nvme_kernel_kvdev_io *kkvIo_ = nullptr;
+    struct doca_kvdev_io *kvIo_ = nullptr;
+    struct doca_ctx *ctx_ = nullptr;
+
+    // Synchronisation owned by the subclass; see class doc.
+    mutable std::deque<nixlDocaMemosBackendReqH *> pendingRequests_;
+    bool initErr_ = false;
+    uint32_t maxValueLen_ = 0;
+};
+
+/**
+ * @brief Synchronous progress engine. The caller's thread drives the DOCA PE
+ * via checkXfer()/queryMem(). All shared state is serialised by lock_.
+ */
+class nixlNoThreadProgressEngine : public nixlDocaMemosProgressEngine {
+public:
+    nixlNoThreadProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                               uint32_t num_tasks,
+                               uint32_t max_value_len);
+    ~nixlNoThreadProgressEngine() override;
+
+    nixl_status_t
+    postXfer(nixlDocaMemosBackendReqH *req_h,
+             const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote) const override;
+    void
+    cancelRequest(nixlDocaMemosBackendReqH *req_h) const override;
+    nixl_status_t
+    checkXfer(nixlDocaMemosBackendReqH *req_h) const override;
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+private:
+    int
+    progress() const;
+    void
+    tryResumePendingRequests() const;
+
+    mutable std::vector<nixlDocaMemosBackendReqH *> cancelledRequests_;
+    mutable std::mutex lock_;
+};
+
+/**
+ * @brief Threaded progress engine — lock-free hot path.
+ *
+ * The progress thread is the sole caller of all DOCA APIs (doca_pe_progress,
+ * doca_kvdev_io_task_*_alloc_init, doca_task_submit, etc.).
+ *
+ * Producers (postXfer, cancelRequest) append to *producerVec_ and to
+ * cancelledRequests_ under queueMutex_ and set hasNewWork_. The progress thread,
+ * when it observes hasNewWork_, briefly takes queueMutex_ to swap producerVec_
+ * between vecA_ and vecB_ and to swap-out cancelledRequests_, then drains the
+ * inactive vector outside the lock. This keeps producers' critical sections
+ * to a single push + pointer swap, regardless of how much work the consumer
+ * has queued up.
+ */
+class nixlThreadedProgressEngine : public nixlDocaMemosProgressEngine {
+public:
+    nixlThreadedProgressEngine(struct doca_nvme_kernel_kvdev *nvme_kvdev,
+                               uint32_t num_tasks,
+                               uint32_t max_value_len,
+                               std::chrono::microseconds thread_delay);
+    ~nixlThreadedProgressEngine() override;
+
+    nixl_status_t
+    postXfer(nixlDocaMemosBackendReqH *req_h,
+             const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote) const override;
+    void
+    cancelRequest(nixlDocaMemosBackendReqH *req_h) const override;
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+private:
+    struct pendingEntry {
+        nixlDocaMemosBackendReqH *reqH;
+        nixl_xfer_op_t operation;
+        std::unique_ptr<nixl_meta_dlist_t> local;
+        std::unique_ptr<nixl_meta_dlist_t> remote;
+    };
+
+    void
+    progressThreadFunc();
+    void
+    processCancellations(std::vector<nixlDocaMemosBackendReqH *> &cancels) const;
+
+    std::chrono::microseconds threadDelay_;
+    std::atomic<bool> threadStop_{false};
+    std::thread progressThread_;
+
+    mutable std::mutex queueMutex_;
+    mutable std::atomic<bool> hasNewWork_{false};
+    mutable std::vector<pendingEntry> vecA_;
+    mutable std::vector<pendingEntry> vecB_;
+    mutable std::vector<pendingEntry> *producerVec_ = &vecA_;
+    mutable std::vector<nixlDocaMemosBackendReqH *> cancelledRequests_;
+    mutable std::vector<nixlDocaMemosBackendReqH *> pendingDeletes_;
+
+    mutable std::mutex wakeupMutex_;
+    mutable std::condition_variable wakeup_;
+};
+
+#endif // NIXL_SRC_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_PROGRESS_ENGINE_H

--- a/src/plugins/doca_memos/meson.build
+++ b/src/plugins/doca_memos/meson.build
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+doca_memos_sources = [
+    'doca_memos_backend.cpp',
+    'doca_memos_backend.h',
+    'doca_memos_plugin.cpp',
+    'doca_memos_progress_engine.cpp',
+    'doca_memos_progress_engine.h',
+]
+
+if not (doca_kv_dep.found() and doca_common_dep.found())
+    if is_explicit_enable
+        if not doca_kv_dep.found()
+            error('DOCA_MEMOS plugin requested but doca-kv dependency not found')
+        else
+            error('DOCA_MEMOS plugin requested but doca-common dependency not found')
+        endif
+    endif
+    subdir_done()
+endif
+
+plugin_deps = [nixl_infra, nixl_common_dep]
+doca_plugin_deps = plugin_deps + [doca_kv_dep, doca_common_dep]
+
+compile_defs = []
+compile_flags = []
+doca_memos_cpp_args = compile_defs + ['-DDOCA_ALLOW_EXPERIMENTAL_API']
+
+if 'DOCA_MEMOS' in static_plugins
+    doca_memos_backend_lib = static_library(
+        'DOCA_MEMOS',
+        doca_memos_sources,
+        dependencies: doca_plugin_deps,
+        cpp_args: doca_memos_cpp_args + compile_flags,
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: false,
+        name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
+else
+    doca_memos_backend_lib = shared_library(
+        'DOCA_MEMOS',
+        doca_memos_sources,
+        dependencies: doca_plugin_deps,
+        cpp_args: doca_memos_cpp_args + ['-fPIC'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        install: true,
+        name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+            'echo "DOCA_MEMOS=' + doca_memos_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+            check: true
+        )
+    endif
+endif
+
+doca_memos_backend_interface = declare_dependency(link_with: doca_memos_backend_lib)

--- a/src/plugins/doca_memos/meson.build
+++ b/src/plugins/doca_memos/meson.build
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-doca_memos_sources = [
+# Backend source list, exported so the unit-test executable
+# (test/unit/plugins/doca_memos) can build the same translation units against
+# the DOCA mocks. Defined unconditionally; everything below is gated on the
+# DOCA dependencies being available, but the test only needs the file list.
+doca_memos_backend_sources = files(
     'doca_memos_backend.cpp',
     'doca_memos_backend.h',
-    'doca_memos_plugin.cpp',
     'doca_memos_progress_engine.cpp',
     'doca_memos_progress_engine.h',
+)
+
+doca_memos_sources = [
+    doca_memos_backend_sources,
+    files('doca_memos_plugin.cpp'),
 ]
 
 if not (doca_kv_dep.found() and doca_common_dep.found())

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -141,15 +141,10 @@ if enabled_plugins.get('GPUNETIO')
 endif
 
 if enabled_plugins.get('DOCA_MEMOS')
-    if (not doca_kv_dep.found() or not doca_common_dep.found()) and is_explicit_enable
-        if not doca_kv_dep.found()
-            error('DOCA_MEMOS plugin requested but doca-kv dependency not found')
-        else
-            error('DOCA_MEMOS plugin requested but doca-common dependency not found')
-        endif
-    elif doca_kv_dep.found() and doca_common_dep.found()
-        subdir('doca_memos')
-    endif
+    # Always entered so doca_memos_backend_sources is defined for the unit
+    # tests; the plugin meson.build short-circuits internally when the DOCA
+    # dependencies are missing.
+    subdir('doca_memos')
 endif
 
 subdir('telemetry')

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -140,6 +140,18 @@ if enabled_plugins.get('GPUNETIO')
     endif
 endif
 
+if enabled_plugins.get('DOCA_MEMOS')
+    if (not doca_kv_dep.found() or not doca_common_dep.found()) and is_explicit_enable
+        if not doca_kv_dep.found()
+            error('DOCA_MEMOS plugin requested but doca-kv dependency not found')
+        else
+            error('DOCA_MEMOS plugin requested but doca-common dependency not found')
+        endif
+    elif doca_kv_dep.found() and doca_common_dep.found()
+        subdir('doca_memos')
+    endif
+endif
+
 subdir('telemetry')
 
 if nixl_trace_enabled

--- a/test/unit/plugins/doca_memos/FAILURE_MODES_ANALYSIS.md
+++ b/test/unit/plugins/doca_memos/FAILURE_MODES_ANALYSIS.md
@@ -1,0 +1,455 @@
+# DOCA KV Backend Failure Modes Analysis
+
+This document analyzes all DOCA API calls in the backend and their possible failure modes to ensure comprehensive test coverage.
+
+## DOCA Error Codes Reference
+
+From `doca_error.h`, DOCA can return 32 different error codes:
+
+| Code | Name | Description |
+|------|------|-------------|
+| 0 | `DOCA_SUCCESS` | Success |
+| 1 | `DOCA_ERROR_UNKNOWN` | Unknown error |
+| 2 | `DOCA_ERROR_NOT_PERMITTED` | Operation not permitted |
+| 3 | `DOCA_ERROR_IN_USE` | Resource already in use |
+| 4 | `DOCA_ERROR_NOT_SUPPORTED` | Operation not supported |
+| 5 | `DOCA_ERROR_AGAIN` | Resource temporarily unavailable |
+| 6 | `DOCA_ERROR_INVALID_VALUE` | Invalid input |
+| 7 | `DOCA_ERROR_NO_MEMORY` | Memory allocation failure |
+| 8 | `DOCA_ERROR_INITIALIZATION` | Resource initialization failure |
+| 9 | `DOCA_ERROR_TIME_OUT` | Timer expired |
+| 10 | `DOCA_ERROR_SHUTDOWN` | Shutdown in process |
+| 11 | `DOCA_ERROR_CONNECTION_RESET` | Connection reset by peer |
+| 12 | `DOCA_ERROR_CONNECTION_ABORTED` | Connection aborted |
+| 13 | `DOCA_ERROR_CONNECTION_INPROGRESS` | Connection in progress |
+| 14 | `DOCA_ERROR_NOT_CONNECTED` | Not connected |
+| 15 | `DOCA_ERROR_NO_LOCK` | Unable to acquire lock |
+| 16 | `DOCA_ERROR_NOT_FOUND` | Resource not found |
+| 17 | `DOCA_ERROR_IO_FAILED` | I/O operation failed |
+| 18 | `DOCA_ERROR_BAD_STATE` | Bad state |
+| 19 | `DOCA_ERROR_UNSUPPORTED_VERSION` | Unsupported version |
+| 20 | `DOCA_ERROR_OPERATING_SYSTEM` | OS call failure |
+| 21 | `DOCA_ERROR_DRIVER` | Driver call failure |
+| 22 | `DOCA_ERROR_UNEXPECTED` | Unexpected scenario |
+| 23 | `DOCA_ERROR_ALREADY_EXIST` | Resource already exists |
+| 24 | `DOCA_ERROR_FULL` | No more space |
+| 25 | `DOCA_ERROR_EMPTY` | No entry available |
+| 26 | `DOCA_ERROR_IN_PROGRESS` | Operation in progress |
+| 27 | `DOCA_ERROR_TOO_BIG` | Operation too big |
+| 28 | `DOCA_ERROR_AUTHENTICATION` | Authentication failure |
+| 29 | `DOCA_ERROR_BAD_CONFIG` | Invalid configuration |
+| 30 | `DOCA_ERROR_SKIPPED` | Data was dropped |
+| 31 | `DOCA_ERROR_DEVICE_FATAL_ERROR` | Device fatal error |
+
+## API Call Analysis
+
+### 1. Initialization Path (Constructor)
+
+#### 1.1 `doca_nvme_kernel_kvdev_create()`
+
+**Location**: Line 247
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters or invalid device name
+- `DOCA_ERROR_NO_MEMORY` - Allocation failure
+- `DOCA_ERROR_NOT_FOUND` - Device doesn't exist
+- `DOCA_ERROR_OPERATING_SYSTEM` - System call failed (e.g., open device)
+- `DOCA_ERROR_DRIVER` - Driver communication failure
+- `DOCA_ERROR_INITIALIZATION` - Failed to initialize device
+
+**Current Tests**: ✅
+
+- `ConstructorDocaKvdevCreateFailure` - Tests `DOCA_ERROR_INVALID_VALUE`
+
+**Missing Tests**: ⚠️
+
+- No tests for `DOCA_ERROR_NOT_FOUND` (device doesn't exist)
+- No tests for `DOCA_ERROR_OPERATING_SYSTEM` (system failure)
+- No tests for `DOCA_ERROR_NO_MEMORY` (allocation failure)
+
+#### 1.2 `doca_nvme_kernel_kvdev_as_kvdev()`
+
+**Location**: Line 255
+**Possible Errors**:
+
+- Returns NULL on failure (not a doca_error_t)
+
+**Current Tests**: ✅ Implicitly tested in constructor success test
+
+#### 1.3 `doca_kvdev_start()`
+
+**Location**: Line 265
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - kvdev is NULL or invalid params
+- `DOCA_ERROR_BAD_STATE` - Already started
+- `DOCA_ERROR_NO_MEMORY` - Allocation failure
+- `DOCA_ERROR_IO_FAILED` - Device I/O error
+- `DOCA_ERROR_DEVICE_FATAL_ERROR` - Device is broken
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for device start failures
+
+#### 1.4 `doca_pe_create()`
+
+**Location**: Line 293
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL output parameter
+- `DOCA_ERROR_NO_MEMORY` - Allocation failure
+- `DOCA_ERROR_INITIALIZATION` - PE initialization failed
+
+**Current Tests**: ✅
+
+- `ConstructorDocaPECreateFailure` - Tests `DOCA_ERROR_NO_MEMORY`
+
+#### 1.5 `doca_kvdev_io_create()`
+
+**Location**: Line 305
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters
+- `DOCA_ERROR_NO_MEMORY` - Allocation failure
+- `DOCA_ERROR_INITIALIZATION` - IO context init failed
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for IO context creation failures
+
+#### 1.6 `doca_kvdev_io_set_conf()`
+
+**Location**: Line 320
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters or invalid num_tasks
+- `DOCA_ERROR_BAD_STATE` - Context already started
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for configuration failures
+
+#### 1.7 `doca_kvdev_io_as_ctx()`
+
+**Location**: Line 336
+**Possible Errors**:
+
+- Returns NULL on failure
+
+**Current Tests**: ❌ No specific tests
+
+#### 1.8 `doca_pe_connect_ctx()`
+
+**Location**: Line 352
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters
+- `DOCA_ERROR_IN_USE` - Context already connected
+- `DOCA_ERROR_BAD_STATE` - Invalid state
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for connection failures
+
+#### 1.9 `doca_ctx_start()`
+
+**Location**: Line 369
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL context
+- `DOCA_ERROR_BAD_STATE` - Already started
+- `DOCA_ERROR_INITIALIZATION` - Start failed
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for context start failures
+
+### 2. Destruction Path (Destructor)
+
+#### 2.1 `doca_ctx_stop()`
+
+**Location**: Line 429
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL context
+- `DOCA_ERROR_BAD_STATE` - Already stopped or tasks pending
+
+**Current Tests**: ❌ No specific tests
+
+#### 2.2 `doca_kvdev_io_destroy()`
+
+**Location**: Line 437
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameter
+- `DOCA_ERROR_BAD_STATE` - Context not idle
+
+**Current Tests**: ❌ No specific tests
+
+#### 2.3 `doca_pe_destroy()`
+
+**Location**: Line 450
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameter
+- `DOCA_ERROR_BAD_STATE` - PE still has contexts
+
+**Current Tests**: ❌ No specific tests
+
+#### 2.4 `doca_kvdev_stop()`
+
+**Location**: Line 457
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL kvdev
+- `DOCA_ERROR_BAD_STATE` - Already stopped
+
+**Current Tests**: ❌ No specific tests
+
+#### 2.5 `doca_nvme_kernel_kvdev_destroy()`
+
+**Location**: Line 461
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameter
+- `DOCA_ERROR_IN_USE` - Still has references
+
+**Current Tests**: ❌ No specific tests
+
+### 3. Data Path Operations
+
+#### 3.1 `doca_kv_task_alloc_init()`
+
+**Location**: Line 764 (postXfer), Line 638 (queryMem)
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters
+- `DOCA_ERROR_NO_MEMORY` - Task pool exhausted
+- `DOCA_ERROR_BAD_STATE` - IO context not started
+
+**Current Tests**: ✅ Partially
+
+- `PostXferTaskAllocationFailure` - Tests task allocation failure
+
+**Missing Tests**: ⚠️
+
+- Need test for task pool exhaustion scenario
+- Need test with different error codes
+
+#### 3.2 `doca_kv_task_store_set_conf()`
+
+**Location**: Line 776
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters, invalid key/value sizes
+- `DOCA_ERROR_TOO_BIG` - Key or value too large
+- `DOCA_ERROR_BAD_STATE` - Task not in correct state
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need tests for key too long
+- Need tests for value too large
+- Need tests for invalid parameters
+
+#### 3.3 `doca_kv_task_retrieve_set_conf()`
+
+**Location**: Line 783
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters, invalid key/buffer sizes
+- `DOCA_ERROR_TOO_BIG` - Key too large
+- `DOCA_ERROR_BAD_STATE` - Task not in correct state
+
+**Current Tests**: ❌ No specific tests
+
+#### 3.4 `doca_kv_task_exist_set_conf()`
+
+**Location**: Line 651
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters, invalid key size
+- `DOCA_ERROR_TOO_BIG` - Key too large
+- `DOCA_ERROR_BAD_STATE` - Task not in correct state
+
+**Current Tests**: ❌ No specific tests
+
+#### 3.5 `doca_task_submit()`
+
+**Location**: Line 800 (postXfer), Line 666 (queryMem)
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL task
+- `DOCA_ERROR_BAD_STATE` - Task not configured or context not started
+- `DOCA_ERROR_FULL` - Task queue full
+- `DOCA_ERROR_IO_FAILED` - Submission hardware error
+
+**Current Tests**: ✅ Partially
+
+- `PostXferTaskSubmissionFailure` - Tests submission failure
+
+**Missing Tests**: ⚠️
+
+- Need test for `DOCA_ERROR_FULL` (queue full)
+- Need test for `DOCA_ERROR_BAD_STATE`
+
+#### 3.6 `doca_pe_progress()`
+
+**Location**: Line 172 (progress thread), Line 698 (queryMem)
+**Possible Errors**:
+
+- Returns 0 (no progress) or >0 (number of completions)
+- No error codes, but can trigger completion callbacks with errors
+
+**Current Tests**: ✅ Implicitly tested via auto_complete_tasks
+
+#### 3.7 `doca_task_free()`
+
+**Location**: Line 80, 108 (callbacks)
+**Possible Errors**:
+
+- No documented errors (void function)
+
+#### 3.8 `doca_pe_get_notification_handle()`
+
+**Location**: Line 685
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL parameters
+- `DOCA_ERROR_NOT_SUPPORTED` - Notification not supported
+- `DOCA_ERROR_OPERATING_SYSTEM` - Failed to get FD
+
+**Current Tests**: ❌ No specific tests
+
+**Missing Tests**: ⚠️
+
+- Need test for `QueryMemNotificationHandleFailure`
+
+#### 3.9 `doca_pe_request_notification()`
+
+**Location**: Line 706
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL PE
+- `DOCA_ERROR_BAD_STATE` - Invalid state
+
+**Current Tests**: ❌ No specific tests
+
+#### 3.10 `doca_pe_clear_notification()`
+
+**Location**: Line 714
+**Possible Errors**:
+
+- `DOCA_ERROR_INVALID_VALUE` - NULL PE or invalid handle
+- `DOCA_ERROR_OPERATING_SYSTEM` - Failed to clear
+
+**Current Tests**: ❌ No specific tests
+
+### 4. Task Completion Callbacks
+
+#### 4.1 Task Completion (Success)
+
+**Location**: Lines 59-83
+**Possible Scenarios**:
+
+- Task completes successfully
+- All tasks in batch complete
+- Partial completion
+
+**Current Tests**: ✅
+
+- Auto-complete mechanism tests this
+
+#### 4.2 Task Error (Failure)
+
+**Location**: Lines 87-113
+**Possible Scenarios**:
+
+- Task fails with various error codes
+- `DOCA_ERROR_NOT_FOUND` - Key doesn't exist (RETRIEVE/EXIST)
+- `DOCA_ERROR_IO_FAILED` - Device I/O error
+- `DOCA_ERROR_TOO_BIG` - Value too large
+- `DOCA_ERROR_DEVICE_FATAL_ERROR` - Device failure
+- Any other DOCA error
+
+**Current Tests**: ✅ Partially
+
+- `ErrorCallback` test exists but marked TODO
+
+**Missing Tests**: ⚠️
+
+- Need tests for specific error scenarios
+- Need test for key not found
+- Need test for device errors
+
+## Test Coverage Summary
+
+### ✅ Well Covered
+
+1. Basic constructor success
+1. Task allocation failure
+1. Task submission failure
+1. Basic completion callbacks
+
+### ⚠️ Partially Covered
+
+1. Constructor failures (only 2 of 9 failure points tested)
+1. Data path errors (only allocation/submission tested)
+
+### ❌ Not Covered
+
+1. Destructor error paths
+1. Device start/stop failures
+1. Context configuration failures
+1. Task configuration errors (key too long, value too big)
+1. Task queue full scenarios
+1. Event notification failures
+1. Specific task error types (NOT_FOUND, IO_FAILED, etc.)
+1. Resource exhaustion scenarios
+1. State machine violations (double start, stop before idle, etc.)
+
+## Recommendations
+
+### Priority 1 (Critical Paths)
+
+1. **Task Pool Exhaustion**: Test `doca_kv_task_alloc_init()` with `DOCA_ERROR_FULL`
+1. **Key Not Found**: Test RETRIEVE/EXIST with `DOCA_ERROR_NOT_FOUND`
+1. **Device I/O Errors**: Test with `DOCA_ERROR_IO_FAILED`
+1. **Task Queue Full**: Test `doca_task_submit()` with `DOCA_ERROR_FULL`
+
+### Priority 2 (Initialization Robustness)
+
+5. **Device Not Found**: Test with non-existent device name
+1. **Device Start Failure**: Test `doca_kvdev_start()` failures
+1. **IO Context Creation**: Test `doca_kvdev_io_create()` failures
+1. **Context Start**: Test `doca_ctx_start()` failures
+
+### Priority 3 (Edge Cases)
+
+9. **Key Too Long**: Test with oversized keys
+1. **Value Too Large**: Test with oversized values
+1. **Bad State Transitions**: Test double-start, early destroy, etc.
+1. **Notification Failures**: Test event-driven mode failures
+
+### Priority 4 (Cleanup Robustness)
+
+13. **Destructor Error Handling**: While less critical (destructor is best-effort), test cleanup failures
+
+## Implementation Plan
+
+1. **Expand MockControl**: Add error injection for all DOCA APIs
+1. **Add Error Scenario Tests**: Create tests for each Priority 1-3 item
+1. **Add Stress Tests**: Test resource exhaustion scenarios
+1. **Add State Machine Tests**: Test invalid state transitions
+1. **Document Coverage**: Update test README with coverage matrix

--- a/test/unit/plugins/doca_memos/README.md
+++ b/test/unit/plugins/doca_memos/README.md
@@ -1,0 +1,278 @@
+# DOCA_MEMOS Backend Unit Tests
+
+This directory contains comprehensive unit tests for the DOCA_MEMOS backend plugin with mocked DOCA library dependencies.
+
+## Overview
+
+The test suite uses mocked DOCA functions to test the backend without requiring actual DOCA hardware or libraries. This enables:
+
+- **Fast execution**: No hardware initialization delays
+- **Deterministic behavior**: Controlled test conditions
+- **Complete coverage**: Test error paths that are hard to trigger with real hardware
+- **CI/CD integration**: Run tests in any environment
+
+## Test Structure
+
+### Files
+
+- **`doca_memos_mocks.h`**: Mock DOCA type definitions and function declarations
+- **`doca_memos_mocks.cpp`**: Mock DOCA function implementations
+- **`doca_memos_backend_test.cpp`**: Comprehensive test cases using Google Test
+- **`meson.build`**: Build configuration for the test executable
+
+### Mock Architecture
+
+The mock layer provides:
+
+1. **Mock DOCA types**: Lightweight replacements for DOCA structures
+1. **Mock DOCA functions**: Implementations that simulate DOCA behavior
+1. **Mock control interface**: `DocaMockControl` singleton for configuring mock behavior
+1. **Simulated KV store**: In-memory map for testing STORE/RETRIEVE operations
+
+### Mock Control
+
+The `DocaMockControl` singleton allows tests to:
+
+- **Configure return values**: Make any DOCA function succeed or fail
+- **Simulate callbacks**: Register and trigger completion/error callbacks
+- **Track submissions**: Monitor which tasks were submitted
+- **Auto-complete tasks**: Automatically process tasks on `doca_pe_progress()`
+- **Simulate KV storage**: Store and retrieve data in a mock key-value store
+
+Example usage:
+
+```cpp
+// Make PE creation fail
+DocaMockControl::instance().pe_create_result = DOCA_ERROR_NO_MEMORY;
+
+// Enable auto-completion of tasks
+DocaMockControl::instance().auto_complete_tasks = true;
+
+// Pre-populate the KV store
+DocaMockControl::instance().kv_store["test_key"] = {0x01, 0x02, 0x03};
+
+// Reset all state
+DocaMockControl::instance().reset();
+```
+
+## Test Categories
+
+Use `--gtest_list_tests` to see the authoritative list. The groupings below
+summarise the suite as currently implemented.
+
+### Constructor / Destructor
+
+- `ConstructorSuccess`, `ConstructorWithProgressThread`
+- `ConstructorMissingDeviceName`, `ConstructorDocaKvdevCreateFailure`,
+  `ConstructorDocaPECreateFailure` (assert on `getInitErr()`)
+- `DestructorCleansPendingDeletes`
+
+### Memory Registration
+
+- `RegisterMemObjSeg`, `RegisterMemObjSegWithoutMetaInfo`
+- `RegisterMemUnsupportedType`
+
+### Transfer Path
+
+- `PostXferHandleReuse` — completed handle re-used for a second submission
+- `EmptyDescriptorList` — `prepXfer` rejects empty `local`/`remote`
+- `KeyNotFoundOnRetrieve`, `KeyNotFoundOnRetrieveIgnored`
+- `DeviceIOErrorOnStore`, `StoreReturnsTooBig`, `KeyTooLarge`
+
+### Query Memory
+
+- Assume-success modes: `QueryMemAssumeSuccessDefault`,
+  `QueryMemAssumeSuccessExplicit`, `QueryMemInvalidMode`
+- Actual EXIST mode: `QueryMemActualKeyExists`,
+  `QueryMemActualKeyDoesNotExist`, `QueryMemActualMixed`
+
+### Threading Modes
+
+- `SingleThreadedMode`, `MultiThreadedModeWithProgressThread`,
+  `MultiThreadedModeWithSyncMode`
+- `ThreadedEngineQueuedRequestsComplete`
+
+### Resource Exhaustion / Backpressure
+
+- `TaskPoolExhaustion`, `TaskQueueFull`, `DeviceNotFound`
+- Queued-request semantics: `QueuedRequestSucceedsAfterResourcesFreed`,
+  `MultipleQueuedRequestsFIFOOrdering`, `QueuedRequestsWithSubmitFailures`,
+  `ManyQueuedRequestsConcurrent`, `QueuedRequestNoPartialSubmission`,
+  `QueuedRequestPartialRetryForwardProgress`
+
+### Release / Cancel
+
+- `ReleaseInFlightRequest`, `ReleasePendingRequest`, `ReleaseCompletedRequest`
+- `ThreadedCancelBeforeProgressPickup`,
+  `CancelAfterFatalSubmissionError_NoThread`,
+  `CancelAfterFatalSubmissionError_Threaded`,
+  `CancelWithInflightAndPendingTasks_Threaded`
+
+## Running the Tests
+
+### Build
+
+```bash
+meson setup build
+meson compile -C build
+```
+
+### Run All DOCA KV Tests
+
+```bash
+meson test -C build --suite doca_memos
+```
+
+### Run with Verbose Output
+
+```bash
+meson test -C build --suite doca_memos --verbose
+```
+
+### Run Specific Test
+
+```bash
+./build/test/unit/plugins/doca_memos/doca_memos_backend_test --gtest_filter=DocMemosBackendTest.ConstructorSuccess
+```
+
+### Run with GTest Options
+
+```bash
+# List all tests
+./build/test/unit/plugins/doca_memos/doca_memos_backend_test --gtest_list_tests
+
+# Run tests matching a pattern
+./build/test/unit/plugins/doca_memos/doca_memos_backend_test --gtest_filter="*RegisterMem*"
+
+# Repeat tests
+./build/test/unit/plugins/doca_memos/doca_memos_backend_test --gtest_repeat=100
+```
+
+## Extending the Tests
+
+### Adding a New Test Case
+
+1. **Add the test** to `doca_memos_backend_test.cpp`:
+
+```cpp
+TEST_F(DocMemosBackendTest, YourNewTest) {
+    // Setup mock behavior
+    DocaMockControl::instance().some_config = some_value;
+
+    // Create engine
+    createEngine();
+
+    // Execute test logic
+    // ...
+
+    // Verify expectations
+    EXPECT_EQ(actual, expected);
+}
+```
+
+2. **Configure mocks** as needed:
+
+```cpp
+// Make a function fail
+DocaMockControl::instance().task_submit_result = DOCA_ERROR_BAD_STATE;
+
+// Enable auto-completion
+DocaMockControl::instance().auto_complete_tasks = true;
+
+// Add data to mock KV store
+DocaMockControl::instance().kv_store["key"] = {0xAA, 0xBB};
+```
+
+3. **Use test fixtures** for common setup:
+
+```cpp
+// The SetUp() method runs before each test
+void SetUp() override {
+    DocaMockControl::instance().reset();
+    setupInitParams();
+}
+```
+
+### Adding Mock Functionality
+
+If you need to mock a new DOCA function:
+
+1. **Add the function signature** to `doca_memos_mocks.h`:
+
+```cpp
+extern "C" {
+doca_error_t doca_new_function(doca_some_type *arg);
+}
+```
+
+2. **Add control variables** to `DocaMockControl`:
+
+```cpp
+doca_error_t new_function_result = DOCA_SUCCESS;
+```
+
+3. **Implement the mock** in `doca_memos_mocks.cpp`:
+
+```cpp
+doca_error_t doca_new_function(doca_some_type *arg) {
+    return DocaMockControl::instance().new_function_result;
+}
+```
+
+4. **Reset in `DocaMockControl::reset()`**:
+
+```cpp
+new_function_result = DOCA_SUCCESS;
+```
+
+## Debugging Tips
+
+### Enable Verbose Logging
+
+The backend uses `NIXL_DEBUG`, `NIXL_INFO`, `NIXL_ERROR` macros. Configure logging level to see detailed execution flow.
+
+### Inspect Mock State
+
+Add debug output in tests:
+
+```cpp
+auto& mock = DocaMockControl::instance();
+std::cout << "Submitted tasks: " << mock.submitted_tasks.size() << std::endl;
+std::cout << "KV store size: " << mock.kv_store.size() << std::endl;
+```
+
+### Use GDB
+
+```bash
+gdb --args ./build/test/unit/plugins/doca_memos/doca_memos_backend_test --gtest_filter=SpecificTest
+```
+
+### Breakpoint in Test
+
+```cpp
+TEST_F(DocMemosBackendTest, DebugTest) {
+    createEngine();
+    __builtin_trap();  // Breakpoint here
+    // ... rest of test
+}
+```
+
+## Known Limitations
+
+1. **Async completion**: mock auto-completion runs synchronously inside
+   `doca_pe_progress()` rather than from a real device interrupt path.
+1. **Threading**: the mock does not model device-side scheduling delays.
+1. **Memory corruption**: the mock does not detect invalid pointers or
+   out-of-bounds access into registered buffers.
+
+## Contributing
+
+When adding new functionality to the DOCA_MEMOS backend:
+
+1. **Write tests first** (TDD approach)
+1. **Cover error paths** explicitly
+1. **Test threading modes** (single-threaded and multi-threaded)
+1. **Document test intent** with clear comments
+1. **Use descriptive test names**: `TEST_F(DocMemosBackendTest, DescriptiveNameOfWhatIsBeingTested)`
+
+All backend changes should maintain or improve test coverage.

--- a/test/unit/plugins/doca_memos/doca_compat.h
+++ b/test/unit/plugins/doca_memos/doca_compat.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DOCA KV Mock - Compatibility Definitions
+ * Mock implementation of DOCA compatibility macros
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_COMPAT_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_COMPAT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__linux__)
+
+#define DOCA_USED __attribute__((used))
+#define DOCA_STABLE __attribute__((visibility("default"))) DOCA_USED
+
+#ifndef DOCA_ALLOW_EXPERIMENTAL_API
+#define DOCA_EXPERIMENTAL                                           \
+    __attribute__((deprecated("Symbol is defined as experimental"), \
+                   section(".text.experimental"))) DOCA_STABLE
+#else
+#define DOCA_EXPERIMENTAL __attribute__((section(".text.experimental"))) DOCA_STABLE
+#endif
+
+#else /* Windows or other */
+
+#define __attribute__(_x_)
+#define DOCA_STABLE
+#define DOCA_EXPERIMENTAL
+
+#endif
+
+/* Compiler optimization hints */
+#define doca_likely(x) __builtin_expect(!!(x), 1)
+#define doca_unlikely(x) __builtin_expect(!!(x), 0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_COMPAT_H */

--- a/test/unit/plugins/doca_memos/doca_ctx.h
+++ b/test/unit/plugins/doca_memos/doca_ctx.h
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DOCA KV Mock - Context API
+ * Mock implementation of DOCA context
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_CTX_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_CTX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <doca_compat.h>
+#include <doca_error.h>
+#include <doca_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct doca_ctx;
+struct doca_task;
+
+/**
+ * @brief Context states
+ */
+enum doca_ctx_states {
+    DOCA_CTX_STATE_IDLE = 0,
+    DOCA_CTX_STATE_STARTING = 1,
+    DOCA_CTX_STATE_RUNNING = 2,
+    DOCA_CTX_STATE_STOPPING = 3,
+};
+
+/**
+ * @brief Finalizes all configurations, and starts the DOCA CTX.
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_start(struct doca_ctx *ctx);
+
+/**
+ * @brief Stops the context allowing reconfiguration.
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_stop(struct doca_ctx *ctx);
+
+/**
+ * @brief Get number of in flight tasks in a doca context
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_get_num_inflight_tasks(const struct doca_ctx *ctx, size_t *num_inflight_tasks);
+
+/**
+ * @brief set user data to context
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_set_user_data(struct doca_ctx *ctx, union doca_data user_data);
+
+/**
+ * @brief get user data from context
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_get_user_data(const struct doca_ctx *ctx, union doca_data *user_data);
+
+/**
+ * @brief Get context state
+ */
+DOCA_STABLE
+doca_error_t
+doca_ctx_get_state(const struct doca_ctx *ctx, enum doca_ctx_states *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_CTX_H */

--- a/test/unit/plugins/doca_memos/doca_error.h
+++ b/test/unit/plugins/doca_memos/doca_error.h
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DOCA KV Mock - Error Types
+ * Mock implementation of DOCA error types
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_ERROR_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_ERROR_H
+
+#include <doca_compat.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DOCA API return codes
+ */
+typedef enum doca_error {
+    DOCA_SUCCESS = 0,
+    DOCA_ERROR_UNKNOWN = 1,
+    DOCA_ERROR_NOT_PERMITTED = 2,
+    DOCA_ERROR_IN_USE = 3,
+    DOCA_ERROR_NOT_SUPPORTED = 4,
+    DOCA_ERROR_AGAIN = 5,
+    DOCA_ERROR_INVALID_VALUE = 6,
+    DOCA_ERROR_NO_MEMORY = 7,
+    DOCA_ERROR_INITIALIZATION = 8,
+    DOCA_ERROR_TIME_OUT = 9,
+    DOCA_ERROR_SHUTDOWN = 10,
+    DOCA_ERROR_CONNECTION_RESET = 11,
+    DOCA_ERROR_CONNECTION_ABORTED = 12,
+    DOCA_ERROR_CONNECTION_INPROGRESS = 13,
+    DOCA_ERROR_NOT_CONNECTED = 14,
+    DOCA_ERROR_NO_LOCK = 15,
+    DOCA_ERROR_NOT_FOUND = 16,
+    DOCA_ERROR_IO_FAILED = 17,
+    DOCA_ERROR_BAD_STATE = 18,
+    DOCA_ERROR_UNSUPPORTED_VERSION = 19,
+    DOCA_ERROR_OPERATING_SYSTEM = 20,
+    DOCA_ERROR_DRIVER = 21,
+    DOCA_ERROR_UNEXPECTED = 22,
+    DOCA_ERROR_ALREADY_EXIST = 23,
+    DOCA_ERROR_FULL = 24,
+    DOCA_ERROR_EMPTY = 25,
+    DOCA_ERROR_IN_PROGRESS = 26,
+    DOCA_ERROR_TOO_BIG = 27,
+    DOCA_ERROR_AUTHENTICATION = 28,
+    DOCA_ERROR_BAD_CONFIG = 29,
+    DOCA_ERROR_SKIPPED = 30,
+    DOCA_ERROR_DEVICE_FATAL_ERROR = 31
+} doca_error_t;
+
+/**
+ * Returns the string representation of an error code name.
+ */
+const char *
+doca_error_get_name(doca_error_t error);
+
+/**
+ * Returns the description string of an error code.
+ */
+const char *
+doca_error_get_descr(doca_error_t error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_ERROR_H */

--- a/test/unit/plugins/doca_memos/doca_memos_backend_test.cpp
+++ b/test/unit/plugins/doca_memos/doca_memos_backend_test.cpp
@@ -1,0 +1,1850 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+#include <cstring>
+
+// Include mocks before the backend
+#include "doca_memos_mocks.h"
+
+// Now we can include the backend header (which will use our mocked DOCA types)
+#include "doca_memos_backend.h"
+#include "nixl_types.h"
+
+class DocMemosBackendTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        // Reset mock state before each test
+        DocaMockControl::instance().reset();
+
+        // Setup default init params
+        setupInitParams();
+    }
+
+    void
+    TearDown() override {
+        // Clean up engine if created
+        if (engine_) {
+            engine_.reset();
+        }
+    }
+
+    void
+    setupInitParams(bool enable_progress_thread = false,
+                    nixl_thread_sync_t sync_mode = nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE,
+                    const std::string &device_name = "/dev/nvme0n1",
+                    const std::string &num_tasks = "8192") {
+        // Setup backend parameters
+        backend_params_ = std::make_unique<nixl_b_params_t>();
+        (*backend_params_)["device_name"] = device_name;
+        (*backend_params_)["num_tasks"] = num_tasks;
+
+        // Setup init params
+        init_params_ = std::make_unique<nixlBackendInitParams>();
+        init_params_->customParams = backend_params_.get();
+        init_params_->enableProgTh = enable_progress_thread;
+        init_params_->syncMode = sync_mode;
+        init_params_->pthrDelay = 1000; // 1ms
+    }
+
+    void
+    createEngine() {
+        engine_ = std::make_unique<nixlDocaMemosEngine>(init_params_.get());
+    }
+
+    // Helper method to register memory and return metadata
+    // Returns the metadata object that should be attached to the descriptor
+    nixlBackendMD *
+    registerMemory(uint64_t dev_id, const std::string &key) {
+        if (!engine_) {
+            return nullptr;
+        }
+
+        nixlBlobDesc blob;
+        blob.devId = dev_id;
+        blob.metaInfo = key;
+        blob.addr = 0; // Not used for KV
+        blob.len = 0; // Not used for KV
+
+        nixlBackendMD *out = nullptr;
+        engine_->registerMem(blob, OBJ_SEG, out);
+        return out;
+    }
+
+    std::unique_ptr<nixlDocaMemosEngine> engine_;
+    std::unique_ptr<nixlBackendInitParams> init_params_;
+    std::unique_ptr<nixl_b_params_t> backend_params_;
+};
+
+// ============================================================================
+// Constructor/Destructor Tests
+// ============================================================================
+
+TEST_F(DocMemosBackendTest, ConstructorSuccess) {
+    createEngine();
+    EXPECT_TRUE(engine_ != nullptr);
+    EXPECT_FALSE(engine_->supportsRemote());
+    EXPECT_TRUE(engine_->supportsLocal());
+}
+
+TEST_F(DocMemosBackendTest, ConstructorMissingDeviceName) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE, ""); // Empty device name
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+TEST_F(DocMemosBackendTest, ConstructorDocaKvdevCreateFailure) {
+    DocaMockControl::instance().nvme_kvdev_create_result = DOCA_ERROR_INVALID_VALUE;
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+TEST_F(DocMemosBackendTest, ConstructorDocaPECreateFailure) {
+    DocaMockControl::instance().pe_create_result = DOCA_ERROR_NO_MEMORY;
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+TEST_F(DocMemosBackendTest, ConstructorWithProgressThread) {
+    setupInitParams(true); // Enable progress thread
+    createEngine();
+    EXPECT_TRUE(engine_ != nullptr);
+}
+
+// ============================================================================
+// Memory Registration Tests
+// ============================================================================
+
+TEST_F(DocMemosBackendTest, RegisterMemObjSeg) {
+    createEngine();
+
+    nixlBlobDesc desc;
+    desc.devId = 100;
+    desc.metaInfo = "test_key_123";
+
+    nixl_mem_t nixl_mem = OBJ_SEG;
+    nixlBackendMD *out = nullptr;
+
+    nixl_status_t status = engine_->registerMem(desc, nixl_mem, out);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(out, nullptr);
+
+    // Cleanup
+    engine_->deregisterMem(out);
+}
+
+TEST_F(DocMemosBackendTest, RegisterMemObjSegWithoutMetaInfo) {
+    createEngine();
+
+    nixlBlobDesc desc;
+    desc.devId = 42;
+    desc.metaInfo = ""; // Empty, should use devId
+
+    nixl_mem_t nixl_mem = OBJ_SEG;
+    nixlBackendMD *out = nullptr;
+
+    nixl_status_t status = engine_->registerMem(desc, nixl_mem, out);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(out, nullptr);
+
+    // Cleanup
+    engine_->deregisterMem(out);
+}
+
+TEST_F(DocMemosBackendTest, RegisterMemUnsupportedType) {
+    createEngine();
+
+    nixlBlobDesc desc;
+    desc.devId = 1;
+
+    nixl_mem_t unsupported_mem = VRAM_SEG; // Not supported by DOCA KV
+    nixlBackendMD *out = nullptr;
+
+    nixl_status_t status = engine_->registerMem(desc, unsupported_mem, out);
+    EXPECT_NE(status, NIXL_SUCCESS);
+}
+
+// ============================================================================
+// Transfer Preparation Tests
+// ============================================================================
+
+// A handle can be re-posted after its prior submission completes; the second
+// post must succeed and produce a fresh round of submissions.
+TEST_F(DocMemosBackendTest, PostXferHandleReuse) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+    local_desc.len = 1024;
+    remote_desc.devId = 9101;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+    remote_desc.metadataP = registerMemory(remote_desc.devId, "reuse_key");
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+
+    for (int round = 0; round < 2; round++) {
+        ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle),
+                  NIXL_IN_PROG)
+            << "round " << round;
+        nixl_status_t status = NIXL_IN_PROG;
+        for (int i = 0; i < 100 && status == NIXL_IN_PROG; i++) {
+            status = engine_->checkXfer(handle);
+        }
+        EXPECT_EQ(status, NIXL_SUCCESS) << "round " << round;
+    }
+
+    free(reinterpret_cast<void *>(local_desc.addr));
+    engine_->deregisterMem(remote_desc.metadataP);
+    engine_->releaseReqH(handle);
+}
+
+// ============================================================================
+// Query Memory Tests
+// ============================================================================
+
+TEST_F(DocMemosBackendTest, QueryMemAssumeSuccessDefault) {
+    // Default mode: queryMem should return success for all descriptors
+    // without actually querying the device
+    createEngine();
+
+    // Register some OBJ_SEG memory
+    nixlBlobDesc desc1;
+    desc1.devId = 500;
+    desc1.metaInfo = "key_1";
+    nixlBackendMD *md1 = nullptr;
+    ASSERT_EQ(engine_->registerMem(desc1, OBJ_SEG, md1), NIXL_SUCCESS);
+
+    nixlBlobDesc desc2;
+    desc2.devId = 501;
+    desc2.metaInfo = "key_2";
+    nixlBackendMD *md2 = nullptr;
+    ASSERT_EQ(engine_->registerMem(desc2, OBJ_SEG, md2), NIXL_SUCCESS);
+
+    // Build a registered descriptor list
+    nixl_reg_dlist_t reg_dlist(OBJ_SEG);
+    nixlBlobDesc reg_desc1;
+    reg_desc1.devId = 500;
+    reg_desc1.metaInfo = "key_1";
+    reg_dlist.addDesc(reg_desc1);
+
+    nixlBlobDesc reg_desc2;
+    reg_desc2.devId = 501;
+    reg_desc2.metaInfo = "key_2";
+    reg_dlist.addDesc(reg_desc2);
+
+    std::vector<nixl_query_resp_t> resp;
+    nixl_status_t status = engine_->queryMem(reg_dlist, resp);
+
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    ASSERT_EQ(resp.size(), 2);
+    EXPECT_TRUE(resp[0].has_value())
+        << "All descriptors should report success in assume_success mode";
+    EXPECT_TRUE(resp[1].has_value())
+        << "All descriptors should report success in assume_success mode";
+
+    // No DOCA tasks should have been submitted
+    EXPECT_EQ(DocaMockControl::instance().submitted_tasks.size(), 0)
+        << "No DOCA tasks should be submitted in assume_success mode";
+
+    engine_->deregisterMem(md1);
+    engine_->deregisterMem(md2);
+}
+
+TEST_F(DocMemosBackendTest, QueryMemAssumeSuccessExplicit) {
+    // Explicitly set assume_success mode
+    (*backend_params_)["query_mem_mode"] = "assume_success";
+    createEngine();
+
+    nixl_reg_dlist_t reg_dlist(OBJ_SEG);
+    nixlBlobDesc reg_desc;
+    reg_desc.devId = 600;
+    reg_desc.metaInfo = "some_key";
+    reg_dlist.addDesc(reg_desc);
+
+    std::vector<nixl_query_resp_t> resp;
+    nixl_status_t status = engine_->queryMem(reg_dlist, resp);
+
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    ASSERT_EQ(resp.size(), 1);
+    EXPECT_TRUE(resp[0].has_value());
+}
+
+TEST_F(DocMemosBackendTest, QueryMemInvalidMode) {
+    (*backend_params_)["query_mem_mode"] = "bogus_value";
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+// queryMem in "actual" mode submits an EXIST task per descriptor and reports
+// presence based on the DOCA error callback.
+TEST_F(DocMemosBackendTest, QueryMemActualKeyExists) {
+    setupInitParams(false);
+    (*backend_params_)["query_mem_mode"] = "actual";
+    createEngine();
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // The mock keys EXIST results off this map; the key string here must
+    // match what resolveMemosKey produces. metaInfo "exists" is not valid
+    // hex (odd length) and <= 16 bytes, so the plugin uses it raw.
+    mock.kv_store["exists"] = std::vector<uint8_t>(8, 0x42);
+
+    nixl_reg_dlist_t reg_dlist(OBJ_SEG);
+    nixlBlobDesc desc;
+    desc.devId = 700;
+    desc.metaInfo = "exists";
+    reg_dlist.addDesc(desc);
+
+    std::vector<nixl_query_resp_t> resp;
+    EXPECT_EQ(engine_->queryMem(reg_dlist, resp), NIXL_SUCCESS);
+    ASSERT_EQ(resp.size(), 1u);
+    EXPECT_TRUE(resp[0].has_value());
+}
+
+TEST_F(DocMemosBackendTest, QueryMemActualKeyDoesNotExist) {
+    setupInitParams(false);
+    (*backend_params_)["query_mem_mode"] = "actual";
+    createEngine();
+    DocaMockControl::instance().auto_complete_tasks = true;
+
+    nixl_reg_dlist_t reg_dlist(OBJ_SEG);
+    nixlBlobDesc desc;
+    desc.devId = 701;
+    desc.metaInfo = "missing";
+    reg_dlist.addDesc(desc);
+
+    std::vector<nixl_query_resp_t> resp;
+    EXPECT_EQ(engine_->queryMem(reg_dlist, resp), NIXL_SUCCESS);
+    ASSERT_EQ(resp.size(), 1u);
+    EXPECT_FALSE(resp[0].has_value());
+}
+
+// Mix of present and absent keys in a single batch.
+TEST_F(DocMemosBackendTest, QueryMemActualMixed) {
+    setupInitParams(false);
+    (*backend_params_)["query_mem_mode"] = "actual";
+    createEngine();
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+    mock.kv_store["alpha"] = std::vector<uint8_t>(4, 0x11);
+    mock.kv_store["gamma"] = std::vector<uint8_t>(4, 0x33);
+
+    nixl_reg_dlist_t reg_dlist(OBJ_SEG);
+    for (const char *name : {"alpha", "beta", "gamma", "delta"}) {
+        nixlBlobDesc desc;
+        desc.devId = 800;
+        desc.metaInfo = name;
+        reg_dlist.addDesc(desc);
+    }
+
+    std::vector<nixl_query_resp_t> resp;
+    EXPECT_EQ(engine_->queryMem(reg_dlist, resp), NIXL_SUCCESS);
+    ASSERT_EQ(resp.size(), 4u);
+    EXPECT_TRUE(resp[0].has_value()); // alpha
+    EXPECT_FALSE(resp[1].has_value()); // beta
+    EXPECT_TRUE(resp[2].has_value()); // gamma
+    EXPECT_FALSE(resp[3].has_value()); // delta
+}
+
+// ============================================================================
+// Threading Mode Tests
+// ============================================================================
+
+TEST_F(DocMemosBackendTest, SingleThreadedMode) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Verify no progress thread is created and no locks are required
+    // This is implicit in the implementation, but we can verify behavior
+}
+
+TEST_F(DocMemosBackendTest, MultiThreadedModeWithProgressThread) {
+    setupInitParams(true, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Progress thread should be created
+}
+
+TEST_F(DocMemosBackendTest, MultiThreadedModeWithSyncMode) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+    createEngine();
+
+    // Locks should be required even without progress thread
+}
+
+TEST_F(DocMemosBackendTest, ThreadedEngineQueuedRequestsComplete) {
+    setupInitParams(true);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+    mock.task_alloc_call_count = 0;
+    mock.task_alloc_fail_after_n = 2;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 4; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 20000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "thr_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // Submission runs on the background progress thread, so wait until it has
+    // actually hit the exhaustion window (2 successful allocs followed by at
+    // least one failed retry) before lifting the fault. Clearing it eagerly
+    // lets the thread drain the whole batch without ever queuing, leaving the
+    // resume path untested.
+    bool exhaustion_observed = false;
+    for (int i = 0; i < 1000; i++) {
+        {
+            auto lk = DocaMockControl::lock();
+            if (mock.task_alloc_call_count > 2) {
+                exhaustion_observed = true;
+                break;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    {
+        auto lk = DocaMockControl::lock();
+        ASSERT_TRUE(exhaustion_observed)
+            << "Progress thread never reached the task-pool exhaustion window";
+        mock.task_alloc_fail_after_n = -1;
+        mock.task_alloc_call_count = 0;
+    }
+
+    nixl_status_t status = NIXL_IN_PROG;
+    for (int i = 0; i < 200; i++) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(status, NIXL_SUCCESS)
+        << "Threaded engine should drain pending queue and complete all tasks";
+
+    for (int i = 0; i < 4; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+    engine_->releaseReqH(handle);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+// prepXfer must reject empty descriptor lists rather than allocating a
+// zero-task request handle.
+TEST_F(DocMemosBackendTest, EmptyDescriptorList) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlBackendReqH *handle = nullptr;
+    EXPECT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle),
+              NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(handle, nullptr);
+}
+
+// =============================================================================
+// Failure Mode Tests
+// =============================================================================
+
+// Test 1: Task Pool Exhaustion - With queueing, requests succeed after resources free up
+TEST_F(DocMemosBackendTest, TaskPoolExhaustion) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Configure mock to fail after 2 successful task allocations initially
+    auto &mock = DocaMockControl::instance();
+    mock.task_alloc_fail_after_n = 2;
+
+    // Create 3 descriptors, but pool can only handle 2 initially
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+        local_desc.len = 1024;
+        remote_desc.devId = 1000 + i; // Unique devId for each descriptor
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+
+        std::string key = "key_" + std::to_string(i);
+        // Register memory and get metadata
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    // Prepare transfer - should succeed
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    // Post transfer - first 2 tasks submit, 3rd gets queued due to resource exhaustion
+    status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Verify partial submission: 2 tasks should be submitted, 1 queued
+    EXPECT_EQ(mock.submitted_tasks.size(), 2)
+        << "Should have submitted 2 tasks (partial submission)";
+
+    // Now allow more allocations and let progress drain the queue
+    mock.task_alloc_fail_after_n = -1;
+    mock.task_alloc_call_count = 0;
+    mock.auto_complete_tasks = true;
+
+    // Check status - should eventually succeed after queued task is retried
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(status, NIXL_SUCCESS) << "Request should succeed after resources become available";
+
+    // Cleanup
+    for (int i = 0; i < 3; i++) {
+        free(reinterpret_cast<void *>(local_dlist[i].addr));
+        engine_->deregisterMem(remote_dlist[i].metadataP);
+    }
+    engine_->releaseReqH(handle);
+}
+
+// Test 2: Key Not Found - RETRIEVE operation on non-existent key
+TEST_F(DocMemosBackendTest, KeyNotFoundOnRetrieve) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Don't store any key in the mock KV store
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+    mock.kv_store.clear(); // Ensure store is empty
+
+    // Try to retrieve a non-existent key
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+    local_desc.len = 1024;
+    remote_desc.devId = 2000;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+
+    std::string key = "nonexistent_key";
+    remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_READ, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    status = engine_->postXfer(NIXL_READ, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    // Wait for completion - should fail with NOT_FOUND
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND); // Key not found
+
+    // Cleanup
+    free(reinterpret_cast<void *>(local_desc.addr));
+    engine_->deregisterMem(remote_desc.metadataP);
+    engine_->releaseReqH(handle);
+}
+
+// Test 2b: Key Not Found with ignore_read_not_found - should succeed
+TEST_F(DocMemosBackendTest, KeyNotFoundOnRetrieveIgnored) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    (*backend_params_)["ignore_read_not_found"] = "true";
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+    mock.kv_store.clear();
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+    local_desc.len = 1024;
+    remote_desc.devId = 2001;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+
+    std::string key = "nonexistent_key";
+    remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_READ, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    status = engine_->postXfer(NIXL_READ, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    free(reinterpret_cast<void *>(local_desc.addr));
+    engine_->deregisterMem(remote_desc.metadataP);
+    engine_->releaseReqH(handle);
+}
+
+// Test 3: Device I/O Error - Simulated during STORE operation
+TEST_F(DocMemosBackendTest, DeviceIOErrorOnStore) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Force task error to simulate I/O failure
+    auto &mock = DocaMockControl::instance();
+    mock.force_task_error = true;
+    mock.forced_task_error_code = DOCA_ERROR_IO_FAILED;
+    mock.auto_complete_tasks = true;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+    local_desc.len = 1024;
+    remote_desc.devId = 3000;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+
+    std::string key = "test_key";
+    remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_IN_PROG);
+
+    // Wait for completion - should fail with I/O error
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+
+    // Cleanup
+    free(reinterpret_cast<void *>(local_desc.addr));
+    engine_->deregisterMem(remote_desc.metadataP);
+    engine_->releaseReqH(handle);
+}
+
+// Test 4: Task Queue Full - With queueing, requests succeed when queue has space
+TEST_F(DocMemosBackendTest, TaskQueueFull) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    // Configure mock to fail after 1 successful submission initially
+    auto &mock = DocaMockControl::instance();
+    mock.task_submit_fail_after_n = 1;
+    mock.auto_complete_tasks = true;
+
+    // Create 2 descriptors
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    for (int i = 0; i < 2; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+        local_desc.len = 1024;
+        remote_desc.devId = 4000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+
+        std::string key = "key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    ASSERT_EQ(status, NIXL_SUCCESS);
+
+    // Post transfer - first task submits, second gets queued due to queue full
+    status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Now allow more submissions (simulating queue having space)
+    mock.task_submit_fail_after_n = -1;
+    mock.task_submit_call_count = 0;
+
+    // Check status - should eventually succeed after queued task is retried
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(status, NIXL_SUCCESS) << "Request should succeed after queue has space";
+
+    // Cleanup
+    for (int i = 0; i < 2; i++) {
+        free(reinterpret_cast<void *>(local_dlist[i].addr));
+        engine_->deregisterMem(remote_dlist[i].metadataP);
+    }
+    engine_->releaseReqH(handle);
+}
+
+TEST_F(DocMemosBackendTest, DeviceNotFound) {
+    DocaMockControl::instance().nvme_kvdev_create_result = DOCA_ERROR_NOT_FOUND;
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+TEST_F(DocMemosBackendTest, GetMaxValueLenFailure) {
+    DocaMockControl::instance().get_max_value_len_result = DOCA_ERROR_INVALID_VALUE;
+    EXPECT_THROW(createEngine(), std::runtime_error);
+}
+
+// Value larger than the device's max value length is rejected host-side before
+// any DOCA submission, not with an opaque DOCA_ERROR_DRIVER from the device.
+TEST_F(DocMemosBackendTest, ValueExceedsDeviceMax) {
+    DocaMockControl::instance().max_value_len = 4096; // 4 KiB device limit
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    // Allocate a buffer larger than the device's 4 KiB max.
+    const size_t oversized = 8192;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(oversized));
+    ASSERT_NE(local_desc.addr, static_cast<uintptr_t>(0));
+    local_desc.len = oversized;
+    local_desc.devId = 0;
+
+    remote_desc.addr = 0;
+    remote_desc.len = oversized;
+    remote_desc.devId = 1;
+    remote_desc.metadataP = registerMemory(remote_desc.devId, "key0001");
+    ASSERT_NE(remote_desc.metadataP, nullptr);
+
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    ASSERT_NE(handle, nullptr);
+
+    status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    engine_->releaseReqH(handle);
+    engine_->deregisterMem(remote_desc.metadataP);
+    free(reinterpret_cast<void *>(local_desc.addr));
+}
+
+// Plugin caps non-hex metaInfo at DOCA_MEMOS_MAX_OBJECT_KEY_LEN (16) bytes.
+TEST_F(DocMemosBackendTest, KeyTooLarge) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    nixlBlobDesc desc;
+    desc.devId = 6000;
+    desc.metaInfo = "this_key_is_way_too_long"; // 24 bytes, not valid hex
+    nixlBackendMD *md = nullptr;
+
+    nixl_status_t status = engine_->registerMem(desc, OBJ_SEG, md);
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(md, nullptr);
+}
+
+// Verify the plugin propagates DOCA_ERROR_TOO_BIG from a STORE task as a
+// backend error, mirroring how a real device would reject an oversized value.
+TEST_F(DocMemosBackendTest, StoreReturnsTooBig) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.force_task_error = true;
+    mock.forced_task_error_code = DOCA_ERROR_TOO_BIG;
+    mock.auto_complete_tasks = true;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+    local_desc.len = 1024;
+    remote_desc.devId = 6100;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+    remote_desc.metadataP = registerMemory(remote_desc.devId, "too_big_key");
+
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    nixl_status_t status = NIXL_IN_PROG;
+    for (int i = 0; i < 100 && status == NIXL_IN_PROG; i++) {
+        status = engine_->checkXfer(handle);
+    }
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+
+    free(reinterpret_cast<void *>(local_desc.addr));
+    engine_->deregisterMem(remote_desc.metadataP);
+    engine_->releaseReqH(handle);
+}
+
+// ============================================================================
+// Request Queueing Tests - Comprehensive coverage for resource exhaustion
+// ============================================================================
+
+// Test that a request completes successfully after temporary resource exhaustion
+TEST_F(DocMemosBackendTest, QueuedRequestSucceedsAfterResourcesFreed) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Configure mock to fail allocation after 1 task (simulating resource exhaustion)
+    mock.task_alloc_call_count = 0;
+    mock.task_alloc_fail_after_n = 1; // Allow 1 allocation, then fail
+
+    // Create request with 3 tasks - first will succeed, rest will be queued
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        local_desc.addr = reinterpret_cast<uintptr_t>(malloc(1024));
+        local_desc.len = 1024;
+        remote_desc.devId = 7000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // Request should be partially submitted (1 task) and queued (2 remaining)
+
+    // Now allow unlimited allocations
+    mock.task_alloc_fail_after_n = -1; // Stop failing (negative = disabled)
+    mock.task_alloc_call_count = 0; // Reset counter
+
+    // Call checkXfer to progress and complete the queued request
+    nixl_status_t status = NIXL_IN_PROG;
+    for (int i = 0; i < 50; i++) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // Request should complete successfully
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    // Cleanup
+    for (int i = 0; i < 3; i++) {
+        free(reinterpret_cast<void *>(local_dlist[i].addr));
+        engine_->deregisterMem(remote_dlist[i].metadataP);
+    }
+    engine_->releaseReqH(handle);
+}
+
+// Test FIFO ordering with multiple queued requests
+TEST_F(DocMemosBackendTest, MultipleQueuedRequestsFIFOOrdering) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Allow only 2 task allocations initially
+    mock.task_alloc_fail_after_n = 2;
+
+    // Create 3 requests, each with 2 tasks (total 6 tasks, but only 2 can submit)
+    std::vector<nixlBackendReqH *> handles;
+    std::vector<nixl_meta_dlist_t> local_dlists;
+    std::vector<nixl_meta_dlist_t> remote_dlists;
+    std::vector<std::vector<void *>> buffers;
+    std::vector<std::vector<nixlBackendMD *>> metadatas;
+
+    for (int req = 0; req < 3; req++) {
+        local_dlists.emplace_back(DRAM_SEG);
+        remote_dlists.emplace_back(OBJ_SEG);
+        buffers.emplace_back();
+        metadatas.emplace_back();
+
+        for (int i = 0; i < 2; i++) {
+            nixlMetaDesc local_desc, remote_desc;
+            void *buf = malloc(1024);
+            // Write a unique marker to verify ordering
+            memset(buf, 'A' + req, 1024);
+            buffers[req].push_back(buf);
+
+            local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+            local_desc.len = 1024;
+            remote_desc.devId = 8000 + req * 10 + i;
+            remote_desc.addr = 0;
+            remote_desc.len = 1024;
+
+            std::string key = "fifo_key_" + std::to_string(req) + "_" + std::to_string(i);
+            auto *kv_md = registerMemory(remote_desc.devId, key);
+            metadatas[req].push_back(kv_md);
+            remote_desc.metadataP = kv_md;
+
+            local_dlists[req].addDesc(local_desc);
+            remote_dlists[req].addDesc(remote_desc);
+        }
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_IN_PROG);
+        handles.push_back(handle);
+    }
+
+    // At this point:
+    // - Request 0: fully submitted (2 tasks)
+    // - Request 1: queued (0 tasks submitted due to allocation limit)
+    // - Request 2: queued (0 tasks submitted due to allocation limit)
+
+    // Now allow unlimited allocations
+    mock.task_alloc_fail_after_n = -1; // Negative = disabled
+    mock.task_alloc_call_count = 0; // Reset counter
+
+    // Check status to progress and complete everything
+    for (int i = 0; i < 100; i++) { // More iterations for multiple requests
+        // Check if all completed
+        bool all_done = true;
+        for (auto *h : handles) {
+            if (engine_->checkXfer(h) == NIXL_IN_PROG) {
+                all_done = false;
+            }
+        }
+        if (all_done) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // All requests should complete successfully in FIFO order
+    for (auto *h : handles) {
+        EXPECT_EQ(engine_->checkXfer(h), NIXL_SUCCESS);
+    }
+
+    // Verify the KV store has all keys
+    for (int req = 0; req < 3; req++) {
+        for (int i = 0; i < 2; i++) {
+            std::string key = "fifo_key_" + std::to_string(req) + "_" + std::to_string(i);
+            EXPECT_TRUE(mock.kv_store.find(key) != mock.kv_store.end())
+                << "Key " << key << " not found in KV store";
+        }
+    }
+
+    // Cleanup
+    for (size_t req = 0; req < handles.size(); req++) {
+        for (size_t i = 0; i < buffers[req].size(); i++) {
+            free(buffers[req][i]);
+            engine_->deregisterMem(metadatas[req][i]);
+        }
+        engine_->releaseReqH(handles[req]);
+    }
+}
+
+// Test that queue handles submit failures (DOCA_ERROR_FULL) correctly
+TEST_F(DocMemosBackendTest, QueuedRequestsWithSubmitFailures) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Allow task allocation but fail submission after 2 tasks
+    mock.task_alloc_fail_after_n = -1; // Allocations succeed (negative = disabled)
+    mock.task_submit_fail_after_n = 2; // Submissions fail after 2
+
+    // Create 2 requests, each with 3 tasks
+    std::vector<nixlBackendReqH *> handles;
+    std::vector<nixl_meta_dlist_t> local_dlists;
+    std::vector<nixl_meta_dlist_t> remote_dlists;
+    std::vector<std::vector<void *>> buffers;
+    std::vector<std::vector<nixlBackendMD *>> metadatas;
+
+    for (int req = 0; req < 2; req++) {
+        local_dlists.emplace_back(DRAM_SEG);
+        remote_dlists.emplace_back(OBJ_SEG);
+        buffers.emplace_back();
+        metadatas.emplace_back();
+
+        for (int i = 0; i < 3; i++) {
+            nixlMetaDesc local_desc, remote_desc;
+            void *buf = malloc(1024);
+            buffers[req].push_back(buf);
+
+            local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+            local_desc.len = 1024;
+            remote_desc.devId = 9000 + req * 10 + i;
+            remote_desc.addr = 0;
+            remote_desc.len = 1024;
+
+            std::string key = "submit_key_" + std::to_string(req) + "_" + std::to_string(i);
+            auto *kv_md = registerMemory(remote_desc.devId, key);
+            metadatas[req].push_back(kv_md);
+            remote_desc.metadataP = kv_md;
+
+            local_dlists[req].addDesc(local_desc);
+            remote_dlists[req].addDesc(remote_desc);
+        }
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_IN_PROG);
+        handles.push_back(handle);
+    }
+
+    // At this point:
+    // - Request 0: 2 tasks submitted, 1 queued
+    // - Request 1: 0 tasks submitted, 3 queued
+
+    // Allow unlimited submissions
+    mock.task_submit_fail_after_n = -1; // Negative = disabled
+    mock.task_submit_call_count = 0; // Reset counter
+
+    // Check status to progress and complete everything
+    for (int i = 0; i < 100; i++) { // More iterations for multiple requests
+        bool all_done = true;
+        for (auto *h : handles) {
+            if (engine_->checkXfer(h) == NIXL_IN_PROG) {
+                all_done = false;
+            }
+        }
+        if (all_done) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // All requests should complete successfully
+    for (auto *h : handles) {
+        EXPECT_EQ(engine_->checkXfer(h), NIXL_SUCCESS);
+    }
+
+    // Cleanup
+    for (size_t req = 0; req < handles.size(); req++) {
+        for (size_t i = 0; i < buffers[req].size(); i++) {
+            free(buffers[req][i]);
+            engine_->deregisterMem(metadatas[req][i]);
+        }
+        engine_->releaseReqH(handles[req]);
+    }
+}
+
+// Test queue with many concurrent requests
+TEST_F(DocMemosBackendTest, ManyQueuedRequestsConcurrent) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Severely limit resources: only 3 tasks can be allocated/submitted initially
+    mock.task_alloc_call_count = 0; // Reset counter
+    mock.task_alloc_fail_after_n = 3; // Allow 3 allocations, then fail
+
+    const int NUM_REQUESTS = 10;
+    const int TASKS_PER_REQUEST = 2;
+
+    std::vector<nixlBackendReqH *> handles;
+    std::vector<nixl_meta_dlist_t> local_dlists;
+    std::vector<nixl_meta_dlist_t> remote_dlists;
+    std::vector<std::vector<void *>> buffers;
+    std::vector<std::vector<nixlBackendMD *>> metadatas;
+
+    // Submit many requests quickly
+    for (int req = 0; req < NUM_REQUESTS; req++) {
+        local_dlists.emplace_back(DRAM_SEG);
+        remote_dlists.emplace_back(OBJ_SEG);
+        buffers.emplace_back();
+        metadatas.emplace_back();
+
+        for (int i = 0; i < TASKS_PER_REQUEST; i++) {
+            nixlMetaDesc local_desc, remote_desc;
+            void *buf = malloc(1024);
+            buffers[req].push_back(buf);
+
+            local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+            local_desc.len = 1024;
+            remote_desc.devId = 10000 + req * 10 + i;
+            remote_desc.addr = 0;
+            remote_desc.len = 1024;
+
+            std::string key = "many_key_" + std::to_string(req) + "_" + std::to_string(i);
+            auto *kv_md = registerMemory(remote_desc.devId, key);
+            metadatas[req].push_back(kv_md);
+            remote_desc.metadataP = kv_md;
+
+            local_dlists[req].addDesc(local_desc);
+            remote_dlists[req].addDesc(remote_desc);
+        }
+
+        nixlBackendReqH *handle = nullptr;
+        ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlists[req], remote_dlists[req], "", handle),
+                  NIXL_IN_PROG);
+        handles.push_back(handle);
+    }
+
+    // Most requests should be queued
+
+    // Now allow unlimited resources
+    mock.task_alloc_fail_after_n = -1; // Negative = disabled
+    mock.task_alloc_call_count = 0; // Reset counter
+
+    // Check status to progress until all complete
+    int max_iterations = 400; // More iterations for many requests
+    for (int i = 0; i < max_iterations; i++) {
+        bool all_done = true;
+        for (auto *h : handles) {
+            if (engine_->checkXfer(h) == NIXL_IN_PROG) {
+                all_done = false;
+            }
+        }
+        if (all_done) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // All requests should complete successfully
+    int success_count = 0;
+    for (auto *h : handles) {
+        if (engine_->checkXfer(h) == NIXL_SUCCESS) {
+            success_count++;
+        }
+    }
+    EXPECT_EQ(success_count, NUM_REQUESTS) << "Not all requests completed successfully";
+
+    // Cleanup
+    for (size_t req = 0; req < handles.size(); req++) {
+        for (size_t i = 0; i < buffers[req].size(); i++) {
+            free(buffers[req][i]);
+            engine_->deregisterMem(metadatas[req][i]);
+        }
+        engine_->releaseReqH(handles[req]);
+    }
+}
+
+// ============================================================================
+// High Queue Depth Tests - Partial Submission and Forward Progress
+// ============================================================================
+
+// Test 1: New request can't submit any tasks - whole request gets queued
+// After resources become available, the request is fully submitted
+TEST_F(DocMemosBackendTest, QueuedRequestNoPartialSubmission) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Configure mock to fail ALL task allocations (simulating complete resource exhaustion)
+    mock.task_alloc_call_count = 0;
+    mock.task_alloc_fail_after_n = 0; // Fail immediately (0 = fail first call)
+
+    // Create request with 5 tasks - none should be able to submit
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> metadatas;
+
+    for (int i = 0; i < 5; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 11000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+
+        std::string key = "no_partial_key_" + std::to_string(i);
+        auto *kv_md = registerMemory(remote_desc.devId, key);
+        metadatas.push_back(kv_md);
+        remote_desc.metadataP = kv_md;
+
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+
+    // Post transfer - should return IN_PROG even though no tasks submitted (request is queued)
+    nixl_status_t status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_IN_PROG) << "Request should be queued even if no tasks submitted";
+
+    // Verify no tasks were actually submitted (allocation failed immediately on first attempt)
+    // The code stops trying after the first allocation fails with DOCA_ERROR_FULL
+    EXPECT_EQ(mock.task_alloc_call_count, 1)
+        << "Should have attempted 1 allocation (stops on first failure)";
+    EXPECT_EQ(mock.submitted_tasks.size(), 0) << "No tasks should be submitted";
+
+    // Now allow unlimited allocations (simulating resources becoming available)
+    mock.task_alloc_fail_after_n = -1; // Disable failure
+    mock.task_alloc_call_count = 0; // Reset counter
+
+    // Call checkXfer to trigger retry of queued request
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // Request should complete successfully after resources become available
+    EXPECT_EQ(status, NIXL_SUCCESS) << "Request should succeed after resources become available";
+    EXPECT_EQ(mock.submitted_tasks.size(), 0) << "All tasks should have completed";
+
+    // Cleanup
+    for (size_t i = 0; i < buffers.size(); i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(metadatas[i]);
+    }
+    engine_->releaseReqH(handle);
+}
+
+// Test 2: Queued request, when retried, can still only be partially submitted
+// This tests that we make forward progress even when retrying queued requests
+TEST_F(DocMemosBackendTest, QueuedRequestPartialRetryForwardProgress) {
+    setupInitParams(false, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    // Configure mock to allow 2 task allocations initially, then fail
+    mock.task_alloc_call_count = 0;
+    mock.task_alloc_fail_after_n = 2; // Allow 2 allocations, then fail
+
+    // Create request with 5 tasks
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> metadatas;
+
+    for (int i = 0; i < 5; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 13000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+
+        std::string key = "rp_key_" + std::to_string(i);
+        auto *kv_md = registerMemory(remote_desc.devId, key);
+        metadatas.push_back(kv_md);
+        remote_desc.metadataP = kv_md;
+
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+
+    // Post transfer - should partially submit (2 tasks) and queue the rest (3 tasks)
+    nixl_status_t status = engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Verify initial partial submission: 2 tasks submitted
+    EXPECT_EQ(mock.submitted_tasks.size(), 2) << "Initial: 2 tasks should be submitted";
+
+    // Reset counter but keep fail_after_n at 2 to simulate limited resources
+    // When we retry, we should be able to submit 2 more tasks (partial progress)
+    mock.task_alloc_call_count = 0; // Reset for retry attempt
+
+    // Call checkXfer to trigger retry of queued tasks
+    // This should submit 2 more tasks (partial progress), leaving 1 still queued
+    status = engine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_IN_PROG) << "Should still be in progress after partial retry";
+
+    // Verify partial retry: should have submitted 2 more tasks (total 4 now)
+    // Note: The first 2 tasks may have completed, so we check that we made progress
+    // by verifying that more allocations were attempted
+    EXPECT_GE(mock.task_alloc_call_count, 2)
+        << "Should have attempted at least 2 more allocations on retry";
+
+    // Now allow unlimited allocations for final submission
+    mock.task_alloc_fail_after_n = -1; // Disable failure
+    mock.task_alloc_call_count = 0; // Reset counter
+
+    // Call checkXfer again to complete remaining tasks
+    int retries = 100;
+    while (retries-- > 0) {
+        status = engine_->checkXfer(handle);
+        if (status != NIXL_IN_PROG) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    // Request should complete successfully
+    EXPECT_EQ(status, NIXL_SUCCESS) << "Request should succeed after all tasks are submitted";
+
+    // Cleanup
+    for (size_t i = 0; i < buffers.size(); i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(metadatas[i]);
+    }
+    engine_->releaseReqH(handle);
+}
+
+// ============================================================================
+// Release While In-Flight Tests
+// ============================================================================
+
+TEST_F(DocMemosBackendTest, ReleaseInFlightRequest) {
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 30000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "cancel_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    EXPECT_EQ(mock.submitted_tasks.size(), 3u);
+
+    // Release while 3 tasks are in flight — must not crash or leak
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    // Now complete the orphaned tasks via progress — callbacks must safely
+    // detect the cancelled request and delete it
+    mock.auto_complete_tasks = true;
+    for (int i = 0; i < 5; i++) {
+        engine_->checkXfer(nullptr);
+    }
+
+    for (int i = 0; i < 3; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+}
+
+TEST_F(DocMemosBackendTest, ReleasePendingRequest) {
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+    mock.task_alloc_fail_after_n = 2;
+    mock.task_alloc_call_count = 0;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 5; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 31000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "pend_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // 2 tasks submitted, 3 tasks queued in pendingRequests_
+    EXPECT_EQ(mock.submitted_tasks.size(), 2u);
+
+    // Release while request is pending — removes from queue, cancels in-flight tasks
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    // Complete orphaned tasks
+    mock.auto_complete_tasks = true;
+    mock.task_alloc_fail_after_n = -1;
+    for (int i = 0; i < 5; i++) {
+        engine_->checkXfer(nullptr);
+    }
+
+    for (int i = 0; i < 5; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+}
+
+TEST_F(DocMemosBackendTest, ReleaseCompletedRequest) {
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = true;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    void *buf = malloc(1024);
+    local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+    local_desc.len = 1024;
+    remote_desc.devId = 32000;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+    auto *md = registerMemory(remote_desc.devId, "done_key");
+    remote_desc.metadataP = md;
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    nixl_status_t status = NIXL_IN_PROG;
+    for (int i = 0; i < 100 && status == NIXL_IN_PROG; i++) {
+        status = engine_->checkXfer(handle);
+    }
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    // Release an already-completed request — immediate delete path
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    free(buf);
+    engine_->deregisterMem(md);
+}
+
+TEST_F(DocMemosBackendTest, ThreadedCancelBeforeProgressPickup) {
+    setupInitParams(true);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+    // Fail every task allocation so the progress thread can never hand buf to
+    // DOCA, regardless of whether it picks the request up before releaseReqH().
+    // Without this the test races: a winning progress thread submits the store
+    // task and the free(buf) below becomes a use-after-free.
+    mock.task_alloc_fail_after_n = 0;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    nixlMetaDesc local_desc, remote_desc;
+    void *buf = malloc(1024);
+    local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+    local_desc.len = 1024;
+    remote_desc.devId = 33000;
+    remote_desc.addr = 0;
+    remote_desc.len = 1024;
+    auto *md = registerMemory(remote_desc.devId, "cancel_qd_key_0");
+    remote_desc.metadataP = md;
+    local_dlist.addDesc(local_desc);
+    remote_dlist.addDesc(remote_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    free(buf);
+    engine_->deregisterMem(md);
+}
+
+// ============================================================================
+// Cancel Request Safety Tests — verify use-after-free fix
+//
+// The bug: processCancellations unconditionally set total_tasks = submitted_tasks.
+// When handleSubmissionFailure had already bumped completed_tasks by +1 (for the
+// failed task) and set total_tasks = submitted_tasks + 1, the overwrite made
+// completed_tasks satisfy the completion threshold one callback early, causing
+// premature deletion of req_h while DOCA callbacks were still pending.
+// ============================================================================
+
+// No-thread engine: cancel a request where some tasks submitted and a later
+// allocation failed fatally (triggering handleSubmissionFailure).  The fixed
+// cancelRequest must drain all in-flight callbacks before deleting.
+TEST_F(DocMemosBackendTest, CancelAfterFatalSubmissionError_NoThread) {
+    setupInitParams(false);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+
+    // First 2 allocs succeed, 3rd fails with a fatal error (not FULL).
+    // This triggers handleSubmissionFailure instead of queueing for retry.
+    mock.task_alloc_fail_after_n = 2;
+    mock.task_alloc_fail_error = DOCA_ERROR_BAD_STATE;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 40000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "fatal_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+
+    // 2 tasks submitted OK, 3rd alloc fails with BAD_STATE → handleSubmissionFailure:
+    //   total_tasks = submitted_tasks + 1 = 3
+    //   ++completed_tasks = 1
+    // postXfer returns IN_PROG (2 tasks still in-flight) or ERR_BACKEND.
+    EXPECT_NE(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    EXPECT_EQ(mock.submitted_tasks.size(), 2u);
+
+    // releaseReqH → cancelRequest marks cancelled, adds to cancelledRequests_.
+    // Tasks are NOT drained here (no-thread engine returns immediately).
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    // Tasks still in flight after cancel.
+    EXPECT_EQ(mock.submitted_tasks.size(), 2u);
+
+    // Enable auto-complete.  The engine destructor drain loop will call
+    // doca_pe_progress to fire callbacks, then clean up cancelledRequests_.
+    // With old code, the callbacks would see wrong total_tasks (from
+    // processCancellations overwriting it) and could delete req_h early.
+    // With the fix, cancelRequest preserves total_tasks so the callback
+    // accounting stays correct.
+    mock.auto_complete_tasks = true;
+
+    for (int i = 0; i < 3; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+
+    // Engine destructor drains DOCA PE and cleans up cancelledRequests_.
+    // Must not crash or double-free.
+}
+
+// Threaded engine: same handleSubmissionFailure scenario.  The progress
+// thread's processCancellations must not overwrite total_tasks when the
+// request was NOT in pendingRequests_ (i.e. handleSubmissionFailure already
+// adjusted it).
+//
+// Timeline with old (buggy) code:
+//   1. Progress thread submits 2 tasks; 3rd alloc fails fatally.
+//      handleSubmissionFailure: total_tasks=3, completed_tasks=1.
+//   2. doca_pe_progress completes 1 task → completed_tasks=2.
+//   3. processCancellations: total_tasks = submitted_tasks = 2.
+//      completed_tasks(2) >= total_tasks(2) → delete req_h.
+//   4. doca_pe_progress fires callback for 2nd task → UAF on line 67.
+//
+// With the fix, processCancellations leaves total_tasks at 3 and adds the
+// request to pendingDeletes_.  The 2nd callback safely completes it.
+TEST_F(DocMemosBackendTest, CancelAfterFatalSubmissionError_Threaded) {
+    setupInitParams(true);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+
+    mock.task_alloc_fail_after_n = 2;
+    mock.task_alloc_fail_error = DOCA_ERROR_BAD_STATE;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 41000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "thr_fatal_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // Wait for the progress thread to attempt all 3 allocations (2 succeed + 1 fatal).
+    for (int i = 0; i < 200; i++) {
+        if (mock.task_alloc_call_count >= 3) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_GE(mock.task_alloc_call_count, 3)
+        << "Progress thread should have attempted 3 allocations";
+    EXPECT_EQ(mock.submitted_tasks.size(), 2u);
+
+    // Enable auto-complete so callbacks start firing, then immediately cancel.
+    // The progress thread will interleave PE progress (callbacks) with
+    // processCancellations.  With the old bug, this is the exact race that
+    // causes UAF.
+    mock.auto_complete_tasks = true;
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    // Wait for the progress thread to drain everything.
+    for (int i = 0; i < 200; i++) {
+        if (mock.submitted_tasks.empty()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_EQ(mock.submitted_tasks.size(), 0u)
+        << "All tasks must be completed after cancel + drain";
+
+    for (int i = 0; i < 3; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+}
+
+// Threaded engine: cancel a request that has both in-flight tasks AND
+// remaining descriptors queued in pendingRequests_ (partial submission
+// due to DOCA_ERROR_FULL).  processCancellations must correctly adjust
+// total_tasks for the pending portion without corrupting the in-flight
+// task accounting.
+TEST_F(DocMemosBackendTest, CancelWithInflightAndPendingTasks_Threaded) {
+    setupInitParams(true);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+
+    // Allow 2 allocations, then return FULL (queuing, not fatal).
+    mock.task_alloc_fail_after_n = 2;
+    mock.task_alloc_fail_error = DOCA_ERROR_FULL;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 5; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 42000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "pend_infl_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // Wait for partial submission (2 submitted, 3 pending).
+    for (int i = 0; i < 200; i++) {
+        if (mock.submitted_tasks.size() >= 2) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_EQ(mock.submitted_tasks.size(), 2u);
+
+    // Cancel while request has both in-flight and pending tasks.
+    // processCancellations will find it in pendingRequests_ and correctly
+    // set total_tasks = submitted_tasks = 2, then add to pendingDeletes_
+    // (since those 2 callbacks haven't fired yet).
+    mock.auto_complete_tasks = true;
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    // Wait for drain.
+    for (int i = 0; i < 200; i++) {
+        if (mock.submitted_tasks.empty()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_EQ(mock.submitted_tasks.size(), 0u);
+
+    for (int i = 0; i < 5; i++) {
+        free(buffers[i]);
+        engine_->deregisterMem(mds[i]);
+    }
+}
+
+// Threaded engine destructor: verify that pendingDeletes_ entries are
+// cleaned up when the engine is destroyed (progress thread joins, DOCA
+// PE is drained, then remaining cancelled requests are deleted).
+TEST_F(DocMemosBackendTest, DestructorCleansPendingDeletes) {
+    setupInitParams(true);
+    createEngine();
+
+    auto &mock = DocaMockControl::instance();
+    mock.auto_complete_tasks = false;
+
+    nixl_meta_dlist_t local_dlist(DRAM_SEG), remote_dlist(OBJ_SEG);
+    std::vector<void *> buffers;
+    std::vector<nixlBackendMD *> mds;
+    for (int i = 0; i < 3; i++) {
+        nixlMetaDesc local_desc, remote_desc;
+        void *buf = malloc(1024);
+        buffers.push_back(buf);
+        local_desc.addr = reinterpret_cast<uintptr_t>(buf);
+        local_desc.len = 1024;
+        remote_desc.devId = 43000 + i;
+        remote_desc.addr = 0;
+        remote_desc.len = 1024;
+        std::string key = "dtor_key_" + std::to_string(i);
+        remote_desc.metadataP = registerMemory(remote_desc.devId, key);
+        mds.push_back(remote_desc.metadataP);
+        local_dlist.addDesc(local_desc);
+        remote_dlist.addDesc(remote_desc);
+    }
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(engine_->prepXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_SUCCESS);
+    ASSERT_EQ(engine_->postXfer(NIXL_WRITE, local_dlist, remote_dlist, "", handle), NIXL_IN_PROG);
+
+    // Wait for submission.
+    for (int i = 0; i < 200; i++) {
+        if (mock.submitted_tasks.size() >= 3) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // Cancel while tasks are in flight — req_h goes into pendingDeletes_.
+    ASSERT_EQ(engine_->releaseReqH(handle), NIXL_SUCCESS);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Enable auto-complete and destroy the engine.  The destructor must
+    // join the thread, drain DOCA PE (firing callbacks), and delete
+    // pendingDeletes_ entries.  Must not leak or crash.
+    mock.auto_complete_tasks = true;
+    for (auto *md : mds) {
+        engine_->deregisterMem(md);
+    }
+    engine_.reset();
+
+    for (int i = 0; i < 3; i++) {
+        free(buffers[i]);
+    }
+}
+
+int
+main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/unit/plugins/doca_memos/doca_memos_mocks.cpp
+++ b/test/unit/plugins/doca_memos/doca_memos_mocks.cpp
@@ -1,0 +1,771 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "doca_memos_mocks.h"
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+
+namespace {
+
+template<typename TypedTask>
+doca_error_t
+alloc_typed_task(union doca_data user_data, doca_task::Type type, TypedTask **out) {
+    auto &mock = DocaMockControl::instance();
+
+    if (mock.task_alloc_fail_after_n >= 0) {
+        if (mock.task_alloc_call_count >= mock.task_alloc_fail_after_n) {
+            mock.task_alloc_call_count++;
+            *out = nullptr;
+            return mock.task_alloc_fail_error;
+        }
+        mock.task_alloc_call_count++;
+    }
+
+    if (mock.kv_task_alloc_result != DOCA_SUCCESS) {
+        *out = nullptr;
+        return mock.kv_task_alloc_result;
+    }
+
+    TypedTask *task = new TypedTask{};
+    task->type = type;
+    task->user_data = user_data;
+    *out = task;
+    return DOCA_SUCCESS;
+}
+
+} // namespace
+
+extern "C" {
+
+/*********************************************************************************************************************
+ * doca_nvme_kernel_kvdev API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_nvme_kernel_kvdev_cap_get_max_path_len(uint32_t *max_path_len) {
+    if (!max_path_len) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *max_path_len = 4096;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_nvme_kernel_kvdev_create(struct doca_nvme_kernel_kvdev **kkvdev) {
+    if (!kkvdev) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+    if (mock.nvme_kvdev_create_result == DOCA_SUCCESS) {
+        *kkvdev = new doca_nvme_kernel_kvdev();
+    } else {
+        *kkvdev = nullptr;
+    }
+    return mock.nvme_kvdev_create_result;
+}
+
+doca_error_t
+doca_nvme_kernel_kvdev_destroy(struct doca_nvme_kernel_kvdev *kkvdev) {
+    delete kkvdev;
+    return DOCA_SUCCESS;
+}
+
+struct doca_kvdev *
+doca_nvme_kernel_kvdev_as_kvdev(struct doca_nvme_kernel_kvdev *kkvdev) {
+    return reinterpret_cast<struct doca_kvdev *>(kkvdev);
+}
+
+doca_error_t
+doca_nvme_kernel_kvdev_set_path(struct doca_nvme_kernel_kvdev *kkvdev, const char *path) {
+    if (!kkvdev || !path) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_nvme_kernel_kvdev_get_path(const struct doca_nvme_kernel_kvdev *kkvdev,
+                                char *path,
+                                uint32_t path_len) {
+    (void)kkvdev;
+    (void)path;
+    (void)path_len;
+    return DOCA_ERROR_NOT_FOUND;
+}
+
+/*********************************************************************************************************************
+ * doca_kvdev API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_kvdev_set_nguid(struct doca_kvdev *kvdev, const uint8_t *nguid) {
+    if (!kvdev || !nguid) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_get_nguid(const struct doca_kvdev *kvdev, uint8_t *nguid, uint16_t nguid_len) {
+    if (!kvdev || !nguid || nguid_len < DOCA_KVDEV_NGUID_LEN) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    std::memset(nguid, 0, DOCA_KVDEV_NGUID_LEN);
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_start(struct doca_kvdev *kvdev) {
+    auto lk = DocaMockControl::lock();
+    (void)kvdev;
+    return DocaMockControl::instance().kvdev_start_result;
+}
+
+doca_error_t
+doca_kvdev_stop(struct doca_kvdev *kvdev) {
+    auto lk = DocaMockControl::lock();
+    (void)kvdev;
+    return DocaMockControl::instance().kvdev_stop_result;
+}
+
+doca_error_t
+doca_kvdev_is_started(const struct doca_kvdev *kvdev, uint8_t *started) {
+    if (!kvdev || !started) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    // The plugin only calls is_started during teardown and only acts on the
+    // "started" branch, so reporting started=1 keeps the teardown path
+    // exercised in tests.
+    *started = 1;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_get_size(const struct doca_kvdev *kvdev, uint64_t *size) {
+    if (!kvdev || !size) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *size = static_cast<uint64_t>(1) << 30; // 1 GiB
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_get_max_key_len(const struct doca_kvdev *kvdev, uint16_t *max_key_len) {
+    if (!kvdev || !max_key_len) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *max_key_len = 16;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_get_max_value_len(const struct doca_kvdev *kvdev, uint32_t *max_value_len) {
+    if (!kvdev || !max_value_len) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto &mock = DocaMockControl::instance();
+    if (mock.get_max_value_len_result != DOCA_SUCCESS) {
+        return mock.get_max_value_len_result;
+    }
+    *max_value_len = mock.max_value_len;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_get_max_tasks(const struct doca_kvdev *kvdev, uint32_t *max_tasks) {
+    if (!kvdev || !max_tasks) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *max_tasks = 65536;
+    return DOCA_SUCCESS;
+}
+
+/*********************************************************************************************************************
+ * doca_nvme_kernel_kvdev_io API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_nvme_kernel_kvdev_io_create(struct doca_nvme_kernel_kvdev *kkvdev,
+                                 struct doca_nvme_kernel_kvdev_io **kio) {
+    if (!kkvdev || !kio) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+    if (mock.kv_io_create_result == DOCA_SUCCESS) {
+        *kio = new doca_nvme_kernel_kvdev_io();
+    } else {
+        *kio = nullptr;
+    }
+    return mock.kv_io_create_result;
+}
+
+doca_error_t
+doca_nvme_kernel_kvdev_io_destroy(struct doca_nvme_kernel_kvdev_io *kio) {
+    auto lk = DocaMockControl::lock();
+    delete kio;
+    return DocaMockControl::instance().kv_io_destroy_result;
+}
+
+struct doca_kvdev_io *
+doca_nvme_kernel_kvdev_io_as_kvdev_io(struct doca_nvme_kernel_kvdev_io *kio) {
+    return reinterpret_cast<struct doca_kvdev_io *>(kio);
+}
+
+/*********************************************************************************************************************
+ * doca_kvdev_io API
+ *********************************************************************************************************************/
+
+struct doca_ctx *
+doca_kvdev_io_as_ctx(struct doca_kvdev_io *io) {
+    return reinterpret_cast<struct doca_ctx *>(io);
+}
+
+doca_error_t
+doca_kvdev_io_get_num_tasks(const struct doca_kvdev_io *io, uint32_t *num_tasks) {
+    if (!io || !num_tasks) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *num_tasks = 8192;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_io_set_num_tasks(struct doca_kvdev_io *io, uint32_t num_tasks) {
+    if (!io || num_tasks == 0) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_io_set_task_completion_cb(struct doca_kvdev_io *io,
+                                     doca_kvdev_io_task_completion_cb_t cb) {
+    if (!io || !cb) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    DocaMockControl::instance().task_completion_cb = cb;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_kvdev_io_set_task_error_cb(struct doca_kvdev_io *io, doca_kvdev_io_task_completion_cb_t cb) {
+    if (!io || !cb) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    DocaMockControl::instance().task_error_cb = cb;
+    return DOCA_SUCCESS;
+}
+
+/*********************************************************************************************************************
+ * Store task API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_kvdev_io_task_store_alloc_init(struct doca_kvdev_io *io,
+                                    union doca_data task_user_data,
+                                    struct doca_kvdev_io_task_store **task) {
+    if (!io || !task) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    return alloc_typed_task(task_user_data, doca_task::STORE, task);
+}
+
+void
+doca_kvdev_io_task_store_set_key_value_conf(struct doca_kvdev_io_task_store *task,
+                                            const void *key,
+                                            uint16_t key_len,
+                                            struct iovec *value_iovecs,
+                                            uint32_t iovcnt,
+                                            uint32_t value_len) {
+    if (!task) {
+        return;
+    }
+    task->key.assign(static_cast<const char *>(key), key_len);
+    task->buffer = (iovcnt > 0) ? value_iovecs[0].iov_base : nullptr;
+    task->buffer_size = (iovcnt > 0) ? value_iovecs[0].iov_len : 0;
+    task->value_len = value_len;
+}
+
+void
+doca_kvdev_io_task_store_set_do_not_overwrite(struct doca_kvdev_io_task_store *task,
+                                              uint8_t do_not_overwrite) {
+    if (task) {
+        task->do_not_overwrite = do_not_overwrite;
+    }
+}
+
+uint8_t
+doca_kvdev_io_task_store_get_do_not_overwrite(const struct doca_kvdev_io_task_store *task) {
+    return task ? task->do_not_overwrite : 0;
+}
+
+void
+doca_kvdev_io_task_store_set_must_exist(struct doca_kvdev_io_task_store *task, uint8_t must_exist) {
+    if (task) {
+        task->must_exist = must_exist;
+    }
+}
+
+uint8_t
+doca_kvdev_io_task_store_get_must_exist(const struct doca_kvdev_io_task_store *task) {
+    return task ? task->must_exist : 0;
+}
+
+struct doca_task *
+doca_kvdev_io_task_store_as_task(struct doca_kvdev_io_task_store *task) {
+    return static_cast<struct doca_task *>(task);
+}
+
+struct doca_kvdev_io_task_store *
+doca_kvdev_io_task_store_from_task(struct doca_task *task) {
+    return static_cast<struct doca_kvdev_io_task_store *>(task);
+}
+
+const void *
+doca_kvdev_io_task_store_get_key(const struct doca_kvdev_io_task_store *task) {
+    return task ? task->key.data() : nullptr;
+}
+
+uint16_t
+doca_kvdev_io_task_store_get_key_len(const struct doca_kvdev_io_task_store *task) {
+    return task ? static_cast<uint16_t>(task->key.size()) : 0;
+}
+
+const struct iovec *
+doca_kvdev_io_task_store_get_value_iovecs(const struct doca_kvdev_io_task_store *task) {
+    (void)task;
+    return nullptr;
+}
+
+uint32_t
+doca_kvdev_io_task_store_get_value_iovcnt(const struct doca_kvdev_io_task_store *task) {
+    return task && task->buffer ? 1 : 0;
+}
+
+uint32_t
+doca_kvdev_io_task_store_get_value_len(const struct doca_kvdev_io_task_store *task) {
+    return task ? task->value_len : 0;
+}
+
+/*********************************************************************************************************************
+ * Retrieve task API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_kvdev_io_task_retrieve_alloc_init(struct doca_kvdev_io *io,
+                                       union doca_data task_user_data,
+                                       struct doca_kvdev_io_task_retrieve **task) {
+    if (!io || !task) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    return alloc_typed_task(task_user_data, doca_task::RETRIEVE, task);
+}
+
+void
+doca_kvdev_io_task_retrieve_set_key_value_conf(struct doca_kvdev_io_task_retrieve *task,
+                                               const void *key,
+                                               uint16_t key_len,
+                                               struct iovec *value_iovecs,
+                                               uint32_t iovcnt,
+                                               uint32_t value_len) {
+    if (!task) {
+        return;
+    }
+    task->key.assign(static_cast<const char *>(key), key_len);
+    task->buffer = (iovcnt > 0) ? value_iovecs[0].iov_base : nullptr;
+    task->buffer_size = (iovcnt > 0) ? value_iovecs[0].iov_len : 0;
+    task->value_len = value_len;
+}
+
+struct doca_task *
+doca_kvdev_io_task_retrieve_as_task(struct doca_kvdev_io_task_retrieve *task) {
+    return static_cast<struct doca_task *>(task);
+}
+
+struct doca_kvdev_io_task_retrieve *
+doca_kvdev_io_task_retrieve_from_task(struct doca_task *task) {
+    return static_cast<struct doca_kvdev_io_task_retrieve *>(task);
+}
+
+const void *
+doca_kvdev_io_task_retrieve_get_key(const struct doca_kvdev_io_task_retrieve *task) {
+    return task ? task->key.data() : nullptr;
+}
+
+uint16_t
+doca_kvdev_io_task_retrieve_get_key_len(const struct doca_kvdev_io_task_retrieve *task) {
+    return task ? static_cast<uint16_t>(task->key.size()) : 0;
+}
+
+const struct iovec *
+doca_kvdev_io_task_retrieve_get_value_iovecs(const struct doca_kvdev_io_task_retrieve *task) {
+    (void)task;
+    return nullptr;
+}
+
+uint32_t
+doca_kvdev_io_task_retrieve_get_value_iovcnt(const struct doca_kvdev_io_task_retrieve *task) {
+    return task && task->buffer ? 1 : 0;
+}
+
+uint32_t
+doca_kvdev_io_task_retrieve_get_value_len(const struct doca_kvdev_io_task_retrieve *task) {
+    return task ? task->value_len : 0;
+}
+
+uint32_t
+doca_kvdev_io_task_retrieve_get_result_value_len(const struct doca_kvdev_io_task_retrieve *task) {
+    return task ? task->result_value_len : 0;
+}
+
+/*********************************************************************************************************************
+ * Exist task API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_kvdev_io_task_exist_alloc_init(struct doca_kvdev_io *io,
+                                    union doca_data task_user_data,
+                                    struct doca_kvdev_io_task_exist **task) {
+    if (!io || !task) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    return alloc_typed_task(task_user_data, doca_task::EXIST, task);
+}
+
+void
+doca_kvdev_io_task_exist_set_key_conf(struct doca_kvdev_io_task_exist *task,
+                                      const void *key,
+                                      uint16_t key_len) {
+    if (!task) {
+        return;
+    }
+    task->key.assign(static_cast<const char *>(key), key_len);
+}
+
+struct doca_task *
+doca_kvdev_io_task_exist_as_task(struct doca_kvdev_io_task_exist *task) {
+    return static_cast<struct doca_task *>(task);
+}
+
+struct doca_kvdev_io_task_exist *
+doca_kvdev_io_task_exist_from_task(struct doca_task *task) {
+    return static_cast<struct doca_kvdev_io_task_exist *>(task);
+}
+
+const void *
+doca_kvdev_io_task_exist_get_key(const struct doca_kvdev_io_task_exist *task) {
+    return task ? task->key.data() : nullptr;
+}
+
+uint16_t
+doca_kvdev_io_task_exist_get_key_len(const struct doca_kvdev_io_task_exist *task) {
+    return task ? static_cast<uint16_t>(task->key.size()) : 0;
+}
+
+/*********************************************************************************************************************
+ * doca_pe API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_pe_create(struct doca_pe **pe) {
+    if (!pe) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+    if (mock.pe_create_result == DOCA_SUCCESS) {
+        *pe = new doca_pe();
+    } else {
+        *pe = nullptr;
+    }
+    return mock.pe_create_result;
+}
+
+doca_error_t
+doca_pe_destroy(struct doca_pe *pe) {
+    auto lk = DocaMockControl::lock();
+    delete pe;
+    return DocaMockControl::instance().pe_destroy_result;
+}
+
+doca_error_t
+doca_pe_connect_ctx(struct doca_pe *pe, struct doca_ctx *ctx) {
+    (void)pe;
+    (void)ctx;
+    auto lk = DocaMockControl::lock();
+    return DocaMockControl::instance().pe_connect_ctx_result;
+}
+
+int
+doca_pe_progress(struct doca_pe *pe) {
+    (void)pe;
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+
+    if (!mock.auto_complete_tasks || mock.submitted_tasks.empty()) {
+        return mock.pe_progress_return;
+    }
+
+    // Drain in submission order (FIFO). Capped per call to mimic the real PE
+    // and to keep a runaway callback (one that re-submits forever) from
+    // hanging the test process.
+    constexpr size_t max_completions_per_progress = 64;
+    size_t drained = 0;
+    while (!mock.submitted_tasks.empty() && drained < max_completions_per_progress) {
+        struct doca_task *task = mock.submitted_tasks.front();
+        mock.submitted_tasks.erase(mock.submitted_tasks.begin());
+        mock.submitted_task_user_data.erase(mock.submitted_task_user_data.begin());
+
+        union doca_data ctx_user_data{};
+        ctx_user_data.ptr = nullptr;
+
+        switch (task->type) {
+        case doca_task::STORE:
+            if (mock.force_task_error) {
+                task->status = mock.forced_task_error_code;
+                if (mock.task_error_cb) {
+                    mock.task_error_cb(task, task->user_data, ctx_user_data);
+                }
+            } else if (mock.task_completion_cb) {
+                std::vector<uint8_t> value(task->buffer_size);
+                std::memcpy(value.data(), task->buffer, task->buffer_size);
+                mock.kv_store[task->key] = std::move(value);
+                mock.task_completion_cb(task, task->user_data, ctx_user_data);
+            }
+            break;
+        case doca_task::RETRIEVE:
+            if (mock.force_task_error) {
+                task->status = mock.forced_task_error_code;
+                if (mock.task_error_cb) {
+                    mock.task_error_cb(task, task->user_data, ctx_user_data);
+                }
+            } else if (mock.task_completion_cb) {
+                auto it = mock.kv_store.find(task->key);
+                if (it != mock.kv_store.end()) {
+                    size_t copy_size = std::min(task->buffer_size, it->second.size());
+                    if (copy_size > 0) {
+                        std::memcpy(task->buffer, it->second.data(), copy_size);
+                    }
+                    task->result_value_len = static_cast<uint32_t>(it->second.size());
+                    mock.task_completion_cb(task, task->user_data, ctx_user_data);
+                } else if (mock.task_error_cb) {
+                    task->status = DOCA_ERROR_NOT_FOUND;
+                    mock.task_error_cb(task, task->user_data, ctx_user_data);
+                }
+            }
+            break;
+        case doca_task::EXIST:
+            // Real DOCA reports EXIST results through the error callback:
+            // ALREADY_EXIST when found, NOT_FOUND when absent.
+            if (mock.force_task_error) {
+                task->status = mock.forced_task_error_code;
+                if (mock.task_error_cb) {
+                    mock.task_error_cb(task, task->user_data, ctx_user_data);
+                }
+            } else if (mock.task_error_cb) {
+                auto it = mock.kv_store.find(task->key);
+                task->status =
+                    (it != mock.kv_store.end()) ? DOCA_ERROR_ALREADY_EXIST : DOCA_ERROR_NOT_FOUND;
+                mock.task_error_cb(task, task->user_data, ctx_user_data);
+            }
+            break;
+        }
+        drained++;
+    }
+
+    return drained > 0 ? 1 : mock.pe_progress_return;
+}
+
+doca_error_t
+doca_pe_get_notification_handle(struct doca_pe *pe, doca_notification_handle_t *handle) {
+    (void)pe;
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+    if (mock.pe_get_notification_handle_result == DOCA_SUCCESS) {
+        *handle = mock.notification_handle;
+    }
+    return mock.pe_get_notification_handle_result;
+}
+
+doca_error_t
+doca_pe_request_notification(struct doca_pe *pe) {
+    (void)pe;
+    auto lk = DocaMockControl::lock();
+    return DocaMockControl::instance().pe_request_notification_result;
+}
+
+void
+doca_pe_clear_notification(struct doca_pe *pe, doca_notification_handle_t handle) {
+    (void)pe;
+    (void)handle;
+}
+
+doca_error_t
+doca_task_submit(struct doca_task *task) {
+    auto lk = DocaMockControl::lock();
+    auto &mock = DocaMockControl::instance();
+
+    if (mock.task_submit_fail_after_n >= 0) {
+        if (mock.task_submit_call_count >= mock.task_submit_fail_after_n) {
+            mock.task_submit_call_count++;
+            return mock.task_submit_fail_error;
+        }
+        mock.task_submit_call_count++;
+    }
+
+    if (mock.task_submit_result == DOCA_SUCCESS) {
+        mock.submitted_tasks.push_back(task);
+        mock.submitted_task_user_data.push_back(task->user_data);
+    }
+    return mock.task_submit_result;
+}
+
+void
+doca_task_free(struct doca_task *task) {
+    auto lk = DocaMockControl::lock();
+    delete task;
+}
+
+doca_error_t
+doca_task_get_status(const struct doca_task *task) {
+    auto lk = DocaMockControl::lock();
+    return task ? task->status : DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_task_get_user_data(const struct doca_task *task, union doca_data *user_data) {
+    if (!task || !user_data) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *user_data = task->user_data;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_task_set_user_data(struct doca_task *task, union doca_data user_data) {
+    if (!task) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    task->user_data = user_data;
+    return DOCA_SUCCESS;
+}
+
+/*********************************************************************************************************************
+ * doca_ctx API
+ *********************************************************************************************************************/
+
+doca_error_t
+doca_ctx_start(struct doca_ctx *ctx) {
+    (void)ctx;
+    auto lk = DocaMockControl::lock();
+    return DocaMockControl::instance().ctx_start_result;
+}
+
+doca_error_t
+doca_ctx_stop(struct doca_ctx *ctx) {
+    (void)ctx;
+    auto lk = DocaMockControl::lock();
+    return DocaMockControl::instance().ctx_stop_result;
+}
+
+doca_error_t
+doca_ctx_get_num_inflight_tasks(const struct doca_ctx *ctx, size_t *num_inflight_tasks) {
+    if (!ctx || !num_inflight_tasks) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    auto lk = DocaMockControl::lock();
+    *num_inflight_tasks = DocaMockControl::instance().submitted_tasks.size();
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_ctx_set_user_data(struct doca_ctx *ctx, union doca_data user_data) {
+    (void)ctx;
+    (void)user_data;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_ctx_get_user_data(const struct doca_ctx *ctx, union doca_data *user_data) {
+    if (!ctx || !user_data) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    user_data->ptr = nullptr;
+    return DOCA_SUCCESS;
+}
+
+doca_error_t
+doca_ctx_get_state(const struct doca_ctx *ctx, enum doca_ctx_states *state) {
+    if (!ctx || !state) {
+        return DOCA_ERROR_INVALID_VALUE;
+    }
+    *state = DOCA_CTX_STATE_RUNNING;
+    return DOCA_SUCCESS;
+}
+
+/*********************************************************************************************************************
+ * doca_error API
+ *********************************************************************************************************************/
+
+const char *
+doca_error_get_descr(doca_error_t error) {
+    switch (error) {
+    case DOCA_SUCCESS:
+        return "Success";
+    case DOCA_ERROR_UNKNOWN:
+        return "Unknown error";
+    case DOCA_ERROR_INVALID_VALUE:
+        return "Invalid value";
+    case DOCA_ERROR_NO_MEMORY:
+        return "Out of memory";
+    case DOCA_ERROR_NOT_FOUND:
+        return "Not found";
+    case DOCA_ERROR_IO_FAILED:
+        return "I/O failed";
+    case DOCA_ERROR_BAD_STATE:
+        return "Bad state";
+    case DOCA_ERROR_OPERATING_SYSTEM:
+        return "Operating system error";
+    case DOCA_ERROR_ALREADY_EXIST:
+        return "Already exists";
+    case DOCA_ERROR_FULL:
+        return "Full";
+    case DOCA_ERROR_IN_PROGRESS:
+        return "In progress";
+    case DOCA_ERROR_TOO_BIG:
+        return "Too big";
+    case DOCA_ERROR_DRIVER:
+        return "Driver error";
+    default:
+        return "Unrecognized error";
+    }
+}
+
+const char *
+doca_error_get_name(doca_error_t error) {
+    return doca_error_get_descr(error);
+}
+
+} // extern "C"

--- a/test/unit/plugins/doca_memos/doca_memos_mocks.h
+++ b/test/unit/plugins/doca_memos/doca_memos_mocks.h
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_MOCKS_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_MOCKS_H
+
+// This header is only consumed from C++ translation units. Including the C++
+// standard library headers up-front keeps the mock state definitions below
+// well-formed regardless of which DOCA header pulls them in.
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <sys/uio.h>
+#include <vector>
+
+#include <doca_compat.h>
+#include <doca_ctx.h>
+#include <doca_error.h>
+#include <doca_kvdev.h>
+#include <doca_kvdev_io.h>
+#include <doca_nvme_kernel_kvdev.h>
+#include <doca_nvme_kernel_kvdev_io.h>
+#include <doca_pe.h>
+#include <doca_types.h>
+
+// Concrete definitions for opaque mock types. These structs are forward
+// declared in the public DOCA headers above; defining them here gives the
+// mocks something to allocate, while still keeping them opaque to the plugin.
+struct doca_kvdev {};
+
+struct doca_kvdev_io {};
+
+struct doca_pe {};
+
+struct doca_ctx {};
+
+struct doca_nvme_kernel_kvdev {};
+
+struct doca_nvme_kernel_kvdev_io {};
+
+// All typed KV tasks are unified into a single mock task carrying the per-op
+// state the implementation needs to observe (key, value buffer, user data,
+// completion status, store/retrieve options). The typed structs in the public
+// headers are forward declarations only; the mocks derive them from doca_task
+// so the *_as_task / *_from_task helpers are simple pointer casts.
+struct doca_task {
+    enum Type { STORE, RETRIEVE, EXIST } type;
+
+    std::string key;
+    void *buffer = nullptr;
+    size_t buffer_size = 0;
+    uint32_t value_len = 0;
+    union doca_data user_data{};
+    doca_error_t status = DOCA_SUCCESS;
+    uint8_t do_not_overwrite = 0;
+    uint8_t must_exist = 0;
+    uint32_t result_value_len = 0;
+};
+
+struct doca_kvdev_io_task_store : doca_task {};
+
+struct doca_kvdev_io_task_retrieve : doca_task {};
+
+struct doca_kvdev_io_task_exist : doca_task {};
+
+// Mock control singleton. Tests set fields here to control how the mock
+// implementation responds to plugin API calls.
+class DocaMockControl {
+public:
+    static DocaMockControl &
+    instance() {
+        static DocaMockControl inst;
+        return inst;
+    }
+
+    // Serialises every singleton access. Recursive so callbacks fired from
+    // doca_pe_progress() can re-enter mocks (e.g. doca_task_free) without
+    // self-deadlock. Tests should hold this lock around any field they read
+    // or mutate when a threaded progress engine is alive.
+    static std::unique_lock<std::recursive_mutex>
+    lock() {
+        return std::unique_lock<std::recursive_mutex>(instance().mutex_);
+    }
+
+    // Configuration for mock behavior - all DOCA API return values
+    doca_error_t nvme_kvdev_create_result = DOCA_SUCCESS;
+    doca_error_t kvdev_start_result = DOCA_SUCCESS;
+    doca_error_t kvdev_stop_result = DOCA_SUCCESS;
+    doca_error_t pe_create_result = DOCA_SUCCESS;
+    doca_error_t pe_destroy_result = DOCA_SUCCESS;
+    doca_error_t kv_io_create_result = DOCA_SUCCESS;
+    doca_error_t kv_io_destroy_result = DOCA_SUCCESS;
+    doca_error_t ctx_start_result = DOCA_SUCCESS;
+    doca_error_t ctx_stop_result = DOCA_SUCCESS;
+    doca_error_t pe_connect_ctx_result = DOCA_SUCCESS;
+    doca_error_t kv_task_alloc_result = DOCA_SUCCESS;
+    doca_error_t task_submit_result = DOCA_SUCCESS;
+    doca_error_t pe_get_notification_handle_result = DOCA_SUCCESS;
+    doca_error_t pe_request_notification_result = DOCA_SUCCESS;
+    doca_error_t get_max_value_len_result = DOCA_SUCCESS;
+    uint32_t max_value_len = 1u << 20; // 1 MiB default
+
+    // Advanced error injection - fail after N successful calls.
+    // task_alloc_fail_after_n: -1 disables; 0 fails first call; N fails the
+    // (N+1)th call onwards. Applies uniformly to store / retrieve / exist.
+    int task_alloc_fail_after_n = -1;
+    int task_alloc_call_count = 0;
+    doca_error_t task_alloc_fail_error = DOCA_ERROR_FULL;
+    int task_submit_fail_after_n = -1;
+    int task_submit_call_count = 0;
+    doca_error_t task_submit_fail_error = DOCA_ERROR_FULL;
+
+    // Force specific task to fail with specific error
+    bool force_task_error = false;
+    doca_error_t forced_task_error_code = DOCA_ERROR_NOT_FOUND;
+
+    // Callbacks installed by doca_kvdev_io_set_task_{completion,error}_cb.
+    // Signatures match the public typedef.
+    using TaskCallback = std::function<void(struct doca_task *, union doca_data, union doca_data)>;
+    TaskCallback task_completion_cb = nullptr;
+    TaskCallback task_error_cb = nullptr;
+
+    // Simulated KV storage
+    std::map<std::string, std::vector<uint8_t>> kv_store;
+
+    // Submitted tasks tracking
+    std::vector<struct doca_task *> submitted_tasks;
+    std::vector<union doca_data> submitted_task_user_data;
+
+    // Progress tracking
+    int pe_progress_return = 0;
+    bool auto_complete_tasks = false;
+
+    // Notification handle
+    doca_notification_handle_t notification_handle = 100;
+
+    // Reset all state. Acquires the mock lock so callers don't have to;
+    // since the lock is recursive this is safe to call from a context that
+    // already holds it.
+    void
+    reset() {
+        std::unique_lock<std::recursive_mutex> guard(mutex_);
+        nvme_kvdev_create_result = DOCA_SUCCESS;
+        kvdev_start_result = DOCA_SUCCESS;
+        kvdev_stop_result = DOCA_SUCCESS;
+        pe_create_result = DOCA_SUCCESS;
+        pe_destroy_result = DOCA_SUCCESS;
+        kv_io_create_result = DOCA_SUCCESS;
+        kv_io_destroy_result = DOCA_SUCCESS;
+        ctx_start_result = DOCA_SUCCESS;
+        ctx_stop_result = DOCA_SUCCESS;
+        pe_connect_ctx_result = DOCA_SUCCESS;
+        kv_task_alloc_result = DOCA_SUCCESS;
+        task_submit_result = DOCA_SUCCESS;
+        pe_get_notification_handle_result = DOCA_SUCCESS;
+        pe_request_notification_result = DOCA_SUCCESS;
+        get_max_value_len_result = DOCA_SUCCESS;
+        max_value_len = 1u << 20;
+
+        task_alloc_fail_after_n = -1;
+        task_alloc_call_count = 0;
+        task_alloc_fail_error = DOCA_ERROR_FULL;
+        task_submit_fail_after_n = -1;
+        task_submit_call_count = 0;
+        task_submit_fail_error = DOCA_ERROR_FULL;
+        force_task_error = false;
+        forced_task_error_code = DOCA_ERROR_NOT_FOUND;
+
+        task_completion_cb = nullptr;
+        task_error_cb = nullptr;
+
+        kv_store.clear();
+        submitted_tasks.clear();
+        submitted_task_user_data.clear();
+
+        pe_progress_return = 0;
+        auto_complete_tasks = false;
+        notification_handle = 100;
+    }
+
+private:
+    DocaMockControl() = default;
+
+    std::recursive_mutex mutex_;
+};
+
+#endif // NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_MEMOS_MOCKS_H

--- a/test/unit/plugins/doca_memos/doca_pe.h
+++ b/test/unit/plugins/doca_memos/doca_pe.h
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DOCA KV Mock - Progress Engine API
+ * Mock implementation of DOCA progress engine
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_PE_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_PE_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <doca_compat.h>
+#include <doca_error.h>
+#include <doca_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct doca_ctx;
+struct doca_pe;
+struct doca_task;
+
+/**
+ * @brief Function to execute on task completion.
+ */
+typedef void (*doca_task_completion_cb_t)(struct doca_task *task,
+                                          union doca_data task_user_data,
+                                          union doca_data ctx_user_data);
+
+/**
+ * @brief Creates DOCA progress engine
+ */
+doca_error_t
+doca_pe_create(struct doca_pe **pe);
+
+/**
+ * @brief Destroy DOCA progress engine
+ */
+doca_error_t
+doca_pe_destroy(struct doca_pe *pe);
+
+/**
+ * @brief Connect context to a progress engine
+ */
+doca_error_t
+doca_pe_connect_ctx(struct doca_pe *pe, struct doca_ctx *ctx);
+
+/**
+ * @brief Progress one or more tasks
+ * @return Number of events processed
+ */
+int
+doca_pe_progress(struct doca_pe *pe);
+
+/**
+ * @brief Get notification handle for event-driven operation
+ */
+doca_error_t
+doca_pe_get_notification_handle(struct doca_pe *pe, doca_notification_handle_t *handle);
+
+/**
+ * @brief Request notification when events are available
+ */
+doca_error_t
+doca_pe_request_notification(struct doca_pe *pe);
+
+/**
+ * @brief Clear notification after event
+ */
+void
+doca_pe_clear_notification(struct doca_pe *pe, doca_notification_handle_t handle);
+
+/**
+ * @brief Submit a DOCA task
+ */
+doca_error_t
+doca_task_submit(struct doca_task *task);
+
+/**
+ * @brief Free a DOCA task
+ */
+void
+doca_task_free(struct doca_task *task);
+
+/**
+ * @brief Get user data from task
+ */
+doca_error_t
+doca_task_get_user_data(const struct doca_task *task, union doca_data *user_data);
+
+/**
+ * @brief Set user data to task
+ */
+doca_error_t
+doca_task_set_user_data(struct doca_task *task, union doca_data user_data);
+
+/**
+ * @brief Get the status/result of a completed task.
+ *
+ * Valid only after the task's completion or error callback has been invoked.
+ */
+doca_error_t
+doca_task_get_status(const struct doca_task *task);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_PE_H */

--- a/test/unit/plugins/doca_memos/doca_types.h
+++ b/test/unit/plugins/doca_memos/doca_types.h
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * DOCA KV Mock - Common Types
+ * Mock implementation of DOCA common types
+ */
+
+#ifndef NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_TYPES_H
+#define NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_TYPES_H
+
+#include <stdint.h>
+
+#ifdef __linux__
+#include <linux/types.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __linux__
+/** 'fd' for blocking with epoll/select/poll, event type will be "read ready" */
+typedef int doca_notification_handle_t;
+#define doca_event_invalid_handle -1
+#else
+typedef void *doca_notification_handle_t;
+#define doca_event_invalid_handle NULL
+#endif
+
+/**
+ * @brief Convenience type for representing opaque data
+ */
+union doca_data {
+    void *ptr;
+    uint64_t u64;
+};
+
+/**
+ * @brief Struct to represent a gather list
+ */
+struct doca_gather_list {
+    void *addr;
+    uint64_t len;
+    struct doca_gather_list *next;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIXL_TEST_UNIT_PLUGINS_DOCA_MEMOS_DOCA_TYPES_H */

--- a/test/unit/plugins/doca_memos/meson.build
+++ b/test/unit/plugins/doca_memos/meson.build
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# DOCA_MEMOS backend unit tests with mocked DOCA (doca_kv) dependencies
+
+# Check for GTest dependency
+gtest_dep_local = dependency('gtest', version : '>=1.11.0', required : false)
+if not gtest_dep_local.found()
+    message('GTest not found, skipping DOCA_MEMOS backend tests')
+    subdir_done()
+endif
+
+# Abseil: use deps from top-level meson.build (system or subproject)
+
+doca_memos_test_sources = files(
+    'doca_memos_backend_test.cpp',
+    'doca_memos_mocks.cpp',
+)
+
+# Builds the backend translation units directly against the DOCA mocks
+# headers in this directory rather than linking the plugin library.
+# doca_memos_backend_sources is exported by src/plugins/doca_memos/meson.build.
+doca_memos_backend_test = executable(
+    'doca_memos_backend_test',
+    sources: [
+        doca_memos_test_sources,
+        doca_memos_backend_sources,
+    ],
+    include_directories: [
+        # Mock foundational headers (doca_compat/ctx/error/pe/types.h) and the
+        # concrete struct definitions in doca_memos_mocks.h. MUST BE FIRST so the
+        # mocks shadow the foundational DOCA headers; the real DOCA KV headers
+        # (doca_kvdev*.h, doca_nvme_kernel_kvdev*.h) are picked up from the SDK
+        # via the doca-kv/doca-common include paths below.
+        include_directories('.'),
+        include_directories('../../../../src/plugins/doca_memos'),  # For backend headers
+        nixl_inc_dirs,  # Use existing NIXL include directories
+        utils_inc_dirs,  # Use existing utils include directories
+    ],
+    dependencies: [
+        gtest_dep_local,
+        absl_strings_dep,
+        absl_log_dep,
+        nixl_infra,  # For nixl_time and other infra
+        dependency('threads'),
+        # Headers only: the DOCA functions are provided by doca_memos_mocks.cpp,
+        # so pull in the real KV API declarations without linking libdoca_kv.
+        doca_kv_dep.partial_dependency(includes: true, compile_args: true),
+        doca_common_dep.partial_dependency(includes: true, compile_args: true),
+    ],
+    cpp_args: [
+        '-DDOCA_ALLOW_EXPERIMENTAL_API',
+        '-DNIXL_UNIT_TEST',  # Optional: can be used to ifdef test-specific code
+    ],
+    link_args: [],
+    install: true,
+)
+
+# Register the test with meson
+test('doca_memos_backend_unit_test', doca_memos_backend_test,
+     timeout: 60,
+     suite: ['unit', 'plugins', 'doca_memos'])

--- a/test/unit/plugins/meson.build
+++ b/test/unit/plugins/meson.build
@@ -127,3 +127,10 @@ if enabled_plugins.get('OBJ')
         subdir('object')
     endif
 endif
+
+# DOCA_MEMOS tests mock the DOCA functions (doca_memos_mocks.cpp) but compile
+# against the real DOCA KV API headers, so they require doca-kv/doca-common to be
+# present. Gate on the plugin being enabled and the dependencies being found.
+if enabled_plugins.get('DOCA_MEMOS') and doca_kv_dep.found() and doca_common_dep.found()
+    subdir('doca_memos')
+endif


### PR DESCRIPTION
## What?
Add a backend to talk to the NVIDIA DOCA MEMOS KV Storage System

## Why?
This is a hardware accelerated KV cache designed specifically for inference workloads.

## How?
The doca_kv library in DOCA is optionally linked against as a dependency and the plugin makes calls to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DOCA_MEMOS backend support with new configuration options (device identity, task count, query memory mode, NVMe-oF addressing, and `ignore_read_not_found`).
  * Added a new `QUERY` operation type for key-existence checks.
* **Documentation**
  * Added DOCA_MEMOS backend plugin documentation and a usage example.
* **Bug Fixes**
  * Improved statistics handling for empty sample sets and refined backend-specific consistency validation/behavior.
* **Tests**
  * Added a comprehensive DOCA_MEMOS unit test suite with mocked dependencies and failure-mode analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->