### PR TITLE
telemetry: pre-allocate event buffer to avoid reallocation

### DIFF
--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -154,6 +154,10 @@ nixlTelemetry::initializeTelemetry() {
         return;
     }
 
+    // Allocate the staging buffer once up to its cap so appending events on the
+    // telemetry path does not trigger repeated vector reallocations.
+    events_.reserve(maxBufferedEvents_);
+
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;
 
     const auto run_interval =

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -154,8 +154,6 @@ nixlTelemetry::initializeTelemetry() {
         return;
     }
 
-    // Allocate the staging buffer once up to its cap so appending events on the
-    // telemetry path does not trigger repeated vector reallocations.
     events_.reserve(maxBufferedEvents_);
 
     NIXL_DEBUG << "NIXL telemetry is enabled with exporter: " << *exporter_name;


### PR DESCRIPTION
## What?
Reserve the telemetry `events_` staging vector up to `maxBufferedEvents_` once, when telemetry has a usable exporter.

## Why?
Without it, `events_` grows from empty toward the cap via normal `std::vector` growth, causing repeated reallocations and `nixlTelemetryEvent` moves/copies on the telemetry path. This is a pure perf change — runtime behavior and event limits are unchanged; only backing-storage allocation differs.

## How?
- `src/core/telemetry/telemetry.cpp`: call `events_.reserve(maxBufferedEvents_)` in `initializeTelemetry()` right after the exporter is confirmed created (so nothing is allocated when telemetry has no sink).

### Test plan
- [x] `ninja -C build install`
- [x] `build/test/gtest/gtest --gtest_filter='telemetryTest.*:prometheusTelemetryTest.*'` — 15/15 passed
- [x] clang-format (diff-scoped) clean on changed lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved telemetry buffering performance by pre-allocating the staging buffer during initialization. This reduces runtime memory allocation overhead and helps steady memory usage when telemetry events begin buffering, with no changes to telemetry behavior or visible features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ai-dynamo/nixl/pull/1719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->