### PR TITLE
telemetry/doca: accumulate counters and add exporter flush

### DIFF
--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -268,23 +268,26 @@ nixlTelemetryDocaExporter::~nixlTelemetryDocaExporter() {
 }
 
 doca_error_t
-nixlTelemetryDocaExporter::registerCounter(const nixlTelemetryEvent &event,
-                                           const char *label_values[]) {
+nixlTelemetryDocaExporter::appendCounterSample(const nixlTelemetryEvent &event,
+                                               const char *label_values[]) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
-    return doca_telemetry_exporter_metrics_add_counter(ctx_->source,
-                                                       docaTimestamp(),
-                                                       event_name.c_str(),
-                                                       event.value_,
-                                                       ctx_->label_set_id,
-                                                       label_values);
+    // Counter events carry a per-operation delta; increment so the exported
+    // counter is a monotonic cumulative total (add_counter would instead push
+    // each delta as an absolute value, yielding a non-monotonic series).
+    return doca_telemetry_exporter_metrics_add_counter_increment(ctx_->source,
+                                                                 docaTimestamp(),
+                                                                 event_name.c_str(),
+                                                                 event.value_,
+                                                                 ctx_->label_set_id,
+                                                                 label_values);
 #pragma GCC diagnostic pop
 }
 
 doca_error_t
-nixlTelemetryDocaExporter::registerGauge(const nixlTelemetryEvent &event,
-                                         const char *label_values[]) {
+nixlTelemetryDocaExporter::appendGaugeSample(const nixlTelemetryEvent &event,
+                                             const char *label_values[]) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
@@ -304,13 +307,13 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
         const char *label_values[] = {agent_name_.c_str()};
 
         if (isCounterEvent(event.eventType_)) {
-            const auto result = registerCounter(event, label_values);
+            const auto result = appendCounterSample(event, label_values);
             if (result != DOCA_SUCCESS) {
                 NIXL_ERROR << "Failed to add counter: " << result;
                 return NIXL_ERR_UNKNOWN;
             }
         } else if (isGaugeEvent(event.eventType_)) {
-            const auto result = registerGauge(event, label_values);
+            const auto result = appendGaugeSample(event, label_values);
             if (result != DOCA_SUCCESS) {
                 NIXL_ERROR << "Failed to add gauge: " << result;
                 return NIXL_ERR_UNKNOWN;
@@ -323,4 +326,18 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
         NIXL_ERROR << "Failed to export telemetry event: " << e.what();
         return NIXL_ERR_UNKNOWN;
     }
+}
+
+nixl_status_t
+nixlTelemetryDocaExporter::flush() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    const std::lock_guard lock(g_metrics_mutex);
+    const auto result = doca_telemetry_exporter_metrics_flush(ctx_->source);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to flush DOCA metrics: " << result;
+        return NIXL_ERR_UNKNOWN;
+    }
+    return NIXL_SUCCESS;
+#pragma GCC diagnostic pop
 }

--- a/src/plugins/telemetry/doca/doca_exporter.h
+++ b/src/plugins/telemetry/doca/doca_exporter.h
@@ -35,15 +35,26 @@ public:
     [[nodiscard]] nixl_status_t
     exportEvent(const nixlTelemetryEvent &event) override;
 
+    // Force-pushes accumulated metrics to the DOCA/CollectX Prometheus endpoint.
+    // Production relies on CollectX auto-flush (buffer fill / flush interval);
+    // this is exposed so tests can flush a few events before scraping, since a
+    // handful of samples will not fill the buffer to trigger an auto-flush.
+    nixl_status_t
+    flush();
+
 private:
     const std::string agent_name_;
     std::shared_ptr<DocaSharedContext> ctx_;
 
+    // Appends a counter sample to the time-series. DOCA accumulates the value
+    // (add_counter_increment), so repeated per-operation deltas produce a
+    // monotonic cumulative total, matching the Prometheus exporter.
     [[nodiscard]] doca_error_t
-    registerCounter(const nixlTelemetryEvent &event, const char *label_values[]);
+    appendCounterSample(const nixlTelemetryEvent &event, const char *label_values[]);
 
+    // Appends a gauge sample to the time-series (absolute last-operation value).
     [[nodiscard]] doca_error_t
-    registerGauge(const nixlTelemetryEvent &event, const char *label_values[]);
+    appendGaugeSample(const nixlTelemetryEvent &event, const char *label_values[]);
 };
 
 #endif // NIXL_SRC_PLUGINS_TELEMETRY_DOCA_EXPORTER_H

--- a/src/plugins/telemetry/doca/doca_exporter.h
+++ b/src/plugins/telemetry/doca/doca_exporter.h
@@ -39,7 +39,7 @@ public:
     // Production relies on CollectX auto-flush (buffer fill / flush interval);
     // this is exposed so tests can flush a few events before scraping, since a
     // handful of samples will not fill the buffer to trigger an auto-flush.
-    nixl_status_t
+    [[nodiscard]] nixl_status_t
     flush();
 
 private:

--- a/test/doca-telemetry/loopback_connection.h
+++ b/test/doca-telemetry/loopback_connection.h
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_DOCA_TELEMETRY_LOOPBACK_CONNECTION_H
+#define NIXL_TEST_DOCA_TELEMETRY_LOOPBACK_CONNECTION_H
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <thread>
+
+namespace nixl::doca_test {
+
+// RAII blocking TCP client to 127.0.0.1:<port>: connects (with send/recv
+// timeouts) on construction and closes the socket on destruction. Single-use
+// and scope-bound, so it is neither copyable nor movable.
+class loopbackConnection {
+public:
+    explicit loopbackConnection(uint16_t port) {
+        fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ < 0) {
+            return;
+        }
+
+        const struct timeval tv{3, 0};
+        ::setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        ::setsockopt(fd_, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        addr.sin_addr.s_addr = ::inet_addr(loopbackAddr);
+        if (::connect(fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+            ::close(fd_);
+            fd_ = -1;
+        }
+    }
+
+    ~loopbackConnection() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    loopbackConnection(const loopbackConnection &) = delete;
+    loopbackConnection &
+    operator=(const loopbackConnection &) = delete;
+
+    bool
+    connected() const {
+        return fd_ >= 0;
+    }
+
+    void
+    send(const std::string &data) const {
+        ::send(fd_, data.data(), data.size(), 0);
+    }
+
+    // Read until the peer closes the connection (Connection: close). Under
+    // SO_RCVTIMEO a slow/not-yet-ready endpoint makes recv() return -1 with
+    // EAGAIN/EWOULDBLOCK (or EINTR on a signal); treat those as transient and
+    // retry after a short sleep instead of bailing out with a truncated body.
+    // A read deadline bounds the retries so the loop can never hang.
+    std::string
+    recvUntilClosed() const {
+        std::string response;
+        char buf[4096];
+        const auto read_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (std::chrono::steady_clock::now() < read_deadline) {
+            const ssize_t n = ::recv(fd_, buf, sizeof(buf), 0);
+            if (n > 0) {
+                response.append(buf, n);
+                continue;
+            }
+            if (n == 0) {
+                break; // peer closed: response complete
+            }
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                continue;
+            }
+            break; // hard error
+        }
+        return response;
+    }
+
+    // Ask the OS for a free TCP port on the loopback interface.
+    static uint16_t
+    findFreePort() {
+        const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (fd < 0) {
+            return 0;
+        }
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = ::inet_addr(loopbackAddr);
+        addr.sin_port = 0;
+        uint16_t port = 0;
+        if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0) {
+            socklen_t len = sizeof(addr);
+            if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0) {
+                port = ntohs(addr.sin_port);
+            }
+        }
+        ::close(fd);
+        return port;
+    }
+
+    // Minimal HTTP/1.1 GET over 127.0.0.1:<port>; returns the response body
+    // (empty on failure). One-shot: opens, sends, reads, and closes.
+    static std::string
+    httpGet(uint16_t port, const std::string &path) {
+        const loopbackConnection conn(port);
+        if (!conn.connected()) {
+            return {};
+        }
+
+        conn.send("GET " + path + " HTTP/1.1\r\nHost: " + loopbackAddr +
+                  "\r\nConnection: close\r\n\r\n");
+
+        const std::string response = conn.recvUntilClosed();
+        const auto pos = response.find("\r\n\r\n");
+        return pos == std::string::npos ? std::string{} : response.substr(pos + 4);
+    }
+
+private:
+    static constexpr const char *loopbackAddr = "127.0.0.1";
+
+    int fd_ = -1;
+};
+
+} // namespace nixl::doca_test
+
+#endif // NIXL_TEST_DOCA_TELEMETRY_LOOPBACK_CONNECTION_H

--- a/test/doca-telemetry/loopback_connection.h
+++ b/test/doca-telemetry/loopback_connection.h
@@ -70,9 +70,25 @@ public:
         return fd_ >= 0;
     }
 
+    // Write the whole buffer, retrying short writes and transient errors
+    // (EINTR/EAGAIN/EWOULDBLOCK) after a short sleep. MSG_NOSIGNAL avoids a
+    // SIGPIPE if the peer closed early. A write deadline bounds the retries.
     void
     send(const std::string &data) const {
-        ::send(fd_, data.data(), data.size(), 0);
+        const auto write_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        size_t off = 0;
+        while (off < data.size() && std::chrono::steady_clock::now() < write_deadline) {
+            const ssize_t n = ::send(fd_, data.data() + off, data.size() - off, MSG_NOSIGNAL);
+            if (n > 0) {
+                off += static_cast<size_t>(n);
+                continue;
+            }
+            if (n < 0 && (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                continue;
+            }
+            break; // hard error
+        }
     }
 
     // Read until the peer closes the connection (Connection: close). Under

--- a/test/doca-telemetry/loopback_connection.h
+++ b/test/doca-telemetry/loopback_connection.h
@@ -73,7 +73,8 @@ public:
     // Write the whole buffer, retrying short writes and transient errors
     // (EINTR/EAGAIN/EWOULDBLOCK) after a short sleep. MSG_NOSIGNAL avoids a
     // SIGPIPE if the peer closed early. A write deadline bounds the retries.
-    void
+    // Returns true only if the entire buffer was written before the deadline.
+    [[nodiscard]] bool
     send(const std::string &data) const {
         const auto write_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
         size_t off = 0;
@@ -87,8 +88,9 @@ public:
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 continue;
             }
-            break; // hard error
+            return false; // hard error
         }
+        return off == data.size();
     }
 
     // Read until the peer closes the connection (Connection: close). Under
@@ -150,8 +152,10 @@ public:
             return {};
         }
 
-        conn.send("GET " + path + " HTTP/1.1\r\nHost: " + loopbackAddr +
-                  "\r\nConnection: close\r\n\r\n");
+        if (!conn.send("GET " + path + " HTTP/1.1\r\nHost: " + loopbackAddr +
+                       "\r\nConnection: close\r\n\r\n")) {
+            return {};
+        }
 
         const std::string response = conn.recvUntilClosed();
         const auto pos = response.find("\r\n\r\n");

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Standalone DOCA telemetry exporter test. It links the DOCA telemetry exporter
-# directly and intentionally pulls in NO nixl libraries, so the process carries
-# only CollectX's gRPC (no duplicate-flag clash with nixl's gRPC). Built only
-# when the DOCA telemetry headers are present, mirroring the plugin gate in
-# src/plugins/telemetry/doca/meson.build.
+# Standalone DOCA telemetry tests. They intentionally avoid linking nixl core
+# (no etcd/gRPC), so each process carries only CollectX's gRPC (no duplicate-flag
+# clash with nixl's gRPC). Built only when the DOCA telemetry headers are present,
+# mirroring the plugin gate in src/plugins/telemetry/doca/meson.build.
+#  - doca_test:      exercises the raw DOCA Metrics API directly.
+#  - doca_nixl_test: exercises the NIXL DOCA exporter (compiled in directly, so
+#                    it pulls only nixl_infra/nixl_common - no gRPC).
 
 if not gtest_dep.found()
     subdir_done()
@@ -54,7 +56,25 @@ if doca_found
     )
 
     test('doca_test', doca_test_exe, is_parallel: false)
-    message('Building standalone DOCA telemetry exporter test')
+
+    doca_exporter_dir = '../../src/plugins/telemetry/doca'
+    doca_nixl_test_exe = executable('doca_nixl_test',
+        sources: [
+            'telemetry_doca_nixl_test.cpp',
+            doca_exporter_dir / 'doca_exporter.cpp',
+        ],
+        include_directories: [
+            nixl_inc_dirs,
+            utils_inc_dirs,
+            include_directories(doca_exporter_dir),
+        ],
+        dependencies: [gtest_dep, doca_dep, nixl_infra, nixl_common_dep, absl_log_dep],
+        cpp_args: ['-Wno-deprecated-declarations'],
+        install: true,
+    )
+
+    test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false)
+    message('Building standalone DOCA telemetry exporter tests')
 else
     warning('DOCA Telemetry Exporter headers not found. DOCA telemetry exporter test will not be built.')
 endif

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standalone DOCA telemetry exporter test. It links the DOCA telemetry exporter
+# directly and intentionally pulls in NO nixl libraries, so the process carries
+# only CollectX's gRPC (no duplicate-flag clash with nixl's gRPC). Built only
+# when the DOCA telemetry headers are present, mirroring the plugin gate in
+# src/plugins/telemetry/doca/meson.build.
+
+if not gtest_dep.found()
+    subdir_done()
+endif
+
+# DOCA discovery - identical to src/plugins/telemetry/doca/meson.build.
+doca_found = false
+doca_base_path = '/opt/mellanox/doca'
+doca_inc_path = doca_base_path / 'include'
+doca_arch = host_machine.cpu_family() + '-linux-gnu'
+doca_lib_path = doca_base_path / 'lib' / doca_arch
+
+if cpp.has_header('doca_telemetry_exporter.h', args: '-I' + doca_inc_path)
+    doca_dep = declare_dependency(
+        include_directories: include_directories(doca_inc_path, is_system: true),
+        link_args: [
+            '-L' + doca_lib_path,
+            '-ldoca_telemetry_exporter',
+            '-ldoca_common',
+            '-Wl,-rpath,' + doca_lib_path
+        ]
+    )
+    doca_found = true
+endif
+
+if doca_found
+    doca_test_exe = executable('doca_test',
+        sources: ['telemetry_doca_test.cpp'],
+        dependencies: [gtest_dep, doca_dep],
+        # DOCA telemetry metrics APIs are marked experimental (deprecated
+        # attribute); mirror the DOCA sample Makefile and the plugin sources.
+        cpp_args: ['-Wno-deprecated-declarations'],
+        install: true,
+    )
+
+    test('doca_test', doca_test_exe, is_parallel: false)
+    message('Building standalone DOCA telemetry exporter test')
+else
+    warning('DOCA Telemetry Exporter headers not found. DOCA telemetry exporter test will not be built.')
+endif

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -17,59 +17,15 @@
 #ifndef NIXL_TEST_DOCA_TELEMETRY_SCRAPE_UTIL_H
 #define NIXL_TEST_DOCA_TELEMETRY_SCRAPE_UTIL_H
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
-
 #include <chrono>
 #include <cstdint>
 #include <sstream>
 #include <string>
 #include <thread>
 
+#include "loopback_connection.h"
+
 namespace nixl::doca_test {
-
-// Minimal HTTP/1.1 GET over 127.0.0.1:<port>; returns the response body (empty
-// on failure).
-inline std::string
-httpGet(uint16_t port, const std::string &path) {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return {};
-    }
-
-    const struct timeval tv{3, 0};
-    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
-    if (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
-        ::close(fd);
-        return {};
-    }
-
-    const std::string req =
-        "GET " + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
-    ::send(fd, req.data(), req.size(), 0);
-
-    std::string response;
-    char buf[4096];
-    while (true) {
-        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
-        if (n <= 0) {
-            break;
-        }
-        response.append(buf, n);
-    }
-    ::close(fd);
-
-    const auto pos = response.find("\r\n\r\n");
-    return pos == std::string::npos ? std::string{} : response.substr(pos + 4);
-}
 
 // Poll /metrics until it contains `needle`, or timeout.
 inline std::string
@@ -77,7 +33,7 @@ scrapeUntil(uint16_t port, const std::string &needle, std::chrono::seconds timeo
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     std::string body;
     do {
-        body = httpGet(port, "/metrics");
+        body = loopbackConnection::httpGet(port, "/metrics");
         if (body.find(needle) != std::string::npos) {
             return body;
         }
@@ -124,28 +80,6 @@ metricValue(const std::string &body, const std::string &metric) {
         }
     }
     return -1.0;
-}
-
-// Ask the OS for a free TCP port on the loopback interface.
-inline uint16_t
-findFreePort() {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) {
-        return 0;
-    }
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
-    addr.sin_port = 0;
-    uint16_t port = 0;
-    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0) {
-        socklen_t len = sizeof(addr);
-        if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0) {
-            port = ntohs(addr.sin_port);
-        }
-    }
-    ::close(fd);
-    return port;
 }
 
 } // namespace nixl::doca_test

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -1,0 +1,153 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_DOCA_TELEMETRY_SCRAPE_UTIL_H
+#define NIXL_TEST_DOCA_TELEMETRY_SCRAPE_UTIL_H
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <thread>
+
+namespace nixl::doca_test {
+
+// Minimal HTTP/1.1 GET over 127.0.0.1:<port>; returns the response body (empty
+// on failure).
+inline std::string
+httpGet(uint16_t port, const std::string &path) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return {};
+    }
+
+    const struct timeval tv{3, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    if (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+        ::close(fd);
+        return {};
+    }
+
+    const std::string req =
+        "GET " + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    ::send(fd, req.data(), req.size(), 0);
+
+    std::string response;
+    char buf[4096];
+    while (true) {
+        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n <= 0) {
+            break;
+        }
+        response.append(buf, n);
+    }
+    ::close(fd);
+
+    const auto pos = response.find("\r\n\r\n");
+    return pos == std::string::npos ? std::string{} : response.substr(pos + 4);
+}
+
+// Poll /metrics until it contains `needle`, or timeout.
+inline std::string
+scrapeUntil(uint16_t port, const std::string &needle, std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::string body;
+    do {
+        body = httpGet(port, "/metrics");
+        if (body.find(needle) != std::string::npos) {
+            return body;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return body;
+}
+
+// Value on the first non-comment exposition line that starts with `metric`.
+// Exposition format is: name{labels} VALUE [TIMESTAMP]  (or  name VALUE [TS]).
+// The value is the token right after the label set, NOT the trailing timestamp.
+inline double
+metricValue(const std::string &body, const std::string &metric) {
+    std::istringstream lines(body);
+    std::string line;
+    while (std::getline(lines, line)) {
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        if (line.rfind(metric, 0) != 0) {
+            continue;
+        }
+
+        size_t value_start;
+        const auto labels_end = line.find("} ");
+        if (labels_end != std::string::npos) {
+            value_start = labels_end + 2;
+        } else {
+            const auto sp = line.find(' ');
+            if (sp == std::string::npos) {
+                continue;
+            }
+            value_start = sp + 1;
+        }
+
+        const auto value_end = line.find(' ', value_start);
+        const std::string token = line.substr(
+            value_start,
+            value_end == std::string::npos ? std::string::npos : value_end - value_start);
+        try {
+            return std::stod(token);
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return -1.0;
+}
+
+// Ask the OS for a free TCP port on the loopback interface.
+inline uint16_t
+findFreePort() {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return 0;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    uint16_t port = 0;
+    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0) {
+        socklen_t len = sizeof(addr);
+        if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0) {
+            port = ntohs(addr.sin_port);
+        }
+    }
+    ::close(fd);
+    return port;
+}
+
+} // namespace nixl::doca_test
+
+#endif // NIXL_TEST_DOCA_TELEMETRY_SCRAPE_UTIL_H

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -1,0 +1,93 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "scrape_util.h"
+
+#include "doca_exporter.h"
+#include "telemetry_event.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using nixl::doca_test::findFreePort;
+using nixl::doca_test::metricValue;
+using nixl::doca_test::scrapeUntil;
+
+namespace {
+
+constexpr char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
+constexpr char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
+
+} // namespace
+
+class docaNixlExporterTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        port_ = findFreePort();
+        ASSERT_NE(port_, 0) << "failed to allocate a free TCP port";
+
+        // The exporter reads these on construction (getBindAddress); bind to
+        // loopback on the just-allocated port so the test is self-contained.
+        ASSERT_EQ(::setenv(docaPrometheusLocalVar, "y", 1), 0);
+        ASSERT_EQ(::setenv(docaPrometheusPortVar, std::to_string(port_).c_str(), 1), 0);
+    }
+
+    uint16_t port_ = 0;
+};
+
+// Drive the real NIXL DOCA exporter end-to-end: push per-operation counter
+// deltas through exportEvent, flush, then scrape the CollectX-backed Prometheus
+// endpoint. A counter event (AGENT_TX_BYTES) must accumulate into a monotonic
+// cumulative total (add_counter_increment), and flush must make the few samples
+// visible (they would not fill the buffer to trigger an auto-flush).
+TEST_F(docaNixlExporterTest, CounterAccumulatesAndFlushServes) {
+    const nixlTelemetryExporterInitParams params{"nixl_doca_exporter_test", 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    constexpr uint64_t delta = 1000;
+    constexpr int iterations = 3;
+    for (int i = 0; i < iterations; ++i) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_TX_BYTES, delta);
+        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
+    }
+
+    // A handful of samples will not fill the CollectX buffer, so the endpoint
+    // would stay empty without this explicit flush.
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const std::string metric = std::string(
+        nixlEnumStrings::telemetryEventTypeStr(nixl_telemetry_event_type_t::AGENT_TX_BYTES));
+    const std::string body = scrapeUntil(port_, metric, std::chrono::seconds(12));
+    std::cout << "=== NIXL DOCA exporter /metrics scrape (port " << port_ << ") ===\n"
+              << body << "\n=== end scrape ===" << std::endl;
+
+    EXPECT_NE(body.find(metric), std::string::npos)
+        << metric << " not served at the DOCA Prometheus endpoint after flush";
+    EXPECT_EQ(metricValue(body, metric), static_cast<double>(delta * iterations))
+        << "per-operation deltas must accumulate into a cumulative counter";
+}
+
+int
+main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -27,7 +27,7 @@
 
 #include <gtest/gtest.h>
 
-using nixl::doca_test::findFreePort;
+using nixl::doca_test::loopbackConnection;
 using nixl::doca_test::metricValue;
 using nixl::doca_test::scrapeUntil;
 
@@ -42,7 +42,7 @@ class docaNixlExporterTest : public ::testing::Test {
 protected:
     void
     SetUp() override {
-        port_ = findFreePort();
+        port_ = loopbackConnection::findFreePort();
         ASSERT_NE(port_, 0) << "failed to allocate a free TCP port";
 
         // The exporter reads these on construction (getBindAddress); bind to

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -51,6 +51,13 @@ protected:
         ASSERT_EQ(::setenv(docaPrometheusPortVar, std::to_string(port_).c_str(), 1), 0);
     }
 
+    void
+    TearDown() override {
+        // Pair with SetUp so the fixture does not leak process-wide env state.
+        ::unsetenv(docaPrometheusLocalVar);
+        ::unsetenv(docaPrometheusPortVar);
+    }
+
     uint16_t port_ = 0;
 };
 

--- a/test/doca-telemetry/telemetry_doca_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_test.cpp
@@ -27,7 +27,7 @@
 
 #include <gtest/gtest.h>
 
-using nixl::doca_test::findFreePort;
+using nixl::doca_test::loopbackConnection;
 using nixl::doca_test::metricValue;
 using nixl::doca_test::scrapeUntil;
 
@@ -35,7 +35,7 @@ class docaTelemetryTest : public ::testing::Test {
 protected:
     void
     SetUp() override {
-        port_ = findFreePort();
+        port_ = loopbackConnection::findFreePort();
         ASSERT_NE(port_, 0) << "failed to allocate a free TCP port";
     }
 

--- a/test/doca-telemetry/telemetry_doca_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_test.cpp
@@ -15,131 +15,21 @@
  * limitations under the License.
  */
 
+#include "scrape_util.h"
+
 #include <doca_telemetry_exporter.h>
 #include <doca_error.h>
-
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
 
 #include <chrono>
 #include <cstdint>
 #include <iostream>
-#include <sstream>
 #include <string>
-#include <thread>
 
 #include <gtest/gtest.h>
 
-namespace {
-
-// Minimal HTTP/1.1 GET over 127.0.0.1:<port>; returns the response body (empty
-// on failure).
-std::string
-httpGet(uint16_t port, const std::string &path) {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) return {};
-
-    const struct timeval tv{3, 0};
-    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
-    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
-    if (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
-        ::close(fd);
-        return {};
-    }
-
-    const std::string req =
-        "GET " + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
-    ::send(fd, req.data(), req.size(), 0);
-
-    std::string response;
-    char buf[4096];
-    while (true) {
-        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
-        if (n <= 0) break;
-        response.append(buf, n);
-    }
-    ::close(fd);
-
-    const auto pos = response.find("\r\n\r\n");
-    return pos == std::string::npos ? std::string{} : response.substr(pos + 4);
-}
-
-// Poll /metrics until it contains `needle`, or timeout.
-std::string
-scrapeUntil(uint16_t port, const std::string &needle, std::chrono::seconds timeout) {
-    const auto deadline = std::chrono::steady_clock::now() + timeout;
-    std::string body;
-    do {
-        body = httpGet(port, "/metrics");
-        if (body.find(needle) != std::string::npos) {
-            return body;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    } while (std::chrono::steady_clock::now() < deadline);
-    return body;
-}
-
-// Value on the first non-comment exposition line that starts with `metric`.
-// Exposition format is: name{labels} VALUE [TIMESTAMP]  (or  name VALUE [TS]).
-// The value is the token right after the label set, NOT the trailing timestamp.
-double
-metricValue(const std::string &body, const std::string &metric) {
-    std::istringstream lines(body);
-    std::string line;
-    while (std::getline(lines, line)) {
-        if (line.empty() || line[0] == '#') continue;
-        if (line.rfind(metric, 0) != 0) continue;
-
-        size_t value_start;
-        const auto labels_end = line.find("} ");
-        if (labels_end != std::string::npos) {
-            value_start = labels_end + 2;
-        } else {
-            const auto sp = line.find(' ');
-            if (sp == std::string::npos) continue;
-            value_start = sp + 1;
-        }
-
-        const auto value_end = line.find(' ', value_start);
-        const std::string token = line.substr(
-            value_start, value_end == std::string::npos ? std::string::npos : value_end - value_start);
-        try {
-            return std::stod(token);
-        }
-        catch (const std::exception &) {
-        }
-    }
-    return -1.0;
-}
-
-// Ask the OS for a free TCP port on the loopback interface.
-uint16_t
-findFreePort() {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) return 0;
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
-    addr.sin_port = 0;
-    uint16_t port = 0;
-    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0) {
-        socklen_t len = sizeof(addr);
-        if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0) {
-            port = ntohs(addr.sin_port);
-        }
-    }
-    ::close(fd);
-    return port;
-}
-
-} // namespace
+using nixl::doca_test::findFreePort;
+using nixl::doca_test::metricValue;
+using nixl::doca_test::scrapeUntil;
 
 class docaTelemetryTest : public ::testing::Test {
 protected:

--- a/test/doca-telemetry/telemetry_doca_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_test.cpp
@@ -1,0 +1,211 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <doca_telemetry_exporter.h>
+#include <doca_error.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Minimal HTTP/1.1 GET over 127.0.0.1:<port>; returns the response body (empty
+// on failure).
+std::string
+httpGet(uint16_t port, const std::string &path) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return {};
+
+    const struct timeval tv{3, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    if (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+        ::close(fd);
+        return {};
+    }
+
+    const std::string req =
+        "GET " + path + " HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    ::send(fd, req.data(), req.size(), 0);
+
+    std::string response;
+    char buf[4096];
+    while (true) {
+        const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n <= 0) break;
+        response.append(buf, n);
+    }
+    ::close(fd);
+
+    const auto pos = response.find("\r\n\r\n");
+    return pos == std::string::npos ? std::string{} : response.substr(pos + 4);
+}
+
+// Poll /metrics until it contains `needle`, or timeout.
+std::string
+scrapeUntil(uint16_t port, const std::string &needle, std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    std::string body;
+    do {
+        body = httpGet(port, "/metrics");
+        if (body.find(needle) != std::string::npos) {
+            return body;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return body;
+}
+
+// Value on the first non-comment exposition line that starts with `metric`.
+// Exposition format is: name{labels} VALUE [TIMESTAMP]  (or  name VALUE [TS]).
+// The value is the token right after the label set, NOT the trailing timestamp.
+double
+metricValue(const std::string &body, const std::string &metric) {
+    std::istringstream lines(body);
+    std::string line;
+    while (std::getline(lines, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        if (line.rfind(metric, 0) != 0) continue;
+
+        size_t value_start;
+        const auto labels_end = line.find("} ");
+        if (labels_end != std::string::npos) {
+            value_start = labels_end + 2;
+        } else {
+            const auto sp = line.find(' ');
+            if (sp == std::string::npos) continue;
+            value_start = sp + 1;
+        }
+
+        const auto value_end = line.find(' ', value_start);
+        const std::string token = line.substr(
+            value_start, value_end == std::string::npos ? std::string::npos : value_end - value_start);
+        try {
+            return std::stod(token);
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return -1.0;
+}
+
+// Ask the OS for a free TCP port on the loopback interface.
+uint16_t
+findFreePort() {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return 0;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    addr.sin_port = 0;
+    uint16_t port = 0;
+    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0) {
+        socklen_t len = sizeof(addr);
+        if (::getsockname(fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0) {
+            port = ntohs(addr.sin_port);
+        }
+    }
+    ::close(fd);
+    return port;
+}
+
+} // namespace
+
+class docaTelemetryTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        port_ = findFreePort();
+        ASSERT_NE(port_, 0) << "failed to allocate a free TCP port";
+    }
+
+    uint16_t port_ = 0;
+};
+
+// Raw DOCA Metrics API proof, mirroring the DOCA prometheus_example sample:
+// stand up schema/source/metrics, accumulate a counter via add_counter_increment,
+// flush explicitly, and confirm the CollectX-backed Prometheus endpoint serves
+// the cumulative value. Establishes that DOCA + CollectX work in-process (the
+// gRPC duplicate-flag clash is resolved by CollectX >= 1.26).
+TEST_F(docaTelemetryTest, RawDocaApiServesAccumulatingCounter) {
+    // PROMETHEUS_ENDPOINT must be set before schema_init (per the DOCA sample).
+    const std::string endpoint = "http://127.0.0.1:" + std::to_string(port_);
+    ASSERT_EQ(::setenv("PROMETHEUS_ENDPOINT", endpoint.c_str(), 1), 0);
+
+    doca_telemetry_exporter_schema *schema = nullptr;
+    ASSERT_EQ(doca_telemetry_exporter_schema_init("nixl_doca_raw_test", &schema), DOCA_SUCCESS);
+    ASSERT_EQ(doca_telemetry_exporter_schema_start(schema), DOCA_SUCCESS);
+
+    doca_telemetry_exporter_source *source = nullptr;
+    ASSERT_EQ(doca_telemetry_exporter_source_create(schema, &source), DOCA_SUCCESS);
+    doca_telemetry_exporter_source_set_id(source, "raw_test_source");
+    doca_telemetry_exporter_source_set_tag(source, "");
+    ASSERT_EQ(doca_telemetry_exporter_source_start(source), DOCA_SUCCESS);
+
+    ASSERT_EQ(doca_telemetry_exporter_metrics_create_context(source), DOCA_SUCCESS);
+    doca_telemetry_exporter_metrics_set_flush_interval_ms(source, 1000);
+
+    doca_telemetry_exporter_label_set_id_t label_set = 0;
+    const char *label_names[] = {"type"};
+    ASSERT_EQ(doca_telemetry_exporter_metrics_add_label_names(source, label_names, 1, &label_set),
+              DOCA_SUCCESS);
+
+    // Increment the same counter three times -> cumulative 3.
+    const char *label_values[] = {"counter"};
+    for (int i = 0; i < 3; ++i) {
+        uint64_t ts = 0;
+        ASSERT_EQ(doca_telemetry_exporter_get_timestamp(&ts), DOCA_SUCCESS);
+        ASSERT_EQ(doca_telemetry_exporter_metrics_add_counter_increment(
+                      source, ts, "raw_ops_total", 1, label_set, label_values),
+                  DOCA_SUCCESS);
+    }
+    ASSERT_EQ(doca_telemetry_exporter_metrics_flush(source), DOCA_SUCCESS);
+
+    const std::string body = scrapeUntil(port_, "raw_ops_total", std::chrono::seconds(12));
+    std::cout << "=== DOCA /metrics scrape (port " << port_ << ") ===\n"
+              << body << "\n=== end scrape ===" << std::endl;
+    EXPECT_NE(body.find("raw_ops_total"), std::string::npos)
+        << "raw_ops_total not served at the DOCA Prometheus endpoint";
+    EXPECT_EQ(metricValue(body, "raw_ops_total"), 3.0)
+        << "add_counter_increment x3 (by 1) must yield a cumulative 3";
+
+    doca_telemetry_exporter_metrics_destroy_context(source);
+    doca_telemetry_exporter_source_destroy(source);
+    doca_telemetry_exporter_schema_destroy(schema);
+}
+
+int
+main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -17,3 +17,8 @@ subdir('nixl')
 subdir('unit')
 
 subdir('gtest')
+
+# Standalone DOCA telemetry exporter test (self-contained; only built when the
+# DOCA telemetry headers are present). Kept out of the main gtest target so the
+# DOCA/CollectX gRPC stack is not linked into every test.
+subdir('doca-telemetry')


### PR DESCRIPTION
## What?
- Fix the DOCA telemetry exporter so counter metrics accumulate into a
  monotonic cumulative total instead of each per-operation delta overwriting
  the previous value.
- Expose `flush()` on the DOCA exporter so buffered samples can be pushed to the
  CollectX/Prometheus endpoint on demand.
- Rename the internal `registerCounter`/`registerGauge` helpers to
  `appendCounterSample`/`appendGaugeSample` to reflect their time-series
  append semantics.
- Add a NIXL-exporter gtest (`doca_nixl_test`) that drives the real exporter
  end to end, and extract the shared HTTP scrape helpers into `scrape_util.h`,
  reused by the existing raw-DOCA test.

## Why?
- Counter events (`AGENT_TX_BYTES`, `AGENT_RX_BYTES`, request counts) carry a
  per-operation delta. The exporter pushed each delta through
  `doca_telemetry_exporter_metrics_add_counter`, which records an *absolute*
  value, so the exported series was non-monotonic and disagreed with the
  Prometheus exporter (which accumulates). `add_counter_increment` is the
  correct API for delta accumulation.
- CollectX flushes reactively (buffer fill / flush interval). A handful of
  samples never fill the buffer, so without an explicit flush the metrics do
  not reach the endpoint within a short window — leaving the exporter
  effectively untestable and unreliable for low-volume scenarios.

## How?
- `exportEvent` routes counter events through `appendCounterSample` →
  `doca_telemetry_exporter_metrics_add_counter_increment`; gauge events keep
  using `add_gauge` (absolute last value).
- `flush()` wraps `doca_telemetry_exporter_metrics_flush` under the metrics
  mutex. Production still relies on CollectX's interval auto-flush
  (`set_flush_interval_ms(1000)`); `flush()` exists for callers/tests that need
  determinism.
- `doca_nixl_test` compiles `doca_exporter.cpp` directly and links only
  `nixl_infra`/`nixl_common` (no etcd/gRPC), avoiding the DOCA/CollectX gRPC
  duplicate-flag clash — the same isolation strategy as the raw DOCA test. It
  pushes 3×1000-byte deltas, flushes, scrapes `/metrics`, and asserts the
  cumulative total of 3000.

## Test
- `meson test -C build doca_test doca_nixl_test` → 2/2 OK
- Diff-scoped `clang-format-19` clean on changed lines
- `ninja -C build src/plugins/telemetry/doca/libtelemetry_exporter_doca.so` builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit flush to the DOCA telemetry exporter for on-demand metric publication
  * Counters now accumulate as monotonic cumulative samples; gauges are appended similarly and per-type error logging added

* **Tests**
  * End-to-end tests verifying counter accumulation and flush-driven exposure
  * Added Prometheus-scraping and loopback test utilities and Meson test integration for DOCA telemetry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->