### PR TITLE
CI: wait full build+test for AWS batch completion

### DIFF
--- a/contrib/aws-efa/aws_test.sh
+++ b/contrib/aws-efa/aws_test.sh
@@ -98,6 +98,12 @@ wait_for_status() {
             set -x
             return 0
         fi
+        # Fail fast on terminal FAILED, don't wait out the timeout.
+        if [ "$status" = "FAILED" ]; then
+            echo -e "\nJob reached terminal status FAILED after ${SECONDS}s"
+            set -x
+            return 1
+        fi
         printf "."
         sleep $interval
     done
@@ -120,9 +126,9 @@ POD=$(aws batch describe-jobs --jobs "$JOB_ID" --query 'jobs[0].eksProperties.po
 echo "Streaming logs from pod: $POD"
 kubectl -n ucx-ci-batch-nodes logs -f "$POD" || kubectl -n ucx-ci-batch-nodes logs "$POD" --previous || true
 
-# Check final job status
-echo "Waiting for job completion (timeout: 10m)..."
-if ! wait_for_status "SUCCEEDED" 600 10; then
+# logs -f can return early (apiserver GOAWAY), so cover the full build+test.
+echo "Waiting for job completion (timeout: 60m)..."
+if ! wait_for_status "SUCCEEDED" 3600 10; then
     echo "Failure running NIXL tests"
     exit 1
 fi

--- a/contrib/aws-efa/aws_test.sh
+++ b/contrib/aws-efa/aws_test.sh
@@ -127,8 +127,10 @@ echo "Streaming logs from pod: $POD"
 kubectl -n ucx-ci-batch-nodes logs -f "$POD" || kubectl -n ucx-ci-batch-nodes logs "$POD" --previous || true
 
 # logs -f can return early (apiserver GOAWAY), so cover the full build+test.
-echo "Waiting for job completion (timeout: 60m)..."
-if ! wait_for_status "SUCCEEDED" 3600 10; then
+# Wait 5m past the in-pod TEST_TIMEOUT (60m) so this layer strictly wraps it
+# and can observe the resulting FAILED instead of timing out alongside it.
+echo "Waiting for job completion (timeout: 65m)..."
+if ! wait_for_status "SUCCEEDED" 3900 10; then
     echo "Failure running NIXL tests"
     exit 1
 fi


### PR DESCRIPTION
## What?

Two fixes to the AWS EFA job-completion wait in `contrib/aws-efa/aws_test.sh`:

1. **Raise the completion timeout from 10m to 60m** - the actual fix for the false failures.
2. **Fail fast on terminal `FAILED`** - a complementary guard so the longer wait can't be abused by a genuinely failed job.

## Why?

Jobs intermittently fail across PRs with `Timeout waiting for status SUCCEEDED after 600s. Final status: RUNNING`.

`kubectl logs -f` returns early on an apiserver HTTP/2 `GOAWAY` (graceful, `ErrCode=NO_ERROR`), after which only 10m was allowed for `SUCCEEDED`. The C++20 switch (#1571) pushed the in-pod build+test past that tail, so healthy jobs timed out while still `RUNNING` and reported a false failure. A green run takes ~35m.

## How?

1. **60m timeout** covers the full build+test even when the log stream drops at the start of `RUNNING`. Real hangs stay capped by the in-pod `timeout` and the job-definition timeout.
2. **`FAILED` early-exit** - with a 60m wait, a genuinely failed job would otherwise idle the full hour. The check applies to both the `RUNNING` and `SUCCEEDED` waits, so a job that dies at startup also exits immediately instead of burning its start timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The test script now detects and reports job failures immediately (with accurate elapsed-time reporting) instead of waiting for the original timeout.
  * On failure, verbose shell tracing is re-enabled to improve diagnostic output.
  * Extended the overall completion wait period to cover the full build+test window; notes added about log streaming possibly ending before completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->