### PR TITLE
Fix missing closing bracket in print

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1804,7 +1804,7 @@ xferBenchNixlWorker::synchronizeStart() {
                   << xferBenchConfig::num_target_dev << " targets)" << std::endl;
     } else {
         std::cout << "Waiting for all processes to start... (expecting " << rt->getSize()
-                  << " total" << std::endl;
+                  << " total)" << std::endl;
     }
 
     if (rt) {


### PR DESCRIPTION
## What?
Missing bracket in print.

Output was:
`Waiting for all processes to start... (expecting 2 total`

After the fix:
`Waiting for all processes to start... (expecting 2 total)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted formatting of a console output message in internal benchmark tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->