### PR TITLE
build: bump DOCA to 3.3 and build the DOCA telemetry exporter in CI

### DIFF
--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -43,7 +43,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260603-1"
+  CI_IMAGE_TAG: "20260604-1"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -52,7 +52,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260602-1"
+  CI_IMAGE_TAG: "20260604-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -50,7 +50,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260602-1"
+  CI_IMAGE_TAG: "20260604-1"
 
 empty_volumes:
   - {mountPath: /root, memory: false}

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -151,11 +151,11 @@ else
     # Add DOCA repository and install packages
     ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi)
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)"
-    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.0/host/doca-host_3.2.0-125000-25.10-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O ${TMPDIR}/doca-host.deb
+    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O ${TMPDIR}/doca-host.deb
     $SUDO dpkg -i ${TMPDIR}/doca-host.deb
     $SUDO apt-get update
     $SUDO apt-get upgrade -y
-    $SUDO apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev
+    $SUDO apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev
 
     # Force reinstall of RDMA packages from DOCA repository
     # Reinstall needed to fix broken libibverbs-dev, which may lead to lack of Infiniband support.

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -314,7 +314,7 @@ cmake --install sdk/identity
 **DOCA (Optional):**
 ```bash
 # Add Mellanox repository and install DOCA
-wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.0/host/doca-host_3.2.0-125000-25.10-ubuntu2404_amd64.deb -O doca-host.deb
+wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2404_amd64.deb -O doca-host.deb
 sudo dpkg -i doca-host.deb
 sudo apt-get update && sudo apt-get install -y doca-sdk-gpunetio libdoca-sdk-gpunetio-dev
 ```

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -316,7 +316,7 @@ cmake --install sdk/identity
 # Add Mellanox repository and install DOCA
 wget https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-ubuntu2404_amd64.deb -O doca-host.deb
 sudo dpkg -i doca-host.deb
-sudo apt-get update && sudo apt-get install -y doca-sdk-gpunetio libdoca-sdk-gpunetio-dev
+sudo apt-get update && sudo apt-get install -y doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev
 ```
 
 **GUSLI (Optional - for GUSLI backend):**

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -52,11 +52,11 @@ RUN apt-get update -y && \
 # Add DOCA repository and install packages
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
-    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.0/host/doca-host_3.2.0-125000-25.10-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
+    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
     dpkg -i doca-host.deb && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev
+    apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev
 
 # Force reinstall of RDMA packages from DOCA repository
 # Reinstall needed to fix broken libibverbs-dev, which may lead to lack of Infiniband support.

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -73,11 +73,11 @@ RUN apt-get update -y && \
 # Add DOCA repository and install packages
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
-    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.0/host/doca-host_3.2.0-125000-25.10-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
+    wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
     dpkg -i doca-host.deb && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev
+    apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev
 
 # Force reinstall of RDMA packages from DOCA repository
 # Reinstall needed to fix broken libibverbs-dev, which may lead to lack of Infiniband support.

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -221,16 +221,18 @@ RUN wget --tries=3 --waitretry=5 "https://static.rust-lang.org/rustup/archive/1.
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
-RUN wget --tries=3 --waitretry=5 https://www.mellanox.com/downloads/DOCA/DOCA_v3.2.1/host/doca-host-3.2.1-044000_25.10_rhel8.${ARCH}.rpm -O doca-host.rpm && \
+RUN wget --tries=3 --waitretry=5 https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host-3.3.0-088000_26.01_rhel8.${ARCH}.rpm -O doca-host.rpm && \
     rpm -i doca-host.rpm && \
     dnf install -y libnl3-devel && \
-    cd /usr/share/doca-host-3.2.1/repo/Packages/ && \
+    cd /usr/share/doca-host-3.3.0/repo/Packages/ && \
     rpm -ivh --nodeps doca-sdk-common-*rpm && \
     rpm -ivh --nodeps doca-sdk-rdma-*rpm && \
     rpm -ivh --nodeps doca-sdk-verbs-*rpm && \
     rpm -ivh --nodeps doca-sdk-gpunetio-*rpm && \
-    # Check that gpunetio development package is installed correctly
-    pkg-config --cflags --libs doca-gpunetio
+    rpm -ivh --nodeps doca-sdk-telemetry-exporter-*rpm && \
+    # Check that gpunetio and telemetry-exporter development packages are installed correctly
+    pkg-config --cflags --libs doca-gpunetio && \
+    pkg-config --cflags --libs doca-telemetry-exporter
 
 ENV LD_LIBRARY_PATH=/usr/lib:/usr/local/lib:$LD_LIBRARY_PATH
 

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -230,6 +230,10 @@ RUN wget --tries=3 --waitretry=5 https://www.mellanox.com/downloads/DOCA/DOCA_v3
     rpm -ivh --nodeps doca-sdk-verbs-*rpm && \
     rpm -ivh --nodeps doca-sdk-gpunetio-*rpm && \
     rpm -ivh --nodeps doca-sdk-telemetry-exporter-*rpm && \
+    # CollectX provides libclx-api.pc, required (Requires.private) by
+    # doca-telemetry-exporter.pc and needed to link the telemetry exporter plugin.
+    # These RPMs use a different naming scheme: collectx_<ver>-...-clxapi[dev].rpm
+    rpm -ivh --nodeps collectx_*rpm && \
     # Check that gpunetio and telemetry-exporter development packages are installed correctly
     pkg-config --cflags --libs doca-gpunetio && \
     pkg-config --cflags --libs doca-telemetry-exporter

--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ if enable_plugins_opt != '' and disable_plugins_opt != ''
     error('Cannot specify both enable_plugins and disable_plugins options')
 endif
 
-all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA']
+all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA']
 
 enabled_plugins = {}
 

--- a/src/plugins/telemetry/doca/meson.build
+++ b/src/plugins/telemetry/doca/meson.build
@@ -13,37 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-doca_found = false
-doca_base_path = '/opt/mellanox/doca'
-doca_inc_path = doca_base_path / 'include'
-doca_arch = host_machine.cpu_family() + '-linux-gnu'
-doca_lib_path = doca_base_path / 'lib' / doca_arch
-
-if cpp.has_header('doca_telemetry_exporter.h', args: '-I' + doca_inc_path)
-    doca_dep = declare_dependency(
-        include_directories: include_directories(doca_inc_path, is_system: true),
-        link_args: [
-            '-L' + doca_lib_path,
-            '-ldoca_telemetry_exporter',
-            '-ldoca_common',
-            '-Wl,-rpath,' + doca_lib_path
-        ]
-    )
-    doca_found = true
-endif
-
-if doca_found
-    shared_library(
-        'libtelemetry_exporter_doca',
-        'doca_plugin.cpp',
-        'doca_exporter.cpp',
-        include_directories: [nixl_inc_dirs, utils_inc_dirs],
-        dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, doca_dep],
-        install: true,
-        install_dir: plugin_install_dir,
-        name_prefix: '',
-    )
-    message('Building DOCA telemetry exporter plugin')
-else
-    warning('DOCA Telemetry Exporter headers not found. DOCA telemetry exporter will not be built.')
-endif
+# Entered only when TELEMETRY_DOCA is enabled and doca_telemetry_dep /
+# doca_common_dep are found (gated in ../meson.build, mirroring the GPUNETIO
+# backend in src/plugins/gpunetio/meson.build). doca_telemetry_dep and
+# doca_common_dep come from the parent scope.
+shared_library(
+    'libtelemetry_exporter_doca',
+    'doca_plugin.cpp',
+    'doca_exporter.cpp',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, doca_telemetry_dep, doca_common_dep],
+    install: true,
+    install_dir: plugin_install_dir,
+    name_prefix: '',
+)
+message('Building DOCA telemetry exporter plugin')

--- a/src/plugins/telemetry/meson.build
+++ b/src/plugins/telemetry/meson.build
@@ -14,4 +14,19 @@
 # limitations under the License.
 
 subdir('prometheus')
-subdir('doca')
+
+# DOCA telemetry exporter: an optional DOCA pkg-config dependency, gated exactly
+# like the GPUNETIO backend (src/plugins/meson.build). Built by default when the
+# DOCA SDK is present; skipped silently when it is absent; errors only if it is
+# explicitly requested via -Denable_plugins=TELEMETRY_DOCA without the SDK; and
+# can be turned off with -Ddisable_plugins=TELEMETRY_DOCA. The exporter links
+# doca_common, so request it explicitly like GPUNETIO does.
+doca_telemetry_dep = dependency('doca-telemetry-exporter', required: false)
+doca_common_dep = dependency('doca-common', required: false)
+if enabled_plugins.get('TELEMETRY_DOCA')
+    if (not doca_telemetry_dep.found() or not doca_common_dep.found()) and is_explicit_enable
+        error('TELEMETRY_DOCA plugin requested but doca-telemetry-exporter/doca-common dependency not found')
+    elif doca_telemetry_dep.found() and doca_common_dep.found()
+        subdir('doca')
+    endif
+endif


### PR DESCRIPTION
## What?
- Bumps NIXL's build/CI DOCA from 3.2 to 3.3 across every install site and `CI_IMAGE_TAG`.
- Makes the DOCA telemetry exporter a first-class, CI-built plugin, on par with the GPUNETIO backend: installs the SDK in the build images, switches detection to pkg-config, and wires it into the `enable_plugins`/`disable_plugins` framework.

## Why?
- The DOCA telemetry exporter Metrics API (`..._metrics_add_counter_increment`, `..._metrics_flush`, …) only exists in DOCA >= 3.3 — the 3.2 header exposes 0 of these symbols, 3.3 exposes 18 — so the plugin cannot compile on 3.2.
- Single DOCA version per process: `libdoca_common` carries the same SONAME (`libdoca_common.so.2`) in 3.2 and 3.3, so per-feature DOCA versions can't coexist; a global bump is the only coherent fix.
- The exporter was never built in CI: no build image installed the telemetry-exporter SDK, and meson only probed for it via a hardcoded header path, so it was silently skipped everywhere. Build regressions (the class of bug #1640 fixed) were therefore invisible to CI.

## How?
- DOCA 3.2 -> 3.3 in `.gitlab/build.sh`, `contrib/Dockerfile`, `benchmark/nixlbench/contrib/Dockerfile` (+ README), and `contrib/Dockerfile.manylinux` (rpm download + version-keyed repo path); `CI_IMAGE_TAG` bumped in all three Jenkins matrices.
- Install `libdoca-sdk-telemetry-exporter-dev` (+ CollectX) in the deb images and `doca-sdk-telemetry-exporter` in the manylinux image so the plugin compiles and links in CI.
- Replace the hardcoded `has_header` + `/opt/mellanox/doca` detection with `dependency('doca-telemetry-exporter')` + `dependency('doca-common')` (pkg-config), mirroring the GPUNETIO backend.
- Add `TELEMETRY_DOCA` to `all_plugins` and gate it with the same `enable_plugins` / `disable_plugins` / `is_explicit_enable` pattern as GPUNETIO. It is deliberately **not** added to the backend static-link path — it is a dynamically-loaded telemetry exporter, not a transfer backend. No DOCA version pin is added (GPUNETIO precedent); CollectX is a runtime-only dependency and is not needed to compile the plugin.

## Test plan
- Local build: meson reports `doca-telemetry-exporter found: YES 3.3.0109` -> `Building DOCA telemetry exporter plugin`; full `ninja -C build` green; the relinked plugin resolves `libdoca_telemetry_exporter.so.2` + `libclx_api.so.1` + `libdoca_common.so.2`; 15/15 telemetry gtests pass.
- Plugin gating: `-Ddisable_plugins=TELEMETRY_DOCA` -> `Building all plugins except: TELEMETRY_DOCA` (skipped); default -> built.
- CI (this PR): full matrix rebuilds the base image via `CI_IMAGE_TAG`. Verifies GPUNETIO/verbs/rdma + nixlbench still build and pass on 3.3, and that `Building DOCA telemetry exporter plugin` appears in the build logs.

## Follow-up
- Un-gate the standalone `doca_test` / `doca_nixl_test` runtime tests once #1720 (which adds those sources) merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DOCA telemetry exporter plugin that can be enabled when DOCA SDK components are available; build now recognizes and gates the plugin on those dependencies.

* **Chores**
  * Upgraded DOCA host/SDK to v3.3.0 across builds and container artifacts and expanded required DOCA-related packages.
  * Updated CI Docker image tags used by pipeline builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->