### PR TITLE
enabling -G flag, with mesor arg -Dnvcc_device_debug=true

### DIFF
--- a/examples/device/ep/csrc/kernels/configs.cuh
+++ b/examples/device/ep/csrc/kernels/configs.cuh
@@ -37,6 +37,13 @@
 #define NUM_CPU_TIMEOUT_SECS 10
 #endif
 
+// Workaround for cg::this_grid().sync() hang under nvcc -G (see nixl_ep_ll dispatch path)
+#ifdef NIXL_EP_NVCC_DEVICE_DEBUG
+#define NIXL_EP_GRID_SYNC_PRESYNC() __syncthreads()
+#else
+#define NIXL_EP_GRID_SYNC_PRESYNC()
+#endif
+
 #define EP_SEND_PHASE 1
 #define EP_RECV_PHASE 2
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ht.cu
@@ -1590,7 +1590,7 @@ template <int kNumRanks,
           int kNumTMALoadBytes = 0,
           typename GetAddrFn,
           typename ReceiveTWFn>
-__device__ int combine_token(bool is_token_in_rank,
+__device__ __forceinline__ int combine_token(bool is_token_in_rank,
                              int head_idx,
                              int lane_id,
                              int hidden_int4,

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -32,7 +32,7 @@ namespace cg = cooperative_groups;
 
 namespace nixl_ep {
 
-__device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst_rank) {
+__device__ __forceinline__ void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst_rank) {
     if (dst_rank == ctx.rank) return (void*) dst_ptr;
 
     void *remote_ptr = nixlGetPtr(ctx.remote_mvh, dst_rank);
@@ -280,9 +280,10 @@ DISPATCH_RECV:
         return;
 
     // For send-and-recv kernels, we need a grid sync for making `packed_recv_count` visible
-    if (phases & EP_SEND_PHASE)
+    if (phases & EP_SEND_PHASE) {
+        NIXL_EP_GRID_SYNC_PRESYNC(); // Workaround for cg::this_grid().sync() hang under nvcc -G ( when -G is not used, this line is equivalent to NOP)
         cg::this_grid().sync();
-
+    }
     // Receiving and packing
     if (responsible_expert_idx < active_expert_bound) {
         const auto src_rank = responsible_expert_idx / num_local_experts;

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -117,9 +117,14 @@ nixl_ep_rpath += ':' + nixl_lib_dir
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'core')
 nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'plugins')
 
-# For now, nixl ep cannot be built with -G due to register usage limits
+
 nixl_ep_override_options = []
-if get_option('buildtype') == 'debug'
+if get_option('nvcc_device_debug')
+    nixl_ep_override_options = ['optimization=3']
+    nixl_ep_cuda_args += ['-G', '-DNIXL_EP_NVCC_DEVICE_DEBUG']
+    nixl_ep_cpp_args += ['-g']
+    nixl_ep_cuda_args += ['-Xcompiler', '-g']
+elif get_option('buildtype') == 'debug'
     nixl_ep_override_options = ['optimization=3']
     nixl_ep_cpp_args += ['-g']
 endif

--- a/meson.build
+++ b/meson.build
@@ -260,6 +260,10 @@ if cuda_dep.found()
     # Build all CUDA targets with C++20 to match the core's standard and ABI.
     add_project_arguments('-std=c++20', language: 'cuda')
 
+    if get_option('nvcc_device_debug')
+        add_project_arguments('-G', language: 'cuda')
+    endif
+
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
     message('nvcc version: ' + nvcc.version())
     message('CUDA targets: ' + ', '.join(selected_cuda_archs) + ' + ' + nvcc_ptx_arch)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -33,6 +33,7 @@ option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen 
 option('release_wheel', type: 'boolean', value: false, description: 'Add nixl-cu12 and nixl-cu13 dependencies to the meta wheel')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
+option('nvcc_device_debug', type: 'boolean', value: false, description: 'Add -G flag to nvcc for CUDA device debug info')
 
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')

--- a/src/api/gpu/ucx/nixl_device.cuh
+++ b/src/api/gpu/ucx/nixl_device.cuh
@@ -117,7 +117,7 @@ nixlGpuGetXferStatus(nixlGpuXferStatusH &xfer_status) {
  * @return NIXL_ERR_BACKEND An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
-__device__ nixl_status_t
+__device__ nixl_status_t __forceinline__
 nixlPut(const nixlMemViewElem &src,
         const nixlMemViewElem &dst,
         size_t size,
@@ -157,7 +157,7 @@ nixlPut(const nixlMemViewElem &src,
  * @return NIXL_ERR_BACKEND An error occurred in UCX backend.
  */
 template<nixl_gpu_level_t level = nixl_gpu_level_t::THREAD>
-__device__ nixl_status_t
+__device__ nixl_status_t __forceinline__
 nixlAtomicAdd(uint64_t value,
               const nixlMemViewElem &counter,
               unsigned channel_id = 0,
@@ -188,7 +188,7 @@ nixlAtomicAdd(uint64_t value,
 
  * @return Pointer to the mapped memory, or nullptr if not available.
  */
-__device__ inline void *
+__device__ __forceinline__ void *
 nixlGetPtr(nixlMemViewH mvh, size_t index) {
     auto mem_list = static_cast<ucp_device_remote_mem_list_h>(mvh);
     void *ptr = nullptr;


### PR DESCRIPTION
## What?

This PR enables building and running NIXL (including nixl_ep) with CUDA **device debug** (`nvcc -G`).

It adds:

- A Meson option `-Dnvcc_device_debug=true` that passes `-G` (and host debug symbols where needed for nixl_ep).
- Targeted `__forceinline__` on selected UCX device helpers so debug builds still link.
- A compile-time workaround for a cooperative grid sync hang under `-G` (`NIXL_EP_GRID_SYNC_PRESYNC()` → `__syncthreads()` only when device debug is enabled).

## Why?

Device-level debugging with **cuda-gdb** and similar tools helps NIXL developers investigate GPU-side behavior in nixl_ep and the UCX device API path.

Today, enabling `-G` is impractical: builds can fail (register / nvlink limits) or runs can hang at `cg::this_grid().sync()`. This PR removes those blockers so debug builds are usable while keeping release behavior unchanged.

## How?

Two main issues had to be addressed when adding `-G`:

### 1. Register pressure and inlining

With `-G`, the compiler often **does not inline** functions that are inlined under normal optimization. That increased register usage and led to **nvlink** failures (e.g. entry kernels with a low register limit calling `nixlGetPtr` and similar helpers as separate functions with much higher register counts).

We added `__forceinline__` on a small set of hot device functions (`nixlPut`, `nixlAtomicAdd`, `nixlGetPtr`, and `p2p_ptr_get` in nixl_ep) after confirming they are inlined in non-`-G` builds, so release performance should be unaffected. 

This trades slightly less convenient single-step debugging in those few call sites for a build that actually completes and can be debugged at all.

### 2. Hang in `cg::this_grid().sync()` under `-G`

The second issue is an **inherent problem** the cooperative-groups call `cg::this_grid().sync()` with `-G` enabled. In the send/recv path in `nixl_ep_ll.cu`, we observed hangs around this grid sync(more precisely, CTA threads got stuck on this sync op, while the other completed it).
By our analysis, there appears to be a bug in that sync path (not resolved in the newer CUDA versions we tested). In our view, it is related to the fact that, under `-G`, barriers inside this function can end up associated with the **same instruction addresses** in the generated code, which can cause "confusion" between CTA-level participation and warp-level threads.
This class of issue has been reported several times in NVBUGS to the relevant teams; so far we have not seen a satisfactory fix in CUDA. We also explored a solution that would require changes in the cooperative_groups library itself, which is out of scope for the NIXL project.
We found that calling another sync primitive—**`__syncthreads()`**—immediately before `cg::this_grid().sync()` avoids the hang. To avoid affecting performance in normal builds, that extra sync is only compiled in when `-Dnvcc_device_debug=true` is passed to Meson (via `NIXL_EP_GRID_SYNC_PRESYNC()`). We consider this a **temporary** workaround until the CUDA team provides a permanent fix; we are publishing this PR now so others can use device debugging in the meantime.
## Build and run

**Meson option:** `nvcc_device_debug` (boolean, default: `false`)

**Release build (unchanged):**

```bash
meson setup build -Dbuild_nixl_ep=true -Dbuildtype=release <other required options, e.g. -Ducx_path=...>
ninja -C build
ninja -C build install
```
**Device debug build(-G):**
```bash
meson setup build -Dbuild_nixl_ep=true -Dnvcc_device_debug=true <other required options, e.g. -Ducx_path=...>
ninja -C build
ninja -C build install
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CUDA device debug compilation mode to the build system, enabling detailed device-level debugging and information collection.

* **Refactor**
  * Optimized performance of device kernel functions through compiler directive improvements.
  * Enhanced kernel synchronization mechanisms with conditional debug support.
  * Updated build system configuration for improved device debugging workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->