### PR TITLE
CI: support building NIXL container with custom DOCA from source

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -43,6 +43,9 @@ credentials:
   - credentialsId: 'svc-nixl-new-artifactory-token'
     usernameVariable: 'ARTIFACTORY_USERNAME'
     passwordVariable: 'ARTIFACTORY_PASSWORD'
+  - credentialsId: 'nbu-swx_gitlab_token'
+    usernameVariable: 'GITLAB_USERNAME'
+    passwordVariable: 'GITLAB_TOKEN'
 
 pipeline_start:
   shell: action
@@ -57,6 +60,7 @@ pipeline_start:
     echo "ENABLE_NIXLBENCH_BUILD: ${env.ENABLE_NIXLBENCH_BUILD}"
     echo "BUILD_TARGET: ${params.BUILD_TARGET}"
     echo "BUILD_NIXL_EP: ${params.BUILD_NIXL_EP}"
+    echo "DOCA_VERSION: ${params.DOCA_VERSION}"
 
 # Build pipeline
 steps:
@@ -99,6 +103,16 @@ steps:
           NIXL_EP_FLAG="--build-nixl-ep"
       fi
 
+      # Optionally build against a custom DOCA.
+      DOCA_FLAG=""
+      if [[ "${DOCA_VERSION}" != "upstream" ]]; then
+          echo "Cloning custom DOCA (ref: ${DOCA_VERSION})"
+          rm -rf "$WORKSPACE/doca-src"
+          git clone "https://${GITLAB_USERNAME}:${GITLAB_TOKEN}@gitlab-master.nvidia.com/storage/doca.git" "$WORKSPACE/doca-src"
+          git -C "$WORKSPACE/doca-src" checkout "${DOCA_VERSION}"
+          DOCA_FLAG="--doca $WORKSPACE/doca-src"
+      fi
+
       "contrib/build-container.sh" \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_IMAGE_TAG}" \
@@ -106,7 +120,8 @@ steps:
         --arch "${arch}" \
         --build-type debug \
         --no-cache \
-        ${NIXL_EP_FLAG}
+        ${NIXL_EP_FLAG} \
+        ${DOCA_FLAG}
 
   - name: Add Version Info
     containerSelector: "{name: 'podman'}"
@@ -227,6 +242,7 @@ pipeline_stop:
                 <p>Build Target: <b>${params.BUILD_TARGET}</b></p>
                 <p>NIXL Version: <b>${params.NIXL_VERSION}</b></p>
                 <p>UCX Version: <b>${params.UCX_VERSION}</b></p>
+                <p>DOCA Version: <b>${params.DOCA_VERSION}</b></p>
                 <p>Base Image: <b>${params.BASE_IMAGE}:${params.BASE_IMAGE_TAG}</b></p>
                 <p>Architectures: <b>x86_64, aarch64</b></p>
                 ${params.UPDATE_LATEST ? '<p>Latest tag updated: <b>Yes</b></p>' : ''}

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -378,6 +378,10 @@
           default: "v1.21.x"
           description: "UCX version to use (tag like v1.21.x, branch name, or commit hash)"
       - string:
+          name: "DOCA_VERSION"
+          default: "upstream"
+          description: "DOCA version to use (tag like v3.2.0, branch name, or commit hash)"
+      - string:
           name: "BASE_IMAGE"
           default: "nvcr.io/nvidia/cuda-dl-base"
           description: "Base Docker image for the container build"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -17,27 +17,12 @@ ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
 ARG OS
 
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
+# DOCA source selection:
+#   upstream - install DOCA from the public DOCA host repo packages (default)
+#   custom   - build DOCA from source provided via the `doca` build-context
+ARG DOCA="upstream"
 
-# Set default OS if not provided
-ARG OS=${OS:-ubuntu24}
-ARG ARCH="x86_64"
-ARG DEFAULT_PYTHON_VERSION="3.12"
-ARG UCX_REF="v1.21.x"
-ARG BUILD_NIXL_EP="true"
-ARG RDMA_CORE_PREFIX="/usr"
-ARG UCX_PREFIX="/usr"
-ARG UCX_PLUGIN_DIR="$UCX_PREFIX/lib/ucx"
-ARG DOCA_PREFIX="/opt/mellanox/doca"
-ARG NIXL_PREFIX="/usr/local/nixl"
-ARG NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/$ARCH-linux-gnu/plugins"
-ARG NPROC
-ARG WHL_DEFAULT_PYTHON_VERSIONS="3.12"
-ARG LIBFABRIC_VERSION="v1.21.0"
-ARG LIBFABRIC_INSTALL_PATH="/usr/local"
-ARG BUILD_TYPE="release"
-ARG ABSL_TAG="lts_2025_08_14"
-ARG GRPC_TAG="v1.73.0"
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS base
 
 # Install build dependencies from Ubuntu repository
 RUN apt-get update -y && \
@@ -70,6 +55,10 @@ RUN apt-get update -y && \
     # azure-sdk-for-cpp dependencies
     libxml2-dev
 
+# === DOCA variant: upstream (host repo packages only) ===
+FROM base AS doca_upstream_image
+RUN echo "INFO: Using DOCA from host repo packages (DOCA=upstream)."
+
 # Add DOCA repository and install packages
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
@@ -85,6 +74,54 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
     --reinstall libibverbs-dev rdma-core ibverbs-utils libibumad-dev \
     libnuma-dev librdmacm-dev ibverbs-providers
+
+# === DOCA variant: custom (build from source provided via the `doca` build-context) ===
+# The host repo packages installed in doca_base above still provide rdma-core,
+# libibverbs and libmlx5 (required by the gpunetio plugin); the source build
+# below overlays the custom doca-* libraries and headers into ${DOCA_PREFIX}.
+# NOTE: adjust the build invocation below to match the storage/doca build system.
+FROM doca_base AS doca_custom_image
+ARG DOCA_PREFIX="/opt/mellanox/doca"
+ARG DOCA_BUILD_TYPE="release"
+ARG NPROC
+RUN mkdir -p /workspace/doca-src
+COPY --from=doca . /workspace/doca-src
+RUN echo "INFO: Building custom DOCA from source into ${DOCA_PREFIX}..." && \
+    cd /workspace/doca-src && \
+    meson setup build/ \
+    -Ddisable_all_applications=true \
+    -Ddisable_all_samples=false \
+    -Ddisable_all_tools=true \
+    -Ddisable_all_services=true \
+    -Ddisable_all_extensions=true \
+    -Denable_grpc_support=false \
+    -Denable_gpu_support=false \
+    -Dbuildtype=${DOCA_BUILD_TYPE} \
+    -Denable_libs=kv,argp \
+    -Dprefix=${DOCA_PREFIX} && \
+    cd build && \
+    ninja && \
+    ninja install
+
+# === Select the DOCA variant and continue the main build ===
+FROM doca_${DOCA}_image AS nixl_build
+
+ARG ARCH="x86_64"
+ARG DEFAULT_PYTHON_VERSION="3.12"
+ARG UCX_REF="v1.21.x"
+ARG BUILD_NIXL_EP="true"
+ARG RDMA_CORE_PREFIX="/usr"
+ARG UCX_PREFIX="/usr"
+ARG UCX_PLUGIN_DIR="$UCX_PREFIX/lib/ucx"
+ARG DOCA_PREFIX="/opt/mellanox/doca"
+ARG NIXL_PREFIX="/usr/local/nixl"
+ARG NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/$ARCH-linux-gnu/plugins"
+ARG NPROC
+ARG LIBFABRIC_VERSION="v1.21.0"
+ARG LIBFABRIC_INSTALL_PATH="/usr/local"
+ARG BUILD_TYPE="release"
+ARG ABSL_TAG="lts_2025_08_14"
+ARG GRPC_TAG="v1.73.0"
 
 WORKDIR /workspace
 

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -36,6 +36,7 @@ WHL_BASE=manylinux_2_39
 WHL_PLATFORM=${WHL_BASE}_${ARCH}
 WHL_PYTHON_VERSIONS="3.12"
 UCX_REF=${UCX_REF:-v1.21.x}
+DOCA_SRC=""
 BUILD_NIXL_EP="true"
 OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
@@ -127,6 +128,15 @@ get_options() {
         --build-nixl-ep)
             BUILD_NIXL_EP=true
             ;;
+        --doca)
+            if [ "$2" ]; then
+                DOCA_SRC=$2
+                BUILD_ARGS+="--build-context doca=$2 --build-arg DOCA=custom"
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
@@ -175,6 +185,11 @@ show_build_options() {
     echo "Python Versions for wheel build: ${WHL_PYTHON_VERSIONS}"
     echo "Wheel Platform: ${WHL_PLATFORM}"
     echo "UCX Ref: ${UCX_REF}"
+    if [ -n "$DOCA_SRC" ]; then
+        echo "DOCA: custom (source: ${DOCA_SRC})"
+    else
+        echo "DOCA: upstream (host repo packages)"
+    fi
     if [ "$BUILD_NIXL_EP" = "true" ]; then
         echo "NIXL EP: Enabled"
     else
@@ -195,6 +210,7 @@ show_help() {
     echo "  [--python-versions python versions to build for, comma separated]"
     echo "  [--ucx-ref ucx git reference (branch, tag, or sha)]"
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
+    echo "  [--doca path/to/doca/source/dir to build DOCA from source instead of host repo packages]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     exit 0


### PR DESCRIPTION
Add an optional custom DOCA build path alongside the default host-repo packages.

## What?
Adds an optional path to build the NIXL container against a **custom DOCA built from source** (from `gitlab-master.nvidia.com/storage/doca`), instead of only the public DOCA host-repo packages. Controlled end-to-end:
- `contrib/Dockerfile`: new `ARG DOCA` (`upstream`/`custom`) multi-stage selection; custom builds the `doca` build-context into `/opt/mellanox/doca`.
- `contrib/build-container.sh`: new `--doca <path>` flag.
- `build-container-matrix.yaml`: new `DOCA_CUSTOM`/`DOCA_VERSION` params + GitLab token credential to clone and pass `--doca`.

Defaults to existing upstream behavior when not requested.

## Why?
Lets us build/validate NIXL (gpunetio + DOCA-telemetry plugins) against in-development or patched DOCA revisions, not just the published release.

## How?
Mirrors the existing custom-UCX pattern. DOCA is cloned in CI and passed as a build-context. The custom stage inherits host-repo packages (for `rdma-core`/`libibverbs`/`libmlx5`) and overlays the custom `doca-*` libs into the same prefix `meson` already discovers — no NIXL build changes needed.