### PR TITLE
build-wheel.sh: extend auditwheel --exclude list for DDN partner libs

### DIFF
--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -91,18 +91,18 @@ fi
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
 if [ "$BUILD_NIXL_EP" = "true" ]; then
-    uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION \
+    uv build --wheel --out-dir "$TMP_DIR" --python $PYTHON_VERSION \
         -Csetup-args=-Dbuild_nixl_ep=true \
         -Csetup-args=-Dbuild_examples=true
 else
-    uv build --wheel --out-dir $TMP_DIR --python $PYTHON_VERSION
+    uv build --wheel --out-dir "$TMP_DIR" --python $PYTHON_VERSION
 fi
 
 # Bundle libraries
-mkdir $TMP_DIR/dist
-auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' --exclude 'libred_client*' --exclude 'libred_async*' --exclude 'liblz4*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
-./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $TMP_DIR/dist/*.whl
-cp $TMP_DIR/dist/*.whl $OUTPUT_DIR
+mkdir "$TMP_DIR/dist"
+auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' --exclude 'libred_client*' --exclude 'libred_async*' --exclude 'liblz4*' "$TMP_DIR"/nixl*.whl --plat "$WHL_PLATFORM" --wheel-dir "$TMP_DIR/dist"
+./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR "$TMP_DIR"/dist/*.whl
+cp "$TMP_DIR"/dist/*.whl $OUTPUT_DIR
 
 # Clean up
 rm -rf "$TMP_DIR"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -91,18 +91,18 @@ fi
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
 ./contrib/tomlutil.py --wheel-name $PKG_NAME pyproject.toml
 if [ "$BUILD_NIXL_EP" = "true" ]; then
-    uv build --wheel --out-dir "$TMP_DIR" --python $PYTHON_VERSION \
+    uv build --wheel --out-dir "$TMP_DIR" --python "$PYTHON_VERSION" \
         -Csetup-args=-Dbuild_nixl_ep=true \
         -Csetup-args=-Dbuild_examples=true
 else
-    uv build --wheel --out-dir "$TMP_DIR" --python $PYTHON_VERSION
+    uv build --wheel --out-dir "$TMP_DIR" --python "$PYTHON_VERSION"
 fi
 
 # Bundle libraries
 mkdir "$TMP_DIR/dist"
 auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' --exclude 'libred_client*' --exclude 'libred_async*' --exclude 'liblz4*' "$TMP_DIR"/nixl*.whl --plat "$WHL_PLATFORM" --wheel-dir "$TMP_DIR/dist"
-./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR "$TMP_DIR"/dist/*.whl
-cp "$TMP_DIR"/dist/*.whl $OUTPUT_DIR
+./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir "$UCX_PLUGINS_DIR" --nixl-plugins-dir "$NIXL_PLUGINS_DIR" "$TMP_DIR"/dist/*.whl
+cp "$TMP_DIR"/dist/*.whl "$OUTPUT_DIR"
 
 # Clean up
 rm -rf "$TMP_DIR"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -100,7 +100,7 @@ fi
 
 # Bundle libraries
 mkdir $TMP_DIR/dist
-auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
+auditwheel repair --exclude 'libcuda*' --exclude 'libcufile*' --exclude 'libssl*' --exclude 'libcrypto*' --exclude 'libefa*' --exclude 'libhwloc*' --exclude 'libfabric*' --exclude 'libtorch*' --exclude 'libc10*' --exclude 'libdoca*' --exclude 'libred_client*' --exclude 'libred_async*' --exclude 'liblz4*' $TMP_DIR/nixl*.whl --plat $WHL_PLATFORM --wheel-dir $TMP_DIR/dist
 ./contrib/wheel_add_ucx_plugins.py --ucx-plugins-dir $UCX_PLUGINS_DIR --nixl-plugins-dir $NIXL_PLUGINS_DIR $TMP_DIR/dist/*.whl
 cp $TMP_DIR/dist/*.whl $OUTPUT_DIR
 


### PR DESCRIPTION
## What?
Adds `libred_client*`, `libred_async*`, `liblz4*` to the `auditwheel repair --exclude` list in `contrib/build-wheel.sh`.

## Why?
The INFINIA backend plugin links against DDN's Infinia client runtime (`libred_client.so.2`, `libred_async.so`, `liblz4.so.1`). Without these excluded, `auditwheel` bundles them into the wheel — redistributing DDN-licensed binaries the operator is supposed to install separately, and pinning a specific DDN release inside the wheel against the `dlopen`-against-host-runtime design. 

The pattern matches existing exclude entries (`libcuda*`, `libcufile*`, `libdoca*`, etc.) — runtime libs the wheel delegates to the host. Generic; no DDN-specific identifiers in the diff.
  
## How?
Three additional `--exclude` glob patterns on the existing `auditwheel repair` line. The plugin `.so` itself (`libplugin_INFINIA.so`) is still bundled via `contrib/wheel_add_ucx_plugins.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Excluded additional native libraries from packaged wheels to reduce package size and avoid shipping incompatible system components.
  * Improved wheel packaging and path handling by ensuring build and intermediate paths are properly quoted, making builds more reliable and consistent across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->