### PR TITLE
nixlbench: Cover FILE_SEG path-mode

### DIFF
--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -57,6 +57,8 @@ run_nixlbench_one_worker() {
 
 for op_type in READ WRITE; do
     run_nixlbench_one_worker --backend POSIX --op_type $op_type --check_consistency
+    run_nixlbench_one_worker --backend POSIX --op_type $op_type \
+        --check_consistency --storage_enable_path_mode
 done
 
 if $HAS_GPU ; then

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -480,6 +480,7 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 --filepath PATH            # File path for storage operations
 --num_files NUM            # Number of files used by benchmark (default: 1)
 --storage_enable_direct    # Enable direct I/O for storage operations
+--storage_enable_path_mode # Use NIXL path-mode FILE registration (encode open spec in metaInfo; the backend opens/owns the fd). FILE_SEG backends only (POSIX, GDS, GDS_MT). Default off.
 ```
 
 #### Backend-Specific Options

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -113,6 +113,7 @@ NB_ARG_STRING(filepath, "", "File path for storage operations");
 NB_ARG_STRING(filenames, "", "Comma-separated filenames for storage operations");
 NB_ARG_INT32(num_files, 1, "Number of files used by benchmark");
 NB_ARG_BOOL(storage_enable_direct, false, "Enable direct I/O for storage operations");
+NB_ARG_BOOL(storage_enable_path_mode, false, "Use NIXL path-mode FILE registration");
 
 // GDS options - only used when backend is GDS
 NB_ARG_INT32(gds_batch_pool_size,
@@ -285,6 +286,7 @@ int xferBenchConfig::posix_kernel_queue_size = 0;
 std::string xferBenchConfig::filepath = "";
 std::string xferBenchConfig::filenames = "";
 bool xferBenchConfig::storage_enable_direct = false;
+bool xferBenchConfig::storage_enable_path_mode = false;
 bool xferBenchConfig::reregister_mem = false;
 bool xferBenchConfig::prepared_xfer = false;
 int xferBenchConfig::pipeline_depth = 1;
@@ -512,6 +514,7 @@ xferBenchConfig::loadParams(void) {
     num_files = NB_ARG(num_files);
     posix_api_type = NB_ARG(posix_api_type);
     storage_enable_direct = NB_ARG(storage_enable_direct);
+    storage_enable_path_mode = isFileSegBackend() && NB_ARG(storage_enable_path_mode);
     recreate_xfer = NB_ARG(recreate_xfer);
     reregister_mem = NB_ARG(reregister_mem);
     prepared_xfer = NB_ARG(prepared_xfer);
@@ -757,6 +760,8 @@ xferBenchConfig::printConfig() {
             printOption("Number of files (--num_files=N)", std::to_string(num_files));
             printOption("Storage enable direct (--storage_enable_direct=[0,1])",
                         std::to_string(storage_enable_direct));
+            printOption("Storage enable path mode (--storage_enable_path_mode=[0,1])",
+                        std::to_string(storage_enable_path_mode));
         }
 
         // Print DOCA GPUNetIO options if backend is DOCA GPUNetIO
@@ -833,6 +838,12 @@ xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+};
+
+bool
+xferBenchConfig::isFileSegBackend() {
+    return isStorageBackend() && !isObjStorageBackend() &&
+        XFERBENCH_BACKEND_GUSLI != xferBenchConfig::backend;
 };
 
 
@@ -1073,6 +1084,26 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
                         ssize_t rc = pread(fd, addr, len, iov.addr);
                         if (rc < 0) {
                             std::cerr << "Failed to read from GUSLI device: " << it->device_path
+                                      << " with error: " << strerror(errno) << std::endl;
+                            close(fd);
+                            exit(EXIT_FAILURE);
+                        }
+                        close(fd);
+                    } else if (xferBenchConfig::storage_enable_path_mode) {
+                        // Path mode: devId is synthetic, not an fd -- open by the metaInfo path.
+                        auto colon = iov.metaInfo.find(':');
+                        std::string path = (colon == std::string::npos) ?
+                            iov.metaInfo :
+                            iov.metaInfo.substr(colon + 1);
+                        int fd = open(path.c_str(), O_RDONLY);
+                        if (fd < 0) {
+                            std::cerr << "Failed to open path-mode file: " << path
+                                      << " with error: " << strerror(errno) << std::endl;
+                            exit(EXIT_FAILURE);
+                        }
+                        ssize_t rc = pread(fd, addr, len, iov.addr);
+                        if (rc < 0) {
+                            std::cerr << "Failed to read from path-mode file: " << path
                                       << " with error: " << strerror(errno) << std::endl;
                             close(fd);
                             exit(EXIT_FAILURE);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -187,6 +187,7 @@ public:
     static int posix_ios_pool_size;
     static int posix_kernel_queue_size;
     static bool storage_enable_direct;
+    static bool storage_enable_path_mode;
     static bool reregister_mem;
     static bool prepared_xfer;
     static int pipeline_depth;
@@ -234,6 +235,8 @@ public:
     isStorageBackend();
     static bool
     isObjStorageBackend();
+    static bool
+    isFileSegBackend();
 
 protected:
     static int

--- a/benchmark/nixlbench/src/worker/nixl/nixl_mem_region.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_mem_region.h
@@ -57,13 +57,15 @@ struct xferFileState {
     int fd = -1;
     uint64_t file_size = 0;
     uint64_t offset = 0;
+    std::string filename;
 
     xferFileState() = default;
 
-    xferFileState(int fd, uint64_t file_size, uint64_t offset) noexcept
+    xferFileState(int fd, uint64_t file_size, uint64_t offset, std::string filename = {}) noexcept
         : fd(fd),
           file_size(file_size),
-          offset(offset) {}
+          offset(offset),
+          filename(std::move(filename)) {}
 
     ~xferFileState() {
         closeFd();
@@ -72,7 +74,8 @@ struct xferFileState {
     xferFileState(xferFileState &&o) noexcept
         : fd(std::exchange(o.fd, -1)),
           file_size(o.file_size),
-          offset(o.offset) {}
+          offset(o.offset),
+          filename(std::move(o.filename)) {}
 
     xferFileState &
     operator=(xferFileState &&o) noexcept {
@@ -81,6 +84,7 @@ struct xferFileState {
             fd = std::exchange(o.fd, -1);
             file_size = o.file_size;
             offset = o.offset;
+            filename = std::move(o.filename);
         }
         return *this;
     }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -691,7 +691,7 @@ openFileWithFlags(const std::string &file_name, int flags) {
         return std::nullopt;
     }
 
-    return xferFileState{fd, file_size, 0};
+    return xferFileState{fd, file_size, 0, file_name};
 }
 
 // Create file descriptors from explicit filenames or auto-generate
@@ -749,12 +749,33 @@ createFileFds(std::string name, int num_files, const std::vector<std::string> &f
     return fds;
 }
 
+// Make path-mode string (flags)*:path
+static std::string
+pathModeMetaInfo(const std::string &filename) {
+    std::string modes = (XFERBENCH_OP_READ == xferBenchConfig::op_type) ? "ro" : "rw,create";
+    if (xferBenchConfig::storage_enable_direct) {
+        modes += ",direct";
+    }
+    return modes + ":" + filename;
+}
+
 std::optional<xferBenchIOV>
-xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id) {
+xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, xferFileState &fstate, int file_idx) {
     int fd = fstate.fd;
     uint64_t start_offset = fstate.offset;
     uint64_t end_offset = fstate.offset + buffer_size;
-    auto ret = std::optional<xferBenchIOV>(std::in_place, fstate.offset, buffer_size, fd);
+
+    std::optional<xferBenchIOV> ret;
+    if (xferBenchConfig::storage_enable_path_mode) {
+        // Path mode: spec in metaInfo, backend owns fd; synthetic per-file devId (file_idx+1).
+        ret = std::optional<xferBenchIOV>(std::in_place,
+                                          start_offset,
+                                          buffer_size,
+                                          file_idx + 1,
+                                          pathModeMetaInfo(fstate.filename));
+    } else {
+        ret = std::optional<xferBenchIOV>(std::in_place, start_offset, buffer_size, fd);
+    }
 
     fstate.offset = end_offset;
 
@@ -1056,7 +1077,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             std::vector<xferBenchIOV> iov_list;
             for (i = 0; i < num_devices; i++) {
                 std::optional<xferBenchIOV> basic_desc;
-                basic_desc = initBasicDescFile(buffer_size, remote_fds[file_idx], i);
+                basic_desc = initBasicDescFile(buffer_size, remote_fds[file_idx], file_idx);
                 if (basic_desc) {
                     iov_list.push_back(basic_desc.value());
                 }
@@ -1093,7 +1114,9 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
 
             if (basic_desc) {
-                if (!remote_regs_.empty()) {
+                // Don't copy a path spec onto DRAM/VRAM -- it'd be mis-parsed on a non-FILE_SEG
+                // register.
+                if (!remote_regs_.empty() && !xferBenchConfig::storage_enable_path_mode) {
                     basic_desc.value().metaInfo = remote_regs_[list_idx].iovs()[i].metaInfo;
                 }
                 iov_list.push_back(basic_desc.value());
@@ -1234,7 +1257,14 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                     xferBenchIOV iov_remote(iov);
                     iov_remote.addr = file_offset;
                     iov_remote.len = block_size;
-                    iov_remote.devId = remote_fds[fd_idx].fd;
+                    // Path mode: devId (file_idx+1) must match registration; re-attach metaInfo for
+                    // --check_consistency.
+                    if (xferBenchConfig::storage_enable_path_mode) {
+                        iov_remote.devId = static_cast<int>(fd_idx + 1);
+                        iov_remote.metaInfo = pathModeMetaInfo(remote_fds[fd_idx].filename);
+                    } else {
+                        iov_remote.devId = remote_fds[fd_idx].fd;
+                    }
                     remote_iov_list.push_back(iov_remote);
                     fd_idx++;
                     if (fd_idx >= remote_fds.size()) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -74,7 +74,7 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::optional<xferBenchIOV>
         initBasicDescVram(size_t buffer_size, int mem_dev_id);
         std::optional<xferBenchIOV>
-        initBasicDescFile(size_t buffer_size, xferFileState &fstate, int mem_dev_id);
+        initBasicDescFile(size_t buffer_size, xferFileState &fstate, int file_idx);
         std::optional<xferBenchIOV>
         initBasicDescObj(size_t buffer_size, int mem_dev_id, std::string name);
         std::optional<xferBenchIOV>


### PR DESCRIPTION
## What?
First commit: Add a --storage_enable_path_mode flag to `nixlbench` that switches the FILE_SEG storage path to NIXL path-mode registration. Use it in CI.

Second commit: Add a microbenchmark that works like NIXL is used in SGLang and shows the speedup of using the path mode in that scenario

Fixes #1730

## Why?

The path-mode was merged, but without nixlbench coverage

## How?

First commit: Follows how POSIX was tested in nixlbench.

Second commit: A self-contained python microbenchmark. 

## Notes:

As far as i know, we have no CI or nixlbench coverage for GDS, GDS_MT or even h3fs. We really should test at least GDS and GDS_MT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional path-mode support for storage-backed file segments via `--storage_enable_path_mode` (default: off).
* **Documentation**
  * Updated NIXLBench CLI documentation to describe `--storage_enable_path_mode` and its applicable backends.
* **Tests**
  * Updated the benchmark consistency script to include `--storage_enable_path_mode` for storage-backed READ/WRITE validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->