### PR TITLE
Default UCX error handling mode to none

### DIFF
--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -143,6 +143,9 @@ class nixl_thread_sync_t(Enum):
         agent creation, can be initialized with create_backend.
 @param sync_mode Thread synchronization mode to use for the agent.
         If None, sync_mode is set based on the enable_listen flag.
+@param ucx_error_handling_mode Error handling mode for UCX and OBJ backend endpoints.
+        String value; valid values are "none" (default) and "peer".
+        Invalid values, including None, raise ValueError.
 """
 
 
@@ -156,6 +159,7 @@ class nixl_agent_config:
         num_threads: int = 0,
         backends: list[str] = ["UCX"],
         sync_mode: Optional[nixl_thread_sync_t] = None,
+        ucx_error_handling_mode: str = "none",
     ):
         # TODO: add backend init parameters
         self.backends = backends
@@ -164,6 +168,12 @@ class nixl_agent_config:
         self.port = listen_port
         self.capture_telemetry = capture_telemetry
         self.num_threads = num_threads
+        if ucx_error_handling_mode not in ("none", "peer"):
+            raise ValueError(
+                "ucx_error_handling_mode must be 'none' or 'peer' "
+                f"(got {ucx_error_handling_mode!r})"
+            )
+        self.ucx_error_handling_mode = ucx_error_handling_mode
         if sync_mode is not None and not isinstance(sync_mode, nixl_thread_sync_t):
             raise TypeError(
                 f"sync_mode must be a nixl_thread_sync_t (got {type(sync_mode).__name__!r})"
@@ -216,6 +226,7 @@ class nixl_agent:
         self.agent = nixlBind.nixlAgent(agent_name, agent_config)
 
         self.name = agent_name
+        self.ucx_error_handling_mode = nixl_conf.ucx_error_handling_mode
         self._leaked_xfer_handles: list[int] = []
         self.notifs: dict[str, list[bytes]] = {}
         self.backends: dict[str, nixl_backend_handle] = {}
@@ -243,7 +254,7 @@ class nixl_agent:
                 # TODO: improve population of init from nixl_conf
                 init: dict[str, str] = {}
                 if nixl_conf.num_threads > 0:
-                    if bknd == "UCX" or bknd == "OBJ":
+                    if bknd in ("UCX", "OBJ"):
                         init["num_threads"] = str(nixl_conf.num_threads)
                     elif bknd == "GDS_MT":
                         init["thread_count"] = str(nixl_conf.num_threads)
@@ -379,7 +390,14 @@ class nixl_agent:
     @param initParams Dictionary of initialization parameters.
     """
 
-    def create_backend(self, backend: str, initParams: dict[str, str] = {}):
+    def create_backend(
+        self, backend: str, initParams: Optional[dict[str, str]] = None
+    ) -> None:
+        if initParams is None:
+            initParams = {}
+        if backend in ("UCX", "OBJ") and "ucx_error_handling_mode" not in initParams:
+            initParams = initParams.copy()
+            initParams["ucx_error_handling_mode"] = self.ucx_error_handling_mode
         self.backends[backend] = self.agent.createBackend(backend, initParams)
 
         (backend_options, mem_types) = self.agent.getBackendParams(

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -817,7 +817,7 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
         num_workers = num_threads + 1;
     }
 
-    ucp_err_handling_mode_t err_handling_mode = UCP_ERR_HANDLING_MODE_PEER;
+    ucp_err_handling_mode_t err_handling_mode = UCP_ERR_HANDLING_MODE_NONE;
     if (const auto opt = nixl::getBackendParamOptional<std::string>(
             custom_params, std::string(nixl_ucx_err_handling_param_name))) {
         err_handling_mode = ucx_err_mode_from_string(*opt);

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -36,7 +36,7 @@ get_ucx_backend_common_options() {
     nixl_b_params_t params = {{"ucx_devices", ""}, {"num_workers", "1"}};
 
     params.emplace(nixl_ucx_err_handling_param_name,
-                   ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));
+                   ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_NONE));
     return params;
 }
 

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -23,8 +23,8 @@
 
 namespace gtest {
 namespace nixl {
-    constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
-    constexpr const char* ucx_err_handling_mode_peer = "peer";
+    constexpr const char *ucx_err_handling_mode_key = "ucx_error_handling_mode";
+    constexpr const char *ucx_err_handling_mode_none = "none";
 
     static nixlBackendH *
     createUcxBackend(nixlAgent &agent,
@@ -43,7 +43,7 @@ namespace nixl {
         EXPECT_EQ(NIXL_SUCCESS, status);
 
         nixlBackendH* backend_handle = nullptr;
-        EXPECT_EQ(ucx_err_handling_mode_peer, params[ucx_err_handling_mode_key]);
+        EXPECT_EQ(ucx_err_handling_mode_none, params[ucx_err_handling_mode_key]);
         params["num_workers"] = std::to_string(num_workers);
         params["num_threads"] = std::to_string(num_threads);
         // If threadpool is configured always force split

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -128,6 +128,71 @@ def test_nixl_conf_bad_sync_mode():
         nixl_agent_config(sync_mode=1)
 
 
+@pytest.mark.parametrize(
+    ("configured_mode", "expected_mode"),
+    [
+        ("none", "none"),
+        ("peer", "peer"),
+    ],
+)
+def test_ucx_error_handling_mode_config(monkeypatch, configured_mode, expected_mode):
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    class FakeAgent:
+        def getAvailPlugins(self) -> list[str]:
+            return ["UCX"]
+
+        def createBackend(self, backend: str, init_params: dict[str, str]) -> int:
+            captured.append((backend, init_params.copy()))
+            return 0
+
+        def getBackendParams(self, backend: int) -> tuple[dict[str, str], list[str]]:
+            return {}, []
+
+    monkeypatch.setattr(bindings, "nixlAgent", lambda agent_name, config: FakeAgent())
+    config = nixl_agent_config(
+        backends=["UCX"], ucx_error_handling_mode=configured_mode
+    )
+    agent = nixl_agent(str(uuid.uuid4()), nixl_conf=config)
+    agent.create_backend("UCX", {})
+
+    assert len(captured) == 2
+    assert captured[0][1]["ucx_error_handling_mode"] == expected_mode
+    assert captured[1][1]["ucx_error_handling_mode"] == expected_mode
+
+
+def test_ucx_error_handling_mode_user_override(monkeypatch):
+    captured: list[tuple[str, dict[str, str]]] = []
+
+    class FakeAgent:
+        def getAvailPlugins(self) -> list[str]:
+            return ["UCX"]
+
+        def createBackend(self, backend: str, init_params: dict[str, str]) -> int:
+            captured.append((backend, init_params.copy()))
+            return 0
+
+        def getBackendParams(self, backend: int) -> tuple[dict[str, str], list[str]]:
+            return {}, []
+
+    monkeypatch.setattr(bindings, "nixlAgent", lambda agent_name, config: FakeAgent())
+    config = nixl_agent_config(backends=[], ucx_error_handling_mode="none")
+    agent = nixl_agent(str(uuid.uuid4()), nixl_conf=config)
+    agent.create_backend("UCX", {"ucx_error_handling_mode": "peer"})
+
+    assert len(captured) == 1
+    assert captured[0][1]["ucx_error_handling_mode"] == "peer"
+
+
+@pytest.mark.parametrize("invalid_mode", ["invalid", None])
+def test_ucx_error_handling_mode_invalid(invalid_mode):
+    with pytest.raises(
+        ValueError,
+        match="ucx_error_handling_mode must be 'none' or 'peer'",
+    ):
+        nixl_agent_config(ucx_error_handling_mode=invalid_mode)
+
+
 def test_make_invalid_op(one_empty_agent, two_xfer_lists):
     # Only READ/WRITE are supported
     with pytest.raises(KeyError):


### PR DESCRIPTION
## Summary

Default UCX error handling mode to `none` and keep `peer` available as an explicit opt-in.

This applies consistently across:

- the UCX backend fallback when `ucx_error_handling_mode` is not supplied
- the UCX plugin's advertised default backend parameter
- Python `nixl_agent_config`, including Python auto-instantiated backends and explicit Python `create_backend(..., initParams)` calls

## Motivation

NIXL already supports the `ucx_error_handling_mode` init parameter with two valid values: `"none"` and `"peer"`. This PR makes `"none"` the default everywhere and keeps `"peer"` configurable for users who want UCX peer-failure semantics.

Historical context:

- #280 added the `ucx_error_handling_mode` backend parameter and initially exposed `"none"` as the default plugin parameter.
- #499 changed the generic UCX default to `"peer"`.
- NIXL's GPU/device EP path still explicitly uses `"none"` today in `examples/device/ep/csrc/nixl_ep.cpp`:

```cpp
init_params["ucx_error_handling_mode"] = "none";
```

This PR intentionally reverts the default part of #499 while preserving configurability. `peer` is still supported and can be requested explicitly from C++ or Python.

UCX itself documents `UCP_ERR_HANDLING_MODE_NONE` as the endpoint default and the minimal-overhead mode. `UCP_ERR_HANDLING_MODE_PEER` provides stronger remote failure guarantees, but it may affect performance/memory footprint and has protocol/API constraints. For GPU-serving and containerized environments, especially where sysfs or network-device visibility can be restricted by the runtime, `none` is the safer default for backend creation and matches the existing NIXL EP usage.

This also avoids downstream patches for Python consumers:

- vLLM's NIXL connector creates the UCX backend through `nixl_agent_config` auto-instantiation.
- SGLang's NIXL paths create an agent with `backends=[]` and then call `create_backend(..., initParams)` explicitly.

The Python wrapper stores the configured mode on the agent and applies it from Python `create_backend()` when the caller has not already supplied `ucx_error_handling_mode` in `initParams`, so both patterns are covered.

## Behavior

- UCX backend missing-param default is `ucx_error_handling_mode="none"`
- UCX plugin advertised default is `ucx_error_handling_mode="none"`
- Python `nixl_agent_config` default is `ucx_error_handling_mode="none"`
- `ucx_error_handling_mode="peer"` explicitly requests peer mode
- only `"none"` and `"peer"` are accepted by the Python config; invalid values, including `None`, raise `ValueError`
- explicit `initParams["ucx_error_handling_mode"]` passed to Python `create_backend()` takes precedence over the config default

## Testing

- `python -m py_compile src/api/python/_api.py test/python/test_nixl_api.py`
- `pre-commit run --files src/api/python/_api.py test/python/test_nixl_api.py test/gtest/error_handling.cpp src/plugins/ucx/ucx_backend.cpp src/plugins/ucx/ucx_utils.cpp`
- Focused pytest against the edited Python source with a temporary fake `_bindings` module:
  - `test_ucx_error_handling_mode_config`
  - `test_ucx_error_handling_mode_user_override`
  - `test_ucx_error_handling_mode_invalid`
  - Result: `5 passed, 1 warning`

The updated tests cover default injection, explicit `none`, explicit `peer`, user-provided `initParams` precedence, and invalid config validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable UCX error-handling mode for backend initialization ("none" default, "peer" supported)
  * Per-backend overrides allowed when creating a backend

* **Changed Behavior**
  * Default UCX error-handling mode changed from "peer" to "none"

* **Bug Fixes / Validation**
  * Input now validated; invalid values raise an error

* **Tests**
  * Added tests covering mode propagation, per-call overrides, and invalid-value handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->