### PR TITLE
nixlbench: verify storage WRITE consistency via transport read-back

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -127,7 +127,8 @@ static int processBatchSizes(xferBenchWorker &worker,
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
 
-            if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
+            if (!xferBenchUtils::validateTransfer(
+                    false, worker, local_trans_lists, local_trans_lists)) {
                 return EXIT_FAILURE;
             }
             if (IS_PAIRWISE_AND_SG()) {
@@ -144,7 +145,8 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return 1;
             }
 
-            if (!xferBenchUtils::validateTransfer(true, local_trans_lists, remote_trans_lists)) {
+            if (!xferBenchUtils::validateTransfer(
+                    true, worker, local_trans_lists, remote_trans_lists)) {
                 return EXIT_FAILURE;
             }
 

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -39,6 +39,7 @@
 #include "runtime/etcd/etcd_rt.h"
 #include "utils/neuron.h"
 #include "utils/utils.h"
+#include "worker/worker.h"
 
 // Define command line parameters
 #define NB_ARG_STRING(param_name, def_val, help_text) DEFINE_string(param_name, def_val, help_text)
@@ -573,6 +574,14 @@ xferBenchConfig::loadParams(void) {
     }
 
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {
+        // The NVSHMEM worker does not implement verifyWriteByReadback(), so a
+        // storage backend (which routes WRITE consistency through it) would fall
+        // back to the base implementation and silently fail. Reject the combo.
+        if (isStorageBackend()) {
+            std::cerr << "Error: NVSHMEM worker does not support storage backends" << std::endl;
+            std::cerr << "Hint: use --worker_type nixl for storage backends" << std::endl;
+            return -1;
+        }
         if (!((XFERBENCH_SEG_TYPE_VRAM == initiator_seg_type) &&
               (XFERBENCH_SEG_TYPE_VRAM == target_seg_type) && (1 == num_threads) &&
               (1 == num_initiator_dev) && (1 == num_target_dev) &&
@@ -1131,6 +1140,7 @@ xferBenchUtils::checkConsistency(std::vector<std::vector<xferBenchIOV>> &iov_lis
 
 bool
 xferBenchUtils::validateTransfer(bool is_initiator,
+                                 xferBenchWorker &worker,
                                  std::vector<std::vector<xferBenchIOV>> &local_lists,
                                  std::vector<std::vector<xferBenchIOV>> &remote_lists) {
     if (!xferBenchConfig::check_consistency) {
@@ -1142,7 +1152,12 @@ xferBenchUtils::validateTransfer(bool is_initiator,
             return checkConsistency(local_lists);
         } else if (xferBenchConfig::op_type == XFERBENCH_OP_WRITE) {
             if (xferBenchConfig::isStorageBackend()) {
-                return checkConsistency(remote_lists);
+                // Verify the write by reading the objects back over the
+                // transport into the local buffers and comparing in memory.
+                // This works for backends that materialize no local file
+                // (object-over-RDMA), and avoids the download-to-local-storage
+                // round-trip the file path would otherwise take.
+                return worker.verifyWriteByReadback(local_lists, remote_lists);
             }
         }
     } else {

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -347,6 +347,8 @@ public:
           metaInfo(m) {}
 };
 
+class xferBenchWorker;
+
 class xferBenchUtils {
 private:
     static xferBenchRT *rt;
@@ -390,6 +392,7 @@ public:
     checkConsistency(std::vector<std::vector<xferBenchIOV>> &desc_lists);
     static bool
     validateTransfer(bool is_initiator,
+                     xferBenchWorker &worker,
                      std::vector<std::vector<xferBenchIOV>> &local_lists,
                      std::vector<std::vector<xferBenchIOV>> &remote_lists);
     static void

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -55,7 +55,9 @@ resolveVramSegment() {
 #elif HAVE_ROCM
     return VRAM_SEG;
 #else
-    if (neuronCoreCount() > 0) return VRAM_SEG;
+    if (neuronCoreCount() > 0) {
+        return VRAM_SEG;
+    }
     std::cerr << "VRAM not supported without CUDA, ROCm or Neuron" << std::endl;
     std::exit(EXIT_FAILURE);
 #endif
@@ -330,9 +332,9 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
 }
 
 xferBenchNixlWorker::~xferBenchNixlWorker() {
-    remote_regs_.clear();
+    remoteRegs_.clear();
     remote_fds.clear();
-    local_regs_.clear();
+    localRegs_.clear();
 
     delete rt;
     rt = nullptr;
@@ -790,7 +792,9 @@ xferBenchNixlWorker::initBasicDescFile(size_t buffer_size, xferFileState &fstate
         write_ptr += rc;
     }
 
-    if (end_offset > fstate.file_size) fstate.file_size = end_offset;
+    if (end_offset > fstate.file_size) {
+        fstate.file_size = end_offset;
+    }
 
     return ret;
 }
@@ -863,7 +867,9 @@ xferBenchNixlWorker::initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t
 bool
 xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &device, size_t size) {
     int flags = O_RDWR | O_CREAT | O_LARGEFILE;
-    if (xferBenchConfig::storage_enable_direct) flags |= O_DIRECT;
+    if (xferBenchConfig::storage_enable_direct) {
+        flags |= O_DIRECT;
+    }
 
     int fd = open(device.device_path.c_str(), flags, 0744);
     if (fd < 0) {
@@ -985,7 +991,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
             nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, OBJ_SEG);
             CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
-            remote_regs_.emplace_back(*agent, backend_engine, OBJ_SEG, std::move(iov_list));
+            remoteRegs_.emplace_back(*agent, backend_engine, OBJ_SEG, std::move(iov_list));
         }
     } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
         // GUSLI backend uses block device descriptors
@@ -1016,7 +1022,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
             nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, BLK_SEG);
             CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
-            remote_regs_.emplace_back(*agent, backend_engine, BLK_SEG, std::move(iov_list));
+            remoteRegs_.emplace_back(*agent, backend_engine, BLK_SEG, std::move(iov_list));
         }
     } else if (xferBenchConfig::isStorageBackend()) {
         int num_buffers = num_threads * num_devices;
@@ -1061,11 +1067,13 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
                     iov_list.push_back(basic_desc.value());
                 }
                 file_idx += 1;
-                if (file_idx >= num_files) file_idx = 0;
+                if (file_idx >= num_files) {
+                    file_idx = 0;
+                }
             }
             nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, FILE_SEG);
             CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
-            remote_regs_.emplace_back(*agent, backend_engine, FILE_SEG, std::move(iov_list));
+            remoteRegs_.emplace_back(*agent, backend_engine, FILE_SEG, std::move(iov_list));
         }
     }
 
@@ -1093,8 +1101,12 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             }
 
             if (basic_desc) {
-                if (!remote_regs_.empty()) {
-                    basic_desc.value().metaInfo = remote_regs_[list_idx].iovs()[i].metaInfo;
+                // Copy the remote metaInfo only when this exact (list_idx, i) slot
+                // exists: earlier paths can skip failed descriptors, so a non-empty
+                // remoteRegs_ does not guarantee the index is in bounds.
+                if (static_cast<size_t>(list_idx) < remoteRegs_.size() &&
+                    static_cast<size_t>(i) < remoteRegs_[list_idx].iovs().size()) {
+                    basic_desc.value().metaInfo = remoteRegs_[list_idx].iovs()[i].metaInfo;
                 }
                 iov_list.push_back(basic_desc.value());
             }
@@ -1103,7 +1115,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, seg_type);
         CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
 
-        local_regs_.emplace_back(*agent, backend_engine, seg_type, iov_list);
+        localRegs_.emplace_back(*agent, backend_engine, seg_type, iov_list);
 
         /*
          * Workaround for a GUSLI registration bug which resets memory to 0, this initialization
@@ -1111,7 +1123,7 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
          * here to avoid memsetting the memory again.
          */
         if (seg_type == DRAM_SEG && xferBenchConfig::check_consistency) {
-            for (auto &iov : local_regs_.back().iovs()) {
+            for (auto &iov : localRegs_.back().iovs()) {
                 if (isInitiator()) {
                     memset((void *)iov.addr, XFERBENCH_INITIATOR_BUFFER_ELEMENT, iov.len);
                 } else if (isTarget()) {
@@ -1131,10 +1143,10 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
     // Ordering: deregister remote regions before local ones
     // (remote registrations may reference local buffers).
     // NixlMemRegion::release() handles deregisterMem + per-IOV cleanup.
-    remote_regs_.clear();
+    remoteRegs_.clear();
     // xferFileState RAII closes backing fds after deregistrations complete.
     remote_fds.clear();
-    local_regs_.clear();
+    localRegs_.clear();
     iov_lists.clear();
 }
 
@@ -1335,6 +1347,175 @@ getRemoteSegType() {
     return GET_SEG_TYPE(false);
 }
 
+// Fill a transfer buffer with a single byte. For VRAM the fill targets the
+// device that owns the buffer, so multi-GPU runs poison the right device.
+static void
+fillTransferBuffer(nixl_mem_t seg_type, uintptr_t addr, size_t len, uint8_t value, int dev_id) {
+    if (seg_type != VRAM_SEG) {
+        std::memset(reinterpret_cast<void *>(addr), value, len);
+        return;
+    }
+    if (neuronCoreCount() > 0) {
+        std::vector<uint8_t> src(len, value);
+        CHECK_NEURON_ERROR(
+            neuronMemcpy(reinterpret_cast<void *>(addr), src.data(), len, neuronMemcpyHostToDevice),
+            "fillTransferBuffer: neuronMemcpy failed");
+        return;
+    }
+#if HAVE_CUDA
+    CHECK_CUDA_ERROR(cudaSetDevice(dev_id), "fillTransferBuffer: cudaSetDevice failed");
+    CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(addr), value, len),
+                     "fillTransferBuffer: cudaMemset failed");
+#elif HAVE_ROCM
+    CHECK_CUDA_ERROR(hipSetDevice(dev_id), "fillTransferBuffer: hipSetDevice failed");
+    CHECK_CUDA_ERROR(hipMemset(reinterpret_cast<void *>(addr), value, len),
+                     "fillTransferBuffer: hipMemset failed");
+#else
+    (void)dev_id;
+    std::cerr << "VRAM consistency check needs CUDA, ROCm or Neuron" << std::endl;
+    exit(EXIT_FAILURE);
+#endif
+}
+
+// Return a host-readable view of a transfer buffer. DRAM is returned in place;
+// VRAM is copied from its owning device into host_scratch (never dereferenced
+// as host memory directly).
+static const uint8_t *
+hostView(nixl_mem_t seg_type,
+         uintptr_t addr,
+         size_t len,
+         std::vector<uint8_t> &host_scratch,
+         int dev_id) {
+    if (seg_type != VRAM_SEG) {
+        return reinterpret_cast<const uint8_t *>(addr);
+    }
+    host_scratch.resize(len);
+    if (neuronCoreCount() > 0) {
+        CHECK_NEURON_ERROR(
+            neuronMemcpy(
+                host_scratch.data(), reinterpret_cast<void *>(addr), len, neuronMemcpyDeviceToHost),
+            "hostView: neuronMemcpy failed");
+        return host_scratch.data();
+    }
+#if HAVE_CUDA
+    CHECK_CUDA_ERROR(cudaSetDevice(dev_id), "hostView: cudaSetDevice failed");
+    CHECK_CUDA_ERROR(
+        cudaMemcpy(
+            host_scratch.data(), reinterpret_cast<void *>(addr), len, cudaMemcpyDeviceToHost),
+        "hostView: cudaMemcpy failed");
+#elif HAVE_ROCM
+    CHECK_CUDA_ERROR(hipSetDevice(dev_id), "hostView: hipSetDevice failed");
+    CHECK_CUDA_ERROR(
+        hipMemcpy(host_scratch.data(), reinterpret_cast<void *>(addr), len, hipMemcpyDeviceToHost),
+        "hostView: hipMemcpy failed");
+#else
+    (void)dev_id;
+    std::cerr << "VRAM consistency check needs CUDA, ROCm or Neuron" << std::endl;
+    exit(EXIT_FAILURE);
+#endif
+    return host_scratch.data();
+}
+
+// Verify a storage WRITE without touching local disk.
+//
+// The data has just been written to the remote backend. Rather than download
+// the object to a local file and re-read it (the file/device path other storage
+// backends use), read the objects back over the same transport into the
+// initiator buffers and compare them to the byte the initiator wrote
+// (XFERBENCH_INITIATOR_BUFFER_ELEMENT). This verifies the round-trip end to end
+// and needs no local copy, so it also covers backends that materialize none.
+//
+// The buffers are poisoned with a different byte first, so a read that moves
+// nothing is caught instead of passing by coincidence. `local_lists` are the
+// initiator buffers; `remote_lists` the matching object descriptors.
+bool
+xferBenchNixlWorker::verifyWriteByReadback(std::vector<std::vector<xferBenchIOV>> &local_lists,
+                                           std::vector<std::vector<xferBenchIOV>> &remote_lists) {
+    constexpr uint8_t poison = 0x00;
+    static_assert(poison != XFERBENCH_INITIATOR_BUFFER_ELEMENT,
+                  "poison value must differ from the initiator sentinel");
+
+    if (local_lists.size() != remote_lists.size()) {
+        std::cerr << "verifyWriteByReadback: list count mismatch (" << local_lists.size()
+                  << " local vs " << remote_lists.size() << " remote)" << std::endl;
+        return false;
+    }
+
+    bool pass = true;
+    for (size_t list_idx = 0; list_idx < local_lists.size(); list_idx++) {
+        if (local_lists[list_idx].size() != remote_lists[list_idx].size()) {
+            std::cerr << "verifyWriteByReadback: descriptor count mismatch in list " << list_idx
+                      << std::endl;
+            return false;
+        }
+
+        for (const auto &iov : local_lists[list_idx]) {
+            fillTransferBuffer(seg_type, iov.addr, iov.len, poison, iov.devId);
+        }
+
+        nixl_xfer_dlist_t local_desc(seg_type);
+        nixl_xfer_dlist_t remote_desc(getRemoteSegType());
+        prepareTransferDescriptors(
+            local_desc, remote_desc, local_lists[list_idx], remote_lists[list_idx]);
+
+        std::string target = xferBenchConfig::isStorageBackend() ? "initiator" : "target";
+        nixl_opt_args_t params;
+        nixlXferReqH *req = nullptr;
+        nixl_status_t rc =
+            agent->createXferReq(NIXL_READ, local_desc, remote_desc, target, req, &params);
+        if (NIXL_SUCCESS != rc) {
+            std::cerr << "verifyWriteByReadback: createXferReq failed for list " << list_idx
+                      << std::endl;
+            return false;
+        }
+        rc = agent->postXferReq(req);
+        if (NIXL_SUCCESS != rc && NIXL_IN_PROG != rc) {
+            std::cerr << "verifyWriteByReadback: postXferReq failed for list " << list_idx
+                      << std::endl;
+            agent->releaseXferReq(req);
+            return false;
+        }
+        // Bounded wait: a stalled backend/peer must not hang the benchmark, and
+        // the terminal status is preserved so a transport failure is reported as
+        // such rather than misattributed to a data mismatch in the check below.
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (NIXL_IN_PROG == (rc = agent->getXferStatus(req))) {
+            if ((rt && !rt->areAllPeersAlive()) || std::chrono::steady_clock::now() >= deadline) {
+                std::cerr << "verifyWriteByReadback: read-back timed out for list " << list_idx
+                          << std::endl;
+                agent->releaseXferReq(req);
+                return false;
+            }
+        }
+        agent->releaseXferReq(req);
+        if (NIXL_SUCCESS != rc) {
+            std::cerr << "verifyWriteByReadback: read-back failed for list " << list_idx << ": "
+                      << nixlEnumStrings::statusStr(rc) << std::endl;
+            return false;
+        }
+
+        size_t iov_idx = 0;
+        for (const auto &iov : local_lists[list_idx]) {
+            std::vector<uint8_t> host_scratch;
+            const uint8_t *bytes = hostView(seg_type, iov.addr, iov.len, host_scratch, iov.devId);
+            for (size_t b = 0; b < iov.len; b++) {
+                if (bytes[b] != XFERBENCH_INITIATOR_BUFFER_ELEMENT) {
+                    std::cerr << "Consistency check failed for iov " << list_idx << ":" << iov_idx
+                              << " at byte " << b << std::endl;
+                    pass = false;
+                    break;
+                }
+            }
+            iov_idx++;
+        }
+    }
+
+    if (!pass) {
+        std::cerr << "Consistency check failed" << std::endl;
+    }
+    return pass;
+}
+
 // Register local and remote memory with the agent.
 static nixl_status_t
 registerIterationMem(nixlAgent *agent,
@@ -1354,6 +1535,8 @@ registerIterationMem(nixlAgent *agent,
         nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
         rc = agent->registerMem(remote_reg, &reg_args);
         if (rc != NIXL_SUCCESS) {
+            // Unwind the local registration so a partial failure leaves nothing pinned.
+            agent->deregisterMem(local_reg, &reg_args);
             return rc;
         }
     }
@@ -1372,19 +1555,18 @@ deregisterIterationMem(nixlAgent *agent,
 
     nixl_reg_dlist_t local_reg = iovListToNixlRegDlist(local_iov, GET_SEG_TYPE(true));
     nixl_status_t rc = agent->deregisterMem(local_reg, &reg_args);
-    if (rc != NIXL_SUCCESS) {
-        return rc;
-    }
 
+    // Always attempt the remote deregistration even if the local one failed, so a
+    // partial teardown does not leak the remote registration. Surface the first error.
     if (xferBenchConfig::isStorageBackend()) {
         nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
-        rc = agent->deregisterMem(remote_reg, &reg_args);
-        if (rc != NIXL_SUCCESS) {
-            return rc;
+        const nixl_status_t remote_rc = agent->deregisterMem(remote_reg, &reg_args);
+        if (rc == NIXL_SUCCESS) {
+            rc = remote_rc;
         }
     }
 
-    return NIXL_SUCCESS;
+    return rc;
 }
 
 // Per-slot state for execTransferLoop. A slot owns its slice of the IOV

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -40,8 +40,8 @@ class xferBenchNixlWorker: public xferBenchWorker {
         nixlBackendH* backend_engine;
         nixl_mem_t seg_type;
         std::vector<xferFileState> remote_fds;
-        std::vector<NixlMemRegion> remote_regs_;
-        std::vector<NixlMemRegion> local_regs_;
+        std::vector<NixlMemRegion> remoteRegs_;
+        std::vector<NixlMemRegion> localRegs_;
         std::vector<GusliDeviceConfig> gusli_devices;
 
     public:
@@ -67,6 +67,10 @@ class xferBenchNixlWorker: public xferBenchWorker {
         transfer(size_t block_size,
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
+
+        bool
+        verifyWriteByReadback(std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
+                              std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
     private:
         std::optional<xferBenchIOV>

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -63,6 +63,20 @@ class xferBenchWorker {
         transfer(size_t block_size,
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) = 0;
+
+        // Consistency check for a storage WRITE: read the written data back
+        // over the transport into the local buffers and compare to the
+        // initiator sentinel. Lets backends that materialize no local file
+        // (e.g. object-over-RDMA) verify --check_consistency in memory instead
+        // of downloading the object to local storage and re-reading it.
+        // Default: unsupported (storage backends are driven by the NIXL worker).
+        virtual bool
+        verifyWriteByReadback(std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
+                              std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
+            (void)local_iov_lists;
+            (void)remote_iov_lists;
+            return false;
+        }
 };
 
 #endif // NIXL_BENCHMARK_NIXLBENCH_SRC_WORKER_WORKER_H


### PR DESCRIPTION
## What

`--check_consistency` verifies a storage WRITE by reading the written data back
and comparing it to the initiator's known fill byte. Today that read-back comes
from local storage: object backends download the object to a temporary file and
`pread` it; block/file backends `pread` the device or file directly.

This adds an alternative: read the data back **over the transport** into the
original buffers, and route the storage WRITE case through it under the same
`--check_consistency` flag.

## Why

For a backend whose transfer is a pure memory movement over the network, nothing
is written to a local file or device, so there is no local copy to read back —
the file path doesn't apply. And even where a local copy could be produced,
materializing the object on local storage just to validate it adds disk I/O that
the transfer under test never performs, and ends up checking that copy rather
than the path the data actually took.

Reading the data back over the same transport avoids both. It needs no local
storage, and it verifies the round-trip end to end (buffer → backend → buffer),
which is the path the benchmark is exercising. It also keeps a single
verification path instead of per-backend assumptions about where bytes land on
disk, so a memory-transport backend gets consistency checking without a
local-file or device special case.

## How

- New `xferBenchWorker::verifyWriteByReadback()` (default: unsupported). The NIXL
  worker implements it: fill the local buffers with a poison byte, issue a
  `NIXL_READ` of the same descriptors back into them, then compare to
  `XFERBENCH_INITIATOR_BUFFER_ELEMENT`. The poison ensures a read that moves
  nothing fails rather than passing by coincidence. It reuses
  `prepareTransferDescriptors` / `getRemoteSegType`, so OBJ/FILE/BLK remote
  segments and DRAM/VRAM local buffers are handled the same way as a normal
  transfer.
- `validateTransfer()` now takes the `worker` and routes the storage WRITE case
  to it. READ, target, and non-storage paths are unchanged.

This does change how a storage WRITE is verified (read-back instead of a
local-file/device read). Happy to scope it differently — e.g. gate it behind an
option — if that's preferred.

## Testing

Built NIXL + nixlbench from this branch. Ran `--check_consistency=1` on a storage
WRITE across a block-size sweep: a correct transfer passes, and an injected byte
mismatch is reported and fails the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional write-verification flow that performs a readback into provided local buffers and compares bytes against expected sentinels.
  * Introduced a worker/back-end hook so storage backends can enable readback-based consistency checks.
  * Implemented the verification for the NIXL backend, including mismatch detection with logged first differing byte and appropriate handling for VRAM-backed buffers.
  * If a backend doesn’t support the hook, write verification remains unsupported by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->