### PR TITLE
obj: add standard-protocol GPU-direct S3-over-RDMA (accelerated=true)

### DIFF
--- a/src/plugins/obj/RDMA_PROTOCOL.md
+++ b/src/plugins/obj/RDMA_PROTOCOL.md
@@ -1,0 +1,152 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# S3-over-RDMA Wire Protocol
+
+This document specifies the GPU-direct S3-over-RDMA protocol the object plugin
+speaks, so that **any S3-compatible storage vendor can comply on the server side
+without NIXL-specific code**. The control plane stays standard HTTP + SigV4,
+while the object payload moves out-of-band over RDMA. A server that implements
+the contract below works with this client when the caller opts in via
+`accelerated=true` (the standard-S3 engine; no `type`, or `type=s3`).
+
+**Provenance.** The `x-amz-rdma-*` header names and the token layout come
+directly from NVIDIA's published [cuObject documentation][cuobj] (the
+client-side API and the RDMA-enabled GET/PUT workflow). The wire protocol was
+written up as a spec ([aws-c-s3 `RDMA_PROTOCOL_SPEC.md`][spec]) and proposed to
+AWS. It is not yet GA'ed by AWS; however AWS refined it inline with what they
+could eventually implement, so it is a stable, vendor-neutral base to
+standardize on rather than an endpoint-specific convention.
+
+[cuobj]: https://docs.nvidia.com/gpudirect-storage/cuobject/index.html
+[spec]: https://github.com/KiranModukuri/aws-c-s3/blob/nvidia_rdma/RDMA_PROTOCOL_SPEC.md
+
+The standard-S3 engine is the **preferred** GPU-direct path: it follows this
+proposed protocol and needs no per-vendor code, so it works against any
+conformant server. Vendor `type=...` engines exist only for servers that speak a
+vendor's own RDMA headers.
+
+> The client treats RDMA as an explicit opt-in and does **not** auto-fall-back to
+> HTTP today (see the README's "No automatic fallback (yet)"). A compliant server
+> signals an unsupported request with `x-amz-rdma-reply: 501`, but a
+> _non_-compliant server may silently ignore the token and accept a body-less PUT
+> as a 0-byte object — so auto-fallback becomes safe only once the `501` contract
+> below is universal.
+
+The reference server implementation is MinIO AIStor (`internal/rdma`, repo at
+`../aistor`).
+
+## Transport
+
+- RDMA **Dynamically Connected (DC)** transport over **InfiniBand** or
+  **RoCEv2** (cuObject protocol `CUOBJ_PROTO_RDMA_DC_V1`).
+- **GET**: the server issues `RDMA_WRITE`, pushing object bytes directly into the
+  client's registered buffer (host DRAM or GPU VRAM).
+- **PUT** / **UploadPart**: the server issues `RDMA_READ`, pulling bytes directly
+  out of the client's registered buffer.
+- The HTTP request/response body is **empty**; payload never traverses it.
+
+## Headers
+
+| Header                                   | Direction        | Meaning                                                                                                                                                                                                                               |
+| ---------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x-amz-rdma-token`                       | request          | RDMA negotiation token (see format below). Its presence is what marks a request as RDMA.                                                                                                                                              |
+| `x-amz-content-sha256: UNSIGNED-PAYLOAD` | request          | Body is not signed (there is no body).                                                                                                                                                                                                |
+| `Content-Length: 0`                      | request (PUT)    | No HTTP body; data is delivered via `RDMA_READ`.                                                                                                                                                                                      |
+| `Range: bytes=a-b`                       | request (GET)    | Optional; selects a byte range (server replies `206`).                                                                                                                                                                                |
+| `x-amz-checksum-crc64nvme`               | request/response | Optional CRC64NVME checksum (PUT/UploadPart).                                                                                                                                                                                         |
+| `x-amz-rdma-reply`                       | response         | Outcome marker. **Required on success.** `200`/`204`/`206` = success; `501` (or absent) = server declined RDMA. Under `accelerated=true` the client treats a decline as a hard error (no automatic HTTP fallback today — see README). |
+| `x-amz-rdma-bytes-transferred`           | response (GET)   | Actual bytes moved over RDMA (may be `< requested` for ranged GETs).                                                                                                                                                                  |
+| `ETag`, `x-amz-checksum-crc64nvme`       | response (PUT)   | Standard S3 result metadata.                                                                                                                                                                                                          |
+
+### Token format
+
+```text
+x-amz-rdma-token: <descriptor>:<start_addr_hex>:<size_hex>
+```
+
+- `<descriptor>` — the opaque, fixed-length RDMA descriptor minted by the
+  client's RDMA provider (cuObject `cuMemObjGetRDMAToken`); it encodes the
+  registered buffer's base address, max size, remote key and NIC routing
+  (GID/LID/DCTN). The server splits it off (it is a known fixed length) and
+  forwards exactly those bytes to its own RDMA provider (cuObjServer); it must
+  not interpret them.
+- `<start_addr_hex>` — client buffer start address for this operation, 16-digit
+  lowercase hex.
+- `<size_hex>` — transfer size in bytes, 16-digit lowercase hex.
+
+Appending the per-operation start address and size to the descriptor mirrors
+cuObject's own **IO descriptor** layout (its reference server reads
+`<descriptor><rem_buf_start>…<rem_msg_size>…`); it is not an endpoint-specific
+addition. Because the HTTP body is empty (`Content-Length: 0`), the token is the
+only place these per-request fields can travel. The two trailing fields are
+`:`-separated and base-16; the server splits them off the end and treats the
+remaining prefix as the descriptor. A trailing `;` (some clients append one)
+must be tolerated.
+
+## Request flow (server obligations)
+
+1. **Authenticate** the request with standard SigV4. `x-amz-rdma-token` is part
+   of the signed headers; `x-amz-content-sha256` is `UNSIGNED-PAYLOAD`.
+2. **Detect** an RDMA request by the presence of `x-amz-rdma-token`; parse it
+   into `(descriptor, start_addr, size)`.
+3. **Decide** whether RDMA can be honored (fabric reachable, buffer registrable,
+   object/permissions valid).
+   - **If not** → respond `x-amz-rdma-reply: 501`. You MAY include a normal HTTP
+     error body (do not force `Content-Length: 0`). The `501` signal is what lets
+     a client safely decide what to do; today this client treats it as an error
+     under `accelerated=true` (it does not auto-retry over HTTP — see README), but the
+     signal is required so future clients can fall back transparently.
+4. **Transfer** using the cuObject server APIs (register a local buffer, then):
+   - GET / RANGE_GET → `RDMA_WRITE` the requested bytes into the client buffer.
+   - PUT / UploadPart → `RDMA_READ` the bytes from the client buffer and persist
+     them as the object/part.
+5. **Respond** on success:
+   - `x-amz-rdma-reply: 200` (full GET/PUT), `204` (PUT, no content), or `206`
+     (ranged GET partial).
+   - `x-amz-rdma-bytes-transferred: <n>` for GET.
+   - `Content-Length: 0` and **no HTTP body** (the data went over RDMA — without
+     this the client blocks waiting for body bytes that never arrive).
+   - `ETag` (and `x-amz-checksum-crc64nvme` if requested) for PUT.
+
+## Completion semantics
+
+`x-amz-rdma-reply` is **not** a strict requirement on the PUT success path — it
+is an outcome marker the server is free to use:
+
+- **PUT success:** the server completes the `RDMA_READ` and returns a standard
+  HTTP `200` + `ETag` (the body is empty; data moved out-of-band). The client
+  treats `200` + a non-empty `ETag` as success. AIStor does not set
+  `x-amz-rdma-reply` on this path, and a client must not require it.
+- **GET success:** the server returns `x-amz-rdma-reply: 200/206` and
+  `x-amz-rdma-bytes-transferred` (the authoritative moved-byte count); the HTTP
+  body is empty.
+- **Decline:** `x-amz-rdma-reply: 501` (or its absence on a non-RDMA server)
+  signals the request was not honored over RDMA.
+
+The data path's integrity is covered by RoCEv2 iCRC and, when requested, the
+`x-amz-checksum-crc64nvme` header — not by the (empty) HTTP-body content hash.
+
+## Multipart uploads
+
+UploadPart uses the same body-less, token-carrying PUT with the standard
+`?uploadId=<id>&partNumber=<n>` query parameters (`1 ≤ n ≤ 10000`). The part's
+`ETag`/checksum are returned as usual; CompleteMultipartUpload is an ordinary
+HTTP call.
+
+## Compliance checklist
+
+- [ ] Parse `x-amz-rdma-token` as `<descriptor>:<addr16>:<size16>` (tolerate a
+      trailing `;`).
+- [ ] Authenticate with SigV4 treating the body as `UNSIGNED-PAYLOAD`.
+- [ ] GET ⇒ `RDMA_WRITE` into the client buffer; PUT ⇒ `RDMA_READ` from it.
+- [ ] Always set `x-amz-rdma-reply` (`200`/`204`/`206`) on success, `501` to decline.
+- [ ] Set `x-amz-rdma-bytes-transferred` on GET; force `Content-Length: 0` with
+      no body on every success.
+- [ ] Return `ETag`/checksum for PUT; honor `Range` for GET (`206`).
+- [ ] Fall through to normal HTTP semantics for non-RDMA requests.
+
+A vendor that satisfies this checklist is supported by the NIXL object plugin's
+default S3 client automatically — no NIXL-side engine or plugin is required.

--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -43,6 +43,7 @@ git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1
 ### Optional Dependencies
 
 **S3 Accelerated Engines** (`cuobjclient-13.1`): Required for GPU-direct and accelerated object storage operations. When available, enables:
+
 - `S3AccelObjEngineImpl` - Base accelerated S3 engine
 - Vendor-specific accelerated implementations under `s3_accel/`
 
@@ -56,30 +57,30 @@ The Object Storage backend supports configuration through two mechanisms: backen
 
 Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creating the backend instance. The Object Storage backend supports AWS S3-compatible storage and accepts the following parameters:
 
-| Parameter | Description | Default | Required |
-|-----------|-------------|---------|----------|
-| `access_key` | AWS access key ID for authentication | - | No* |
-| `secret_key` | AWS secret access key for authentication | - | No* |
-| `session_token` | AWS session token for temporary credentials | - | No |
-| `bucket` | S3 bucket name for operations | - | Yes** |
-| `endpoint_override` | Custom S3 endpoint URL | - | No*** |
-| `scheme` | HTTP scheme (`http` or `https`) | `https` | No |
-| `region` | AWS region for the S3 service | `us-east-1` | No |
-| `use_virtual_addressing` | Use virtual-hosted-style addressing (`true`/`false`) | `false` | No |
-| `req_checksum` | Request checksum validation (`required`/`supported`) | - | No |
-| `resp_checksum` | Response checksum validation (`required`/`supported`) | - | No |
-| `ca_bundle` | path to a custom certificate bundle | - | No |
-| `crtMinLimit` | Minimum object size (bytes) to use S3 CRT client for high-performance transfers | Disabled**** | No |
-| `accelerated` | Enable S3 Accelerated engine (`true`/`false`) | `false` | No |
-| `type` | Accelerated engine type (`dell`, etc.) | - | No |
+| Parameter                | Description                                                                                                                                                                                                                                                                                         | Default          | Required |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- |
+| `access_key`             | AWS access key ID for authentication                                                                                                                                                                                                                                                                | -                | No\*     |
+| `secret_key`             | AWS secret access key for authentication                                                                                                                                                                                                                                                            | -                | No\*     |
+| `session_token`          | AWS session token for temporary credentials                                                                                                                                                                                                                                                         | -                | No       |
+| `bucket`                 | S3 bucket name for operations                                                                                                                                                                                                                                                                       | -                | Yes\*\*  |
+| `endpoint_override`      | Custom S3 endpoint URL                                                                                                                                                                                                                                                                              | -                | No\*\*\* |
+| `scheme`                 | HTTP scheme (`http` or `https`)                                                                                                                                                                                                                                                                     | `https`          | No       |
+| `region`                 | AWS region for the S3 service                                                                                                                                                                                                                                                                       | `us-east-1`      | No       |
+| `use_virtual_addressing` | Use virtual-hosted-style addressing (`true`/`false`)                                                                                                                                                                                                                                                | `false`          | No       |
+| `req_checksum`           | Request checksum validation (`required`/`supported`)                                                                                                                                                                                                                                                | -                | No       |
+| `resp_checksum`          | Response checksum validation (`required`/`supported`)                                                                                                                                                                                                                                               | -                | No       |
+| `ca_bundle`              | path to a custom certificate bundle                                                                                                                                                                                                                                                                 | -                | No       |
+| `crtMinLimit`            | Minimum object size (bytes) to use S3 CRT client for high-performance transfers                                                                                                                                                                                                                     | Disabled\*\*\*\* | No       |
+| `accelerated`            | Enable GPU-direct S3-over-RDMA (`true`/`false`). With no `type` (or `type=s3`), selects the standard-S3, protocol-compliant engine using the standard `x-amz-rdma-*` headers. Opt-in; requires an endpoint that implements the protocol. See [GPU-Direct (S3 over RDMA)](#gpu-direct-s3-over-rdma). | `false`          | No       |
+| `type`                   | Accel engine type. Omit (or set `s3`) for the vendor-neutral standard-protocol engine; `dell` selects a vendor-specific Dell engine that uses the vendor-specific `x-rdma-info` header.                                                                                                             | -                | No       |
 
 \* If `access_key` and `secret_key` are not provided, the AWS SDK will attempt to use default credential providers (IAM roles, environment variables, credential files, etc.)
 
-\** If `bucket` parameter is not provided, the `AWS_DEFAULT_BUCKET` environment variable will be used as fallback.
+\*\* If `bucket` parameter is not provided, the `AWS_DEFAULT_BUCKET` environment variable will be used as fallback.
 
-\*** If `endpoint_override` parameter is not provided, the `AWS_ENDPOINT_OVERRIDE` environment variable will be used as fallback.
+\*\*\* If `endpoint_override` parameter is not provided, the `AWS_ENDPOINT_OVERRIDE` environment variable will be used as fallback.
 
-\**** If `crtMinLimit` is not provided, the S3 CRT client is disabled and all transfers use the standard S3 client. When set, objects with size >= `crtMinLimit` will use the high-performance CRT client, while smaller objects continue to use the standard client. Recommended value: 10485760 (10 MB) or higher for optimal performance on large objects.
+\*\*\*\* If `crtMinLimit` is not provided, the S3 CRT client is disabled and all transfers use the standard S3 client. When set, objects with size >= `crtMinLimit` will use the high-performance CRT client, while smaller objects continue to use the standard client. Recommended value: 10485760 (10 MB) or higher for optimal performance on large objects.
 
 Setting `crtMinLimit` also configures the CRT client's `partSize` and `multipartUploadThreshold` to the same value, ensuring multipart upload (MPU) is always used for transfers routed to the CRT client. Note that AWS S3 enforces a **5 MiB minimum part size** for all parts except the last: if `crtMinLimit` is set below 5 MiB (5,242,880 bytes), the CRT SDK will silently clamp the part size to 5 MiB and log a warning, but MPU still activates at `crtMinLimit`. Objects smaller than 5 MiB uploaded via MPU will be sent as a single-part multipart upload, which S3 allows. To avoid the silent clamp and warning, use `crtMinLimit >= 5242880`.
 
@@ -87,22 +88,22 @@ Setting `crtMinLimit` also configures the CRT client's `partSize` and `multipart
 
 The following environment variables are supported for Object Storage configuration:
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `AWS_DEFAULT_BUCKET` | Default S3 bucket name when not specified in parameters | `my-default-bucket` |
+| Variable                | Description                                             | Example                 |
+| ----------------------- | ------------------------------------------------------- | ----------------------- |
+| `AWS_DEFAULT_BUCKET`    | Default S3 bucket name when not specified in parameters | `my-default-bucket`     |
 | `AWS_ENDPOINT_OVERRIDE` | Custom S3 endpoint URL when not specified in parameters | `http://localhost:9000` |
 
 Standard AWS SDK environment variables are also supported when credentials are not provided via backend parameters. For a complete list and detailed documentation, see the [AWS CLI Environment Variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) documentation.
 
 Common AWS SDK environment variables include:
 
-| Variable | Description |
-|----------|-------------|
-| `AWS_ACCESS_KEY_ID` | AWS access key ID |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
-| `AWS_SESSION_TOKEN` | AWS session token for temporary credentials |
-| `AWS_REGION` | Default AWS region |
-| `AWS_PROFILE` | AWS credential profile to use |
+| Variable                | Description                                 |
+| ----------------------- | ------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`     | AWS access key ID                           |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key                       |
+| `AWS_SESSION_TOKEN`     | AWS session token for temporary credentials |
+| `AWS_REGION`            | Default AWS region                          |
+| `AWS_PROFILE`           | AWS credential profile to use               |
 
 ### Configuration Priority
 
@@ -215,6 +216,58 @@ This configuration automatically uses the high-performance S3 CRT client for obj
 
 > **Part size and the 5 MiB floor**: AWS S3 requires a minimum part size of 5 MiB for all parts except the last. If `crtMinLimit` is set below 5 MiB, the CRT SDK silently clamps the part size to 5 MiB (logging a warning) while still triggering multipart at `crtMinLimit`. Objects smaller than 5 MiB are uploaded as a single-part multipart request, which S3 permits. The 5 MiB minimum is an AWS service constraint and cannot be bypassed. To avoid the silent clamp, use `crtMinLimit >= 5242880` (5 MiB).
 
+## GPU-Direct (S3 over RDMA)
+
+When built against the `cuobjclient` library, run on a host with an RDMA fabric
+(InfiniBand or RoCEv2), and **explicitly enabled with `accelerated=true`** (with
+no `type`, or `type=s3`), the standard S3 client accelerates GET/PUT using
+**GPU-direct S3 over RDMA**. This standard-S3 engine speaks the standard
+`x-amz-rdma-*` protocol and works against any compliant endpoint; enable it only
+against an endpoint you know implements the protocol:
+
+> **Use the standard-S3 engine (preferred).** `accelerated=true` with no `type`
+> (or `type=s3`) is the recommended GPU-direct path: it complies with the proposed
+> S3-over-RDMA protocol (`x-amz-rdma-*`) and needs no per-vendor code, so it works
+> against any conformant server. The vendor `type=...` engines (e.g. `type=dell`)
+> are vendor-specific engines for servers that speak a vendor's own RDMA headers.
+
+```cpp
+nixl_b_params_t params = {
+    {"bucket", "models"}, {"endpoint_override", "http://aistor:9000"},
+    {"accelerated", "true"}
+};
+agent.createBackend("obj", params);
+```
+
+> **Why opt-in and not auto-detected?** See
+> [Explicit opt-in; no automatic fallback (yet)](#explicit-opt-in-no-automatic-fallback-yet).
+>
+> **GPUDirect topology note:** RDMA into/out of GPU VRAM requires the GPU and the
+> RDMA NIC to share a PCIe path that permits peer DMA. On some systems GPU 0 sits
+> behind a bridge/ACS configuration that blocks this (the NIC's `RDMA_READ` of
+> GPU 0 memory fails with `IBV_WC_REM_OP_ERR`), while the other GPUs work. Select
+> a topology-compatible GPU for the buffer (e.g. via `CUDA_VISIBLE_DEVICES`);
+> `nvidia-smi topo -m` shows NIC↔GPU affinity (`PIX`/`NODE` are RDMA-friendly,
+> `SYS` crosses NUMA). This is a host/fabric property, independent of nixl.
+
+### How it works
+
+The standard-S3 engine pins DRAM/VRAM buffers for RDMA on `registerMem`
+(cuObject `cuMemObjGetDescriptor`), then on each transfer mints a per-op token
+and issues a body-less, SigV4 `UNSIGNED-PAYLOAD` GET/PUT carrying
+`x-amz-rdma-token`. The server moves the bytes directly to/from the registered
+buffer (including GPU VRAM) via `RDMA_WRITE` (GET) / `RDMA_READ` (PUT),
+bypassing the host CPU and the HTTP body. It is an **explicit opt-in**: an RDMA
+decline/failure is a hard error, not a silent HTTP fallback, since
+`accelerated=true` asserts the endpoint speaks the protocol (VRAM is always
+RDMA-only — the SDK cannot stream a GPU pointer).
+
+The full wire contract — headers, token format, transport, server obligations,
+completion rules, and a vendor compliance checklist — is in
+[**RDMA_PROTOCOL.md**](RDMA_PROTOCOL.md); a server that implements it is
+supported out of the box with no NIXL-side changes. The `type=dell` engine
+serves servers that use the vendor-specific `x-rdma-info` header.
+
 ## Transfer Operations
 
 The Object Storage backend supports read and write operations between local memory and S3 objects. Here are the key aspects of transfer operations:
@@ -261,11 +314,22 @@ The client selection happens transparently during transfer operations, requiring
 
 ## Extending with Vendor-Specific Implementations
 
+> **Prefer the standard-S3 engine.** For GPU-direct/RDMA acceleration, the
+> recommended path is the
+> [GPU-Direct (S3 over RDMA)](#gpu-direct-s3-over-rdma) standard-S3 engine
+> (`accelerated=true` with no `type`, or `type=s3`), which complies with the
+> proposed S3-over-RDMA protocol and requires no per-vendor code. A new vendor only
+> needs to implement the standard `x-amz-rdma-*` protocol on its server to be
+> supported by the standard-S3 engine; no NIXL-side vendor engine is required.
+> Bespoke per-vendor engines remain available for servers that use
+> vendor-specific RDMA headers.
+
 The object plugin uses a modular, inheritance-based architecture that makes it easy to add vendor-specific backends without modifying core engine logic.
 
 ### Architecture Overview
 
 The plugin uses a **pImpl (Pointer to Implementation)** design pattern to provide:
+
 - **ABI Stability**: Interface changes don't require recompiling client code
 - **Modularity**: Easy to add vendor-specific engines without modifying core logic
 - **Encapsulation**: Implementation details hidden behind abstract interface
@@ -306,6 +370,7 @@ The architecture separates concerns into:
 ```
 
 **Key Points:**
+
 - `nixlObjEngine` is the public interface that clients use
 - `nixlObjEngineImpl` is the abstract base class for all engine implementations
 - Concrete implementations inherit from `nixlObjEngineImpl` (or its subclasses) and override specific methods
@@ -316,12 +381,12 @@ The architecture separates concerns into:
 
 Each engine implementation defines its own supported memory segment types via `getSupportedMems()`:
 
-| Engine | Supported Memory Types | Description |
-|--------|----------------------|-------------|
-| `DefaultObjEngineImpl` | `OBJ_SEG`, `DRAM_SEG` | Standard S3 client - CPU memory only |
-| `S3CrtObjEngineImpl` | `OBJ_SEG`, `DRAM_SEG` | S3 CRT client - CPU memory only |
-| `S3AccelObjEngineImpl` | `OBJ_SEG`, `DRAM_SEG` | S3 Accelerated base - CPU memory by default |
-| Vendor engines | `OBJ_SEG`, `DRAM_SEG`, `VRAM_SEG` | Vendor-specific - override to add GPU support |
+| Engine                 | Supported Memory Types            | Description                                   |
+| ---------------------- | --------------------------------- | --------------------------------------------- |
+| `DefaultObjEngineImpl` | `OBJ_SEG`, `DRAM_SEG`             | Standard S3 client - CPU memory only          |
+| `S3CrtObjEngineImpl`   | `OBJ_SEG`, `DRAM_SEG`             | S3 CRT client - CPU memory only               |
+| `S3AccelObjEngineImpl` | `OBJ_SEG`, `DRAM_SEG`             | S3 Accelerated base - CPU memory by default   |
+| Vendor engines         | `OBJ_SEG`, `DRAM_SEG`, `VRAM_SEG` | Vendor-specific - override to add GPU support |
 
 **Important:** Vendor engines that support GPU-direct transfers should override `getSupportedMems()` to include `VRAM_SEG`. The base `S3AccelObjEngineImpl` does not include `VRAM_SEG` by default - each vendor must explicitly expose this capability.
 
@@ -330,7 +395,6 @@ Each engine implementation defines its own supported memory segment types via `g
 > **⚠️ Important: Conditional Compilation for S3 Accelerated Engines**
 >
 > The S3 Accelerated path (`s3_accel`) and any vendor implementations under it require the `cuobjclient-13.1` library. When adding new extensions to `s3_accel`:
->
 >
 > Vendor engines self-register via `objAccelEngineRegistrar`
 >
@@ -343,7 +407,6 @@ Each engine implementation defines its own supported memory segment types via `g
 >        ]
 >    endif
 >    ```
->
 > 2. **Guard cuobjclient-specific code** within your engine with `#if defined(HAVE_CUOBJ_CLIENT)`
 >
 > This ensures the plugin builds correctly both with and without the `cuobjclient` library available.
@@ -355,6 +418,7 @@ Follow these steps to add a vendor-specific client and engine:
 Create a new directory under `s3_accel/` for your vendor (e.g., `s3_accel/vendor_name/`).
 
 **client.h**
+
 ```cpp
 #pragma once
 #include "s3_accel/client.h"
@@ -370,6 +434,7 @@ public:
 ```
 
 **client.cpp**
+
 ```cpp
 #include "client.h"
 #include "common/nixl_log.h"
@@ -384,6 +449,7 @@ awsVendorClient::awsVendorClient(nixl_b_params_t *custom_params,
 #### 2. Create Vendor Engine Implementation
 
 **engine_impl.h**
+
 ```cpp
 #pragma once
 #include "s3_accel/engine_impl.h"
@@ -407,6 +473,7 @@ public:
 ```
 
 **engine_impl.cpp**
+
 ```cpp
 #include "engine_impl.h"
 #include "s3_accel/vendor_name/client.h"

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -24,6 +24,19 @@ obj_sources = [
     's3/client.h',
     's3/engine_impl.cpp',
     's3/engine_impl.h',
+    # Generic, vendor-neutral S3-over-RDMA (x-amz-rdma-*) data path. rdma.cpp is
+    # internally guarded by HAVE_CUOBJ_CLIENT and compiles to nothing when the
+    # cuObjClient library is absent; rdma_protocol.h is dependency-free.
+    's3/rdma_protocol.h',
+    's3/rdma.cpp',
+    's3/rdma.h',
+    # Standard, protocol-compliant S3-over-RDMA engine. Built unconditionally (it
+    # is just a DefaultObjEngineImpl subclass) so that accelerated=true with no
+    # type (or type=s3) is always recognized; the RDMA transport is guarded
+    # by HAVE_CUOBJ_CLIENT in the standard client, which throws at construction
+    # when RDMA is requested but cuObjClient is absent.
+    's3_accel/generic/engine_impl.cpp',
+    's3_accel/generic/engine_impl.h',
     's3_crt/engine_impl.cpp',
     's3_crt/engine_impl.h',
     's3_crt/client.cpp',

--- a/src/plugins/obj/obj_backend.cpp
+++ b/src/plugins/obj/obj_backend.cpp
@@ -26,24 +26,43 @@
 // -----------------------------------------------------------------------------
 // Obj Engine Implementation
 // -----------------------------------------------------------------------------
+//
+// Engine selection:
+//   * Default (no params)                         -> DefaultObjEngineImpl
+//   * crtMinLimit > 0                             -> S3CrtObjEngineImpl
+//   * accelerated=true (no type / type=s3)        -> GenericObjEngineImpl
+//   * accelerated=true, type=dell                 -> vendor-specific engine
+//
+// The preferred GPU-direct path is the standard, protocol-compliant
+// S3-over-RDMA engine selected by `accelerated=true` with no `type` (or
+// `type=s3`). It is built on the S3-over-RDMA capability of the standard S3
+// client (see s3/rdma.h): it complies with the published `x-amz-rdma-*` protocol
+// and requires NO per-vendor code — any S3 endpoint that implements the protocol
+// (e.g. MinIO AIStor) works, and so would AWS S3 if it adopted it. RDMA is an
+// explicit assertion (not auto-probed, and no silent HTTP fallback — see
+// s3/client.cpp for the rationale and the future auto-fallback path).
+//
+// `accelerated=true, type=dell` selects a vendor-specific engine for servers
+// that use vendor-specific RDMA headers; Dell uses an `x-rdma-info` header. Both
+// the standard and vendor engines resolve through `objAccelEngineRegistry`: the
+// standard engine registers under "s3" (a missing `type` is normalized to "s3"
+// below), the Dell engine under "dell".
 
 namespace {
-
-std::string
-getAccelType(const nixl_b_params_t *custom_params) {
-    if (!custom_params) {
-        return "";
-    }
-    auto it = custom_params->find("type");
-    return (it != custom_params->end()) ? it->second : "";
-}
 
 template<typename... Args>
 std::unique_ptr<nixlObjEngineImpl>
 createAccelEngine(const nixl_b_params_t *custom_params, Args &&...args) {
+    // A missing `type` selects the standard protocol-compliant engine. Normalize
+    // to "s3" rather than looking up "" so resolution is deterministic: the
+    // cuobj-gated s3_accel base also registers under "", and the registry
+    // keeps whichever registrar runs first (unspecified static-init order).
+    std::string type = getAccelType(custom_params);
+    if (type.empty()) {
+        type = "s3";
+    }
     try {
-        return objAccelEngineRegistry::instance().create(getAccelType(custom_params),
-                                                         std::forward<Args>(args)...);
+        return objAccelEngineRegistry::instance().create(type, std::forward<Args>(args)...);
     }
     catch (const std::exception &e) {
         NIXL_ERROR << "Failed to create accelerated engine: " << e.what();

--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -85,6 +85,17 @@ public:
      */
     virtual void
     checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) = 0;
+
+    /**
+     * Whether this client's GPU-direct S3-over-RDMA fast path is fully ready
+     * (cuObject fabric connected AND control plane + executor available). The
+     * engine uses this to decide whether VRAM_SEG can be safely advertised:
+     * a GPU pointer must never reach the HTTP path. Defaults to false.
+     */
+    virtual bool
+    supportsRdma() const {
+        return false;
+    }
 };
 
 /**

--- a/src/plugins/obj/s3/client.cpp
+++ b/src/plugins/obj/s3/client.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "client.h"
+#include "engine_utils.h"
 #include "object/s3/utils.h"
 #include "object/s3/aws_sdk_init.h"
 #include "common/nixl_log.h"
@@ -28,29 +29,84 @@
 #include <absl/strings/str_format.h>
 
 awsS3Client::awsS3Client(nixl_b_params_t *custom_params,
-                         std::shared_ptr<Aws::Utils::Threading::Executor> executor) {
+                         std::shared_ptr<Aws::Utils::Threading::Executor> executor)
+    // RDMA is enabled only when the caller explicitly opts in with
+    // accelerated=true (standard S3-over-RDMA, i.e. no type or type=s3).
+    : awsS3Client(custom_params, executor, isGenericAccelRequested(custom_params)) {}
+
+awsS3Client::awsS3Client(nixl_b_params_t *custom_params,
+                         std::shared_ptr<Aws::Utils::Threading::Executor> executor,
+                         bool enable_rdma_fast_path) {
     // Initialize AWS SDK (thread-safe, only happens once)
     nixl_s3_utils::initAWSSDK();
 
     Aws::Client::ClientConfiguration config;
     nixl_s3_utils::configureClientCommon(config, custom_params);
-    if (executor) config.executor = executor;
+    if (executor) {
+        config.executor = executor;
+    }
+    executor_ = executor;
+    rdma_requested_ = enable_rdma_fast_path;
 
     auto credentials_opt = nixl_s3_utils::createAWSCredentials(custom_params);
     bool use_virtual_addressing = nixl_s3_utils::getUseVirtualAddressing(custom_params);
     bucketName_ = Aws::String(nixl_s3_utils::getBucketName(custom_params));
 
-    if (credentials_opt.has_value())
+    if (credentials_opt.has_value()) {
         s3Client_ = std::make_unique<Aws::S3::S3Client>(
             credentials_opt.value(),
             config,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
             use_virtual_addressing);
-    else
+    } else {
         s3Client_ = std::make_unique<Aws::S3::S3Client>(
             config,
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
             use_virtual_addressing);
+    }
+
+#ifdef HAVE_CUOBJ_CLIENT
+    // Opportunistically attach the RDMA fast path. When no cuObject fabric is
+    // present (or the control plane fails to initialize) rdma_ stays null and
+    // every transfer takes the plain HTTP path below. Disabled for the
+    // accelerated/vendor clients, which manage RDMA on their own.
+    if (enable_rdma_fast_path) {
+        rdma_ = nixl_obj_rdma::SharedCuObjClient::instance();
+    }
+    if (rdma_) {
+        rdmaCp_ = std::make_unique<nixl_obj_rdma::S3RdmaControlPlane>(custom_params);
+        if (!rdmaCp_->valid()) {
+            rdmaCp_.reset();
+            rdma_ = nullptr;
+        }
+    }
+#endif
+
+    // Fail fast: an accelerated=true (generic S3-over-RDMA) client whose RDMA
+    // fast path is not fully ready (no cuObjClient build, no executor, fabric
+    // down, or control plane invalid) can never recover — setExecutor() is
+    // unsupported and rdma_/rdmaCp_ are set once here. Surface it at construction
+    // instead of hard-failing every transfer later.
+    if (rdma_requested_ && !rdmaReady()) {
+        throw std::runtime_error(
+            "accelerated=true (generic S3-over-RDMA) requested but the "
+            "S3-over-RDMA fast path is unavailable (requires a cuObjClient build, "
+            "an executor, a reachable RDMA fabric, and a valid control plane)");
+    }
+}
+
+bool
+awsS3Client::rdmaReady() const {
+#ifdef HAVE_CUOBJ_CLIENT
+    return rdma_ != nullptr && rdmaCp_ != nullptr && executor_ != nullptr;
+#else
+    return false;
+#endif
+}
+
+bool
+awsS3Client::supportsRdma() const {
+    return rdmaReady();
 }
 
 void
@@ -66,6 +122,31 @@ awsS3Client::putObjectAsync(std::string_view key,
                             size_t offset,
                             put_object_callback_t callback) {
     if (offset != 0) {
+        callback(false);
+        return;
+    }
+
+    // Under accelerated=true, transfers are RDMA-only: if the fast path is not
+    // ready we fail rather than silently write a body-less (0-byte) PUT over
+    // HTTP. No auto-fallback today (see header).
+    if (rdma_requested_) {
+#ifdef HAVE_CUOBJ_CLIENT
+        if (rdmaReady()) {
+            executor_->Submit([this, k = std::string(key), data_ptr, data_len, callback]() {
+                nixl_obj_rdma::S3RdmaClientCtx ctx;
+                ctx.bucket = bucketName_.c_str();
+                ctx.object = k;
+                const ssize_t r = nixl_obj_rdma::rdmaPutWithRetry(
+                    *rdma_, *rdmaCp_, ctx, reinterpret_cast<void *>(data_ptr), data_len);
+                callback(r >= 0);
+                if (r < 0) {
+                    NIXL_ERROR << "RDMA PUT failed (accelerated enabled); no HTTP fallback";
+                }
+            });
+            return;
+        }
+#endif
+        NIXL_ERROR << "accelerated=true but RDMA fast path unavailable; failing PUT";
         callback(false);
         return;
     }
@@ -97,6 +178,30 @@ awsS3Client::getObjectAsync(std::string_view key,
                             size_t data_len,
                             size_t offset,
                             get_object_callback_t callback) {
+    // See putObjectAsync: under accelerated=true (generic S3-over-RDMA), GET is
+    // RDMA-only with no silent HTTP fallback; fail if the fast path is not ready.
+    if (rdma_requested_) {
+#ifdef HAVE_CUOBJ_CLIENT
+        if (rdmaReady()) {
+            executor_->Submit([this, k = std::string(key), data_ptr, data_len, offset, callback]() {
+                nixl_obj_rdma::S3RdmaClientCtx ctx;
+                ctx.bucket = bucketName_.c_str();
+                ctx.object = k;
+                const ssize_t r = nixl_obj_rdma::rdmaGetWithRetry(
+                    *rdma_, *rdmaCp_, ctx, reinterpret_cast<void *>(data_ptr), data_len, offset);
+                callback(r >= 0);
+                if (r < 0) {
+                    NIXL_ERROR << "RDMA GET failed (accelerated enabled); no HTTP fallback";
+                }
+            });
+            return;
+        }
+#endif
+        NIXL_ERROR << "accelerated=true but RDMA fast path unavailable; failing GET";
+        callback(false);
+        return;
+    }
+
     auto preallocated_stream_buf = Aws::MakeShared<Aws::Utils::Stream::PreallocatedStreamBuf>(
         "GetObjectStreamBuf", reinterpret_cast<unsigned char *>(data_ptr), data_len);
     auto stream_factory = Aws::MakeShared<Aws::IOStreamFactory>(

--- a/src/plugins/obj/s3/client.h
+++ b/src/plugins/obj/s3/client.h
@@ -26,6 +26,7 @@
 #include <aws/core/Aws.h>
 #include "obj_backend.h"
 #include "nixl_types.h"
+#include "rdma.h"
 
 /**
  * S3 Vanilla Object Client - Base implementation using AWS SDK S3Client.
@@ -63,9 +64,37 @@ public:
     void
     checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) override;
 
+    bool
+    supportsRdma() const override;
+
 protected:
+    /**
+     * Internal constructor. @p enable_rdma_fast_path attaches the S3-over-RDMA
+     * path. Vendor clients (awsS3AccelClient and its Dell subclass) pass false:
+     * they manage RDMA themselves, so the base must not spin up the shared
+     * cuObjClient.
+     */
+    awsS3Client(nixl_b_params_t *custom_params,
+                std::shared_ptr<Aws::Utils::Threading::Executor> executor,
+                bool enable_rdma_fast_path);
+
+    // True iff the RDMA fast path is fully usable (accelerated=true with no type
+    // / type=s3, plus cuObject fabric, control plane, and executor). The single
+    // predicate gating both VRAM advertisement and the RDMA transfer branch.
+    bool
+    rdmaReady() const;
+
     std::unique_ptr<Aws::S3::S3Client> s3Client_;
     Aws::String bucketName_;
+    std::shared_ptr<Aws::Utils::Threading::Executor> executor_;
+    bool rdma_requested_ = false;
+
+#ifdef HAVE_CUOBJ_CLIENT
+    // RDMA fast path. Null when no RDMA fabric is present; under accelerated=true
+    // an unavailable fast path fails backend construction (see client.cpp).
+    nixl_obj_rdma::SharedCuObjClient *rdma_ = nullptr;
+    std::unique_ptr<nixl_obj_rdma::S3RdmaControlPlane> rdmaCp_;
+#endif
 };
 
 #endif // OBJ_PLUGIN_S3_CLIENT_H

--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -28,15 +28,16 @@ isValidPrepXferParams(const nixl_xfer_op_t &operation,
         return false;
     }
 
-    if (remote_agent != local_agent)
+    if (remote_agent != local_agent) {
         NIXL_WARN << absl::StrFormat(
             "Warning: Remote agent doesn't match the requesting agent (%s). Got %s",
             local_agent,
             remote_agent);
+    }
 
-    if (local.getType() != DRAM_SEG) {
-        NIXL_ERROR << absl::StrFormat("Error: Local memory type must be DRAM_SEG, got %d",
-                                      local.getType());
+    if (local.getType() != DRAM_SEG && local.getType() != VRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat(
+            "Error: Local memory type must be DRAM_SEG or VRAM_SEG, got %d", local.getType());
         return false;
     }
 
@@ -80,17 +81,28 @@ public:
 
 class nixlObjMetadata : public nixlBackendMD {
 public:
-    nixlObjMetadata(nixl_mem_t nixl_mem, uint64_t dev_id, std::string obj_key)
+    // Object segment: maps a device id to an S3 object key.
+    nixlObjMetadata(nixl_mem_t nixl_mem, uint64_t dev_id, const std::string &obj_key)
         : nixlBackendMD(true),
           nixlMem(nixl_mem),
           devId(dev_id),
           objKey(obj_key) {}
 
+    // Memory segment (DRAM/VRAM) pinned for RDMA; records the address to
+    // release on deregister.
+    nixlObjMetadata(nixl_mem_t nixl_mem, uintptr_t addr)
+        : nixlBackendMD(true),
+          nixlMem(nixl_mem),
+          localAddr(addr),
+          rdmaRegistered(true) {}
+
     ~nixlObjMetadata() = default;
 
     nixl_mem_t nixlMem;
-    uint64_t devId;
+    uint64_t devId = 0;
     std::string objKey;
+    uintptr_t localAddr = 0;
+    bool rdmaRegistered = false;
 };
 
 } // namespace
@@ -117,7 +129,9 @@ DefaultObjEngineImpl::DefaultObjEngineImpl(const nixlBackendInitParams *init_par
     // The s3_client_crt parameter is accepted for API consistency with derived
     // engine implementations (e.g., S3CrtObjEngineImpl) but is intentionally unused here.
     (void)s3_client_crt;
-    if (s3Client_) s3Client_->setExecutor(executor_);
+    if (s3Client_) {
+        s3Client_->setExecutor(executor_);
+    }
     NIXL_INFO << "Object storage backend initialized with injected S3 clients";
 }
 
@@ -129,19 +143,38 @@ nixl_status_t
 DefaultObjEngineImpl::registerMem(const nixlBlobDesc &mem,
                                   const nixl_mem_t &nixl_mem,
                                   nixlBackendMD *&out) {
-    nixl_mem_list_t supported_mems = {OBJ_SEG, DRAM_SEG};
-    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end())
+    nixl_mem_list_t supported_mems = getSupportedMems();
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end()) {
         return NIXL_ERR_NOT_SUPPORTED;
+    }
 
     if (nixl_mem == OBJ_SEG) {
         std::unique_ptr<nixlObjMetadata> obj_md = std::make_unique<nixlObjMetadata>(
             nixl_mem, mem.devId, mem.metaInfo.empty() ? std::to_string(mem.devId) : mem.metaInfo);
         devIdToObjKey_[mem.devId] = obj_md->objKey;
         out = obj_md.release();
-    } else {
-        out = nullptr;
+        return NIXL_SUCCESS;
     }
 
+    // DRAM_SEG / VRAM_SEG: persistently pin the buffer for RDMA so the client
+    // can mint a token for it. DRAM is best-effort (still usable over HTTP);
+    // VRAM is mandatory (no HTTP path can read a GPU pointer).
+    bool registered = false;
+#ifdef HAVE_CUOBJ_CLIENT
+    // Register only when the client's RDMA fast path is fully ready.
+    if (s3Client_ && s3Client_->supportsRdma()) {
+        if (auto *rdma = nixl_obj_rdma::SharedCuObjClient::instance()) {
+            registered = rdma->registerBuffer(reinterpret_cast<void *>(mem.addr), mem.len);
+        }
+    }
+#endif
+    if (nixl_mem == VRAM_SEG && !registered) {
+        NIXL_ERROR << "VRAM registration requires accelerated=true (generic S3-over-RDMA) and a "
+                      "ready RDMA fast path (cuObject)";
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    out = registered ? std::make_unique<nixlObjMetadata>(nixl_mem, mem.addr).release() : nullptr;
     return NIXL_SUCCESS;
 }
 
@@ -150,7 +183,16 @@ DefaultObjEngineImpl::deregisterMem(nixlBackendMD *meta) {
     nixlObjMetadata *obj_md = static_cast<nixlObjMetadata *>(meta);
     if (obj_md) {
         std::unique_ptr<nixlObjMetadata> obj_md_ptr = std::unique_ptr<nixlObjMetadata>(obj_md);
-        devIdToObjKey_.erase(obj_md->devId);
+        if (obj_md->nixlMem == OBJ_SEG) {
+            devIdToObjKey_.erase(obj_md->devId);
+        }
+#ifdef HAVE_CUOBJ_CLIENT
+        else if (obj_md->rdmaRegistered) {
+            if (auto *rdma = nixl_obj_rdma::SharedCuObjClient::instance()) {
+                rdma->deregisterBuffer(reinterpret_cast<void *>(obj_md->localAddr));
+            }
+        }
+#endif
     }
 
     return NIXL_SUCCESS;
@@ -191,7 +233,9 @@ DefaultObjEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
                 desc.metaInfo,
                 [&resp, &has_error, i, promise = state.promise, completed = state.completed](
                     std::optional<bool> exists) {
-                    if (completed->exchange(true)) return;
+                    if (completed->exchange(true)) {
+                        return;
+                    }
                     if (!exists.has_value()) {
                         resp[i] = std::nullopt;
                         has_error.store(true, std::memory_order_relaxed);
@@ -225,8 +269,9 @@ DefaultObjEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
         // Wait for all callbacks to complete their writes to resp/has_error
         // to avoid use-after-free if a callback passed the exchange check
         // but was preempted before writing.
-        for (size_t j = 0; j < futures.size(); ++j)
+        for (size_t j = 0; j < futures.size(); ++j) {
             futures[j].wait();
+        }
         NIXL_ERROR << "Failed to query memory: " << e.what();
         return NIXL_ERR_BACKEND;
     }
@@ -264,8 +309,9 @@ DefaultObjEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
                                const std::string &local_agent,
                                nixlBackendReqH *&handle,
                                const nixl_opt_b_args_t *opt_args) const {
-    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent))
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
         return NIXL_ERR_INVALID_PARAM;
+    }
 
     auto req_h = std::make_unique<nixlObjBackendReqH>();
     handle = req_h.release();
@@ -315,12 +361,13 @@ DefaultObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
             status_promise->set_value(success ? NIXL_SUCCESS : NIXL_ERR_BACKEND);
         };
 
-        if (operation == NIXL_WRITE)
+        if (operation == NIXL_WRITE) {
             client->putObjectAsync(
                 obj_key_search->second, data_ptr, data_len, offset, status_callback);
-        else
+        } else {
             client->getObjectAsync(
                 obj_key_search->second, data_ptr, data_len, offset, status_callback);
+        }
     }
 
     return NIXL_IN_PROG;

--- a/src/plugins/obj/s3/engine_impl.h
+++ b/src/plugins/obj/s3/engine_impl.h
@@ -7,6 +7,7 @@
 #define OBJ_PLUGIN_S3_ENGINE_IMPL_H
 
 #include "obj_backend.h"
+#include "rdma.h"
 
 class DefaultObjEngineImpl : public nixlObjEngineImpl {
 public:
@@ -16,8 +17,16 @@ public:
                          std::shared_ptr<iS3Client> s3_client_crt);
     ~DefaultObjEngineImpl() override;
 
+    // VRAM_SEG (GPU-direct) is advertised only when the standard client's RDMA
+    // fast path is fully ready (accelerated=true generic S3-over-RDMA + cuObject
+    // fabric + control plane + executor). This is the same predicate the client
+    // uses to take the RDMA branch, so a GPU pointer can never reach the HTTP
+    // path.
     nixl_mem_list_t
     getSupportedMems() const override {
+        if (s3Client_ && s3Client_->supportsRdma()) {
+            return {DRAM_SEG, OBJ_SEG, VRAM_SEG};
+        }
         return {DRAM_SEG, OBJ_SEG};
     }
 

--- a/src/plugins/obj/s3/rdma.cpp
+++ b/src/plugins/obj/s3/rdma.cpp
@@ -1,0 +1,512 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "rdma.h"
+
+#ifdef HAVE_CUOBJ_CLIENT
+
+#include <algorithm>
+#include <exception>
+#include <map>
+#include <sstream>
+
+#include <aws/core/Aws.h>
+#include <aws/core/auth/AWSAuthSigner.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/http/URI.h>
+#include <aws/core/utils/DateTime.h>
+#include <aws/core/utils/HashingUtils.h>
+#include <aws/core/utils/StringUtils.h>
+
+#include "object/s3/utils.h"
+#include "object/s3/aws_sdk_init.h"
+#include "common/nixl_log.h"
+
+namespace nixl_obj_rdma {
+
+namespace {
+    // S3 ETag values are returned wrapped in double quotes; strip them.
+    std::string
+    stripQuotes(const std::string &s) {
+        size_t b = 0, e = s.size();
+        if (e >= 2 && s.front() == '"' && s.back() == '"') {
+            b = 1;
+            e = s.size() - 1;
+        }
+        return s.substr(b, e - b);
+    }
+} // namespace
+
+// ---------------------------------------------------------------------------
+// SharedCuObjClient
+// ---------------------------------------------------------------------------
+
+SharedCuObjClient::SharedCuObjClient() {
+    try {
+        // The token-based flow does not use the get/put callbacks, so empty ops
+        // suffice (matches the reference SDKs' availability probe).
+        client_ = std::make_unique<cuObjClient>(ops_, CUOBJ_PROTO_RDMA_DC_V1);
+        connected_ = client_ && client_->isConnected();
+        if (connected_) {
+            NIXL_INFO << "S3 RDMA fabric connected (cuObject)";
+        } else {
+            NIXL_INFO << "S3 RDMA fabric not connected; transfers use HTTP";
+        }
+    }
+    catch (const std::exception &e) {
+        NIXL_WARN << "cuObjClient init failed: " << e.what() << "; transfers use HTTP";
+        connected_ = false;
+    }
+}
+
+SharedCuObjClient *
+SharedCuObjClient::instance() {
+    static SharedCuObjClient inst;
+    return inst.connected_ ? &inst : nullptr;
+}
+
+bool
+SharedCuObjClient::registerBuffer(void *ptr, size_t size) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    cuObjErr_t rc = client_->cuMemObjGetDescriptor(ptr, size);
+    if (rc != CU_OBJ_SUCCESS) {
+        NIXL_ERROR << "cuMemObjGetDescriptor failed rc=" << rc << " ptr=" << ptr
+                   << " size=" << size;
+        return false;
+    }
+    NIXL_DEBUG << "cuMemObjGetDescriptor OK ptr=" << ptr << " size=" << size;
+    return true;
+}
+
+void
+SharedCuObjClient::deregisterBuffer(void *ptr) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (client_->cuMemObjPutDescriptor(ptr) != CU_OBJ_SUCCESS) {
+        NIXL_WARN << "cuMemObjPutDescriptor failed for ptr " << ptr;
+    }
+}
+
+bool
+SharedCuObjClient::isDeviceMemory(const void *ptr) const {
+    return cuObjClient::getMemoryType(ptr) == CUOBJ_MEMORY_CUDA_DEVICE;
+}
+
+char *
+SharedCuObjClient::getToken(void *ptr, size_t size, size_t offset, cuObjOpType_t op) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    char *token = nullptr;
+    cuObjErr_t rc = client_->cuMemObjGetRDMAToken(ptr, size, offset, op, &token);
+    if (rc != CU_OBJ_SUCCESS || token == nullptr) {
+        NIXL_ERROR << "cuMemObjGetRDMAToken failed rc=" << rc << " ptr=" << ptr << " size=" << size
+                   << " op=" << op << " token=" << static_cast<void *>(token);
+        return nullptr;
+    }
+    return token;
+}
+
+void
+SharedCuObjClient::putToken(char *token) {
+    if (token == nullptr) {
+        return;
+    }
+    const std::lock_guard<std::mutex> lock(mutex_);
+    client_->cuMemObjPutRDMAToken(token);
+}
+
+// ---------------------------------------------------------------------------
+// S3RdmaControlPlane
+//
+// === UNVERIFIED SEAM ===
+// Everything in Impl touches the AWS SDK low-level HTTP/signing layer and could
+// not be compiled in the authoring environment (no aws-sdk-cpp present). The
+// surrounding protocol logic (rdmaPut/rdmaGet below) is SDK-agnostic and unit
+// tested via rdma_protocol.h. A reviewer with the SDK should focus validation
+// here: SigV4 UNSIGNED-PAYLOAD signing, URI construction (path vs virtual
+// addressing), and response-header retrieval.
+// ---------------------------------------------------------------------------
+
+struct S3RdmaControlPlane::Impl {
+    Aws::String scheme; // "http" / "https"
+    Aws::String host; // endpoint host (no port; GetAuthority strips it)
+    unsigned port = 0; // explicit port (0 => scheme default)
+    Aws::String region;
+    bool virtual_addressing = false;
+    std::shared_ptr<Aws::Http::HttpClient> http;
+    Aws::String access_key;
+    Aws::String secret_key;
+    Aws::String session_token;
+
+    // SigV4-sign the request with payload hash "UNSIGNED-PAYLOAD". We sign
+    // manually (rather than via the SDK's AWSAuthV4Signer) because that signer
+    // hashes the empty body over plain HTTP — the S3 RDMA server only skips
+    // content-sha256 validation when the header is exactly UNSIGNED-PAYLOAD, and
+    // the data here travels out-of-band over RDMA. Mirrors minio-cpp/rs SignV4S3.
+    // All non-signed headers (host, x-amz-rdma-token, content-*, checksum) must
+    // already be set on the request before calling this.
+    void
+    signV4(Aws::Http::HttpRequest &req) const {
+        using Aws::Utils::HashingUtils;
+        using Aws::Utils::StringUtils;
+        const Aws::String service = "s3";
+        const Aws::String payload_hash = "UNSIGNED-PAYLOAD";
+
+        Aws::Utils::DateTime now = Aws::Utils::DateTime::Now();
+        const Aws::String amz_date = now.ToGmtString("%Y%m%dT%H%M%SZ");
+        const Aws::String date_stamp = now.ToGmtString("%Y%m%d");
+
+        // Host header (with port) must be signed and match what is sent.
+        Aws::String host = req.GetUri().GetAuthority();
+        const unsigned p = req.GetUri().GetPort();
+        if (p != 0 && p != 80 && p != 443) {
+            host += ":" + std::to_string(p);
+        }
+        req.SetHeaderValue("host", host);
+        req.SetHeaderValue("x-amz-date", amz_date);
+        req.SetHeaderValue("x-amz-content-sha256", payload_hash);
+        if (!session_token.empty()) {
+            req.SetHeaderValue("x-amz-security-token", session_token);
+        }
+
+        // Canonical headers: lowercase name, trimmed value, sorted by name.
+        std::map<Aws::String, Aws::String> hdrs;
+        for (const auto &h : req.GetHeaders()) {
+            hdrs[StringUtils::ToLower(h.first.c_str())] = StringUtils::Trim(h.second.c_str());
+        }
+        Aws::String canonical_headers, signed_headers;
+        for (const auto &kv : hdrs) {
+            canonical_headers += kv.first + ":" + kv.second + "\n";
+            if (!signed_headers.empty()) {
+                signed_headers += ";";
+            }
+            signed_headers += kv.first;
+        }
+
+        // Canonical query string: sorted, RFC3986-encoded key=value.
+        const auto qp = req.GetUri().GetQueryStringParameters();
+        std::map<Aws::String, Aws::String> q(qp.begin(), qp.end());
+        Aws::String canonical_query;
+        for (const auto &kv : q) {
+            if (!canonical_query.empty()) {
+                canonical_query += "&";
+            }
+            canonical_query += StringUtils::URLEncode(kv.first.c_str()) + "=" +
+                StringUtils::URLEncode(kv.second.c_str());
+        }
+
+        Aws::String canonical_uri = req.GetUri().GetURLEncodedPathRFC3986();
+        if (canonical_uri.empty()) {
+            canonical_uri = "/";
+        }
+
+        const Aws::String method =
+            Aws::Http::HttpMethodMapper::GetNameForHttpMethod(req.GetMethod());
+        const Aws::String canonical_request = method + "\n" + canonical_uri + "\n" +
+            canonical_query + "\n" + canonical_headers + "\n" + signed_headers + "\n" +
+            payload_hash;
+
+        const Aws::String scope = date_stamp + "/" + region + "/" + service + "/aws4_request";
+        const Aws::String cr_hash =
+            HashingUtils::HexEncode(HashingUtils::CalculateSHA256(canonical_request));
+        const Aws::String string_to_sign =
+            "AWS4-HMAC-SHA256\n" + amz_date + "\n" + scope + "\n" + cr_hash;
+
+        auto hmac = [](const Aws::Utils::ByteBuffer &key, const Aws::String &data) {
+            return HashingUtils::CalculateSHA256HMAC(
+                Aws::Utils::ByteBuffer(reinterpret_cast<const unsigned char *>(data.c_str()),
+                                       data.size()),
+                key);
+        };
+        const Aws::String k_secret_str = "AWS4" + secret_key;
+        Aws::Utils::ByteBuffer k_secret(
+            reinterpret_cast<const unsigned char *>(k_secret_str.c_str()), k_secret_str.size());
+        Aws::Utils::ByteBuffer k_date = hmac(k_secret, date_stamp);
+        Aws::Utils::ByteBuffer k_region = hmac(k_date, region);
+        Aws::Utils::ByteBuffer k_service = hmac(k_region, service);
+        Aws::Utils::ByteBuffer k_signing = hmac(k_service, "aws4_request");
+        const Aws::String signature = HashingUtils::HexEncode(hmac(k_signing, string_to_sign));
+
+        req.SetHeaderValue("authorization",
+                           "AWS4-HMAC-SHA256 Credential=" + access_key + "/" + scope +
+                               ", SignedHeaders=" + signed_headers + ", Signature=" + signature);
+    }
+
+    // Build the request URI for a given object key, applying path-style or
+    // virtual-hosted-style addressing.
+    Aws::Http::URI
+    buildUri(const std::string &bucket, const std::string &key) const {
+        Aws::Http::URI uri;
+        uri.SetScheme(scheme == "http" ? Aws::Http::Scheme::HTTP : Aws::Http::Scheme::HTTPS);
+        if (virtual_addressing) {
+            uri.SetAuthority(Aws::String(bucket.c_str()) + "." + host);
+            uri.SetPath("/" + Aws::String(key.c_str()));
+        } else {
+            uri.SetAuthority(host);
+            uri.SetPath("/" + Aws::String(bucket.c_str()) + "/" + Aws::String(key.c_str()));
+        }
+        // GetAuthority() drops the port, so set it explicitly — otherwise the
+        // request goes to the scheme default (80/443) and fails to connect.
+        if (port != 0) {
+            uri.SetPort(static_cast<uint16_t>(port));
+        }
+        return uri;
+    }
+};
+
+S3RdmaControlPlane::S3RdmaControlPlane(nixl_b_params_t *custom_params) : impl_(new Impl()) {
+    try {
+        nixl_s3_utils::initAWSSDK();
+
+        Aws::Client::ClientConfiguration config;
+        nixl_s3_utils::configureClientCommon(config, custom_params);
+
+        impl_->region = config.region.empty() ? Aws::String("us-east-1") : config.region;
+        impl_->scheme = (config.scheme == Aws::Http::Scheme::HTTP) ? "http" : "https";
+        impl_->virtual_addressing = nixl_s3_utils::getUseVirtualAddressing(custom_params);
+
+        // Endpoint authority: explicit override (AIStor / S3-compatible) or the
+        // default AWS S3 regional host.
+        if (!config.endpointOverride.empty()) {
+            Aws::Http::URI ep(config.endpointOverride);
+            impl_->scheme = (ep.GetScheme() == Aws::Http::Scheme::HTTP) ? "http" : impl_->scheme;
+            impl_->host = ep.GetAuthority();
+            impl_->port = ep.GetPort();
+        } else {
+            impl_->host = "s3." + impl_->region + ".amazonaws.com";
+            impl_->port = (impl_->scheme == "http") ? 80 : 443;
+        }
+
+        // Resolve credentials once (explicit params, else the default chain) and
+        // store them for manual SigV4 signing (see Impl::signV4).
+        Aws::Auth::AWSCredentials creds;
+        auto explicit_creds = nixl_s3_utils::createAWSCredentials(custom_params);
+        if (explicit_creds.has_value()) {
+            creds = explicit_creds.value();
+        } else {
+            creds = Aws::Auth::DefaultAWSCredentialsProviderChain().GetAWSCredentials();
+        }
+        impl_->access_key = creds.GetAWSAccessKeyId();
+        impl_->secret_key = creds.GetAWSSecretKey();
+        impl_->session_token = creds.GetSessionToken();
+
+        config.connectTimeoutMs = rdma_connect_timeout_secs * 1000;
+        config.requestTimeoutMs = rdma_timeout_secs * 1000;
+        impl_->http = Aws::Http::CreateHttpClient(config);
+
+        valid_ = impl_->http != nullptr && !impl_->access_key.empty();
+    }
+    catch (const std::exception &e) {
+        NIXL_WARN << "S3 RDMA control plane init failed: " << e.what();
+        valid_ = false;
+    }
+}
+
+S3RdmaControlPlane::~S3RdmaControlPlane() = default;
+
+ssize_t
+S3RdmaControlPlane::rdmaPut(S3RdmaClientCtx &ctx,
+                            const char *token,
+                            uint64_t buf_addr,
+                            uint64_t size) {
+    try {
+        Aws::Http::URI uri = impl_->buildUri(ctx.bucket, ctx.object);
+        if (!ctx.upload_id.empty()) {
+            if (ctx.part_number == 0 || ctx.part_number > 10000) {
+                NIXL_ERROR << "rdmaPut: invalid partNumber " << ctx.part_number
+                           << " (expected 1..10000) for key=" << ctx.object;
+                return rdma_error;
+            }
+            uri.AddQueryStringParameter("uploadId", ctx.upload_id.c_str());
+            uri.AddQueryStringParameter("partNumber", std::to_string(ctx.part_number).c_str());
+        }
+
+        auto req =
+            Aws::Http::CreateHttpRequest(uri,
+                                         Aws::Http::HttpMethod::HTTP_PUT,
+                                         Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+        req->SetHeaderValue("x-amz-content-sha256", unsigned_payload);
+        req->SetHeaderValue(amz_rdma_token, formatRdmaToken(token, buf_addr, size).c_str());
+        req->SetHeaderValue("content-type", "application/octet-stream");
+        req->SetContentLength("0");
+        if (!ctx.checksum_crc64nvme.empty()) {
+            req->SetHeaderValue("x-amz-checksum-crc64nvme", ctx.checksum_crc64nvme.c_str());
+        }
+
+        impl_->signV4(*req); // manual SigV4 with UNSIGNED-PAYLOAD
+
+        auto resp = impl_->http->MakeRequest(req);
+        if (!resp) {
+            NIXL_ERROR << "rdmaPut: MakeRequest returned null for key=" << ctx.object;
+            return rdma_error;
+        }
+
+        const int http_status = static_cast<int>(resp->GetResponseCode());
+        const std::string etag =
+            resp->HasHeader("etag") ? stripQuotes(resp->GetHeader("etag").c_str()) : "";
+
+        // Success: the server completed the RDMA_READ and returns a standard
+        // HTTP 200 + ETag (the object payload moved out-of-band, so the HTTP body
+        // is empty). Matches minio-cpp/minio-rs rdmaPut.
+        if (http_status == 200 && !etag.empty()) {
+            ctx.etag = etag;
+            if (resp->HasHeader("x-amz-checksum-crc64nvme")) {
+                ctx.checksum_crc64nvme = resp->GetHeader("x-amz-checksum-crc64nvme").c_str();
+            }
+            return static_cast<ssize_t>(size);
+        }
+
+        // Otherwise inspect the RDMA reply marker: 501 (or absent) => declined.
+        const std::string reply = resp->HasHeader(amz_rdma_reply) ?
+            std::string(resp->GetHeader(amz_rdma_reply).c_str()) :
+            "";
+        const int reply_code = parseRdmaReply(reply);
+        std::ostringstream body;
+        body << resp->GetResponseBody().rdbuf();
+        if (reply_code == static_cast<int>(rdma_not_supported)) {
+            NIXL_ERROR << "rdmaPut declined: http=" << http_status << " x-amz-rdma-reply='" << reply
+                       << "' url=" << uri.GetURIString() << " body=" << body.str().substr(0, 400)
+                       << " key=" << ctx.object;
+            return rdma_not_supported;
+        }
+        NIXL_ERROR << "rdmaPut failed: http=" << http_status << " x-amz-rdma-reply='" << reply
+                   << "' reply_code=" << reply_code << " key=" << ctx.object
+                   << " body=" << body.str().substr(0, 400);
+        return rdma_error;
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "rdmaPut failed: " << e.what();
+        return rdma_error;
+    }
+}
+
+ssize_t
+S3RdmaControlPlane::rdmaGet(S3RdmaClientCtx &ctx,
+                            const char *token,
+                            uint64_t buf_addr,
+                            uint64_t size,
+                            uint64_t offset) {
+    try {
+        Aws::Http::URI uri = impl_->buildUri(ctx.bucket, ctx.object);
+        auto req =
+            Aws::Http::CreateHttpRequest(uri,
+                                         Aws::Http::HttpMethod::HTTP_GET,
+                                         Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+        req->SetHeaderValue("x-amz-content-sha256", unsigned_payload);
+        req->SetHeaderValue(amz_rdma_token, formatRdmaToken(token, buf_addr, size).c_str());
+        // Byte-range fetch when reading a slice of the object (server replies 206).
+        if (size != 0) {
+            req->SetHeaderValue(
+                "range",
+                ("bytes=" + std::to_string(offset) + "-" + std::to_string(offset + size - 1))
+                    .c_str());
+        }
+
+        impl_->signV4(*req);
+
+        auto resp = impl_->http->MakeRequest(req);
+        if (!resp) {
+            NIXL_ERROR << "rdmaGet: MakeRequest returned null for key=" << ctx.object;
+            return rdma_error;
+        }
+
+        // GET is inherently fail-safe: a non-RDMA server omits x-amz-rdma-reply,
+        // which parseRdmaReply maps to "declined" (caller errors under
+        // accelerated=true).
+        const int http_status = static_cast<int>(resp->GetResponseCode());
+        const std::string reply = resp->HasHeader(amz_rdma_reply) ?
+            std::string(resp->GetHeader(amz_rdma_reply).c_str()) :
+            "";
+        const int reply_code = parseRdmaReply(reply);
+        if (reply_code == static_cast<int>(rdma_not_supported)) {
+            return rdma_not_supported;
+        }
+        if (reply_code != rdma_reply_success && reply_code != rdma_reply_partial_content) {
+            NIXL_ERROR << "rdmaGet failed: http=" << http_status << " x-amz-rdma-reply='" << reply
+                       << "' reply_code=" << reply_code << " key=" << ctx.object;
+            return rdma_error;
+        }
+
+        if (resp->HasHeader("etag")) {
+            ctx.etag = stripQuotes(resp->GetHeader("etag").c_str());
+        }
+
+        // Trust the server's reported transferred byte count (can be < requested
+        // for ranged/partial GETs).
+        if (resp->HasHeader(amz_rdma_bytes_transferred)) {
+            try {
+                const long long n = std::stoll(resp->GetHeader(amz_rdma_bytes_transferred).c_str());
+                return n < 0 ? rdma_error : static_cast<ssize_t>(n);
+            }
+            catch (const std::exception &) {
+                return rdma_error;
+            }
+        }
+        return static_cast<ssize_t>(size);
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "rdmaGet failed: " << e.what();
+        return rdma_error;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Retry wrappers (token lifecycle + one transient retry). A token-mint failure
+// is itself transient (cuObject NIC selection / registration hiccup), so it is
+// retried rather than aborting on the first attempt.
+// ---------------------------------------------------------------------------
+
+ssize_t
+rdmaPutWithRetry(SharedCuObjClient &rdma,
+                 S3RdmaControlPlane &cp,
+                 S3RdmaClientCtx &ctx,
+                 void *buf,
+                 size_t size) {
+    ssize_t ret = -1;
+    for (int attempt = 0; attempt < rdma_max_attempts; ++attempt) {
+        char *token = rdma.getToken(buf, size, 0, CUOBJ_PUT);
+        if (token == nullptr) {
+            ret = -1;
+            continue; // transient mint failure: retry
+        }
+        ret = cp.rdmaPut(ctx, token, reinterpret_cast<uint64_t>(buf), size);
+        rdma.putToken(token);
+        if (ret > 0 || ret == rdma_not_supported) {
+            break;
+        }
+    }
+    return ret;
+}
+
+ssize_t
+rdmaGetWithRetry(SharedCuObjClient &rdma,
+                 S3RdmaControlPlane &cp,
+                 S3RdmaClientCtx &ctx,
+                 void *buf,
+                 size_t size,
+                 size_t offset) {
+    ssize_t ret = -1;
+    for (int attempt = 0; attempt < rdma_max_attempts; ++attempt) {
+        char *token = rdma.getToken(buf, size, 0, CUOBJ_GET);
+        if (token == nullptr) {
+            ret = -1;
+            continue; // transient mint failure: retry
+        }
+        ret = cp.rdmaGet(ctx, token, reinterpret_cast<uint64_t>(buf), size, offset);
+        rdma.putToken(token);
+        if (ret > 0 || ret == rdma_not_supported) {
+            break;
+        }
+    }
+    return ret;
+}
+
+} // namespace nixl_obj_rdma
+
+#endif // HAVE_CUOBJ_CLIENT

--- a/src/plugins/obj/s3/rdma.h
+++ b/src/plugins/obj/s3/rdma.h
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_S3_RDMA_H
+#define NIXL_SRC_PLUGINS_OBJ_S3_RDMA_H
+
+// Generic S3-over-RDMA data path for the object backend.
+//
+// RDMA is NOT a separate engine or a vendor plugin. It is an optimization of
+// the normal S3 GET/PUT path on the standard client, enabled per backend via
+// `accelerated=true` (generic S3-over-RDMA): the client issues an out-of-band
+// RDMA transfer over the published `x-amz-rdma-*` protocol. Under
+// `accelerated=true` an RDMA decline/failure is a hard
+// error — there is no silent HTTP fallback today, because a server that ignores
+// the token (instead of returning `x-amz-rdma-reply: 501`) would accept a
+// body-less PUT as a 0-byte object (see s3/client.cpp). The protocol is an AWS
+// S3 convention (not vendor-specific), so the same code works against MinIO
+// AIStor today and against any future endpoint (including AWS S3) that adopts
+// it.
+//
+// This entire translation unit is compiled only when the cuObjClient library is
+// present (HAVE_CUOBJ_CLIENT). The pure wire-protocol helpers live in
+// rdma_protocol.h and have no such dependency.
+
+#include "rdma_protocol.h"
+
+#ifdef HAVE_CUOBJ_CLIENT
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <cuobjclient.h>
+
+#include "nixl_types.h"
+
+namespace nixl_obj_rdma {
+
+/**
+ * Process-wide cuObjClient singleton.
+ *
+ * libcuobjclient is expensive to construct and its callbacks may fire on
+ * threads other than the caller's; constructing one per backend (or per call)
+ * was observed to corrupt allocator state under concurrency in the reference
+ * SDKs. A single instance per process is the supported pattern. Buffer
+ * registration (cuMemObjGetDescriptor) and token minting are serialized through
+ * an internal mutex.
+ */
+class SharedCuObjClient {
+public:
+    /// Returns the process-wide instance, or nullptr if the fabric is unavailable.
+    static SharedCuObjClient *
+    instance();
+
+    bool
+    isConnected() const {
+        return connected_;
+    }
+
+    /// Pin a buffer for RDMA. Required before minting a token for it.
+    bool
+    registerBuffer(void *ptr, size_t size);
+
+    /// Release a buffer registration acquired via registerBuffer().
+    void
+    deregisterBuffer(void *ptr);
+
+    /// True if the pointer is CUDA device (VRAM) memory (no HTTP fallback possible).
+    bool
+    isDeviceMemory(const void *ptr) const;
+
+    /// Mint an RDMA token for a registered buffer (caller releases via putToken()).
+    char *
+    getToken(void *ptr, size_t size, size_t offset, cuObjOpType_t op);
+    void
+    putToken(char *token);
+
+private:
+    SharedCuObjClient();
+    CUObjIOOps ops_{};
+    std::unique_ptr<cuObjClient> client_;
+    bool connected_ = false;
+    std::mutex mutex_;
+};
+
+/// Per-call context for an RDMA PUT/GET control-plane request.
+/// (region/credentials live in the control plane's signer, not here.)
+struct S3RdmaClientCtx {
+    std::string bucket;
+    std::string object;
+    std::string upload_id; // empty for single-shot (non-multipart)
+    uint32_t part_number = 0; // 1..=10000 when upload_id is set
+    std::string checksum_crc64nvme; // optional, in/out
+    std::string etag; // populated on success
+};
+
+/**
+ * S3 RDMA control plane.
+ *
+ * Owns the AWS SDK primitives (SigV4 signer + HTTP client + resolved endpoint)
+ * used to issue the body-less, RDMA-token-carrying GET/PUT that negotiates the
+ * out-of-band transfer. This is the only component that touches the AWS SDK's
+ * low-level HTTP layer; it is deliberately narrow so the protocol logic around
+ * it stays SDK-agnostic and testable.
+ */
+class S3RdmaControlPlane {
+public:
+    explicit S3RdmaControlPlane(nixl_b_params_t *custom_params);
+    ~S3RdmaControlPlane();
+
+    bool
+    valid() const {
+        return valid_;
+    }
+
+    /**
+     * Issue the signed control-plane PUT carrying the RDMA token.
+     * @return bytes transferred (>0) on RDMA success, rdma_not_supported if the
+     *         server declined, or rdma_error on transport failure.
+     */
+    ssize_t
+    rdmaPut(S3RdmaClientCtx &ctx, const char *token, uint64_t buf_addr, uint64_t size);
+
+    /**
+     * Issue the signed control-plane GET carrying the RDMA token. When
+     * @p offset is non-zero a byte-range request is made (server replies 206).
+     * @return bytes transferred (>0), rdma_not_supported if declined, or
+     *         rdma_error on failure.
+     */
+    ssize_t
+    rdmaGet(S3RdmaClientCtx &ctx,
+            const char *token,
+            uint64_t buf_addr,
+            uint64_t size,
+            uint64_t offset);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+    bool valid_ = false;
+};
+
+/**
+ * Mint a token, run rdmaPut, release the token, with one transient retry
+ * (covering token-mint and control-plane hiccups). The buffer must already be
+ * registered via SharedCuObjClient::registerBuffer().
+ *
+ * @return >0 bytes transferred (success), rdma_not_supported (server declined),
+ *         or rdma_error (failure). The caller treats anything < 0 as an error —
+ *         there is no HTTP fallback under accelerated=true.
+ */
+ssize_t
+rdmaPutWithRetry(SharedCuObjClient &rdma,
+                 S3RdmaControlPlane &cp,
+                 S3RdmaClientCtx &ctx,
+                 void *buf,
+                 size_t size);
+
+ssize_t
+rdmaGetWithRetry(SharedCuObjClient &rdma,
+                 S3RdmaControlPlane &cp,
+                 S3RdmaClientCtx &ctx,
+                 void *buf,
+                 size_t size,
+                 size_t offset);
+
+} // namespace nixl_obj_rdma
+
+#endif // HAVE_CUOBJ_CLIENT
+
+#endif // NIXL_SRC_PLUGINS_OBJ_S3_RDMA_H

--- a/src/plugins/obj/s3/rdma_protocol.h
+++ b/src/plugins/obj/s3/rdma_protocol.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_S3_RDMA_PROTOCOL_H
+#define NIXL_SRC_PLUGINS_OBJ_S3_RDMA_PROTOCOL_H
+
+// Generic S3-over-RDMA wire protocol helpers.
+//
+// This header is intentionally free of any AWS SDK or cuObject dependency so the
+// protocol logic can be unit-tested on its own. It encodes the published S3 RDMA
+// convention (the `x-amz-rdma-*` headers) used by NVIDIA cuObject and implemented
+// by any compliant S3 endpoint (MinIO AIStor today; transparently usable against
+// AWS S3 if/when it adopts the same convention). Nothing here is vendor-specific.
+
+#include <charconv>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <system_error>
+
+namespace nixl_obj_rdma {
+
+// S3 RDMA protocol headers (AWS S3 RDMA spec, compatible with NVIDIA aws-c-s3).
+inline constexpr const char *amz_rdma_token = "x-amz-rdma-token";
+inline constexpr const char *amz_rdma_reply = "x-amz-rdma-reply";
+inline constexpr const char *amz_rdma_bytes_transferred = "x-amz-rdma-bytes-transferred";
+
+// SigV4 payload hash sentinel for body-less RDMA control-plane requests.
+inline constexpr const char *unsigned_payload = "UNSIGNED-PAYLOAD";
+
+// RDMA reply status codes (carried in x-amz-rdma-reply, aligned with HTTP codes).
+inline constexpr int rdma_reply_success = 200; // transfer completed (PUT/GET)
+inline constexpr int rdma_reply_no_content = 204; // transfer completed, no content (PUT)
+inline constexpr int rdma_reply_partial_content = 206; // partial transfer (ranged GET)
+inline constexpr int rdma_reply_not_implemented =
+    501; // server declined RDMA (under accelerated=true: hard error)
+
+// Return-code sentinels shared by rdmaPut/rdmaGet (negative => caller errors; no
+// HTTP fallback). >0 is the number of bytes transferred on success.
+inline constexpr ssize_t rdma_not_supported = -2; // server declined RDMA
+inline constexpr ssize_t rdma_error = -1; // transport / unexpected failure
+
+// One transient retry: a fresh token mint + control-plane attempt recovers from
+// a transient cuObject token-acquisition or transport hiccup. (NIC-aware failover
+// is a future enhancement; it requires binding the control-plane socket to the
+// token's source NIC, which the AWS SDK HTTP client does not expose today.)
+inline constexpr int rdma_max_attempts = 2;
+
+// Aggressive control-plane timeouts (seconds) so a transport stall surfaces fast
+// and the retry path can take over.
+inline constexpr long rdma_connect_timeout_secs = 5;
+inline constexpr long rdma_timeout_secs = 10;
+
+/**
+ * Format the value of the x-amz-rdma-token header.
+ *
+ * Wire format (see AIStor server eos/internal/rdma/rdma.go Request.String):
+ *   "<descriptor>:<start_addr_hex>:<size_hex>"
+ * where the two trailing fields are 16-digit zero-padded lowercase hex. The
+ * server parses the address/size with a base-16 parser, so zero-padding is
+ * accepted and keeps the field widths fixed.
+ */
+inline std::string
+formatRdmaToken(const char *descriptor, uint64_t buf_addr, uint64_t size) {
+    char out[512];
+    std::snprintf(out,
+                  sizeof(out),
+                  "%s:%016lx:%016lx",
+                  descriptor ? descriptor : "",
+                  static_cast<unsigned long>(buf_addr),
+                  static_cast<unsigned long>(size));
+    return std::string(out);
+}
+
+/**
+ * Map the server's x-amz-rdma-reply header value to a transfer outcome.
+ *
+ *   >0  reply code (200/204/206): treat as RDMA success
+ *    0  unparsable non-empty value: treat as failure (-1) by the caller
+ *   -2  reply is "501" OR absent/empty: server declined RDMA
+ *
+ * This drives the GET path and decline detection. A GET success carries
+ * x-amz-rdma-reply: 200/206; its absence (a non-RDMA server never sets it) is
+ * read as a decline. PUT success is determined separately by HTTP 200 + ETag
+ * (the server does not set this header on the PUT success path).
+ */
+inline int
+parseRdmaReply(const std::string &reply) {
+    if (reply.empty() || reply == "501") {
+        return static_cast<int>(rdma_not_supported);
+    }
+    // Require the ENTIRE value to be a valid integer. std::stoi would accept
+    // trailing junk ("200xyz" -> 200), which could mask a malformed reply as a
+    // success code; from_chars rejects it.
+    int value = 0;
+    const char *begin = reply.data();
+    const char *end = begin + reply.size();
+    auto [parsed_end, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc{} || parsed_end != end) {
+        return 0; // malformed -> caller treats as failure
+    }
+    return value;
+}
+
+} // namespace nixl_obj_rdma
+
+#endif // NIXL_SRC_PLUGINS_OBJ_S3_RDMA_PROTOCOL_H

--- a/src/plugins/obj/s3_accel/TODO.md
+++ b/src/plugins/obj/s3_accel/TODO.md
@@ -1,0 +1,22 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# s3_accel engines
+
+The `s3_accel/` tree provides S3-over-RDMA engines selected through the
+`objAccelEngineRegistry`, enabled per backend via `accelerated=true`.
+
+The standard-S3 engine is the preferred choice because it complies with the
+agreed, published S3-over-RDMA protocol. It lives in `s3_accel/generic/`, speaks
+the `x-amz-rdma-*` headers, and is vendor-neutral, so it needs no per-vendor
+code. It is selected via `accelerated=true` with no `type`, or `type=s3`. Its
+protocol helpers live in `../s3/rdma_protocol.h` and its transport in
+`../s3/rdma.cpp`. See [`../RDMA_PROTOCOL.md`](../RDMA_PROTOCOL.md) and the
+[GPU-Direct section of the README](../README.md#gpu-direct-s3-over-rdma).
+
+Vendor engines serve servers that use vendor-specific RDMA headers. For example,
+the Dell engine (`s3_accel/dell`, `type=dell`) uses the `x-rdma-info` header and
+selects its engine statically at backend creation. It is enabled via
+`accelerated=true, type=dell`.

--- a/src/plugins/obj/s3_accel/client.cpp
+++ b/src/plugins/obj/s3_accel/client.cpp
@@ -8,7 +8,10 @@
 
 awsS3AccelClient::awsS3AccelClient(nixl_b_params_t *custom_params,
                                    std::shared_ptr<Aws::Utils::Threading::Executor> executor)
-    : awsS3Client(custom_params, executor) {
+    // Opt out of the base client's standard S3-over-RDMA fast path: vendor
+    // accelerated engines (e.g. Dell) manage RDMA themselves via their own
+    // cuObjClient, so the base must not also construct the shared one.
+    : awsS3Client(custom_params, executor, /*enable_rdma_fast_path=*/false) {
     // Base class already initializes the S3 client, bucket name, and credentials.
     // Derived vendor clients can add their specific initialization here.
     NIXL_DEBUG << "S3 Accelerated client initialized";

--- a/src/plugins/obj/s3_accel/dell/README.md
+++ b/src/plugins/obj/s3_accel/dell/README.md
@@ -17,36 +17,45 @@ limitations under the License.
 
 # NIXL Dell ObjectScale accelerated S3 engine
 
-This vendor-specific accelerated engine provides S3 over RDMA for Dell ObjectScale.  This engine utilizes the CUDA Toolkit CUObject Client library and the AWS S3 SDK.
+> **Note:** This Dell vendor engine (selected via `accelerated=true, type=dell`)
+> is a vendor-specific engine for servers that use vendor-specific
+> RDMA headers: it uses the `x-rdma-info` header and selects its engine
+> statically at backend creation. The standard-S3 engine
+> (`accelerated=true` with no `type`, or `type=s3`) is preferred because it
+> complies with the proposed S3-over-RDMA protocol, using the standard
+> `x-amz-rdma-*` headers with no per-vendor code. See the main
+> [object plugin README](../../README.md#gpu-direct-s3-over-rdma).
+
+This vendor-specific accelerated engine provides S3 over RDMA for Dell ObjectScale. This engine utilizes the CUDA Toolkit CUObject Client library and the AWS S3 SDK.
 
 If a Dell ObjectScale endpoint is utilized, but RDMA is not enabled, the standard S3 engine should be used instead.
 
 ## Dependencies
 
-This engine requires aws-sdk-cpp.  This dependency and steps to install it are provided in the OBJ backend documentation.
+This engine requires aws-sdk-cpp. This dependency and steps to install it are provided in the OBJ backend documentation.
 
 This engine requires the CUDA Toolkit version 13.1.1 or later to be installed.
 
 [CUDA GDS Install and Setup](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
 
-The CUDA toolkit provides the CUObject Client library, which is required for this engine to function.  The library is included in the CUDA Toolkit installation.
+The CUDA toolkit provides the CUObject Client library, which is required for this engine to function. The library is included in the CUDA Toolkit installation.
 
 ## Configuration
 
-The Dell ObjectScale engine supports configuration through two mechanisms: backend parameter maps passed during backend creation, and environment variables for system-wide settings. Backend parameters take precedence over environment variables.  The backend parameters described below are required to enable the Dell ObjectScale engine.
+The Dell ObjectScale engine supports configuration through two mechanisms: backend parameter maps passed during backend creation, and environment variables for system-wide settings. Backend parameters take precedence over environment variables. The backend parameters described below are required to enable the Dell ObjectScale engine.
 
 ### Backend Parameters
 
-Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creating the backend instance. The Dell ObjectScale Object Storage backend supports AWS S3-compatible storage.  These parameters are described in the OBJ backend documentation.  In addition to the parameters described in the OBJ backend documentation, the following parameters are required to enable the Dell ObjectScale engine:
+Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creating the backend instance. The Dell ObjectScale Object Storage backend supports AWS S3-compatible storage. These parameters are described in the OBJ backend documentation. In addition to the parameters described in the OBJ backend documentation, the following parameters are required to enable the Dell ObjectScale engine:
 
-| Parameter | Description | Default | Required |
-|-----------|-------------|---------|----------|
-| `req_checksum` | Request checksum validation (`required`/`supported`) | - | No |
-| `resp_checksum` | Response checksum validation (`required`/`supported`) | `required` | No |
-| `accelerated` | Enable accelerated engine (`true`/`false`) | `false` | No |
-| `type` | Vendor Type for accelerated engine | - | No |
+| Parameter       | Description                                           | Default    | Required |
+| --------------- | ----------------------------------------------------- | ---------- | -------- |
+| `req_checksum`  | Request checksum validation (`required`/`supported`)  | -          | No       |
+| `resp_checksum` | Response checksum validation (`required`/`supported`) | `required` | No       |
+| `accelerated`   | Enable accelerated engine (`true`/`false`)            | `false`    | No       |
+| `type`          | Vendor Type for accelerated engine                    | -          | No       |
 
-To enable the Dell ObjectScale engine, the `accelerated` parameter must be set to `true` and the `type` parameter must be set to `dell`.  It is recommended that the `req_checksum` parameter be set to `required` to disable the AWS SDK's proactive request body checksum validation.  Setting the value to `supported` will allow the AWS SDK to perform request body checksum validation, but this is not recommended for Dell ObjectScale.
+To enable the Dell ObjectScale engine, the `accelerated` parameter must be set to `true` and the `type` parameter must be set to `dell`. It is recommended that the `req_checksum` parameter be set to `required` to disable the AWS SDK's proactive request body checksum validation. Setting the value to `supported` will allow the AWS SDK to perform request body checksum validation, but this is not recommended for Dell ObjectScale.
 
 > **Note:** The Dell engine defaults `resp_checksum` to `required` (i.e.,
 > `ResponseChecksumValidation::WHEN_REQUIRED`). This disables the AWS SDK's
@@ -97,20 +106,20 @@ agent.createBackend("OBJ", params);
 
 ### CUObject Client Configuration
 
-The CUObject Client library requires the configuration of the RDMA device address list in the JSON configuration file.  Each client IP address associated with an RDMA device is specified in the "rdma_dev_addr_list" property.  The following is an example JSON file:
+The CUObject Client library requires the configuration of the RDMA device address list in the JSON configuration file. Each client IP address associated with an RDMA device is specified in the "rdma_dev_addr_list" property. The following is an example JSON file:
 
 ```json
 {
-    "execution": {
-        "parallel_io" : false
-    },
+  "execution": {
+    "parallel_io": false
+  },
 
-    "properties": {
-        "allow_compat_mode": true,
-        "use_pci_p2pdma": true,
-        "rdma_peer_type": "dmabuf",
-        "rdma_dev_addr_list": ["10.0.1.2", "10.0.2.2"]
-    }
+  "properties": {
+    "allow_compat_mode": true,
+    "use_pci_p2pdma": true,
+    "rdma_peer_type": "dmabuf",
+    "rdma_dev_addr_list": ["10.0.1.2", "10.0.2.2"]
+  }
 }
 ```
 

--- a/src/plugins/obj/s3_accel/engine_impl.cpp
+++ b/src/plugins/obj/s3_accel/engine_impl.cpp
@@ -7,19 +7,10 @@
 #include "s3_accel/client.h"
 #include "common/nixl_log.h"
 
-#include "obj_engine_registry.h"
-
-namespace {
-
-// "" matches the default from getAccelType() when no "type" key is set in custom params
-objAccelEngineRegistrar reg_s3_accel(
-    "",
-    [](const nixlBackendInitParams *p) { return std::make_unique<S3AccelObjEngineImpl>(p); },
-    [](const nixlBackendInitParams *p, std::shared_ptr<iS3Client> s3, std::shared_ptr<iS3Client>) {
-        return std::make_unique<S3AccelObjEngineImpl>(p, std::move(s3));
-    });
-
-} // namespace
+// S3AccelObjEngineImpl is the shared base for vendor accel engines (e.g. Dell).
+// It is not registered for direct selection: `accelerated=true` with no `type`
+// resolves to the generic engine (see s3_accel/generic/engine_impl.cpp), and
+// vendor engines register under their own type (e.g. "dell").
 
 S3AccelObjEngineImpl::S3AccelObjEngineImpl(const nixlBackendInitParams *init_params)
     : DefaultObjEngineImpl(init_params) {

--- a/src/plugins/obj/s3_accel/generic/engine_impl.cpp
+++ b/src/plugins/obj/s3_accel/generic/engine_impl.cpp
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "engine_impl.h"
+#include "obj_engine_registry.h"
+
+namespace {
+
+// Register the standard-S3 engine under "s3" (the preferred, protocol-compliant
+// S3-over-RDMA engine). obj_backend normalizes a missing `type` to "s3" before
+// lookup, so `accelerated=true` with no type also resolves here. (We deliberately
+// avoid registering under "" because the cuobj-gated s3_accel base also claims
+// "", and the registry keeps the first-inserted entry — static-init order across
+// translation units is unspecified, so a "" registration here would be a
+// non-deterministic collision. Routing through "s3" is collision-free and
+// deterministic in every build.)
+//
+// Built unconditionally; the RDMA transport itself is guarded by
+// HAVE_CUOBJ_CLIENT in the standard client, which throws at construction if RDMA
+// is requested but unavailable.
+objAccelEngineRegistrar reg_generic(
+    "s3",
+    [](const nixlBackendInitParams *p) { return std::make_unique<GenericObjEngineImpl>(p); },
+    [](const nixlBackendInitParams *p,
+       std::shared_ptr<iS3Client> s3,
+       std::shared_ptr<iS3Client> s3_crt) {
+        return std::make_unique<GenericObjEngineImpl>(p, std::move(s3), std::move(s3_crt));
+    });
+
+} // namespace

--- a/src/plugins/obj/s3_accel/generic/engine_impl.h
+++ b/src/plugins/obj/s3_accel/generic/engine_impl.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_S3_ACCEL_GENERIC_ENGINE_IMPL_H
+#define NIXL_SRC_PLUGINS_OBJ_S3_ACCEL_GENERIC_ENGINE_IMPL_H
+
+#include "s3/engine_impl.h"
+
+/**
+ * Standard-S3, protocol-compliant S3-over-RDMA engine (the preferred engine).
+ *
+ * Selected by `accelerated=true` with no `type` (or `type=s3`). It carries
+ * no new logic: DefaultObjEngineImpl already advertises VRAM and registers RDMA
+ * buffers gated on the client's supportsRdma(), and the standard S3 client
+ * enables its RDMA fast path because the params carry accelerated=true with no
+ * type. It is preferred because it requires no per-vendor code and speaks only
+ * the published, vendor-neutral `x-amz-rdma-*` protocol.
+ */
+class GenericObjEngineImpl : public DefaultObjEngineImpl {
+public:
+    explicit GenericObjEngineImpl(const nixlBackendInitParams *init_params)
+        : DefaultObjEngineImpl(init_params) {}
+
+    GenericObjEngineImpl(const nixlBackendInitParams *init_params,
+                         std::shared_ptr<iS3Client> s3_client,
+                         std::shared_ptr<iS3Client> s3_client_crt)
+        : DefaultObjEngineImpl(init_params, std::move(s3_client), std::move(s3_client_crt)) {}
+};
+
+#endif // NIXL_SRC_PLUGINS_OBJ_S3_ACCEL_GENERIC_ENGINE_IMPL_H

--- a/src/plugins/obj/s3_crt/engine_impl.h
+++ b/src/plugins/obj/s3_crt/engine_impl.h
@@ -15,6 +15,14 @@ public:
                        std::shared_ptr<iS3Client> s3_client,
                        std::shared_ptr<iS3Client> s3_client_crt);
 
+    // The CRT client is an HTTP multipart optimization for large objects and
+    // cannot do GPU-direct RDMA, so the CRT engine does not advertise VRAM_SEG.
+    // GPUDirect transfers require the default (non-CRT) configuration.
+    nixl_mem_list_t
+    getSupportedMems() const override {
+        return {DRAM_SEG, OBJ_SEG};
+    }
+
 protected:
     iS3Client *
     getClient() const override;

--- a/src/utils/object/engine_utils.h
+++ b/src/utils/object/engine_utils.h
@@ -10,6 +10,7 @@
 #include "common/nixl_log.h"
 #include "nixl_types.h"
 #include <algorithm>
+#include <string>
 #include <thread>
 
 [[nodiscard]] inline std::size_t
@@ -28,4 +29,30 @@ isAcceleratedRequested(nixl_b_params_t *custom_params) {
     return nixl::getBackendParamDefaulted(custom_params, "accelerated", false);
 }
 
-#endif
+[[nodiscard]] inline std::string
+getAccelType(const nixl_b_params_t *custom_params) {
+    return nixl::getBackendParamDefaulted(custom_params, "type", std::string());
+}
+
+// Standard, protocol-compliant S3-over-RDMA path: `accelerated=true` with no
+// `type` (or `type=s3`). This is the preferred engine because it complies with
+// the published `x-amz-rdma-*` S3-over-RDMA protocol and requires no per-vendor
+// code, unlike the vendor-specific engines selected by an explicit `type` (e.g.
+// `type=dell`) for servers that use vendor-specific RDMA headers.
+//
+// RDMA is asserted rather than auto-probed because the fallback handshake depends
+// on the server returning `x-amz-rdma-reply: 501` (or omitting the reply header)
+// when it cannot honor RDMA. A server that instead *silently ignores* the
+// `x-amz-rdma-token` header would accept our body-less PUT as a 0-byte object —
+// a chicken-and-egg the client cannot safely resolve by probing. Until server
+// implementations reliably signal 501, the caller must assert RDMA support via
+// `accelerated=true`; on a decline/failure the transfer errors rather than
+// silently falling back. (See the fallback note in s3/client.cpp for the future
+// path.)
+[[nodiscard]] inline bool
+isGenericAccelRequested(nixl_b_params_t *custom_params) {
+    return isAcceleratedRequested(custom_params) &&
+        (getAccelType(custom_params).empty() || getAccelType(custom_params) == "s3");
+}
+
+#endif // NIXL_SRC_UTILS_OBJECT_ENGINE_UTILS_H

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-obj_test_sources = ['obj.cpp']
+obj_test_sources = ['obj.cpp', 'rdma_protocol.cpp']
 
 if cuobj_dep.found()
     obj_test_sources += ['mock_dell_s3_client.cpp', 'obj_cuobj.cpp']

--- a/test/gtest/unit/obj/rdma_protocol.cpp
+++ b/test/gtest/unit/obj/rdma_protocol.cpp
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Unit tests for the dependency-free S3-over-RDMA wire-protocol helpers. These
+// exercise the parts of the RDMA path that do not require the AWS SDK or the
+// cuObjClient library, so they run on any build.
+
+#include <gtest/gtest.h>
+
+#include "s3/rdma_protocol.h"
+
+namespace {
+
+using namespace nixl_obj_rdma;
+
+TEST(RdmaProtocol, FormatTokenIsDescColonAddrColonSize) {
+    // Wire format: "<descriptor>:<addr:016x>:<size:016x>" (lowercase, zero-padded).
+    EXPECT_EQ(formatRdmaToken("DESC", 0x10, 0x200), "DESC:0000000000000010:0000000000000200");
+    EXPECT_EQ(formatRdmaToken("", 0, 0), ":0000000000000000:0000000000000000");
+}
+
+TEST(RdmaProtocol, FormatTokenHandlesFullWidthAndNullDescriptor) {
+    // Full 64-bit values render as 16 lowercase hex digits (no truncation).
+    EXPECT_EQ(formatRdmaToken("D", 0xffffffffffffffffULL, 0xdeadbeefcafef00dULL),
+              "D:ffffffffffffffff:deadbeefcafef00d");
+    // A null descriptor is treated as an empty one (no crash, leading ':').
+    EXPECT_EQ(formatRdmaToken(nullptr, 0x1, 0x2), ":0000000000000001:0000000000000002");
+}
+
+TEST(RdmaProtocol, ParseReplySuccessCodes) {
+    EXPECT_EQ(parseRdmaReply("200"), rdma_reply_success);
+    EXPECT_EQ(parseRdmaReply("204"), rdma_reply_no_content);
+    EXPECT_EQ(parseRdmaReply("206"), rdma_reply_partial_content);
+}
+
+TEST(RdmaProtocol, ParseReplyDeclinedAndAbsentMapToNotSupported) {
+    // Explicit decline.
+    EXPECT_EQ(parseRdmaReply("501"), static_cast<int>(rdma_not_supported));
+    // An absent header (a non-RDMA server never sets it) reads as "declined".
+    // This drives GET decline detection; PUT success is decided separately by
+    // HTTP 200 + ETag, not by this header.
+    EXPECT_EQ(parseRdmaReply(""), static_cast<int>(rdma_not_supported));
+    // Garbage parses to 0 (caller treats as failure).
+    EXPECT_EQ(parseRdmaReply("not-a-number"), 0);
+}
+
+TEST(RdmaProtocol, ParseReplyRejectsTrailingJunk) {
+    // A reply with trailing junk must NOT be accepted as a success code: std::stoi
+    // would return 200 for "200xyz" and mask a malformed reply as RDMA success.
+    EXPECT_EQ(parseRdmaReply("200xyz"), 0);
+    EXPECT_EQ(parseRdmaReply("200 "), 0);
+    EXPECT_EQ(parseRdmaReply("2 06"), 0);
+    EXPECT_EQ(parseRdmaReply("0x200"), 0);
+    // "501" with trailing junk is not the exact decline token, so it is malformed.
+    EXPECT_EQ(parseRdmaReply("501x"), 0);
+}
+
+TEST(RdmaProtocol, ParseReplyRejectsLeadingWhitespaceAndSign) {
+    // from_chars does not skip leading whitespace or accept a leading '+'.
+    EXPECT_EQ(parseRdmaReply(" 200"), 0);
+    EXPECT_EQ(parseRdmaReply("+200"), 0);
+    EXPECT_EQ(parseRdmaReply("\t206"), 0);
+}
+
+TEST(RdmaProtocol, ProtocolConstantsHaveExpectedValues) {
+    // Guard the wire contract: header names and status codes must not drift.
+    EXPECT_STREQ(amz_rdma_token, "x-amz-rdma-token");
+    EXPECT_STREQ(amz_rdma_reply, "x-amz-rdma-reply");
+    EXPECT_STREQ(amz_rdma_bytes_transferred, "x-amz-rdma-bytes-transferred");
+    EXPECT_STREQ(unsigned_payload, "UNSIGNED-PAYLOAD");
+    EXPECT_EQ(rdma_reply_success, 200);
+    EXPECT_EQ(rdma_reply_no_content, 204);
+    EXPECT_EQ(rdma_reply_partial_content, 206);
+    EXPECT_EQ(rdma_reply_not_implemented, 501);
+    EXPECT_EQ(rdma_not_supported, -2);
+}
+
+} // namespace

--- a/test/unit/plugins/object/nixl_object_test.cpp
+++ b/test/unit/plugins/object/nixl_object_test.cpp
@@ -90,28 +90,33 @@ parse_size(const char *size_str) {
  */
 void
 print_usage(const char *program_name) {
-    std::cerr << "Usage: " << program_name << " [options]\n"
-              << "Options:\n"
-              << "  -n, --num-transfers N   Number of transfers to perform (default: "
-              << DEFAULT_NUM_TRANSFERS << ")\n"
-              << "  -s, --size SIZE         Size of each transfer (default: "
-              << DEFAULT_TRANSFER_SIZE << " bytes)\n"
-              << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
-              << "  -t, --iterations N      Number of iterations for each transfer (default: "
-              << DEFAULT_ITERATIONS << ")\n"
-              << "  -e, --endpoint ENDPOINT S3 Endpoint URL\n"
-              << "  -u, --bucket BUCKET     S3 Bucket name\n"
-              << "  -a, --accelerated       Enable accelerated engine mode\n"
-              << "  -T, --type TYPE         Vendor type for accelerated engine (e.g., dell)\n"
-              << "  -v, --vram              Use VRAM (GPU memory) instead of DRAM\n"
-              << "                          (requires --accelerated and CUDA/GPU support)\n"
-              << "  -h, --help              Show this help message\n"
-              << "\nExamples:\n"
-              << "  " << program_name << " -n 100 -s 16M -t 5\n"
-              << "  " << program_name
-              << " -n 100 -s 16M -t 5 -e http://s3.example.com:9000 -u my-bucket\n"
-              << "  " << program_name << " -a -T dell -e http://10.10.10.10:9000 -u my-bucket\n"
-              << "  " << program_name << " -v -a -T dell -e http://10.10.10.10:9000 -u my-bucket\n";
+    std::cerr
+        << "Usage: " << program_name << " [options]\n"
+        << "Options:\n"
+        << "  -n, --num-transfers N   Number of transfers to perform (default: "
+        << DEFAULT_NUM_TRANSFERS << ")\n"
+        << "  -s, --size SIZE         Size of each transfer (default: " << DEFAULT_TRANSFER_SIZE
+        << " bytes)\n"
+        << "                          Can use K, M, or G suffix (e.g., 1K, 2M, 3G)\n"
+        << "  -t, --iterations N      Number of iterations for each transfer (default: "
+        << DEFAULT_ITERATIONS << ")\n"
+        << "  -e, --endpoint ENDPOINT S3 Endpoint URL\n"
+        << "  -u, --bucket BUCKET     S3 Bucket name\n"
+        << "  -a, --accelerated       Enable protocol-compliant S3-over-RDMA (accelerated=true).\n"
+        << "                          Requires an endpoint that implements the protocol.\n"
+        << "  -T, --type TYPE         Vendor type for vendor-specific accel (e.g., dell)\n"
+        << "  -v, --vram              Use VRAM (GPU memory) instead of DRAM\n"
+        << "                          (requires --accelerated, and CUDA/GPU)\n"
+        << "  -h, --help              Show this help message\n"
+        << "\nExamples:\n"
+        << "  " << program_name << " -n 100 -s 16M -t 5\n"
+        << "  " << program_name
+        << " -n 100 -s 16M -t 5 -e http://s3.example.com:9000 -u my-bucket\n"
+        << "  " << program_name << " -a -e http://aistor:9000 -u my-bucket          # RDMA (DRAM)\n"
+        << "  " << program_name
+        << " -v -a -e http://aistor:9000 -u my-bucket       # RDMA (GPU-direct)\n"
+        << "  " << program_name
+        << " -a -T dell -e http://10.10.10.10:9000 -u my-bucket  # vendor (Dell)\n";
 }
 
 /**
@@ -125,12 +130,13 @@ printProgress(float progress) {
     std::cout << "[";
     int pos = barWidth * progress;
     for (int i = 0; i < barWidth; ++i) {
-        if (i < pos)
+        if (i < pos) {
             std::cout << "=";
-        else if (i == pos)
+        } else if (i == pos) {
             std::cout << ">";
-        else
+        } else {
             std::cout << " ";
+        }
     }
     std::cout << "] " << std::fixed << std::setprecision(1) << (progress * 100.0) << "% ";
 
@@ -345,11 +351,11 @@ main(int argc, char *argv[]) {
         }
     }
 
-    // Validate VRAM option: requires --accelerated and CUDA
+    // Validate VRAM option: requires the RDMA (accelerated) path and CUDA.
     if (use_vram) {
         if (!use_accelerated) {
-            std::cerr << "Error: --vram requires --accelerated (VRAM_SEG is not supported by the "
-                         "default OBJ backend)\n";
+            std::cerr << "Error: --vram requires --accelerated: VRAM_SEG is only supported on the "
+                         "RDMA path\n";
             return 1;
         }
 #ifndef HAVE_CUDA
@@ -398,7 +404,7 @@ main(int argc, char *argv[]) {
     std::cout << "Configuration:" << std::endl;
     std::cout << "- Mode: " << (use_vram ? "VRAM" : "DRAM") << std::endl;
     if (use_accelerated) {
-        std::cout << "- Accelerated: true" << std::endl;
+        std::cout << "- Accelerated (S3 over RDMA): true" << std::endl;
         if (!accel_type.empty()) {
             std::cout << "- Type: " << accel_type << std::endl;
         }
@@ -420,8 +426,10 @@ main(int argc, char *argv[]) {
                               {"use_virtual_addressing", "false"},
                               {"req_checksum", "required"}};
 
-    // Enable accelerated engine and vendor type when requested.
-    // For Dell ObjectScale: accelerated=true, type=dell enables S3 over RDMA.
+    // accelerated=true with no type selects the preferred, protocol-compliant
+    // standard-S3 over-RDMA path (vendor-neutral x-amz-rdma-* protocol). Adding a
+    // vendor type (e.g. dell) selects a vendor-specific accel engine for servers
+    // that use vendor-specific RDMA headers.
     if (use_accelerated) {
         params["accelerated"] = "true";
         if (!accel_type.empty()) {
@@ -816,14 +824,18 @@ cleanup:
     if (use_vram) {
 #ifdef HAVE_CUDA
         for (i = 0; i < num_transfers; i++) {
-            if (vram_addr[i]) cudaFree(vram_addr[i]);
+            if (vram_addr[i]) {
+                cudaFree(vram_addr[i]);
+            }
         }
 #endif
         delete[] vram_addr;
         delete[] vram_buf;
     } else {
         for (i = 0; i < num_transfers; i++) {
-            if (dram_addr[i]) free(dram_addr[i]);
+            if (dram_addr[i]) {
+                free(dram_addr[i]);
+            }
         }
         delete[] dram_addr;
         delete[] dram_buf;


### PR DESCRIPTION
## What

Adds a vendor-neutral S3-over-RDMA data path to the object plugin, selected via `accelerated=true` with no `type` (or `type=s3`). It implements the published `x-amz-rdma-*` protocol (the NVIDIA cuObject / aws-c-s3 convention) and needs no per-vendor code — any conformant endpoint works (MinIO AIStor today; AWS S3 if it adopts it). The control plane stays standard HTTP + SigV4 while the object payload moves out-of-band over RDMA (server `RDMA_READ` on PUT, `RDMA_WRITE` on GET; the HTTP body is empty).

This is the preferred GPU-direct path. `accelerated=true, type=dell` selects a vendor-specific engine for servers that speak Dell's `x-rdma-info` header.

## Changes

- **`s3/rdma_protocol.h`** — dependency-free wire helpers (token formatting, reply parsing), covered by a unit test.
- **`s3/rdma.{h,cpp}`** — the cuObject RDMA token API plus a SigV4 `UNSIGNED-PAYLOAD` control plane that carries `x-amz-rdma-token` and reads `x-amz-rdma-reply` / `x-amz-rdma-bytes-transferred`.
- **`s3_accel/generic/`** — the standard-S3 engine, registered in the accel registry under `type=s3`; `accelerated=true` with no `type` resolves to it. RDMA is a capability of the standard S3 client, enabled for this engine.
- **Explicit opt-in** — an RDMA decline/failure is a hard error; no automatic HTTP fallback.
- **Docs** — `RDMA_PROTOCOL.md` documents the server-side wire contract and a vendor compliance checklist; the README gains a GPU-Direct section.
- **`nixl_object_test`** — gains `-a/--accelerated` (standard-S3); keeps `-T/--type` for vendor engines.

## Verification

Validated end-to-end against MinIO AIStor over RoCEv2: `accelerated=true` (no type) and `type=s3` both complete host-DRAM and GPU-direct VRAM PUT/GET with data verification. The protocol layer is covered by a unit test.

> GPU-direct into VRAM requires the GPU and NIC to share a PCIe path that permits peer DMA (see the README's PCIe-ACS note) — a host/fabric property, independent of NIXL.