### PR TITLE
UTILS/CONFIG: Make config file reading unit-testable and re-enable test.

### DIFF
--- a/src/utils/common/configuration.cpp
+++ b/src/utils/common/configuration.cpp
@@ -18,9 +18,6 @@
 #include "configuration.h"
 #include "exception.h"
 
-#include <memory>
-#include <mutex>
-
 namespace nixl::config {
 
 namespace {
@@ -77,25 +74,15 @@ namespace {
         return toml::table();
     }
 
-    struct configGlobal {
-        std::mutex mutex;
-        std::shared_ptr<const toml::table> data;
-    };
-
-    [[nodiscard]] configGlobal &
-    getConfigGlobal() {
-        static configGlobal cg;
-        return cg;
+    [[nodiscard]] toml::table &
+    staticConfig() {
+        static toml::table config = readFile();
+        return config;
     }
 
-    [[nodiscard]] std::shared_ptr<const toml::table>
-    getConfigFile() {
-        configGlobal &cg = getConfigGlobal();
-        const std::lock_guard ml(cg.mutex);
-        if (!cg.data) {
-            cg.data = std::make_shared<toml::table>(readFile());
-        }
-        return cg.data;
+    [[nodiscard]] const toml::table &
+    getConfig() {
+        return staticConfig();
     }
 
 } // namespace
@@ -123,35 +110,37 @@ namespace internal {
         return fallback;
     }
 
-    [[nodiscard]] tomlFindResult
+    [[nodiscard]] toml::node_view<const toml::node>
     findTomlNode(const toml::path &path) {
-        const auto config = getConfigFile();
-        const auto result = config->at_path(path);
+        const auto result = getConfig().at_path(path);
         if (result) {
             NIXL_DEBUG << "Found config file entry '" << path << "'";
         } else {
             NIXL_DEBUG << "Missing config file entry '" << path << "'";
         }
-        return tomlFindResult(result, config);
+        return result;
     }
 
-    [[nodiscard]] tomlFindResult
+    [[nodiscard]] toml::node_view<const toml::node>
     findTomlNode(const std::string &path) {
         return findTomlNode(toml::path(path));
     }
 
     void
     warnIgnoreToml(const std::string &path) {
-        if (getConfigFile()->at_path(toml::path(path))) {
+        if (getConfig().at_path(toml::path(path))) {
             NIXL_DEBUG << "Ignoring config file entry '" << path << "' for environment variable";
         }
     }
 
+    // The refresh function's handling of the config is NOT multi-thread-safe;
+    // this function should only be used by the one unit test that needs it,
+    // and when it is used then nothing else that might access the config is
+    // is allowed to run in parallel in the same process in other threads.
+
     void
-    invalidateConfigFileForUnitTest() {
-        configGlobal &cg = getConfigGlobal();
-        const std::lock_guard ml(cg.mutex);
-        cg.data.reset();
+    refreshConfigFileForUnitTest() {
+        staticConfig() = readFile();
     }
 
 } // namespace internal

--- a/src/utils/common/configuration.cpp
+++ b/src/utils/common/configuration.cpp
@@ -18,6 +18,9 @@
 #include "configuration.h"
 #include "exception.h"
 
+#include <memory>
+#include <mutex>
+
 namespace nixl::config {
 
 namespace {
@@ -74,10 +77,25 @@ namespace {
         return toml::table();
     }
 
-    [[nodiscard]] const toml::table &
-    getConfig() {
-        static const toml::table config = readFile();
-        return config;
+    struct configGlobal {
+        std::mutex mutex;
+        std::shared_ptr<const toml::table> data;
+    };
+
+    [[nodiscard]] configGlobal &
+    getConfigGlobal() {
+        static configGlobal cg;
+        return cg;
+    }
+
+    [[nodiscard]] std::shared_ptr<const toml::table>
+    getConfigFile() {
+        configGlobal &cg = getConfigGlobal();
+        const std::lock_guard ml(cg.mutex);
+        if (!cg.data) {
+            cg.data = std::make_shared<toml::table>(readFile());
+        }
+        return cg.data;
     }
 
 } // namespace
@@ -105,27 +123,35 @@ namespace internal {
         return fallback;
     }
 
-    [[nodiscard]] toml::node_view<const toml::node>
+    [[nodiscard]] tomlFindResult
     findTomlNode(const toml::path &path) {
-        const auto result = getConfig().at_path(path);
+        const auto config = getConfigFile();
+        const auto result = config->at_path(path);
         if (result) {
             NIXL_DEBUG << "Found config file entry '" << path << "'";
         } else {
             NIXL_DEBUG << "Missing config file entry '" << path << "'";
         }
-        return result;
+        return tomlFindResult(result, config);
     }
 
-    [[nodiscard]] toml::node_view<const toml::node>
+    [[nodiscard]] tomlFindResult
     findTomlNode(const std::string &path) {
         return findTomlNode(toml::path(path));
     }
 
     void
     warnIgnoreToml(const std::string &path) {
-        if (getConfig().at_path(toml::path(path))) {
+        if (getConfigFile()->at_path(toml::path(path))) {
             NIXL_DEBUG << "Ignoring config file entry '" << path << "' for environment variable";
         }
+    }
+
+    void
+    invalidateConfigFileForUnitTest() {
+        configGlobal &cg = getConfigGlobal();
+        const std::lock_guard ml(cg.mutex);
+        cg.data.reset();
     }
 
 } // namespace internal

--- a/src/utils/common/configuration.h
+++ b/src/utils/common/configuration.h
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <strings.h>
@@ -55,10 +56,22 @@ namespace internal {
     [[nodiscard]] std::string
     getenvDefaulted(const std::string &name, const std::string &fallback);
 
-    [[nodiscard]] toml::node_view<const toml::node>
+    struct tomlFindResult {
+        tomlFindResult(const toml::node_view<const toml::node> &view,
+                       const std::shared_ptr<const toml::table> &data)
+            : view(view),
+              keep_view_alive(data) {}
+
+        const toml::node_view<const toml::node> view;
+
+    private:
+        const std::shared_ptr<const toml::table> keep_view_alive;
+    };
+
+    [[nodiscard]] tomlFindResult
     findTomlNode(const toml::path &path);
 
-    [[nodiscard]] toml::node_view<const toml::node>
+    [[nodiscard]] tomlFindResult
     findTomlNode(const std::string &path);
 
     void
@@ -250,9 +263,11 @@ getValueWithStatus(type &result, const std::string &env) {
         return NIXL_SUCCESS;
     }
 
-    if (const auto view = internal::findTomlNode(env)) {
+    const internal::tomlFindResult find_result = internal::findTomlNode(env);
+
+    if (find_result.view) {
         try {
-            result = traits<std::decay_t<type>>::convert(view);
+            result = traits<std::decay_t<type>>::convert(find_result.view);
         }
         catch (const std::exception &e) {
             NIXL_DEBUG << "Unable to convert config value '" << env << "' to target type "
@@ -273,8 +288,10 @@ getValue(const std::string &env) {
         return result;
     }
 
-    if (const auto view = internal::findTomlNode(env)) {
-        return traits<type>::convert(view);
+    const internal::tomlFindResult find_result = internal::findTomlNode(env);
+
+    if (find_result.view) {
+        return traits<type>::convert(find_result.view);
     }
     throwRuntimeError("Missing config entry '", env, "'");
 }
@@ -288,8 +305,10 @@ getValueOptional(const std::string &env) {
         return result;
     }
 
-    if (const auto view = internal::findTomlNode(env)) {
-        return traits<type>::convert(view);
+    const internal::tomlFindResult find_result = internal::findTomlNode(env);
+
+    if (find_result.view) {
+        return traits<type>::convert(find_result.view);
     }
     return std::nullopt;
 }
@@ -312,7 +331,8 @@ getNonEmptyString(const std::string &env) {
 
 [[nodiscard]] inline bool
 checkExistence(const std::string &env) {
-    return (std::getenv(env.c_str()) != nullptr) || bool(internal::findTomlNode(env));
+    const internal::tomlFindResult find_result = internal::findTomlNode(env);
+    return (std::getenv(env.c_str()) != nullptr) || bool(find_result.view);
 }
 
 } // namespace nixl::config

--- a/src/utils/common/configuration.h
+++ b/src/utils/common/configuration.h
@@ -24,7 +24,6 @@
 #include <cstdlib>
 #include <filesystem>
 #include <limits>
-#include <memory>
 #include <optional>
 #include <string>
 #include <strings.h>
@@ -56,22 +55,10 @@ namespace internal {
     [[nodiscard]] std::string
     getenvDefaulted(const std::string &name, const std::string &fallback);
 
-    struct tomlFindResult {
-        tomlFindResult(const toml::node_view<const toml::node> &view,
-                       const std::shared_ptr<const toml::table> &data)
-            : view(view),
-              keep_view_alive(data) {}
-
-        const toml::node_view<const toml::node> view;
-
-    private:
-        const std::shared_ptr<const toml::table> keep_view_alive;
-    };
-
-    [[nodiscard]] tomlFindResult
+    [[nodiscard]] toml::node_view<const toml::node>
     findTomlNode(const toml::path &path);
 
-    [[nodiscard]] tomlFindResult
+    [[nodiscard]] toml::node_view<const toml::node>
     findTomlNode(const std::string &path);
 
     void
@@ -263,11 +250,9 @@ getValueWithStatus(type &result, const std::string &env) {
         return NIXL_SUCCESS;
     }
 
-    const internal::tomlFindResult find_result = internal::findTomlNode(env);
-
-    if (find_result.view) {
+    if (const auto view = internal::findTomlNode(env)) {
         try {
-            result = traits<std::decay_t<type>>::convert(find_result.view);
+            result = traits<std::decay_t<type>>::convert(view);
         }
         catch (const std::exception &e) {
             NIXL_DEBUG << "Unable to convert config value '" << env << "' to target type "
@@ -288,10 +273,8 @@ getValue(const std::string &env) {
         return result;
     }
 
-    const internal::tomlFindResult find_result = internal::findTomlNode(env);
-
-    if (find_result.view) {
-        return traits<type>::convert(find_result.view);
+    if (const auto view = internal::findTomlNode(env)) {
+        return traits<type>::convert(view);
     }
     throwRuntimeError("Missing config entry '", env, "'");
 }
@@ -305,10 +288,8 @@ getValueOptional(const std::string &env) {
         return result;
     }
 
-    const internal::tomlFindResult find_result = internal::findTomlNode(env);
-
-    if (find_result.view) {
-        return traits<type>::convert(find_result.view);
+    if (const auto view = internal::findTomlNode(env)) {
+        return traits<type>::convert(view);
     }
     return std::nullopt;
 }
@@ -331,8 +312,7 @@ getNonEmptyString(const std::string &env) {
 
 [[nodiscard]] inline bool
 checkExistence(const std::string &env) {
-    const internal::tomlFindResult find_result = internal::findTomlNode(env);
-    return (std::getenv(env.c_str()) != nullptr) || bool(find_result.view);
+    return (std::getenv(env.c_str()) != nullptr) || bool(internal::findTomlNode(env));
 }
 
 } // namespace nixl::config

--- a/test/gtest/configuration.cpp
+++ b/test/gtest/configuration.cpp
@@ -216,12 +216,6 @@ TEST(Config, ConvertUnsigned) {
     testUnsigned<std::uint64_t>();
 }
 
-#if 0
-
-  // ReadConfigFile is temporarily disabled because it always fails when it is
-  // not the first or only test to run. TODO: Enable again with more robust
-  // file handling.
-
 namespace {
 
     const std::string pid = std::to_string(::getpid());
@@ -235,20 +229,34 @@ namespace {
 
 } // namespace
 
+namespace internal {
+
+    void
+    invalidateConfigFileForUnitTest();
+
+} // namespace internal
+
 TEST(Config, ReadConfigFile) {
     const auto pid = ::getpid();
-    const auto file = "nixl_test_" + std::to_string(pid) + ".cfg";
-    const auto path = std::filesystem::temp_directory_path() / file;
+    const auto tmp_path = std::filesystem::temp_directory_path();
+    const auto tmp_file = "nixl_test_" + std::to_string(pid) + ".tmp";
+    const auto cfg_file = "nixl_test_" + std::to_string(pid) + ".cfg";
     {
-        std::ofstream ofs(path, std::ios::out | std::ios::trunc);
+        std::ofstream ofs(tmp_path / tmp_file, std::ios::out | std::ios::trunc);
         ofs << bool_name << " = true\n";
         ofs << number_name << " = 42\n";
         ofs << string_name << " = \"hello\"\n";
         ofs << env1name << " = \"dummy\"\n";
         ofs << env2name << " = 0\n";
     }
+    // Atomically move into place to prevent problems should other tests
+    // run concurrently within the same process (if that ever happens).
+    std::filesystem::rename(tmp_path / tmp_file, tmp_path / cfg_file);
+
+    internal::invalidateConfigFileForUnitTest();
+
     gtest::ScopedEnv vars;
-    vars.addVar("NIXL_CONFIG_FILE", path.native());
+    vars.addVar("NIXL_CONFIG_FILE", (tmp_path / cfg_file).native());
     vars.addVar(env1name, env1value);
     vars.addVar(env2name, env2value);
     {
@@ -273,7 +281,5 @@ TEST(Config, ReadConfigFile) {
         EXPECT_THROW((void)nixl::config::getValue<int>(env2name), std::runtime_error);
     }
 }
-
-#endif
 
 } // namespace nixl::config

--- a/test/gtest/configuration.cpp
+++ b/test/gtest/configuration.cpp
@@ -253,7 +253,7 @@ TEST(Config, ReadConfigFile) {
     internal::refreshConfigFileForUnitTest();
 
     gtest::ScopedEnv vars;
-    vars.addVar("NIXL_CONFIG_FILE", (tmp_path / cfg_file).native());
+    vars.addVar("NIXL_CONFIG_FILE", path.native());
     vars.addVar(env1name, env1value);
     vars.addVar(env2name, env2value);
     {

--- a/test/gtest/configuration.cpp
+++ b/test/gtest/configuration.cpp
@@ -231,29 +231,26 @@ namespace {
 
 namespace internal {
 
+    // This function is safe to be called because no other thread is accessing the config.
+
     void
-    invalidateConfigFileForUnitTest();
+    refreshConfigFileForUnitTest();
 
 } // namespace internal
 
 TEST(Config, ReadConfigFile) {
     const auto pid = ::getpid();
-    const auto tmp_path = std::filesystem::temp_directory_path();
-    const auto tmp_file = "nixl_test_" + std::to_string(pid) + ".tmp";
-    const auto cfg_file = "nixl_test_" + std::to_string(pid) + ".cfg";
+    const auto file = "nixl_test_" + std::to_string(pid) + ".cfg";
+    const auto path = std::filesystem::temp_directory_path() / file;
     {
-        std::ofstream ofs(tmp_path / tmp_file, std::ios::out | std::ios::trunc);
+        std::ofstream ofs(path, std::ios::out | std::ios::trunc);
         ofs << bool_name << " = true\n";
         ofs << number_name << " = 42\n";
         ofs << string_name << " = \"hello\"\n";
         ofs << env1name << " = \"dummy\"\n";
         ofs << env2name << " = 0\n";
     }
-    // Atomically move into place to prevent problems should other tests
-    // run concurrently within the same process (if that ever happens).
-    std::filesystem::rename(tmp_path / tmp_file, tmp_path / cfg_file);
-
-    internal::invalidateConfigFileForUnitTest();
+    internal::refreshConfigFileForUnitTest();
 
     gtest::ScopedEnv vars;
     vars.addVar("NIXL_CONFIG_FILE", (tmp_path / cfg_file).native());

--- a/test/gtest/configuration.cpp
+++ b/test/gtest/configuration.cpp
@@ -250,12 +250,11 @@ TEST(Config, ReadConfigFile) {
         ofs << env1name << " = \"dummy\"\n";
         ofs << env2name << " = 0\n";
     }
-    internal::refreshConfigFileForUnitTest();
-
     gtest::ScopedEnv vars;
     vars.addVar("NIXL_CONFIG_FILE", path.native());
     vars.addVar(env1name, env1value);
     vars.addVar(env2name, env2value);
+    internal::refreshConfigFileForUnitTest();
     {
         const auto value = nixl::config::getValue<bool>(bool_name);
         EXPECT_TRUE(value);


### PR DESCRIPTION
## What?
Allow the config file reading unit test to re-load config file data.

## Why?
Otherwise the config file reading test only succeeds when it is the first test to run inside of a process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled the configuration test to verify reading from the config file and correct precedence of environment variables over file values; includes a test-only helper to refresh cached configuration during testing.

* **Refactor**
  * Made the configuration handling more flexible so the cached config can be replaced at runtime (note: the test helper is intended for single-threaded test use).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->