### PR TITLE
fix(core): deregister duplicate descriptors without double free

### DIFF
--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -208,6 +208,35 @@ nixlLocalSection::addDescList(const nixl_reg_dlist_t &mem_elms,
     return ret;
 }
 
+namespace {
+// Map each element to a distinct entry sharing its descriptor; duplicates share a getIndex match.
+// Returns false (resolving nothing) on any missing/over-counted element, keeping callers
+// all-or-nothing.
+bool
+resolveDuplicateIndices(const nixl_reg_dlist_t &mem_elms,
+                        const nixlSecDescList &target,
+                        std::vector<size_t> &indices) {
+    indices.clear();
+    indices.reserve(mem_elms.descCount());
+    std::map<size_t, size_t> claimed; // first-match index -> entries already taken
+    for (auto &elm : mem_elms) {
+        const int match = target.getIndex(elm);
+        if (match < 0) {
+            return false;
+        }
+        const size_t first = static_cast<size_t>(match);
+        const size_t idx = first + claimed[first]++;
+        // idx must still name the same region as first (mutual covers == equality)
+        if (idx >= static_cast<size_t>(target.descCount()) ||
+            !(target[idx].covers(target[first]) && target[first].covers(target[idx]))) {
+            return false;
+        }
+        indices.push_back(idx);
+    }
+    return true;
+}
+} // namespace
+
 nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
                                              nixlBackendEngine *backend) {
     if (!backend) {
@@ -222,15 +251,9 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
 
     nixlSecDescList &target = it->second;
 
-    // First check if the mem_elms are present in the list,
-    // don't deregister anything in case any is missing.
     std::vector<size_t> indices;
-    indices.reserve(mem_elms.descCount());
-    for (auto &elm : mem_elms) {
-        int index = target.getIndex(elm);
-        if (index < 0)
-            return NIXL_ERR_NOT_FOUND;
-        indices.push_back(static_cast<size_t>(index));
+    if (!resolveDuplicateIndices(mem_elms, target, indices)) {
+        return NIXL_ERR_NOT_FOUND;
     }
 
     for (size_t idx : indices) {
@@ -450,12 +473,8 @@ nixlRemoteSection::removeLocalData(const nixl_reg_dlist_t &mem_elms, nixlBackend
     nixlSecDescList &target = it->second;
 
     std::vector<size_t> indices;
-    indices.reserve(mem_elms.descCount());
-    for (auto &elm : mem_elms) {
-        const int index = target.getIndex(elm);
-        if (index >= 0) {
-            indices.push_back(static_cast<size_t>(index));
-        }
+    if (!resolveDuplicateIndices(mem_elms, target, indices)) {
+        return;
     }
 
     for (size_t idx : indices) {

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -334,6 +334,97 @@ namespace agent {
                              << timed1_ns << " ns2=" << timed2_ns << " ratio=" << ratio << ")";
     }
 
+    // Deregistering duplicate descriptors must release each copy exactly once on both paths:
+    // the local section (deregisterMem) and the mirrored self section (unloadMD).
+    TEST_F(singleAgentSessionFixture, DeregisterDuplicateDescriptorsTest) {
+        constexpr int kDup = 3;
+
+        nixl_b_params_t params;
+        nixlBackendH *backend;
+        ASSERT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        nixl_opt_args_t extra_params;
+        extra_params.backends.push_back(backend);
+
+        // Distinct local and self MDs per registration so the two cleanup paths are told apart.
+        char local_md[kDup] = {};
+        char self_md[kDup] = {};
+        int reg_idx = 0;
+
+        auto &engine = const_cast<mocks::GMockBackendEngine &>(agent_helper_->getGMockEngine());
+        EXPECT_CALL(engine, registerMem(testing::_, testing::_, testing::_))
+            .Times(kDup)
+            .WillRepeatedly([&](const nixlBlobDesc &, const nixl_mem_t &, nixlBackendMD *&out) {
+                out = reinterpret_cast<nixlBackendMD *>(&local_md[reg_idx++]);
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(engine, loadLocalMD(testing::_, testing::_))
+            .Times(kDup)
+            .WillRepeatedly([&](nixlBackendMD *input, nixlBackendMD *&output) {
+                const auto i = reinterpret_cast<char *>(input) - local_md;
+                output = reinterpret_cast<nixlBackendMD *>(&self_md[i]);
+                return NIXL_SUCCESS;
+            });
+
+        for (int i = 0; i < kDup; ++i) {
+            EXPECT_CALL(engine, deregisterMem(reinterpret_cast<nixlBackendMD *>(&local_md[i])))
+                .Times(1);
+            EXPECT_CALL(engine, unloadMD(reinterpret_cast<nixlBackendMD *>(&self_md[i]))).Times(1);
+        }
+
+        blob region;
+        nixl_reg_dlist_t reg(DRAM_SEG);
+        for (int i = 0; i < kDup; ++i) {
+            reg.addDesc(region.getDesc());
+        }
+        ASSERT_EQ(agent_->registerMem(reg, &extra_params), NIXL_SUCCESS);
+        EXPECT_EQ(agent_->deregisterMem(reg, &extra_params), NIXL_SUCCESS);
+    }
+
+    // A deregister containing an unregistered descriptor must fail and free nothing
+    // (all-or-nothing).
+    TEST_F(singleAgentSessionFixture, DeregisterMissingDescriptorFreesNothing) {
+        nixl_b_params_t params;
+        nixlBackendH *backend;
+        ASSERT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        nixl_opt_args_t extra_params;
+        extra_params.backends.push_back(backend);
+
+        char local_md[2] = {};
+        int reg_idx = 0;
+        auto &engine = const_cast<mocks::GMockBackendEngine &>(agent_helper_->getGMockEngine());
+        EXPECT_CALL(engine, registerMem(testing::_, testing::_, testing::_))
+            .WillRepeatedly([&](const nixlBlobDesc &, const nixl_mem_t &, nixlBackendMD *&out) {
+                out = reinterpret_cast<nixlBackendMD *>(&local_md[reg_idx++]);
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(engine, loadLocalMD(testing::_, testing::_))
+            .WillRepeatedly([](nixlBackendMD *input, nixlBackendMD *&output) {
+                output = input;
+                return NIXL_SUCCESS;
+            });
+
+        blob registered, missing;
+        nixl_reg_dlist_t reg(DRAM_SEG);
+        reg.addDesc(registered.getDesc());
+        reg.addDesc(registered.getDesc());
+        ASSERT_EQ(agent_->registerMem(reg, &extra_params), NIXL_SUCCESS);
+
+        // {A, A, missing}: the unregistered descriptor must abort both cleanup paths.
+        EXPECT_CALL(engine, deregisterMem(testing::_)).Times(0);
+        EXPECT_CALL(engine, unloadMD(testing::_)).Times(0);
+
+        nixl_reg_dlist_t bad(DRAM_SEG);
+        bad.addDesc(registered.getDesc());
+        bad.addDesc(registered.getDesc());
+        bad.addDesc(missing.getDesc());
+        EXPECT_NE(agent_->deregisterMem(bad, &extra_params), NIXL_SUCCESS);
+
+        // Verify the Times(0) now -- fixture teardown deregisters the still-registered copies.
+        testing::Mock::VerifyAndClearExpectations(&engine);
+    }
+
     INSTANTIATE_TEST_SUITE_P(DramRegisterMemoryInstantiation,
                              singleAgentWithMemParamFixture,
                              testing::Values(DRAM_SEG));


### PR DESCRIPTION

#1635 introduces/surfaces a bug if two exact same regions get registered twice: they collapse to the same sort keys so the sequence: `register(A), register(A), deregister([A, A])` causes a double free on the second deregister.

This bugfix makes sure the correct metadata gets freed, even under the presence of duplicate registered regions. This will in turn lead to correct FD closing and no double-frees.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deregistration now performs an all-or-nothing resolution of requested memory descriptors before any cleanup, preventing partial deregistration or unload when descriptors are duplicated or mismatched.

* **Tests**
  * Added unit tests validating deregistration with duplicated descriptors and failing cases with missing descriptors to ensure cleanup runs exactly once per item or not at all on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->