### PR TITLE
Fix libfabric transfer request lifecycle bugs

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -388,6 +388,7 @@ nixlLibfabricEngine::vramApplyCtxEx(bool &use_cuda_addr_wa) const {
 nixlLibfabricBackendH::nixlLibfabricBackendH(nixl_xfer_op_t op, const std::string &remote_agent)
     : completed_requests_(0),
       submitted_requests_(0),
+      error_status_(NIXL_SUCCESS),
       operation_(op),
       remote_agent_(remote_agent),
       total_notif_msg_len(0) {
@@ -408,6 +409,7 @@ void
 nixlLibfabricBackendH::init_request_tracking(size_t num_requests) {
     submitted_requests_.store(num_requests);
     completed_requests_.store(0);
+    error_status_.store(NIXL_SUCCESS);
     NIXL_DEBUG << "Initialized request tracking for " << num_requests << " requests";
 }
 
@@ -432,6 +434,17 @@ void
 nixlLibfabricBackendH::adjust_total_submitted_requests(size_t actual_count) {
     submitted_requests_.store(actual_count);
     NIXL_DEBUG << "Adjusted total requests to actual count: " << actual_count;
+}
+
+void
+nixlLibfabricBackendH::set_error(nixl_status_t status) {
+    nixl_status_t expected = NIXL_SUCCESS;
+    error_status_.compare_exchange_strong(expected, status);
+}
+
+nixl_status_t
+nixlLibfabricBackendH::get_error_status() const {
+    return error_status_.load();
 }
 
 bool
@@ -1353,7 +1366,12 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
             conn->rail_remote_addr_list_,
             imm_agent_idx,
             backend_handle->post_xfer_id,
-            [backend_handle]() { backend_handle->increment_completed_requests(); },
+            [backend_handle](nixl_status_t status) {
+                backend_handle->increment_completed_requests();
+                if (status != NIXL_SUCCESS) {
+                    backend_handle->set_error(status);
+                }
+            }, // Completion callback
             desc_submitted_count,
             desc_idx,
             xfer_base_offset,
@@ -1630,6 +1648,13 @@ nixlLibfabricEngine::checkXfer(nixlBackendReqH *handle) const {
 
     // Then check for completions after processing any pending completions
     if (backend_handle->is_completed()) {
+        // Check if any request completed with error
+        nixl_status_t err = backend_handle->get_error_status();
+        if (err != NIXL_SUCCESS) {
+            NIXL_ERROR << "Transfer completed with CQ error";
+            return err;
+        }
+
         NIXL_DEBUG << "Data transfer completed successfully";
         if (backend_handle->has_notif && backend_handle->operation_ == nixl_xfer_op_t::NIXL_READ) {
             nixl_status_t notif_status = notifSendPriv(backend_handle->remote_agent_,

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -388,6 +388,7 @@ nixlLibfabricEngine::vramApplyCtxEx(bool &use_cuda_addr_wa) const {
 nixlLibfabricBackendH::nixlLibfabricBackendH(nixl_xfer_op_t op, const std::string &remote_agent)
     : completed_requests_(0),
       submitted_requests_(0),
+      error_status_(NIXL_SUCCESS),
       operation_(op),
       remote_agent_(remote_agent),
       total_notif_msg_len(0) {
@@ -408,14 +409,23 @@ void
 nixlLibfabricBackendH::init_request_tracking(size_t num_requests) {
     submitted_requests_.store(num_requests);
     completed_requests_.store(0);
+    error_status_.store(NIXL_SUCCESS);
     NIXL_DEBUG << "Initialized request tracking for " << num_requests << " requests";
 }
 
 void
-nixlLibfabricBackendH::increment_completed_requests() {
-    completed_requests_.fetch_add(1);
-    NIXL_DEBUG << "Request completed, total completed: " << completed_requests_.load() << "/"
-               << submitted_requests_.load();
+nixlLibfabricBackendH::complete_request(nixl_status_t status) {
+    if (status != NIXL_SUCCESS) {
+        nixl_status_t expected = NIXL_SUCCESS;
+        error_status_.compare_exchange_strong(
+            expected, status, std::memory_order_relaxed, std::memory_order_relaxed);
+    }
+    // Release ensures the error store above is visible to any thread that
+    // observes the incremented count via an acquire load in is_completed().
+    completed_requests_.fetch_add(1, std::memory_order_release);
+    NIXL_DEBUG << "Request completed (status=" << status
+               << "), total completed: " << completed_requests_.load(std::memory_order_relaxed)
+               << "/" << submitted_requests_.load(std::memory_order_relaxed);
 }
 
 size_t
@@ -434,10 +444,17 @@ nixlLibfabricBackendH::adjust_total_submitted_requests(size_t actual_count) {
     NIXL_DEBUG << "Adjusted total requests to actual count: " << actual_count;
 }
 
+nixl_status_t
+nixlLibfabricBackendH::get_error_status() const {
+    return error_status_.load(std::memory_order_acquire);
+}
+
 bool
 nixlLibfabricBackendH::is_completed() const {
-    // Transfer is completed when all requests have local completions
-    return completed_requests_.load() == submitted_requests_.load();
+    // Acquire pairs with release in complete_request() — guarantees we see
+    // any error_status_ written before the final increment.
+    return completed_requests_.load(std::memory_order_acquire) ==
+        submitted_requests_.load(std::memory_order_relaxed);
 }
 
 /****************************************
@@ -1353,7 +1370,9 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
             conn->rail_remote_addr_list_,
             imm_agent_idx,
             backend_handle->post_xfer_id,
-            [backend_handle]() { backend_handle->increment_completed_requests(); },
+            [backend_handle](nixl_status_t status) {
+                backend_handle->complete_request(status);
+            }, // Completion callback
             desc_submitted_count,
             desc_idx,
             xfer_base_offset,
@@ -1630,6 +1649,13 @@ nixlLibfabricEngine::checkXfer(nixlBackendReqH *handle) const {
 
     // Then check for completions after processing any pending completions
     if (backend_handle->is_completed()) {
+        // Check if any request completed with error
+        nixl_status_t err = backend_handle->get_error_status();
+        if (err != NIXL_SUCCESS) {
+            NIXL_ERROR << "Transfer completed with CQ error";
+            return err;
+        }
+
         NIXL_DEBUG << "Data transfer completed successfully";
         if (backend_handle->has_notif && backend_handle->operation_ == nixl_xfer_op_t::NIXL_READ) {
             nixl_status_t notif_status = notifSendPriv(backend_handle->remote_agent_,

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1649,17 +1649,11 @@ nixlLibfabricEngine::checkXfer(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlLibfabricEngine::releaseReqH(nixlBackendReqH *handle) const {
-    // Add any necessary cleanup for libfabric specific request handling
-    // For example, if we're using a custom request structure:
-    // nixlLibfabricReqH* req = static_cast<nixlLibfabricReqH*>(handle);
-    // // Perform any necessary cleanup
-    // delete req;
-
     if (!handle) {
         return NIXL_SUCCESS;
     }
 
-    // Let NIXL framework handle the deletion
+    delete static_cast<nixlLibfabricBackendH *>(handle);
     NIXL_DEBUG << "releaseReqH completed successfully";
     return NIXL_SUCCESS;
 }

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -113,6 +113,7 @@ class nixlLibfabricBackendH : public nixlBackendReqH {
 private:
     std::atomic<size_t> completed_requests_; // Atomic count of completed requests
     std::atomic<size_t> submitted_requests_; // Total number of submitted requests
+    std::atomic<nixl_status_t> error_status_; // Error status from CQ failures
 
 public:
     uint16_t post_xfer_id;
@@ -134,9 +135,11 @@ public:
     void
     init_request_tracking(size_t num_requests);
 
-    /** Atomically increment completed request count */
+    /** Record completion of one request (with status).
+     *  Stores error before incrementing the counter so that is_completed()
+     *  observers always see the error_status_ that caused the transition. */
     void
-    increment_completed_requests();
+    complete_request(nixl_status_t status);
 
     /** Get current count of requests completed as part of this transfer */
     size_t
@@ -149,6 +152,10 @@ public:
     /** Adjust total submitted request count to actual value after submissions complete */
     void
     adjust_total_submitted_requests(size_t actual_count);
+
+    /** Get error status */
+    nixl_status_t
+    get_error_status() const;
 };
 
 class nixlLibfabricEngine : public nixlBackendEngine {

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -27,7 +27,6 @@
 #include <atomic>
 #include <chrono>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "nixl.h"
 #include "backend/backend_engine.h"
@@ -206,7 +205,6 @@ private:
 
     // Receiver Side XFER_ID Tracking
     std::mutex receiver_tracking_mutex_;
-    std::unordered_set<uint32_t> received_remote_writes_; // All received XFER_IDs (global)
 
     // Notification Queuing
     struct PendingNotification {

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -113,6 +113,7 @@ class nixlLibfabricBackendH : public nixlBackendReqH {
 private:
     std::atomic<size_t> completed_requests_; // Atomic count of completed requests
     std::atomic<size_t> submitted_requests_; // Total number of submitted requests
+    std::atomic<nixl_status_t> error_status_; // Error status from CQ failures
 
 public:
     uint16_t post_xfer_id;
@@ -149,6 +150,14 @@ public:
     /** Adjust total submitted request count to actual value after submissions complete */
     void
     adjust_total_submitted_requests(size_t actual_count);
+
+    /** Set error status (called from CQ error path via callback) */
+    void
+    set_error(nixl_status_t status);
+
+    /** Get error status */
+    nixl_status_t
+    get_error_status() const;
 };
 
 class nixlLibfabricEngine : public nixlBackendEngine {

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -755,6 +755,17 @@ nixlLibfabricRail::progressCompletionQueue() {
                 NIXL_ERROR << "CQ read failed on rail " << rail_id
                            << " with error: " << fi_strerror(err_entry.err)
                            << " prov_errno: " << err_entry.prov_errno << " len: " << err_entry.len;
+
+                // Notify the owning handle of the error and release the request
+                if (err_entry.op_context) {
+                    nixlLibfabricReq *req = findRequestFromContext(err_entry.op_context);
+                    if (req && req->in_use) {
+                        if (req->completion_callback) {
+                            req->completion_callback(NIXL_ERR_BACKEND);
+                        }
+                        releaseRequest(req);
+                    }
+                }
             } else {
                 NIXL_ERROR << "fi_cq_readerr failed with " << err_ret;
             }
@@ -887,7 +898,7 @@ nixlLibfabricRail::processLocalSendCompletion(struct fi_cq_data_entry *comp) con
         // Call completion callback if it exists
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for send request " << req->xfer_id;
-            req->completion_callback();
+            req->completion_callback(NIXL_SUCCESS);
             NIXL_TRACE << "Completion callback completed for send";
         }
         releaseRequest(req);
@@ -914,7 +925,7 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
                        << req->xfer_id;
-            req->completion_callback();
+            req->completion_callback(NIXL_SUCCESS);
             NIXL_TRACE << "Completion callback completed for " << operation_type;
         }
         releaseRequest(req);
@@ -1185,7 +1196,10 @@ nixlLibfabricRail::drainPostQueue() {
                 // completion is notified also for failed requests
                 // (otherwise counters would never match)
                 if (pr.req && pr.req->completion_callback) {
-                    pr.req->completion_callback();
+                    pr.req->completion_callback(status);
+                }
+                if (pr.req) {
+                    releaseRequest(pr.req);
                 }
 
                 // defrred request cannot be executed, continue to the next
@@ -1200,7 +1214,10 @@ nixlLibfabricRail::drainPostQueue() {
                     // completion is notified also for failed requests
                     // (otherwise counters would never match)
                     if (pr.req && pr.req->completion_callback) {
-                        pr.req->completion_callback();
+                        pr.req->completion_callback(NIXL_ERR_BACKEND);
+                    }
+                    if (pr.req) {
+                        releaseRequest(pr.req);
                     }
 
                     // defrred request cannot be executed, continue to the next
@@ -1271,7 +1288,10 @@ nixlLibfabricRail::drainPostQueue() {
             if (pr.req && pr.req->completion_callback) {
                 // completion is notified also for failed requests
                 // (otherwise counters would never match)
-                pr.req->completion_callback();
+                pr.req->completion_callback(NIXL_ERR_BACKEND);
+            }
+            if (pr.req) {
+                releaseRequest(pr.req);
             }
             continue;
         }

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -755,6 +755,17 @@ nixlLibfabricRail::progressCompletionQueue() {
                 NIXL_ERROR << "CQ read failed on rail " << rail_id
                            << " with error: " << fi_strerror(err_entry.err)
                            << " prov_errno: " << err_entry.prov_errno << " len: " << err_entry.len;
+
+                // Notify the owning handle of the error and release the request
+                if (err_entry.op_context) {
+                    nixlLibfabricReq *req = findRequestFromContext(err_entry.op_context);
+                    if (req && req->in_use) {
+                        if (req->completion_callback) {
+                            req->completion_callback(NIXL_ERR_BACKEND);
+                        }
+                        releaseRequest(req);
+                    }
+                }
             } else {
                 NIXL_ERROR << "fi_cq_readerr failed with " << err_ret;
             }
@@ -887,7 +898,7 @@ nixlLibfabricRail::processLocalSendCompletion(struct fi_cq_data_entry *comp) con
         // Call completion callback if it exists
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for send request " << req->xfer_id;
-            req->completion_callback();
+            req->completion_callback(NIXL_SUCCESS);
             NIXL_TRACE << "Completion callback completed for send";
         }
         releaseRequest(req);
@@ -914,7 +925,7 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
                        << req->xfer_id;
-            req->completion_callback();
+            req->completion_callback(NIXL_SUCCESS);
             NIXL_TRACE << "Completion callback completed for " << operation_type;
         }
         releaseRequest(req);
@@ -1185,7 +1196,7 @@ nixlLibfabricRail::drainPostQueue() {
                 // completion is notified also for failed requests
                 // (otherwise counters would never match)
                 if (pr.req && pr.req->completion_callback) {
-                    pr.req->completion_callback();
+                    pr.req->completion_callback(status);
                 }
 
                 // defrred request cannot be executed, continue to the next
@@ -1200,7 +1211,7 @@ nixlLibfabricRail::drainPostQueue() {
                     // completion is notified also for failed requests
                     // (otherwise counters would never match)
                     if (pr.req && pr.req->completion_callback) {
-                        pr.req->completion_callback();
+                        pr.req->completion_callback(NIXL_ERR_BACKEND);
                     }
 
                     // defrred request cannot be executed, continue to the next
@@ -1271,7 +1282,7 @@ nixlLibfabricRail::drainPostQueue() {
             if (pr.req && pr.req->completion_callback) {
                 // completion is notified also for failed requests
                 // (otherwise counters would never match)
-                pr.req->completion_callback();
+                pr.req->completion_callback(NIXL_ERR_BACKEND);
             }
             continue;
         }

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -53,7 +53,7 @@ struct nixlLibfabricReq {
     bool in_use; ///< Pool management flag
     size_t chunk_offset; ///< Chunk offset for DATA requests
     size_t chunk_size; ///< Chunk size for DATA requests
-    std::function<void()> completion_callback; ///< Completion callback function
+    std::function<void(nixl_status_t)> completion_callback; ///< Completion callback function
     void *local_addr; ///< Local memory address for transfers
     uint64_t remote_addr; ///< Remote memory address for transfers
     struct fid_mr *local_mr; ///< Local memory registration for transfers

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -386,7 +386,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     const std::unordered_map<size_t, std::vector<fi_addr_t>> &dest_addrs,
     uint16_t agent_idx,
     uint16_t xfer_id,
-    std::function<void()> completion_callback,
+    std::function<void(nixl_status_t)> completion_callback,
     size_t &submitted_count_out,
     int desc_idx,
     size_t base_offset,
@@ -993,11 +993,12 @@ nixlLibfabricRailManager::cleanupConnection(const std::vector<fi_addr_t> &fi_add
 }
 
 nixl_status_t
-nixlLibfabricRailManager::postControlMessage(ControlMessageType msg_type,
-                                             nixlLibfabricReq *req,
-                                             fi_addr_t dest_addr,
-                                             uint16_t agent_idx,
-                                             std::function<void()> completion_callback) {
+nixlLibfabricRailManager::postControlMessage(
+    ControlMessageType msg_type,
+    nixlLibfabricReq *req,
+    fi_addr_t dest_addr,
+    uint16_t agent_idx,
+    std::function<void(nixl_status_t)> completion_callback) {
     // Validation - use rail 0 for notifications
     if (rails_.empty()) {
         NIXL_ERROR << "No rails available";

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -231,7 +231,7 @@ public:
                              const std::unordered_map<size_t, std::vector<fi_addr_t>> &dest_addrs,
                              uint16_t agent_idx,
                              uint16_t xfer_id,
-                             std::function<void()> completion_callback,
+                             std::function<void(nixl_status_t)> completion_callback,
                              size_t &submitted_count_out,
                              int desc_idx,
                              size_t base_offset,
@@ -284,13 +284,14 @@ public:
                        nixlLibfabricReq *req,
                        fi_addr_t dest_addr,
                        uint16_t agent_idx = 0,
-                       std::function<void()> completion_callback = nullptr);
+                       std::function<void(nixl_status_t)> completion_callback = nullptr);
     // Progress APIs
     /** Process completions on active rails only (optimized for CPU overhead)
      * @return NIXL_SUCCESS if completions processed, NIXL_IN_PROG if none, error on failure
      */
     nixl_status_t
     progressActiveRails();
+
     /** Validate that all rails are properly initialized
      * @return NIXL_SUCCESS if all rails initialized, error code otherwise
      */


### PR DESCRIPTION
## What?
Three fixes to the libfabric backend's transfer request lifecycle (Fixes https://github.com/ai-dynamo/nixl/issues/1722)

  1. releaseReqH() now deletes the nixlLibfabricBackendH handle
  2. Removed dead received_remote_writes_ field and unused <unordered_set> include
  3. CQ errors are now propagated to the transfer handle via the completion callback, and the failed request is released back to the pool

## Why?
- Memory leak: Every postXfer() allocates a new nixlLibfabricBackendH that was never freed 
- Dead code: received_remote_writes_ was declared but never used in any .cpp file
- CQ error hang: When fi_cq_read returned an error, the failed request was never released to the pool and the owning handle was never notified — causing transfers to hang indefinitely (and leaking pool entries)

## How?
Memory leak fix: Added delete static_cast<nixlLibfabricBackendH *>(handle) in releaseReqH()

CQ error propagation: Changed completion_callback signature from void() to void(nixl_status_t). On CQ error, the callback is invoked with NIXL_ERR_BACKEND — this increments the completion counter (so is_completed() eventually becomes true) and sets an error flag on the handle. On success, NIXL_SUCCESS is passed as before.
checkXfer() waits for all requests to resolve before returning status. This avoids premature cancellation of in-flight requests on other rails — following the same drain-then-report pattern used by the UCX backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer failures are now recorded and reported promptly, preventing false successes and stuck requests.
  * Completion errors now trigger failure notifications and reliably release affected requests.
  * Failed transfers no longer continue through success-only completion handling.

* **API Changes**
  * Transfer and control-message completion callbacks now provide explicit status results.

* **Chores**
  * Improved request cleanup and removed redundant transfer-tracking state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->