### PR TITLE
test/doca: run DOCA telemetry exporter tests in CI and broaden coverage

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -107,6 +107,12 @@ kill -s INT $telePID
 gtest-parallel --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
 ./bin/test_plugin
 
+# DOCA telemetry exporter tests: present only when built with the DOCA SDK
+# (TELEMETRY_DOCA). Self-contained - each binds a free loopback port via
+# findFreePort(); DOCA + CollectX libs resolve through ldconfig.
+if [ -x ./bin/doca_test ]; then ./bin/doca_test; fi
+if [ -x ./bin/doca_nixl_test ]; then ./bin/doca_nixl_test; fi
+
 # Run NIXL client-server test
 nixl_test_port=$(get_next_tcp_port)
 parallel --line-buffer --halt now,fail=1 ::: "./bin/nixl_test target" "sleep 3 ; ./bin/nixl_test initiator" ::: "127.0.0.1 $nixl_test_port"

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -109,7 +109,7 @@ gtest-parallel --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port=
 
 # DOCA telemetry exporter tests: present only when built with the DOCA SDK
 # (TELEMETRY_DOCA). Self-contained - each binds a free loopback port via
-# findFreePort(); DOCA + CollectX libs resolve through ldconfig.
+# findFreePort(); the DOCA telemetry exporter libs resolve through ldconfig.
 if [ -x ./bin/doca_test ]; then ./bin/doca_test; fi
 if [ -x ./bin/doca_nixl_test ]; then ./bin/doca_nixl_test; fi
 

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -15,8 +15,9 @@
 
 # Standalone DOCA telemetry tests. They intentionally avoid linking nixl core
 # (no etcd/gRPC), so each process carries only CollectX's gRPC (no duplicate-flag
-# clash with nixl's gRPC). Built only when the DOCA telemetry headers are present,
-# mirroring the plugin gate in src/plugins/telemetry/doca/meson.build.
+# clash with nixl's gRPC). Built under the same gate as the exporter plugin in
+# src/plugins/telemetry/meson.build: the doca-telemetry-exporter/doca-common
+# pkg-config dependencies plus the TELEMETRY_DOCA plugin toggle.
 #  - doca_test:      exercises the raw DOCA Metrics API directly.
 #  - doca_nixl_test: exercises the NIXL DOCA exporter (compiled in directly, so
 #                    it pulls only nixl_infra/nixl_common - no gRPC).
@@ -25,30 +26,17 @@ if not gtest_dep.found()
     subdir_done()
 endif
 
-# DOCA discovery - identical to src/plugins/telemetry/doca/meson.build.
-doca_found = false
-doca_base_path = '/opt/mellanox/doca'
-doca_inc_path = doca_base_path / 'include'
-doca_arch = host_machine.cpu_family() + '-linux-gnu'
-doca_lib_path = doca_base_path / 'lib' / doca_arch
+# DOCA discovery via pkg-config + the TELEMETRY_DOCA plugin toggle - identical to
+# the exporter plugin in src/plugins/telemetry/meson.build, so the tests build
+# under the exact same condition (and honor -Ddisable_plugins=TELEMETRY_DOCA).
+doca_telemetry_dep = dependency('doca-telemetry-exporter', required: false)
+doca_common_dep = dependency('doca-common', required: false)
+build_doca_tests = enabled_plugins.get('TELEMETRY_DOCA') and doca_telemetry_dep.found() and doca_common_dep.found()
 
-if cpp.has_header('doca_telemetry_exporter.h', args: '-I' + doca_inc_path)
-    doca_dep = declare_dependency(
-        include_directories: include_directories(doca_inc_path, is_system: true),
-        link_args: [
-            '-L' + doca_lib_path,
-            '-ldoca_telemetry_exporter',
-            '-ldoca_common',
-            '-Wl,-rpath,' + doca_lib_path
-        ]
-    )
-    doca_found = true
-endif
-
-if doca_found
+if build_doca_tests
     doca_test_exe = executable('doca_test',
         sources: ['telemetry_doca_test.cpp'],
-        dependencies: [gtest_dep, doca_dep],
+        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep],
         # DOCA telemetry metrics APIs are marked experimental (deprecated
         # attribute); mirror the DOCA sample Makefile and the plugin sources.
         cpp_args: ['-Wno-deprecated-declarations'],
@@ -68,13 +56,11 @@ if doca_found
             utils_inc_dirs,
             include_directories(doca_exporter_dir),
         ],
-        dependencies: [gtest_dep, doca_dep, nixl_infra, nixl_common_dep, absl_log_dep],
+        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep],
         cpp_args: ['-Wno-deprecated-declarations'],
         install: true,
     )
 
     test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false)
     message('Building standalone DOCA telemetry exporter tests')
-else
-    warning('DOCA Telemetry Exporter headers not found. DOCA telemetry exporter test will not be built.')
 endif

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Standalone DOCA telemetry tests. They intentionally avoid linking nixl core
-# (no etcd/gRPC), so each process carries only CollectX's gRPC (no duplicate-flag
+# (no etcd/gRPC), so each process carries only the DOCA exporter's gRPC (no duplicate-flag
 # clash with nixl's gRPC). Built under the same gate as the exporter plugin in
 # src/plugins/telemetry/meson.build: the doca-telemetry-exporter/doca-common
 # pkg-config dependencies plus the TELEMETRY_DOCA plugin toggle.

--- a/test/doca-telemetry/open_metrics_text_parser.h
+++ b/test/doca-telemetry/open_metrics_text_parser.h
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_DOCA_TELEMETRY_OPEN_METRICS_TEXT_PARSER_H
+#define NIXL_TEST_DOCA_TELEMETRY_OPEN_METRICS_TEXT_PARSER_H
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "timeseries.h"
+
+namespace nixl::doca_test {
+
+// Parses a Prometheus / OpenMetrics text exposition body into time series.
+//
+// The grammar handled is the line format DOCA's endpoint serves:
+//   name[{key="value"(,key="value")*}] value [timestamp]
+// Comment (`#`) and blank lines are skipped. The parser is deliberately strict --
+// a malformed label block (missing/doubled/trailing comma, repeated key, stray
+// text) rejects the whole line rather than yielding partial labels -- so an
+// exporter-format regression surfaces as a missing series in these tests instead
+// of being silently absorbed.
+class OpenMetricsTextParser {
+public:
+    // Parse a whole /metrics body once. Each well-formed line contributes one
+    // sample to its (name+labels) series; the resulting map lets a caller query
+    // any number of series without rescanning the raw text.
+    [[nodiscard]] static seriesMap
+    parse(const std::string &body) {
+        seriesMap series;
+        std::istringstream stream(body);
+        std::string line;
+        while (std::getline(stream, line)) {
+            if (auto parsed = parseLine(line)) {
+                series[std::move(parsed->first)].push_back(parsed->second);
+            }
+        }
+        return series;
+    }
+
+private:
+    // Parse one exposition line into a series id + sample. Returns nullopt for
+    // comment/blank/malformed lines. Label values are assumed free of embedded
+    // quotes (true for these metrics).
+    [[nodiscard]] static std::optional<std::pair<seriesId, sample>>
+    parseLine(const std::string &line) {
+        // name, optional brace-delimited label block, value, optional timestamp.
+        static const std::regex lineRe(R"(^([^\s{]+)(?:\{([^}]*)\})?\s+(\S+)(?:\s+(\S+))?\s*$)");
+
+        std::smatch match;
+        if (line.empty() || line[0] == '#' || !std::regex_match(line, match, lineRe)) {
+            return std::nullopt;
+        }
+        const std::optional<sample> value = parseSample(
+            match[3].str(),
+            match[4].matched ? std::optional<std::string>(match[4].str()) : std::nullopt);
+        if (!value) {
+            return std::nullopt;
+        }
+        std::optional<labelSet> labels = parseLabels(match[2].str());
+        if (!labels) {
+            return std::nullopt;
+        }
+        return std::make_pair(seriesId{match[1].str(), std::move(*labels)}, *value);
+    }
+
+    // Build a sample from its value token (required) and the optional timestamp
+    // token (the exposition's trailing field). Returns nullopt if the value is
+    // non-numeric; a missing or non-numeric timestamp is left unset, since
+    // Prometheus timestamps are optional.
+    [[nodiscard]] static std::optional<sample>
+    parseSample(const std::string &valueToken, const std::optional<std::string> &timestampToken) {
+        sample s;
+        try {
+            s.value = std::stod(valueToken);
+        }
+        catch (const std::exception &) {
+            return std::nullopt;
+        }
+        if (timestampToken) {
+            try {
+                s.timestamp = static_cast<uint64_t>(std::stoull(*timestampToken));
+            }
+            catch (const std::exception &) {
+                // Leave the timestamp unset on a non-numeric token.
+            }
+        }
+        return s;
+    }
+
+    // The gap between two matched pairs must hold exactly one comma (pairs are
+    // comma-separated); the gap before the first pair must hold none. Whitespace
+    // may pad either side, but no other character is allowed.
+    [[nodiscard]] static bool
+    validSeparator(const std::string &gap, bool leading) {
+        if (gap.find_first_not_of(", \t") != std::string::npos) {
+            return false;
+        }
+        return std::count(gap.begin(), gap.end(), ',') == (leading ? 0 : 1);
+    }
+
+    // Extract the key="value" pairs from a label block (the text inside `{}`).
+    // Returns nullopt if the block is malformed -- a repeated key, a missing or
+    // doubled comma between pairs, a trailing comma, or any other stray text -- so
+    // a bad exposition line is rejected rather than silently parsed into partial
+    // or first-wins labels (these are regression tests).
+    [[nodiscard]] static std::optional<labelSet>
+    parseLabels(const std::string &block) {
+        // Custom raw-string delimiter so the pattern's )" does not close it early.
+        static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
+        labelSet labels;
+        size_t cursor = 0;
+        for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
+             it != std::sregex_iterator();
+             ++it) {
+            const auto &match = *it;
+            const auto position = static_cast<size_t>(match.position());
+            if (!validSeparator(block.substr(cursor, position - cursor), cursor == 0)) {
+                return std::nullopt;
+            }
+            // A duplicate label key within one series is malformed; reject it.
+            if (!labels.emplace(match[1].str(), match[2].str()).second) {
+                return std::nullopt;
+            }
+            cursor = position + static_cast<size_t>(match.length());
+        }
+        // Any leftover after the last pair must be whitespace only (no trailing comma).
+        if (block.find_first_not_of(" \t", cursor) != std::string::npos) {
+            return std::nullopt;
+        }
+        return labels;
+    }
+};
+
+} // namespace nixl::doca_test
+
+#endif // NIXL_TEST_DOCA_TELEMETRY_OPEN_METRICS_TEXT_PARSER_H

--- a/test/doca-telemetry/open_metrics_text_parser.h
+++ b/test/doca-telemetry/open_metrics_text_parser.h
@@ -17,6 +17,19 @@
 #ifndef NIXL_TEST_DOCA_TELEMETRY_OPEN_METRICS_TEXT_PARSER_H
 #define NIXL_TEST_DOCA_TELEMETRY_OPEN_METRICS_TEXT_PARSER_H
 
+// -----------------------------------------------------------------------------
+// Test-only helper -- NOT a production-grade or spec-complete parser.
+//
+// A minimal Prometheus/OpenMetrics text-exposition parser used solely by the
+// doca-telemetry unit tests to turn a scraped /metrics body into the in-memory
+// series model in timeseries.h. It handles only the narrow line grammar DOCA's
+// endpoint emits (documented below) and is intentionally strict so that an
+// exporter-format regression fails a test rather than being silently absorbed --
+// it is not a general OpenMetrics implementation (no HELP/TYPE metadata,
+// exemplars, quote escaping, etc.). Do not promote it into product code; use a
+// real parser there.
+// -----------------------------------------------------------------------------
+
 #include <algorithm>
 #include <cstdint>
 #include <exception>
@@ -39,128 +52,135 @@ namespace nixl::doca_test {
 // text) rejects the whole line rather than yielding partial labels -- so an
 // exporter-format regression surfaces as a missing series in these tests instead
 // of being silently absorbed.
-class OpenMetricsTextParser {
-public:
+namespace open_metrics_text {
+
+    // Implementation helpers for parse(); not part of the public surface.
+    namespace detail {
+
+        // Build a sample from its value token (required) and the optional timestamp
+        // token (the exposition's trailing field). Returns nullopt if the value is
+        // non-numeric; a missing or non-numeric timestamp is left unset, since
+        // Prometheus timestamps are optional. std::stod/std::stoull stop at the first
+        // non-numeric character (so "1abc" would parse as 1), so the whole token must
+        // be consumed; std::stoull also wraps a leading '-' into a huge unsigned, so a
+        // negative timestamp is treated as malformed.
+        [[nodiscard]] inline std::optional<sample>
+        parseSample(const std::string &valueToken,
+                    const std::optional<std::string> &timestampToken) {
+            sample s;
+            try {
+                size_t pos = 0;
+                s.value = std::stod(valueToken, &pos);
+                if (pos != valueToken.size()) {
+                    return std::nullopt;
+                }
+            }
+            catch (const std::exception &) {
+                return std::nullopt;
+            }
+            if (timestampToken && !timestampToken->empty() && timestampToken->front() != '-') {
+                try {
+                    size_t pos = 0;
+                    const unsigned long long ts = std::stoull(*timestampToken, &pos);
+                    if (pos == timestampToken->size()) {
+                        s.timestamp = static_cast<uint64_t>(ts);
+                    }
+                }
+                catch (const std::exception &) {
+                    // Leave the timestamp unset on a non-numeric token.
+                }
+            }
+            return s;
+        }
+
+        // The gap between two matched pairs must hold exactly one comma (pairs are
+        // comma-separated); the gap before the first pair must hold none. Whitespace
+        // may pad either side, but no other character is allowed.
+        [[nodiscard]] inline bool
+        validSeparator(const std::string &gap, bool leading) {
+            if (gap.find_first_not_of(", \t") != std::string::npos) {
+                return false;
+            }
+            return std::count(gap.begin(), gap.end(), ',') == (leading ? 0 : 1);
+        }
+
+        // Extract the key="value" pairs from a label block (the text inside `{}`).
+        // Returns nullopt if the block is malformed -- a repeated key, a missing or
+        // doubled comma between pairs, a trailing comma, or any other stray text -- so
+        // a bad exposition line is rejected rather than silently parsed into partial
+        // or first-wins labels (these are regression tests).
+        [[nodiscard]] inline std::optional<labelSet>
+        parseLabels(const std::string &block) {
+            // Custom raw-string delimiter so the pattern's )" does not close it early.
+            static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
+            labelSet labels;
+            size_t cursor = 0;
+            for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
+                 it != std::sregex_iterator();
+                 ++it) {
+                const auto &match = *it;
+                const auto position = static_cast<size_t>(match.position());
+                if (!validSeparator(block.substr(cursor, position - cursor), cursor == 0)) {
+                    return std::nullopt;
+                }
+                // A duplicate label key within one series is malformed; reject it.
+                if (!labels.emplace(match[1].str(), match[2].str()).second) {
+                    return std::nullopt;
+                }
+                cursor = position + static_cast<size_t>(match.length());
+            }
+            // Any leftover after the last pair must be whitespace only (no trailing comma).
+            if (block.find_first_not_of(" \t", cursor) != std::string::npos) {
+                return std::nullopt;
+            }
+            return labels;
+        }
+
+        // Parse one exposition line into a series id + sample. Returns nullopt for
+        // comment/blank/malformed lines. Label values are assumed free of embedded
+        // quotes (true for these metrics).
+        [[nodiscard]] inline std::optional<std::pair<seriesId, sample>>
+        parseLine(const std::string &line) {
+            // name, optional brace-delimited label block, value, optional timestamp.
+            static const std::regex lineRe(
+                R"(^([^\s{]+)(?:\{([^}]*)\})?\s+(\S+)(?:\s+(\S+))?\s*$)");
+
+            std::smatch match;
+            if (line.empty() || line[0] == '#' || !std::regex_match(line, match, lineRe)) {
+                return std::nullopt;
+            }
+            const std::optional<sample> value = parseSample(
+                match[3].str(),
+                match[4].matched ? std::optional<std::string>(match[4].str()) : std::nullopt);
+            if (!value) {
+                return std::nullopt;
+            }
+            std::optional<labelSet> labels = parseLabels(match[2].str());
+            if (!labels) {
+                return std::nullopt;
+            }
+            return std::make_pair(seriesId{match[1].str(), std::move(*labels)}, *value);
+        }
+
+    } // namespace detail
+
     // Parse a whole /metrics body once. Each well-formed line contributes one
     // sample to its (name+labels) series; the resulting map lets a caller query
     // any number of series without rescanning the raw text.
-    [[nodiscard]] static seriesMap
+    [[nodiscard]] inline seriesMap
     parse(const std::string &body) {
         seriesMap series;
         std::istringstream stream(body);
         std::string line;
         while (std::getline(stream, line)) {
-            if (auto parsed = parseLine(line)) {
+            if (auto parsed = detail::parseLine(line)) {
                 series[std::move(parsed->first)].push_back(parsed->second);
             }
         }
         return series;
     }
 
-private:
-    // Parse one exposition line into a series id + sample. Returns nullopt for
-    // comment/blank/malformed lines. Label values are assumed free of embedded
-    // quotes (true for these metrics).
-    [[nodiscard]] static std::optional<std::pair<seriesId, sample>>
-    parseLine(const std::string &line) {
-        // name, optional brace-delimited label block, value, optional timestamp.
-        static const std::regex lineRe(R"(^([^\s{]+)(?:\{([^}]*)\})?\s+(\S+)(?:\s+(\S+))?\s*$)");
-
-        std::smatch match;
-        if (line.empty() || line[0] == '#' || !std::regex_match(line, match, lineRe)) {
-            return std::nullopt;
-        }
-        const std::optional<sample> value = parseSample(
-            match[3].str(),
-            match[4].matched ? std::optional<std::string>(match[4].str()) : std::nullopt);
-        if (!value) {
-            return std::nullopt;
-        }
-        std::optional<labelSet> labels = parseLabels(match[2].str());
-        if (!labels) {
-            return std::nullopt;
-        }
-        return std::make_pair(seriesId{match[1].str(), std::move(*labels)}, *value);
-    }
-
-    // Build a sample from its value token (required) and the optional timestamp
-    // token (the exposition's trailing field). Returns nullopt if the value is
-    // non-numeric; a missing or non-numeric timestamp is left unset, since
-    // Prometheus timestamps are optional. std::stod/std::stoull stop at the first
-    // non-numeric character (so "1abc" would parse as 1), so the whole token must
-    // be consumed; std::stoull also wraps a leading '-' into a huge unsigned, so a
-    // negative timestamp is treated as malformed.
-    [[nodiscard]] static std::optional<sample>
-    parseSample(const std::string &valueToken, const std::optional<std::string> &timestampToken) {
-        sample s;
-        try {
-            size_t pos = 0;
-            s.value = std::stod(valueToken, &pos);
-            if (pos != valueToken.size()) {
-                return std::nullopt;
-            }
-        }
-        catch (const std::exception &) {
-            return std::nullopt;
-        }
-        if (timestampToken && !timestampToken->empty() && timestampToken->front() != '-') {
-            try {
-                size_t pos = 0;
-                const unsigned long long ts = std::stoull(*timestampToken, &pos);
-                if (pos == timestampToken->size()) {
-                    s.timestamp = static_cast<uint64_t>(ts);
-                }
-            }
-            catch (const std::exception &) {
-                // Leave the timestamp unset on a non-numeric token.
-            }
-        }
-        return s;
-    }
-
-    // The gap between two matched pairs must hold exactly one comma (pairs are
-    // comma-separated); the gap before the first pair must hold none. Whitespace
-    // may pad either side, but no other character is allowed.
-    [[nodiscard]] static bool
-    validSeparator(const std::string &gap, bool leading) {
-        if (gap.find_first_not_of(", \t") != std::string::npos) {
-            return false;
-        }
-        return std::count(gap.begin(), gap.end(), ',') == (leading ? 0 : 1);
-    }
-
-    // Extract the key="value" pairs from a label block (the text inside `{}`).
-    // Returns nullopt if the block is malformed -- a repeated key, a missing or
-    // doubled comma between pairs, a trailing comma, or any other stray text -- so
-    // a bad exposition line is rejected rather than silently parsed into partial
-    // or first-wins labels (these are regression tests).
-    [[nodiscard]] static std::optional<labelSet>
-    parseLabels(const std::string &block) {
-        // Custom raw-string delimiter so the pattern's )" does not close it early.
-        static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
-        labelSet labels;
-        size_t cursor = 0;
-        for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
-             it != std::sregex_iterator();
-             ++it) {
-            const auto &match = *it;
-            const auto position = static_cast<size_t>(match.position());
-            if (!validSeparator(block.substr(cursor, position - cursor), cursor == 0)) {
-                return std::nullopt;
-            }
-            // A duplicate label key within one series is malformed; reject it.
-            if (!labels.emplace(match[1].str(), match[2].str()).second) {
-                return std::nullopt;
-            }
-            cursor = position + static_cast<size_t>(match.length());
-        }
-        // Any leftover after the last pair must be whitespace only (no trailing comma).
-        if (block.find_first_not_of(" \t", cursor) != std::string::npos) {
-            return std::nullopt;
-        }
-        return labels;
-    }
-};
+} // namespace open_metrics_text
 
 } // namespace nixl::doca_test
 

--- a/test/doca-telemetry/open_metrics_text_parser.h
+++ b/test/doca-telemetry/open_metrics_text_parser.h
@@ -58,12 +58,13 @@ namespace open_metrics_text {
     namespace detail {
 
         // Build a sample from its value token (required) and the optional timestamp
-        // token (the exposition's trailing field). Returns nullopt if the value is
-        // non-numeric; a missing or non-numeric timestamp is left unset, since
-        // Prometheus timestamps are optional. std::stod/std::stoull stop at the first
-        // non-numeric character (so "1abc" would parse as 1), so the whole token must
-        // be consumed; std::stoull also wraps a leading '-' into a huge unsigned, so a
-        // negative timestamp is treated as malformed.
+        // token (the exposition's trailing field). Returns nullopt (rejecting the
+        // line) if the value is non-numeric or only partially numeric, or if a
+        // timestamp is present but malformed (empty, negative, non-numeric, or only
+        // partially consumed). A missing timestamp is fine -- Prometheus timestamps
+        // are optional. std::stod/std::stoull stop at the first non-numeric character
+        // (so "1abc" would parse as 1), hence the full-consumption checks; std::stoull
+        // also wraps a leading '-' into a huge unsigned, hence the explicit reject.
         [[nodiscard]] inline std::optional<sample>
         parseSample(const std::string &valueToken,
                     const std::optional<std::string> &timestampToken) {
@@ -78,16 +79,22 @@ namespace open_metrics_text {
             catch (const std::exception &) {
                 return std::nullopt;
             }
-            if (timestampToken && !timestampToken->empty() && timestampToken->front() != '-') {
+            // A missing timestamp is fine; a PRESENT one must be well-formed -- reject
+            // the line on an empty, negative, non-numeric, or partially-consumed token.
+            if (timestampToken) {
+                if (timestampToken->empty() || timestampToken->front() == '-') {
+                    return std::nullopt;
+                }
                 try {
                     size_t pos = 0;
                     const unsigned long long ts = std::stoull(*timestampToken, &pos);
-                    if (pos == timestampToken->size()) {
-                        s.timestamp = static_cast<uint64_t>(ts);
+                    if (pos != timestampToken->size()) {
+                        return std::nullopt;
                     }
+                    s.timestamp = static_cast<uint64_t>(ts);
                 }
                 catch (const std::exception &) {
-                    // Leave the timestamp unset on a non-numeric token.
+                    return std::nullopt;
                 }
             }
             return s;

--- a/test/doca-telemetry/open_metrics_text_parser.h
+++ b/test/doca-telemetry/open_metrics_text_parser.h
@@ -86,19 +86,30 @@ private:
     // Build a sample from its value token (required) and the optional timestamp
     // token (the exposition's trailing field). Returns nullopt if the value is
     // non-numeric; a missing or non-numeric timestamp is left unset, since
-    // Prometheus timestamps are optional.
+    // Prometheus timestamps are optional. std::stod/std::stoull stop at the first
+    // non-numeric character (so "1abc" would parse as 1), so the whole token must
+    // be consumed; std::stoull also wraps a leading '-' into a huge unsigned, so a
+    // negative timestamp is treated as malformed.
     [[nodiscard]] static std::optional<sample>
     parseSample(const std::string &valueToken, const std::optional<std::string> &timestampToken) {
         sample s;
         try {
-            s.value = std::stod(valueToken);
+            size_t pos = 0;
+            s.value = std::stod(valueToken, &pos);
+            if (pos != valueToken.size()) {
+                return std::nullopt;
+            }
         }
         catch (const std::exception &) {
             return std::nullopt;
         }
-        if (timestampToken) {
+        if (timestampToken && !timestampToken->empty() && timestampToken->front() != '-') {
             try {
-                s.timestamp = static_cast<uint64_t>(std::stoull(*timestampToken));
+                size_t pos = 0;
+                const unsigned long long ts = std::stoull(*timestampToken, &pos);
+                if (pos == timestampToken->size()) {
+                    s.timestamp = static_cast<uint64_t>(ts);
+                }
             }
             catch (const std::exception &) {
                 // Leave the timestamp unset on a non-numeric token.

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -19,207 +19,20 @@
 
 #include <chrono>
 #include <cstdint>
-#include <map>
-#include <optional>
-#include <regex>
-#include <sstream>
 #include <string>
 #include <thread>
-#include <tuple>
-#include <utility>
-#include <vector>
 
 #include "loopback_connection.h"
+#include "open_metrics_text_parser.h"
+#include "timeseries.h"
 
 namespace nixl::doca_test {
 
-using labelSet = std::map<std::string, std::string>;
-
-// A single sample of a time series: a value and, when the exposition carries one,
-// a timestamp (stored verbatim). DOCA tracks time internally in microseconds, but
-// the Prometheus text exposition DOCA serves uses milliseconds.
-struct sample {
-    double value = 0.0;
-    std::optional<uint64_t> timestamp;
-
-    // Build a sample from its value token (required) and the optional timestamp
-    // token (the exposition's trailing field). Returns nullopt if the value is
-    // non-numeric; a missing or non-numeric timestamp is left unset, since
-    // Prometheus timestamps are optional.
-    [[nodiscard]] static std::optional<sample>
-    parse(const std::string &valueToken, const std::optional<std::string> &timestampToken) {
-        sample s;
-        try {
-            s.value = std::stod(valueToken);
-        }
-        catch (const std::exception &) {
-            return std::nullopt;
-        }
-        if (timestampToken) {
-            try {
-                s.timestamp = static_cast<uint64_t>(std::stoull(*timestampToken));
-            }
-            catch (const std::exception &) {
-                // Leave the timestamp unset on a non-numeric token.
-            }
-        }
-        return s;
-    }
-};
-
-// Identity of a Prometheus time series: a metric name plus its label set. Every
-// sample of a series shares this identity, so it is the natural key -- the name
-// and labels live here once, not duplicated onto each sample.
-struct seriesId {
-    std::string name;
-    labelSet labels;
-
-    friend bool
-    operator<(const seriesId &lhs, const seriesId &rhs) {
-        return std::tie(lhs.name, lhs.labels) < std::tie(rhs.name, rhs.labels);
-    }
-};
-
-// The samples of one series, and the id -> samples map produced by one parse.
-using samples = std::vector<sample>;
-using seriesMap = std::map<seriesId, samples>;
-
-// A set of Prometheus time series parsed from a /metrics body: each series
-// (name+labels) maps to its samples. The body is parsed ONCE so a caller can
-// look up any number of series without rescanning the raw text per metric. A
-// metric name alone is ambiguous when the same metric is exported with different
-// label sets, so it is never the key. A single scrape yields one sample per
-// series; the sample vector also accommodates repeated scrapes.
-class timeSeries {
-public:
-    explicit timeSeries(const std::string &body) {
-        std::istringstream stream(body);
-        std::string line;
-        while (std::getline(stream, line)) {
-            seriesId id;
-            sample s;
-            if (parseLine(line, id, s)) {
-                series_[std::move(id)].push_back(s);
-            }
-        }
-    }
-
-    // Latest sampled value of the series named `name` whose labels include every
-    // pair in `where` (subset match -- pass only the labels you care about).
-    // Returns nullopt if nothing matches, if more than one series matches
-    // (ambiguous: add labels to disambiguate), or if the matched series is empty.
-    [[nodiscard]] std::optional<double>
-    latestValue(const std::string &name, const labelSet &where = {}) const {
-        std::optional<double> result;
-        bool matched = false;
-        for (const auto &[id, seriesSamples] : series_) {
-            if (id.name != name || !labelsContain(id.labels, where)) {
-                continue;
-            }
-            if (matched) {
-                return std::nullopt; // ambiguous: same name, different label sets
-            }
-            matched = true;
-            if (!seriesSamples.empty()) {
-                result = seriesSamples.back().value;
-            }
-        }
-        return result;
-    }
-
-    // The full id -> samples map, for any assertion the helpers above do not
-    // cover (e.g. timestamps or multi-sample series). Zero-copy.
-    [[nodiscard]] const seriesMap &
-    series() const noexcept {
-        return series_;
-    }
-
-    [[nodiscard]] bool
-    empty() const noexcept {
-        return series_.empty();
-    }
-
-private:
-    // true if `labels` contains every key/value pair in `required`.
-    [[nodiscard]] static bool
-    labelsContain(const labelSet &labels, const labelSet &required) {
-        for (const auto &[key, value] : required) {
-            const auto it = labels.find(key);
-            if (it == labels.end() || it->second != value) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Parse one exposition line into a series id + sample. Returns false for
-    // comment/blank/malformed lines. Format: name[{k="v",...}] value [timestamp].
-    // Label values are assumed free of embedded quotes (true for these metrics).
-    [[nodiscard]] static bool
-    parseLine(const std::string &line, seriesId &id, sample &out) {
-        // name, optional brace-delimited label block, value, optional timestamp.
-        static const std::regex lineRe(R"(^([^\s{]+)(?:\{([^}]*)\})?\s+(\S+)(?:\s+(\S+))?\s*$)");
-
-        std::smatch match;
-        if (line.empty() || line[0] == '#' || !std::regex_match(line, match, lineRe)) {
-            return false;
-        }
-        const std::optional<sample> parsed = sample::parse(
-            match[3].str(),
-            match[4].matched ? std::optional<std::string>(match[4].str()) : std::nullopt);
-        if (!parsed) {
-            return false;
-        }
-        out = *parsed;
-        std::optional<labelSet> labels = parseLabels(match[2].str());
-        if (!labels) {
-            return false;
-        }
-        id.name = match[1].str();
-        id.labels = std::move(*labels);
-        return true;
-    }
-
-    // Extract the key="value" pairs from a label block (the text inside `{}`).
-    // Returns nullopt if the block is malformed -- anything other than well-formed
-    // pairs separated by commas/whitespace, or a repeated label key -- so a bad
-    // exposition line is rejected rather than silently parsed into partial or
-    // first-wins labels (these are regression tests).
-    [[nodiscard]] static std::optional<labelSet>
-    parseLabels(const std::string &block) {
-        // Custom raw-string delimiter so the pattern's )" does not close it early.
-        static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
-        labelSet labels;
-        size_t cursor = 0;
-        for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
-             it != std::sregex_iterator();
-             ++it) {
-            const auto &match = *it;
-            // Only commas/whitespace may separate (and precede) the matched pairs.
-            if (block.find_first_not_of(", \t", cursor) < static_cast<size_t>(match.position())) {
-                return std::nullopt;
-            }
-            // A duplicate label key within one series is malformed; reject it.
-            if (!labels.emplace(match[1].str(), match[2].str()).second) {
-                return std::nullopt;
-            }
-            cursor = static_cast<size_t>(match.position() + match.length());
-        }
-        // Any leftover after the last pair must also be only commas/whitespace.
-        if (block.find_first_not_of(", \t", cursor) != std::string::npos) {
-            return std::nullopt;
-        }
-        return labels;
-    }
-
-    seriesMap series_;
-};
-
 // Poll /metrics until the series `name` (matching optional label subset `where`)
-// reads exactly `expected`, or until timeout. Returns the final parsed scrape
-// (each poll parses the body once) so the caller can assert that series and any
-// others without rescanning. Cumulative counters settle asynchronously after a
-// flush, so a single read can observe a stale value.
+// reads exactly `expected`, or until timeout. Each poll parses the body once into
+// a timeSeries; the final scrape is returned so the caller can assert that series
+// and any others without rescanning. Cumulative counters settle asynchronously
+// after a flush, so a single read can observe a stale value.
 [[nodiscard]] inline timeSeries
 scrapeUntilValue(uint16_t port,
                  const std::string &name,
@@ -227,9 +40,10 @@ scrapeUntilValue(uint16_t port,
                  std::chrono::seconds timeout,
                  const labelSet &where = {}) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
-    timeSeries metrics{std::string{}};
+    timeSeries metrics{seriesMap{}};
     do {
-        metrics = timeSeries(loopbackConnection::httpGet(port, "/metrics"));
+        metrics =
+            timeSeries(OpenMetricsTextParser::parse(loopbackConnection::httpGet(port, "/metrics")));
         if (metrics.latestValue(name, where) == expected) {
             return metrics;
         }

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -19,67 +19,203 @@
 
 #include <chrono>
 #include <cstdint>
+#include <map>
+#include <optional>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include "loopback_connection.h"
 
 namespace nixl::doca_test {
 
-// Poll /metrics until it contains `needle`, or timeout.
-inline std::string
-scrapeUntil(uint16_t port, const std::string &needle, std::chrono::seconds timeout) {
+using labelSet = std::map<std::string, std::string>;
+
+// A single sample of a time series: a value and, when the exposition carries one
+// (DOCA/CollectX appends a millisecond timestamp after the value), the sample
+// timestamp.
+struct sample {
+    double value = 0.0;
+    std::optional<uint64_t> timestamp;
+
+    // Build a sample from its value token (required) and the optional timestamp
+    // token (the exposition's trailing field). Returns nullopt if the value is
+    // non-numeric; a missing or non-numeric timestamp is left unset, since
+    // Prometheus timestamps are optional.
+    [[nodiscard]] static std::optional<sample>
+    parse(const std::string &valueToken, const std::optional<std::string> &timestampToken) {
+        sample s;
+        try {
+            s.value = std::stod(valueToken);
+        }
+        catch (const std::exception &) {
+            return std::nullopt;
+        }
+        if (timestampToken) {
+            try {
+                s.timestamp = static_cast<uint64_t>(std::stoull(*timestampToken));
+            }
+            catch (const std::exception &) {
+                // Leave the timestamp unset on a non-numeric token.
+            }
+        }
+        return s;
+    }
+};
+
+// Identity of a Prometheus time series: a metric name plus its label set. Every
+// sample of a series shares this identity, so it is the natural key -- the name
+// and labels live here once, not duplicated onto each sample.
+struct seriesId {
+    std::string name;
+    labelSet labels;
+
+    friend bool
+    operator<(const seriesId &lhs, const seriesId &rhs) {
+        return std::tie(lhs.name, lhs.labels) < std::tie(rhs.name, rhs.labels);
+    }
+};
+
+// The samples of one series, and the id -> samples map produced by one parse.
+using samples = std::vector<sample>;
+using seriesMap = std::map<seriesId, samples>;
+
+// A set of Prometheus time series parsed from a /metrics body: each series
+// (name+labels) maps to its samples. The body is parsed ONCE so a caller can
+// look up any number of series without rescanning the raw text per metric. A
+// metric name alone is ambiguous when the same metric is exported with different
+// label sets, so it is never the key. A single scrape yields one sample per
+// series; the sample vector also accommodates repeated scrapes.
+class timeSeries {
+public:
+    explicit timeSeries(const std::string &body) {
+        std::istringstream stream(body);
+        std::string line;
+        while (std::getline(stream, line)) {
+            seriesId id;
+            sample s;
+            if (parseLine(line, id, s)) {
+                series_[std::move(id)].push_back(s);
+            }
+        }
+    }
+
+    // Latest sampled value of the series named `name` whose labels include every
+    // pair in `where` (subset match -- pass only the labels you care about).
+    // Returns nullopt if nothing matches, if more than one series matches
+    // (ambiguous: add labels to disambiguate), or if the matched series is empty.
+    [[nodiscard]] std::optional<double>
+    latestValue(const std::string &name, const labelSet &where = {}) const {
+        std::optional<double> result;
+        bool matched = false;
+        for (const auto &[id, seriesSamples] : series_) {
+            if (id.name != name || !labelsContain(id.labels, where)) {
+                continue;
+            }
+            if (matched) {
+                return std::nullopt; // ambiguous: same name, different label sets
+            }
+            matched = true;
+            if (!seriesSamples.empty()) {
+                result = seriesSamples.back().value;
+            }
+        }
+        return result;
+    }
+
+    // The full id -> samples map, for any assertion the helpers above do not
+    // cover (e.g. timestamps or multi-sample series). Zero-copy.
+    [[nodiscard]] const seriesMap &
+    series() const noexcept {
+        return series_;
+    }
+
+    [[nodiscard]] bool
+    empty() const noexcept {
+        return series_.empty();
+    }
+
+private:
+    // true if `labels` contains every key/value pair in `required`.
+    [[nodiscard]] static bool
+    labelsContain(const labelSet &labels, const labelSet &required) {
+        for (const auto &[key, value] : required) {
+            const auto it = labels.find(key);
+            if (it == labels.end() || it->second != value) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Parse one exposition line into a series id + sample. Returns false for
+    // comment/blank/malformed lines. Format: name[{k="v",...}] value [timestamp].
+    // Label values are assumed free of embedded quotes (true for these metrics).
+    [[nodiscard]] static bool
+    parseLine(const std::string &line, seriesId &id, sample &out) {
+        // name, optional brace-delimited label block, value, optional timestamp.
+        static const std::regex lineRe(R"(^([^\s{]+)(?:\{([^}]*)\})?\s+(\S+)(?:\s+(\S+))?\s*$)");
+
+        std::smatch match;
+        if (line.empty() || line[0] == '#' || !std::regex_match(line, match, lineRe)) {
+            return false;
+        }
+        const std::optional<sample> parsed = sample::parse(
+            match[3].str(),
+            match[4].matched ? std::optional<std::string>(match[4].str()) : std::nullopt);
+        if (!parsed) {
+            return false;
+        }
+        out = *parsed;
+        id.name = match[1].str();
+        id.labels = parseLabels(match[2].str());
+        return true;
+    }
+
+    // Extract the key="value" pairs from a label block (the text inside `{}`). The
+    // regex matches each pair and skips the ", " separators, so there is no manual
+    // splitting or whitespace trimming.
+    [[nodiscard]] static labelSet
+    parseLabels(const std::string &block) {
+        // Custom raw-string delimiter so the pattern's )" does not close it early.
+        static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
+        labelSet labels;
+        for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
+             it != std::sregex_iterator();
+             ++it) {
+            labels.emplace((*it)[1].str(), (*it)[2].str());
+        }
+        return labels;
+    }
+
+    seriesMap series_;
+};
+
+// Poll /metrics until the series `name` (matching optional label subset `where`)
+// reads exactly `expected`, or until timeout. Returns the final parsed scrape
+// (each poll parses the body once) so the caller can assert that series and any
+// others without rescanning. Cumulative counters settle asynchronously after a
+// flush, so a single read can observe a stale value.
+[[nodiscard]] inline timeSeries
+scrapeUntilValue(uint16_t port,
+                 const std::string &name,
+                 double expected,
+                 std::chrono::seconds timeout,
+                 const labelSet &where = {}) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
-    std::string body;
+    timeSeries metrics{std::string{}};
     do {
-        body = loopbackConnection::httpGet(port, "/metrics");
-        if (body.find(needle) != std::string::npos) {
-            return body;
+        metrics = timeSeries(loopbackConnection::httpGet(port, "/metrics"));
+        if (metrics.latestValue(name, where) == expected) {
+            return metrics;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     } while (std::chrono::steady_clock::now() < deadline);
-    return body;
-}
-
-// Value on the first non-comment exposition line that starts with `metric`.
-// Exposition format is: name{labels} VALUE [TIMESTAMP]  (or  name VALUE [TS]).
-// The value is the token right after the label set, NOT the trailing timestamp.
-inline double
-metricValue(const std::string &body, const std::string &metric) {
-    std::istringstream lines(body);
-    std::string line;
-    while (std::getline(lines, line)) {
-        if (line.empty() || line[0] == '#') {
-            continue;
-        }
-        if (line.rfind(metric, 0) != 0) {
-            continue;
-        }
-
-        size_t value_start;
-        const auto labels_end = line.find("} ");
-        if (labels_end != std::string::npos) {
-            value_start = labels_end + 2;
-        } else {
-            const auto sp = line.find(' ');
-            if (sp == std::string::npos) {
-                continue;
-            }
-            value_start = sp + 1;
-        }
-
-        const auto value_end = line.find(' ', value_start);
-        const std::string token = line.substr(
-            value_start,
-            value_end == std::string::npos ? std::string::npos : value_end - value_start);
-        try {
-            return std::stod(token);
-        }
-        catch (const std::exception &) {
-        }
-    }
-    return -1.0;
+    return metrics;
 }
 
 } // namespace nixl::doca_test

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -182,8 +182,9 @@ private:
 
     // Extract the key="value" pairs from a label block (the text inside `{}`).
     // Returns nullopt if the block is malformed -- anything other than well-formed
-    // pairs separated by commas/whitespace -- so a bad exposition line is rejected
-    // rather than silently parsed into partial labels (these are regression tests).
+    // pairs separated by commas/whitespace, or a repeated label key -- so a bad
+    // exposition line is rejected rather than silently parsed into partial or
+    // first-wins labels (these are regression tests).
     [[nodiscard]] static std::optional<labelSet>
     parseLabels(const std::string &block) {
         // Custom raw-string delimiter so the pattern's )" does not close it early.
@@ -198,7 +199,10 @@ private:
             if (block.find_first_not_of(", \t", cursor) < static_cast<size_t>(match.position())) {
                 return std::nullopt;
             }
-            labels.emplace(match[1].str(), match[2].str());
+            // A duplicate label key within one series is malformed; reject it.
+            if (!labels.emplace(match[1].str(), match[2].str()).second) {
+                return std::nullopt;
+            }
             cursor = static_cast<size_t>(match.position() + match.length());
         }
         // Any leftover after the last pair must also be only commas/whitespace.

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -35,9 +35,9 @@ namespace nixl::doca_test {
 
 using labelSet = std::map<std::string, std::string>;
 
-// A single sample of a time series: a value and, when the exposition carries one
-// (DOCA/CollectX appends a millisecond timestamp after the value), the sample
-// timestamp.
+// A single sample of a time series: a value and, when the exposition carries one,
+// a timestamp (stored verbatim). DOCA tracks time internally in microseconds, but
+// the Prometheus text exposition DOCA serves uses milliseconds.
 struct sample {
     double value = 0.0;
     std::optional<uint64_t> timestamp;
@@ -171,23 +171,39 @@ private:
             return false;
         }
         out = *parsed;
+        std::optional<labelSet> labels = parseLabels(match[2].str());
+        if (!labels) {
+            return false;
+        }
         id.name = match[1].str();
-        id.labels = parseLabels(match[2].str());
+        id.labels = std::move(*labels);
         return true;
     }
 
-    // Extract the key="value" pairs from a label block (the text inside `{}`). The
-    // regex matches each pair and skips the ", " separators, so there is no manual
-    // splitting or whitespace trimming.
-    [[nodiscard]] static labelSet
+    // Extract the key="value" pairs from a label block (the text inside `{}`).
+    // Returns nullopt if the block is malformed -- anything other than well-formed
+    // pairs separated by commas/whitespace -- so a bad exposition line is rejected
+    // rather than silently parsed into partial labels (these are regression tests).
+    [[nodiscard]] static std::optional<labelSet>
     parseLabels(const std::string &block) {
         // Custom raw-string delimiter so the pattern's )" does not close it early.
         static const std::regex labelRe(R"re(([^=,\s]+)\s*=\s*"([^"]*)")re");
         labelSet labels;
+        size_t cursor = 0;
         for (auto it = std::sregex_iterator(block.begin(), block.end(), labelRe);
              it != std::sregex_iterator();
              ++it) {
-            labels.emplace((*it)[1].str(), (*it)[2].str());
+            const auto &match = *it;
+            // Only commas/whitespace may separate (and precede) the matched pairs.
+            if (block.find_first_not_of(", \t", cursor) < static_cast<size_t>(match.position())) {
+                return std::nullopt;
+            }
+            labels.emplace(match[1].str(), match[2].str());
+            cursor = static_cast<size_t>(match.position() + match.length());
+        }
+        // Any leftover after the last pair must also be only commas/whitespace.
+        if (block.find_first_not_of(", \t", cursor) != std::string::npos) {
+            return std::nullopt;
         }
         return labels;
     }

--- a/test/doca-telemetry/scrape_util.h
+++ b/test/doca-telemetry/scrape_util.h
@@ -43,7 +43,7 @@ scrapeUntilValue(uint16_t port,
     timeSeries metrics{seriesMap{}};
     do {
         metrics =
-            timeSeries(OpenMetricsTextParser::parse(loopbackConnection::httpGet(port, "/metrics")));
+            timeSeries(open_metrics_text::parse(loopbackConnection::httpGet(port, "/metrics")));
         if (metrics.latestValue(name, where) == expected) {
             return metrics;
         }

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <optional>
+#include <stdexcept>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -159,8 +160,9 @@ TEST_F(docaNixlExporterTest, DistinguishesSeriesByAgentLabel) {
     EXPECT_EQ(metrics.latestValue(metric, {{"agent_name", agentAlpha}}),
               std::optional<double>(700.0));
     EXPECT_EQ(metrics.latestValue(metric, {{"agent_name", agentBeta}}), std::optional<double>(4.0));
-    // Same name, two label sets -> a name-only lookup cannot pick one.
-    EXPECT_EQ(metrics.latestValue(metric), std::nullopt)
+    // Same name, two label sets -> a name-only lookup is ambiguous and is
+    // rejected with a throw (a too-loose query is a test mistake, not a miss).
+    EXPECT_THROW((void)metrics.latestValue(metric), std::runtime_error)
         << metric << " is exported by two agents; a name-only lookup must be ambiguous";
 }
 

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -62,13 +62,13 @@ protected:
 };
 
 // Drive the real NIXL DOCA exporter end-to-end and verify EVERY pushed value is
-// accounted for at the CollectX-backed Prometheus endpoint. The exported counter
+// accounted for at the DOCA Prometheus endpoint. The exported counter
 // is cumulative (add_counter_increment), so the final total must equal the exact
 // sum of all pushed deltas: any dropped or duplicated sample shifts that sum and
 // fails the check. Deltas are deliberately distinct so the sum is sensitive to a
 // single bad sample. One flush + one settle-and-scrape -- no per-iteration
 // rescraping (the final total is the stable invariant; intermediate cumulative
-// values aren't reliably observable through CollectX's async/coalescing flush).
+// values aren't reliably observable through DOCA's async/coalescing flush).
 TEST_F(docaNixlExporterTest, CounterAccumulatesAllPushedValues) {
     constexpr char agentName[] = "nixl_doca_exporter_test";
     const nixlTelemetryExporterInitParams params{agentName, 4096};
@@ -87,8 +87,8 @@ TEST_F(docaNixlExporterTest, CounterAccumulatesAllPushedValues) {
         ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
         expected_total += delta;
     }
-    // A handful of samples never fill the CollectX buffer, so the endpoint would
-    // stay empty without an explicit flush.
+    // A handful of samples never fill the DOCA metrics buffer, so the endpoint
+    // would stay empty without an explicit flush.
     ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
 
     const auto metrics = scrapeUntilValue(

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -20,16 +20,16 @@
 #include "doca_exporter.h"
 #include "telemetry_event.h"
 
+#include <array>
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
+#include <optional>
 #include <string>
 
 #include <gtest/gtest.h>
 
 using nixl::doca_test::loopbackConnection;
-using nixl::doca_test::metricValue;
-using nixl::doca_test::scrapeUntil;
+using nixl::doca_test::scrapeUntilValue;
 
 namespace {
 
@@ -61,36 +61,44 @@ protected:
     uint16_t port_ = 0;
 };
 
-// Drive the real NIXL DOCA exporter end-to-end: push per-operation counter
-// deltas through exportEvent, flush, then scrape the CollectX-backed Prometheus
-// endpoint. A counter event (AGENT_TX_BYTES) must accumulate into a monotonic
-// cumulative total (add_counter_increment), and flush must make the few samples
-// visible (they would not fill the buffer to trigger an auto-flush).
-TEST_F(docaNixlExporterTest, CounterAccumulatesAndFlushServes) {
-    const nixlTelemetryExporterInitParams params{"nixl_doca_exporter_test", 4096};
+// Drive the real NIXL DOCA exporter end-to-end and verify EVERY pushed value is
+// accounted for at the CollectX-backed Prometheus endpoint. The exported counter
+// is cumulative (add_counter_increment), so the final total must equal the exact
+// sum of all pushed deltas: any dropped or duplicated sample shifts that sum and
+// fails the check. Deltas are deliberately distinct so the sum is sensitive to a
+// single bad sample. One flush + one settle-and-scrape -- no per-iteration
+// rescraping (the final total is the stable invariant; intermediate cumulative
+// values aren't reliably observable through CollectX's async/coalescing flush).
+TEST_F(docaNixlExporterTest, CounterAccumulatesAllPushedValues) {
+    constexpr char agentName[] = "nixl_doca_exporter_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
     nixlTelemetryDocaExporter exporter(params);
-
-    constexpr uint64_t delta = 1000;
-    constexpr int iterations = 3;
-    for (int i = 0; i < iterations; ++i) {
-        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_TX_BYTES, delta);
-        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
-    }
-
-    // A handful of samples will not fill the CollectX buffer, so the endpoint
-    // would stay empty without this explicit flush.
-    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
 
     const std::string metric = std::string(
         nixlEnumStrings::telemetryEventTypeStr(nixl_telemetry_event_type_t::AGENT_TX_BYTES));
-    const std::string body = scrapeUntil(port_, metric, std::chrono::seconds(12));
-    std::cout << "=== NIXL DOCA exporter /metrics scrape (port " << port_ << ") ===\n"
-              << body << "\n=== end scrape ===" << std::endl;
+    // The exporter tags every sample with the agent_name label, so look the
+    // series up by name + that label rather than by name alone.
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
 
-    EXPECT_NE(body.find(metric), std::string::npos)
-        << metric << " not served at the DOCA Prometheus endpoint after flush";
-    EXPECT_EQ(metricValue(body, metric), static_cast<double>(delta * iterations))
-        << "per-operation deltas must accumulate into a cumulative counter";
+    constexpr std::array<uint64_t, 5> deltas{1000, 250, 4096, 1, 75000};
+    uint64_t expected_total = 0;
+    for (const uint64_t delta : deltas) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_TX_BYTES, delta);
+        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
+        expected_total += delta;
+    }
+    // A handful of samples never fill the CollectX buffer, so the endpoint would
+    // stay empty without an explicit flush.
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const auto metrics = scrapeUntilValue(
+        port_, metric, static_cast<double>(expected_total), std::chrono::seconds(12), labels);
+    const std::optional<double> observed = metrics.latestValue(metric, labels);
+    ASSERT_TRUE(observed.has_value())
+        << metric << "{agent_name=" << agentName << "} not served at the endpoint after flush";
+    EXPECT_EQ(*observed, static_cast<double>(expected_total))
+        << "cumulative counter must equal the sum of all " << deltas.size() << " pushed deltas ("
+        << expected_total << "); a drop or duplicate would miss this total";
 }
 
 int

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -101,6 +101,69 @@ TEST_F(docaNixlExporterTest, CounterAccumulatesAllPushedValues) {
         << expected_total << "); a drop or duplicate would miss this total";
 }
 
+// A gauge is absolute (add_gauge), unlike the cumulative counter above: the
+// endpoint must reflect the LAST pushed value, not the sum. Push a sequence of
+// distinct values and confirm only the final one is served -- if the exporter
+// wrongly accumulated, the served value would be the sum and this would fail.
+TEST_F(docaNixlExporterTest, GaugeReflectsLastPushedValue) {
+    constexpr char agentName[] = "nixl_doca_exporter_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    const std::string metric = std::string(nixlEnumStrings::telemetryEventTypeStr(
+        nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED));
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+
+    constexpr std::array<uint64_t, 4> values{4096, 65536, 1024, 8192};
+    for (const uint64_t v : values) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED, v);
+        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
+    }
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const uint64_t expected = values.back();
+    const auto metrics = scrapeUntilValue(
+        port_, metric, static_cast<double>(expected), std::chrono::seconds(12), labels);
+    const std::optional<double> observed = metrics.latestValue(metric, labels);
+    ASSERT_TRUE(observed.has_value())
+        << metric << "{agent_name=" << agentName << "} not served at the endpoint after flush";
+    EXPECT_EQ(*observed, static_cast<double>(expected))
+        << "a gauge must reflect the last pushed value (" << expected << "), not a sum";
+}
+
+// Two agents export the SAME metric name; the DOCA exporter tags each sample
+// with its agent_name, producing two distinct series that differ only by label.
+// A single scrape must keep them apart: a name + agent_name lookup returns that
+// agent's value, while a name-only lookup is ambiguous. Both exporters share the
+// process-wide DOCA context (one Prometheus endpoint), as in a real multi-agent
+// process.
+TEST_F(docaNixlExporterTest, DistinguishesSeriesByAgentLabel) {
+    constexpr char agentAlpha[] = "agent_alpha";
+    constexpr char agentBeta[] = "agent_beta";
+    constexpr auto txBytes = nixl_telemetry_event_type_t::AGENT_TX_BYTES;
+
+    nixlTelemetryDocaExporter exporterAlpha(nixlTelemetryExporterInitParams{agentAlpha, 4096});
+    nixlTelemetryDocaExporter exporterBeta(nixlTelemetryExporterInitParams{agentBeta, 4096});
+
+    ASSERT_EQ(exporterAlpha.exportEvent(nixlTelemetryEvent(txBytes, 700)), NIXL_SUCCESS);
+    ASSERT_EQ(exporterBeta.exportEvent(nixlTelemetryEvent(txBytes, 4)), NIXL_SUCCESS);
+    // Both exporters share the one process-wide DOCA context/source, so a single
+    // flush on either drains both agents' buffered samples.
+    ASSERT_EQ(exporterAlpha.flush(), NIXL_SUCCESS);
+
+    const std::string metric = std::string(nixlEnumStrings::telemetryEventTypeStr(txBytes));
+
+    // Wait for alpha's series, then read both from that one parsed scrape.
+    const auto metrics = scrapeUntilValue(
+        port_, metric, 700.0, std::chrono::seconds(12), {{"agent_name", agentAlpha}});
+    EXPECT_EQ(metrics.latestValue(metric, {{"agent_name", agentAlpha}}),
+              std::optional<double>(700.0));
+    EXPECT_EQ(metrics.latestValue(metric, {{"agent_name", agentBeta}}), std::optional<double>(4.0));
+    // Same name, two label sets -> a name-only lookup cannot pick one.
+    EXPECT_EQ(metrics.latestValue(metric), std::nullopt)
+        << metric << " is exported by two agents; a name-only lookup must be ambiguous";
+}
+
 int
 main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/doca-telemetry/telemetry_doca_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_test.cpp
@@ -43,9 +43,9 @@ protected:
 
 // Raw DOCA Metrics API proof, mirroring the DOCA prometheus_example sample:
 // stand up schema/source/metrics, accumulate a counter via add_counter_increment,
-// flush explicitly, and confirm the CollectX-backed Prometheus endpoint serves
-// the cumulative value. Establishes that DOCA + CollectX work in-process (the
-// gRPC duplicate-flag clash is resolved by CollectX >= 1.26).
+// flush explicitly, and confirm the DOCA Prometheus endpoint serves the
+// cumulative value. Establishes that the DOCA telemetry exporter works in-process
+// (the gRPC duplicate-flag clash is resolved in current DOCA).
 TEST_F(docaTelemetryTest, RawDocaApiServesAccumulatingCounter) {
     // PROMETHEUS_ENDPOINT must be set before schema_init (per the DOCA sample).
     const std::string endpoint = "http://127.0.0.1:" + std::to_string(port_);

--- a/test/doca-telemetry/telemetry_doca_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_test.cpp
@@ -22,14 +22,13 @@
 
 #include <chrono>
 #include <cstdint>
-#include <iostream>
+#include <optional>
 #include <string>
 
 #include <gtest/gtest.h>
 
 using nixl::doca_test::loopbackConnection;
-using nixl::doca_test::metricValue;
-using nixl::doca_test::scrapeUntil;
+using nixl::doca_test::scrapeUntilValue;
 
 class docaTelemetryTest : public ::testing::Test {
 protected:
@@ -81,13 +80,13 @@ TEST_F(docaTelemetryTest, RawDocaApiServesAccumulatingCounter) {
     }
     ASSERT_EQ(doca_telemetry_exporter_metrics_flush(source), DOCA_SUCCESS);
 
-    const std::string body = scrapeUntil(port_, "raw_ops_total", std::chrono::seconds(12));
-    std::cout << "=== DOCA /metrics scrape (port " << port_ << ") ===\n"
-              << body << "\n=== end scrape ===" << std::endl;
-    EXPECT_NE(body.find("raw_ops_total"), std::string::npos)
-        << "raw_ops_total not served at the DOCA Prometheus endpoint";
-    EXPECT_EQ(metricValue(body, "raw_ops_total"), 3.0)
-        << "add_counter_increment x3 (by 1) must yield a cumulative 3";
+    const nixl::doca_test::labelSet labels{{"type", "counter"}};
+    const auto metrics =
+        scrapeUntilValue(port_, "raw_ops_total", 3.0, std::chrono::seconds(12), labels);
+    const std::optional<double> value = metrics.latestValue("raw_ops_total", labels);
+    ASSERT_TRUE(value.has_value())
+        << "raw_ops_total{type=counter} not served at the DOCA Prometheus endpoint";
+    EXPECT_EQ(*value, 3.0) << "add_counter_increment x3 (by 1) must yield a cumulative 3";
 
     doca_telemetry_exporter_metrics_destroy_context(source);
     doca_telemetry_exporter_source_destroy(source);

--- a/test/doca-telemetry/timeseries.h
+++ b/test/doca-telemetry/timeseries.h
@@ -17,9 +17,24 @@
 #ifndef NIXL_TEST_DOCA_TELEMETRY_TIMESERIES_H
 #define NIXL_TEST_DOCA_TELEMETRY_TIMESERIES_H
 
+// -----------------------------------------------------------------------------
+// Test-only helper -- NOT a production-grade time-series implementation.
+//
+// This header provides a deliberately small, readable model for working with
+// Prometheus/OpenMetrics series scraped during a unit test: a value/label data
+// model (sample, seriesId, labelSet, seriesMap) plus a thin query view
+// (timeSeries). It lives entirely in the test domain (no dependency on the NIXL
+// core) and favors clarity over performance, completeness, or generality -- it
+// is not a PromQL engine or a TSDB. The strictness it does enforce exists only so
+// that an exporter-format regression surfaces as a failing assertion in these
+// tests, not because it aims to be a general-purpose parser/store. Do not promote
+// it into product code; use a real client there.
+// -----------------------------------------------------------------------------
+
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -43,12 +58,14 @@ struct sample {
 struct seriesId {
     std::string name;
     labelSet labels;
-
-    bool
-    operator<(const seriesId &rhs) const {
-        return std::tie(name, labels) < std::tie(rhs.name, rhs.labels);
-    }
 };
+
+// Order by (name, labels) so seriesId can key the std::map below. Free
+// (non-member) operator so both operands are treated symmetrically.
+[[nodiscard]] inline bool
+operator<(const seriesId &lhs, const seriesId &rhs) noexcept {
+    return std::tie(lhs.name, lhs.labels) < std::tie(rhs.name, rhs.labels);
+}
 
 // The samples of one series, and the id -> samples map produced by one parse.
 using samples = std::vector<sample>;
@@ -56,7 +73,7 @@ using seriesMap = std::map<seriesId, samples>;
 
 // A queryable view over a set of Prometheus time series: each series (name+labels)
 // maps to its samples. It is a pure view over an already-parsed seriesMap -- it
-// does not know how the text became series (OpenMetricsTextParser does that), so a
+// does not know how the text became series (open_metrics_text::parse does that), so a
 // caller looks up any number of series without rescanning the raw text. A metric
 // name alone is ambiguous when the same metric is exported with different label
 // sets, so it is never the key. A single scrape yields one sample per series; the
@@ -67,8 +84,10 @@ public:
 
     // Latest sampled value of the series named `name` whose labels include every
     // pair in `where` (subset match -- pass only the labels you care about).
-    // Returns nullopt if nothing matches, if more than one series matches
-    // (ambiguous: add labels to disambiguate), or if the matched series is empty.
+    // Returns nullopt if nothing matches or the matched series is empty. Throws
+    // std::runtime_error if more than one series matches (ambiguous -- the query
+    // is too loose; add labels to disambiguate): that is a caller/test mistake, so
+    // it is surfaced as a hard failure rather than a silent miss.
     [[nodiscard]] std::optional<double>
     latestValue(const std::string &name, const labelSet &where = {}) const {
         std::optional<double> result;
@@ -78,7 +97,10 @@ public:
                 continue;
             }
             if (matched) {
-                return std::nullopt; // ambiguous: same name, different label sets
+                throw std::runtime_error("timeSeries::latestValue: ambiguous lookup for metric '" +
+                                         name +
+                                         "' -- it matches multiple label sets; add labels to "
+                                         "disambiguate");
             }
             matched = true;
             if (!seriesSamples.empty()) {

--- a/test/doca-telemetry/timeseries.h
+++ b/test/doca-telemetry/timeseries.h
@@ -1,0 +1,121 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_DOCA_TELEMETRY_TIMESERIES_H
+#define NIXL_TEST_DOCA_TELEMETRY_TIMESERIES_H
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace nixl::doca_test {
+
+using labelSet = std::map<std::string, std::string>;
+
+// A single sample of a time series: a value and, when the exposition carries one,
+// a timestamp (stored verbatim). DOCA tracks time internally in microseconds, but
+// the Prometheus text exposition DOCA serves uses milliseconds.
+struct sample {
+    double value = 0.0;
+    std::optional<uint64_t> timestamp;
+};
+
+// Identity of a Prometheus time series: a metric name plus its label set. Every
+// sample of a series shares this identity, so it is the natural key -- the name
+// and labels live here once, not duplicated onto each sample.
+struct seriesId {
+    std::string name;
+    labelSet labels;
+
+    friend bool
+    operator<(const seriesId &lhs, const seriesId &rhs) {
+        return std::tie(lhs.name, lhs.labels) < std::tie(rhs.name, rhs.labels);
+    }
+};
+
+// The samples of one series, and the id -> samples map produced by one parse.
+using samples = std::vector<sample>;
+using seriesMap = std::map<seriesId, samples>;
+
+// A queryable view over a set of Prometheus time series: each series (name+labels)
+// maps to its samples. It is a pure view over an already-parsed seriesMap -- it
+// does not know how the text became series (OpenMetricsTextParser does that), so a
+// caller looks up any number of series without rescanning the raw text. A metric
+// name alone is ambiguous when the same metric is exported with different label
+// sets, so it is never the key. A single scrape yields one sample per series; the
+// sample vector also accommodates repeated scrapes.
+class timeSeries {
+public:
+    explicit timeSeries(seriesMap series) : series_(std::move(series)) {}
+
+    // Latest sampled value of the series named `name` whose labels include every
+    // pair in `where` (subset match -- pass only the labels you care about).
+    // Returns nullopt if nothing matches, if more than one series matches
+    // (ambiguous: add labels to disambiguate), or if the matched series is empty.
+    [[nodiscard]] std::optional<double>
+    latestValue(const std::string &name, const labelSet &where = {}) const {
+        std::optional<double> result;
+        bool matched = false;
+        for (const auto &[id, seriesSamples] : series_) {
+            if (id.name != name || !labelsContain(id.labels, where)) {
+                continue;
+            }
+            if (matched) {
+                return std::nullopt; // ambiguous: same name, different label sets
+            }
+            matched = true;
+            if (!seriesSamples.empty()) {
+                result = seriesSamples.back().value;
+            }
+        }
+        return result;
+    }
+
+    // The full id -> samples map, for any assertion the helpers above do not
+    // cover (e.g. timestamps or multi-sample series). Zero-copy.
+    [[nodiscard]] const seriesMap &
+    series() const noexcept {
+        return series_;
+    }
+
+    [[nodiscard]] bool
+    empty() const noexcept {
+        return series_.empty();
+    }
+
+private:
+    // true if `labels` contains every key/value pair in `required`.
+    [[nodiscard]] static bool
+    labelsContain(const labelSet &labels, const labelSet &required) {
+        for (const auto &[key, value] : required) {
+            const auto it = labels.find(key);
+            if (it == labels.end() || it->second != value) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    seriesMap series_;
+};
+
+} // namespace nixl::doca_test
+
+#endif // NIXL_TEST_DOCA_TELEMETRY_TIMESERIES_H

--- a/test/doca-telemetry/timeseries.h
+++ b/test/doca-telemetry/timeseries.h
@@ -44,9 +44,9 @@ struct seriesId {
     std::string name;
     labelSet labels;
 
-    friend bool
-    operator<(const seriesId &lhs, const seriesId &rhs) {
-        return std::tie(lhs.name, lhs.labels) < std::tie(rhs.name, rhs.labels);
+    bool
+    operator<(const seriesId &rhs) const {
+        return std::tie(name, labels) < std::tie(rhs.name, rhs.labels);
     }
 };
 


### PR DESCRIPTION
## What?
- Run the standalone DOCA telemetry tests (`doca_test`, `doca_nixl_test`) in CI — they currently build but are never executed.
- Align `test/doca-telemetry/meson.build` with how the exporter plugin is gated (pkg-config `dependency()` + `TELEMETRY_DOCA`), replacing the hardcoded `/opt/mellanox/doca` path.
- Broaden exporter coverage: counter (all values), gauge (last value), and multi-agent label distinction.
- Rework the scrape helper into three focused headers: a strict OpenMetrics text parser, an in-memory time-series model + query view, and a thin polling helper.

## Why?
The DOCA telemetry tests build but never run — `.gitlab/test_cpp.sh` invokes explicit binaries (not `meson test`) and omits them — so the DOCA exporter has no end-to-end coverage in CI. The test's meson gate also still uses a hardcoded `/opt/mellanox/doca` header/lib path (with a now-stale comment), inconsistent with the pkg-config gate the exporter plugin uses. Running these tests exercises the exporter end-to-end (`exportEvent` → `flush` → `/metrics` scrape); the stronger, label-aware assertions catch dropped, duplicated, or mis-typed samples that a name-only or last-value check would miss. The scrape parser is deliberately strict, so an exporter-format regression surfaces as a missing series (a failing assertion) instead of being silently absorbed.

## How?
- **`.gitlab/test_cpp.sh`**: invoke `./bin/doca_test` and `./bin/doca_nixl_test`, guarded by `-x` so they no-op on non-DOCA images. No `LD_LIBRARY_PATH` change — the DOCA telemetry libraries resolve via ldconfig (`ld.so.conf.d`).
- **`test/doca-telemetry/meson.build`**: build under `dependency('doca-telemetry-exporter'/'doca-common')` + `enabled_plugins.get('TELEMETRY_DOCA')`, matching `src/plugins/telemetry/meson.build`; honors `-Ddisable_plugins=TELEMETRY_DOCA`.
- **Scrape helper split into three headers** (acyclic layering: model ← parser ← scrape loop):
  - `timeseries.h` — the time-series data model (`labelSet`, `sample`, `seriesId`, `samples`, `seriesMap`) plus the `timeSeries` query view, looked up by metric name **+ label subset**. The view is built from an already-parsed `seriesMap`, decoupling it from parsing.
  - `open_metrics_text_parser.h` — `OpenMetricsTextParser`, a `std::regex`-based Prometheus/OpenMetrics text parser (no new deps). Strict by design: it rejects malformed label blocks (partial parse, missing/doubled comma, trailing comma, duplicate key) and non-fully-numeric value/timestamp tokens.
  - `scrape_util.h` — `scrapeUntilValue`, the polling helper that wires HTTP → parse → `timeSeries`.
- **Tests**: `telemetry_doca_nixl_test.cpp` — counter asserts cumulative == exact sum of distinct deltas; gauge asserts last-value-wins (`add_gauge` is absolute); two agents emit the same metric under different `agent_name` labels, kept apart by label set (a name-only lookup is ambiguous). `telemetry_doca_test.cpp` keeps the raw-DOCA-API counter test.

Validated locally: `meson test doca_test doca_nixl_test` (4 tests) green; `-Ddisable_plugins=TELEMETRY_DOCA` skips/unregisters them; clang-format clean; `-Werror` build. Confirmed green in CI (`nixl-ci-non-gpu` runs the DOCA tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded DOCA telemetry end-to-end coverage for labeled counters and gauges, including per-agent isolation and verification that label-aware queries succeed while name-only lookups are rejected when ambiguous.
* **Refactor**
  * Reworked telemetry checks to use label-aware metric polling with a stricter OpenMetrics/Prometheus text parser and an in-memory time-series model for consistent “latest value” assertions.
* **Chores**
  * Improved standalone telemetry exporter test build/run gating by using build-time dependency discovery and conditionally executing only when the relevant test binaries are present and runnable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->