### PR TITLE
nixl_ep: Optimize low-latency NVLink path

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -46,6 +46,7 @@ struct gpu_nixl_ctx {
     uint64_t *last_ht_barrier_counter;
     uint64_t *local_ht_barrier_counter_ptr;
     void *rdma_buffer_ptr;
+    void **p2p_ptrs;
     int max_num_ranks;
     int num_rdma_ranks;
     int rank;
@@ -246,6 +247,8 @@ void barrier(gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycl
 void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
 
 void update_mask_buffer(int* mask_buffer_ptr, int rank_to_mask, bool mask, cudaStream_t stream);
+
+void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream);
 
 } // namespace ep_kernels
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -35,7 +35,7 @@ namespace nixl_ep {
 __device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst_rank) {
     if (dst_rank == ctx.rank) return (void*) dst_ptr;
 
-    void *remote_ptr = nixlGetPtr(ctx.remote_mvh, dst_rank);
+    void *remote_ptr = ctx.p2p_ptrs[dst_rank];
     if (remote_ptr == nullptr) return nullptr;
 
     return (void*) ((uint64_t) remote_ptr + ctx.offset_get(dst_ptr));
@@ -1109,6 +1109,29 @@ void update_mask_buffer(int* mask_buffer_ptr, int rank, bool mask, cudaStream_t 
     constexpr int kNumThreads = 32;
     SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
     LAUNCH_KERNEL(&cfg, update_mask_buffer<kNumThreads>, mask_buffer_ptr, rank, mask);
+}
+
+
+template <int kNumThreads> __launch_bounds__(kNumThreads, 1)
+__global__ void cache_p2p_ptrs_kernel(nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
+    const auto thread_id = static_cast<int>(threadIdx.x);
+    auto nixl_ctx = *nixl_ctx_ptr;
+
+    for (int rank_id = thread_id; rank_id < nixl_ctx.max_num_ranks; rank_id += kNumThreads) {
+        if (rank_id == nixl_ctx.rank) {
+            nixl_ctx.p2p_ptrs[rank_id] = nixl_ctx.rdma_buffer_ptr;
+        } else {
+            nixl_ctx.p2p_ptrs[rank_id] =
+                nixl_ctx.remote_mvh == nullptr ? nullptr : nixlGetPtr(nixl_ctx.remote_mvh, rank_id);
+        }
+    }
+}
+
+void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream) {
+    constexpr int num_sms = 1;
+    constexpr int kNumThreads = 128;
+    SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
+    LAUNCH_KERNEL(&cfg, cache_p2p_ptrs_kernel<kNumThreads>, nixl_ctx);
 }
 
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -43,16 +43,22 @@ __device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst
 
 namespace ep_kernels {
 
+constexpr int kSmemAlignment = 1024;
+
 template<bool use_warp_sync = false>
 __forceinline__ __device__ bool is_rank_masked(int* mask_buffer_ptr, int rank) {
-    if (mask_buffer_ptr == nullptr) {
-        return false;
-    }
     if constexpr (use_warp_sync) {
-        return __shfl_sync(0xffffffff, ld_acquire_global(mask_buffer_ptr + rank), 0) != 0;
+        int masked = 0;
+        if (get_lane_id() == 0)
+            masked = ld_acquire_global(mask_buffer_ptr + rank);
+        return __shfl_sync(0xffffffff, masked, 0) != 0;
     } else {
         return ld_acquire_global(mask_buffer_ptr + rank) != 0;
     }
+}
+
+__forceinline__ __device__ bool is_rank_masked_smem(const int* rank_mask, int rank) {
+    return rank_mask[rank] != 0;
 }
 
 __device__ __forceinline__ uint64_t doorbell_flag(int idx) {
@@ -323,8 +329,6 @@ DISPATCH_RECV:
                        rank,
                        local_expert_idx,
                        src_rank);
-                if (mask_buffer_ptr == nullptr)
-                    trap();
                 atomicExch(mask_buffer_ptr + src_rank, 1);
             }
 
@@ -851,8 +855,6 @@ COMBINE_RECV:
                        rank,
                        responsible_expert_idx % num_local_experts,
                        src_rank);
-                if (mask_buffer_ptr == nullptr)
-                    trap();
                 atomicExch(mask_buffer_ptr + src_rank, 1);
             }
 
@@ -862,6 +864,11 @@ COMBINE_RECV:
         }
     }
     cg::this_grid().sync();
+    const int rank_mask_smem_bytes = align_up<int>(active_rank_bound * static_cast<int>(sizeof(int)), kSmemAlignment);
+    auto rank_mask_smem = reinterpret_cast<int*>(smem_buffer);
+    if (thread_id < active_rank_bound)
+        rank_mask_smem[thread_id] = ld_acquire_global(mask_buffer_ptr + thread_id);
+    __syncthreads();
 
     // Reassign warp groups
     constexpr int kMaxNumGroups = 2;
@@ -882,7 +889,7 @@ COMBINE_RECV:
         constexpr int kNumBytesPerGroup = kNumStages * kNumTMABufferBytes + kHidden * 2 + kNumStages * kNumDivisionBytes * 3;
 
         // Reallocate shared memory
-        const auto smem_group_buffer = smem_buffer + kNumBytesPerGroup * group_idx;
+        const auto smem_group_buffer = smem_buffer + rank_mask_smem_bytes + kNumBytesPerGroup * group_idx;
         auto full_barriers  = PatternVisitor([=](const int& i) { return reinterpret_cast<uint64_t*>(smem_group_buffer + i * kNumTMABufferBytes); });
         auto empty_barriers = PatternVisitor([=](const int& i) { return reinterpret_cast<uint64_t*>(smem_group_buffer + i * kNumTMABufferBytes + 8); });
         auto tma_ld_buffers = PatternVisitor([=](const int& i) { return reinterpret_cast<uint8_t* >(smem_group_buffer + i * kNumTMABufferBytes + 16); });
@@ -918,7 +925,7 @@ COMBINE_RECV:
                     if (topk_idx_reg < 0)
                         continue;
                     EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
-                    if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
+                    if (is_rank_masked_smem(rank_mask_smem, topk_idx_reg / num_local_experts))
                         continue;
 
                     mbarrier_wait<true>(empty_barriers[stage_idx], tma_phase, stage_idx);
@@ -959,7 +966,7 @@ COMBINE_RECV:
                     if (topk_idx_reg < 0)
                         continue;
                     EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
-                    if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
+                    if (is_rank_masked_smem(rank_mask_smem, topk_idx_reg / num_local_experts))
                         continue;
                     const auto& topk_weight = __shfl_sync(0xffffffff, topk_weights_by_lane, i);
 
@@ -1028,6 +1035,11 @@ void combine(void* combined_x,
     const auto num_sms = max(ceil_div(active_expert_bound, num_warp_groups),
                              num_recv_per_sm == 0 ? 1 : ceil_div(num_combined_tokens, num_recv_per_sm));
 
+    // We use one thread per active rank to populate the combine receive active rank mask cache.
+    // 1 <= num_warp_groups <= 32, num_warps = num_warp_groups * floor(32 / num_warp_groups) >= 17,
+    // so num_warps * 32 >= 544 threads, well over any reasonable active_rank_bound.
+    EP_HOST_ASSERT(active_rank_bound <= num_warps * 32);
+
     // Check workspace
     auto atomic_clean_flag = static_cast<int*>(workspace);
     EP_HOST_ASSERT(sizeof(int) <= NUM_WORKSPACE_BYTES);
@@ -1048,9 +1060,10 @@ void combine(void* combined_x,
     // Receive buffer size
     const int num_recv_tma_bytes = 16 + hidden * 2;
     const int smem_recv_size = kMaxNumGroups * (kNumStages * num_recv_tma_bytes + hidden * 2 + kNumStages * num_meta_bytes * 3);
+    const int rank_mask_smem_bytes = align_up<int>(active_rank_bound * static_cast<int>(sizeof(int)), kSmemAlignment);
 
     // Total requirement
-    const int smem_size = max(smem_send_size, smem_recv_size);
+    const int smem_size = max(smem_send_size, rank_mask_smem_bytes + smem_recv_size);
 
 #define COMBINE_LAUNCH_CASE(hidden) { \
 auto combine_func = use_logfmt ? \
@@ -1156,8 +1169,6 @@ __forceinline__ __device__ void barrier(nixl_ep::gpu_nixl_ctx nixl_ctx, int* mas
             if (wait_recv_cost > timeout_cycles) {
                 printf("Warning: NixlEP timeout for barrier, rank %d, thread %d, dst_rank %d, expected value %d, actual value %d\n",
                        nixl_ctx.rank, thread_id, dst_rank, expected_cnt, ld_acquire_global(nixl_ctx.sync_buffer_ptr + dst_rank));
-                if (mask_buffer_ptr == nullptr)
-                    trap();
                 atomicExch(mask_buffer_ptr + dst_rank, 1);
             }
         }

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -867,7 +867,7 @@ COMBINE_RECV:
     const int rank_mask_smem_bytes = align_up<int>(active_rank_bound * static_cast<int>(sizeof(int)), kSmemAlignment);
     auto rank_mask_smem = reinterpret_cast<int*>(smem_buffer);
     if (thread_id < active_rank_bound)
-        rank_mask_smem[thread_id] = ld_acquire_global(mask_buffer_ptr + thread_id);
+        rank_mask_smem[thread_id] = mask_buffer_ptr[thread_id];
     __syncthreads();
 
     // Reassign warp groups

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -179,7 +179,7 @@ __device__  __forceinline__ int64_t ld_volatile_global(const uint64_t *ptr) {
 #ifndef DISABLE_AGGRESSIVE_PTX_INSTRS
 #define LD_NC_FUNC "ld.global.nc.L1::no_allocate.L2::256B"
 #else
-#define LD_NC_FUNC "ld.volatile.global"
+#define LD_NC_FUNC "ld.volatile.global.L2::256B"
 #endif
 
 // `ld.global.nc.L1::no_allocate` will be translated into `LDG.E.NA.[width].CONSTANT` in SASS

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -377,7 +377,7 @@ __device__ __forceinline__ void tma_store_1d(const void* smem_ptr, const void* g
 
 template <int N = 0>
 __device__ __forceinline__ void tma_store_wait() {
-    asm volatile("cp.async.bulk.wait_group.read %0;" :: "n"(N) : "memory");
+    asm volatile("cp.async.bulk.wait_group %0;" :: "n"(N) : "memory");
 }
 
 #endif

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1282,8 +1282,8 @@ void Buffer::query_mask_buffer(const torch::Tensor& mask_status) {
     EP_HOST_ASSERT(mask_status.numel() == max_num_ranks && mask_status.scalar_type() == torch::kInt32);
 
     ep_kernels::query_mask_buffer(mask_buffer_ptr, max_num_ranks,
-                                    reinterpret_cast<int*>(mask_status.data_ptr()),
-                                    at::cuda::getCurrentCUDAStream());
+                                  reinterpret_cast<int*>(mask_status.data_ptr()),
+                                  at::cuda::getCurrentCUDAStream());
 }
 
 void Buffer::clean_mask_buffer() {

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1340,6 +1340,10 @@ void Buffer::_nixl_ep_memory_views_create(void) {
         }
     }
     CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
+    ep_kernels::cache_p2p_ptrs(gpu_ctx_ptr, comm_stream);
+    // Hook-mode LL kernels launch on the compute stream, so make the
+    // refreshed cache visible before this control-path call returns.
+    CUDA_CHECK(cudaStreamSynchronize(comm_stream));
 }
 
 void Buffer::_nixl_ep_memory_views_destroy(void) {
@@ -1354,12 +1358,16 @@ void Buffer::_nixl_ep_memory_views_destroy(void) {
 }
 
 void Buffer::_nixl_ep_init(void) {
+    CUDA_CHECK(cudaMalloc(&p2p_ptrs, max_num_ranks * sizeof(void*)));
+    CUDA_CHECK(cudaMemset(p2p_ptrs, 0, max_num_ranks * sizeof(void*)));
+
     gpu_ctx = {
         .sync_buffer_ptr = sync_buffer_ptr,
         .sync_count_ptr = sync_count_ptr,
         .last_ht_barrier_counter = last_ht_barrier_counter,
         .local_ht_barrier_counter_ptr = local_ht_barrier_counter,
         .rdma_buffer_ptr = rdma_buffer_ptr,
+        .p2p_ptrs = p2p_ptrs,
         .max_num_ranks = max_num_ranks,
         .num_rdma_ranks = num_rdma_ranks,
         .rank = rank,
@@ -1370,6 +1378,10 @@ void Buffer::_nixl_ep_init(void) {
 
 void Buffer::_nixl_ep_destroy(void) {
     _nixl_ep_memory_views_destroy();
+    if (p2p_ptrs != nullptr) {
+        cudaFree(p2p_ptrs);
+        p2p_ptrs = nullptr;
+    }
     if (gpu_ctx_ptr != nullptr) {
         cudaFree(gpu_ctx_ptr);
         gpu_ctx_ptr = nullptr;

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -158,6 +158,7 @@ private:
     NixlPeerInfo my_peer_info;
     nixl_ep::gpu_nixl_ctx gpu_ctx;
     nixl_ep::gpu_nixl_ctx* gpu_ctx_ptr = nullptr;
+    void** p2p_ptrs = nullptr;
     uint64_t* last_ht_barrier_counter = nullptr;
     uint64_t* local_ht_barrier_counter = nullptr;
 

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -101,7 +101,7 @@ nixl_ep_cuda_args = [
     '-Xcompiler', '-Wno-attributes',
 ]
 
-topk_idx_bits = meson.get_external_property('topk_idx_bits', '64')
+topk_idx_bits = meson.get_external_property('topk_idx_bits', '32')
 nixl_ep_cpp_args += ['-DTOPK_IDX_BITS=' + topk_idx_bits]
 nixl_ep_cuda_args += ['-DTOPK_IDX_BITS=' + topk_idx_bits]
 

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -91,6 +91,7 @@ nixl_ep_cpp_args = [
 nixl_ep_cuda_args = [
     '-DHAVE_CUDA',
     '-DTORCH_EXTENSION_NAME=nixl_ep_cpp',
+    '-DDISABLE_AGGRESSIVE_PTX_INSTRS',
     '--expt-relaxed-constexpr',  # Allow calling constexpr __host__ functions from __device__ functions
     '--ptxas-options=--register-usage-level=10',  # Allow more register usage (matches setup.py)
     '-Xcompiler', '-Wno-deprecated-declarations',


### PR DESCRIPTION
This PR adds a set of optimizations for NIXL EP low-latency NVLink path.

Each optimization is in a separate commit, with the explanation included in the commit message.

On the TRT-LLM MoE communication benchmark ([bench_moe_comm.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tests/microbenchmarks/bench_moe_comm.py)) over single-node NVLink, 8xH100, these changes bring NIXL EP dispatch to parity with DeepEP low latency and reduce the remaining combine gaps.

<details>
<summary>Full dispatch benchmark table</summary>

| Batch | deepep low latency | nixl ep main | main vs deepep | nixl ep PR 1749 | PR vs deepep |
|---:|---:|---:|---:|---:|---:|
| 16  | 32.06 µs  | 38.34 µs  | 0.836x | 32.55 µs  | **0.985x** |
| 32  | 37.61 µs  | 45.49 µs  | 0.827x | 37.98 µs  | **0.990x** |
| 64  | 49.38 µs  | 61.12 µs  | 0.808x | 49.69 µs  | **0.994x** |
| 128 | 75.21 µs  | 92.18 µs  | 0.816x | 74.76 µs  | **1.006x** |
| 256 | 128.85 µs | 147.32 µs | 0.875x | 128.20 µs | **1.005x** |
| 512 | 229.28 µs | 248.60 µs | 0.922x | 228.14 µs | **1.005x** |

</details>

**Note that there is no visible performance impact on NIXL EP’s [elastic.py](https://github.com/ai-dynamo/nixl/blob/main/examples/device/ep/tests/elastic/elastic.py).**

Follow-up PRs will continue optimizing NIXL EP combine, with the goal of matching and then exceeding DeepEP low-latency performance.