### PR TITLE
nixl_ep: Optimize low-latency NVLink path

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -248,7 +248,7 @@ void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_ten
 
 void update_mask_buffer(int* mask_buffer_ptr, int rank_to_mask, bool mask, cudaStream_t stream);
 
-void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream);
+void cache_p2p_ptr(gpu_nixl_ctx* nixl_ctx, int rank_id, cudaStream_t stream);
 
 } // namespace ep_kernels
 

--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -46,6 +46,7 @@ struct gpu_nixl_ctx {
     uint64_t *last_ht_barrier_counter;
     uint64_t *local_ht_barrier_counter_ptr;
     void *rdma_buffer_ptr;
+    void **p2p_ptrs;
     int max_num_ranks;
     int num_rdma_ranks;
     int rank;
@@ -246,6 +247,8 @@ void barrier(gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycl
 void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
 
 void update_mask_buffer(int* mask_buffer_ptr, int rank_to_mask, bool mask, cudaStream_t stream);
+
+void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream);
 
 } // namespace ep_kernels
 

--- a/examples/device/ep/csrc/kernels/configs.cuh
+++ b/examples/device/ep/csrc/kernels/configs.cuh
@@ -77,7 +77,7 @@ typedef uint8_t __nv_fp8_storage_t;
 namespace nixl_ep {
 
 #ifndef TOPK_IDX_BITS
-#define TOPK_IDX_BITS 64
+#define TOPK_IDX_BITS 32
 #endif
 
 #define INT_BITS_T2(bits) int##bits##_t

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -1123,22 +1123,18 @@ void update_mask_buffer(int* mask_buffer_ptr, int rank, bool mask, cudaStream_t 
 }
 
 
-template <int kNumThreads> __launch_bounds__(kNumThreads, 1)
-__global__ void cache_p2p_ptrs_kernel(nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
-    const auto thread_id = static_cast<int>(threadIdx.x);
+__global__ void cache_p2p_ptr_kernel(nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr,
+                                     int rank_id) {
     auto nixl_ctx = *nixl_ctx_ptr;
-
-    for (int rank_id = thread_id; rank_id < nixl_ctx.max_num_ranks; rank_id += kNumThreads) {
-        nixl_ctx.p2p_ptrs[rank_id] =
-            nixl_ctx.remote_mvh == nullptr ? nullptr : nixlGetPtr(nixl_ctx.remote_mvh, rank_id);
-    }
+    nixl_ctx.p2p_ptrs[rank_id] =
+        nixl_ctx.remote_mvh == nullptr ? nullptr : nixlGetPtr(nixl_ctx.remote_mvh, rank_id);
 }
 
-void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream) {
+void cache_p2p_ptr(gpu_nixl_ctx* nixl_ctx, int rank_id, cudaStream_t stream) {
     constexpr int num_sms = 1;
-    constexpr int kNumThreads = 128;
+    constexpr int kNumThreads = 1;
     SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
-    LAUNCH_KERNEL(&cfg, cache_p2p_ptrs_kernel<kNumThreads>, nixl_ctx);
+    LAUNCH_KERNEL(&cfg, cache_p2p_ptr_kernel, nixl_ctx, rank_id);
 }
 
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -43,15 +43,24 @@ __device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst
 
 namespace ep_kernels {
 
-template<bool use_warp_sync = false>
+template<bool use_warp_sync = false, bool use_acquire = true>
 __forceinline__ __device__ bool is_rank_masked(int* mask_buffer_ptr, int rank) {
     if (mask_buffer_ptr == nullptr) {
         return false;
     }
     if constexpr (use_warp_sync) {
-        return __shfl_sync(0xffffffff, ld_acquire_global(mask_buffer_ptr + rank), 0) != 0;
+        if constexpr (use_acquire) {
+            return __shfl_sync(
+                       0xffffffff, ld_acquire_global(mask_buffer_ptr + rank), 0) != 0;
+        } else {
+            return __shfl_sync(0xffffffff, mask_buffer_ptr[rank], 0) != 0;
+        }
     } else {
-        return ld_acquire_global(mask_buffer_ptr + rank) != 0;
+        if constexpr (use_acquire) {
+            return ld_acquire_global(mask_buffer_ptr + rank) != 0;
+        } else {
+            return mask_buffer_ptr[rank] != 0;
+        }
     }
 }
 
@@ -918,7 +927,8 @@ COMBINE_RECV:
                     if (topk_idx_reg < 0)
                         continue;
                     EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
-                    if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
+                    if (is_rank_masked<false, false>(
+                            mask_buffer_ptr, topk_idx_reg / num_local_experts))
                         continue;
 
                     mbarrier_wait<true>(empty_barriers[stage_idx], tma_phase, stage_idx);
@@ -959,7 +969,8 @@ COMBINE_RECV:
                     if (topk_idx_reg < 0)
                         continue;
                     EP_DEVICE_ASSERT(topk_idx_reg < active_expert_bound);
-                    if (is_rank_masked(mask_buffer_ptr, topk_idx_reg / num_local_experts))
+                    if (is_rank_masked<false, false>(
+                            mask_buffer_ptr, topk_idx_reg / num_local_experts))
                         continue;
                     const auto& topk_weight = __shfl_sync(0xffffffff, topk_weights_by_lane, i);
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -35,7 +35,7 @@ namespace nixl_ep {
 __device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst_rank) {
     if (dst_rank == ctx.rank) return (void*) dst_ptr;
 
-    void *remote_ptr = nixlGetPtr(ctx.remote_mvh, dst_rank);
+    void *remote_ptr = ctx.p2p_ptrs[dst_rank];
     if (remote_ptr == nullptr) return nullptr;
 
     return (void*) ((uint64_t) remote_ptr + ctx.offset_get(dst_ptr));
@@ -1109,6 +1109,25 @@ void update_mask_buffer(int* mask_buffer_ptr, int rank, bool mask, cudaStream_t 
     constexpr int kNumThreads = 32;
     SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
     LAUNCH_KERNEL(&cfg, update_mask_buffer<kNumThreads>, mask_buffer_ptr, rank, mask);
+}
+
+
+template <int kNumThreads> __launch_bounds__(kNumThreads, 1)
+__global__ void cache_p2p_ptrs_kernel(nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
+    const auto thread_id = static_cast<int>(threadIdx.x);
+    auto nixl_ctx = *nixl_ctx_ptr;
+
+    for (int rank_id = thread_id; rank_id < nixl_ctx.max_num_ranks; rank_id += kNumThreads) {
+        nixl_ctx.p2p_ptrs[rank_id] =
+            nixl_ctx.remote_mvh == nullptr ? nullptr : nixlGetPtr(nixl_ctx.remote_mvh, rank_id);
+    }
+}
+
+void cache_p2p_ptrs(gpu_nixl_ctx* nixl_ctx, cudaStream_t stream) {
+    constexpr int num_sms = 1;
+    constexpr int kNumThreads = 128;
+    SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);
+    LAUNCH_KERNEL(&cfg, cache_p2p_ptrs_kernel<kNumThreads>, nixl_ctx);
 }
 
 

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -179,7 +179,7 @@ __device__  __forceinline__ int64_t ld_volatile_global(const uint64_t *ptr) {
 #ifndef DISABLE_AGGRESSIVE_PTX_INSTRS
 #define LD_NC_FUNC "ld.global.nc.L1::no_allocate.L2::256B"
 #else
-#define LD_NC_FUNC "ld.volatile.global"
+#define LD_NC_FUNC "ld.volatile.global.L2::256B"
 #endif
 
 // `ld.global.nc.L1::no_allocate` will be translated into `LDG.E.NA.[width].CONSTANT` in SASS

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -377,7 +377,7 @@ __device__ __forceinline__ void tma_store_1d(const void* smem_ptr, const void* g
 
 template <int N = 0>
 __device__ __forceinline__ void tma_store_wait() {
-    asm volatile("cp.async.bulk.wait_group.read %0;" :: "n"(N) : "memory");
+    asm volatile("cp.async.bulk.wait_group %0;" :: "n"(N) : "memory");
 }
 
 #endif

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1340,6 +1340,10 @@ void Buffer::_nixl_ep_memory_views_create(void) {
         }
     }
     CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
+    ep_kernels::cache_p2p_ptrs(gpu_ctx_ptr, comm_stream);
+    // Hook-mode LL kernels launch on the compute stream, so make the
+    // refreshed cache visible before this control-path call returns.
+    CUDA_CHECK(cudaStreamSynchronize(comm_stream));
 }
 
 void Buffer::_nixl_ep_memory_views_destroy(void) {
@@ -1360,16 +1364,23 @@ void Buffer::_nixl_ep_init(void) {
         .last_ht_barrier_counter = last_ht_barrier_counter,
         .local_ht_barrier_counter_ptr = local_ht_barrier_counter,
         .rdma_buffer_ptr = rdma_buffer_ptr,
+        .p2p_ptrs = nullptr,
         .max_num_ranks = max_num_ranks,
         .num_rdma_ranks = num_rdma_ranks,
         .rank = rank,
     };
+    CUDA_CHECK(cudaMalloc(&gpu_ctx.p2p_ptrs, max_num_ranks * sizeof(void*)));
+    CUDA_CHECK(cudaMemset(gpu_ctx.p2p_ptrs, 0, max_num_ranks * sizeof(void*)));
     CUDA_CHECK(cudaMalloc(&gpu_ctx_ptr, sizeof(gpu_nixl_ctx)));
     CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
 }
 
 void Buffer::_nixl_ep_destroy(void) {
     _nixl_ep_memory_views_destroy();
+    if (gpu_ctx.p2p_ptrs != nullptr) {
+        cudaFree(gpu_ctx.p2p_ptrs);
+        gpu_ctx.p2p_ptrs = nullptr;
+    }
     if (gpu_ctx_ptr != nullptr) {
         cudaFree(gpu_ctx_ptr);
         gpu_ctx_ptr = nullptr;

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -504,6 +504,9 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
 
         _nixl_ep_memory_views_create();
 
+        for (int remote_rank : new_ranks)
+            ep_kernels::cache_p2p_ptr(gpu_ctx_ptr, remote_rank, comm_stream);
+
         CUDA_CHECK(cudaDeviceSynchronize());
     }
 
@@ -529,6 +532,7 @@ void Buffer::disconnect_ranks(const std::vector<int>& remote_ranks_list) {
         EP_HOST_ASSERT(removed_rank != rank);
         EP_HOST_ASSERT(_is_rank_connected(removed_rank));
         update_mask_buffer(removed_rank, true);  // mask=true
+        CUDA_CHECK(cudaMemset(gpu_ctx.p2p_ptrs + removed_rank, 0, sizeof(void*)));
     }
 
     _nixl_ep_memory_views_destroy();
@@ -1340,10 +1344,6 @@ void Buffer::_nixl_ep_memory_views_create(void) {
         }
     }
     CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
-    ep_kernels::cache_p2p_ptrs(gpu_ctx_ptr, comm_stream);
-    // Hook-mode LL kernels launch on the compute stream, so make the
-    // refreshed cache visible before this control-path call returns.
-    CUDA_CHECK(cudaStreamSynchronize(comm_stream));
 }
 
 void Buffer::_nixl_ep_memory_views_destroy(void) {

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -101,7 +101,7 @@ nixl_ep_cuda_args = [
     '-Xcompiler', '-Wno-attributes',
 ]
 
-topk_idx_bits = meson.get_external_property('topk_idx_bits', '64')
+topk_idx_bits = meson.get_external_property('topk_idx_bits', '32')
 nixl_ep_cpp_args += ['-DTOPK_IDX_BITS=' + topk_idx_bits]
 nixl_ep_cuda_args += ['-DTOPK_IDX_BITS=' + topk_idx_bits]
 

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -91,6 +91,7 @@ nixl_ep_cpp_args = [
 nixl_ep_cuda_args = [
     '-DHAVE_CUDA',
     '-DTORCH_EXTENSION_NAME=nixl_ep_cpp',
+    '-DDISABLE_AGGRESSIVE_PTX_INSTRS',
     '--expt-relaxed-constexpr',  # Allow calling constexpr __host__ functions from __device__ functions
     '--ptxas-options=--register-usage-level=10',  # Allow more register usage (matches setup.py)
     '-Xcompiler', '-Wno-deprecated-declarations',


### PR DESCRIPTION
This PR adds a set of optimizations for NIXL EP low-latency NVLink path.

Each optimization is in a separate commit, with the explanation included in the commit message.

On the TRT-LLM MoE communication benchmark ([bench_moe_comm.py](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tests/microbenchmarks/bench_moe_comm.py)) over single-node NVLink, 8xH100, these changes bring NIXL EP dispatch to parity with DeepEP low latency and reduce the remaining combine gaps.

<details>
<summary>Full dispatch benchmark table</summary>

| Batch | deepep low latency | nixl ep main | main vs deepep | nixl ep PR 1749 | PR vs deepep |
|---:|---:|---:|---:|---:|---:|
| 16  | 32.06 µs  | 38.34 µs  | 0.836x | 32.55 µs  | **0.985x** |
| 32  | 37.61 µs  | 45.49 µs  | 0.827x | 37.98 µs  | **0.990x** |
| 64  | 49.38 µs  | 61.12 µs  | 0.808x | 49.69 µs  | **0.994x** |
| 128 | 75.21 µs  | 92.18 µs  | 0.816x | 74.76 µs  | **1.006x** |
| 256 | 128.85 µs | 147.32 µs | 0.875x | 128.20 µs | **1.005x** |
| 512 | 229.28 µs | 248.60 µs | 0.922x | 228.14 µs | **1.005x** |

</details>

<details>
<summary>Combine active rank mask optimization</summary>

| Batch | disable mask / speed-of-light | current: load acq | current vs speed-of-light | this PR: plain load | PR vs speed-of-light |
|---:|---:|---:|---:|---:|---:|
| 16   | 25.03 µs  | 27.24 µs  | 0.919x | 26.26 µs  | **0.953x** |
| 32   | 31.74 µs  | 33.79 µs  | 0.939x | 33.06 µs  | **0.960x** |
| 64   | 45.65 µs  | 48.48 µs  | 0.942x | 46.94 µs  | **0.973x** |
| 128  | 73.58 µs  | 76.75 µs  | 0.959x | 74.37 µs  | **0.989x** |
| 256  | 137.18 µs | 141.01 µs | 0.973x | 137.34 µs | **0.999x** |
| 512  | 258.57 µs | 266.23 µs | 0.971x | 258.68 µs | **1.000x** |

</details>

**Note that there is no visible performance impact on NIXL EP’s [elastic.py](https://github.com/ai-dynamo/nixl/blob/main/examples/device/ep/tests/elastic/elastic.py).**

Follow-up PRs will continue optimizing NIXL EP combine, with the goal of matching and then exceeding DeepEP low-latency performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-side P2P pointer caching to improve peer-to-peer GPU memory access performance.

* **Chores**
  * Reduced default index width from 64-bit to 32-bit.
  * Added a CUDA compile flag to alter PTX instruction selection for targeted memory operations.
  * Improved allocation, initialization, population, and cleanup of the GPU pointer cache to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->