### PR TITLE
rados-nkv: add NIXL backend for NVMe Key-Value over SPDK

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('nixl', 'CPP', version: '1.2.0',
+project('nixl', ['CPP', 'C'], version: '1.2.0',
     default_options: ['buildtype=release',
                 'werror=true',
                 'cpp_std=c++20',
@@ -29,7 +29,7 @@ if enable_plugins_opt != '' and disable_plugins_opt != ''
     error('Cannot specify both enable_plugins and disable_plugins options')
 endif
 
-all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA']
+all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA', 'RADOS_NKV']
 
 enabled_plugins = {}
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -31,10 +31,14 @@ option('wheel_variant', type: 'string', value: '', description: 'Override wheel 
 option('static_plugins', type: 'string', value: '', description: 'Plugins to be built-in, comma-separated')
 option('enable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to build. Default (empty) builds all available plugins.')
 option('disable_plugins', type: 'string', value: '', description: 'Comma-separated list of plugins to exclude from build. Cannot be used with enable_plugins.')
+option('spdk_root', type: 'string', value: '/mnt/spdk', description: 'Path to the SPDK build tree used by the RADOS_NKV plugin')
+option('spdk_kv_shim_dir', type: 'string', value: '/mnt/spdk/test/nvmf/kv_shim', description: 'Directory containing kv_host_shim.{h,c} for the RADOS_NKV plugin')
+option('rados_nkv_build_test', type: 'boolean', value: false, description: 'Build the RADOS_NKV direct-engine round-trip test executable')
 option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen documentation')
 option('release_wheel', type: 'boolean', value: false, description: 'Add nixl-cu12 and nixl-cu13 dependencies to the meta wheel')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
+option('build_python_bindings', type: 'boolean', value: true, description: 'Build the Python (pybind11) bindings')
 
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')

--- a/src/bindings/meson.build
+++ b/src/bindings/meson.build
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-subdir('python')
+if get_option('build_python_bindings')
+    subdir('python')
+endif
 
 # Shared library exposing the nixl C API (nixl_capi_* symbols).
 # Always built so LD_PRELOAD can override stub symbols at runtime when

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -42,6 +42,12 @@ if 'OBJ' in static_plugins
     nixl_lib_deps += [ obj_backend_interface ]
 endif
 
+# RADOS_NKV is gated on the SPDK KV shim being present; the interface variable
+# only exists when the plugin was actually built (see src/plugins/rados-nkv).
+if is_variable('rados_nkv_backend_interface') and 'RADOS_NKV' in static_plugins
+    nixl_lib_deps += [ rados_nkv_backend_interface ]
+endif
+
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and 'GDS' in static_plugins
     nixl_lib_deps += [ gds_backend_interface, cuda_dep ]

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -703,6 +703,10 @@ void nixlPluginManager::registerBuiltinPlugins() {
     NIXL_REGISTER_STATIC_PLUGIN(Backend, MOONCAKE)
 #endif
 
+#ifdef STATIC_PLUGIN_RADOS_NKV
+    NIXL_REGISTER_STATIC_PLUGIN(Backend, RADOS_NKV)
+#endif
+
 #ifdef STATIC_PLUGIN_HF3FS
     NIXL_REGISTER_STATIC_PLUGIN(Backend, HF3FS)
 #endif

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -140,4 +140,8 @@ if enabled_plugins.get('GPUNETIO')
     endif
 endif
 
+if enabled_plugins.get('RADOS_NKV')
+    subdir('rados-nkv')
+endif
+
 subdir('telemetry')

--- a/src/plugins/rados-nkv/README.md
+++ b/src/plugins/rados-nkv/README.md
@@ -1,0 +1,146 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL RADOS NVMe-KV Plugin (`RADOS_NKV`)
+
+This backend maps NIXL transfers onto the **NVMe Key-Value (KV) command set**
+through an in-process SPDK KV host shim (`kv_host_shim.{h,c}`). It lets a NIXL
+agent Store/Retrieve values keyed by an NVMe KV key, and probe key existence,
+over the SPDK VFIOUSER transport.
+
+The KV namespace on the SPDK target is **backend-agnostic**: the same plugin and
+tests run unchanged against an in-memory `kvdev` or a **librados-backed** `kvdev`
+(real Ceph/RADOS), where each value lands as an object in a Ceph pool/namespace.
+The plugin name `rados-nkv` reflects this RADOS-over-NVMe-KV use case.
+
+## Operation and memory-type mapping
+
+The plugin mirrors the OBJ plugin's memory-type shape:
+
+| NIXL operation        | Local mem  | Remote mem | NVMe KV command |
+| --------------------- | ---------- | ---------- | --------------- |
+| `NIXL_WRITE`          | `DRAM_SEG` | `OBJ_SEG`  | KV **Store**    |
+| `NIXL_READ`           | `DRAM_SEG` | `OBJ_SEG`  | KV **Retrieve** |
+| `queryMem` (lookup)   | —          | `OBJ_SEG`  | KV **Exist**    |
+
+The remote `OBJ_SEG` descriptor carries the NVMe KV key in its `metaInfo` blob
+(the same channel the OBJ plugin uses for an object key). `queryMem` maps to the
+NVMe KV Exist command, building a cache hit/miss mask without transferring any
+value data (the llm-d lookup path).
+
+### Key handling
+
+The token sequence in `metaInfo` may be any non-empty length. The backend hashes
+it (128-bit FNV-1a) into a fixed-length NVMe KV key of `min(16, kvkml)` bytes,
+where `kvkml` is the max key length advertised by the namespace (falling back to
+16 when the namespace reports no limit). Callers therefore pass a token sequence,
+not a raw NVMe KV key; an empty `metaInfo` is **rejected**
+(`NIXL_ERR_INVALID_PARAM`).
+
+## Dependencies
+
+- An **SPDK** build tree providing `libspdk_nvme` and the related static
+  archives, plus the `kv_host_shim.{h,c}` host shim sources.
+- **DPDK** and **isa-l** static archives (built as part of SPDK).
+- **libvfio-user** (SPDK VFIOUSER transport).
+- System libraries pulled in by the SPDK/DPDK static archives (e.g. `numa`,
+  `uuid`, `ssl`, `crypto`, `aio`).
+- Optional: **librados/Ceph** when running against a librados-backed KV
+  namespace (`librados`, `librbd`).
+
+## Build Instructions
+
+The plugin is gated behind the SPDK locations and is skipped automatically when
+the SPDK shim or `libspdk_nvme.a` are not found.
+
+```bash
+# Build with the plugin enabled (adjust the SPDK paths for your tree)
+meson setup build \
+    -Dspdk_root=/path/to/spdk \
+    -Dspdk_kv_shim_dir=/path/to/spdk/test/nvmf/kv_shim
+ninja -C build
+
+# Build the standalone round-trip test executable as well
+meson configure build -Drados_nkv_build_test=true
+ninja -C build
+```
+
+Relevant Meson options (see `meson_options.txt`):
+
+| Option                  | Default                         | Description                                       |
+| ----------------------- | ------------------------------- | ------------------------------------------------- |
+| `spdk_root`             | `/mnt/spdk`                     | Path to the SPDK build tree to link against.      |
+| `spdk_kv_shim_dir`      | `/mnt/spdk/test/nvmf/kv_shim`   | Directory containing `kv_host_shim.{h,c}`.        |
+| `rados_nkv_build_test`  | `false`                         | Build the direct-engine round-trip test binary.   |
+
+To build **without** the plugin, omit it from `-Denable_plugins` (or add it to
+`-Ddisable_plugins`).
+
+## API Reference
+
+`nixlRadosNkvEngine` (in `rados_nkv_backend.h`) implements the NIXL South Bound
+API for a storage-style backend (`supportsLocal() == true`,
+`supportsRemote() == false`, `supportsNotif() == false`).
+
+- `getSupportedMems()` → `{DRAM_SEG, OBJ_SEG}`
+- `registerMem()` — records the NVMe KV key for `OBJ_SEG` descriptors.
+- `queryMem()` — KV Exist; present ⇒ engaged response, absent ⇒ `std::nullopt`,
+  transport error ⇒ `NIXL_ERR_BACKEND` (never masked as a miss).
+- `prepXfer()` / `postXfer()` / `checkXfer()` / `releaseReqH()` — issue the KV
+  Store/Retrieve synchronously through the shim and report completion inline.
+
+### Custom backend parameters (`nixl_b_params_t`)
+
+| Parameter   | Required | Default | Meaning                                                              |
+| ----------- | -------- | ------- | -------------------------------------------------------------------- |
+| `vfu_addr`  | yes      | —       | VFIOUSER transport directory for the SPDK KV target. Aliases: `socket`, `vfio_user_path`, `device`. |
+| `nsid`      | no       | `0`     | NVMe namespace id; `0`/unset auto-selects the first KV namespace.    |
+| `init_env`  | no       | `false` | When `false`, the host/agent owns the SPDK env (multiple engines per process). When `true`, the shim brings up its own no-hugepage SPDK env (single instance; for standalone tests). |
+
+## Example Usage
+
+```cpp
+nixl_b_params_t params;
+params["vfu_addr"] = "/path/to/vfio-user/domain/muser0/0";
+
+nixlBackendInitParams init{};
+init.localAgent  = "my_agent";
+init.type        = "RADOS_NKV";
+init.customParams = &params;
+
+nixlRadosNkvEngine eng(&init);
+// register a DRAM source and an OBJ_SEG descriptor whose metaInfo holds the
+// token sequence (the engine hashes it into the KV key), then prepXfer/postXfer
+// with NIXL_WRITE (Store) or NIXL_READ (Retrieve). See
+// rados_nkv_roundtrip_test.cpp for a full example.
+```
+
+## Testing
+
+- **Unit (no SPDK)**: `test/gtest/unit/rados-nkv/test_rados_nkv_key.cpp` covers
+  the key derivation (`radosNkvDeriveKey`) — known-answer vector, determinism,
+  distinct/arbitrary-length inputs, truncation, and empty/zero rejection. It is
+  SPDK-free and runs as part of the standard `ninja -C build test` unit suite.
+- **End-to-end (needs SPDK)**: two bring-up scripts stand up an SPDK `nvmf_tgt`
+  KV namespace over VFIOUSER and run the round-trip test against it:
+  - `run_roundtrip.sh` — in-memory KV namespace (`kvdev_mem`).
+  - `run_roundtrip_rados.sh` — librados-backed KV namespace (real Ceph/RADOS);
+    also asserts the stored value lands as an object in the Ceph pool/namespace.
+
+  Both require a built SPDK tree and `-Drados_nkv_build_test=true`. `SPDK_ROOT`
+  and the Ceph config/keyring/`rados` paths are overridable via environment.

--- a/src/plugins/rados-nkv/meson.build
+++ b/src/plugins/rados-nkv/meson.build
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# RADOS_NKV plugin: maps NIXL transfers onto the NVMe KV command set via the
+# in-process SPDK KV host shim (kv_host_shim.{h,c}). WRITE -> KV Store,
+# READ -> KV Retrieve.
+# ---------------------------------------------------------------------------
+
+cc = meson.get_compiler('c')
+
+# Locations of the SPDK tree we link against. Overridable via meson options.
+spdk_root = get_option('spdk_root')
+spdk_shim_dir = get_option('spdk_kv_shim_dir')
+
+spdk_build_lib = spdk_root / 'build' / 'lib'
+spdk_build_inc = spdk_root / 'build' / 'include'
+spdk_inc = spdk_root / 'include'
+dpdk_lib = spdk_root / 'dpdk' / 'build' / 'lib'
+vfu_inc = spdk_root / 'build' / 'libvfio-user' / 'usr' / 'local' / 'include'
+vfu_lib = spdk_root / 'build' / 'libvfio-user' / 'usr' / 'local' / 'lib'
+
+shim_c = spdk_shim_dir / 'kv_host_shim.c'
+
+if not fs.exists(shim_c)
+    warning('RADOS_NKV plugin disabled: SPDK KV shim not found at ' + shim_c)
+    subdir_done()
+endif
+if not fs.exists(spdk_build_lib / 'libspdk_nvme.a')
+    warning('RADOS_NKV plugin disabled: SPDK nvme lib not found under ' + spdk_build_lib)
+    subdir_done()
+endif
+
+# Build the C shim into its own static lib so the C compile flags (and the
+# C-only SPDK headers) stay isolated from the C++ plugin TU.
+kv_shim_lib = static_library(
+    'nixl_kv_host_shim',
+    [shim_c],
+    c_args: ['-D_GNU_SOURCE', '-w'],
+    include_directories: include_directories(
+        spdk_inc, spdk_build_inc, vfu_inc, spdk_shim_dir, is_system: true),
+    install: false,
+)
+
+# SPDK whole-archive set (mirrors the kv_shim_test link line). The ordering and
+# the whole-archive wrapping around the SPDK + DPDK static libs is required so
+# the env/transport registration constructors are pulled in.
+spdk_libs = [
+    'spdk_sock_posix', 'spdk_nvme', 'spdk_keyring', 'spdk_sock', 'spdk_trace',
+    'spdk_rpc', 'spdk_jsonrpc', 'spdk_json', 'spdk_dma', 'spdk_vfio_user',
+    'spdk_vmd', 'spdk_util', 'spdk_log',
+]
+
+dpdk_libs = [
+    'rte_argparse', 'rte_bus_pci', 'rte_cryptodev', 'rte_dmadev', 'rte_eal',
+    'rte_ethdev', 'rte_hash', 'rte_kvargs', 'rte_log', 'rte_mbuf',
+    'rte_mempool', 'rte_mempool_ring', 'rte_meter', 'rte_net', 'rte_pci',
+    'rte_power', 'rte_power_acpi', 'rte_power_amd_pstate', 'rte_power_cppc',
+    'rte_power_intel_pstate', 'rte_power_intel_uncore', 'rte_power_kvm_vm',
+    'rte_rcu', 'rte_ring', 'rte_telemetry', 'rte_timer', 'rte_vhost',
+]
+
+spdk_link_args = ['-L' + spdk_build_lib, '-L' + vfu_lib, '-L' + dpdk_lib]
+spdk_link_args += ['-Wl,--whole-archive', '-Wl,--no-as-needed']
+foreach l : spdk_libs
+    spdk_link_args += ['-l' + l]
+endforeach
+spdk_link_args += ['-Wl,--no-whole-archive']
+spdk_link_args += [spdk_build_lib / 'libspdk_env_dpdk.a']
+spdk_link_args += ['-Wl,--whole-archive']
+foreach l : dpdk_libs
+    spdk_link_args += [dpdk_lib / ('lib' + l + '.a')]
+endforeach
+spdk_link_args += ['-Wl,--no-whole-archive']
+
+# isa-l static archives provide the crc/xor symbols referenced by spdk_util.
+foreach isal : [spdk_root / 'isa-l' / '.libs' / 'libisal.a',
+                spdk_root / 'isa-l-crypto' / '.libs' / 'libisal_crypto.a']
+    if fs.exists(isal)
+        spdk_link_args += [isal]
+    endif
+endforeach
+
+# Tail system deps required by the SPDK/DPDK static archives.
+foreach syslib : ['numa', 'dl', 'rt', 'uuid', 'ssl', 'crypto', 'm', 'lz4',
+                  'keyutils', 'aio', 'rados', 'rbd', 'vfio-user', 'json-c']
+    dep = cc.find_library(syslib, required: false)
+    if dep.found()
+        spdk_link_args += ['-l' + syslib]
+    endif
+endforeach
+
+rados_nkv_sources = [
+    'rados_nkv_backend.cpp',
+    'rados_nkv_backend.h',
+    'rados_nkv_key.cpp',
+    'rados_nkv_key.h',
+    'rados_nkv_plugin.cpp',
+]
+
+plugin_deps = [nixl_infra, nixl_common_dep]
+# The C++ plugin TU (and the test) include kv_host_shim.h, which pulls in SPDK
+# headers (spdk/stdinc.h, ...), so the SPDK include dirs must be on their path
+# too -- not just the shim dir.
+shim_inc = include_directories(
+    spdk_shim_dir, spdk_inc, spdk_build_inc, vfu_inc, is_system: true)
+
+if 'RADOS_NKV' in static_plugins
+    rados_nkv_backend_lib = static_library(
+        'RADOS_NKV',
+        rados_nkv_sources,
+        dependencies: plugin_deps,
+        link_with: kv_shim_lib,
+        link_args: spdk_link_args,
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, shim_inc],
+        install: false,
+        name_prefix: 'libplugin_')
+else
+    rados_nkv_backend_lib = shared_library(
+        'RADOS_NKV',
+        rados_nkv_sources,
+        dependencies: plugin_deps,
+        link_with: kv_shim_lib,
+        link_args: spdk_link_args,
+        cpp_args: ['-fPIC'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, shim_inc],
+        install: true,
+        name_prefix: 'libplugin_',
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+            'echo "RADOS_NKV=' + rados_nkv_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+            check: true
+        )
+    endif
+endif
+
+if 'RADOS_NKV' in static_plugins
+    rados_nkv_backend_interface = declare_dependency(link_whole: rados_nkv_backend_lib)
+else
+    rados_nkv_backend_interface = declare_dependency(link_with: rados_nkv_backend_lib)
+endif
+
+# Direct-engine round-trip test (links the engine TU + shim against a live
+# SPDK KV target). Enabled by -Drados_nkv_build_test=true.
+if get_option('rados_nkv_build_test')
+    executable(
+        'rados_nkv_roundtrip_test',
+        ['rados_nkv_roundtrip_test.cpp', 'rados_nkv_backend.cpp', 'rados_nkv_backend.h',
+         'rados_nkv_key.cpp', 'rados_nkv_key.h'],
+        dependencies: plugin_deps,
+        link_with: kv_shim_lib,
+        link_args: spdk_link_args,
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, shim_inc],
+        install: false,
+    )
+endif

--- a/src/plugins/rados-nkv/rados_nkv_backend.cpp
+++ b/src/plugins/rados-nkv/rados_nkv_backend.cpp
@@ -1,0 +1,398 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rados_nkv_backend.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <stdexcept>
+
+#include "common/nixl_log.h"
+
+extern "C" {
+#include "kv_host_shim.h"
+}
+
+// -----------------------------------------------------------------------------
+// Per-descriptor metadata for an OBJ_SEG (remote KV-key) registration.
+// -----------------------------------------------------------------------------
+namespace {
+
+class nixlRadosNkvMetadata : public nixlBackendMD {
+public:
+    explicit nixlRadosNkvMetadata(std::vector<uint8_t> key)
+        : nixlBackendMD(true),
+          key(std::move(key)) {}
+
+    ~nixlRadosNkvMetadata() override = default;
+
+    std::vector<uint8_t> key;
+};
+
+// Synchronous request handle: the shim ops complete inline, so we just stash
+// the final status produced by postXfer and report it back in checkXfer.
+class nixlRadosNkvBackendReqH : public nixlBackendReqH {
+public:
+    nixlRadosNkvBackendReqH() = default;
+    ~nixlRadosNkvBackendReqH() override = default;
+
+    nixl_status_t status = NIXL_IN_PROG;
+};
+
+// Parse "true"/"1"/"yes"/"on" (case-insensitive) as boolean true.
+bool
+parseBool(const std::string &v) {
+    std::string s;
+    s.reserve(v.size());
+    for (char c : v) {
+        s.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+    return s == "true" || s == "1" || s == "yes" || s == "on";
+}
+
+} // namespace
+
+// -----------------------------------------------------------------------------
+// nixlRadosNkvEngine
+// -----------------------------------------------------------------------------
+
+nixlRadosNkvEngine::nixlRadosNkvEngine(const nixlBackendInitParams *init_params)
+    : nixlBackendEngine(init_params) {
+    // The vfio-user socket directory is taken from the backend's custom params.
+    // Accept a couple of common spellings for convenience.
+    std::string vfu_addr;
+    for (const char *k : {"vfu_addr", "socket", "vfio_user_path", "device"}) {
+        if (getInitParam(k, vfu_addr) == NIXL_SUCCESS && !vfu_addr.empty()) {
+            break;
+        }
+        vfu_addr.clear();
+    }
+
+    if (vfu_addr.empty()) {
+        NIXL_ERROR << "RADOS_NKV: missing required custom param 'vfu_addr' "
+                      "(the VFIOUSER transport directory)";
+        initErr = true;
+        return;
+    }
+
+    std::string nsid_str;
+    uint32_t nsid = 0; // 0 selects the first CSI==KV namespace
+    if (getInitParam("nsid", nsid_str) == NIXL_SUCCESS && !nsid_str.empty()) {
+        try {
+            nsid = static_cast<uint32_t>(std::stoul(nsid_str));
+        }
+        catch (const std::exception &e) {
+            NIXL_WARN << "RADOS_NKV: bad nsid '" << nsid_str << "', using auto-select";
+            nsid = 0;
+        }
+    }
+
+    // init_env defaults to false: in production the host/agent owns the SPDK
+    // env, which lets multiple engines coexist in one process (the future
+    // nixlAgent path). Standalone tests with no host env pass init_env=true so
+    // the shim brings up its own (no-hugepage, single-instance) SPDK env.
+    bool init_env = false;
+    std::string init_env_str;
+    if (getInitParam("init_env", init_env_str) == NIXL_SUCCESS && !init_env_str.empty()) {
+        init_env = parseBool(init_env_str);
+    }
+
+    struct kv_host_shim_opts opts = {};
+    opts.opts_size = sizeof(opts);
+    opts.name = "nixl_rados_nkv";
+    opts.vfu_addr = vfu_addr.c_str();
+    opts.nsid = nsid;
+    opts.init_env = init_env;
+
+    int rc = kv_host_shim_open(&opts, &shim_);
+    if (rc != 0 || shim_ == nullptr) {
+        NIXL_ERROR << "RADOS_NKV: kv_host_shim_open(" << vfu_addr << ") failed: rc=" << rc;
+        shim_ = nullptr;
+        initErr = true;
+        return;
+    }
+
+    // Clamp the derived-key length to the namespace-advertised kvkml so the
+    // hashed key (radosNkvDeriveKey) always fits the device key space. A
+    // namespace that advertises kvkml==0 reports no usable key-length limit;
+    // fall back to kMaxKeyLen rather than clamping to 0 (which would reject
+    // every key).
+    uint32_t shim_kvkml = kv_host_shim_max_key_len(shim_);
+    if (shim_kvkml == 0) {
+        NIXL_WARN << "RADOS_NKV: namespace advertised kvkml=0 (no key-length limit "
+                     "reported); using default max key length "
+                  << static_cast<unsigned>(kMaxKeyLen);
+        shim_kvkml = kMaxKeyLen;
+    }
+    maxKeyLen_ = static_cast<uint8_t>(std::min<uint32_t>(kMaxKeyLen, shim_kvkml));
+
+    NIXL_INFO << "RADOS_NKV: opened SPDK KV shim on " << vfu_addr
+              << " (init_env=" << (init_env ? "true" : "false") << ", max_key=" << shim_kvkml
+              << ", effective_max_key=" << static_cast<unsigned>(maxKeyLen_)
+              << ", max_value=" << kv_host_shim_max_value_len(shim_) << ")";
+}
+
+nixlRadosNkvEngine::~nixlRadosNkvEngine() {
+    if (shim_) {
+        kv_host_shim_close(shim_);
+        shim_ = nullptr;
+    }
+}
+
+nixl_mem_list_t
+nixlRadosNkvEngine::getSupportedMems() const {
+    // Mirror obj: local DRAM source, remote OBJ-style key-addressed dest.
+    return {DRAM_SEG, OBJ_SEG};
+}
+
+nixl_status_t
+nixlRadosNkvEngine::registerMem(const nixlBlobDesc &mem,
+                                const nixl_mem_t &nixl_mem,
+                                nixlBackendMD *&out) {
+    if (nixl_mem != DRAM_SEG && nixl_mem != OBJ_SEG) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    if (nixl_mem == OBJ_SEG) {
+        // The remote descriptor carries the token sequence in metaInfo; derive
+        // the fixed-length KV key by hashing it. The key lives in the per-desc
+        // metadata and is read back from the descriptor at transfer time.
+        std::vector<uint8_t> key;
+        if (!radosNkvDeriveKey(mem.metaInfo, maxKeyLen_, key)) {
+            NIXL_ERROR << "RADOS_NKV: empty token sequence (metaInfo); cannot derive a KV key";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        out = new nixlRadosNkvMetadata(std::move(key));
+    } else {
+        // Local DRAM registration: nothing to do for the staging skeleton (we
+        // stage through a per-request shim DMA buffer in postXfer). No backend
+        // metadata is needed for the DRAM side.
+        out = nullptr;
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::deregisterMem(nixlBackendMD *meta) {
+    delete static_cast<nixlRadosNkvMetadata *>(meta);
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::queryMem(const nixl_reg_dlist_t &descs,
+                             std::vector<nixl_query_resp_t> &resp) const {
+    // Mirror the OBJ backend's queryMem result/absence convention exactly:
+    //   - resp is sized to descCount() and defaulted to std::nullopt (absent).
+    //   - present  => resp[i] = nixl_query_resp_t{nixl_b_params_t{}} (engaged).
+    //   - absent   => resp[i] = std::nullopt (left as the default).
+    //   - on a backend/transport error we return an error status (NIXL_ERR_*)
+    //     rather than encoding the failure as "absent", so callers never mask a
+    //     transport failure as a cache miss.
+    resp.assign(descs.descCount(), std::nullopt);
+
+    if (!shim_) {
+        NIXL_ERROR << "RADOS_NKV: shim not initialized";
+        return NIXL_ERR_BACKEND;
+    }
+
+    for (int i = 0; i < descs.descCount(); ++i) {
+        const auto &desc = descs[i];
+
+        // Derive the KV key from the OBJ_SEG descriptor's token sequence using
+        // the SAME hash path as registerMem.
+        std::vector<uint8_t> key;
+        if (!radosNkvDeriveKey(desc.metaInfo, maxKeyLen_, key)) {
+            NIXL_ERROR << "RADOS_NKV: empty token sequence (metaInfo) in queryMem descriptor " << i;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        int rc = kv_host_shim_exist(shim_, key.data(), static_cast<uint8_t>(key.size()));
+        if (rc == 0) {
+            // Present.
+            resp[i] = nixl_query_resp_t{nixl_b_params_t{}};
+        } else if (rc == 0x87) {
+            // KEY_DOES_NOT_EXIST: absent. Leave resp[i] as std::nullopt.
+            resp[i] = std::nullopt;
+        } else {
+            // rc < 0: a submit-/transport-level error. Surface it as an error,
+            // NOT as a miss, so failures are not silently masked as absent.
+            NIXL_ERROR << "RADOS_NKV: kv_host_shim_exist failed for descriptor " << i
+                       << ": rc=" << rc;
+            return NIXL_ERR_BACKEND;
+        }
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::prepXfer(const nixl_xfer_op_t &operation,
+                             const nixl_meta_dlist_t &local,
+                             const nixl_meta_dlist_t &remote,
+                             const std::string &remote_agent,
+                             nixlBackendReqH *&handle,
+                             const nixl_opt_b_args_t *opt_args) const {
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << "RADOS_NKV: invalid operation " << operation;
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << "RADOS_NKV: local memory type must be DRAM_SEG, got " << local.getType();
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << "RADOS_NKV: remote memory type must be OBJ_SEG, got " << remote.getType();
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (local.descCount() != remote.descCount()) {
+        NIXL_ERROR << "RADOS_NKV: local/remote descriptor count mismatch";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    handle = new nixlRadosNkvBackendReqH();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::postXfer(const nixl_xfer_op_t &operation,
+                             const nixl_meta_dlist_t &local,
+                             const nixl_meta_dlist_t &remote,
+                             const std::string &remote_agent,
+                             nixlBackendReqH *&handle,
+                             const nixl_opt_b_args_t *opt_args) const {
+    if (!handle) {
+        NIXL_ERROR << "RADOS_NKV: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (!shim_) {
+        NIXL_ERROR << "RADOS_NKV: shim not initialized";
+        return NIXL_ERR_BACKEND;
+    }
+    auto *req_h = static_cast<nixlRadosNkvBackendReqH *>(handle);
+
+    for (int i = 0; i < local.descCount(); ++i) {
+        const auto &local_desc = local[i];
+        const auto &remote_desc = remote[i];
+
+        // Cross-check the local and remote descriptor lengths. The op uses the
+        // local length for the DMA staging buffer and the KV value size; a
+        // mismatch means the caller's view of the value size disagrees, so fail
+        // rather than silently store/retrieve a different number of bytes.
+        if (local_desc.len != remote_desc.len) {
+            NIXL_ERROR << "RADOS_NKV: descriptor " << i
+                       << " length mismatch: local=" << local_desc.len
+                       << " remote=" << remote_desc.len;
+            req_h->status = NIXL_ERR_INVALID_PARAM;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        // The KV key lives in the descriptor's registration metadata (set by
+        // registerMem). Read it from there rather than re-deriving or keying on
+        // devId, so the transfer uses exactly the key the descriptor registered.
+        auto *md = static_cast<nixlRadosNkvMetadata *>(remote_desc.metadataP);
+        if (!md) {
+            NIXL_ERROR << "RADOS_NKV: remote descriptor " << i
+                       << " has no registered KV-key metadata";
+            req_h->status = NIXL_ERR_INVALID_PARAM;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const std::vector<uint8_t> &key = md->key;
+
+        const auto data_ptr = reinterpret_cast<void *>(local_desc.addr);
+        const size_t data_len = local_desc.len;
+
+        // Stage through an SPDK-DMA buffer (see header for the rationale).
+        void *dma = kv_host_shim_dma_alloc(data_len);
+        if (!dma) {
+            NIXL_ERROR << "RADOS_NKV: DMA buffer alloc failed (" << data_len << " bytes)";
+            req_h->status = NIXL_ERR_BACKEND;
+            return NIXL_ERR_BACKEND;
+        }
+
+        int rc = 0;
+        if (operation == NIXL_WRITE) {
+            std::memcpy(dma, data_ptr, data_len);
+            rc = kv_host_shim_store(shim_,
+                                    key.data(),
+                                    static_cast<uint8_t>(key.size()),
+                                    dma,
+                                    static_cast<uint32_t>(data_len));
+            if (rc != 0) {
+                NIXL_ERROR << "RADOS_NKV: kv_host_shim_store failed: rc=" << rc;
+            }
+        } else { // NIXL_READ
+            uint32_t value_len_out = 0;
+            rc = kv_host_shim_retrieve(shim_,
+                                       key.data(),
+                                       static_cast<uint8_t>(key.size()),
+                                       dma,
+                                       static_cast<uint32_t>(data_len),
+                                       &value_len_out);
+            if (rc == 0) {
+                // value_len_out is the device's TRUE value length and may exceed
+                // buf_len (data truncated). The transfer is sized to data_len
+                // (local==remote, cross-checked above), so any size difference
+                // means the request cannot be satisfied exactly: a larger value
+                // would be truncated (silent data loss) and a shorter one would
+                // leave the tail of the caller's buffer undefined. Surface that
+                // as an error instead of copying a partial value.
+                if (value_len_out != data_len) {
+                    NIXL_ERROR << "RADOS_NKV: stored value length " << value_len_out
+                               << " != requested transfer length " << data_len << " for descriptor "
+                               << i << "; refusing partial copy";
+                    rc = -1;
+                } else {
+                    std::memcpy(data_ptr, dma, data_len);
+                }
+            } else {
+                NIXL_ERROR << "RADOS_NKV: kv_host_shim_retrieve failed: rc=" << rc;
+            }
+        }
+
+        kv_host_shim_dma_free(dma);
+
+        if (rc != 0) {
+            req_h->status = NIXL_ERR_BACKEND;
+            return NIXL_ERR_BACKEND;
+        }
+    }
+
+    // The shim ops are synchronous, so the transfer is already complete.
+    req_h->status = NIXL_SUCCESS;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::checkXfer(nixlBackendReqH *handle) const {
+    if (!handle) {
+        NIXL_ERROR << "RADOS_NKV: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return static_cast<nixlRadosNkvBackendReqH *>(handle)->status;
+}
+
+nixl_status_t
+nixlRadosNkvEngine::releaseReqH(nixlBackendReqH *handle) const {
+    if (!handle) {
+        NIXL_ERROR << "RADOS_NKV: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    delete static_cast<nixlRadosNkvBackendReqH *>(handle);
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/rados-nkv/rados_nkv_backend.h
+++ b/src/plugins/rados-nkv/rados_nkv_backend.h
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_BACKEND_H
+#define NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_BACKEND_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "backend/backend_engine.h"
+#include "rados_nkv_key.h" // radosNkvDeriveKey (SPDK-free key derivation)
+
+// Forward declaration of the opaque SPDK KV host shim handle (C ABI).
+struct kv_host_shim;
+
+/**
+ * nixlRadosNkvEngine maps NIXL transfers onto the NVMe Key-Value command set
+ * via the in-process SPDK KV host shim (kv_host_shim.h).
+ *
+ * Memory-type mapping (MIRRORS the OBJ plugin):
+ *   - local  source/destination: DRAM_SEG (host DRAM)
+ *   - remote key-addressed blob : OBJ_SEG  (reused as the "remote KV key" space)
+ *
+ * Operation mapping:
+ *   - NIXL_WRITE (local DRAM -> remote) becomes a KV Store
+ *   - NIXL_READ  (remote -> local DRAM) becomes a KV Retrieve
+ *
+ * The remote OBJ_SEG descriptor carries the token sequence in its metaInfo blob
+ * (the same channel obj uses for the object key). The engine derives the
+ * fixed-length NVMe KV key as a hash of those bytes (radosNkvDeriveKey: a
+ * 128-bit FNV-1a truncated to min(16, kvkml-advertised-by-the-namespace)). This
+ * mirrors OBJ in keying off metaInfo rather than devId, lets an arbitrary-length
+ * token sequence map to a stable key with no over-length restriction, and stores
+ * the derived key in the per-descriptor metadata so transfers read it back from
+ * the descriptor. An empty metaInfo is rejected (NIXL_ERR_INVALID_PARAM).
+ *
+ * Custom backend params (nixl_b_params_t):
+ *   - "vfu_addr" (or "socket"/"vfio_user_path"/"device"): REQUIRED, the
+ *     VFIOUSER transport directory for the SPDK KV target.
+ *   - "nsid": OPTIONAL, NVMe namespace id (0 / unset auto-selects first KV ns).
+ *   - "init_env": OPTIONAL bool ("true"/"1"/"yes"/"on"), DEFAULT false. When
+ *     false (production), the host/agent owns the SPDK env and this engine does
+ *     not initialize it, allowing multiple engines per process. When true, the
+ *     shim brings up its own (no-hugepage) SPDK env; this is single-instance
+ *     per process and is intended for standalone tests that have no host env.
+ *
+ * Staging / zero-copy approach (DOCUMENTED):
+ *   The SPDK Store/Retrieve primitives require the value buffer to be an
+ *   SPDK-DMA buffer (kv_host_shim_dma_alloc). User DRAM registered through
+ *   registerMem() is ordinary host memory and is generally NOT DMA-capable, so
+ *   for this skeleton we STAGE through a per-request shim DMA buffer and copy:
+ *     - WRITE: memcpy(user DRAM -> DMA buf) then Store(key, DMA buf)
+ *     - READ : Retrieve(key, DMA buf) then memcpy(DMA buf -> user DRAM)
+ *   This keeps the skeleton correct and simple. A future optimization can
+ *   register user buffers that are already DMA memory and skip the copy.
+ */
+class nixlRadosNkvEngine : public nixlBackendEngine {
+public:
+    explicit nixlRadosNkvEngine(const nixlBackendInitParams *init_params);
+    ~nixlRadosNkvEngine() override;
+
+    bool
+    supportsRemote() const override {
+        return false;
+    }
+
+    bool
+    supportsLocal() const override {
+        return true;
+    }
+
+    bool
+    supportsNotif() const override {
+        return false;
+    }
+
+    nixl_mem_list_t
+    getSupportedMems() const override;
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    // Existence probe: maps a NIXL queryMem onto the NVMe KV Exist command.
+    // This is llm-d's lookup path (agent.query_memory() -> backend queryMem),
+    // used to build a cache hit/miss mask without transferring any value data.
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    connect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    disconnect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    unloadMD(nixlBackendMD *input) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        output = input;
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+private:
+    // Maximum NVMe KV key length (bytes) the device key space can hold.
+    static constexpr uint8_t kMaxKeyLen = 16;
+
+    // The SPDK KV host shim handle (owns the controller attach + qpair).
+    kv_host_shim *shim_ = nullptr;
+
+    // Length of the derived key: min(kMaxKeyLen, kvkml advertised by the shim).
+    uint8_t maxKeyLen_ = kMaxKeyLen;
+};
+
+#endif // NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_BACKEND_H

--- a/src/plugins/rados-nkv/rados_nkv_key.cpp
+++ b/src/plugins/rados-nkv/rados_nkv_key.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "rados_nkv_key.h"
+
+#include <algorithm>
+
+bool
+radosNkvDeriveKey(const std::string &token_seq, uint8_t key_len, std::vector<uint8_t> &out) {
+    if (token_seq.empty() || key_len == 0) {
+        return false;
+    }
+
+    // FNV-1a, 128-bit (offset basis and prime per the FNV spec).
+    const __uint128_t k_offset =
+        (static_cast<__uint128_t>(0x6c62272e07bb0142ULL) << 64) | 0x62b821756295c58dULL;
+    const __uint128_t k_prime =
+        (static_cast<__uint128_t>(0x0000000001000000ULL) << 64) | 0x000000000000013bULL;
+
+    __uint128_t h = k_offset;
+    for (unsigned char c : token_seq) {
+        h ^= static_cast<__uint128_t>(c);
+        h *= k_prime;
+    }
+
+    // Serialize big-endian, then keep the first key_len bytes.
+    uint8_t buf[16];
+    for (int i = 15; i >= 0; --i) {
+        buf[i] = static_cast<uint8_t>(h & 0xff);
+        h >>= 8;
+    }
+    out.assign(buf, buf + std::min<size_t>(key_len, sizeof(buf)));
+    return true;
+}

--- a/src/plugins/rados-nkv/rados_nkv_key.h
+++ b/src/plugins/rados-nkv/rados_nkv_key.h
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_KEY_H
+#define NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_KEY_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+/**
+ * Derive the fixed-length NVMe KV key from a token sequence (the OBJ_SEG
+ * descriptor's metaInfo blob).
+ *
+ * Uses a 128-bit FNV-1a hash emitted big-endian and truncated to @p key_len, so
+ * an arbitrary-length token sequence maps to a stable, fixed-size key. This is
+ * intentionally free of any SPDK dependency so it can be unit-tested without a
+ * KV target, and reproduced by tooling (e.g. the RADOS round-trip script
+ * computes the same hash to find the expected object id).
+ *
+ * @param token_seq The token sequence to hash (the descriptor's metaInfo).
+ * @param key_len   Desired key length in bytes; clamped to 16 (the hash width).
+ * @param out       On success, set to the derived key (@p key_len bytes).
+ * @return true on success; false if @p token_seq is empty or @p key_len is 0
+ *         (no key produced).
+ */
+bool
+radosNkvDeriveKey(const std::string &token_seq, uint8_t key_len, std::vector<uint8_t> &out);
+
+#endif // NIXL_SRC_PLUGINS_RADOS_NKV_RADOS_NKV_KEY_H

--- a/src/plugins/rados-nkv/rados_nkv_plugin.cpp
+++ b/src/plugins/rados-nkv/rados_nkv_plugin.cpp
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nixl_types.h"
+#include "rados_nkv_backend.h"
+#include "backend/backend_plugin.h"
+
+// Plugin type alias for convenience
+using rados_nkv_plugin_t = nixlBackendPluginCreator<nixlRadosNkvEngine>;
+
+// Local DRAM source, remote OBJ-style key-addressed destination (mirrors OBJ).
+static const nixl_mem_list_t supported_segments = {DRAM_SEG, OBJ_SEG};
+
+#ifdef STATIC_PLUGIN_RADOS_NKV
+nixlBackendPlugin *
+createStaticRADOS_NKVPlugin() {
+    return rados_nkv_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, "RADOS_NKV", "0.1.0", {}, supported_segments);
+}
+#else
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
+nixl_plugin_init() {
+    return rados_nkv_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, "RADOS_NKV", "0.1.0", {}, supported_segments);
+}
+
+extern "C" NIXL_PLUGIN_EXPORT void
+nixl_plugin_fini() {}
+#endif

--- a/src/plugins/rados-nkv/rados_nkv_roundtrip_test.cpp
+++ b/src/plugins/rados-nkv/rados_nkv_roundtrip_test.cpp
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Direct-engine round-trip test for the RADOS_NKV backend.
+ *
+ * Instantiates nixlRadosNkvEngine directly (no nixlAgent), registers a DRAM
+ * source buffer and an OBJ_SEG remote descriptor carrying a token sequence in
+ * metaInfo (the engine hashes it into the NVMe KV key), then:
+ *   1. WRITE (DRAM -> remote)  => KV Store
+ *   2. READ  (remote -> DRAM)  => KV Retrieve
+ * and verifies the retrieved bytes match the stored bytes.
+ *
+ * Usage: rados_nkv_roundtrip_test <vfio-user-dir>
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "nixl_descriptors.h"
+#include "backend/backend_aux.h"
+#include "rados_nkv_backend.h"
+
+namespace {
+
+bool
+checkComplete(const nixlRadosNkvEngine &eng, nixlBackendReqH *h) {
+    // Shim ops are synchronous; checkXfer should report SUCCESS immediately.
+    for (int i = 0; i < 1000; ++i) {
+        nixl_status_t s = eng.checkXfer(h);
+        if (s == NIXL_SUCCESS) {
+            return true;
+        }
+        if (s != NIXL_IN_PROG) {
+            std::cerr << "checkXfer error status=" << s << "\n";
+            return false;
+        }
+    }
+    std::cerr << "checkXfer never completed\n";
+    return false;
+}
+
+} // namespace
+
+int
+main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0] << " <vfio-user-dir>\n";
+        return 2;
+    }
+    const std::string vfu_dir = argv[1];
+
+    nixl_b_params_t params;
+    params["vfu_addr"] = vfu_dir;
+    // Standalone test: no host owns the SPDK env, so this engine brings it up.
+    params["init_env"] = "true";
+
+    nixlBackendInitParams init{};
+    init.localAgent = "rados_nkv_test_agent";
+    init.type = "RADOS_NKV";
+    init.customParams = &params;
+    init.enableProgTh = false;
+    init.pthrDelay = 0;
+    init.enableTelemetry_ = false;
+
+    nixlRadosNkvEngine eng(&init);
+    if (eng.getInitErr()) {
+        std::cerr << "FAIL: engine init error (shim open failed)\n";
+        return 1;
+    }
+    std::cout << "engine initialized against " << vfu_dir << "\n";
+
+    // --- Source DRAM buffer ---
+    const std::string payload = "RADOS_NKV-NIXL-roundtrip-slice2-0123456789";
+    std::vector<uint8_t> src(payload.begin(), payload.end());
+    std::vector<uint8_t> dst(src.size(), 0);
+
+    const uint64_t dram_dev = 0;
+    const uint64_t key_dev = 1;
+    const std::string kv_key = "nixl-key-0000001"; // 16 bytes
+
+    // Register the local DRAM region (source).
+    nixlBlobDesc dram_desc(reinterpret_cast<uintptr_t>(src.data()), src.size(), dram_dev, "");
+    nixlBackendMD *dram_md = nullptr;
+    if (eng.registerMem(dram_desc, DRAM_SEG, dram_md) != NIXL_SUCCESS) {
+        std::cerr << "FAIL: registerMem(DRAM) failed\n";
+        return 1;
+    }
+
+    // Register the remote OBJ_SEG descriptor carrying the KV key in metaInfo.
+    nixlBlobDesc key_desc(0, src.size(), key_dev, kv_key);
+    nixlBackendMD *key_md = nullptr;
+    if (eng.registerMem(key_desc, OBJ_SEG, key_md) != NIXL_SUCCESS) {
+        std::cerr << "FAIL: registerMem(OBJ key) failed\n";
+        return 1;
+    }
+    std::cout << "registered DRAM source and KV key '" << kv_key << "'\n";
+
+    // Build meta dlists for the transfer.
+    nixl_meta_dlist_t local(DRAM_SEG);
+    local.addDesc(
+        nixlMetaDesc(reinterpret_cast<uintptr_t>(src.data()), src.size(), dram_dev, dram_md));
+
+    nixl_meta_dlist_t remote(OBJ_SEG);
+    remote.addDesc(nixlMetaDesc(0, src.size(), key_dev, key_md));
+
+    nixl_meta_dlist_t local_dst(DRAM_SEG);
+    local_dst.addDesc(
+        nixlMetaDesc(reinterpret_cast<uintptr_t>(dst.data()), dst.size(), dram_dev, dram_md));
+
+    // --- WRITE => KV Store ---
+    {
+        nixlBackendReqH *h = nullptr;
+        if (eng.prepXfer(NIXL_WRITE, local, remote, init.localAgent, h) != NIXL_SUCCESS) {
+            std::cerr << "FAIL: prepXfer(WRITE) failed\n";
+            return 1;
+        }
+        nixl_status_t ps = eng.postXfer(NIXL_WRITE, local, remote, init.localAgent, h);
+        if (ps != NIXL_SUCCESS && ps != NIXL_IN_PROG) {
+            std::cerr << "FAIL: postXfer(WRITE) status=" << ps << "\n";
+            return 1;
+        }
+        if (!checkComplete(eng, h)) {
+            std::cerr << "FAIL: WRITE did not complete\n";
+            return 1;
+        }
+        eng.releaseReqH(h);
+        std::cout << "WRITE (KV Store) of " << src.size() << " bytes complete\n";
+    }
+
+    // --- READ => KV Retrieve ---
+    {
+        nixlBackendReqH *h = nullptr;
+        if (eng.prepXfer(NIXL_READ, local_dst, remote, init.localAgent, h) != NIXL_SUCCESS) {
+            std::cerr << "FAIL: prepXfer(READ) failed\n";
+            return 1;
+        }
+        nixl_status_t ps = eng.postXfer(NIXL_READ, local_dst, remote, init.localAgent, h);
+        if (ps != NIXL_SUCCESS && ps != NIXL_IN_PROG) {
+            std::cerr << "FAIL: postXfer(READ) status=" << ps << "\n";
+            return 1;
+        }
+        if (!checkComplete(eng, h)) {
+            std::cerr << "FAIL: READ did not complete\n";
+            return 1;
+        }
+        eng.releaseReqH(h);
+        std::cout << "READ (KV Retrieve) of " << dst.size() << " bytes complete\n";
+    }
+
+    // --- Verify byte-for-byte ---
+    if (src != dst) {
+        std::cerr << "FAIL: data mismatch after round-trip\n";
+        std::cerr << "  wrote: " << payload << "\n";
+        std::cerr << "  read : " << std::string(dst.begin(), dst.end()) << "\n";
+        return 1;
+    }
+
+    std::cout << "verified " << dst.size() << " bytes match: \""
+              << std::string(dst.begin(), dst.end()) << "\"\n";
+
+    // --- queryMem => KV Exist (llm-d lookup / cache hit-miss mask) ---
+    // A queryMem for the just-Stored key must report PRESENT (engaged optional);
+    // a queryMem for a never-stored key must report ABSENT (std::nullopt) and
+    // must NOT error (a real miss is not a failure).
+    {
+        // PRESENT: probe the key we stored above.
+        nixl_reg_dlist_t q_present(OBJ_SEG);
+        q_present.addDesc(nixlBlobDesc(0, src.size(), key_dev, kv_key));
+        std::vector<nixl_query_resp_t> r_present;
+        nixl_status_t qs = eng.queryMem(q_present, r_present);
+        if (qs != NIXL_SUCCESS) {
+            std::cerr << "FAIL: queryMem(present) status=" << qs << "\n";
+            return 1;
+        }
+        if (r_present.size() != 1 || !r_present[0].has_value()) {
+            std::cerr << "FAIL: queryMem of stored key '" << kv_key << "' did NOT report PRESENT\n";
+            return 1;
+        }
+        std::cout << "queryMem (KV Exist) of stored key '" << kv_key << "' reports PRESENT (hit)\n";
+
+        // ABSENT: probe a key we never stored. Must be absent, not an error.
+        const std::string missing_key = "nixl-key-MISSING"; // 16 bytes, never stored
+        nixl_reg_dlist_t q_absent(OBJ_SEG);
+        q_absent.addDesc(nixlBlobDesc(0, src.size(), 2, missing_key));
+        std::vector<nixl_query_resp_t> r_absent;
+        qs = eng.queryMem(q_absent, r_absent);
+        if (qs != NIXL_SUCCESS) {
+            std::cerr << "FAIL: queryMem(absent) errored (status=" << qs
+                      << ") instead of reporting a miss\n";
+            return 1;
+        }
+        if (r_absent.size() != 1 || r_absent[0].has_value()) {
+            std::cerr << "FAIL: queryMem of never-stored key '" << missing_key
+                      << "' did NOT report ABSENT\n";
+            return 1;
+        }
+        std::cout << "queryMem (KV Exist) of never-stored key '" << missing_key
+                  << "' reports ABSENT (miss), not an error\n";
+    }
+
+    // --- Key derivation: the KV key is a fixed-length hash of the (arbitrary-
+    // length) token sequence in metaInfo. A long token sequence is accepted (no
+    // over-length rejection), distinct sequences derive distinct keys, and an
+    // empty sequence is rejected. This is a pure check (no Store) so it does not
+    // create objects in the backing store. ---
+    {
+        std::vector<uint8_t> k_short, k_long, k_empty;
+        const bool ok_short = radosNkvDeriveKey("nixl-key-0000001", 16, k_short);
+        const bool ok_long = radosNkvDeriveKey(std::string(4096, 'x'), 16, k_long);
+        if (!ok_short || !ok_long || k_short.size() != 16 || k_long.size() != 16) {
+            std::cerr << "FAIL: radosNkvDeriveKey did not produce 16-byte keys\n";
+            return 1;
+        }
+        if (k_short == k_long) {
+            std::cerr << "FAIL: distinct token sequences derived the same KV key\n";
+            return 1;
+        }
+        if (radosNkvDeriveKey("", 16, k_empty)) {
+            std::cerr << "FAIL: empty token sequence was NOT rejected\n";
+            return 1;
+        }
+        std::cout << "key derivation: arbitrary-length token sequences hash to "
+                     "distinct 16-byte keys; empty rejected\n";
+    }
+
+    // --- Short-read regression: a READ whose transfer length does not match the
+    // stored value length must error, not silently truncate. The value stored
+    // above under 'kv_key' is payload.size() bytes; read it back with a
+    // deliberately short transfer and require the engine to surface an error. ---
+    {
+        const size_t short_len = 10; // < payload.size()
+        std::vector<uint8_t> short_dst(short_len, 0);
+
+        nixl_meta_dlist_t s_local(DRAM_SEG);
+        s_local.addDesc(nixlMetaDesc(
+            reinterpret_cast<uintptr_t>(short_dst.data()), short_len, dram_dev, dram_md));
+        nixl_meta_dlist_t s_remote(OBJ_SEG);
+        s_remote.addDesc(nixlMetaDesc(0, short_len, key_dev, key_md));
+
+        nixlBackendReqH *h = nullptr;
+        if (eng.prepXfer(NIXL_READ, s_local, s_remote, init.localAgent, h) != NIXL_SUCCESS) {
+            std::cerr << "FAIL: prepXfer(short READ) failed\n";
+            return 1;
+        }
+        nixl_status_t ps = eng.postXfer(NIXL_READ, s_local, s_remote, init.localAgent, h);
+        nixl_status_t cs = eng.checkXfer(h);
+        eng.releaseReqH(h);
+        if (ps == NIXL_SUCCESS || cs == NIXL_SUCCESS) {
+            std::cerr << "FAIL: short READ (" << short_len << " bytes) of a " << payload.size()
+                      << "-byte value did NOT error (post=" << ps << " check=" << cs << ")\n";
+            return 1;
+        }
+        std::cout << "short READ (" << short_len << " bytes) of a " << payload.size()
+                  << "-byte value correctly errored (no silent truncation)\n";
+    }
+
+    eng.deregisterMem(key_md);
+    eng.deregisterMem(dram_md);
+
+    std::cout << "rados_nkv_roundtrip_test: PASS\n";
+    return 0;
+}

--- a/src/plugins/rados-nkv/run_roundtrip.sh
+++ b/src/plugins/rados-nkv/run_roundtrip.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Brings up an SPDK nvmf target with an in-memory KV namespace over VFIOUSER,
+# then runs the RADOS_NKV direct-engine round-trip test against it.
+set -euo pipefail
+
+SPDK_ROOT="${SPDK_ROOT:-/mnt/spdk}"
+TEST_BIN="$(dirname "$0")/../../../builddir/src/plugins/rados-nkv/rados_nkv_roundtrip_test"
+TEST_BIN="$(readlink -f "$TEST_BIN")"
+
+nqn="nqn.2026-06.io.spdk:rados-kv-cnode0"
+kvdev_name="RadosNkvMem0"
+sock_dir="$(mktemp -d /tmp/rados_nkv_rt.XXXXXX)"
+muser_dir="$sock_dir/domain/muser0/0"
+rpc_sock="$sock_dir/rpc.sock"
+rpc_py="$SPDK_ROOT/scripts/rpc.py -s $rpc_sock"
+mkdir -p "$muser_dir"
+
+nvmfpid=""
+cleanup() {
+    [[ -n "$nvmfpid" ]] && kill "$nvmfpid" 2>/dev/null || true
+    rm -rf "$sock_dir"
+}
+trap cleanup EXIT
+
+echo "== starting nvmf_tgt =="
+"$SPDK_ROOT/build/bin/nvmf_tgt" -r "$rpc_sock" -m 0x1 --no-huge -s 512 &
+nvmfpid=$!
+
+# Wait for the RPC socket to be ready.
+for _ in $(seq 1 50); do
+    if $rpc_py rpc_get_methods >/dev/null 2>&1; then break; fi
+    sleep 0.2
+done
+
+echo "== configuring KV namespace =="
+$rpc_py nvmf_create_transport -t VFIOUSER
+$rpc_py kvdev_mem_create "$kvdev_name"
+$rpc_py nvmf_create_subsystem "$nqn" -s SPDKKV001 -a
+$rpc_py nvmf_subsystem_add_kv_ns "$nqn" "$kvdev_name"
+$rpc_py nvmf_subsystem_add_listener "$nqn" -t VFIOUSER -a "$muser_dir" -s 0
+
+echo "== running round-trip test =="
+"$TEST_BIN" "$muser_dir"
+rc=$?
+echo "== test exit code: $rc =="
+exit $rc

--- a/src/plugins/rados-nkv/run_roundtrip_rados.sh
+++ b/src/plugins/rados-nkv/run_roundtrip_rados.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Brings up an SPDK nvmf target with a *librados-backed* KV namespace over
+# VFIOUSER (real Ceph/RADOS), then runs the RADOS_NKV direct-engine round-trip
+# test against it. This proves the SAME plugin/test that round-trips against the
+# in-memory kvdev (run_roundtrip.sh) also works unchanged against a librados KV
+# namespace, and that the stored value actually lands as an object in the
+# tenant rados namespace.
+#
+# Modeled on:
+#   - src/plugins/rados-nkv/run_roundtrip.sh                  (the in-mem bring-up)
+#   - $SPDK_ROOT/test/nvmf/kv_rados/kv_rados_vfio_user.sh     (librados kvdev wiring)
+#
+# The librados kvdev maps the NVMe KV key to a lowercase-hex oid
+# (kvdev_rados_key_to_oid). The engine derives that key by hashing the token
+# sequence in the descriptor's metaInfo (radosNkvDeriveKey: 128-bit FNV-1a).
+# The round-trip test uses the token sequence "nixl-key-0000001"; its oid is the
+# hex of the 16-byte hash. After the WRITE we assert via the rados CLI that this
+# oid exists in $KV_POOL/$KV_NS with a size matching the stored value length,
+# then the test's READ + queryMem prove Retrieve and Exist. The test object is
+# removed at the end so the pool is not polluted.
+set -euo pipefail
+
+SPDK_ROOT="${SPDK_ROOT:-/mnt/spdk}"
+TEST_BIN="$(dirname "$0")/../../../builddir/src/plugins/rados-nkv/rados_nkv_roundtrip_test"
+TEST_BIN="$(readlink -f "$TEST_BIN")"
+
+# --- Ceph / RADOS environment (override via env to match your cluster) -----
+# Defaults assume a standard Ceph install; point these at your cluster's config,
+# keyring, and rados binary as needed.
+CEPH_CONF="${CEPH_CONF:-/etc/ceph/ceph.conf}"
+CEPH_KEYRING="${CEPH_KEYRING:-/etc/ceph/ceph.client.admin.keyring}"
+RADOS_BIN="${RADOS_BIN:-rados}"
+CEPH_USER="${CEPH_USER:-admin}"
+KV_POOL="${KV_POOL:-kvpool}"
+KV_NS="${KV_NS:-kvns}"
+
+# The round-trip test (rados_nkv_roundtrip_test.cpp) uses this token sequence
+# and this exact payload; keep them in sync with that file.
+KV_KEY="nixl-key-0000001"
+PAYLOAD="RADOS_NKV-NIXL-roundtrip-slice2-0123456789"
+VAL_LEN=${#PAYLOAD}
+# oid = lowercase hex of the derived 16-byte KV key. The engine derives the key
+# as a 128-bit FNV-1a hash of the token sequence; reproduce it here (this MUST
+# stay in sync with radosNkvDeriveKey in rados_nkv_backend.cpp).
+OID_HEX=$(python3 -c '
+import sys
+seq = sys.argv[1].encode()
+h = 0x6c62272e07bb014262b821756295c58d            # FNV-1a 128-bit offset basis
+prime = 0x0000000001000000000000000000013b        # FNV-1a 128-bit prime
+mask = (1 << 128) - 1
+for b in seq:
+    h ^= b
+    h = (h * prime) & mask
+print(h.to_bytes(16, "big").hex())               # 16-byte key, big-endian, as hex
+' "$KV_KEY")
+
+rados() { "$RADOS_BIN" -c "$CEPH_CONF" -k "$CEPH_KEYRING" -p "$KV_POOL" -N "$KV_NS" "$@"; }
+
+nqn="nqn.2026-06.io.spdk:rados-kv-cnode0"
+cluster_name="ceph0"
+kvdev_name="RadosNkv0"
+sock_dir="$(mktemp -d /tmp/rados_nkv_rados_rt.XXXXXX)"
+muser_dir="$sock_dir/domain/muser0/0"
+rpc_sock="$sock_dir/rpc.sock"
+mkdir -p "$muser_dir"
+
+# rpc.py needs to talk to the (possibly sudo-owned) RPC socket. RPC_PFX is set
+# to "sudo" when the target runs under sudo so the helper can reach the socket.
+RPC_PFX=""
+rpc_py() { $RPC_PFX "$SPDK_ROOT/scripts/rpc.py" -s "$rpc_sock" "$@"; }
+
+nvmfpid=""
+SUDO_RUN=""
+cleanup() {
+    if [[ -n "$nvmfpid" ]]; then
+        $SUDO_RUN kill "$nvmfpid" 2>/dev/null || true
+        wait "$nvmfpid" 2>/dev/null || true
+    fi
+    # Remove the test object so we do not pollute the pool.
+    rados rm "$OID_HEX" >/dev/null 2>&1 || true
+    $SUDO_RUN rm -rf "$sock_dir" 2>/dev/null || rm -rf "$sock_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_rpc() {
+    for _ in $(seq 1 50); do
+        if rpc_py rpc_get_methods >/dev/null 2>&1; then return 0; fi
+        sleep 0.2
+    done
+    return 1
+}
+
+echo "== Ceph target: pool=$KV_POOL ns=$KV_NS user=$CEPH_USER =="
+echo "== oid for key '$KV_KEY' = $OID_HEX (hex-encoded), expected size=$VAL_LEN =="
+
+# Pre-clean any stale object from a previous aborted run.
+rados rm "$OID_HEX" >/dev/null 2>&1 || true
+
+# --- Start the target ------------------------------------------------------
+# Try --no-huge first (no special privileges). librados/DMA may require real
+# hugepages; if the no-huge target fails to come up, fall back to sudo +
+# hugepages exactly like the SPDK kv_rados tests (-m 0x3 --iova-mode=va).
+echo "== starting nvmf_tgt (attempt 1: --no-huge -s 1024) =="
+"$SPDK_ROOT/build/bin/nvmf_tgt" -r "$rpc_sock" -m 0x1 --no-huge -s 1024 \
+    >"$sock_dir/tgt.log" 2>&1 &
+nvmfpid=$!
+
+if ! wait_for_rpc; then
+    echo "== --no-huge target did not come up; falling back to sudo + hugepages =="
+    sed -n '1,200p' "$sock_dir/tgt.log" || true
+    kill "$nvmfpid" 2>/dev/null || true
+    wait "$nvmfpid" 2>/dev/null || true
+    nvmfpid=""
+
+    SUDO_RUN="sudo"
+    RPC_PFX="sudo"
+    echo "== starting nvmf_tgt (attempt 2: sudo, hugepages, -m 0x3 --iova-mode=va) =="
+    sudo "$SPDK_ROOT/build/bin/nvmf_tgt" -r "$rpc_sock" -m 0x3 --iova-mode=va \
+        >"$sock_dir/tgt.log" 2>&1 &
+    nvmfpid=$!
+    if ! wait_for_rpc; then
+        echo "FAIL: target did not come up under sudo either"
+        sed -n '1,200p' "$sock_dir/tgt.log" || true
+        exit 1
+    fi
+    TGT_MODE="sudo+hugepages"
+else
+    TGT_MODE="--no-huge -s 1024"
+fi
+echo "== target up via: $TGT_MODE =="
+
+# --- Wire up the librados KV namespace -------------------------------------
+echo "== configuring librados KV namespace =="
+rpc_py nvmf_create_transport -t VFIOUSER
+rpc_py kvdev_rados_register_cluster "$cluster_name" \
+    --user "$CEPH_USER" --config-file "$CEPH_CONF" --key-file "$CEPH_KEYRING"
+rpc_py kvdev_rados_create "$kvdev_name" "$cluster_name" "$KV_POOL" --namespace "$KV_NS"
+rpc_py nvmf_create_subsystem "$nqn" -s SPDKKVR01 -a
+rpc_py nvmf_subsystem_add_kv_ns "$nqn" "$kvdev_name"
+rpc_py nvmf_subsystem_add_listener "$nqn" -t VFIOUSER -a "$muser_dir" -s 0
+
+# The VFIOUSER socket dir may be sudo-owned; make sure the (non-sudo) test
+# binary can open it.
+if [[ -n "$SUDO_RUN" ]]; then
+    sudo chmod -R a+rwx "$sock_dir" || true
+fi
+
+# --- Run the round-trip test (Store / Retrieve / queryMem over librados) ----
+echo "== running round-trip test against librados KV namespace =="
+"$TEST_BIN" "$muser_dir"
+rc=$?
+echo "== round-trip test exit code: $rc =="
+if [[ $rc -ne 0 ]]; then
+    echo "FAIL: round-trip test failed"
+    exit $rc
+fi
+
+# --- Verify the value actually landed in RADOS -----------------------------
+# The round-trip test's WRITE issued a KV Store; the librados kvdev wrote it as
+# object oid=hex(key) in $KV_POOL/$KV_NS. Confirm it exists with the right size.
+echo "== RADOS verification: object must exist in $KV_POOL/$KV_NS =="
+echo "--- rados ls (grep for $OID_HEX) ---"
+ls_out="$(rados ls 2>/dev/null)"
+echo "$ls_out" | grep -F "$OID_HEX" || { echo "FAIL: oid $OID_HEX not in rados ls"; exit 1; }
+
+echo "--- rados stat $OID_HEX ---"
+stat_out="$(rados stat "$OID_HEX")"
+echo "$stat_out"
+
+# Parse the size from `rados stat` output ("... size <N> ...") and assert it
+# matches the stored value length.
+got_size="$(echo "$stat_out" | grep -oE 'size [0-9]+' | grep -oE '[0-9]+' | head -1)"
+if [[ "$got_size" != "$VAL_LEN" ]]; then
+    echo "FAIL: rados object size $got_size != expected stored value length $VAL_LEN"
+    exit 1
+fi
+echo "== RADOS object $OID_HEX present in $KV_POOL/$KV_NS, size=$got_size matches stored value length $VAL_LEN =="
+
+echo "run_roundtrip_rados: PASS"
+exit 0

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -29,6 +29,10 @@ unit_test_deps += [agent_unit_test_dep]
 subdir('descriptors')
 unit_test_deps += [descriptors_unit_test_dep]
 
+# RADOS_NKV key derivation is SPDK-free, so its unit test always builds/runs.
+subdir('rados-nkv')
+unit_test_deps += [rados_nkv_unit_test_dep]
+
 cpp = meson.get_compiler('cpp')
 azure_storage_blobs = cpp.find_library('azure-storage-blobs', required: false)
 if enabled_plugins.get('AZURE_BLOB') and azure_storage_blobs.found()

--- a/test/gtest/unit/rados-nkv/meson.build
+++ b/test/gtest/unit/rados-nkv/meson.build
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pure (SPDK-free) unit tests for the RADOS_NKV key derivation. Compiles the
+# key source directly so it builds and runs without the SPDK KV shim.
+rados_nkv_plugin_dir = '../../../../src/plugins/rados-nkv'
+rados_nkv_unit_test_dep = declare_dependency(
+    sources: [
+        'test_rados_nkv_key.cpp',
+        rados_nkv_plugin_dir / 'rados_nkv_key.cpp',
+    ],
+    include_directories: [
+        nixl_inc_dirs, utils_inc_dirs,
+        rados_nkv_plugin_dir,
+    ],
+)

--- a/test/gtest/unit/rados-nkv/test_rados_nkv_key.cpp
+++ b/test/gtest/unit/rados-nkv/test_rados_nkv_key.cpp
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 IBM Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Unit tests for radosNkvDeriveKey, the RADOS_NKV plugin's token-sequence ->
+// NVMe KV key hash. This is SPDK-free, so it runs in CI without a KV target.
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "rados_nkv_key.h"
+
+namespace {
+
+std::string
+toHex(const std::vector<uint8_t> &bytes) {
+    static const char *digits = "0123456789abcdef";
+    std::string s;
+    s.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) {
+        s.push_back(digits[b >> 4]);
+        s.push_back(digits[b & 0x0f]);
+    }
+    return s;
+}
+
+// Known-answer vector: pins the 128-bit FNV-1a algorithm so it cannot change
+// silently. run_roundtrip_rados.sh reproduces this hash in Python to compute
+// the expected RADOS object id; the two MUST agree.
+TEST(RadosNkvKey, KnownAnswerVector) {
+    std::vector<uint8_t> key;
+    ASSERT_TRUE(radosNkvDeriveKey("nixl-key-0000001", 16, key));
+    EXPECT_EQ(key.size(), 16u);
+    EXPECT_EQ(toHex(key), "1e693b52e8fadc63d197f78380a9f974");
+}
+
+TEST(RadosNkvKey, Deterministic) {
+    std::vector<uint8_t> a, b;
+    ASSERT_TRUE(radosNkvDeriveKey("the-same-sequence", 16, a));
+    ASSERT_TRUE(radosNkvDeriveKey("the-same-sequence", 16, b));
+    EXPECT_EQ(a, b);
+}
+
+TEST(RadosNkvKey, DistinctSequencesDeriveDistinctKeys) {
+    std::vector<uint8_t> a, b;
+    ASSERT_TRUE(radosNkvDeriveKey("sequence-a", 16, a));
+    ASSERT_TRUE(radosNkvDeriveKey("sequence-b", 16, b));
+    EXPECT_NE(a, b);
+}
+
+TEST(RadosNkvKey, ArbitraryLengthAccepted) {
+    // No over-length restriction: a long token sequence still yields a key.
+    std::vector<uint8_t> key;
+    ASSERT_TRUE(radosNkvDeriveKey(std::string(64 * 1024, 'x'), 16, key));
+    EXPECT_EQ(key.size(), 16u);
+}
+
+TEST(RadosNkvKey, TruncatesToKeyLen) {
+    std::vector<uint8_t> full, eight;
+    ASSERT_TRUE(radosNkvDeriveKey("clamp-me", 16, full));
+    ASSERT_TRUE(radosNkvDeriveKey("clamp-me", 8, eight));
+    EXPECT_EQ(eight.size(), 8u);
+    // Truncation keeps the leading bytes of the big-endian hash.
+    EXPECT_TRUE(std::equal(eight.begin(), eight.end(), full.begin()));
+}
+
+TEST(RadosNkvKey, KeyLenAboveMaxIsClampedTo16) {
+    std::vector<uint8_t> key;
+    ASSERT_TRUE(radosNkvDeriveKey("seq", 255, key));
+    EXPECT_EQ(key.size(), 16u);
+}
+
+TEST(RadosNkvKey, EmptySequenceRejected) {
+    std::vector<uint8_t> key;
+    EXPECT_FALSE(radosNkvDeriveKey("", 16, key));
+}
+
+TEST(RadosNkvKey, ZeroKeyLenRejected) {
+    std::vector<uint8_t> key;
+    EXPECT_FALSE(radosNkvDeriveKey("seq", 0, key));
+}
+
+} // namespace


### PR DESCRIPTION
## What?

Adds a new NIXL backend plugin, **`RADOS_NKV`** (`src/plugins/rados-nkv`),
that maps NIXL transfers onto the **NVMe Key-Value (KV) command set** through
an in-process SPDK KV host shim (`kv_host_shim.{h,c}`):

- `NIXL_WRITE` (local `DRAM_SEG` -> remote `OBJ_SEG`) -> KV **Store**
- `NIXL_READ` (remote `OBJ_SEG` -> local `DRAM_SEG`) -> KV **Retrieve**
- `queryMem` (lookup / cache hit-miss, remote `OBJ_SEG`) -> KV **Exist**

The memory-type shape mirrors the OBJ plugin (DRAM source, key-addressed
`OBJ_SEG` remote), so the plugin slots into NIXL's existing descriptor model.
The KV namespace on the SPDK target is **backend-agnostic**: the same plugin
and tests run unchanged against an in-memory `kvdev` or a **librados-backed**
`kvdev` (real Ceph/RADOS), where each stored value lands as an object in a
Ceph pool/namespace -- hence `rados-nkv` (RADOS over NVMe-KV).

## Why?

NIXL needs a path to move value blobs (e.g. LLM KV-cache pages) to and from
NVMe Key-Value storage, and -- via a librados-backed KV namespace -- to
Ceph/RADOS. Expressing this as the NVMe KV command set lets the existing NIXL
lookup path (`agent.query_memory()` -> backend `queryMem`, the llm-d cache
hit/miss probe) and the WRITE/READ transfer path reuse one backend, addressed
by an opaque token sequence rather than a fixed object name.

> This is a new, self-contained storage backend; it does not change any
> existing plugin or core behavior beyond the additive build/registration
> wiring described below. Happy to open a tracking issue for design
> discussion if the maintainers prefer.

## How?

### Key derivation (token sequence -> NVMe KV key)

The remote `OBJ_SEG` descriptor carries an arbitrary-length **token sequence**
in its `metaInfo` blob (the same channel OBJ uses for an object key). The
engine derives the fixed-length NVMe KV key as a **128-bit FNV-1a hash** of
those bytes (`radosNkvDeriveKey`), truncated to `min(16, kvkml)` where `kvkml`
is the namespace-advertised max key length (a namespace advertising
`kvkml == 0` falls back to 16). This:

- removes any restriction on token-sequence length (no over-length rejection
  or aliasing);
- keys off the descriptor's `metaInfo`, mirroring OBJ, so the key is **never
  coupled to `devId`**;
- stores the derived key in the per-descriptor metadata, and `postXfer` reads
  it back from the descriptor (`metadataP`) rather than any side table.

`radosNkvDeriveKey` is isolated in `rados_nkv_key.{h,cpp}` with **no SPDK
dependency**, so it is unit-testable without a KV target and can be reproduced
by tooling (the RADOS round-trip script recomputes the same hash to find the
expected object id).

### Transfer + lookup semantics

- `postXfer` stages value data through a per-request SPDK-DMA buffer and issues
  Store/Retrieve synchronously, so `checkXfer` reports completion inline.
- A `NIXL_READ` whose stored value length differs from the requested transfer
  length is **rejected** (`NIXL_ERR_BACKEND`) rather than silently truncated
  or zero-padded.
- `queryMem` follows OBJ's result convention: present => engaged response,
  absent => `std::nullopt`, transport error => `NIXL_ERR_BACKEND` (a backend
  failure is never masked as a cache miss).

### Custom backend params (`nixl_b_params_t`)

- **`vfu_addr`** (required) -- VFIOUSER transport directory for the SPDK KV
  target. Aliases: `socket`, `vfio_user_path`, `device`.
- **`nsid`** (optional, default `0`) -- NVMe namespace id; `0`/unset
  auto-selects the first KV namespace.
- **`init_env`** (optional bool, default `false`) -- `false`: the host/agent
  owns the SPDK env (multiple engines per process); `true`: the shim brings up
  a private no-hugepage env (standalone tests).

### Build wiring

- `meson.build` / `src/plugins/meson.build` / `meson_options.txt`: register
  the `RADOS_NKV` plugin; add `spdk_root`, `spdk_kv_shim_dir`,
  `rados_nkv_build_test` options; gate the Python bindings behind
  `build_python_bindings`.
- `src/plugins/rados-nkv/meson.build`: compile `kv_host_shim.c` into a static
  lib and link the SPDK nvme + env_dpdk + DPDK + isa-l static archives; SPDK
  include dirs are on the plugin/test compile path. The plugin is **skipped
  automatically** (`subdir_done`) when the SPDK shim / `libspdk_nvme.a` are
  not present, so it never breaks a default build.
- Static builds (`-Dstatic_plugins=RADOS_NKV`): `src/core/meson.build` links
  the plugin interface (guarded by `is_variable`, since the plugin is gated on
  the SPDK shim) and `nixl_plugin_manager` registers the static plugin.

### Testing

- **`test/gtest/unit/rados-nkv/`** -- SPDK-free GoogleTest for
  `radosNkvDeriveKey` (known-answer vector, determinism, distinct and
  arbitrary-length inputs, truncation, empty/zero rejection). Always built;
  runs in the standard `ninja -C build test` unit suite **without SPDK**.
- **`rados_nkv_roundtrip_test.cpp`** -- instantiates the engine directly and
  does WRITE -> READ (byte-for-byte verify), `queryMem` PRESENT/ABSENT, a
  key-derivation check, and a short-read check (a length-mismatched READ must
  error, not truncate).
- **`run_roundtrip.sh`** (in-memory kvdev) and **`run_roundtrip_rados.sh`**
  (librados kvdev -- also asserts the value lands as a Ceph object,
  recomputing the object id from the derived-key hash) bring up an SPDK
  `nvmf_tgt` KV namespace over VFIOUSER and run the test. `SPDK_ROOT` and the
  Ceph config/keyring/`rados` paths are overridable via environment.

**Verified locally**: built against an SPDK tree and ran `run_roundtrip.sh`
end-to-end (`rados_nkv_roundtrip_test: PASS`, including the short-read
rejection); the SPDK-free key gtest passes; the static-plugin path compiles
and exposes `createStaticRADOS_NKVPlugin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RADOS_NKV backend plugin for NVMe Key-Value operations (SPDK-backed) and a direct-engine round-trip test

* **Chores**
  * New build options to configure SPDK paths, shim location, and test build toggle; build now conditionally includes Python bindings and the RADOS_NKV plugin

* **Documentation**
  * Comprehensive RADOS_NKV README with API, build/runtime instructions, and examples

* **Tests**
  * Unit tests for key derivation and integration round-trip test harness/scripts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->