### PR TITLE
ucx: warn when registered CUDA memory is not legacy IPC-capable

### DIFF
--- a/src/plugins/ucx/README.md
+++ b/src/plugins/ucx/README.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NIXL UCX Plugin
+
+This plugin provides the default communication backend for NIXL using
+[UCX](https://github.com/openucx/ucx). It supports both DRAM (`DRAM_SEG`) and
+GPU (`VRAM_SEG`) memory, and selects the best available transport for each
+transfer: RDMA (InfiniBand/RoCE) and `cuda_ipc` for intra-node GPU-to-GPU
+transfers, falling back to TCP where nothing faster is available.
+
+## Known limitations
+
+### PyTorch `expandable_segments:True` / CUDA VMM memory falls back to the slow path
+
+CUDA buffers allocated through the CUDA Virtual Memory Management API
+(`cuMemCreate` / `cuMemMap`) — which is what PyTorch uses when
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` is set — **cannot be exported
+through the legacy `cuIpcGetMemHandle` mechanism** that UCX's `cuda_ipc`
+transport relies on.
+
+Such regions still register successfully with NIXL. However, on an intra-node
+transfer where `cuda_ipc` would otherwise be used (e.g. two processes on the
+same node sharing GPUs over NVLink) and **no RDMA NIC is available as an
+alternative**, UCX silently falls back to its software-emulated path over TCP.
+The data stays correct, but throughput can drop by orders of magnitude (e.g.
+from hundreds of GB/s on `cuda_ipc` to well under 1 GB/s on the emulated path).
+Because the fallback is silent and the result is correct, this is difficult to
+diagnose in production.
+
+This commonly affects RL / large-model training and inference colocation
+setups, where `expandable_segments:True` is a popular fragmentation-mitigation
+setting and trainer/inference processes are colocated on a single node.
+
+The UCX plugin emits a one-time `NIXL_WARN` when it registers a CUDA region
+that is not legacy CUDA IPC-capable, naming the region and the consequence.
+Warnings are visible at the default log level.
+
+> UCX can share CUDA VMM memory across processes via *fabric handles*, but that
+> requires fabric-enabled allocations plus IMEX, which PyTorch does not produce
+> and which is unavailable on most deployments. See
+> [ai-dynamo/nixl#1754](https://github.com/ai-dynamo/nixl/issues/1754) for the
+> tracking issue, which also covers supporting POSIX-FD VMM handles intra-node.
+
+#### Workaround
+
+Allocate the buffer that NIXL registers and transfers **outside** expandable
+segments, so it comes from a plain `cudaMalloc` allocation that `cuda_ipc` can
+export:
+
+```python
+import torch
+
+# Carve the NIXL transfer/staging buffer out of a non-expandable allocation.
+torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+bucket = torch.empty(nbytes, dtype=torch.uint8, device="cuda")
+torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+```
+
+This restores the `cuda_ipc` zero-copy fast path for the registered buffer while
+leaving the rest of the process on expandable segments.
+
+## Troubleshooting
+
+Enable UCX and NIXL logging to inspect transport selection:
+
+```bash
+# Print the protocol/transport UCX selects for each operation.
+export UCX_PROTO_INFO=y
+
+# NIXL debug logging.
+export NIXL_LOG_LEVEL=debug
+```
+
+With `UCX_PROTO_INFO=y`, a healthy intra-node GPU transfer reports
+`zero-copy | cuda_ipc/cuda`, whereas the degraded fallback described above
+reports `software emulation | tcp/...`.

--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -32,6 +32,14 @@ ucx_backend_dependencies = [asio_dep,
                             thread_dep,
                             ucx_dep]
 
+ucx_backend_cpp_args = []
+
+# CUDA driver API, used to warn when registered VRAM cannot take the cuda_ipc fast path.
+if cuda_dep.found()
+    ucx_backend_dependencies += [cuda_dep]
+    ucx_backend_cpp_args += ['-DHAVE_CUDA']
+endif
+
 ucx_backend_include_directories = [nixl_inc_dirs,
                                    utils_inc_dirs]
 
@@ -41,6 +49,7 @@ if 'UCX' in static_plugins
                dependencies: ucx_backend_dependencies,
                include_directories: ucx_backend_include_directories,
                install: false,
+               cpp_args : ucx_backend_cpp_args,
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     ucx_backend_lib = shared_library('UCX',
@@ -48,7 +57,7 @@ else
                dependencies: ucx_backend_dependencies,
                include_directories: ucx_backend_include_directories,
                install: true,
-               cpp_args : ['-fPIC'],
+               cpp_args : ucx_backend_cpp_args + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir,
                build_rpath: get_option('ucx_path') != '' ? get_option('ucx_path') + '/lib' : '',

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -18,6 +18,7 @@
 #include "ucx_utils.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstring>
 #include <exception>
 #include <stdexcept>
@@ -30,6 +31,10 @@
 #include "common/nixl_log.h"
 #include "config.h"
 #include "serdes/serdes.h"
+
+#ifdef HAVE_CUDA
+#include <cuda.h>
+#endif
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {
@@ -543,6 +548,40 @@ nixlUcxWorker::connect(void *addr, std::size_t size) {
  * Memory management
  * =========================================== */
 
+#ifdef HAVE_CUDA
+namespace {
+// CUDA VMM allocations (cuMemCreate/cuMemMap, e.g. PyTorch's
+// expandable_segments:True) cannot be exported through the legacy
+// cuIpcGetMemHandle mechanism that UCX's cuda_ipc transport relies on, so
+// intra-node transfers silently degrade to UCX's software-emulated path when
+// no RDMA NIC is available. Warn once at registration so the degradation is
+// diagnosable. See README.md.
+void
+warnIfNotCudaIpcCapable(const void *addr, size_t size) {
+    int is_legacy_ipc_capable = 0;
+    const CUresult status = cuPointerGetAttribute(&is_legacy_ipc_capable,
+                                                  CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE,
+                                                  reinterpret_cast<CUdeviceptr>(addr));
+    if (status != CUDA_SUCCESS || is_legacy_ipc_capable) {
+        return;
+    }
+
+    static std::atomic<bool> warned{false};
+    if (warned.exchange(true)) {
+        return;
+    }
+
+    NIXL_WARN << "Registered CUDA region at " << addr << " (" << size
+              << " bytes) is not legacy CUDA IPC-capable (e.g. PyTorch "
+                 "expandable_segments:True / CUDA VMM allocations). UCX cannot "
+                 "export it through the cuda_ipc transport, so intra-node "
+                 "transfers with no RDMA NIC available fall back to UCX's slow "
+                 "software-emulated path instead of the cuda_ipc zero-copy path. "
+                 "Allocate the transfer buffer with expandable_segments disabled "
+                 "to keep the fast path. See src/plugins/ucx/README.md.";
+}
+} // namespace
+#endif
 
 int
 nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl_mem_type) {
@@ -579,6 +618,12 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
             ucp_mem_unmap(ctx, mem.memh);
             return -1;
         }
+
+#ifdef HAVE_CUDA
+        if (attr.mem_type == UCS_MEMORY_TYPE_CUDA) {
+            warnIfNotCudaIpcCapable(addr, size);
+        }
+#endif
     }
 
     return 0;


### PR DESCRIPTION
## What?

Make the UCX plugin warn when it registers a CUDA region that cannot use the
`cuda_ipc` fast path, and document the limitation.

- `ucx_utils.cpp`: in `nixlUcxContext::memReg`, when registering `VRAM_SEG`,
  query `CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE` via
  `cuPointerGetAttribute`. If the region is not legacy-CUDA-IPC-capable, emit a
  one-time `NIXL_WARN` naming the region and the consequence.
- `meson.build`: link `cuda_dep` into the UCX plugin and define `HAVE_CUDA`,
  gated on `cuda_dep.found()` so non-CUDA builds are unaffected. The new code is
  entirely under `#ifdef HAVE_CUDA`.
- `src/plugins/ucx/README.md` (new): document the limitation, the
  `UCX_PROTO_INFO=y` diagnostic, and the workaround. The UCX plugin was the only
  major plugin without a README.

## Why?

Fixes the silent-degradation half of #1754.

CUDA buffers allocated via the CUDA VMM API (`cuMemCreate`/`cuMemMap`) — what
PyTorch produces under `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` —
cannot be exported through the legacy `cuIpcGetMemHandle` mechanism that UCX's
`cuda_ipc` transport relies on. Registration still succeeds, but an intra-node
transfer that would otherwise use `cuda_ipc`, with no RDMA NIC available as an
alternative, silently falls back to UCX's software-emulated path over TCP. The
data stays correct while throughput collapses (we measured ~200 GB/s on
`cuda_ipc` vs ~0.3 GB/s on the emulated path, same-node H100/NVLink).
`expandable_segments:True` is a very common large-model-training setting, so
this trap is broadly armed — and with no log anywhere it cost us days to
diagnose. A one-line warning at registration time turns a silent ~600x
slowdown into something immediately diagnosable.

This is request #1 (loud failure) + request #3 (documentation) from #1754.
Request #2 (intra-node POSIX-FD VMM IPC support) is a larger feature I'd like to
discuss in the issue first, per CONTRIBUTING.

## How?

`CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE` returns 0 for VMM/expandable
allocations and 1 for plain `cudaMalloc` allocations, so it precisely
distinguishes the two cases at registration time. The warning:

- fires only for `UCS_MEMORY_TYPE_CUDA` regions that report not-IPC-capable;
- is emitted at most once per process (`std::atomic<bool>` guard) to avoid spam;
- is phrased conditionally ("intra-node transfers with no RDMA NIC available
  fall back...") because VMM memory still registers and transfers fine over an
  RDMA NIC when one is present — the slow path only bites when `cuda_ipc` is the
  only fast lane;
- silently skips if `cuPointerGetAttribute` fails, so it can never break
  registration.

Detection example (UCX's `UCX_PROTO_INFO=y`): a healthy intra-node GPU READ
reports `zero-copy | cuda_ipc/cuda`; the degraded fallback reports
`software emulation | tcp/...`.

### Testing note

I don't have a CUDA/GPU machine to build or run on, so the `HAVE_CUDA` path has
not been compiled or exercised locally — I'm relying on CI for the build and
would appreciate a maintainer sanity-check on a GPU box. The change follows the
existing CUDA-driver-API usage pattern in the libfabric plugin
(`cuPointerGetAttributes`, `#ifdef HAVE_CUDA`, `cuda_dep` wiring). I'm also happy
to share the self-contained ~150-line repro scripts from #1754 for validating
the warning fires on `expandable_segments:True` memory and stays silent on
`cudaMalloc` memory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive UCX plugin README covering supported memory types, transport selection, CUDA-related limitations, troubleshooting steps, diagnostic environment variables, expected log-path differences, and a recommended workaround for affected allocations.

* **Improvements**
  * Build now enables CUDA support for the UCX plugin when available.
  * Emits a one-time per-process warning when non-legacy CUDA allocations are registered to surface cases that may fall back to slower TCP paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->