### PR TITLE
feat(kv): add shared KV backend interfaces under src/plugins/kv

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -439,7 +439,7 @@ if get_option('buildtype') == 'debug'
     run_command('truncate', '-s 0', plugfile, check: true)
 endif
 
-nixl_inc_dirs = include_directories('src/api/cpp', 'src/api/cpp/backend', 'src/infra', 'src/core', 'src/core/telemetry')
+nixl_inc_dirs = include_directories('src/api/cpp', 'src/api/cpp/backend', 'src/infra', 'src/core', 'src/core/telemetry', 'src/plugins/kv')
 nixl_gpu_inc_dirs = include_directories('src/api/gpu/ucx')
 plugins_inc_dirs = include_directories('src/plugins')
 utils_inc_dirs = include_directories('src/utils')
@@ -469,6 +469,9 @@ if get_option('install_headers')
   install_headers('src/core/transfer_request.h', install_dir: prefix_inc)
   install_headers('src/core/agent_data.h', install_dir: prefix_inc)
   install_headers('src/infra/mem_section.h', install_dir: prefix_inc)
+  install_headers('src/plugins/kv/kv_store.h', install_dir: prefix_inc + '/plugins/kv')
+  install_headers('src/plugins/kv/kv_engine_impl.h', install_dir: prefix_inc + '/plugins/kv')
+  install_headers('src/plugins/kv/kv_engine.h', install_dir: prefix_inc + '/plugins/kv')
   install_headers('src/core/telemetry/telemetry_event.h', install_dir: prefix_inc)
 
   if ucx_gpu_device_api_available

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine.cpp
+ * @brief nixlKVEngine delegation layer; forwards nixlBackendEngine calls to impl_.
+ */
+
+#include "kv_engine.h"
+
+nixlKVEngine::nixlKVEngine(const nixlBackendInitParams *init_params,
+                           std::unique_ptr<nixlKVEngineImpl> impl)
+    : nixlBackendEngine(init_params),
+      impl_(std::move(impl)) {}
+
+nixlKVEngine::~nixlKVEngine() = default;
+
+nixl_mem_list_t
+nixlKVEngine::getSupportedMems() const {
+    return impl_->getSupportedMems();
+}
+
+nixl_status_t
+nixlKVEngine::registerMem(const nixlBlobDesc &mem,
+                          const nixl_mem_t &nixl_mem,
+                          nixlBackendMD *&out) {
+    return impl_->registerMem(mem, nixl_mem, out);
+}
+
+nixl_status_t
+nixlKVEngine::deregisterMem(nixlBackendMD *meta) {
+    return impl_->deregisterMem(meta);
+}
+
+nixl_status_t
+nixlKVEngine::queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const {
+    return impl_->queryMem(descs, resp);
+}
+
+nixl_status_t
+nixlKVEngine::prepXfer(const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       const std::string &remote_agent,
+                       nixlBackendReqH *&handle,
+                       const nixl_opt_b_args_t *opt_args) const {
+    return impl_->prepXfer(operation, local, remote, remote_agent, localAgent, handle, opt_args);
+}
+
+nixl_status_t
+nixlKVEngine::postXfer(const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       const std::string &remote_agent,
+                       nixlBackendReqH *&handle,
+                       const nixl_opt_b_args_t *opt_args) const {
+    return impl_->postXfer(operation, local, remote, remote_agent, handle, opt_args);
+}
+
+nixl_status_t
+nixlKVEngine::checkXfer(nixlBackendReqH *handle) const {
+    return impl_->checkXfer(handle);
+}
+
+nixl_status_t
+nixlKVEngine::releaseReqH(nixlBackendReqH *handle) const {
+    return impl_->releaseReqH(handle);
+}

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -71,7 +71,7 @@ nixlKVEngine::postXfer(const nixl_xfer_op_t &operation,
                        const std::string &remote_agent,
                        nixlBackendReqH *&handle,
                        const nixl_opt_b_args_t *opt_args) const {
-    return impl_->postXfer(operation, local, remote, remote_agent, handle, opt_args);
+    return impl_->postXfer(operation, local, remote, remote_agent, localAgent, handle, opt_args);
 }
 
 nixl_status_t

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -21,11 +21,14 @@
  */
 
 #include "kv_engine.h"
+#include <cassert>
 
 nixlKVEngine::nixlKVEngine(const nixlBackendInitParams *init_params,
                            std::unique_ptr<nixlKVEngineImpl> impl)
     : nixlBackendEngine(init_params),
-      impl_(std::move(impl)) {}
+      impl_(std::move(impl)) {
+    assert(impl_ && "nixlKVEngine requires a non-null nixlKVEngineImpl");
+}
 
 nixlKVEngine::~nixlKVEngine() = default;
 

--- a/src/plugins/kv/kv_engine.h
+++ b/src/plugins/kv/kv_engine.h
@@ -26,8 +26,8 @@
  * register the resulting engine with nixlBackendPluginCreator.
  */
 
-#ifndef NIXL_KV_ENGINE_H
-#define NIXL_KV_ENGINE_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_ENGINE_H
+#define NIXL_SRC_PLUGINS_KV_KV_ENGINE_H
 
 #include "kv_engine_impl.h"
 #include <memory>
@@ -92,8 +92,18 @@ public:
         return NIXL_SUCCESS;
     }
 
+    /**
+     * @brief Passes local metadata through unchanged.
+     *
+     * Local-only KV backends do not transform metadata. input must be the
+     * nixlBackendMD* returned by registerMem().
+     */
     nixl_status_t
     loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        if (input == nullptr) {
+            output = nullptr;
+            return NIXL_ERR_INVALID_PARAM;
+        }
         output = input;
         return NIXL_SUCCESS;
     }
@@ -124,4 +134,4 @@ private:
     std::unique_ptr<nixlKVEngineImpl> impl_;
 };
 
-#endif // NIXL_KV_ENGINE_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_ENGINE_H

--- a/src/plugins/kv/kv_engine.h
+++ b/src/plugins/kv/kv_engine.h
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine.h
+ * @brief Shared thin wrapper base class for KV-style NIXL backend engines.
+ *
+ * nixlKVEngine implements nixlBackendEngine and forwards all data-plane calls
+ * to a nixlKVEngineImpl instance supplied by each plugin.
+ *
+ * Plugin authors subclass nixlKVEngine (or use it directly with a factory) and
+ * register the resulting engine with nixlBackendPluginCreator.
+ */
+
+#ifndef NIXL_KV_ENGINE_H
+#define NIXL_KV_ENGINE_H
+
+#include "kv_engine_impl.h"
+#include <memory>
+
+/**
+ * @class nixlKVEngine
+ * @brief Thin nixlBackendEngine wrapper that delegates to nixlKVEngineImpl.
+ *
+ * Common KV backend capabilities (local-only, no notifications) are declared here
+ * so individual plugins only need to supply a concrete nixlKVEngineImpl.
+ */
+class nixlKVEngine : public nixlBackendEngine {
+public:
+    /**
+     * @brief Construct a KV engine with a plugin-specific implementation.
+     * @param init_params NIXL initialization parameters.
+     * @param impl Concrete nixlKVEngineImpl (ownership transferred).
+     */
+    nixlKVEngine(const nixlBackendInitParams *init_params, std::unique_ptr<nixlKVEngineImpl> impl);
+
+    ~nixlKVEngine() override;
+
+    bool
+    supportsRemote() const override {
+        return false;
+    }
+
+    bool
+    supportsLocal() const override {
+        return true;
+    }
+
+    bool
+    supportsNotif() const override {
+        return false;
+    }
+
+    nixl_mem_list_t
+    getSupportedMems() const override;
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    connect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    disconnect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    unloadMD(nixlBackendMD *input) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        output = input;
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+private:
+    std::unique_ptr<nixlKVEngineImpl> impl_;
+};
+
+#endif // NIXL_KV_ENGINE_H

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -54,7 +54,8 @@ class nixlKVEngineImpl {
 public:
     virtual ~nixlKVEngineImpl() = default;
 
-    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically DRAM_SEG). */
+    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically
+     * DRAM_SEG). */
     virtual nixl_mem_list_t
     getSupportedMems() const = 0;
 

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -35,8 +35,8 @@
  * on NIXL descriptor/key mapping while iKVStore handles put/get/exists.
  */
 
-#ifndef NIXL_KV_ENGINE_IMPL_H
-#define NIXL_KV_ENGINE_IMPL_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H
+#define NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H
 
 #include "backend/backend_engine.h"
 #include <string>
@@ -97,4 +97,4 @@ public:
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };
 
-#endif // NIXL_KV_ENGINE_IMPL_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -54,24 +54,54 @@ class nixlKVEngineImpl {
 public:
     virtual ~nixlKVEngineImpl() = default;
 
-    /** @return Memory segment types supported by this KV backend (typically DRAM_SEG). */
+    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically DRAM_SEG). */
     virtual nixl_mem_list_t
     getSupportedMems() const = 0;
 
+    /**
+     * @brief Registers a local memory descriptor as a KV key.
+     *
+     * @param mem Descriptor blob including key metadata (metaInfo or devId).
+     * @param nixl_mem Memory segment type; must be supported by getSupportedMems().
+     * @param out On success, receives a newly allocated nixlBackendMD* owned by the caller
+     *            until deregisterMem().
+     * @return NIXL_SUCCESS on success, or an error status on invalid input or backend failure.
+     */
     virtual nixl_status_t
     registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) = 0;
 
+    /**
+     * @brief Deregisters backend metadata created by registerMem().
+     *
+     * @param meta Metadata pointer returned by registerMem(); must be non-null.
+     * @return NIXL_SUCCESS on success, or an error status if meta is invalid.
+     */
     virtual nixl_status_t
     deregisterMem(nixlBackendMD *meta) = 0;
 
+    /**
+     * @brief Queries whether registered keys exist in the backing store.
+     *
+     * @param descs Registered descriptors to query.
+     * @param resp Output vector; each entry is set when the key exists, or std::nullopt otherwise.
+     * @return NIXL_SUCCESS on success, or an error status on backend failure.
+     */
     virtual nixl_status_t
     queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const = 0;
 
     /**
-     * @brief Prepare a transfer request.
+     * @brief Prepares a transfer request and allocates a backend request handle.
      *
-     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     * @param operation Transfer operation (NIXL_WRITE or NIXL_READ).
+     * @param local Local descriptor metadata list.
+     * @param remote Remote descriptor metadata list.
+     * @param remote_agent Remote agent name (unused for local-only KV backends).
+     * @param local_agent Local agent name from nixlKVEngine::localAgent (passed explicitly
      *                    so impl does not depend on nixlBackendEngine protected members).
+     * @param handle On success, receives a newly allocated nixlBackendReqH* owned by the caller
+     *               until releaseReqH().
+     * @param opt_args Optional backend arguments; may be nullptr.
+     * @return NIXL_SUCCESS on success, or an error status on invalid parameters.
      */
     virtual nixl_status_t
     prepXfer(const nixl_xfer_op_t &operation,
@@ -83,10 +113,17 @@ public:
              const nixl_opt_b_args_t *opt_args) const = 0;
 
     /**
-     * @brief Execute a prepared transfer request.
+     * @brief Executes a prepared transfer request.
      *
-     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     * @param operation Transfer operation (NIXL_WRITE or NIXL_READ).
+     * @param local Local descriptor metadata list.
+     * @param remote Remote descriptor metadata list.
+     * @param remote_agent Remote agent name (unused for local-only KV backends).
+     * @param local_agent Local agent name from nixlKVEngine::localAgent (passed explicitly
      *                    so impl does not depend on nixlBackendEngine protected members).
+     * @param handle Request handle allocated by prepXfer(); must be non-null.
+     * @param opt_args Optional backend arguments; may be nullptr.
+     * @return NIXL_SUCCESS on success, or an error status on transfer or backend failure.
      */
     virtual nixl_status_t
     postXfer(const nixl_xfer_op_t &operation,
@@ -97,9 +134,21 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 
+    /**
+     * @brief Checks transfer completion status for a request handle.
+     *
+     * @param handle Request handle from prepXfer(); must be non-null.
+     * @return NIXL_SUCCESS when the transfer is complete, or an in-progress/error status.
+     */
     virtual nixl_status_t
     checkXfer(nixlBackendReqH *handle) const = 0;
 
+    /**
+     * @brief Releases a request handle allocated by prepXfer().
+     *
+     * @param handle Request handle to release; must be non-null.
+     * @return NIXL_SUCCESS on success.
+     */
     virtual nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -82,11 +82,18 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 
+    /**
+     * @brief Execute a prepared transfer request.
+     *
+     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     *                    so impl does not depend on nixlBackendEngine protected members).
+     */
     virtual nixl_status_t
     postXfer(const nixl_xfer_op_t &operation,
              const nixl_meta_dlist_t &local,
              const nixl_meta_dlist_t &remote,
              const std::string &remote_agent,
+             const std::string &local_agent,
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine_impl.h
+ * @brief Abstract implementation interface for KV-style NIXL backend engines.
+ *
+ * Architecture:
+ *
+ *   nixlBackendEngine          NIXL agent-facing protocol (registerMem, prepXfer, ...)
+ *        ^
+ *        |  nixlKVEngine        Thin wrapper; delegates lifecycle calls to impl_
+ *        |
+ *   nixlKVEngineImpl           Vendor/backend-specific logic (this header)
+ *        ^
+ *        |
+ *   nixlInMemKVEngineImpl      Example: in-process map via iKVStore
+ *   nixlRedisKVEngineImpl      Future: Redis via hiredis implementing iKVStore
+ *
+ * Storage is further factored through iKVStore (kv_store.h) so impl classes focus
+ * on NIXL descriptor/key mapping while iKVStore handles put/get/exists.
+ */
+
+#ifndef NIXL_KV_ENGINE_IMPL_H
+#define NIXL_KV_ENGINE_IMPL_H
+
+#include "backend/backend_engine.h"
+#include <string>
+#include <vector>
+
+/**
+ * @class nixlKVEngineImpl
+ * @brief Abstract implementation interface for KV-style backend engines.
+ *
+ * Each KV plugin (INMEMKV example, REDIS src plugin, etc.) provides a concrete
+ * subclass that implements register/deregister, query, and synchronous transfer
+ * operations against its chosen iKVStore backend.
+ */
+class nixlKVEngineImpl {
+public:
+    virtual ~nixlKVEngineImpl() = default;
+
+    /** @return Memory segment types supported by this KV backend (typically DRAM_SEG). */
+    virtual nixl_mem_list_t
+    getSupportedMems() const = 0;
+
+    virtual nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) = 0;
+
+    virtual nixl_status_t
+    deregisterMem(nixlBackendMD *meta) = 0;
+
+    virtual nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const = 0;
+
+    /**
+     * @brief Prepare a transfer request.
+     *
+     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     *                    so impl does not depend on nixlBackendEngine protected members).
+     */
+    virtual nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const = 0;
+
+    virtual nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const = 0;
+
+    virtual nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const = 0;
+
+    virtual nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const = 0;
+};
+
+#endif // NIXL_KV_ENGINE_IMPL_H

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -59,7 +59,7 @@ public:
      * @param buffer Output buffer for stored value bytes.
      * @param len Maximum number of bytes to read into buffer.
      * @param bytes_read Set to min(stored_len, len) on success.
-     * @return NIXL_SUCCESS on success, or NIXL_ERR_BACKEND when key does not exist.
+     * @return NIXL_SUCCESS on success, or NIXL_ERR_NOT_FOUND when key does not exist.
      */
     virtual nixl_status_t
     get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -23,8 +23,8 @@
  * backend-specific storage while sharing this synchronous put/get/exists API.
  */
 
-#ifndef NIXL_KV_STORE_H
-#define NIXL_KV_STORE_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_STORE_H
+#define NIXL_SRC_PLUGINS_KV_KV_STORE_H
 
 #include "nixl_types.h"
 #include <cstddef>
@@ -41,20 +41,37 @@ class iKVStore {
 public:
     virtual ~iKVStore() = default;
 
+    /**
+     * @brief Stores value bytes for key.
+     *
+     * @param key Storage key.
+     * @param data Pointer to value bytes to store.
+     * @param len Number of bytes to copy from data.
+     * @return NIXL_SUCCESS on success, or a backend error code on failure.
+     */
     virtual nixl_status_t
     put(std::string_view key, const uint8_t *data, size_t len) = 0;
 
     /**
      * @brief Reads value for key into buffer.
      *
-     * bytes_read is set to min(stored_len, len) on success.
-     * Returns NIXL_ERR_BACKEND when key does not exist.
+     * @param key Storage key.
+     * @param buffer Output buffer for stored value bytes.
+     * @param len Maximum number of bytes to read into buffer.
+     * @param bytes_read Set to min(stored_len, len) on success.
+     * @return NIXL_SUCCESS on success, or NIXL_ERR_BACKEND when key does not exist.
      */
     virtual nixl_status_t
     get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;
 
+    /**
+     * @brief Checks whether key is present in the store.
+     *
+     * @param key Storage key.
+     * @return true if key exists, false otherwise.
+     */
     virtual bool
     exists(std::string_view key) const = 0;
 };
 
-#endif // NIXL_KV_STORE_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_STORE_H

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_store.h
+ * @brief Shared minimal key-value storage interface for NIXL KV backends.
+ *
+ * Implementations (e.g. INMEMKV example plugin, REDIS src plugin) provide
+ * backend-specific storage while sharing this synchronous put/get/exists API.
+ */
+
+#ifndef NIXL_KV_STORE_H
+#define NIXL_KV_STORE_H
+
+#include "nixl_types.h"
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+/**
+ * @brief Minimal key-value storage interface for KV-style NIXL backends.
+ *
+ * This interface intentionally keeps only the smallest synchronous API
+ * needed by current KV backend flows (INMEMKV, REDIS, etc.).
+ */
+class iKVStore {
+public:
+    virtual ~iKVStore() = default;
+
+    virtual nixl_status_t
+    put(std::string_view key, const uint8_t *data, size_t len) = 0;
+
+    /**
+     * @brief Reads value for key into buffer.
+     *
+     * bytes_read is set to min(stored_len, len) on success.
+     * Returns NIXL_ERR_BACKEND when key does not exist.
+     */
+    virtual nixl_status_t
+    get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;
+
+    virtual bool
+    exists(std::string_view key) const = 0;
+};
+
+#endif // NIXL_KV_STORE_H


### PR DESCRIPTION
## What?
Introduce shared KV backend interfaces under src/plugins/kv/:

kv_store.h — iKVStore storage abstraction (put, get, exists)
kv_engine_impl.h — nixlKVEngineImpl abstract backend logic interface
kv_engine.h / kv_engine.cpp — nixlKVEngine thin nixlBackendEngine wrapper that delegates data-plane calls to impl_
Also updates meson.build to add src/plugins/kv to include paths and install the new public headers under include/nixl/plugins/kv/.

This is PR 1 of 3. It adds interfaces and the shared delegation layer only — no plugin behavior changes. INMEMKV and REDIS plugin work will follow in separate PRs.

## Why?
NIXL needs a consistent way to add KV-style backends (in-memory, Redis, etc.). These backends share the same NIXL lifecycle (registerMem, prepXfer, postXfer, …) but differ in how they store data.

Without shared interfaces, each plugin would duplicate the same nixlBackendEngine boilerplate (capability flags, connect/disconnect no-ops, delegation wiring). Centralizing that in src/plugins/kv/ gives future KV plugins a clear, reusable foundation.

## How?
Three-layer design:

nixlKVEngine              Shared thin wrapper (nixlBackendEngine)
    -> nixlKVEngineImpl   Plugin-specific logic (subclass per backend)
        -> iKVStore       Storage backend (in-memory, Redis, etc.)
nixlKVEngine owns common KV backend traits:

- local-only (supportsLocal() == true)

- no remote connection (supportsRemote() == false)

- no notifications (supportsNotif() == false)

All data-plane methods forward to a std::unique_ptr<nixlKVEngineImpl> impl_ supplied at construction time.

nixlKVEngineImpl defines the contract each KV plugin must implement: registerMem, deregisterMem, queryMem, prepXfer, postXfer, checkXfer, releaseReqH. prepXfer receives local_agent explicitly so impl classes do not depend on nixlBackendEngine protected members.

iKVStore isolates raw storage (put/get/exists) from NIXL descriptor-to-key mapping, which stays in the concrete nixlKVEngineImpl subclass.

Follow-up PRs:

PR	Scope
#2	Refactor INMEMKV example plugin onto these interfaces
#3	Add REDIS KV plugin (nixlRedisKVEngineImpl + hiredis iKVStore)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KV backend support: a KV engine wrapper, a plugin-facing KV engine interface, and a minimal synchronous KV store API to handle memory registration/deregistration, queries, and transfer lifecycle operations.
  * KV engine is declared local-only and provides standard engine entrypoints for plugins.

* **Chores**
  * KV plugin include directory exposed and public KV headers are installed into the include tree for plugin integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->