### PR TITLE
Fix deregister backend status

### DIFF
--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -21,6 +21,7 @@
 #include "nixl_descriptors.h"
 #include "mem_section.h"
 #include "backend/backend_engine.h"
+#include "common/nixl_log.h"
 #include "nixl_types.h"
 #include "serdes/serdes.h"
 
@@ -234,7 +235,10 @@ nixl_status_t nixlLocalSection::remDescList (const nixl_reg_dlist_t &mem_elms,
     }
 
     for (size_t idx : indices) {
-        backend->deregisterMem(target[idx].metadataP);
+        const nixl_status_t ret = backend->deregisterMem(target[idx].metadataP);
+        if (ret != NIXL_SUCCESS) {
+            NIXL_WARN << "backend deregisterMem failed with status " << ret;
+        }
     }
 
     target.remDescs(std::move(indices));

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -270,6 +270,26 @@ namespace agent {
         EXPECT_EQ(agent_->deregisterMem(reg_dlist, &extra_params), NIXL_SUCCESS);
     }
 
+    TEST_P(singleAgentWithMemParamFixture, DeregisterMemoryIgnoresBackendFailure) {
+        using testing::_;
+        using testing::Return;
+
+        nixl_b_params_t params;
+        nixlBackendH *backend;
+        EXPECT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        blob blob;
+        nixl_opt_args_t extra_params;
+        nixl_reg_dlist_t reg_dlist(GetParam());
+        EXPECT_EQ(agent_helper_->initAndRegisterMemory(blob, reg_dlist, extra_params, backend),
+                  NIXL_SUCCESS);
+
+        auto &engine = const_cast<mocks::GMockBackendEngine &>(agent_helper_->getGMockEngine());
+        EXPECT_CALL(engine, deregisterMem(_)).WillOnce(Return(NIXL_ERR_BACKEND));
+
+        EXPECT_EQ(agent_->deregisterMem(reg_dlist, &extra_params), NIXL_SUCCESS);
+    }
+
     TEST_F(singleAgentSessionFixture, RegisterDeregisterMemRepeatedTest) {
         constexpr int kWarmupIters = 3;
         constexpr int kTimedIters = 64;


### PR DESCRIPTION
Fix https://github.com/ai-dynamo/nixl/issues/1758

## What?

Fix `nixlLocalSection::remDescList()` backend deregistration failures are propagated instead of being ignored.

The change removes descriptors from the internal section list only when their corresponding `backend->deregisterMem()` call succeeds. If any backend deregistration fails, the function returns that failure status.

## Why?
Before this change, `remDescList()` called `backend->deregisterMem()` but ignored the returned status:

```cpp
for (size_t idx : indices) {
    backend->deregisterMem(target[idx].metadataP);
}

target.remDescs(std::move(indices));
return NIXL_SUCCESS;
```
This allowed `nixlAgent::deregisterMem()` to report `NIXL_SUCCESS` even when the backend failed to deregister one or more metadata objects.

## How?
The fix records the result of each backend deregistration call:

For each descriptor:

- if backend deregistration succeeds, its index is added to a list of descriptors to remove;

- if backend deregistration fails, its index is not removed and the failure status is recorded.

After all attempts complete:

- successfully deregistered descriptors are removed from the section list;

- failed descriptors remain registered internally;

- the function returns the recorded failure status if any deregistration failed, otherwise `NIXL_SUCCESS`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deregistration now logs a warning when a backend deregistration attempt fails but continues processing remaining descriptors and reports overall success to callers.

* **Tests**
  * Added a unit test verifying that a backend deregistration failure is ignored and that the deregistration call still returns success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->