### PR TITLE
CI/WA: disable UCX direct-NIC on DL CPP test to avoid dmabuf 524

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -176,7 +176,8 @@ steps:
       credentialsId: "${SSH_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
       slurmEnv: [
-        'UCX_IB_REG_METHODS=rcache'
+        'UCX_IB_REG_METHODS=rcache',
+        'UCX_IB_DIRECT_NIC=n'
       ]
 
   - name: Run DL Nixlbench tests


### PR DESCRIPTION
## What?
**Workaround (WA).** Add `UCX_IB_DIRECT_NIC=n` to the DL CPP test env.

## Why?
DL CPP VRAM test fails `ibv_reg_dmabuf_mr ... 524` on `gb200-nvl4-ts2` nodes: UCX finds a data-direct ("direct NIC") sibling rail NIC for the GPU and exports the CUDA buffer PCIe-mapped, then registers it on `mlx5_16` - a non-sibling NIC in a different IOMMU group → NVIDIA driver rejects (`FORCE_PCIE` topology) → 524.

`UCX_IB_DIRECT_NIC=n` disables only the **data-direct/direct-NIC** path (unusable here anyway - the sibling rail NICs `mlx5_0..15` are down). GPU RDMA is **not** disabled: the buffer registers via the standard dmabuf mapping and the test still runs RDMA over `mlx5_16` (verified `ucp_mem_map` Success on ts2-65/79/88; default config 524s).

WA only; proper fix is cluster-side (enable the GPU-sibling rail NICs, or `GrdmaPciTopoCheckOverride=1`).