### PR TITLE
feat(obj): add throughput_target_gbps param to the CRT S3 client

### DIFF
--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -70,6 +70,7 @@ Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creati
 | `resp_checksum` | Response checksum validation (`required`/`supported`) | - | No |
 | `ca_bundle` | path to a custom certificate bundle | - | No |
 | `crtMinLimit` | Minimum object size (bytes) to use S3 CRT client for high-performance transfers | Disabled**** | No |
+| `throughput_target_gbps` | Target throughput for the S3 CRT client in **whole Gbps** (integer); sizes its parallel connection count | `10` | No |
 | `accelerated` | Enable S3 Accelerated engine (`true`/`false`) | `false` | No |
 | `type` | Accelerated engine type (`dell`, etc.) | - | No |
 
@@ -82,6 +83,8 @@ Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creati
 \**** If `crtMinLimit` is not provided, the S3 CRT client is disabled and all transfers use the standard S3 client. When set, objects with size >= `crtMinLimit` will use the high-performance CRT client, while smaller objects continue to use the standard client. Recommended value: 10485760 (10 MB) or higher for optimal performance on large objects.
 
 Setting `crtMinLimit` also configures the CRT client's `partSize` and `multipartUploadThreshold` to the same value, ensuring multipart upload (MPU) is always used for transfers routed to the CRT client. Note that AWS S3 enforces a **5 MiB minimum part size** for all parts except the last: if `crtMinLimit` is set below 5 MiB (5,242,880 bytes), the CRT SDK will silently clamp the part size to 5 MiB and log a warning, but MPU still activates at `crtMinLimit`. Objects smaller than 5 MiB uploaded via MPU will be sent as a single-part multipart upload, which S3 allows. To avoid the silent clamp and warning, use `crtMinLimit >= 5242880`.
+
+`throughput_target_gbps` (default: 10 Gbps, whole numbers only) sets the CRT client's target throughput, which the CRT scheduler uses to size how many parallel connections it opens. On high-bandwidth links (e.g., 25 GbE, InfiniBand), raise this value to allow more concurrency.
 
 ### Environment Variables
 
@@ -202,7 +205,8 @@ agent.createBackend("obj", params);
 nixl_b_params_t params = {
     {"bucket", "large-model-storage"},
     {"region", "us-west-2"},
-    {"crtMinLimit", "10485760"}  // Use CRT client for objects >= 10 MB
+    {"crtMinLimit", "10485760"},        // Use CRT client for objects >= 10 MB
+    {"throughput_target_gbps", "25"}    // increase on high-bandwidth links, e.g. 25 GbE
 };
 agent.createBackend("obj", params);
 ```

--- a/src/plugins/obj/s3_crt/client.cpp
+++ b/src/plugins/obj/s3_crt/client.cpp
@@ -40,6 +40,12 @@ awsS3CrtClient::awsS3CrtClient(nixl_b_params_t *custom_params,
         config.multipartUploadThreshold = crt_min_limit;
     }
 
+    // Optional CRT throughput target in whole Gbps (integer); sizes connection count, default 10.
+    if (const auto opt =
+            nixl::getBackendParamOptional<size_t>(custom_params, "throughput_target_gbps")) {
+        config.throughputTargetGbps = *opt;
+    }
+
     auto credentials_opt = nixl_s3_utils::createAWSCredentials(custom_params);
     bool use_virtual_addressing = nixl_s3_utils::getUseVirtualAddressing(custom_params);
     config.useVirtualAddressing = use_virtual_addressing;


### PR DESCRIPTION
See also #1770 for an alternate approach

## What?

The OBJ CRT backend always used the AWS SDK default throughput target (10.0 Gbps), which bounds how many parallel connections the CRT scheduler opens. Expose it as an optional backend parameter so callers can raise the target (and thus concurrency) for high-bandwidth object stores.

## Why?

Running a client to Cloudian HyperStore S3 system. 

```
  ┌────────────────────────┬────────┬──────────────────────────┐
  │ throughput_target_gbps │  Time  │        Throughput        │
  ├────────────────────────┼────────┼──────────────────────────┤
  │ 10 (default)           │ 12.72s │ 10.06 GB/s               │
  ├────────────────────────┼────────┼──────────────────────────┤
  │ 150                    │ 7.06s  │ 18.13 GB/s (~145 Gbit/s) │
  ├────────────────────────┼────────┼──────────────────────────┤
  │ 400                    │ 9.80s  │ 13.06 GB/s               │
  └────────────────────────┴────────┴──────────────────────────┘
```

Before this PR we were only able to achieve 10GiB/s. With this PR , the CRT can be configured to achieve 18.13 GiB/s. 

### Comparison with s5cmd

To my knowledge, the [s5cmd ](https://github.com/peak/s5cmd)client achieves the best performance. On this machine, the best parameter configuration i found is: `s5cmd cp --concurrency=5` and copy to a ramdisk. With this command I achieve `16.9GiB/s`.  Hence, with exposing and correctly tuning the `throughput_target_gbps`  we can outperform the s5cmd tool.

### Workload
```
Fetch of 32x4GiB objects
```


### Machine details:
```
2x AMD EPYC 9555 (64-core / 128-thread each, 256 logical CPUs total), 1.5 TiB DRAM, 8x NVIDIA RTX PRO 6000 Blackwell Server Edition GPUs, and a mix
of high-speed NICs — the bond used by the bench is bond0 = LACP 802.3ad over ens1f0np0 + ens1f1np1 (2x 200 GbE = 400 GbE aggregate), plus three standalone 400 GbE ports (ens15f0np0,
ens20f0np0, ens21f0np0) and a separate RDMA bond — none of which were exercised in these tests.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring S3 CRT throughput targeting via the new `throughput_target_gbps` backend parameter (default: 10) to tune parallel connection sizing for uploads.

* **Documentation**
  * Updated the S3 plugin documentation to describe `throughput_target_gbps` and how it works alongside existing CRT upload tuning (including the behavior and implications of `crtMinLimit`).

* **Chores**
  * Minor formatting improvements to client configuration and error logging (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->