### PR TITLE
feat(obj): size the CRT event-loop thread pool from num_threads

### DIFF
--- a/src/plugins/obj/s3_crt/client.cpp
+++ b/src/plugins/obj/s3_crt/client.cpp
@@ -19,7 +19,12 @@
 
 awsS3CrtClient::awsS3CrtClient(nixl_b_params_t *custom_params,
                                std::shared_ptr<Aws::Utils::Threading::Executor> executor)
-    : awsS3Client(custom_params, executor) {
+    : awsS3Client(custom_params, executor),
+      crtEventLoopGroup_(static_cast<uint16_t>(getNumThreads(custom_params))),
+      crtHostResolver_(crtEventLoopGroup_, 8 /*maxHosts*/, 30 /*maxTTL_s*/),
+      crtBootstrap_(Aws::MakeShared<Aws::Crt::Io::ClientBootstrap>("NixlObjCrtBootstrap",
+                                                                   crtEventLoopGroup_,
+                                                                   crtHostResolver_)) {
     // Initialize AWS SDK (thread-safe, only happens once)
     nixl_s3_utils::initAWSSDK();
 
@@ -27,6 +32,8 @@ awsS3CrtClient::awsS3CrtClient(nixl_b_params_t *custom_params,
     Aws::S3Crt::ClientConfiguration config;
     nixl_s3_utils::configureClientCommon(config, custom_params);
     if (executor) config.executor = executor;
+
+    config.clientBootstrap = crtBootstrap_;
 
     // Align the CRT multipart thresholds with crtMinLimit so that every object
     // routed to this client (size >= crtMinLimit) is uploaded via multipart.

--- a/src/plugins/obj/s3_crt/client.h
+++ b/src/plugins/obj/s3_crt/client.h
@@ -10,6 +10,9 @@
 #include <string_view>
 #include <cstdint>
 #include <aws/s3-crt/S3CrtClient.h>
+#include <aws/crt/io/EventLoopGroup.h>
+#include <aws/crt/io/HostResolver.h>
+#include <aws/crt/io/Bootstrap.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/Aws.h>
 #include "s3/client.h"
@@ -55,6 +58,9 @@ public:
     checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) override;
 
 private:
+    Aws::Crt::Io::EventLoopGroup crtEventLoopGroup_;
+    Aws::Crt::Io::DefaultHostResolver crtHostResolver_;
+    std::shared_ptr<Aws::Crt::Io::ClientBootstrap> crtBootstrap_;
     std::unique_ptr<Aws::S3Crt::S3CrtClient> s3CrtClient_;
 };
 

--- a/src/utils/object/meson.build
+++ b/src/utils/object/meson.build
@@ -17,8 +17,11 @@
 aws_s3 = dependency('aws-cpp-sdk-s3', static: false, required: false)
 aws_s3_crt = dependency('aws-cpp-sdk-s3-crt', static: false, required: false)
 aws_core = dependency('aws-cpp-sdk-core', required: false, static: false)
+# aws-crt-cpp has no pkg-config file; the CRT S3 client (s3_crt/client.cpp) uses
+# its EventLoopGroup/Bootstrap/HostResolver symbols directly, so link it explicitly.
+aws_crt = meson.get_compiler('cpp').find_library('aws-crt-cpp', required: false)
 
-if aws_s3.found() and aws_s3_crt.found() and aws_core.found()
+if aws_s3.found() and aws_s3_crt.found() and aws_core.found() and aws_crt.found()
     # By default aws-cpp-sdk sets c++11 compile flag for the whole project
     partial_aws_s3 = aws_s3.partial_dependency(compile_args: false, includes: true, link_args: true, links: true)
     partial_aws_s3_crt = aws_s3_crt.partial_dependency(compile_args: false, includes: true, link_args: true, links: true)
@@ -28,13 +31,13 @@ if aws_s3.found() and aws_s3_crt.found() and aws_core.found()
     obj_utils_lib = library('obj_utils',
                's3/utils.cpp', 's3/utils.h',
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
-               dependencies: [nixl_common_dep, partial_aws_s3, partial_aws_s3_crt, partial_aws_core],
+               dependencies: [nixl_common_dep, partial_aws_s3, partial_aws_s3_crt, partial_aws_core, aws_crt],
                install: true)
 
     obj_utils_interface = declare_dependency(
         link_with: obj_utils_lib,
         include_directories: [include_directories('.'), include_directories('s3')],
-        dependencies: [partial_aws_s3, partial_aws_s3_crt, partial_aws_core]
+        dependencies: [partial_aws_s3, partial_aws_s3_crt, partial_aws_core, aws_crt]
     )
 else
     warning('AWS SDK dependencies not found, skipping obj_utils library build')


### PR DESCRIPTION
## What?
Use `num_thread` to control the thread pool size of AWS CRT.

## Why?
We don't give the CRT backend enough concurrency to saturate high-speed NICs. See PR  #1769  for justification and some benchmarks.

Using num_threads to size the CRT thread pool keeps the object backends consistent rather than introducing a CRT-specific knob. num_threads is already the established parameter for sizing object-backend I/O concurrency: getNumThreads() in engine_utils.h reads it with a hardware_concurrency()/2 default, and it is used by both the standard S3 engine to size its ASIO executor pool and the Azure Blob backend (which carries its own copy of the same helper) for the same purpose. Before this change the CRT path was the outlier -- it honored num_threads for the ASIO executor but left the CRT EventLoopGroup at the SDK default (one event-loop thread per logical CPU, with no way to override it).

## How?
This one differs from  #1769 - instead of setting the `throughput_target_gbps` we do the slightly more complicated way of creating a thread pool ourselves using the pre-existing `num_thread` backend parameter. 


## Testing 

Verified that the `num_threads` changes the worker threads. However, the actually observed number of threads created might be surprising: Each `num_thread` creates two threads in CRT, one for the pool and one for the body reader. Additionally, there is a singelton EventLoopGroup that is always present and uses `hardware_concurrency()/2` threads. 

For example, setting `num_threads` to 8 on a 256 core machine. We will get `2*8 + 128 = 144` threads from the CRT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for S3-based object storage operations with a more robust client setup.
  * Enhanced compatibility for builds that use S3 CRT functionality.

* **Bug Fixes**
  * Fixed client initialization so object upload, download, and existence checks can use the correct runtime networking components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->