### PR TITLE
Nixlbench: register remote IOVs only for storage backends

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1350,10 +1350,12 @@ registerIterationMem(nixlAgent *agent,
         return rc;
     }
 
-    nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
-    rc = agent->registerMem(remote_reg, &reg_args);
-    if (rc != NIXL_SUCCESS) {
-        return rc;
+    if (xferBenchConfig::isStorageBackend()) {
+        nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
+        rc = agent->registerMem(remote_reg, &reg_args);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
     }
 
     return NIXL_SUCCESS;
@@ -1374,10 +1376,12 @@ deregisterIterationMem(nixlAgent *agent,
         return rc;
     }
 
-    nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
-    rc = agent->deregisterMem(remote_reg, &reg_args);
-    if (rc != NIXL_SUCCESS) {
-        return rc;
+    if (xferBenchConfig::isStorageBackend()) {
+        nixl_reg_dlist_t remote_reg = iovListToNixlRegDlist(remote_iov, getRemoteSegType());
+        rc = agent->deregisterMem(remote_reg, &reg_args);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
     }
 
     return NIXL_SUCCESS;


### PR DESCRIPTION
## What?
Bugfix https://nvbugspro.nvidia.com/bug/6310482
Fix `--reregister_mem` failing for memory/network backends (e.g. UCX) with
"VRAM is detected as host by UCX".

## Why?
`registerIterationMem()`/`deregisterIterationMem()` register the *remote* IOVs
locally on every iteration, unconditionally. For memory backends the remote side
is a peer process's memory (exchanged via metadata), not a local allocation, so
registering those peer addresses locally is invalid — UCX can't resolve them and
reports VRAM as host. The normal alloc/dealloc path only registers remote memory
for storage backends; the per-iteration path missed that gate. Regression from
#1474.

## How?
Gate the remote register/deregister on `isStorageBackend()`, matching
`allocateMemory()`/`deallocateMemory()`. Memory backends now (de)register only
local memory per iteration, as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized memory management for non-storage backends to only register local memory regions, reducing unnecessary remote operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->