### PR TITLE
fix(core): forbid duplicate descriptor registration

### DIFF
--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -117,7 +117,6 @@ fn create_storage_list(agent: &Agent, opt_args: &OptArgs, size: usize) -> Vec<Sy
         let mut storage = SystemStorage::new(1024).unwrap();
         storage.register(agent, Some(opt_args)).expect("Failed to register storage memory");
         storage.memset(0);
-        agent.register_memory(&storage, Some(opt_args)).expect("Failed to register storage memory");
         storage_list.push(storage);
     }
     storage_list

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include <map>
+#include <set>
 #include <algorithm>
 #include <iostream>
 #include "nixl.h"
@@ -23,6 +24,7 @@
 #include "backend/backend_engine.h"
 #include "nixl_types.h"
 #include "serdes/serdes.h"
+#include "common/nixl_log.h"
 
 /*** Class nixlMemSection implementation ***/
 
@@ -141,6 +143,17 @@ nixlLocalSection::addDescList(const nixl_reg_dlist_t &mem_elms,
     const nixl_mem_t nixl_mem = mem_elms.getType();
 
     nixlSecDescList &target = emplace(nixl_mem, backend);
+
+    // Reject duplicates - within args (seen) and against registered entries (target)
+    std::set<nixlBasicDesc> seen;
+    for (const auto &mem : mem_elms) {
+        const nixlBasicDesc key = normalizeSecDesc(mem, nixl_mem);
+        if (!seen.insert(key).second || target.getIndex(key) >= 0) {
+            NIXL_ERROR << "duplicate descriptor registration (addr=" << key.addr
+                       << " len=" << key.len << " devId=" << key.devId << ")";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
 
     nixlSectionDesc local_sec, self_sec;
     nixlBasicDesc *lp = &local_sec;

--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -74,9 +74,15 @@ nixl_status_t nixlGdsEngine::registerMem(const nixlBlobDesc &mem,
                                          nixlBackendMD* &out)
 {
     if (nixl_mem == FILE_SEG) {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            NIXL_ERROR << "GDS path-mode requires a unique devId per file (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         std::unique_ptr<nixlGdsMetadata> md;
         try {
-            md = std::make_unique<nixlGdsMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+            md = std::make_unique<nixlGdsMetadata>(mem.devId, mem.metaInfo);
         }
         catch (const std::system_error &e) {
             NIXL_ERROR << "GDS path-mode open failed: " << e.what();
@@ -95,6 +101,7 @@ nixl_status_t nixlGdsEngine::registerMem(const nixlBlobDesc &mem,
             }
             gds_file_map[fd] = md->handle;
         }
+        resv.commit();
         out = md.release();
         return NIXL_SUCCESS;
     }
@@ -126,6 +133,9 @@ nixl_status_t nixlGdsEngine::deregisterMem (nixlBackendMD* meta)
 {
     nixlGdsMetadata *md = (nixlGdsMetadata *)meta;
     if (md->type == FILE_SEG) {
+        if (!md->file_fd.path().empty()) {
+            path_mode_devids_.release(md->devId);
+        }
         gds_utils->deregisterFileHandle(md->handle);
         gds_file_map.erase(md->handle.fd);
     } else {

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -38,7 +38,9 @@ public:
 
     nixlGdsMetadata() = default;
 
-    explicit nixlGdsMetadata(nixl::FileFd &&fd) : nixlFilePathMD(std::move(fd)), type(FILE_SEG) {}
+    nixlGdsMetadata(uint64_t devid, const std::string &metaInfo)
+        : nixlFilePathMD(devid, metaInfo),
+          type(FILE_SEG) {}
 };
 
 class GdsTransferRequestH {
@@ -90,6 +92,7 @@ class nixlGdsEngine : public nixlBackendEngine {
     private:
         gdsUtil *gds_utils;
         std::unordered_map<int, gdsFileHandle> gds_file_map;
+        nixl::PathModeDevIdRegistry path_mode_devids_;
 
         mutable std::mutex batch_pool_lock;
         mutable std::list<nixlGdsIOBatch*> batch_pool;

--- a/src/plugins/gds_mt/gds_mt_backend.cpp
+++ b/src/plugins/gds_mt/gds_mt_backend.cpp
@@ -43,8 +43,11 @@ const size_t default_thread_count = std::max (1u, std::thread::hardware_concurre
 
 struct FileSegData {
     std::shared_ptr<gdsMtFileHandle> handle;
+    uint64_t devId;
 
-    FileSegData(std::shared_ptr<gdsMtFileHandle> h) : handle(std::move(h)) {}
+    FileSegData(std::shared_ptr<gdsMtFileHandle> h, uint64_t devid)
+        : handle(std::move(h)),
+          devId(devid) {}
 };
 
 struct MemSegData {
@@ -74,9 +77,9 @@ struct GdsMtTransferRequestH {
 
 class nixlGdsMtMetadata : public nixlBackendMD {
 public:
-    explicit nixlGdsMtMetadata (std::shared_ptr<gdsMtFileHandle> file_handle)
-        : nixlBackendMD (true),
-          data_ (FileSegData{std::move (file_handle)}) {}
+    nixlGdsMtMetadata(std::shared_ptr<gdsMtFileHandle> file_handle, uint64_t devid)
+        : nixlBackendMD(true),
+          data_(FileSegData{std::move(file_handle), devid}) {}
 
     explicit nixlGdsMtMetadata (void *addr, size_t size, int flags)
         : nixlBackendMD (true),
@@ -189,6 +192,12 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
                               nixlBackendMD *&out) {
     switch (nixl_mem) {
     case FILE_SEG: {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            NIXL_ERROR << "GDS_MT: path-mode requires a unique devId per file (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         nixl::FileFd file_fd;
         try {
             file_fd = nixl::FileFd(mem.devId, mem.metaInfo);
@@ -217,7 +226,8 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
             }
             gds_mt_file_map_[fd] = handle;
         }
-        out = new nixlGdsMtMetadata(std::move(handle));
+        resv.commit();
+        out = new nixlGdsMtMetadata(std::move(handle), mem.devId);
         return NIXL_SUCCESS;
     }
 
@@ -254,6 +264,9 @@ nixlGdsMtEngine::deregisterMem (nixlBackendMD *meta) {
     if (auto *file_data = std::get_if<FileSegData> (&md->data_)) {
         if (file_data->handle) {
             int key = file_data->handle->file_fd.fd();
+            if (!file_data->handle->file_fd.path().empty()) {
+                path_mode_devids_.release(file_data->devId);
+            }
             md.reset(); // Release metadata first
 
             auto it = gds_mt_file_map_.find (key);

--- a/src/plugins/gds_mt/gds_mt_backend.h
+++ b/src/plugins/gds_mt/gds_mt_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,7 @@ public:
 private:
     gdsMtUtil gds_mt_utils_;
     std::unordered_map<int, std::weak_ptr<gdsMtFileHandle>> gds_mt_file_map_;
+    nixl::PathModeDevIdRegistry path_mode_devids_;
     size_t thread_count_;
     std::unique_ptr<tf::Executor> executor_;
 };

--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -191,9 +191,16 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
         break;
     }
     case FILE_SEG: {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
+                             absl::StrFormat("HF3FS path-mode requires a unique devId per file "
+                                             "(devId=%llu already registered)",
+                                             static_cast<unsigned long long>(mem.devId)));
+        }
         std::unique_ptr<nixlHf3fsFileMetadata> md;
         try {
-            md = std::make_unique<nixlHf3fsFileMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+            md = std::make_unique<nixlHf3fsFileMetadata>(mem.devId, mem.metaInfo);
         }
         catch (const std::system_error &e) {
             HF3FS_LOG_RETURN(NIXL_ERR_BACKEND,
@@ -212,6 +219,7 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
             hf3fs_file_set.insert(fd);
         }
 
+        resv.commit();
         md->handle.fd = fd;
         md->handle.size = mem.len;
         md->handle.metadata = mem.metaInfo;
@@ -230,6 +238,9 @@ nixl_status_t nixlHf3fsEngine::deregisterMem (nixlBackendMD* meta)
     nixlHf3fsMetadata *md = (nixlHf3fsMetadata *)meta;
     if (md->type == NIXL_HF3FS_MEM_TYPE_FILE) {
         nixlHf3fsFileMetadata *file_md = (nixlHf3fsFileMetadata *)md;
+        if (!file_md->file_fd.path().empty()) {
+            path_mode_devids_.release(file_md->devId);
+        }
         hf3fs_file_set.erase(file_md->handle.fd);
         hf3fs_utils->deregisterFileHandle(file_md->handle.fd);
     } else if (md->type != NIXL_HF3FS_MEM_TYPE_DRAM && md->type != NIXL_HF3FS_MEM_TYPE_DRAM_ZC) {

--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -58,12 +58,14 @@ class nixlHf3fsFileMetadata : public nixlHf3fsMetadata {
 public:
     hf3fsFileHandle handle;
     nixl::FileFd file_fd;
+    uint64_t devId = 0;
 
     nixlHf3fsFileMetadata() : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE) {}
 
-    explicit nixlHf3fsFileMetadata(nixl::FileFd &&fd)
+    nixlHf3fsFileMetadata(uint64_t devid, const std::string &metaInfo)
         : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE),
-          file_fd(std::move(fd)) {}
+          file_fd(devid, metaInfo),
+          devId(devid) {}
 };
 
 class nixlHf3fsDramMetadata : public nixlHf3fsMetadata {
@@ -122,6 +124,7 @@ class nixlHf3fsEngine : public nixlBackendEngine {
     private:
         hf3fsUtil *hf3fs_utils;
         std::unordered_set<int> hf3fs_file_set;
+        nixl::PathModeDevIdRegistry path_mode_devids_;
         nixl_hf3fs_mem_config mem_config;
         static long page_size;
 

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -232,13 +232,20 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
     if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) != supported_mems.end()) {
         out = nullptr;
         if (nixl_mem == FILE_SEG) {
+            auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+            if (!resv.ok()) {
+                NIXL_ERROR << "POSIX path-mode requires a unique devId per file (devId="
+                           << mem.devId << " already registered)";
+                return NIXL_ERR_INVALID_PARAM;
+            }
             try {
-                out = new nixlPosixFileMD(nixl::FileFd(mem.devId, mem.metaInfo));
+                out = new nixlPosixFileMD(mem.devId, mem.metaInfo);
             }
             catch (const std::system_error &e) {
                 NIXL_ERROR << "POSIX path-mode open failed: " << e.what();
                 return NIXL_ERR_BACKEND;
             }
+            resv.commit();
         }
         return NIXL_SUCCESS;
     }
@@ -248,6 +255,14 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
 
 nixl_status_t
 nixlPosixEngine::deregisterMem(nixlBackendMD *meta) {
+    // non-null meta is always a file MD. Release the path-mode reservation (path() empty in
+    // fd-mode)
+    if (meta) {
+        auto *file_md = static_cast<nixlPosixFileMD *>(meta);
+        if (!file_md->file_fd.path().empty()) {
+            path_mode_devids_.release(file_md->devId);
+        }
+    }
     delete meta;
     return NIXL_SUCCESS;
 }

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -29,7 +29,7 @@
 #include "io_queue.h"
 #include "sync.h"
 
-// POSIX reuses the shared owned-fd base (no extra per-descriptor state).
+// POSIX reuses the shared owned-fd base (path-mode devId stored for dereg).
 using nixlPosixFileMD = nixlFilePathMD;
 
 class nixlPosixBackendReqH : public nixlBackendReqH {
@@ -80,6 +80,7 @@ private:
     std::string_view io_queue_type_;
     mutable std::unique_ptr<nixlPosixIOQueue> io_queue_;
     mutable nixlLock io_queue_lock_;
+    nixl::PathModeDevIdRegistry path_mode_devids_;
 
 public:
     nixlPosixEngine(const nixlBackendInitParams *init_params);

--- a/src/utils/file/file_path_mode.h
+++ b/src/utils/file/file_path_mode.h
@@ -19,8 +19,10 @@
 
 #include <sys/types.h>
 
+#include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 #include "backend/backend_engine.h"
 
@@ -37,6 +39,9 @@
 //             | "create"           # | O_CREAT (mode 0644)
 //
 // Unknown tokens: parsePathMeta returns std::nullopt (fail-loud).
+//
+// Path-mode contract: each path-mode file must use a unique devId - the section keys
+// on devId, so two files sharing one collide; backends reject a reused path-mode devId on register.
 
 namespace nixl {
 
@@ -89,15 +94,92 @@ private:
     std::string path_;
 };
 
+// Tracks the path-mode devIds currently registered by one FILE_SEG backend, enforcing
+// a unique devId per path-mode file (the section keys descriptors on devId). Not
+// thread-safe: callers (de)register under the agent lock. reserve() returns an RAII
+// Reservation that rolls the hold back if registration fails before commit().
+class PathModeDevIdRegistry {
+public:
+    class Reservation {
+    public:
+        Reservation(Reservation &&other) noexcept
+            : reg_(other.reg_),
+              devId_(other.devId_),
+              ok_(other.ok_),
+              held_(other.held_) {
+            other.reg_ = nullptr;
+            other.held_ = false;
+        }
+
+        Reservation(const Reservation &) = delete;
+        Reservation &
+        operator=(const Reservation &) = delete;
+
+        ~Reservation() {
+            if (reg_ && held_) {
+                reg_->release(devId_);
+            }
+        }
+
+        // false: this devId is already registered in path-mode -> caller must reject.
+        bool
+        ok() const noexcept {
+            return ok_;
+        }
+
+        // Keep the hold past this scope; released later via release() on deregister.
+        void
+        commit() noexcept {
+            held_ = false;
+        }
+
+    private:
+        friend class PathModeDevIdRegistry;
+
+        Reservation(PathModeDevIdRegistry *reg, uint64_t devId, bool ok, bool held)
+            : reg_(reg),
+              devId_(devId),
+              ok_(ok),
+              held_(held) {}
+
+        PathModeDevIdRegistry *reg_;
+        uint64_t devId_;
+        bool ok_;
+        bool held_;
+    };
+
+    // fd-mode (metaInfo not path-mode) is always ok and untracked.
+    Reservation
+    reserve(uint64_t devId, const std::string &metaInfo) {
+        if (!parsePathMeta(metaInfo)) {
+            return Reservation(this, devId, true, false);
+        }
+        const bool inserted = devids_.insert(devId).second;
+        return Reservation(this, devId, inserted, inserted);
+    }
+
+    void
+    release(uint64_t devId) {
+        devids_.erase(devId);
+    }
+
+private:
+    std::unordered_set<uint64_t> devids_;
+};
+
 } // namespace nixl
 
 class nixlFilePathMD : public nixlBackendMD {
 public:
     nixl::FileFd file_fd;
+    uint64_t devId = 0;
 
     nixlFilePathMD() : nixlBackendMD(true /*isPrivate*/) {}
 
-    explicit nixlFilePathMD(nixl::FileFd &&fd) : nixlBackendMD(true), file_fd(std::move(fd)) {}
+    nixlFilePathMD(uint64_t devid, const std::string &metaInfo)
+        : nixlBackendMD(true),
+          file_fd(devid, metaInfo),
+          devId(devid) {}
 };
 
 #endif // __FILE_PATH_MODE_H

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -334,6 +334,68 @@ namespace agent {
                              << timed1_ns << " ns2=" << timed2_ns << " ratio=" << ratio << ")";
     }
 
+    // Registering a descriptor that is already registered must be rejected without
+    // re-registering it, so the section never holds two entries with the same sort key.
+    TEST_F(singleAgentSessionFixture, RegisterDuplicateDescriptorRejectedTest) {
+        nixl_b_params_t params;
+        nixlBackendH *backend;
+        ASSERT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        nixl_opt_args_t extra_params;
+        extra_params.backends.push_back(backend);
+
+        char local_md[1] = {};
+        char self_md[1] = {};
+        auto &engine = const_cast<mocks::GMockBackendEngine &>(agent_helper_->getGMockEngine());
+        // Only the first registration may reach the backend; the duplicate is rejected earlier.
+        EXPECT_CALL(engine, registerMem(testing::_, testing::_, testing::_))
+            .Times(1)
+            .WillRepeatedly([&](const nixlBlobDesc &, const nixl_mem_t &, nixlBackendMD *&out) {
+                out = reinterpret_cast<nixlBackendMD *>(&local_md[0]);
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(engine, loadLocalMD(testing::_, testing::_))
+            .WillRepeatedly([&](nixlBackendMD *, nixlBackendMD *&output) {
+                output = reinterpret_cast<nixlBackendMD *>(&self_md[0]);
+                return NIXL_SUCCESS;
+            });
+
+        blob region;
+        nixl_reg_dlist_t reg(DRAM_SEG);
+        reg.addDesc(region.getDesc());
+        ASSERT_EQ(agent_->registerMem(reg, &extra_params), NIXL_SUCCESS);
+
+        nixl_reg_dlist_t dup(DRAM_SEG);
+        dup.addDesc(region.getDesc());
+        EXPECT_NE(agent_->registerMem(dup, &extra_params), NIXL_SUCCESS);
+
+        testing::Mock::VerifyAndClearExpectations(&engine);
+        EXPECT_EQ(agent_->deregisterMem(reg, &extra_params), NIXL_SUCCESS);
+    }
+
+    // A single registration list containing the same descriptor twice must be rejected
+    // all-or-nothing: nothing is registered on the backend.
+    TEST_F(singleAgentSessionFixture, RegisterDuplicateWithinListRejectedTest) {
+        nixl_b_params_t params;
+        nixlBackendH *backend;
+        ASSERT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        nixl_opt_args_t extra_params;
+        extra_params.backends.push_back(backend);
+
+        auto &engine = const_cast<mocks::GMockBackendEngine &>(agent_helper_->getGMockEngine());
+        EXPECT_CALL(engine, registerMem(testing::_, testing::_, testing::_)).Times(0);
+        EXPECT_CALL(engine, deregisterMem(testing::_)).Times(0);
+
+        blob region;
+        nixl_reg_dlist_t reg(DRAM_SEG);
+        reg.addDesc(region.getDesc());
+        reg.addDesc(region.getDesc());
+        EXPECT_NE(agent_->registerMem(reg, &extra_params), NIXL_SUCCESS);
+
+        testing::Mock::VerifyAndClearExpectations(&engine);
+    }
+
     INSTANTIATE_TEST_SUITE_P(DramRegisterMemoryInstantiation,
                              singleAgentWithMemParamFixture,
                              testing::Values(DRAM_SEG));

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -834,6 +834,154 @@ runPathModeCreateCheck() {
     return 0;
 }
 
+// Path-mode requires a unique devId per file: reused devId rejected, distinct OK (addr differs so
+// the dup-descriptor check is not what rejects).
+static int
+runPathModeUniqueDevIdCheck() {
+    constexpr const char *kFileA = "/tmp/nixl_posix_path_mode_devid_a.bin";
+    constexpr const char *kFileB = "/tmp/nixl_posix_path_mode_devid_b.bin";
+    for (const char *p : {kFileA, kFileB}) {
+        if (auto *f = std::fopen(p, "wb")) {
+            std::fputc(0, f);
+            std::fclose(f);
+        } else {
+            return 1;
+        }
+    }
+    auto cleanup = [&]() {
+        std::remove(kFileA);
+        std::remove(kFileB);
+    };
+
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXPathModeDevId", cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend("POSIX", params, be) != NIXL_SUCCESS) {
+        cleanup();
+        return 1;
+    }
+
+    auto pathDesc = [](const char *p, uint64_t devid, uintptr_t addr) {
+        nixlBlobDesc d;
+        d.addr = addr;
+        d.len = 4096;
+        d.devId = devid;
+        d.metaInfo = std::string("rw:") + p;
+        return d;
+    };
+
+    // Two different files sharing one devId within a single list: rejected.
+    {
+        nixl_reg_dlist_t d(FILE_SEG);
+        d.addDesc(pathDesc(kFileA, 0, 0));
+        d.addDesc(pathDesc(kFileB, 0, 4096));
+        if (agent.registerMem(d) == NIXL_SUCCESS) {
+            agent.deregisterMem(d);
+            std::cerr << "path-mode duplicate devId (within list) was not rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+    }
+
+    // devId reused across registrations: rejected, the first stays valid, and the devId
+    // is reusable for a different file once the first is deregistered.
+    {
+        nixl_reg_dlist_t a(FILE_SEG);
+        a.addDesc(pathDesc(kFileA, 0, 0));
+        if (agent.registerMem(a) != NIXL_SUCCESS) {
+            cleanup();
+            return 1;
+        }
+
+        nixl_reg_dlist_t b(FILE_SEG);
+        b.addDesc(pathDesc(kFileB, 0, 4096));
+        if (agent.registerMem(b) == NIXL_SUCCESS) {
+            agent.deregisterMem(b);
+            agent.deregisterMem(a);
+            std::cerr << "path-mode duplicate devId (across calls) was not rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+
+        agent.deregisterMem(a);
+        nixl_reg_dlist_t b2(FILE_SEG);
+        b2.addDesc(pathDesc(kFileB, 0, 0));
+        if (agent.registerMem(b2) != NIXL_SUCCESS) {
+            std::cerr << "devId not freed on deregister" << std::endl;
+            cleanup();
+            return 1;
+        }
+        agent.deregisterMem(b2);
+    }
+
+    // Distinct devIds: both files register together.
+    {
+        nixl_reg_dlist_t d(FILE_SEG);
+        d.addDesc(pathDesc(kFileA, 0, 0));
+        d.addDesc(pathDesc(kFileB, 1, 0));
+        if (agent.registerMem(d) != NIXL_SUCCESS) {
+            std::cerr << "distinct devIds rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+        agent.deregisterMem(d);
+    }
+
+    cleanup();
+    std::cout << "path-mode unique devId: OK" << std::endl;
+    return 0;
+}
+
+// fd-mode (devId is a real fd, metaInfo not path-mode) is NOT subject to the unique-devId
+// rule, so one fd may back several descriptors (e.g. different offsets in the same file).
+static int
+runFdModeReuseCheck() {
+    constexpr const char *kFile = "/tmp/nixl_posix_fd_mode_reuse.bin";
+    const int fd = open(kFile, O_RDWR | O_CREAT, 0644);
+    if (fd < 0) {
+        return 1;
+    }
+    auto cleanup = [&]() {
+        close(fd);
+        std::remove(kFile);
+    };
+
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXFdModeReuse", cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend("POSIX", params, be) != NIXL_SUCCESS) {
+        cleanup();
+        return 1;
+    }
+
+    auto fdDesc = [&](uintptr_t addr) {
+        nixlBlobDesc d;
+        d.addr = addr;
+        d.len = 4096;
+        d.devId = static_cast<uint64_t>(fd); // fd-mode: devId is the open fd
+        d.metaInfo = ""; // not path-mode
+        return d;
+    };
+
+    // Same fd (devId) under two descriptors at different offsets must register, not be
+    // rejected as a duplicate path-mode devId.
+    nixl_reg_dlist_t d(FILE_SEG);
+    d.addDesc(fdDesc(0));
+    d.addDesc(fdDesc(4096));
+    if (agent.registerMem(d) != NIXL_SUCCESS) {
+        std::cerr << "fd-mode devId reuse was wrongly rejected" << std::endl;
+        cleanup();
+        return 1;
+    }
+    agent.deregisterMem(d);
+
+    cleanup();
+    std::cout << "fd-mode devId reuse: OK" << std::endl;
+    return 0;
+}
+
 int
 main (int argc, char *argv[]) {
     if (page_size <= 0) {
@@ -907,6 +1055,12 @@ main (int argc, char *argv[]) {
     if (run_path_mode_smoke) {
         checkPathModeParser();
         if (int rc = runPathModeCreateCheck(); rc != 0) {
+            return rc;
+        }
+        if (int rc = runPathModeUniqueDevIdCheck(); rc != 0) {
+            return rc;
+        }
+        if (int rc = runFdModeReuseCheck(); rc != 0) {
             return rc;
         }
         if (int rc = nixl_test::runPathModeSmoke(


### PR DESCRIPTION
### Summary

This is a follow up for PR #1744 . Note the discussion there, at the end we agreed on a different approach ([comment](https://github.com/ai-dynamo/nixl/pull/1744#issuecomment-4678598319)) to prevent duplicate registrations instead of searching for duplicates. This PR implements this approach

### Existing client behavior

**Note**: This PR introduces user facing changes. Before it was allowed to perform a `register(A), register(A)` - after this PR the second register will return an error


### Problem

Backends  free metadata on deregister (e.g. POSIX `deregisterMem` closes the file descriptor). The section keys descriptors on the `nixlBasicDesc` sort key `(devId, addr, len)`. Registering the same descriptor twice collapses to one section entry while producing two distinct backend metadata objects, so `getIndex()` (first match) returns the same entry twice: deregistration frees it twice (double free) and the duplicate leaks.

### Fix

Two complementary, all-or-nothing rules: 

1. **Forbid duplicate descriptors** -- `nixlLocalSection::addDescList` rejects a descriptor that duplicates another in the same list or one already registered, before any `backend->registerMem`. Returns `NIXL_ERR_INVALID_PARAM`.
2. **Unique devId per path-mode file** -- in path-mode the file is named by the path while the section keys on `devId`, so distinct files must use distinct devIds. Each FILE_SEG backend (posix, cuda_gds, gds_mt, hf3fs) keeps a set of in-use path-mode devIds, rejects reuse, and releases on deregister. Serialized by the agent lock (`nixlAgent::registerMem`/`deregisterMem`), so no backend lock. Rule 2 also turns "different file, same devId" into a clear error instead of the confusing duplicate-descriptor rejection Rule 1 would give.

Because the section can never hold two entries with the same sort key, `getIndex()` always resolves uniquely -- so `remDescList` / `removeLocalData` stay as their original simple loops and no `resolveDuplicateIndices` helper is needed.

### Alternative designs considered


**Composition helper.** A small reusable `PathModeDevIdRegistry` class (living in `utils/file`, held as a member by each file engine) that centralizes the set, the `parsePathMeta` detection, the reject+log, and an RAII reservation that auto-rolls-back on error. Pro: single source of truth and the RAII guard removes the rollback footgun, with no engine-interface change. Con: each backend still has ~2 call sites (reserve in register, release in deregister), so it dedups the logic but not the wiring.


**Inline the registration logic**: instead of the helper we could also inline the reservations

**Boolean + NVI in nixlBackendEngine.** Add an "enforce unique devId" bool to the base ctor (subclasses opt in), make base `registerMem`/`deregisterMem` non-virtual wrappers that do the enforcement around new pure-virtual `registerMemImpl`/`deregisterMemImpl`, and store the devId on the `nixlBackendMD` base so deregister can release it. Pro: truly single enforcement point that removes all per-backend bookkeeping *and* the call sites. Con: it forces a mechanical `registerMem`->`registerMemImpl` rename in *every* engine (not just file ones) plus a field on the shared MD base and a path-mode-detection layering question - too much for this fix.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reject duplicate memory registration descriptors during registration, with clear error logging and atomic all-or-nothing behavior.
  * Enforce unique `devId` for FILE_SEG path-mode registrations across backends, including safe reservation rollback on failure and correct `devId` release on deregistration.
* **Documentation**
  * Strengthened the path-mode contract: each path-mode file segment must use a unique `devId`.
* **Tests**
  * Added unit tests covering descriptor de-duplication and path-mode `devId` uniqueness, plus POSIX fd-mode `devId` reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->