### PR TITLE
fix(posix): define compile_flags so static POSIX plugin builds

### DIFF
--- a/src/plugins/posix/meson.build
+++ b/src/plugins/posix/meson.build
@@ -30,6 +30,7 @@ posix_sources = [
 ]
 
 compile_defs = []
+compile_flags = []
 plugin_link_args = []
 
 if has_linux_aio


### PR DESCRIPTION
## What broke

On `main` (verified at `03ea9a22`), `src/plugins/posix/meson.build:67` -- the
`'POSIX' in static_plugins` branch -- passes:

```meson
cpp_args: compile_defs + compile_flags,
```

but `compile_flags` is never defined in `posix/meson.build`; only `compile_defs`
and `plugin_link_args` are. `posix` is `subdir()`'d at `src/plugins/meson.build:25`,
*before* every plugin that does define `compile_flags` (`obj` at :29, then
libfabric/mooncake/uccl/infinia/gpunetio). Meson variables only propagate forward
into later subdirs, so `compile_flags` is undefined whenever POSIX is built as a
**static** plugin -- regardless of which other plugins are enabled.

Before this change, configuring with POSIX as a static plugin fails outright:

```
$ meson setup build -Denable_plugins=POSIX -Dstatic_plugins=POSIX
src/plugins/posix/meson.build:67:33: ERROR: Unknown variable "compile_flags".
```

The same failure occurs with the full default plugin set plus `-Dstatic_plugins=POSIX`.
The default (shared) build is unaffected because it takes the `shared_library`
branch (`compile_defs + ['-fPIC']`), which never references `compile_flags` -- which
is why CI does not catch it.

## The fix

Define `compile_flags = []` alongside `compile_defs`, matching the pattern already
used by the other plugins (e.g. `obj/meson.build`). `-fPIC` for the static library
is supplied by Meson's `b_staticpic` (on by default), so no explicit flag is needed.

## What works now

With the fix, the previously-failing static build both configures and compiles:

```
$ meson setup build -Denable_plugins=POSIX -Dstatic_plugins=POSIX
... configures, exit 0
$ ninja -C build
[95/95] Linking target ...    exit 0
```

The default shared build is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for the POSIX plugin to properly initialize compile flags before applying them during compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->