### PR TITLE
Introduce Scality AI Connector

### DIFF
--- a/benchmark/kvbench/commands/args.py
+++ b/benchmark/kvbench/commands/args.py
@@ -279,6 +279,23 @@ def nixl_bench_args(func):
         type=str,
         help="Path to CA bundle for S3 backend (only used with OBJ backend)",
     )(func)
+    func = click.option(
+        "--obj_accelerated_enable",
+        is_flag=True,
+        default=False,
+        help="Enable the accelerated OBJ client for GPU-direct transfers (only used with OBJ backend)",
+    )(func)
+    func = click.option(
+        "--obj_accelerated_type",
+        type=str,
+        help="Accelerated OBJ client type, e.g. 'scality_ai_connector' (only used with OBJ backend)",
+    )(func)
+    func = click.option(
+        "--obj_num_threads",
+        type=click.IntRange(min=0),
+        help="HTTP worker pool size for the accelerated OBJ connector; 0 = engine default "
+        "(only used with OBJ backend)",
+    )(func)
     return func
 
 

--- a/benchmark/kvbench/commands/nixlbench.py
+++ b/benchmark/kvbench/commands/nixlbench.py
@@ -74,6 +74,9 @@ class NIXLBench:
         obj_use_virtual_addressing=False,
         obj_endpoint_override="",
         obj_req_checksum="supported",
+        obj_accelerated_enable=False,
+        obj_accelerated_type="",
+        obj_num_threads=0,
         # Additional nixlbench arguments
         large_blk_iter_ftr=16,
         recreate_xfer=False,
@@ -176,6 +179,9 @@ class NIXLBench:
         self.obj_use_virtual_addressing = obj_use_virtual_addressing
         self.obj_endpoint_override = obj_endpoint_override
         self.obj_req_checksum = obj_req_checksum
+        self.obj_accelerated_enable = obj_accelerated_enable
+        self.obj_accelerated_type = obj_accelerated_type
+        self.obj_num_threads = obj_num_threads
         self.large_blk_iter_ftr = large_blk_iter_ftr
         self.recreate_xfer = recreate_xfer
         self._override_defaults()
@@ -354,6 +360,9 @@ class NIXLBench:
             "obj_use_virtual_addressing": self.obj_use_virtual_addressing,
             "obj_endpoint_override": self.obj_endpoint_override,
             "obj_req_checksum": self.obj_req_checksum,
+            "obj_accelerated_enable": self.obj_accelerated_enable,
+            "obj_accelerated_type": self.obj_accelerated_type,
+            "obj_num_threads": self.obj_num_threads,
             # Additional nixlbench parameters
             "large_blk_iter_ftr": self.large_blk_iter_ftr,
             "recreate_xfer": self.recreate_xfer,
@@ -415,6 +424,9 @@ class NIXLBench:
             "obj_use_virtual_addressing": False,
             "obj_endpoint_override": "",
             "obj_req_checksum": "supported",
+            "obj_accelerated_enable": False,
+            "obj_accelerated_type": "",
+            "obj_num_threads": 0,
             # Additional nixlbench defaults
             "large_blk_iter_ftr": 16,
             "recreate_xfer": False,
@@ -455,7 +467,11 @@ class NIXLBench:
         else:  # for text format, exclude defaults to keep command concise
             for name, value in params.items():
                 if should_include(name, value):
-                    command_parts.append(f"--{name} {value}")
+                    if isinstance(value, bool):
+                        if value:
+                            command_parts.append(f"--{name}")
+                    else:
+                        command_parts.append(f"--{name} {value}")
 
             command = " \\\n    ".join(command_parts)
             return command
@@ -485,6 +501,10 @@ class NIXLBench:
         params = self._params()
         for name, value in params.items():
             if should_include(name, value):
-                command_parts.append(f"--{name}")
-                command_parts.append(f"{value}")
+                if isinstance(value, bool):
+                    if value:
+                        command_parts.append(f"--{name}")
+                else:
+                    command_parts.append(f"--{name}")
+                    command_parts.append(f"{value}")
         return subprocess.run(command_parts, capture_output=False, env=env)

--- a/benchmark/nixlbench/src/utils/meson.build
+++ b/benchmark/nixlbench/src/utils/meson.build
@@ -25,7 +25,8 @@ utils_deps = [
   openmp_dep,
   gflags_dep,
   tomlplusplus_dep,
-  dependency('dl', required: true)
+  dependency('dl', required: true),
+  dependency('libcurl', required: true)
 ]
 
 if cuda_available

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -18,14 +18,19 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <memory>
+#include <mutex>
 #include <numeric>
 #include <sstream>
 #include <sys/time.h>
+#include <thread>
 #include <unistd.h>
 #include <utility>
 #include <iomanip>
 #include <omp.h>
 #include <set>
+#include <vector>
+#include <curl/curl.h>
 
 #if HAVE_CUDA
 #include <cuda_runtime.h>
@@ -185,7 +190,7 @@ NB_ARG_STRING(obj_endpoint_override, "", "Endpoint override for S3 backend");
 NB_ARG_STRING(obj_req_checksum,
               XFERBENCH_OBJ_REQ_CHECKSUM_SUPPORTED,
               "Required checksum for S3 backend [supported, required]");
-NB_ARG_STRING(obj_ca_bundle, "", "Path to CA bundle for S3 backend");
+NB_ARG_STRING(obj_ca_bundle, "", "Path to CA bundle for OBJ backend (S3 and REST)");
 NB_ARG_UINT64(obj_crt_min_limit,
               0,
               "Minimum object size (bytes) to use S3 CRT client for high-performance transfers. "
@@ -198,6 +203,10 @@ NB_ARG_STRING(obj_accelerated_type,
               "",
               "S3 Accelerated client vendor type to use. "
               "Only used when obj_accelerated_enable=true");
+NB_ARG_UINT64(obj_num_threads,
+              0,
+              "HTTP worker pool size for the accelerated OBJ connector. "
+              "0 means use the engine default. Only used when obj_accelerated_enable=true");
 
 // AZURE BLOB options - only used when backend is AZURE_BLOB
 NB_ARG_STRING(azure_blob_account_url, "", "Account URL for Azure Blob backend");
@@ -302,6 +311,7 @@ std::string xferBenchConfig::obj_ca_bundle = "";
 size_t xferBenchConfig::obj_crt_min_limit = 0;
 bool xferBenchConfig::obj_accelerated_enable = false;
 std::string xferBenchConfig::obj_accelerated_type = "";
+size_t xferBenchConfig::obj_num_threads = 0;
 std::string xferBenchConfig::azure_blob_account_url = "";
 std::string xferBenchConfig::azure_blob_container_name = "";
 std::string xferBenchConfig::azure_blob_connection_string = "";
@@ -453,6 +463,7 @@ xferBenchConfig::loadParams(void) {
             obj_crt_min_limit = NB_ARG(obj_crt_min_limit);
             obj_accelerated_enable = NB_ARG(obj_accelerated_enable);
             obj_accelerated_type = NB_ARG(obj_accelerated_type);
+            obj_num_threads = NB_ARG(obj_num_threads);
 
             // Validate OBJ S3 scheme
             if (obj_scheme != XFERBENCH_OBJ_SCHEME_HTTP &&
@@ -729,7 +740,7 @@ xferBenchConfig::printConfig() {
                         obj_endpoint_override);
             printOption("OBJ S3 required checksum (--obj_req_checksum=[supported, required])",
                         obj_req_checksum);
-            printOption("OBJ S3 CA bundle (--obj_ca_bundle=cert-path)", obj_ca_bundle);
+            printOption("OBJ CA bundle (--obj_ca_bundle=cert-path)", obj_ca_bundle);
             printOption("OBJ S3 CRT min limit (--obj_crt_min_limit=N bytes)",
                         obj_crt_min_limit > 0 ?
                             std::to_string(obj_crt_min_limit) + " (CRT enabled)" :
@@ -739,6 +750,9 @@ xferBenchConfig::printConfig() {
                                                  "false (Accelerated disabled)");
             printOption("OBJ S3 Accelerated type (--obj_accelerated_type=type)",
                         obj_accelerated_type.empty() ? "(default)" : obj_accelerated_type);
+            printOption("OBJ accelerated connector threads (--obj_num_threads=N)",
+                        obj_num_threads > 0 ? std::to_string(obj_num_threads) :
+                                              "0 (engine default)");
         }
 
         if (backend == XFERBENCH_BACKEND_AZURE_BLOB) {
@@ -833,6 +847,15 @@ xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+};
+
+bool
+xferBenchConfig::isRestBackend() {
+    return XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend &&
+        // CRT takes precedence over acceleration in the worker, so don't route
+        // pre-population/cleanup through REST when CRT is active.
+        xferBenchConfig::obj_crt_min_limit == 0 && xferBenchConfig::obj_accelerated_enable &&
+        xferBenchConfig::obj_accelerated_type == "scality_ai_connector";
 };
 
 
@@ -1303,6 +1326,191 @@ xferBenchUtils::buildAwsCredentials() {
     return env_setup;
 }
 
+// --- libcurl helpers for the REST object setup/cleanup path ---
+
+namespace {
+
+void
+restLogLine(std::ostream &os, const std::string &line) {
+    static std::mutex log_mutex;
+    std::lock_guard<std::mutex> lock(log_mutex);
+    os << line << std::endl;
+}
+
+size_t
+restCurlCaptureBody(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    auto *body = static_cast<std::string *>(userdata);
+    body->append(static_cast<char *>(ptr), size * nmemb);
+    return size * nmemb;
+}
+
+struct restUploadCtx {
+    size_t remaining;
+};
+
+size_t
+restCurlReadBody(char *buffer, size_t size, size_t nitems, void *userdata) {
+    auto *ctx = static_cast<restUploadCtx *>(userdata);
+    size_t want = size * nitems;
+    size_t n = std::min(want, ctx->remaining);
+    if (n > 0) {
+        // Generate the fixed payload byte on the fly so we never materialize a
+        // full buffer_size buffer per (parallel) request.
+        std::memset(buffer, XFERBENCH_TARGET_BUFFER_ELEMENT, n);
+        ctx->remaining -= n;
+    }
+    return n;
+}
+
+// curl_global_init is not thread-safe; serialize it before the OpenMP regions
+// spawn worker threads.
+void
+restCurlGlobalInit() {
+    static std::once_flag flag;
+    std::call_once(flag, []() { curl_global_init(CURL_GLOBAL_DEFAULT); });
+}
+
+// Per-thread handle; curl_easy_reset() clears options while keeping the
+// connection cache so successive requests on a thread reuse the keep-alive.
+CURL *
+restAcquireHandle() {
+    restCurlGlobalInit();
+    thread_local std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> handle(curl_easy_init(),
+                                                                            &curl_easy_cleanup);
+    if (handle) {
+        curl_easy_reset(handle.get());
+    }
+    return handle.get();
+}
+
+} // namespace
+
+bool
+xferBenchUtils::putObjRest(size_t buffer_size, const std::string &name) {
+    std::string endpoint = xferBenchConfig::obj_endpoint_override;
+    if (endpoint.empty()) {
+        std::cerr << "Error: obj_endpoint_override required for REST object put" << std::endl;
+        return false;
+    }
+
+    CURL *curl = restAcquireHandle();
+    if (!curl) {
+        restLogLine(std::cerr, "Failed to put REST object " + name + ": curl handle unavailable");
+        return false;
+    }
+
+    restUploadCtx upload{buffer_size};
+
+    std::string url = endpoint + "/" + name;
+    std::string response_body;
+
+    restLogLine(std::cout,
+                "Putting REST object: " + name + " (size: " + std::to_string(buffer_size) +
+                    " bytes)");
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    if (!xferBenchConfig::obj_ca_bundle.empty()) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, xferBenchConfig::obj_ca_bundle.c_str());
+    }
+    // These handles run on OpenMP worker threads; disable libcurl signal use to
+    // avoid signal-handler races across threads.
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)buffer_size);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, restCurlReadBody);
+    curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, restCurlCaptureBody);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    // Bound a stalled endpoint: cap connection setup, and abort if the transfer
+    // makes no progress for a while. A no-progress guard (rather than a hard
+    // total cap) avoids killing a legitimately large but still-advancing upload.
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 30L);
+
+    CURLcode res = curl_easy_perform(curl);
+    long http_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+    bool ok = (res == CURLE_OK) && (http_code >= 200 && http_code < 300);
+    if (!ok) {
+        std::string msg = "Failed to put REST object " + name + " (curl_code " +
+            std::to_string((int)res) + ", HTTP " + std::to_string(http_code) + ") PUT " + url;
+        if (!response_body.empty()) {
+            msg += "\n  response: " + response_body;
+        }
+        restLogLine(std::cerr, msg);
+    }
+    return ok;
+}
+
+bool
+xferBenchUtils::rmObjRest(const std::string &name) {
+    std::string endpoint = xferBenchConfig::obj_endpoint_override;
+    if (endpoint.empty()) {
+        std::cerr << "Error: obj_endpoint_override required for REST object cleanup" << std::endl;
+        return false;
+    }
+
+    CURL *curl = restAcquireHandle();
+    if (!curl) {
+        restLogLine(std::cerr,
+                    "Warning: Failed to delete REST object " + name + ": curl handle unavailable");
+        return false;
+    }
+
+    std::string url = endpoint + "/" + name;
+    std::string response_body;
+
+    restLogLine(std::cout, "Removing REST object: " + name);
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    if (!xferBenchConfig::obj_ca_bundle.empty()) {
+        curl_easy_setopt(curl, CURLOPT_CAINFO, xferBenchConfig::obj_ca_bundle.c_str());
+    }
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, restCurlCaptureBody);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_body);
+    // Bound a stalled endpoint: the DELETE carries no body, so a hard total
+    // timeout is safe here in addition to the connection-setup cap.
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
+
+    // DELETE is idempotent, so retry connect-class failures. A burst of cold
+    // connections at teardown can overflow the endpoint's accept backlog,
+    // surfacing as CURLE_COULDNT_CONNECT / CURLE_OPERATION_TIMEDOUT.
+    constexpr int kMaxAttempts = 4;
+    CURLcode res = CURLE_OK;
+    long http_code = 0;
+    for (int attempt = 0; attempt < kMaxAttempts; attempt++) {
+        response_body.clear();
+        res = curl_easy_perform(curl);
+        http_code = 0;
+        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+        bool transient = (res == CURLE_COULDNT_CONNECT) || (res == CURLE_OPERATION_TIMEDOUT) ||
+            (res == CURLE_COULDNT_RESOLVE_HOST) || (res == CURLE_SEND_ERROR) ||
+            (res == CURLE_RECV_ERROR);
+        if (!transient || attempt == kMaxAttempts - 1) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50 << attempt));
+    }
+
+    // A missing object (404) is acceptable for best-effort cleanup.
+    bool ok = (res == CURLE_OK) && ((http_code >= 200 && http_code < 300) || http_code == 404);
+    if (!ok) {
+        std::string msg = "Warning: Failed to delete REST object " + name + " (curl_code " +
+            std::to_string((int)res) + ", HTTP " + std::to_string(http_code) + ") DELETE " + url;
+        if (!response_body.empty()) {
+            msg += "\n  response: " + response_body;
+        }
+        restLogLine(std::cerr, msg);
+    }
+    return ok;
+}
+
 bool
 xferBenchUtils::putObj(size_t buffer_size, const std::string &name) {
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_INFINIA) {
@@ -1310,6 +1518,9 @@ xferBenchUtils::putObj(size_t buffer_size, const std::string &name) {
         return true;
     }
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_OBJ) {
+        if (xferBenchConfig::isRestBackend()) {
+            return putObjRest(buffer_size, name);
+        }
         return putObjS3(buffer_size, name);
     } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_AZURE_BLOB) {
         return putObjAzure(buffer_size, name);
@@ -1343,6 +1554,9 @@ xferBenchUtils::rmObj(const std::string &name) {
         return true;
     }
     if (xferBenchConfig::backend == XFERBENCH_BACKEND_OBJ) {
+        if (xferBenchConfig::isRestBackend()) {
+            return rmObjRest(name);
+        }
         return rmObjS3(name);
     } else if (xferBenchConfig::backend == XFERBENCH_BACKEND_AZURE_BLOB) {
         return rmObjAzure(name);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -209,6 +209,7 @@ public:
     static size_t obj_crt_min_limit;
     static bool obj_accelerated_enable;
     static std::string obj_accelerated_type;
+    static size_t obj_num_threads;
     static std::string azure_blob_account_url;
     static std::string azure_blob_container_name;
     static std::string azure_blob_connection_string;
@@ -234,6 +235,8 @@ public:
     isStorageBackend();
     static bool
     isObjStorageBackend();
+    static bool
+    isRestBackend();
 
 protected:
     static int
@@ -385,6 +388,10 @@ public:
     getObjS3(const std::string &name);
     static bool
     rmObjS3(const std::string &name);
+    static bool
+    putObjRest(size_t buffer_size, const std::string &name);
+    static bool
+    rmObjRest(const std::string &name);
 
     static bool
     checkConsistency(std::vector<std::vector<xferBenchIOV>> &desc_lists);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -29,6 +29,7 @@
 #endif
 #include <fcntl.h>
 #include <filesystem>
+#include <atomic>
 #include <iomanip>
 #include <memory>
 #include <numeric>
@@ -962,19 +963,49 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         gettimeofday(&tv, nullptr);
         uint64_t timestamp = tv.tv_sec * 1000000ULL + tv.tv_usec;
 
+        // Pre-populate objects for READ benchmarks. Each putObj is one HTTP PUT
+        // (network-bound), so seed all objects concurrently; the descriptor /
+        // registration bookkeeping below stays sequential. Errors are recorded
+        // in a flag rather than exit()-ing inside the OpenMP region.
+        if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
+            std::vector<std::string> obj_names;
+            obj_names.reserve((size_t)num_threads * num_devices);
+            for (int list_idx = 0; list_idx < num_threads; list_idx++) {
+                for (i = 0; i < num_devices; i++) {
+                    obj_names.push_back("nixlbench_obj" + std::to_string(list_idx) + "_" +
+                                        std::to_string(i) + "_" + std::to_string(timestamp));
+                }
+            }
+
+            std::atomic<bool> put_failed(false);
+#pragma omp parallel for num_threads(num_threads)
+            for (size_t idx = 0; idx < obj_names.size(); idx++) {
+                if (put_failed.load(std::memory_order_relaxed)) {
+                    continue;
+                }
+                if (!xferBenchUtils::putObj(buffer_size, obj_names[idx])) {
+                    std::cerr << "Failed to put object: " << obj_names[idx]
+                              << " -- cannot pre-populate objects for READ benchmark, aborting."
+                              << std::endl;
+                    put_failed.store(true, std::memory_order_relaxed);
+                }
+            }
+            if (put_failed.load()) {
+                // Best-effort cleanup of objects seeded before the failure so a
+                // partial pre-population doesn't leak benchmark objects.
+                for (const auto &obj_name : obj_names) {
+                    xferBenchUtils::rmObj(obj_name);
+                }
+                exit(EXIT_FAILURE);
+            }
+        }
+
         for (int list_idx = 0; list_idx < num_threads; list_idx++) {
             std::vector<xferBenchIOV> iov_list;
             for (i = 0; i < num_devices; i++) {
                 std::optional<xferBenchIOV> basic_desc;
                 std::string unique_name = "nixlbench_obj" + std::to_string(list_idx) + "_" +
                     std::to_string(i) + "_" + std::to_string(timestamp);
-
-                if (xferBenchConfig::op_type == XFERBENCH_OP_READ) {
-                    if (!xferBenchUtils::putObj(buffer_size, unique_name)) {
-                        std::cerr << "Failed to put object: " << unique_name << std::endl;
-                        continue;
-                    }
-                }
 
                 int obj_dev_id = list_idx * num_devices + i;
                 basic_desc = initBasicDescObj(buffer_size, obj_dev_id, unique_name);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -252,10 +252,15 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
                       << xferBenchConfig::obj_crt_min_limit << " bytes" << std::endl;
         } else if (xferBenchConfig::obj_accelerated_enable) {
             backend_params["accelerated"] = "true";
-            std::cout << "OBJ backend with S3 Accelerated client enabled";
+            const bool is_s3_accelerated = !xferBenchConfig::isRestBackend();
+            std::cout << "OBJ backend with " << (is_s3_accelerated ? "S3 " : "")
+                      << "Accelerated client enabled";
             if (!xferBenchConfig::obj_accelerated_type.empty()) {
                 backend_params["type"] = xferBenchConfig::obj_accelerated_type;
                 std::cout << " (type: " << xferBenchConfig::obj_accelerated_type << ")";
+            }
+            if (xferBenchConfig::obj_num_threads > 0) {
+                backend_params["num_threads"] = std::to_string(xferBenchConfig::obj_num_threads);
             }
             std::cout << std::endl;
         } else {
@@ -537,6 +542,7 @@ cleanupVramNeuron(xferBenchIOV &iov) {
 static std::optional<xferBenchIOV>
 getVramDescCuda(int devid, size_t buffer_size, uint8_t memset_value) {
     void *addr;
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
     CHECK_CUDA_ERROR(cudaMalloc(&addr, buffer_size), "Failed to allocate CUDA buffer");
     CHECK_CUDA_ERROR(cudaMemset(addr, memset_value, buffer_size), "Failed to set device memory");
 
@@ -639,6 +645,13 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
     }
 
 #if HAVE_CUDA
+    int device_count = 0;
+    CHECK_CUDA_ERROR(cudaGetDeviceCount(&device_count), "Failed to get CUDA device count");
+    if (devid < 0 || devid >= device_count) {
+        std::cerr << "Requested CUDA device " << devid << " but only " << device_count
+                  << " device(s) available (override with CUDA_VISIBLE_DEVICES)" << std::endl;
+        return std::nullopt;
+    }
     CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
     if (xferBenchConfig::enable_vmm) {
         return getVramDescCudaVmm(devid, buffer_size, memset_value);

--- a/meson.build
+++ b/meson.build
@@ -123,8 +123,19 @@ has_posix_aio = cpp.has_function('aio_cancel', prefix: '#include <aio.h>', depen
 # Check whether the POSIX plugin is enabled
 has_posix_plugin = has_linux_aio or has_io_uring or has_posix_aio
 
-# Check for CUObject Client library
-cuobj_dep = dependency('cuobjclient-13.1', required: false)
+# Check for CUObject Client library. The pkg-config name is usually versioned
+# (e.g. cuobjclient-13.1); fall back to discovering the highest installed version.
+pkgconfig = find_program('pkg-config', required: false)
+cuobj_dep = dependency('cuobjclient', required: false)
+if not cuobj_dep.found() and pkgconfig.found()
+    cuobj_pkg_name = run_command('sh', '-c',
+        pkgconfig.full_path() + ' --list-all 2>/dev/null' +
+        ' | awk \'$1 ~ /^cuobjclient-/ {print $1}\' | sort -V | tail -n1',
+        check: false).stdout().strip()
+    if cuobj_pkg_name != ''
+        cuobj_dep = dependency(cuobj_pkg_name, required: false)
+    endif
+endif
 if cuobj_dep.found()
     add_project_arguments('-DHAVE_CUOBJ_CLIENT', language: ['cpp'])
 endif

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -65,8 +65,8 @@ if cuobj_dep.found()
         scality_connector_lib = static_library(
             'scality_ai_connector',
             [
-                'rest_accel/scality_ai_connector/client.cpp',
-                'rest_accel/scality_ai_connector/client.h',
+                'rest_accel/scality_ai_connector/rest_client.cpp',
+                'rest_accel/scality_ai_connector/rest_client.h',
                 'rest_accel/scality_ai_connector/engine_impl.cpp',
                 'rest_accel/scality_ai_connector/engine_impl.h',
                 'rest_accel/scality_ai_connector/rdma_token_client.h',

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -40,8 +40,10 @@ plugin_deps = [nixl_infra, nixl_common_dep, obj_utils_interface, dependency('asi
 compile_defs = []
 compile_flags = []
 
+obj_link_whole = []
+
 if cuobj_dep.found()
-    message('Found CUObjClient Library. Enabling S3 Accelerated engines')
+    message('Found CUObjClient Library. Enabling object accelerated engines')
     obj_sources += [
         's3_accel/client.cpp',
         's3_accel/client.h',
@@ -53,8 +55,35 @@ if cuobj_dep.found()
         's3_accel/dell/engine_impl.h',
     ]
     plugin_deps += [ cuobj_dep ]
+
+    curl_dep = dependency('libcurl', required: false)
+    if curl_dep.found()
+        message('Enabling Scality AI Connector engine')
+        # link_whole pulls in the static lib's objects but not its dependencies,
+        # so add libcurl to plugin_deps to propagate it to the final OBJ target.
+        plugin_deps += [ curl_dep ]
+        scality_connector_lib = static_library(
+            'scality_ai_connector',
+            [
+                'rest_accel/scality_ai_connector/client.cpp',
+                'rest_accel/scality_ai_connector/client.h',
+                'rest_accel/scality_ai_connector/engine_impl.cpp',
+                'rest_accel/scality_ai_connector/engine_impl.h',
+                'rest_accel/scality_ai_connector/rdma_token_client.h',
+                'rest_accel/scality_ai_connector/cuobj_rdma_token_client.cpp',
+                'rest_accel/scality_ai_connector/cuobj_rdma_token_client.h',
+            ],
+            dependencies: plugin_deps + [ cuda_dep ],
+            cpp_args: compile_defs + compile_flags,
+            include_directories: [nixl_inc_dirs, utils_inc_dirs],
+            pic: true,
+            install: false)
+        obj_link_whole += [ scality_connector_lib ]
+    else
+        message('libcurl not found. Skipping Scality AI Connector engine')
+    endif
 else
-    message('Could not find CUObjClient Library. Skipping S3 Accelerated engines')
+    message('Could not find CUObjClient Library. Skipping object accelerated engines')
 endif
 
 if 'OBJ' in static_plugins
@@ -64,6 +93,7 @@ if 'OBJ' in static_plugins
         dependencies: plugin_deps,
         cpp_args: compile_defs + compile_flags,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        link_whole: obj_link_whole,
         install: false,
         name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
@@ -73,6 +103,7 @@ else
         dependencies: plugin_deps,
         cpp_args: compile_defs + compile_flags + ['-fPIC'],
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        link_whole: obj_link_whole,
         install: true,
         name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
         install_dir: plugin_install_dir,

--- a/src/plugins/obj/rest_accel/scality_ai_connector/README.md
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/README.md
@@ -1,0 +1,150 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Scality AI Connector
+
+A plugin engine for the OBJ backend of
+[NIXL](https://github.com/ai-dynamo/nixl), the NVIDIA Inference Xfer Library:
+one API for moving data between HBM, DRAM, NVMe, file, and object storage, with
+pluggable backends.
+
+This engine connects NIXL to a Scality endpoint and splits each transfer into
+two planes: the **data plane** is RDMA; the **control plane** is a header-only
+HTTP request that names the operation and the object id. Object bytes never
+travel over HTTP.
+
+## Overview
+
+The connector splits each transfer into two independent channels:
+
+- **Data plane (RDMA):** the object bytes move directly between the local
+  buffer and Scality over RDMA, zero-copy and GPUDirect-capable, so data in
+  GPU memory never needs a staging copy through host memory.
+- **Control plane (HTTP):** a header-only HTTP request tells Scality *what* to do
+  (`PUT`/`GET` of an object). Its body is **empty**: no payload travels
+  over HTTP. The RDMA "token" (a descriptor identifying the registered buffer)
+  is passed to Scality in a custom `x-scal-rdma` header.
+
+```text
+  local buffer (DRAM/VRAM) ─RDMA──────────────────────────► Scality endpoint
+                                                              ▲
+  control: HTTP PUT/GET {endpoint}/{object_id}                │
+           header  x-scal-rdma: <token>     ──────────────────┘
+           body    (empty)
+```
+
+**Terms:**
+
+- **RDMA** (Remote Direct Memory Access): network transfers straight into
+  registered memory, bypassing CPU copies.
+- **DC** (Dynamically Connected): the RDMA transport mode used here.
+- **cuObject**: NVIDIA's GPUDirect Storage client library that provides the
+  RDMA path.
+
+## When to use it
+
+| Use this engine when | Use `s3` / `s3_crt` instead when |
+|---|---|
+| The store is a **Scality AI Connector** (REST) endpoint | The store is **S3-compatible** |
+| **RDMA-capable** hardware and the cuObject stack are available | Plain HTTP(S) data transfer is sufficient |
+| Transfers are large buffers, often in **GPU memory** | RDMA / GPUDirect is not needed |
+
+The Scality AI Connector speaks Scality's own REST dialect; it is **not** an S3
+client and uses no AWS SDK or AWS authentication.
+
+## Prerequisites
+
+- **NVIDIA cuObject / GPUDirect Storage** installed and working. This provides
+  the DC RDMA path and is mandatory. The engine uses the
+  `CUOBJ_PROTO_RDMA_DC_V1` protocol and is developed against the CUDA 13.x
+  cuObject stack.
+- An **RDMA-capable fabric/NIC** reachable by the Scality endpoint.
+- A reachable **Scality AI Connector REST endpoint**.
+- Build dependencies: `cuobjclient` and `libcurl`.
+
+## Building
+
+The engine is part of NIXL's standard Meson build and is compiled in
+automatically when both `cuobjclient` and `libcurl` are detected at configure
+time:
+
+```sh
+meson setup build
+ninja -C build
+```
+
+If `cuobjclient` is not found, the accelerated OBJ engines (including this one)
+are skipped, and the engine reports `Accelerated engine support not available
+(not compiled)` at run time.
+
+## Configuration
+
+The engine is selected and configured through the backend's `customParams`:
+
+| Parameter | Required | Default | Meaning |
+|---|---|---|---|
+| `accelerated` | yes | n/a | Must be `"true"` to request an accelerated engine |
+| `type` | yes | n/a | Must be `"scality_ai_connector"` to select this engine |
+| `endpoint_override` | yes | n/a | Base URL of the connector, e.g. `http://10.0.0.1:10000` |
+| `num_threads` | no | `max(2, cpu_threads / 4)` | Size of the callback worker pool (see [Concurrency model](#concurrency-model)). |
+
+Requests are issued to `{endpoint_override}/{object_id}`.
+
+Example (parameters as passed to the OBJ backend):
+
+```ini
+accelerated       = true
+type              = scality_ai_connector
+endpoint_override = http://10.0.0.1:10000
+num_threads       = 8            # optional: callback pool size
+```
+
+## Concurrency model
+
+A single poller thread drives all HTTP requests through libcurl's multi
+interface, so the in-flight request count does not depend on `num_threads` (the
+bulk data moves over RDMA; curl only carries the header-only command). Each completed
+request's callback runs in a worker pool sized by `num_threads`, so a slow
+callback cannot stall the poller. Size `num_threads` according to the amount of
+work each callback does. The default value is sufficient for lightweight callbacks.
+
+## How a transfer works
+
+1. **Register memory.** Local **DRAM or VRAM (GPU)** buffers are registered for
+   RDMA; remote **object** segments are mapped to their object ids.
+2. **Prepare.** For each piece of the transfer the connector obtains an RDMA
+   token for the buffer (no data moves yet).
+3. **Post.** It issues the HTTP `PUT`/`GET` for the object id, carrying the
+   token in the `x-scal-rdma` header, and returns immediately; the request is
+   in progress. Scality performs the actual RDMA transfer against the buffer.
+4. **Poll.** The transfer is checked for completion until all parts succeed (or
+   one reports an error).
+
+## Limitations
+
+- **DC transport only.** There is no fallback to other RDMA transports.
+- **4 GiB** maximum per memory registration (a cuObject limit).
+- The **cuObject stack is required** at both build and run time; without it the
+  engine does not exist.
+
+## Troubleshooting
+
+| Symptom (in logs) | Potential cause / fix |
+|---|---|
+| `'endpoint_override' parameter is required` | Set `endpoint_override` in `customParams`. |
+| `RDMA token client failed to connect` | cuObject / GPUDirect Storage or the RDMA fabric is not ready on this host. |
+| `<op>: failed url=<url> curl_code=<n> http_code=<n>` | The HTTP call reached the endpoint but failed; check the object id, endpoint URL. A non-2xx `http_code` comes from Scality. |
+| `Accelerated engine support not available (not compiled)` | cuObject was not detected at build time, so the connector was not compiled in. |
+
+## For contributors
+
+Source layout (see the code for details):
+
+| File | Role |
+|---|---|
+| `engine_impl.{h,cpp}` | `ScalityObjEngineImpl`: the engine (register / prepare / post / check). |
+| `client.{h,cpp}` | `RestClient`: the libcurl HTTP control-plane client, an event-driven `curl_multi` poller with a callback worker pool (behind the `iRestClient` interface, which is also the test-injection seam). See [Concurrency model](#concurrency-model). |
+| `rdma_token_client.h` | `iRdmaTokenClient`: the data-plane interface and the `getCtx()` helper. |
+| `cuobj_rdma_token_client.{h,cpp}` | `CuObjRdmaTokenClient`: the DC RDMA implementation, a thin wrapper over NVIDIA `cuObjClient` (`CUOBJ_PROTO_RDMA_DC_V1`). |

--- a/src/plugins/obj/rest_accel/scality_ai_connector/README.md
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/README.md
@@ -145,6 +145,7 @@ Source layout (see the code for details):
 | File | Role |
 |---|---|
 | `engine_impl.{h,cpp}` | `ScalityObjEngineImpl`: the engine (register / prepare / post / check). |
+| `device_select.h` | `targetCudaDevice()`: maps a buffer to the CUDA device whose closest NIC its MR binds to. |
 | `client.{h,cpp}` | `RestClient`: the libcurl HTTP control-plane client, an event-driven `curl_multi` poller with a callback worker pool (behind the `iRestClient` interface, which is also the test-injection seam). See [Concurrency model](#concurrency-model). |
 | `rdma_token_client.h` | `iRdmaTokenClient`: the data-plane interface and the `getCtx()` helper. |
 | `cuobj_rdma_token_client.{h,cpp}` | `CuObjRdmaTokenClient`: the DC RDMA implementation, a thin wrapper over NVIDIA `cuObjClient` (`CUOBJ_PROTO_RDMA_DC_V1`). |

--- a/src/plugins/obj/rest_accel/scality_ai_connector/README.md
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/README.md
@@ -146,6 +146,6 @@ Source layout (see the code for details):
 |---|---|
 | `engine_impl.{h,cpp}` | `ScalityObjEngineImpl`: the engine (register / prepare / post / check). |
 | `device_select.h` | `targetCudaDevice()`: maps a buffer to the CUDA device whose closest NIC its MR binds to. |
-| `client.{h,cpp}` | `RestClient`: the libcurl HTTP control-plane client, an event-driven `curl_multi` poller with a callback worker pool (behind the `iRestClient` interface, which is also the test-injection seam). See [Concurrency model](#concurrency-model). |
+| `rest_client.{h,cpp}` | `RestClient`: the libcurl HTTP control-plane client, an event-driven `curl_multi` poller with a callback worker pool (behind the `iRestClient` interface, which is also the test-injection seam). See [Concurrency model](#concurrency-model). |
 | `rdma_token_client.h` | `iRdmaTokenClient`: the data-plane interface and the `getCtx()` helper. |
 | `cuobj_rdma_token_client.{h,cpp}` | `CuObjRdmaTokenClient`: the DC RDMA implementation, a thin wrapper over NVIDIA `cuObjClient` (`CUOBJ_PROTO_RDMA_DC_V1`). |

--- a/src/plugins/obj/rest_accel/scality_ai_connector/client.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/client.cpp
@@ -1,0 +1,440 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "client.h"
+#include "common/nixl_log.h"
+#include <absl/strings/str_format.h>
+#include <asio/post.hpp>
+#include <curl/curl.h>
+#include <algorithm>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+#include <unordered_set>
+#include <utility>
+
+namespace {
+
+size_t
+captureBody(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    auto *body = static_cast<std::string *>(userdata);
+    body->append(static_cast<char *>(ptr), size * nmemb);
+    return size * nmemb;
+}
+
+std::once_flag curl_init_flag;
+
+std::size_t
+parseNumThreads(nixl_b_params_t *params) {
+    if (!params || params->count("num_threads") == 0) {
+        return std::max(2u, std::thread::hardware_concurrency() / 4);
+    }
+    // A zero pool would accept callbacks but never run them, hanging every
+    // transfer; reject non-positive / malformed values instead.
+    const std::string &value = params->at("num_threads");
+    std::size_t consumed = 0;
+    const std::size_t parsed = std::stoul(value, &consumed);
+    if (consumed != value.size() || parsed == 0) {
+        throw std::invalid_argument("RestClient: num_threads must be a positive integer");
+    }
+    return parsed;
+}
+
+} // namespace
+
+enum class restMethod { PUT, GET, HEAD };
+
+// Per-request state for an in-flight curl_multi transfer. Owns its easy handle,
+// header list, and response buffer for the full transfer lifetime; the user
+// callback (exactly one of the two, by method) is moved out on completion.
+struct RestClient::RequestCtx {
+    CURL *easy = nullptr;
+    struct curl_slist *headers = nullptr;
+    std::string url;
+    std::string response_body;
+    const char *op_name = "";
+    restMethod method = restMethod::GET;
+    std::function<void(bool)> bool_cb; // Put/Get
+    std::function<void(std::optional<bool>)> check_cb; // Head
+
+    ~RequestCtx() {
+        if (headers) {
+            curl_slist_free_all(headers);
+        }
+        if (easy) {
+            // Must already be removed from the multi handle by the poller.
+            curl_easy_cleanup(easy);
+        }
+    }
+};
+
+// Apply URL + method-specific options to a fresh easy handle. Wire format is
+// kept byte-identical to the previous synchronous implementation.
+void
+RestClient::buildEasy(RequestCtx *ctx) {
+    CURL *curl = ctx->easy;
+    curl_easy_setopt(curl, CURLOPT_URL, ctx->url.c_str());
+    switch (ctx->method) {
+    case restMethod::PUT:
+        curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)0);
+        break;
+    case restMethod::GET:
+        curl_easy_setopt(curl, CURLOPT_HTTPGET, 1L);
+        break;
+    case restMethod::HEAD:
+        curl_easy_setopt(curl, CURLOPT_NOBODY, 1L); // HTTP HEAD
+        break;
+    }
+    if (ctx->headers) {
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, ctx->headers);
+    }
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, captureBody);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ctx->response_body);
+    curl_easy_setopt(curl, CURLOPT_PRIVATE, ctx);
+    // Bound the control-plane request so a stalled endpoint can't leave a
+    // transfer in-flight forever (the body is empty; bulk data is on RDMA).
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 5000L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
+}
+
+// Map a finished transfer to its callback, dispatch it on the worker pool, and
+// free the context. Runs on the poller thread; the posted closure captures only
+// the moved callback plus the plain result, so the pool never touches curl state.
+// Callbacks are expected not to throw; the dispatch guards against it defensively
+// so a misbehaving callback cannot take down a pool worker.
+void
+RestClient::finishRequest(RequestCtx *ctx, CURLcode res, long http_code) {
+    if (ctx->method == restMethod::HEAD) {
+        std::optional<bool> result;
+        if (res != CURLE_OK) {
+            NIXL_ERROR << absl::StrFormat("checkObjectExistsAsync: curl_code=%d for HEAD %s",
+                                          static_cast<int>(res),
+                                          ctx->url);
+            result = std::nullopt;
+        } else if (http_code >= 200 && http_code < 300) {
+            result = true;
+        } else if (http_code == 404) {
+            result = false;
+        } else {
+            NIXL_ERROR << absl::StrFormat(
+                "checkObjectExistsAsync: HTTP %ld for HEAD %s", http_code, ctx->url);
+            result = std::nullopt;
+        }
+        auto cb = std::move(ctx->check_cb);
+        asio::post(pool_, [cb = std::move(cb), result]() {
+            try {
+                if (cb) {
+                    cb(result);
+                }
+            }
+            catch (...) {
+            }
+        });
+    } else {
+        bool success = (res == CURLE_OK) && (http_code >= 200 && http_code < 300);
+        if (!success) {
+            NIXL_ERROR << absl::StrFormat("%s: failed url=%s curl_code=%d http_code=%ld body=%s",
+                                          ctx->op_name,
+                                          ctx->url,
+                                          static_cast<int>(res),
+                                          http_code,
+                                          ctx->response_body.empty() ? "<empty>" :
+                                                                       ctx->response_body);
+        } else {
+            NIXL_DEBUG << absl::StrFormat(
+                "%s: success url=%s http_code=%ld", ctx->op_name, ctx->url, http_code);
+        }
+        auto cb = std::move(ctx->bool_cb);
+        asio::post(pool_, [cb = std::move(cb), success]() {
+            try {
+                if (cb) {
+                    cb(success);
+                }
+            }
+            catch (...) {
+            }
+        });
+    }
+    delete ctx;
+}
+
+RestClient::RestClient(nixl_b_params_t *custom_params)
+    : numThreads_(parseNumThreads(custom_params)),
+      pool_(numThreads_) {
+    std::call_once(curl_init_flag, []() { curl_global_init(CURL_GLOBAL_DEFAULT); });
+    if (!custom_params) {
+        throw std::invalid_argument("RestClient: custom_params is null");
+    }
+
+    auto ep_it = custom_params->find("endpoint_override");
+    if (ep_it == custom_params->end() || ep_it->second.empty()) {
+        throw std::invalid_argument("RestClient: 'endpoint_override' parameter is required");
+    }
+    endpoint_ = ep_it->second;
+
+    // Create the multi handle and start the poller only after validation, so a
+    // throwing constructor leaves no thread or handle behind.
+    multi_ = curl_multi_init();
+    if (!multi_) {
+        throw std::runtime_error("RestClient: curl_multi_init failed");
+    }
+    poller_ = std::thread(&RestClient::pollerLoop, this);
+
+    NIXL_INFO << absl::StrFormat(
+        "RestClient initialized: endpoint=%s, callback_threads=%zu (curl_multi poller)",
+        endpoint_,
+        numThreads_);
+}
+
+RestClient::~RestClient() {
+    stop_.store(true);
+    if (multi_) {
+        curl_multi_wakeup(multi_); // break the poller out of curl_multi_poll
+    }
+    if (poller_.joinable()) {
+        poller_.join(); // poller fails any outstanding requests before returning
+    }
+    pool_.join(); // drain queued callbacks
+    if (multi_) {
+        curl_multi_cleanup(multi_);
+    }
+}
+
+std::string
+RestClient::buildUrl(std::string_view key) const {
+    return absl::StrFormat("%s/%s", endpoint_, key);
+}
+
+void
+RestClient::enqueue(std::unique_ptr<RequestCtx> ctx) {
+    {
+        const std::lock_guard<std::mutex> lk(queueMtx_);
+        incoming_.push(std::move(ctx));
+    }
+    curl_multi_wakeup(multi_); // thread-safe; nudges the poller to drain the queue
+}
+
+void
+RestClient::reapCompletions() {
+    CURLMsg *msg = nullptr;
+    int in_queue = 0;
+    while ((msg = curl_multi_info_read(multi_, &in_queue)) != nullptr) {
+        if (msg->msg != CURLMSG_DONE) {
+            continue;
+        }
+        CURL *easy = msg->easy_handle;
+        CURLcode res = msg->data.result;
+        RequestCtx *ctx = nullptr;
+        curl_easy_getinfo(easy, CURLINFO_PRIVATE, &ctx);
+        long http_code = 0;
+        curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &http_code);
+
+        curl_multi_remove_handle(multi_, easy);
+        inflight_.erase(ctx);
+        finishRequest(ctx, res, http_code);
+    }
+}
+
+void
+RestClient::pollerLoop() {
+    for (;;) {
+        const bool stopping = stop_.load();
+
+        // 1. Drain the producer queue. On shutdown, fail queued requests instead
+        //    of starting them.
+        std::queue<std::unique_ptr<RequestCtx>> batch;
+        {
+            const std::lock_guard<std::mutex> lk(queueMtx_);
+            std::swap(batch, incoming_);
+        }
+        while (!batch.empty()) {
+            std::unique_ptr<RequestCtx> ctx = std::move(batch.front());
+            batch.pop();
+            if (stopping) {
+                finishRequest(ctx.release(), CURLE_ABORTED_BY_CALLBACK, 0);
+                continue;
+            }
+            RequestCtx *raw = ctx.get();
+            CURLMcode mc = curl_multi_add_handle(multi_, raw->easy);
+            if (mc != CURLM_OK) {
+                NIXL_ERROR << absl::StrFormat(
+                    "%s: curl_multi_add_handle failed: %s", raw->op_name, curl_multi_strerror(mc));
+                finishRequest(ctx.release(), CURLE_FAILED_INIT, 0);
+                continue;
+            }
+            ctx.release(); // ownership tracked via CURLOPT_PRIVATE until completion
+            inflight_.insert(raw);
+        }
+
+        // 2. Advance all in-flight transfers (non-blocking).
+        int running = 0;
+        curl_multi_perform(multi_, &running);
+
+        // 3. Hand finished transfers' callbacks to the worker pool.
+        reapCompletions();
+
+        // 4. On shutdown, abort anything still in flight so every callback fires.
+        if (stopping) {
+            for (RequestCtx *ctx : inflight_) {
+                curl_multi_remove_handle(multi_, ctx->easy);
+                finishRequest(ctx, CURLE_ABORTED_BY_CALLBACK, 0);
+            }
+            inflight_.clear();
+            break;
+        }
+
+        // 5. Block until socket activity, the 1s backstop, or curl_multi_wakeup().
+        int numfds = 0;
+        curl_multi_poll(multi_, nullptr, 0, 1000, &numfds);
+    }
+}
+
+void
+RestClient::submitRdmaRequest(const char *op_name,
+                              std::string_view key,
+                              std::string_view rdma_desc,
+                              bool is_upload,
+                              std::function<void(bool)> callback) {
+    auto ctx = std::make_unique<RequestCtx>();
+    ctx->op_name = op_name;
+    ctx->method = is_upload ? restMethod::PUT : restMethod::GET;
+    ctx->url = buildUrl(key);
+    ctx->bool_cb = std::move(callback);
+
+    ctx->easy = curl_easy_init();
+    if (!ctx->easy) {
+        NIXL_ERROR << absl::StrFormat("%s: curl_easy_init failed", op_name);
+        if (ctx->bool_cb) {
+            ctx->bool_cb(false);
+        }
+        return;
+    }
+
+    std::string rdma_header = absl::StrFormat("x-scal-rdma: %s", rdma_desc);
+    ctx->headers = curl_slist_append(ctx->headers, rdma_header.c_str());
+    if (is_upload) {
+        // Content-Length: 0; data is transferred via RDMA, not the HTTP body.
+        ctx->headers = curl_slist_append(ctx->headers, "Content-Length: 0");
+    }
+
+    buildEasy(ctx.get());
+    enqueue(std::move(ctx));
+}
+
+void
+RestClient::putObjectRdmaAsync(std::string_view key,
+                               uintptr_t data_ptr,
+                               size_t data_len,
+                               size_t offset,
+                               std::string_view rdma_desc,
+                               put_object_callback_t callback) {
+    // The RDMA descriptor is sensitive transfer-capability metadata; log only
+    // its length, never the raw token.
+    NIXL_DEBUG << absl::StrFormat(
+        "putObjectRdmaAsync: key=%s, data_ptr=%p, data_len=%zu, offset=%zu, rdma_desc_len=%zu",
+        key,
+        reinterpret_cast<void *>(data_ptr),
+        data_len,
+        offset,
+        rdma_desc.size());
+
+    if (data_len == 0) {
+        NIXL_ERROR << "putObjectRdmaAsync: data_len is 0, returning failure";
+        if (callback) {
+            callback(false);
+        }
+        return;
+    }
+
+    if (rdma_desc.empty()) {
+        NIXL_ERROR << "putObjectRdmaAsync: rdma_desc is empty, returning failure";
+        if (callback) {
+            callback(false);
+        }
+        return;
+    }
+
+    submitRdmaRequest(
+        "putObjectRdmaAsync", key, rdma_desc, /*is_upload=*/true, std::move(callback));
+}
+
+void
+RestClient::getObjectRdmaAsync(std::string_view key,
+                               uintptr_t data_ptr,
+                               size_t data_len,
+                               size_t offset,
+                               std::string_view rdma_desc,
+                               get_object_callback_t callback) {
+    // Log only the descriptor length, never the raw RDMA token (sensitive).
+    NIXL_DEBUG << absl::StrFormat(
+        "getObjectRdmaAsync: key=%s, data_ptr=%p, data_len=%zu, offset=%zu, rdma_desc_len=%zu",
+        key,
+        reinterpret_cast<void *>(data_ptr),
+        data_len,
+        offset,
+        rdma_desc.size());
+
+    if (data_len == 0) {
+        NIXL_ERROR << "getObjectRdmaAsync: data_len is 0, returning failure";
+        if (callback) {
+            callback(false);
+        }
+        return;
+    }
+
+    if ((data_len > 0) && (offset > (SIZE_MAX - (data_len - 1)))) {
+        NIXL_ERROR << "getObjectRdmaAsync: offset + data_len would overflow, returning failure";
+        if (callback) {
+            callback(false);
+        }
+        return;
+    }
+
+    if (rdma_desc.empty()) {
+        NIXL_ERROR << "getObjectRdmaAsync: rdma_desc is empty, returning failure";
+        if (callback) {
+            callback(false);
+        }
+        return;
+    }
+
+    submitRdmaRequest(
+        "getObjectRdmaAsync", key, rdma_desc, /*is_upload=*/false, std::move(callback));
+}
+
+void
+RestClient::checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) {
+    auto ctx = std::make_unique<RequestCtx>();
+    ctx->op_name = "checkObjectExistsAsync";
+    ctx->method = restMethod::HEAD;
+    ctx->url = buildUrl(key);
+    ctx->check_cb = std::move(callback);
+
+    ctx->easy = curl_easy_init();
+    if (!ctx->easy) {
+        NIXL_ERROR << "checkObjectExistsAsync: curl_easy_init failed";
+        if (ctx->check_cb) {
+            ctx->check_cb(std::nullopt);
+        }
+        return;
+    }
+
+    buildEasy(ctx.get());
+    enqueue(std::move(ctx));
+}

--- a/src/plugins/obj/rest_accel/scality_ai_connector/client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/client.h
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H
+
+#include <asio/thread_pool.hpp>
+#include <asio/post.hpp>
+#include <curl/curl.h>
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_set>
+#include "obj_backend.h"
+#include "nixl_types.h"
+
+/**
+ * Interface for Scality AI Connector clients that support RDMA operations.
+ */
+class iRestClient {
+public:
+    virtual ~iRestClient() = default;
+
+    /**
+     * Asynchronously put an object using RDMA.
+     * @param key The object key
+     * @param data_ptr Pointer to the data to upload
+     * @param data_len Length of the data in bytes
+     * @param offset Offset within the object
+     * @param rdma_desc RDMA descriptor for the transfer
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    putObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       put_object_callback_t callback) = 0;
+
+    /**
+     * Asynchronously get an object using RDMA.
+     * @param key The object key
+     * @param data_ptr Pointer to the buffer to store the downloaded data
+     * @param data_len Maximum length of data to read
+     * @param offset Offset within the object to start reading from
+     * @param rdma_desc RDMA descriptor for the transfer
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    getObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       get_object_callback_t callback) = 0;
+
+    /**
+     * Asynchronously check whether an object exists (HTTP HEAD).
+     * @param key The object key
+     * @param callback Receives true (exists), false (404), or std::nullopt (error)
+     */
+    virtual void
+    checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) = 0;
+};
+
+/**
+ * Scality AI Connector HTTP client with RDMA support.
+ * Uses libcurl to perform HTTP PUT/GET requests, passing the RDMA
+ * descriptor via the x-scal-rdma custom header.
+ *
+ * URL format: {endpoint}/{key}
+ */
+class RestClient : public iRestClient {
+public:
+    /**
+     * Constructor.
+     * @param custom_params Backend init params; must contain "endpoint_override".
+     *                      Optional "num_threads" sizes the callback worker pool
+     *                      (default: max(2, hardware_concurrency / 4)).
+     */
+    explicit RestClient(nixl_b_params_t *custom_params);
+
+    ~RestClient() override;
+
+    void
+    putObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       put_object_callback_t callback) override;
+
+    void
+    getObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       get_object_callback_t callback) override;
+
+    void
+    checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) override;
+
+private:
+    /// Per-request state for an in-flight curl_multi transfer. Defined in client.cpp.
+    struct RequestCtx;
+
+    /// Base endpoint, e.g. "http://10.0.0.1:81"
+    std::string endpoint_;
+
+    // A single poller thread owns the curl multi handle and drives all transfers;
+    // completed callbacks are offloaded to this pool (sized by numThreads_) so a
+    // slow callback can't stall the event loop. curl multi handles are not
+    // thread-safe: every curl_multi_* call runs on the poller thread, except
+    // curl_multi_wakeup() which producers use to nudge it.
+    std::size_t numThreads_;
+    asio::thread_pool pool_; // callback worker pool
+
+    CURLM *multi_ = nullptr;
+    std::thread poller_;
+    std::mutex queueMtx_;
+    std::queue<std::unique_ptr<RequestCtx>> incoming_;
+    std::atomic<bool> stop_{false};
+    /// Handles currently added to multi_. Poller-thread access only (no lock).
+    std::unordered_set<RequestCtx *> inflight_;
+
+    /**
+     * Build the full URL for a given key.
+     * @param key Object key
+     * @return Full URL string
+     */
+    std::string
+    buildUrl(std::string_view key) const;
+
+    /**
+     * Build a PUT/GET RDMA request context and hand it to the poller. PUT and GET
+     * differ only in the curl method options, so they share this path.
+     * @param op_name Operation label for logging (string literal)
+     * @param key Object key
+     * @param rdma_desc RDMA descriptor for the x-scal-rdma header
+     * @param is_upload true for PUT (upload), false for GET
+     * @param callback Result callback (invoked on the worker pool)
+     */
+    void
+    submitRdmaRequest(const char *op_name,
+                      std::string_view key,
+                      std::string_view rdma_desc,
+                      bool is_upload,
+                      std::function<void(bool)> callback);
+
+    /// Apply URL + method-specific curl options to a request's easy handle.
+    static void
+    buildEasy(RequestCtx *ctx);
+
+    /// Push a fully-built request onto the queue and wake the poller.
+    void
+    enqueue(std::unique_ptr<RequestCtx> ctx);
+
+    /// Body of the poller thread: drain queue, perform, reap, poll.
+    void
+    pollerLoop();
+
+    /// Reap finished transfers (poller thread only) and dispatch their callbacks.
+    void
+    reapCompletions();
+
+    /// Map a finished transfer to its callback, dispatch it on the worker pool,
+    /// and free the context. Poller-thread only.
+    void
+    finishRequest(RequestCtx *ctx, CURLcode res, long http_code);
+};
+
+#endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuobj_rdma_token_client.h"
+#include "common/nixl_log.h"
+
+CuObjRdmaTokenClient::CuObjRdmaTokenClient(CUObjOps_t &ops)
+    : inner_(std::make_shared<cuObjClient>(ops, CUOBJ_PROTO_RDMA_DC_V1)) {
+    NIXL_INFO << "CuObjRdmaTokenClient initialized (DC transport)";
+}
+
+bool
+CuObjRdmaTokenClient::isConnected() const {
+    return inner_->isConnected();
+}
+
+cuObjErr_t
+CuObjRdmaTokenClient::cuMemObjGetDescriptor(void *ptr, size_t size) {
+    return inner_->cuMemObjGetDescriptor(ptr, size);
+}
+
+cuObjErr_t
+CuObjRdmaTokenClient::cuMemObjPutDescriptor(void *ptr) {
+    return inner_->cuMemObjPutDescriptor(ptr);
+}
+
+ssize_t
+CuObjRdmaTokenClient::cuObjGet(void *ctx,
+                               void *ptr,
+                               size_t size,
+                               loff_t offset,
+                               loff_t buf_offset) {
+    return inner_->cuObjGet(ctx, ptr, size, offset, buf_offset);
+}
+
+ssize_t
+CuObjRdmaTokenClient::cuObjPut(void *ctx,
+                               void *ptr,
+                               size_t size,
+                               loff_t offset,
+                               loff_t buf_offset) {
+    return inner_->cuObjPut(ctx, ptr, size, offset, buf_offset);
+}

--- a/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CUOBJ_RDMA_TOKEN_CLIENT_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CUOBJ_RDMA_TOKEN_CLIENT_H
+
+#include "rdma_token_client.h"
+
+/**
+ * Thin wrapper around NVIDIA cuObjClient (DC transport).
+ */
+class CuObjRdmaTokenClient : public iRdmaTokenClient {
+public:
+    explicit CuObjRdmaTokenClient(CUObjOps_t &ops);
+    ~CuObjRdmaTokenClient() override = default;
+
+    bool
+    isConnected() const override;
+    cuObjErr_t
+    cuMemObjGetDescriptor(void *ptr, size_t size) override;
+    cuObjErr_t
+    cuMemObjPutDescriptor(void *ptr) override;
+    ssize_t
+    cuObjGet(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) override;
+    ssize_t
+    cuObjPut(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) override;
+
+private:
+    std::shared_ptr<cuObjClient> inner_;
+};
+
+#endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CUOBJ_RDMA_TOKEN_CLIENT_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/cuobj_rdma_token_client.h
@@ -26,7 +26,7 @@
 class CuObjRdmaTokenClient : public iRdmaTokenClient {
 public:
     explicit CuObjRdmaTokenClient(CUObjOps_t &ops);
-    ~CuObjRdmaTokenClient() override = default;
+    ~CuObjRdmaTokenClient() = default;
 
     bool
     isConnected() const override;

--- a/src/plugins/obj/rest_accel/scality_ai_connector/device_select.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/device_select.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_DEVICE_SELECT_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_DEVICE_SELECT_H
+
+#include <cstdint>
+
+#include "nixl_types.h"
+
+/**
+ * Select the CUDA device whose closest NIC cuObject should bind a buffer's
+ * memory region (and thus its primary GID) to.
+ *
+ * cuObject bakes a single primary device GID into the RDMA descriptor at MR
+ * registration, chosen from the current CUDA device context. We exploit that:
+ *  - VRAM: bind to the buffer's own GPU (devId).
+ *  - DRAM: host memory has no GPU affinity, so spread successive buffers across
+ *    all GPUs (devId % gpuCount). Each GPU maps to a different NIC, fanning
+ *    host transfers across the available NICs instead of pinning them to one.
+ *
+ * @return target CUDA device, or -1 to leave the current device unchanged
+ *         (DRAM with no GPUs present, or an unsupported segment type).
+ */
+inline int
+targetCudaDevice(nixl_mem_t mem, uint64_t devId, int gpuCount) {
+    if (mem == VRAM_SEG) {
+        return static_cast<int>(devId);
+    }
+    if (mem == DRAM_SEG && gpuCount > 0) {
+        return static_cast<int>(devId % static_cast<uint64_t>(gpuCount));
+    }
+    return -1;
+}
+
+#endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_DEVICE_SELECT_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "engine_impl.h"
-#include "client.h"
+#include "rest_client.h"
 #include "common/nixl_log.h"
 #include <absl/strings/str_format.h>
 #include "cuobj_rdma_token_client.h"
@@ -80,10 +80,10 @@ objAccelEngineRegistrar reg_scality(
 /**
  * RDMA context structure for cuObject operations.
  */
-typedef struct rdma_ctx {
+struct rdma_ctx_t {
     /// RDMA descriptor string
     std::string rdma_desc;
-} rdma_ctx_t;
+};
 
 std::string
 objKeyFor(const std::string &metaInfo, uint64_t devId) {
@@ -146,14 +146,9 @@ public:
     std::string obj_key;
     rdma_ctx_t ctx;
 
-    scalityObjTransferRequestH() : addr(0), size(0), offset(0), rdma_desc(""), obj_key("") {}
+    scalityObjTransferRequestH() : addr(0), size(0), offset(0) {}
 
-    scalityObjTransferRequestH(uintptr_t a, size_t s, size_t off)
-        : addr(a),
-          size(s),
-          offset(off),
-          rdma_desc(""),
-          obj_key("") {}
+    scalityObjTransferRequestH(uintptr_t a, size_t s, size_t off) : addr(a), size(s), offset(off) {}
 
     ~scalityObjTransferRequestH() = default;
 };
@@ -273,23 +268,31 @@ objectPut(const void *handle,
 /// cuObject I/O operations for Scality AI Connector
 CUObjIOOps scality_ops = {.get = objectGet, .put = objectPut};
 
+// Return the injected client when provided (the test seam), otherwise build the
+// production RestClient. Lets connectorClient_ be initialized as const in the
+// member initializer list.
+std::shared_ptr<iRestClient>
+makeConnectorClient(const nixlBackendInitParams *init_params,
+                    const std::shared_ptr<iRestClient> &injected) {
+    if (injected) {
+        return injected;
+    }
+    // init_params is only optional when a client is injected (the test seam);
+    // the production constructor always supplies a non-null init_params.
+    assert(init_params != nullptr && "init_params must be non-null when no RestClient is injected");
+    return std::make_shared<RestClient>(init_params->customParams);
+}
+
 } // namespace
 
 ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_params)
     : ScalityObjEngineImpl(init_params, nullptr) {}
 
 ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_params,
-                                           std::shared_ptr<iRestClient> connector_client) {
-    if (connector_client) {
-        connectorClient_ = connector_client;
-    } else {
-        // init_params is only optional when a client is injected (the test seam);
-        // the production constructor always supplies a non-null init_params.
-        assert(init_params != nullptr &&
-               "init_params must be non-null when no RestClient is injected");
-        connectorClient_ = std::make_shared<RestClient>(init_params->customParams);
-    }
-
+                                           const std::shared_ptr<iRestClient> &connector_client)
+    // DC transport via NVIDIA cuObject (CUOBJ_PROTO_RDMA_DC_V1).
+    : cuClient_(std::make_shared<CuObjRdmaTokenClient>(scality_ops)),
+      connectorClient_(makeConnectorClient(init_params, connector_client)) {
     NIXL_INFO << "Object storage backend initialized with Scality AI Connector RDMA client";
 
     // Number of GPUs, used to spread DRAM MRs across NICs (see targetCudaDevice).
@@ -297,9 +300,6 @@ ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_par
     if (cudaGetDeviceCount(&gpuCount_) != cudaSuccess || gpuCount_ < 0) {
         gpuCount_ = 0;
     }
-
-    // DC transport via NVIDIA cuObject (CUOBJ_PROTO_RDMA_DC_V1).
-    cuClient_ = std::make_shared<CuObjRdmaTokenClient>(scality_ops);
 
     if (!cuClient_ || !cuClient_->isConnected()) {
         NIXL_ERROR << "RDMA token client failed to connect.";

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
@@ -20,6 +20,7 @@
 #include "common/nixl_log.h"
 #include <absl/strings/str_format.h>
 #include "cuobj_rdma_token_client.h"
+#include "device_select.h"
 #include <cassert>
 #include <cstdlib>
 #include <memory>
@@ -291,6 +292,12 @@ ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_par
 
     NIXL_INFO << "Object storage backend initialized with Scality AI Connector RDMA client";
 
+    // Number of GPUs, used to spread DRAM MRs across NICs (see targetCudaDevice).
+    // On error, leave gpuCount_ at 0 so DRAM registration keeps the current device.
+    if (cudaGetDeviceCount(&gpuCount_) != cudaSuccess || gpuCount_ < 0) {
+        gpuCount_ = 0;
+    }
+
     // DC transport via NVIDIA cuObject (CUOBJ_PROTO_RDMA_DC_V1).
     cuClient_ = std::make_shared<CuObjRdmaTokenClient>(scality_ops);
 
@@ -333,9 +340,12 @@ ScalityObjEngineImpl::registerMem(const nixlBlobDesc &mem,
         std::unique_ptr<nixlScalityObjMetadata> mem_md =
             std::make_unique<nixlScalityObjMetadata>(nixl_mem, mem.addr, mem.devId);
 
+        // Bind this MR (and its primary GID/NIC) to a CUDA device: VRAM to its own
+        // GPU, DRAM round-robin across GPUs so host buffers fan across NICs.
         std::optional<CudaDeviceGuard> dev_guard;
-        if (nixl_mem == VRAM_SEG) {
-            dev_guard.emplace((int)mem.devId);
+        int target = targetCudaDevice(nixl_mem, mem.devId, gpuCount_);
+        if (target >= 0) {
+            dev_guard.emplace(target);
         }
 
         cuObjErr_t cuda_status = cuClient_->cuMemObjGetDescriptor((void *)(mem.addr), mem.len);
@@ -362,9 +372,12 @@ ScalityObjEngineImpl::deregisterMem(nixlBackendMD *meta) {
         } else if ((md->nixlMem == DRAM_SEG) || (md->nixlMem == VRAM_SEG)) {
             std::unique_ptr<nixlScalityObjMetadata> mem_md_ptr =
                 std::unique_ptr<nixlScalityObjMetadata>(md);
+            // Deregister under the same device the MR was registered on so
+            // cuObject releases it against the matching context (see registerMem).
             std::optional<CudaDeviceGuard> dev_guard;
-            if (mem_md_ptr->nixlMem == VRAM_SEG) {
-                dev_guard.emplace((int)mem_md_ptr->devId);
+            int target = targetCudaDevice(mem_md_ptr->nixlMem, mem_md_ptr->devId, gpuCount_);
+            if (target >= 0) {
+                dev_guard.emplace(target);
             }
             cuObjErr_t cuda_status =
                 cuClient_->cuMemObjPutDescriptor((void *)(mem_md_ptr->localAddr));

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.cpp
@@ -1,0 +1,578 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "engine_impl.h"
+#include "client.h"
+#include "common/nixl_log.h"
+#include <absl/strings/str_format.h>
+#include "cuobj_rdma_token_client.h"
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <future>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+#include <atomic>
+#include <optional>
+
+#include <cuda_runtime.h>
+
+#include "obj_engine_registry.h"
+
+namespace {
+
+/**
+ * Scoped CUDA device switch. cuFile's buffer registration validates that a
+ * device pointer belongs to the current CUDA context; when buffers live on
+ * different GPUs (multi-GPU initiator), the current device must match the
+ * buffer's device or cuFileBufRegister fails the device-memory check (-5011).
+ * Restores the previous device on scope exit.
+ */
+class CudaDeviceGuard {
+public:
+    explicit CudaDeviceGuard(int dev) {
+        if (cudaGetDevice(&prevDev_) != cudaSuccess) {
+            return;
+        }
+        if (dev >= 0 && dev != prevDev_ && cudaSetDevice(dev) == cudaSuccess) {
+            restore_ = true;
+        }
+    }
+
+    ~CudaDeviceGuard() {
+        if (restore_) {
+            cudaSetDevice(prevDev_);
+        }
+    }
+
+    CudaDeviceGuard(const CudaDeviceGuard &) = delete;
+    CudaDeviceGuard &
+    operator=(const CudaDeviceGuard &) = delete;
+
+private:
+    int prevDev_ = 0;
+    bool restore_ = false;
+};
+
+objAccelEngineRegistrar reg_scality(
+    "scality_ai_connector",
+    [](const nixlBackendInitParams *p) { return std::make_unique<ScalityObjEngineImpl>(p); },
+    [](const nixlBackendInitParams *p, std::shared_ptr<iS3Client>, std::shared_ptr<iS3Client>) {
+        return std::make_unique<ScalityObjEngineImpl>(p);
+    });
+
+/**
+ * RDMA context structure for cuObject operations.
+ */
+typedef struct rdma_ctx {
+    /// RDMA descriptor string
+    std::string rdma_desc;
+} rdma_ctx_t;
+
+std::string
+objKeyFor(const std::string &metaInfo, uint64_t devId) {
+    return metaInfo.empty() ? std::to_string(devId) : metaInfo;
+}
+
+/**
+ * Validate parameters for prepXfer operation.
+ */
+bool
+isValidPrepXferParams(const nixl_xfer_op_t &operation,
+                      const nixl_meta_dlist_t &local,
+                      const nixl_meta_dlist_t &remote,
+                      const std::string &remote_agent,
+                      const std::string &local_agent) {
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << absl::StrFormat("Error: Invalid operation type: %d", operation);
+        return false;
+    }
+
+    if (remote_agent != local_agent) {
+        NIXL_WARN << absl::StrFormat(
+            "Warning: Remote agent doesn't match the requesting agent (%s). Got %s",
+            local_agent,
+            remote_agent);
+    }
+
+    if ((local.getType() != DRAM_SEG) && (local.getType() != VRAM_SEG)) {
+        NIXL_ERROR << absl::StrFormat(
+            "Error: Local memory type must be VRAM_SEG or DRAM_SEG, got %d", local.getType());
+        return false;
+    }
+
+    if (remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << absl::StrFormat("Error: Remote memory type must be OBJ_SEG, got %d",
+                                      remote.getType());
+        return false;
+    }
+
+    if (local.descCount() != remote.descCount()) {
+        NIXL_ERROR << absl::StrFormat(
+            "Error: Local and remote descriptor counts must match. Got %d local, %d remote",
+            local.descCount(),
+            remote.descCount());
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Transfer request handle for Scality AI Connector RDMA operations.
+ */
+class scalityObjTransferRequestH {
+public:
+    uintptr_t addr;
+    size_t size;
+    size_t offset;
+    std::string rdma_desc;
+    std::string obj_key;
+    rdma_ctx_t ctx;
+
+    scalityObjTransferRequestH() : addr(0), size(0), offset(0), rdma_desc(""), obj_key("") {}
+
+    scalityObjTransferRequestH(uintptr_t a, size_t s, size_t off)
+        : addr(a),
+          size(s),
+          offset(off),
+          rdma_desc(""),
+          obj_key("") {}
+
+    ~scalityObjTransferRequestH() = default;
+};
+
+/**
+ * Backend request handle for Scality AI Connector RDMA operations.
+ * Manages multiple transfer requests and their completion futures.
+ */
+class nixlScalityObjBackendReqH : public nixlBackendReqH {
+public:
+    std::vector<scalityObjTransferRequestH> reqs_;
+    std::vector<std::future<nixl_status_t>> statusFutures_;
+
+    nixlScalityObjBackendReqH() = default;
+    ~nixlScalityObjBackendReqH() = default;
+
+    nixl_status_t
+    getOverallStatus() {
+        bool has_pending = false;
+        auto it = statusFutures_.begin();
+        while (it != statusFutures_.end()) {
+            if (it->wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
+                auto current_status = it->get();
+                if (current_status != NIXL_SUCCESS) {
+                    statusFutures_.clear();
+                    return current_status;
+                }
+                it = statusFutures_.erase(it);
+            } else {
+                ++it;
+                has_pending = true;
+            }
+        }
+        return has_pending ? NIXL_IN_PROG : NIXL_SUCCESS;
+    }
+};
+
+/**
+ * Metadata for Scality AI Connector RDMA operations.
+ */
+class nixlScalityObjMetadata : public nixlBackendMD {
+public:
+    nixlScalityObjMetadata(nixl_mem_t nixl_mem, uint64_t dev_id, std::string obj_key)
+        : nixlBackendMD(true),
+          nixlMem(nixl_mem),
+          devId(dev_id),
+          objKey(obj_key),
+          localAddr(0) {}
+
+    nixlScalityObjMetadata(nixl_mem_t nixl_mem, uintptr_t addr, uint64_t dev_id = 0)
+        : nixlBackendMD(true),
+          nixlMem(nixl_mem),
+          devId(dev_id),
+          objKey(""),
+          localAddr(addr) {}
+
+    ~nixlScalityObjMetadata() = default;
+
+    nixl_mem_t nixlMem;
+    uint64_t devId;
+    std::string objKey;
+    uintptr_t localAddr;
+};
+
+/**
+ * cuObject get callback: extracts RDMA descriptor from cuFile RDMA info.
+ */
+static ssize_t
+objectGet(const void *handle,
+          char *buf,
+          size_t size,
+          loff_t offset,
+          const cufileRDMAInfo_t *infop) {
+    if (infop == nullptr || infop->desc_str == nullptr) {
+        NIXL_ERROR << "objectGet: infop or infop->desc_str is null";
+        return -EINVAL;
+    }
+
+    void *ctx = iRdmaTokenClient::getCtx(handle);
+    if (ctx == nullptr) {
+        NIXL_ERROR << "objectGet: context is null";
+        return -EINVAL;
+    }
+    NIXL_DEBUG << "objectGet: handle=" << handle << ", buf=" << static_cast<const void *>(buf)
+               << ", size=" << size << ", offset=" << offset << ", infop=" << infop;
+    rdma_ctx_t *rctx = static_cast<rdma_ctx_t *>(ctx);
+    rctx->rdma_desc = infop->desc_str;
+    return 0;
+}
+
+/**
+ * cuObject put callback: extracts RDMA descriptor from cuFile RDMA info.
+ */
+static ssize_t
+objectPut(const void *handle,
+          const char *buf,
+          size_t size,
+          loff_t offset,
+          const cufileRDMAInfo_t *infop) {
+    if (infop == nullptr || infop->desc_str == nullptr) {
+        NIXL_ERROR << "objectPut: infop or infop->desc_str is null";
+        return -EINVAL;
+    }
+
+    void *ctx = iRdmaTokenClient::getCtx(handle);
+    if (ctx == nullptr) {
+        NIXL_ERROR << "objectPut: context is null";
+        return -EINVAL;
+    }
+    NIXL_DEBUG << "objectPut: handle=" << handle << ", buf=" << static_cast<const void *>(buf)
+               << ", size=" << size << ", offset=" << offset << ", infop=" << infop;
+    rdma_ctx_t *rctx = static_cast<rdma_ctx_t *>(ctx);
+    rctx->rdma_desc = infop->desc_str;
+    return 0;
+}
+
+/// cuObject I/O operations for Scality AI Connector
+CUObjIOOps scality_ops = {.get = objectGet, .put = objectPut};
+
+} // namespace
+
+ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_params)
+    : ScalityObjEngineImpl(init_params, nullptr) {}
+
+ScalityObjEngineImpl::ScalityObjEngineImpl(const nixlBackendInitParams *init_params,
+                                           std::shared_ptr<iRestClient> connector_client) {
+    if (connector_client) {
+        connectorClient_ = connector_client;
+    } else {
+        // init_params is only optional when a client is injected (the test seam);
+        // the production constructor always supplies a non-null init_params.
+        assert(init_params != nullptr &&
+               "init_params must be non-null when no RestClient is injected");
+        connectorClient_ = std::make_shared<RestClient>(init_params->customParams);
+    }
+
+    NIXL_INFO << "Object storage backend initialized with Scality AI Connector RDMA client";
+
+    // DC transport via NVIDIA cuObject (CUOBJ_PROTO_RDMA_DC_V1).
+    cuClient_ = std::make_shared<CuObjRdmaTokenClient>(scality_ops);
+
+    if (!cuClient_ || !cuClient_->isConnected()) {
+        NIXL_ERROR << "RDMA token client failed to connect.";
+        return;
+    }
+}
+
+nixl_status_t
+ScalityObjEngineImpl::registerMem(const nixlBlobDesc &mem,
+                                  const nixl_mem_t &nixl_mem,
+                                  nixlBackendMD *&out) {
+    if (!cuClient_ || !cuClient_->isConnected()) {
+        NIXL_ERROR << "RDMA token client is not connected.";
+        return NIXL_ERR_BACKEND;
+    }
+
+    auto supported_mems = {OBJ_SEG, DRAM_SEG, VRAM_SEG};
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end()) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    if (nixl_mem == OBJ_SEG) {
+        std::unique_ptr<nixlScalityObjMetadata> obj_md = std::make_unique<nixlScalityObjMetadata>(
+            nixl_mem, mem.devId, objKeyFor(mem.metaInfo, mem.devId));
+        devIdToObjKey_[mem.devId] = obj_md->objKey;
+        out = obj_md.release();
+    } else if ((nixl_mem == DRAM_SEG) || (nixl_mem == VRAM_SEG)) {
+        if (mem.len > CUOBJ_MAX_MEMORY_REG_SIZE) {
+            NIXL_ERROR << "Memory size too large for cuObject registration: " << mem.len;
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+
+        NIXL_DEBUG << absl::StrFormat("registerMem: addr=0x%016x, len=%zu, nixl_mem=%d, devId=%d",
+                                      mem.addr,
+                                      mem.len,
+                                      nixl_mem,
+                                      mem.devId);
+        std::unique_ptr<nixlScalityObjMetadata> mem_md =
+            std::make_unique<nixlScalityObjMetadata>(nixl_mem, mem.addr, mem.devId);
+
+        std::optional<CudaDeviceGuard> dev_guard;
+        if (nixl_mem == VRAM_SEG) {
+            dev_guard.emplace((int)mem.devId);
+        }
+
+        cuObjErr_t cuda_status = cuClient_->cuMemObjGetDescriptor((void *)(mem.addr), mem.len);
+        if (cuda_status != CU_OBJ_SUCCESS) {
+            NIXL_ERROR << "cuMemObjGetDescriptor failed with status: " << cuda_status;
+            const char *cfg = std::getenv("CUFILE_ENV_PATH_JSON");
+            NIXL_ERROR << "Hint: check rdma_dev_addr_list in " << (cfg ? cfg : "/etc/cufile.json");
+            return NIXL_ERR_BACKEND;
+        }
+        out = mem_md.release();
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+ScalityObjEngineImpl::deregisterMem(nixlBackendMD *meta) {
+    nixlScalityObjMetadata *md = static_cast<nixlScalityObjMetadata *>(meta);
+    if (md) {
+        if (md->nixlMem == OBJ_SEG) {
+            std::unique_ptr<nixlScalityObjMetadata> obj_md_ptr =
+                std::unique_ptr<nixlScalityObjMetadata>(md);
+            devIdToObjKey_.erase(obj_md_ptr->devId);
+        } else if ((md->nixlMem == DRAM_SEG) || (md->nixlMem == VRAM_SEG)) {
+            std::unique_ptr<nixlScalityObjMetadata> mem_md_ptr =
+                std::unique_ptr<nixlScalityObjMetadata>(md);
+            std::optional<CudaDeviceGuard> dev_guard;
+            if (mem_md_ptr->nixlMem == VRAM_SEG) {
+                dev_guard.emplace((int)mem_md_ptr->devId);
+            }
+            cuObjErr_t cuda_status =
+                cuClient_->cuMemObjPutDescriptor((void *)(mem_md_ptr->localAddr));
+            if (cuda_status != CU_OBJ_SUCCESS) {
+                NIXL_ERROR << "cuMemObjPutDescriptor failed with status: " << cuda_status;
+                // mem_md_ptr destructor frees the metadata as deregisterMem consumes it
+                // regardless of outcome.
+                return NIXL_ERR_BACKEND;
+            }
+        }
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+ScalityObjEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
+                               const nixl_meta_dlist_t &local,
+                               const nixl_meta_dlist_t &remote,
+                               const std::string &remote_agent,
+                               const std::string &local_agent,
+                               nixlBackendReqH *&handle,
+                               const nixl_opt_b_args_t *opt_args) const {
+    if (!cuClient_ || !cuClient_->isConnected()) {
+        NIXL_ERROR << "RDMA token client is not connected.";
+        return NIXL_ERR_BACKEND;
+    }
+
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto req_h = std::make_unique<nixlScalityObjBackendReqH>();
+
+    for (int i = 0; i < local.descCount(); ++i) {
+        scalityObjTransferRequestH req(local[i].addr, local[i].len, remote[i].addr);
+
+        auto obj_key_search = devIdToObjKey_.find(remote[i].devId);
+        if (obj_key_search == devIdToObjKey_.end()) {
+            NIXL_ERROR << "The object segment key " << remote[i].devId
+                       << " is not registered with the backend";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        req.obj_key = obj_key_search->second;
+
+        if (operation == NIXL_WRITE) {
+            ssize_t cuda_status =
+                cuClient_->cuObjPut(&req.ctx, (void *)req.addr, req.size, req.offset);
+            if (cuda_status < 0) {
+                NIXL_ERROR << "cuObjPut failed with status: " << cuda_status;
+                return NIXL_ERR_BACKEND;
+            }
+        } else if (operation == NIXL_READ) {
+            ssize_t cuda_status =
+                cuClient_->cuObjGet(&req.ctx, (void *)req.addr, req.size, req.offset);
+            if (cuda_status < 0) {
+                NIXL_ERROR << "cuObjGet failed with status: " << cuda_status;
+                return NIXL_ERR_BACKEND;
+            }
+        }
+        req.rdma_desc = req.ctx.rdma_desc;
+        // Log only the descriptor length, never the raw RDMA token (sensitive).
+        NIXL_DEBUG << absl::StrFormat(
+            "prepXfer: addr=0x%016x, size=%zu, offset=%zu, rdma_desc_len=%zu",
+            req.addr,
+            req.size,
+            req.offset,
+            req.rdma_desc.size());
+
+        req_h->reqs_.push_back(req);
+    }
+
+    handle = req_h.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+ScalityObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
+                               const nixl_meta_dlist_t &local,
+                               const nixl_meta_dlist_t &remote,
+                               const std::string &remote_agent,
+                               nixlBackendReqH *&handle,
+                               const nixl_opt_b_args_t *opt_args) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    nixlScalityObjBackendReqH *req_h = static_cast<nixlScalityObjBackendReqH *>(handle);
+
+    for (const auto &req : req_h->reqs_) {
+        auto status_promise = std::make_shared<std::promise<nixl_status_t>>();
+        req_h->statusFutures_.push_back(status_promise->get_future());
+
+        if (operation == NIXL_WRITE) {
+            connectorClient_->putObjectRdmaAsync(req.obj_key,
+                                                 req.addr,
+                                                 req.size,
+                                                 req.offset,
+                                                 req.rdma_desc,
+                                                 [status_promise](bool success) {
+                                                     status_promise->set_value(
+                                                         success ? NIXL_SUCCESS : NIXL_ERR_BACKEND);
+                                                 });
+        } else {
+            connectorClient_->getObjectRdmaAsync(req.obj_key,
+                                                 req.addr,
+                                                 req.size,
+                                                 req.offset,
+                                                 req.rdma_desc,
+                                                 [status_promise](bool success) {
+                                                     status_promise->set_value(
+                                                         success ? NIXL_SUCCESS : NIXL_ERR_BACKEND);
+                                                 });
+        }
+    }
+
+    return NIXL_IN_PROG;
+}
+
+nixl_status_t
+ScalityObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    nixlScalityObjBackendReqH *req_h = static_cast<nixlScalityObjBackendReqH *>(handle);
+    return req_h->getOverallStatus();
+}
+
+nixl_status_t
+ScalityObjEngineImpl::releaseReqH(nixlBackendReqH *handle) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    nixlScalityObjBackendReqH *req_h = static_cast<nixlScalityObjBackendReqH *>(handle);
+    delete req_h;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+ScalityObjEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
+                               std::vector<nixl_query_resp_t> &resp) const {
+    resp.assign(descs.descCount(), std::nullopt);
+
+    if (!connectorClient_) {
+        NIXL_ERROR << "queryMem: REST client not available";
+        return NIXL_ERR_BACKEND;
+    }
+
+    struct perDescriptorState {
+        std::shared_ptr<std::promise<void>> promise;
+        std::shared_ptr<std::atomic<bool>> completed;
+    };
+
+    std::vector<std::future<void>> futures;
+    std::vector<perDescriptorState> states;
+    futures.reserve(descs.descCount());
+    states.reserve(descs.descCount());
+    // Shared so an async callback that fires after queryMem returns (e.g. a
+    // timed-out request) never touches this stack frame.
+    auto shared_resp =
+        std::make_shared<std::vector<nixl_query_resp_t>>(descs.descCount(), std::nullopt);
+    auto has_error = std::make_shared<std::atomic<bool>>(false);
+
+    // One aggregate deadline for all checks: concurrent HEADs share a single
+    // bound, so a hung endpoint can't make this block for 30s * descCount().
+    constexpr auto kQueryTimeout = std::chrono::seconds(30);
+    const auto deadline = std::chrono::steady_clock::now() + kQueryTimeout;
+
+    for (int i = 0; i < descs.descCount(); ++i) {
+        const auto &desc = descs[i];
+        // Mirror the key convention used by registerMem: metaInfo, or the
+        // device id when no key was supplied.
+        std::string key = objKeyFor(desc.metaInfo, desc.devId);
+
+        perDescriptorState state{std::make_shared<std::promise<void>>(),
+                                 std::make_shared<std::atomic<bool>>(false)};
+        futures.push_back(state.promise->get_future());
+        states.push_back(state);
+
+        connectorClient_->checkObjectExistsAsync(
+            key,
+            [shared_resp, has_error, i, promise = state.promise, completed = state.completed](
+                std::optional<bool> exists) {
+                if (completed->exchange(true)) {
+                    return;
+                }
+                if (!exists.has_value()) {
+                    (*shared_resp)[i] = std::nullopt;
+                    has_error->store(true, std::memory_order_relaxed);
+                } else {
+                    (*shared_resp)[i] =
+                        *exists ? nixl_query_resp_t{nixl_b_params_t{}} : std::nullopt;
+                }
+                promise->set_value();
+            });
+    }
+
+    for (size_t i = 0; i < futures.size(); ++i) {
+        if (futures[i].wait_until(deadline) == std::future_status::timeout) {
+            if (!states[i].completed->exchange(true)) {
+                (*shared_resp)[i] = std::nullopt;
+                has_error->store(true, std::memory_order_relaxed);
+            }
+        }
+    }
+
+    resp = *shared_resp;
+    return has_error->load() ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
+}

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
@@ -96,6 +96,9 @@ private:
     std::shared_ptr<iRdmaTokenClient> cuClient_;
     /// Scality AI Connector HTTP client with RDMA support
     std::shared_ptr<iRestClient> connectorClient_;
+    /// Number of CUDA devices, queried once at construction (0 if none).
+    /// Used to spread DRAM MRs across GPUs so cuObject fans them across NICs.
+    int gpuCount_ = 0;
 };
 
 #endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_ENGINE_IMPL_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
@@ -19,7 +19,7 @@
 #define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_ENGINE_IMPL_H
 
 #include "obj_backend.h"
-#include "rest_accel/scality_ai_connector/client.h"
+#include "rest_accel/scality_ai_connector/rest_client.h"
 #include "rest_accel/scality_ai_connector/rdma_token_client.h"
 #include <unordered_map>
 
@@ -50,7 +50,7 @@ public:
      * @param connector_client Pre-configured client (can be mock for testing)
      */
     ScalityObjEngineImpl(const nixlBackendInitParams *init_params,
-                         std::shared_ptr<iRestClient> connector_client);
+                         const std::shared_ptr<iRestClient> &connector_client);
 
     nixl_mem_list_t
     getSupportedMems() const override {
@@ -93,9 +93,9 @@ private:
     /// Maps device IDs to object keys
     std::unordered_map<uint64_t, std::string> devIdToObjKey_;
     /// RDMA token client (DC via cuObjClient)
-    std::shared_ptr<iRdmaTokenClient> cuClient_;
+    const std::shared_ptr<iRdmaTokenClient> cuClient_;
     /// Scality AI Connector HTTP client with RDMA support
-    std::shared_ptr<iRestClient> connectorClient_;
+    const std::shared_ptr<iRestClient> connectorClient_;
     /// Number of CUDA devices, queried once at construction (0 if none).
     /// Used to spread DRAM MRs across GPUs so cuObject fans them across NICs.
     int gpuCount_ = 0;

--- a/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/engine_impl.h
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_ENGINE_IMPL_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_ENGINE_IMPL_H
+
+#include "obj_backend.h"
+#include "rest_accel/scality_ai_connector/client.h"
+#include "rest_accel/scality_ai_connector/rdma_token_client.h"
+#include <unordered_map>
+
+/**
+ * Scality AI Connector RDMA Engine Implementation.
+ * Provides RDMA-accelerated object storage operations using Scality's
+ * AI Connector HTTP service. Implements nixlObjEngineImpl directly and
+ * uses the cuObject API for GPU-direct storage operations.
+ *
+ * The RDMA descriptor obtained from cuObject is transmitted via the
+ * x-scal-rdma custom HTTP header, enabling the connector to perform the data
+ * transfer via RDMA instead of the HTTP body.
+ */
+class ScalityObjEngineImpl : public nixlObjEngineImpl {
+public:
+    /**
+     * Constructor that initializes the Scality AI Connector engine.
+     * Creates both the HTTP client and cuObject client for RDMA operations.
+     *
+     * @param init_params Backend initialization parameters
+     */
+    explicit ScalityObjEngineImpl(const nixlBackendInitParams *init_params);
+
+    /**
+     * Constructor that accepts an injected client (for testing).
+     *
+     * @param init_params Backend initialization parameters
+     * @param connector_client Pre-configured client (can be mock for testing)
+     */
+    ScalityObjEngineImpl(const nixlBackendInitParams *init_params,
+                         std::shared_ptr<iRestClient> connector_client);
+
+    nixl_mem_list_t
+    getSupportedMems() const override {
+        return {OBJ_SEG, DRAM_SEG, VRAM_SEG};
+    }
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+private:
+    /// Maps device IDs to object keys
+    std::unordered_map<uint64_t, std::string> devIdToObjKey_;
+    /// RDMA token client (DC via cuObjClient)
+    std::shared_ptr<iRdmaTokenClient> cuClient_;
+    /// Scality AI Connector HTTP client with RDMA support
+    std::shared_ptr<iRestClient> connectorClient_;
+};
+
+#endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_ENGINE_IMPL_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/rdma_token_client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/rdma_token_client.h
@@ -30,50 +30,53 @@
  */
 class iRdmaTokenClient {
 public:
-    virtual ~iRdmaTokenClient() = default;
-
     /** Return true when the transport layer is ready for transfers. */
-    virtual bool
+    [[nodiscard]] virtual bool
     isConnected() const = 0;
 
     /**
      * Register a memory region and obtain an RDMA descriptor (token).
      * @return CU_OBJ_SUCCESS on success.
      */
-    virtual cuObjErr_t
+    [[nodiscard]] virtual cuObjErr_t
     cuMemObjGetDescriptor(void *ptr, size_t size) = 0;
 
     /**
      * Deregister a previously registered memory region.
      * @return CU_OBJ_SUCCESS on success.
      */
-    virtual cuObjErr_t
+    [[nodiscard]] virtual cuObjErr_t
     cuMemObjPutDescriptor(void *ptr) = 0;
 
     /**
      * Initiate a GET (read) transfer, calls the user-supplied get callback
      * with the RDMA token so that the remote side can perform the data transfer.
      */
-    virtual ssize_t
+    [[nodiscard]] virtual ssize_t
     cuObjGet(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) = 0;
 
     /**
      * Initiate a PUT (write) transfer; calls the user-supplied put callback
      * with the RDMA token so that the remote side can perform the data transfer.
      */
-    virtual ssize_t
+    [[nodiscard]] virtual ssize_t
     cuObjPut(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) = 0;
 
     /**
      * Extract the user context pointer from cuObjClient's opaque handle.
      */
-    static void *
+    [[nodiscard]] static void *
     getCtx(const void *handle) {
         if (!handle) {
             return nullptr;
         }
         return cuObjClient::getCtx(handle);
     }
+
+protected:
+    // Owned only through shared_ptr (never deleted via an iRdmaTokenClient*), so
+    // a protected non-virtual destructor suffices.
+    ~iRdmaTokenClient() = default;
 };
 
 #endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_RDMA_TOKEN_CLIENT_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/rdma_token_client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/rdma_token_client.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_RDMA_TOKEN_CLIENT_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_RDMA_TOKEN_CLIENT_H
+
+#include <cuobjclient.h>
+
+#include <memory>
+
+/**
+ * Abstract RDMA token client interface.
+ *
+ * Implementation:
+ *  - CuObjRdmaTokenClient: thin wrapper around NVIDIA cuObjClient (DC transport)
+ */
+class iRdmaTokenClient {
+public:
+    virtual ~iRdmaTokenClient() = default;
+
+    /** Return true when the transport layer is ready for transfers. */
+    virtual bool
+    isConnected() const = 0;
+
+    /**
+     * Register a memory region and obtain an RDMA descriptor (token).
+     * @return CU_OBJ_SUCCESS on success.
+     */
+    virtual cuObjErr_t
+    cuMemObjGetDescriptor(void *ptr, size_t size) = 0;
+
+    /**
+     * Deregister a previously registered memory region.
+     * @return CU_OBJ_SUCCESS on success.
+     */
+    virtual cuObjErr_t
+    cuMemObjPutDescriptor(void *ptr) = 0;
+
+    /**
+     * Initiate a GET (read) transfer, calls the user-supplied get callback
+     * with the RDMA token so that the remote side can perform the data transfer.
+     */
+    virtual ssize_t
+    cuObjGet(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) = 0;
+
+    /**
+     * Initiate a PUT (write) transfer; calls the user-supplied put callback
+     * with the RDMA token so that the remote side can perform the data transfer.
+     */
+    virtual ssize_t
+    cuObjPut(void *ctx, void *ptr, size_t size, loff_t offset, loff_t buf_offset = 0) = 0;
+
+    /**
+     * Extract the user context pointer from cuObjClient's opaque handle.
+     */
+    static void *
+    getCtx(const void *handle) {
+        if (!handle) {
+            return nullptr;
+        }
+        return cuObjClient::getCtx(handle);
+    }
+};
+
+#endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_RDMA_TOKEN_CLIENT_H

--- a/src/plugins/obj/rest_accel/scality_ai_connector/rest_client.cpp
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/rest_client.cpp
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "client.h"
+#include "rest_client.h"
 #include "common/nixl_log.h"
 #include <absl/strings/str_format.h>
 #include <asio/post.hpp>
@@ -113,63 +113,75 @@ RestClient::buildEasy(RequestCtx *ctx) {
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, 30000L);
 }
 
-// Map a finished transfer to its callback, dispatch it on the worker pool, and
-// free the context. Runs on the poller thread; the posted closure captures only
-// the moved callback plus the plain result, so the pool never touches curl state.
-// Callbacks are expected not to throw; the dispatch guards against it defensively
-// so a misbehaving callback cannot take down a pool worker.
+// Dispatch a finished HEAD transfer's callback on the worker pool. Runs on the
+// poller thread; the posted closure captures only the moved callback plus the
+// plain result, so the pool never touches curl state. An empty callback is
+// skipped rather than posted, and a throwing callback is contained so it cannot
+// take down a pool worker.
+void
+RestClient::dispatchHeadResult(RequestCtx *ctx, CURLcode res, long http_code) {
+    std::optional<bool> result;
+    if (res != CURLE_OK) {
+        NIXL_ERROR << absl::StrFormat(
+            "checkObjectExistsAsync: curl_code=%d for HEAD %s", static_cast<int>(res), ctx->url);
+    } else if (http_code >= 200 && http_code < 300) {
+        result = true;
+    } else if (http_code == 404) {
+        result = false;
+    } else {
+        NIXL_ERROR << absl::StrFormat(
+            "checkObjectExistsAsync: HTTP %ld for HEAD %s", http_code, ctx->url);
+    }
+    if (ctx->check_cb) {
+        asio::post(pool_, [cb = std::move(ctx->check_cb), result]() {
+            try {
+                cb(result);
+            }
+            catch (...) {
+                NIXL_WARN << "checkObjectExistsAsync: callback threw an exception";
+            }
+        });
+    }
+}
+
+// Dispatch a finished PUT/GET transfer's callback on the worker pool. Same
+// threading and safety contract as dispatchHeadResult. op_name is a string
+// literal (static storage), so the lambda captures the pointer by value and it
+// stays valid after ctx is freed.
+void
+RestClient::dispatchXferResult(RequestCtx *ctx, CURLcode res, long http_code) {
+    const bool success = (res == CURLE_OK) && (http_code >= 200 && http_code < 300);
+    if (!success) {
+        NIXL_ERROR << absl::StrFormat("%s: failed url=%s curl_code=%d http_code=%ld body=%s",
+                                      ctx->op_name,
+                                      ctx->url,
+                                      static_cast<int>(res),
+                                      http_code,
+                                      ctx->response_body.empty() ? "<empty>" : ctx->response_body);
+    } else {
+        NIXL_DEBUG << absl::StrFormat(
+            "%s: success url=%s http_code=%ld", ctx->op_name, ctx->url, http_code);
+    }
+    if (ctx->bool_cb) {
+        asio::post(pool_, [cb = std::move(ctx->bool_cb), success, op_name = ctx->op_name]() {
+            try {
+                cb(success);
+            }
+            catch (...) {
+                NIXL_WARN << absl::StrFormat("%s: callback threw an exception", op_name);
+            }
+        });
+    }
+}
+
+// Map a finished transfer to its callback dispatcher and free the context.
+// Poller-thread only.
 void
 RestClient::finishRequest(RequestCtx *ctx, CURLcode res, long http_code) {
     if (ctx->method == restMethod::HEAD) {
-        std::optional<bool> result;
-        if (res != CURLE_OK) {
-            NIXL_ERROR << absl::StrFormat("checkObjectExistsAsync: curl_code=%d for HEAD %s",
-                                          static_cast<int>(res),
-                                          ctx->url);
-            result = std::nullopt;
-        } else if (http_code >= 200 && http_code < 300) {
-            result = true;
-        } else if (http_code == 404) {
-            result = false;
-        } else {
-            NIXL_ERROR << absl::StrFormat(
-                "checkObjectExistsAsync: HTTP %ld for HEAD %s", http_code, ctx->url);
-            result = std::nullopt;
-        }
-        auto cb = std::move(ctx->check_cb);
-        asio::post(pool_, [cb = std::move(cb), result]() {
-            try {
-                if (cb) {
-                    cb(result);
-                }
-            }
-            catch (...) {
-            }
-        });
+        dispatchHeadResult(ctx, res, http_code);
     } else {
-        bool success = (res == CURLE_OK) && (http_code >= 200 && http_code < 300);
-        if (!success) {
-            NIXL_ERROR << absl::StrFormat("%s: failed url=%s curl_code=%d http_code=%ld body=%s",
-                                          ctx->op_name,
-                                          ctx->url,
-                                          static_cast<int>(res),
-                                          http_code,
-                                          ctx->response_body.empty() ? "<empty>" :
-                                                                       ctx->response_body);
-        } else {
-            NIXL_DEBUG << absl::StrFormat(
-                "%s: success url=%s http_code=%ld", ctx->op_name, ctx->url, http_code);
-        }
-        auto cb = std::move(ctx->bool_cb);
-        asio::post(pool_, [cb = std::move(cb), success]() {
-            try {
-                if (cb) {
-                    cb(success);
-                }
-            }
-            catch (...) {
-            }
-        });
+        dispatchXferResult(ctx, res, http_code);
     }
     delete ctx;
 }
@@ -289,7 +301,8 @@ RestClient::pollerLoop() {
         // 3. Hand finished transfers' callbacks to the worker pool.
         reapCompletions();
 
-        // 4. On shutdown, abort anything still in flight so every callback fires.
+        // 4. On shutdown, abort anything still in flight so every callback fires
+        //    and every request is freed (finishRequest deletes the context).
         if (stopping) {
             for (RequestCtx *ctx : inflight_) {
                 curl_multi_remove_handle(multi_, ctx->easy);
@@ -326,7 +339,7 @@ RestClient::submitRdmaRequest(const char *op_name,
         return;
     }
 
-    std::string rdma_header = absl::StrFormat("x-scal-rdma: %s", rdma_desc);
+    const std::string rdma_header = absl::StrFormat("x-scal-rdma: %s", rdma_desc);
     ctx->headers = curl_slist_append(ctx->headers, rdma_header.c_str());
     if (is_upload) {
         // Content-Length: 0; data is transferred via RDMA, not the HTTP body.

--- a/src/plugins/obj/rest_accel/scality_ai_connector/rest_client.h
+++ b/src/plugins/obj/rest_accel/scality_ai_connector/rest_client.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H
-#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H
+#ifndef NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_REST_CLIENT_H
+#define NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_REST_CLIENT_H
 
 #include <asio/thread_pool.hpp>
 #include <asio/post.hpp>
@@ -39,8 +39,6 @@
  */
 class iRestClient {
 public:
-    virtual ~iRestClient() = default;
-
     /**
      * Asynchronously put an object using RDMA.
      * @param key The object key
@@ -82,6 +80,12 @@ public:
      */
     virtual void
     checkObjectExistsAsync(std::string_view key, check_object_callback_t callback) = 0;
+
+protected:
+    // Implementations are only ever owned through shared_ptr (never deleted via
+    // an iRestClient*), so a protected non-virtual destructor suffices and
+    // avoids the vtable cost of a public virtual one.
+    ~iRestClient() = default;
 };
 
 /**
@@ -101,7 +105,7 @@ public:
      */
     explicit RestClient(nixl_b_params_t *custom_params);
 
-    ~RestClient() override;
+    ~RestClient();
 
     void
     putObjectRdmaAsync(std::string_view key,
@@ -150,7 +154,7 @@ private:
      * @param key Object key
      * @return Full URL string
      */
-    std::string
+    [[nodiscard]] std::string
     buildUrl(std::string_view key) const;
 
     /**
@@ -185,10 +189,18 @@ private:
     void
     reapCompletions();
 
-    /// Map a finished transfer to its callback, dispatch it on the worker pool,
-    /// and free the context. Poller-thread only.
+    /// Map a finished transfer to its callback dispatcher and free the context.
+    /// Poller-thread only.
     void
     finishRequest(RequestCtx *ctx, CURLcode res, long http_code);
+
+    /// Dispatch a finished HEAD transfer's callback on the worker pool.
+    void
+    dispatchHeadResult(RequestCtx *ctx, CURLcode res, long http_code);
+
+    /// Dispatch a finished PUT/GET transfer's callback on the worker pool.
+    void
+    dispatchXferResult(RequestCtx *ctx, CURLcode res, long http_code);
 };
 
 #endif // NIXL_SRC_PLUGINS_OBJ_REST_ACCEL_SCALITY_AI_CONNECTOR_CLIENT_H

--- a/test/gtest/unit/obj/device_select_test.cpp
+++ b/test/gtest/unit/obj/device_select_test.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the Scality AI Connector DRAM-across-NICs device mapping.
+ *
+ * targetCudaDevice() decides which CUDA device a buffer's MR (and thus its
+ * cuObject primary GID / NIC) is bound to. It needs no CUDA or cuObject, so
+ * this test is always built.
+ */
+#include <gtest/gtest.h>
+
+#include "rest_accel/scality_ai_connector/device_select.h"
+
+namespace gtest::obj {
+
+/** VRAM binds to the buffer's own GPU, unchanged regardless of GPU count. */
+TEST(DeviceSelectTest, VramBindsToOwnGpu) {
+    EXPECT_EQ(targetCudaDevice(VRAM_SEG, 0, 8), 0);
+    EXPECT_EQ(targetCudaDevice(VRAM_SEG, 3, 8), 3);
+    EXPECT_EQ(targetCudaDevice(VRAM_SEG, 7, 8), 7);
+    // VRAM mapping ignores gpuCount (the buffer is a real device pointer).
+    EXPECT_EQ(targetCudaDevice(VRAM_SEG, 5, 0), 5);
+}
+
+/** DRAM spreads round-robin across the available GPUs. */
+TEST(DeviceSelectTest, DramSpreadsAcrossGpus) {
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 0, 4), 0);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 1, 4), 1);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 2, 4), 2);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 3, 4), 3);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 4, 4), 0);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 5, 4), 1);
+}
+
+/** DRAM with no GPUs present leaves the current device unchanged. */
+TEST(DeviceSelectTest, DramNoGpusKeepsCurrentDevice) {
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 0, 0), -1);
+    EXPECT_EQ(targetCudaDevice(DRAM_SEG, 3, 0), -1);
+}
+
+/** Other segment types never switch the device. */
+TEST(DeviceSelectTest, OtherSegmentsKeepCurrentDevice) {
+    EXPECT_EQ(targetCudaDevice(OBJ_SEG, 1, 8), -1);
+    EXPECT_EQ(targetCudaDevice(BLK_SEG, 1, 8), -1);
+}
+
+} // namespace gtest::obj

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -19,6 +19,10 @@ if cuobj_dep.found()
     obj_test_sources += ['mock_dell_s3_client.cpp', 'obj_cuobj.cpp']
 endif
 
+if cuobj_dep.found() and dependency('libcurl', required: false).found()
+    obj_test_sources += ['rest_client.cpp', 'rest_client_concurrency.cpp']
+endif
+
 obj_unit_test_dep = declare_dependency(
     sources: obj_test_sources,
     include_directories: [

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-obj_test_sources = ['obj.cpp']
+obj_test_sources = ['obj.cpp', 'device_select_test.cpp']
 
 if cuobj_dep.found()
     obj_test_sources += ['mock_dell_s3_client.cpp', 'obj_cuobj.cpp']

--- a/test/gtest/unit/obj/rest_client.cpp
+++ b/test/gtest/unit/obj/rest_client.cpp
@@ -39,7 +39,7 @@
 #include <vector>
 
 #include "nixl_types.h"
-#include "rest_accel/scality_ai_connector/client.h"
+#include "rest_accel/scality_ai_connector/rest_client.h"
 
 namespace gtest::obj {
 

--- a/test/gtest/unit/obj/rest_client.cpp
+++ b/test/gtest/unit/obj/rest_client.cpp
@@ -1,0 +1,353 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * RestClient HTTP wire-format tests.
+ *
+ * Confirms that RestClient sends correctly-formed HTTP requests to the
+ * connector endpoint without any RDMA hardware, cuObject, or nvidia-fs: each
+ * test starts a one-shot loopback TCP server, points a RestClient at it, issues
+ * a request with a fake RDMA descriptor, and asserts on the raw HTTP captured.
+ */
+
+#include <gtest/gtest.h>
+#include <arpa/inet.h>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <future>
+#include <netinet/in.h>
+#include <optional>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "nixl_types.h"
+#include "rest_accel/scality_ai_connector/client.h"
+
+namespace gtest::obj {
+
+// A throwaway single-request HTTP server: binds to localhost:0, reads one full
+// HTTP request, replies "200 OK", and hands the raw request text back.
+class TcpServer {
+public:
+    explicit TcpServer(int status_code = 200, std::string reason = "OK")
+        : status_code_(status_code),
+          reason_(std::move(reason)) {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        EXPECT_GE(listen_fd_, 0) << "socket() failed: " << strerror(errno);
+
+        int opt = 1;
+        setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        struct sockaddr_in addr{};
+
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0; // let the OS assign a free port
+
+        EXPECT_EQ(bind(listen_fd_, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0)
+            << "bind() failed: " << strerror(errno);
+        EXPECT_EQ(listen(listen_fd_, 1), 0) << "listen() failed: " << strerror(errno);
+
+        socklen_t len = sizeof(addr);
+        getsockname(listen_fd_, reinterpret_cast<struct sockaddr *>(&addr), &len);
+        port_ = ntohs(addr.sin_port);
+
+        future_ = promise_.get_future();
+        thread_ = std::thread(&TcpServer::acceptAndRead, this);
+    }
+
+    ~TcpServer() {
+        if (listen_fd_ >= 0) {
+            close(listen_fd_);
+        }
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
+    int
+    port() const {
+        return port_;
+    }
+
+    // Block until one full HTTP request is captured (or timeout); "" on timeout.
+    std::string
+    capturedRequest(int timeout_sec = 5) {
+        if (future_.wait_for(std::chrono::seconds(timeout_sec)) == std::future_status::timeout) {
+            return "";
+        }
+        return future_.get();
+    }
+
+private:
+    void
+    acceptAndRead() {
+        int client_fd = accept(listen_fd_, nullptr, nullptr);
+        if (client_fd < 0) {
+            promise_.set_value("");
+            return;
+        }
+
+        std::string request;
+        char buf[4096];
+        while (request.find("\r\n\r\n") == std::string::npos) {
+            ssize_t n = recv(client_fd, buf, sizeof(buf), 0);
+            if (n <= 0) {
+                break;
+            }
+            request.append(buf, static_cast<std::string::size_type>(n));
+        }
+
+        std::string response = "HTTP/1.1 " + std::to_string(status_code_) + " " + reason_ +
+            "\r\nContent-Length: 0\r\n\r\n";
+        send(client_fd, response.data(), response.size(), 0);
+        close(client_fd);
+
+        promise_.set_value(request);
+    }
+
+    int status_code_;
+    std::string reason_;
+    int listen_fd_ = -1;
+    int port_ = 0;
+    std::thread thread_;
+    std::promise<std::string> promise_;
+    std::future<std::string> future_;
+};
+
+static nixl_b_params_t
+makeRestParams(const std::string &endpoint) {
+    return {{"endpoint_override", endpoint}};
+}
+
+// The async calls dispatch to an internal thread pool and return immediately;
+// spin-wait until the callback fires (or timeout).
+static void
+waitForCallback(const std::atomic<bool> &done, int timeout_ms = 5000) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    while (!done.load() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+}
+
+class RestClientTest : public testing::Test {};
+
+TEST_F(RestClientTest, PutSendsCorrectUrlAndHeaders) {
+    TcpServer server;
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:" + std::to_string(server.port()));
+    RestClient client(&params);
+
+    const std::string rdma_desc = "fake-rdma-descriptor-for-testing";
+    const size_t offset = 512;
+    const size_t data_len = 1024;
+    std::vector<char> buf(data_len);
+
+    std::atomic<bool> done{false}, success{false};
+    client.putObjectRdmaAsync("mykey",
+                              reinterpret_cast<uintptr_t>(buf.data()),
+                              data_len,
+                              offset,
+                              rdma_desc,
+                              [&](bool ok) {
+                                  success = ok;
+                                  done = true;
+                              });
+
+    std::string req = server.capturedRequest();
+    waitForCallback(done);
+
+    EXPECT_NE(req.find("PUT /mykey"), std::string::npos) << "Expected 'PUT /mykey' in request:\n"
+                                                         << req;
+    EXPECT_NE(req.find("x-scal-rdma: " + rdma_desc), std::string::npos)
+        << "x-scal-rdma header missing or wrong in:\n"
+        << req;
+    // Body must be empty; the data moves via RDMA, not the HTTP body.
+    EXPECT_NE(req.find("Content-Length: 0"), std::string::npos) << "Content-Length: 0 missing in:\n"
+                                                                << req;
+    EXPECT_TRUE(success.load()) << "putObjectRdmaAsync reported failure";
+}
+
+TEST_F(RestClientTest, GetSendsCorrectUrlAndHeaders) {
+    TcpServer server;
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:" + std::to_string(server.port()));
+    RestClient client(&params);
+
+    const size_t offset = 128;
+    std::vector<char> buf(512);
+
+    std::atomic<bool> done{false}, success{false};
+    client.getObjectRdmaAsync("readkey",
+                              reinterpret_cast<uintptr_t>(buf.data()),
+                              buf.size(),
+                              offset,
+                              "rdma-get-token",
+                              [&](bool ok) {
+                                  success = ok;
+                                  done = true;
+                              });
+
+    std::string req = server.capturedRequest();
+    waitForCallback(done);
+
+    EXPECT_NE(req.find("GET /readkey"), std::string::npos) << "Expected 'GET /readkey' in:\n"
+                                                           << req;
+    EXPECT_EQ(req.find("PUT"), std::string::npos) << "GET request must not contain PUT method in:\n"
+                                                  << req;
+    EXPECT_NE(req.find("x-scal-rdma: rdma-get-token"), std::string::npos)
+        << "x-scal-rdma missing in:\n"
+        << req;
+    EXPECT_TRUE(success.load()) << "getObjectRdmaAsync reported failure";
+}
+
+TEST_F(RestClientTest, PutRejectsEmptyRdmaDesc) {
+    // Port 1 won't accept connections, so a stray connection attempt fails loudly.
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:1");
+    RestClient client(&params);
+
+    std::vector<char> buf(64);
+    std::atomic<bool> done{false}, success{true};
+
+    client.putObjectRdmaAsync("k",
+                              reinterpret_cast<uintptr_t>(buf.data()),
+                              buf.size(),
+                              0,
+                              /*rdma_desc=*/"",
+                              [&](bool ok) {
+                                  success = ok;
+                                  done = true;
+                              });
+
+    waitForCallback(done);
+    EXPECT_TRUE(done.load()) << "Callback was never invoked";
+    EXPECT_FALSE(success.load()) << "Expected failure with empty rdma_desc";
+}
+
+TEST_F(RestClientTest, PutRejectsZeroDataLen) {
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:1");
+    RestClient client(&params);
+
+    std::atomic<bool> done{false}, success{true};
+    client.putObjectRdmaAsync("k",
+                              /*data_ptr=*/0,
+                              /*data_len=*/0,
+                              0,
+                              "some-token",
+                              [&](bool ok) {
+                                  success = ok;
+                                  done = true;
+                              });
+
+    waitForCallback(done);
+    EXPECT_TRUE(done.load()) << "Callback was never invoked";
+    EXPECT_FALSE(success.load()) << "Expected failure with data_len=0";
+}
+
+TEST_F(RestClientTest, GetRejectsEmptyRdmaDesc) {
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:1");
+    RestClient client(&params);
+
+    std::vector<char> buf(64);
+    std::atomic<bool> done{false}, success{true};
+    client.getObjectRdmaAsync("k",
+                              reinterpret_cast<uintptr_t>(buf.data()),
+                              buf.size(),
+                              0,
+                              /*rdma_desc=*/"",
+                              [&](bool ok) {
+                                  success = ok;
+                                  done = true;
+                              });
+
+    waitForCallback(done);
+    EXPECT_TRUE(done.load()) << "Callback was never invoked";
+    EXPECT_FALSE(success.load()) << "Expected failure with empty rdma_desc";
+}
+
+TEST_F(RestClientTest, ConstructorThrowsOnMissingEndpoint) {
+    nixl_b_params_t params = {}; // intentionally empty
+    EXPECT_THROW({ RestClient c(&params); }, std::invalid_argument);
+}
+
+TEST_F(RestClientTest, ConstructorThrowsOnNullParams) {
+    EXPECT_THROW({ RestClient c(nullptr); }, std::invalid_argument);
+}
+
+// ─── Existence check (HTTP HEAD) tests ────────────────────────────────────────
+
+TEST_F(RestClientTest, CheckExistsReturnsTrueOn200) {
+    TcpServer server(200, "OK");
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:" + std::to_string(server.port()));
+    RestClient client(&params);
+
+    std::atomic<bool> done{false};
+    std::optional<bool> result;
+    client.checkObjectExistsAsync("mykey", [&](std::optional<bool> exists) {
+        result = exists;
+        done = true;
+    });
+
+    std::string req = server.capturedRequest();
+    waitForCallback(done);
+
+    EXPECT_NE(req.find("HEAD /mykey"), std::string::npos) << "Expected 'HEAD /mykey' in:\n" << req;
+    ASSERT_TRUE(result.has_value()) << "Expected a definite result, got error";
+    EXPECT_TRUE(*result) << "Expected exists=true for HTTP 200";
+}
+
+TEST_F(RestClientTest, CheckExistsReturnsFalseOn404) {
+    TcpServer server(404, "Not Found");
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:" + std::to_string(server.port()));
+    RestClient client(&params);
+
+    std::atomic<bool> done{false};
+    std::optional<bool> result;
+    client.checkObjectExistsAsync("missing", [&](std::optional<bool> exists) {
+        result = exists;
+        done = true;
+    });
+
+    server.capturedRequest();
+    waitForCallback(done);
+
+    ASSERT_TRUE(result.has_value()) << "Expected a definite result, got error";
+    EXPECT_FALSE(*result) << "Expected exists=false for HTTP 404";
+}
+
+TEST_F(RestClientTest, CheckExistsReturnsErrorOn500) {
+    TcpServer server(500, "Internal Server Error");
+    nixl_b_params_t params = makeRestParams("http://127.0.0.1:" + std::to_string(server.port()));
+    RestClient client(&params);
+
+    std::atomic<bool> done{false};
+    std::optional<bool> result{false}; // sentinel; a 500 must reset this to nullopt
+    client.checkObjectExistsAsync("boom", [&](std::optional<bool> exists) {
+        result = exists;
+        done = true;
+    });
+
+    server.capturedRequest();
+    waitForCallback(done);
+
+    EXPECT_TRUE(done.load()) << "Callback was never invoked";
+    EXPECT_FALSE(result.has_value()) << "Expected error (nullopt) for HTTP 500";
+}
+
+} // namespace gtest::obj

--- a/test/gtest/unit/obj/rest_client_concurrency.cpp
+++ b/test/gtest/unit/obj/rest_client_concurrency.cpp
@@ -41,7 +41,7 @@
 #include <vector>
 
 #include "nixl_types.h"
-#include "rest_accel/scality_ai_connector/client.h"
+#include "rest_accel/scality_ai_connector/rest_client.h"
 
 namespace gtest::obj {
 

--- a/test/gtest/unit/obj/rest_client_concurrency.cpp
+++ b/test/gtest/unit/obj/rest_client_concurrency.cpp
@@ -1,0 +1,288 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * RestClient concurrency tests.
+ *
+ * The curl_multi-based RestClient drives all transfers from a single poller
+ * thread, so the number of simultaneously-open connections is decoupled from
+ * the thread count. These tests prove that with a loopback server that accepts
+ * many connections and holds them open before replying, and verify graceful
+ * teardown while requests are still in flight.
+ */
+
+#include <gtest/gtest.h>
+#include <arpa/inet.h>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <netinet/in.h>
+#include <optional>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "nixl_types.h"
+#include "rest_accel/scality_ai_connector/client.h"
+
+namespace gtest::obj {
+
+// A loopback HTTP server that accepts many connections concurrently, reads each
+// request, and HOLDS the connection open (no reply) until release() is called.
+// Tracks the peak number of simultaneously-held connections so a test can prove
+// that in-flight request count exceeds the client's thread count.
+class HoldingTcpServer {
+public:
+    HoldingTcpServer() {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        EXPECT_GE(listen_fd_, 0) << "socket() failed: " << strerror(errno);
+
+        int opt = 1;
+        setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        struct sockaddr_in addr{};
+
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        addr.sin_port = 0; // OS-assigned free port
+
+        EXPECT_EQ(bind(listen_fd_, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0)
+            << "bind() failed: " << strerror(errno);
+        EXPECT_EQ(listen(listen_fd_, 128), 0) << "listen() failed: " << strerror(errno);
+
+        socklen_t len = sizeof(addr);
+        getsockname(listen_fd_, reinterpret_cast<struct sockaddr *>(&addr), &len);
+        port_ = ntohs(addr.sin_port);
+
+        accept_thread_ = std::thread(&HoldingTcpServer::acceptLoop, this);
+    }
+
+    ~HoldingTcpServer() {
+        stop_.store(true);
+        release(); // unblock any held handlers
+        if (listen_fd_ >= 0) {
+            ::shutdown(listen_fd_, SHUT_RDWR);
+            close(listen_fd_);
+            listen_fd_ = -1;
+        }
+        if (accept_thread_.joinable()) {
+            accept_thread_.join();
+        }
+        std::vector<std::thread> conns;
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            conns.swap(conns_);
+        }
+        for (auto &t : conns) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    }
+
+    int
+    port() const {
+        return port_;
+    }
+
+    int
+    maxConcurrent() const {
+        return max_concurrent_.load();
+    }
+
+    // Wait until at least n connections are simultaneously held (or timeout).
+    bool
+    waitUntilHeld(int n, int timeout_ms = 5000) {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+        while (concurrent_.load() < n) {
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        return true;
+    }
+
+    // Let all held (and future) connections send "200 OK" and close.
+    void
+    release() {
+        {
+            std::lock_guard<std::mutex> lk(mtx_);
+            released_ = true;
+        }
+        cv_.notify_all();
+    }
+
+private:
+    void
+    acceptLoop() {
+        while (!stop_.load()) {
+            int client_fd = accept(listen_fd_, nullptr, nullptr);
+            if (client_fd < 0) {
+                break; // listen socket closed
+            }
+            std::lock_guard<std::mutex> lk(mtx_);
+            conns_.emplace_back(&HoldingTcpServer::handleConn, this, client_fd);
+        }
+    }
+
+    void
+    handleConn(int fd) {
+        std::string request;
+        char buf[4096];
+        while (request.find("\r\n\r\n") == std::string::npos) {
+            ssize_t n = recv(fd, buf, sizeof(buf), 0);
+            if (n <= 0) {
+                close(fd);
+                return;
+            }
+            request.append(buf, static_cast<std::string::size_type>(n));
+        }
+
+        int now = concurrent_.fetch_add(1) + 1;
+        int prev_max = max_concurrent_.load();
+        while (now > prev_max && !max_concurrent_.compare_exchange_weak(prev_max, now)) {}
+
+        {
+            std::unique_lock<std::mutex> lk(mtx_);
+            cv_.wait(lk, [this] { return released_; });
+        }
+
+        const char *resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+        // The peer may already be gone (client destroyed mid-flight); avoid a
+        // SIGPIPE killing the test process.
+#ifdef MSG_NOSIGNAL
+        (void)send(fd, resp, strlen(resp), MSG_NOSIGNAL);
+#else
+        (void)send(fd, resp, strlen(resp), 0);
+#endif
+        close(fd);
+        concurrent_.fetch_sub(1);
+    }
+
+    int listen_fd_ = -1;
+    int port_ = 0;
+    std::thread accept_thread_;
+    std::vector<std::thread> conns_;
+    std::mutex mtx_;
+    std::condition_variable cv_;
+    bool released_ = false;
+    std::atomic<bool> stop_{false};
+    std::atomic<int> concurrent_{0};
+    std::atomic<int> max_concurrent_{0};
+};
+
+static nixl_b_params_t
+makeRestParams(const std::string &endpoint, const std::string &num_threads) {
+    return {{"endpoint_override", endpoint}, {"num_threads", num_threads}};
+}
+
+class RestClientConcurrencyTest : public testing::Test {};
+
+// Many requests are in flight at once even though the client has a single poller
+// thread and a tiny callback pool, proving connection count is decoupled from
+// thread count.
+TEST_F(RestClientConcurrencyTest, ManyConcurrentInFlightExceedThreadCount) {
+    constexpr int kN = 16;
+    constexpr int kThreshold = 8; // comfortably above 1 poller + 2 callback threads
+
+    HoldingTcpServer server;
+    // num_threads sizes only the callback pool now (2); it must NOT gate in-flight.
+    nixl_b_params_t params =
+        makeRestParams("http://127.0.0.1:" + std::to_string(server.port()), "2");
+    RestClient client(&params);
+
+    std::vector<char> buf(1024);
+    std::atomic<int> done{0};
+    std::atomic<int> ok{0};
+
+    for (int i = 0; i < kN; i++) {
+        client.getObjectRdmaAsync("key" + std::to_string(i),
+                                  reinterpret_cast<uintptr_t>(buf.data()),
+                                  buf.size(),
+                                  0,
+                                  "rdma-token",
+                                  [&](bool success) {
+                                      if (success) {
+                                          ok.fetch_add(1);
+                                      }
+                                      done.fetch_add(1);
+                                  });
+    }
+
+    // The server should hold many connections open simultaneously before we
+    // release any of them.
+    EXPECT_TRUE(server.waitUntilHeld(kThreshold))
+        << "only reached " << server.maxConcurrent() << " concurrent connections";
+    EXPECT_GE(server.maxConcurrent(), kThreshold);
+
+    server.release();
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (done.load() < kN && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(done.load(), kN) << "not all callbacks fired";
+    EXPECT_EQ(ok.load(), kN) << "some requests did not succeed";
+}
+
+// Destroying the client while requests are stuck in flight must return promptly
+// and fire every callback exactly once (with failure).
+TEST_F(RestClientConcurrencyTest, TeardownWithOutstandingRequestsFiresAllCallbacks) {
+    constexpr int kN = 8;
+
+    HoldingTcpServer server; // never released → requests stay in flight
+    nixl_b_params_t params =
+        makeRestParams("http://127.0.0.1:" + std::to_string(server.port()), "2");
+
+    std::vector<char> buf(1024);
+    std::atomic<int> done{0};
+    std::atomic<int> ok{0};
+
+    {
+        RestClient client(&params);
+        for (int i = 0; i < kN; i++) {
+            client.getObjectRdmaAsync("key" + std::to_string(i),
+                                      reinterpret_cast<uintptr_t>(buf.data()),
+                                      buf.size(),
+                                      0,
+                                      "rdma-token",
+                                      [&](bool success) {
+                                          if (success) {
+                                              ok.fetch_add(1);
+                                          }
+                                          done.fetch_add(1);
+                                      });
+        }
+        ASSERT_TRUE(server.waitUntilHeld(1)) << "no request reached the server";
+
+        auto t0 = std::chrono::steady_clock::now();
+        // client destructor runs here at end of scope
+        (void)t0;
+    }
+
+    // After the destructor returns, the callback pool has been drained, so every
+    // callback must already have fired, all as failures (aborted in flight).
+    EXPECT_EQ(done.load(), kN) << "not all callbacks fired on teardown";
+    EXPECT_EQ(ok.load(), 0) << "aborted requests should report failure";
+}
+
+} // namespace gtest::obj


### PR DESCRIPTION
## What?

Adds a new NIXL **OBJ-plugin accelerated engine, "Scality AI Connector"**, that moves object data to and from a Scality endpoint over **RDMA** (cuObject DC transport), using a header-only HTTP request to carry the command.

The PR includes:

- **The engine** (`src/plugins/obj/rest_accel/scality_ai_connector/`): a two-plane design where object bytes move over RDMA (GPU-direct capable) while a header-only HTTP `PUT`/`GET` carries the cuObject RDMA descriptor in an `x-scal-rdma` header. The HTTP control-plane client (`RestClient`) drives all requests with libcurl's multi interface from a single poller thread, dispatching completion callbacks to a worker pool sized by `num_threads`.
- **Build detection**: discovers the version-suffixed `cuobjclient-<ver>` pkg-config name so the accelerated engines build without hard-coding a CUDA version.
- **Unit tests**: HTTP wire-format tests (correct `PUT`/`GET`/`HEAD`, header, empty body, against a loopback server, no RDMA/cuObject required) and concurrency tests (poller keeps more requests in flight than its thread count; teardown with outstanding requests fires every callback exactly once).
- **nixlbench integration**: wires up the OBJ accelerated path (flags, REST object pre-population/cleanup, kvbench args) so the engine can be benchmarked. Object **pre-population** for READ benchmarks is seeded concurrently (OpenMP); teardown uses nixlbench's standard RAII deregistration/cleanup.

## Why?

Scality's AI Connector speaks its own REST dialect and is **not** S3-compatible, so the existing `s3`/`s3_crt` engines cannot target it. This engine lets NIXL move large buffers (often in GPU memory) to and from a Scality store over RDMA/GPUDirect, with HTTP used purely as a lightweight control plane. The nixlbench and test changes make the new path measurable and verifiable in CI without requiring RDMA hardware.

## How?

- **Two independent channels.** Data plane is RDMA (zero-copy, GPU-direct); control plane is an HTTP request with an empty body whose `x-scal-rdma` header carries the RDMA token. Scality performs the actual RDMA transfer against the registered buffer.
- **Concurrency.** A single dedicated poller thread owns the curl multi handle and runs the non-blocking event loop, so in-flight request count is decoupled from the thread count (curl only carries the header-only command; bulk data is on RDMA). Completion callbacks are offloaded to a `num_threads`-sized worker pool so a slow callback cannot stall the loop.
- **Multi-GPU correctness.** `registerMem`/`deregisterMem` set the current CUDA device to the buffer's GPU before `cuMemObjGet`/`PutDescriptor`, so multi-GPU registrations do not fail cuFile's device-memory check.
- **DC-only transport** via a thin `CuObjRdmaTokenClient` wrapper over NVIDIA `cuObjClient` (`CUOBJ_PROTO_RDMA_DC_V1`), behind the `iRdmaTokenClient` seam (also the test-injection point). The `cuObject` stack is required at build and run time; without it the engine is not compiled in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Scality AI Connector: REST-based accelerated OBJ backend supporting RDMA-style PUT/GET and HTTP HEAD object existence checks
  * Added CLI options to enable/configure accelerated OBJ: `--obj_accelerated_enable`, `--obj_accelerated_type`, `--obj_num_threads`
* **Bug Fixes**
  * Improved CUDA device handling with explicit device selection and safer device-id validation
  * Enhanced OBJ benchmark setup by parallelizing object pre-population
* **Documentation**
  * Added backend guide for Scality AI Connector
* **Tests**
  * Expanded REST client unit tests for formatting, concurrency, and teardown behavior
* **Build/Chores**
  * Improved cuobjclient discovery and linked libcurl where required
<!-- end of auto-generated comment: release notes by coderabbit.ai -->