### PR TITLE
telemetry: fall back to NOP collector when requested without a sink

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -72,9 +72,10 @@ Telemetry is configured by environment variables:
 | `NIXL_TELEMETRY_EXPORTER` | Name of the exporter plugin to use | - |
 
 - `NIXL_TELEMETRY_ENABLE` can be set to `y`/`yes`/`on`/`true`/`enable`/`1` to be enabled, and `n`/`no`/`off`/`false`/`disable`/`0` (or not set) to be disabled. Matching is case insensitive.
-- Telemetry is active only when an exporter or sink can be created. If telemetry is requested but neither `NIXL_TELEMETRY_EXPORTER` nor `NIXL_TELEMETRY_DIR` is configured, telemetry collection is disabled.
-- If telemetry is enabled but no exporter is set, or the exporter name is empty, then behaviour depends on `NIXL_TELEMETRY_DIR` as explained below.
-- Set `NIXL_TELEMETRY_EXPORTER=NOP` to keep telemetry active (events are collected and `getXferTelemetry()` works) while discarding all output. It needs no sink and writes nothing, so it can be used to measure the overhead of the telemetry collection path in isolation.
+- Telemetry is requested either via `NIXL_TELEMETRY_ENABLE` or via the agent config flag `captureTelemetry` (`capture_telemetry=True` in Python). It is fully off only when it is not requested.
+- When telemetry is requested but no output sink is configured (neither `NIXL_TELEMETRY_EXPORTER` nor `NIXL_TELEMETRY_DIR`), it falls back to the collect-only NOP exporter: events are collected in-process so `getXferTelemetry()` / `get_xfer_telemetry()` works, but nothing is written out.
+- If telemetry is enabled but no exporter is set, or the exporter name is empty, then the sink depends on `NIXL_TELEMETRY_DIR` as explained below (falling back to NOP when it is unset).
+- Set `NIXL_TELEMETRY_EXPORTER=NOP` to explicitly keep telemetry active (events are collected and `getXferTelemetry()` works) while discarding all output. It needs no sink and writes nothing, so it can be used to measure the overhead of the telemetry collection path in isolation.
 
 ## Cyclic Buffer
 
@@ -86,7 +87,7 @@ Following sections applied specifically for configuration and usage of cyclic bu
 | -------- | ----------- | ------- |
 | `NIXL_TELEMETRY_DIR` | Directory for telemetry files | - |
 
-- If telemetry is enabled via `NIXL_TELEMETRY_ENABLE`, but `NIXL_TELEMETRY_DIR` is not set, no telemetry file is generated and `NIXL_TELEMETRY_RUN_INTERVAL` is not used.
+- If telemetry is requested but `NIXL_TELEMETRY_DIR` is not set (and no other exporter is selected), no telemetry file is generated; telemetry instead falls back to the collect-only NOP exporter, so events are collected in-process (`getXferTelemetry()` works) but nothing is written and `NIXL_TELEMETRY_RUN_INTERVAL` has no observable effect.
 
 ### Telemetry File Format
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -72,11 +72,15 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) {
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;
 constexpr size_t DEFAULT_TELEMETRY_BUFFER_SIZE = 4096;
 constexpr const char *defaultTelemetryPlugin = "BUFFER";
+// Collect-only sink (registered as "NOP"): keeps telemetry active so the
+// datapath records events and getXferTelemetry() works, but writes nowhere.
+// Used when telemetry is explicitly requested but no output sink is configured.
+constexpr const char *collectOnlyTelemetryPlugin = "NOP";
 
 namespace {
 // Defined below; declared here for use by create() and the constructor's
 // member-initializer list.
-[[nodiscard]] std::optional<std::string>
+[[nodiscard]] std::string
 getExporterName();
 [[nodiscard]] std::string
 validateAgentName(const std::string &agent_name);
@@ -86,16 +90,11 @@ resolveMaxBufferedEvents();
 
 [[nodiscard]] std::unique_ptr<nixlTelemetry>
 nixlTelemetry::create(const std::string &agent_name) {
-    const std::optional<std::string> exporter_name = getExporterName();
-
-    // No exporter/sink configured: telemetry is intentionally disabled, so do
-    // not construct a nixlTelemetry at all (avoids spinning up its thread pool
-    // only to tear it down).
-    if (!exporter_name) {
-        return nullptr;
-    }
-
-    return std::make_unique<nixlTelemetry>(agent_name, *exporter_name);
+    // create() is only called when telemetry is explicitly requested (see
+    // nixlAgent's constructor), so it always produces an active instance:
+    // getExporterName() falls back to the collect-only NOP sink when no output
+    // sink is configured.
+    return std::make_unique<nixlTelemetry>(agent_name, getExporterName());
 }
 
 nixlTelemetry::nixlTelemetry(const std::string &agent_name, const std::string &exporter_name)
@@ -130,24 +129,28 @@ nixlTelemetry::~nixlTelemetry() {
 }
 
 namespace {
-[[nodiscard]] std::optional<std::string>
+[[nodiscard]] std::string
 getExporterName() {
     if (const auto name = nixl::config::getValueOptional<std::string>(telemetryExporterVar)) {
         if (!name->empty()) {
-            return name;
+            return *name;
         }
         NIXL_DEBUG << "Ignoring empty " << telemetryExporterVar << " environment variable";
     }
 
-    if (!nixl::config::checkExistence(telemetryDirVar)) {
-        NIXL_DEBUG << telemetryDirVar
-                   << " is not set and no exporter was specified; NIXL telemetry is disabled";
-        return std::nullopt;
+    if (nixl::config::checkExistence(telemetryDirVar)) {
+        NIXL_INFO << "No telemetry exporter was specified, using default: "
+                  << defaultTelemetryPlugin;
+        return defaultTelemetryPlugin;
     }
 
-    NIXL_INFO << "No telemetry exporter was specified, using default: " << defaultTelemetryPlugin;
-
-    return defaultTelemetryPlugin;
+    // Telemetry was explicitly requested but no output sink is configured. Fall
+    // back to the collect-only NOP sink so in-process consumers such as
+    // getXferTelemetry() keep working; nothing is written out.
+    NIXL_INFO << telemetryDirVar << " is not set and no exporter was specified; collecting "
+              << "in-process via " << collectOnlyTelemetryPlugin
+              << " so get_xfer_telemetry() works";
+    return collectOnlyTelemetryPlugin;
 }
 
 [[nodiscard]] std::string

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -144,12 +144,9 @@ getExporterName() {
         return defaultTelemetryPlugin;
     }
 
-    // Telemetry was explicitly requested but no output sink is configured. Fall
-    // back to the collect-only NOP sink so in-process consumers such as
-    // getXferTelemetry() keep working; nothing is written out.
-    NIXL_INFO << telemetryDirVar << " is not set and no exporter was specified; collecting "
-              << "in-process via " << collectOnlyTelemetryPlugin
-              << " so get_xfer_telemetry() works";
+    // No output sink configured; collect in-process via the NOP sink.
+    NIXL_INFO << "No telemetry sink configured; using in-process telemetry collection via "
+              << collectOnlyTelemetryPlugin;
     return collectOnlyTelemetryPlugin;
 }
 

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -72,9 +72,9 @@ nixlTelemetryEventTypeForStatus(nixl_status_t s) {
 constexpr std::chrono::milliseconds DEFAULT_TELEMETRY_RUN_INTERVAL = 100ms;
 constexpr size_t DEFAULT_TELEMETRY_BUFFER_SIZE = 4096;
 constexpr const char *defaultTelemetryPlugin = "BUFFER";
-// Collect-only sink (registered as "NOP"): keeps telemetry active so the
-// datapath records events and getXferTelemetry() works, but writes nowhere.
-// Used when telemetry is explicitly requested but no output sink is configured.
+// Collect-only sink (registered as "NOP"): events are still recorded in process
+// (so getXferTelemetry() returns data) but nothing is written out. Used when
+// telemetry is explicitly requested but no output sink is configured.
 constexpr const char *collectOnlyTelemetryPlugin = "NOP";
 
 namespace {

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -51,10 +51,15 @@ struct periodicTask {
 class nixlTelemetry {
 public:
     /**
-     * @brief Creates a telemetry instance if an exporter/sink is configured.
+     * @brief Creates an active telemetry instance.
+     *
+     * Only called when telemetry is explicitly requested (NIXL_TELEMETRY_ENABLE
+     * or the agent's captureTelemetry config), so it always returns a non-null,
+     * active instance. With an output sink configured it exports there; without
+     * one it falls back to the collect-only NOP sink so in-process consumers
+     * such as getXferTelemetry() keep working.
      * @param agent_name Non-empty agent name.
-     * @return A telemetry instance, or nullptr when no exporter/sink is
-     *         configured (telemetry is intentionally disabled).
+     * @return A non-null, active telemetry instance.
      * @throws std::invalid_argument / std::runtime_error on genuine
      *         configuration or plugin-load errors.
      */

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -51,15 +51,15 @@ struct periodicTask {
 class nixlTelemetry {
 public:
     /**
-     * @brief Creates an active telemetry instance.
+     * @brief Creates a telemetry instance that records transfer events.
      *
      * Only called when telemetry is explicitly requested (NIXL_TELEMETRY_ENABLE
-     * or the agent's captureTelemetry config), so it always returns a non-null,
-     * active instance. With an output sink configured it exports there; without
-     * one it falls back to the collect-only NOP sink so in-process consumers
-     * such as getXferTelemetry() keep working.
+     * or the agent's captureTelemetry config), so it always returns a non-null
+     * instance. With an output sink configured it exports events there; without
+     * one it falls back to the collect-only NOP sink, which still records events
+     * in process (so getXferTelemetry() returns data) but writes nothing.
      * @param agent_name Non-empty agent name.
-     * @return A non-null, active telemetry instance.
+     * @return A non-null telemetry instance.
      * @throws std::invalid_argument / std::runtime_error on genuine
      *         configuration or plugin-load errors.
      */

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -146,8 +146,13 @@ TEST_F(telemetryTest, CreateFallsBackToNopWithoutSink) {
     // It falls back to the collect-only NOP exporter rather than disabling
     // telemetry (the in-process consumer that broke vLLM).
     envHelper_.popVar(); // drop NIXL_TELEMETRY_DIR set by SetUp -> no sink
+    // Neutralize any inherited NIXL_TELEMETRY_EXPORTER (empty is ignored by
+    // getExporterName) so the no-sink NOP path is exercised deterministically.
+    envHelper_.addVar(TELEMETRY_EXPORTER_VAR, "");
 
     auto telemetry = nixlTelemetry::create(testFile_);
+
+    envHelper_.popVar(); // drop empty NIXL_TELEMETRY_EXPORTER
     envHelper_.addVar(TELEMETRY_DIR_VAR, testDir_.string()); // restore for TearDown symmetry
 
     ASSERT_NE(telemetry, nullptr)

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -139,15 +139,9 @@ TEST_F(telemetryTest, NonexistentExporterThrows) {
 }
 
 TEST_F(telemetryTest, CreateFallsBackToNopWithoutSink) {
-    // Regression (#1716 / NIX-1361): when telemetry is explicitly requested
-    // (NIXL_TELEMETRY_ENABLE=y, set by SetUp) but no sink is configured (no
-    // NIXL_TELEMETRY_DIR / NIXL_TELEMETRY_EXPORTER), create() must still return
-    // an active instance that collects in-process so getXferTelemetry() works.
-    // It falls back to the collect-only NOP exporter rather than disabling
-    // telemetry (the in-process consumer that broke vLLM).
     envHelper_.popVar(); // drop NIXL_TELEMETRY_DIR set by SetUp -> no sink
-    // Neutralize any inherited NIXL_TELEMETRY_EXPORTER (empty is ignored by
-    // getExporterName) so the no-sink NOP path is exercised deterministically.
+    // Neutralize any inherited NIXL_TELEMETRY_EXPORTER (empty is ignored) so the
+    // sinkless NOP path is exercised deterministically.
     envHelper_.addVar(TELEMETRY_EXPORTER_VAR, "");
 
     auto telemetry = nixlTelemetry::create(testFile_);

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -138,12 +138,24 @@ TEST_F(telemetryTest, NonexistentExporterThrows) {
         { nixlTelemetry telemetry(testFile_, "nixl_nonexistent_exporter"); }, std::runtime_error);
 }
 
-TEST_F(telemetryTest, CreateReturnsNullWithoutSink) {
-    // With no exporter and no telemetry dir configured, create() resolves no
-    // sink and returns nullptr without constructing a telemetry instance.
-    envHelper_.popVar(); // drop NIXL_TELEMETRY_DIR set by SetUp
-    EXPECT_EQ(nixlTelemetry::create(testFile_), nullptr);
+TEST_F(telemetryTest, CreateFallsBackToNopWithoutSink) {
+    // Regression (#1716 / NIX-1361): when telemetry is explicitly requested
+    // (NIXL_TELEMETRY_ENABLE=y, set by SetUp) but no sink is configured (no
+    // NIXL_TELEMETRY_DIR / NIXL_TELEMETRY_EXPORTER), create() must still return
+    // an active instance that collects in-process so getXferTelemetry() works.
+    // It falls back to the collect-only NOP exporter rather than disabling
+    // telemetry (the in-process consumer that broke vLLM).
+    envHelper_.popVar(); // drop NIXL_TELEMETRY_DIR set by SetUp -> no sink
+
+    auto telemetry = nixlTelemetry::create(testFile_);
     envHelper_.addVar(TELEMETRY_DIR_VAR, testDir_.string()); // restore for TearDown symmetry
+
+    ASSERT_NE(telemetry, nullptr)
+        << "telemetry requested without a sink must collect in-process via NOP";
+    EXPECT_NO_THROW(telemetry->updateTxBytes(1024));
+
+    // Collect-only NOP fallback writes nothing to disk.
+    EXPECT_FALSE(fs::exists(testDir_.string() + "/" + testFile_));
 }
 
 TEST_F(telemetryTest, NopExporterIsActiveAndWritesNothing) {

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -636,11 +636,9 @@ TEST_P(TestTransferTelemetry, GetXferTelemetryAPI) {
 }
 
 TEST_P(TestTransferTelemetry, GetXferTelemetryCaptureNoSink) {
-    // Regression (#1716 / NIX-1361): the vLLM scenario -- telemetry requested
-    // purely through the agent config (capture_telemetry=true), with no
-    // NIXL_TELEMETRY_ENABLE and no sink (NIXL_TELEMETRY_DIR/EXPORTER). Telemetry
-    // must collect in-process via the NOP fallback so the in-process consumer
-    // getXferTelemetry() succeeds.
+    // Telemetry requested only via capture_telemetry=true (no
+    // NIXL_TELEMETRY_ENABLE, no sink): the in-process NOP fallback keeps
+    // getXferTelemetry() working.
     runTelemetryTransferTest(1024, NIXL_SUCCESS, true);
 }
 

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -628,10 +628,20 @@ TEST_P(TestTransferTelemetry, GetXferTelemetryFile) {
 }
 
 TEST_P(TestTransferTelemetry, GetXferTelemetryAPI) {
-    // Enabling telemetry without a configured exporter or buffer sink should
-    // not create a half-active telemetry instance.
+    // Telemetry explicitly enabled via NIXL_TELEMETRY_ENABLE=y but with no sink
+    // (no NIXL_TELEMETRY_DIR/EXPORTER) collects in-process via the collect-only
+    // NOP fallback, so getXferTelemetry() still works.
     env.addVar("NIXL_TELEMETRY_ENABLE", "y");
-    runTelemetryTransferTest(1024, NIXL_ERR_NO_TELEMETRY, false);
+    runTelemetryTransferTest(1024, NIXL_SUCCESS, false);
+}
+
+TEST_P(TestTransferTelemetry, GetXferTelemetryCaptureNoSink) {
+    // Regression (#1716 / NIX-1361): the vLLM scenario -- telemetry requested
+    // purely through the agent config (capture_telemetry=true), with no
+    // NIXL_TELEMETRY_ENABLE and no sink (NIXL_TELEMETRY_DIR/EXPORTER). Telemetry
+    // must collect in-process via the NOP fallback so the in-process consumer
+    // getXferTelemetry() succeeds.
+    runTelemetryTransferTest(1024, NIXL_SUCCESS, true);
 }
 
 TEST_P(TestTransferTelemetry, GetXferTelemetryAPICfg) {

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -302,6 +302,8 @@ def _run_xfer_telemetry_check(agent1, agent2, expect_telemetry: bool = True) -> 
 
 
 def test_get_xfer_telemetry_without_sink(backend_name):
+    # Telemetry enabled with no sink still collects in-process via the NOP
+    # fallback, so get_xfer_telemetry() works (#1716 / NIX-1361 regression).
     os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
     try:
         agent1 = nixl_agent(
@@ -310,7 +312,7 @@ def test_get_xfer_telemetry_without_sink(backend_name):
         agent2 = nixl_agent(
             str(uuid.uuid4()), nixl_conf=nixl_agent_config(backends=[backend_name])
         )
-        _run_xfer_telemetry_check(agent1, agent2, expect_telemetry=False)
+        _run_xfer_telemetry_check(agent1, agent2, expect_telemetry=True)
     finally:
         os.environ.pop("NIXL_TELEMETRY_ENABLE")
 

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -303,8 +303,8 @@ def _run_xfer_telemetry_check(agent1, agent2, expect_telemetry: bool = True) -> 
 
 def test_get_xfer_telemetry_without_sink(backend_name):
     # Telemetry enabled with no sink still collects in-process via the NOP
-    # fallback, so get_xfer_telemetry() works (#1716 / NIX-1361 regression).
-    # Clear any inherited sink vars so the sinkless path is exercised.
+    # fallback, so get_xfer_telemetry() works. Clear any inherited sink vars so
+    # the sinkless path is exercised.
     prev_enable = os.environ.get("NIXL_TELEMETRY_ENABLE")
     os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
     prev_dir = os.environ.pop("NIXL_TELEMETRY_DIR", None)

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -305,6 +305,7 @@ def test_get_xfer_telemetry_without_sink(backend_name):
     # Telemetry enabled with no sink still collects in-process via the NOP
     # fallback, so get_xfer_telemetry() works (#1716 / NIX-1361 regression).
     # Clear any inherited sink vars so the sinkless path is exercised.
+    prev_enable = os.environ.get("NIXL_TELEMETRY_ENABLE")
     os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
     prev_dir = os.environ.pop("NIXL_TELEMETRY_DIR", None)
     prev_exporter = os.environ.pop("NIXL_TELEMETRY_EXPORTER", None)
@@ -317,7 +318,9 @@ def test_get_xfer_telemetry_without_sink(backend_name):
         )
         _run_xfer_telemetry_check(agent1, agent2, expect_telemetry=True)
     finally:
-        os.environ.pop("NIXL_TELEMETRY_ENABLE")
+        os.environ.pop("NIXL_TELEMETRY_ENABLE", None)
+        if prev_enable is not None:
+            os.environ["NIXL_TELEMETRY_ENABLE"] = prev_enable
         if prev_dir is not None:
             os.environ["NIXL_TELEMETRY_DIR"] = prev_dir
         if prev_exporter is not None:

--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -304,7 +304,10 @@ def _run_xfer_telemetry_check(agent1, agent2, expect_telemetry: bool = True) -> 
 def test_get_xfer_telemetry_without_sink(backend_name):
     # Telemetry enabled with no sink still collects in-process via the NOP
     # fallback, so get_xfer_telemetry() works (#1716 / NIX-1361 regression).
+    # Clear any inherited sink vars so the sinkless path is exercised.
     os.environ["NIXL_TELEMETRY_ENABLE"] = "y"
+    prev_dir = os.environ.pop("NIXL_TELEMETRY_DIR", None)
+    prev_exporter = os.environ.pop("NIXL_TELEMETRY_EXPORTER", None)
     try:
         agent1 = nixl_agent(
             str(uuid.uuid4()), nixl_conf=nixl_agent_config(backends=[backend_name])
@@ -315,6 +318,10 @@ def test_get_xfer_telemetry_without_sink(backend_name):
         _run_xfer_telemetry_check(agent1, agent2, expect_telemetry=True)
     finally:
         os.environ.pop("NIXL_TELEMETRY_ENABLE")
+        if prev_dir is not None:
+            os.environ["NIXL_TELEMETRY_DIR"] = prev_dir
+        if prev_exporter is not None:
+            os.environ["NIXL_TELEMETRY_EXPORTER"] = prev_exporter
 
 
 def test_get_xfer_telemetry_with_buffer(backend_name):


### PR DESCRIPTION
## What?

Fixes the regression introduced by #1716 (NIX-1361) where telemetry requested
through the API but with no exporter/sink configured was silently disabled,
breaking in-process `get_xfer_telemetry()`.

- `getExporterName()` now falls back to the collect-only **NOP** exporter when
  telemetry is requested but neither `NIXL_TELEMETRY_EXPORTER` nor
  `NIXL_TELEMETRY_DIR` is set, instead of returning "no sink".
- `getExporterName()` returns `std::string` (it can no longer be empty) and
  `nixlTelemetry::create()` is simplified to always build an active instance.
- Tests and `docs/telemetry.md` updated.

## Why?

vLLM uses telemetry in-process: `nixl_agent_config(..., capture_telemetry=True)`
followed by `get_xfer_telemetry(handle)` at completion, with no
`NIXL_TELEMETRY_DIR`/`NIXL_TELEMETRY_EXPORTER`. After #1716, `create()` decided
enablement purely from the sink env vars and returned `nullptr`, so
`get_xfer_telemetry()` returned `NIXL_ERR_NO_TELEMETRY` and the transfer was
treated as failed.

`get_xfer_telemetry()` is an in-process consumer that needs no sink, so #1716's
assumption "no sink = nothing consumes telemetry" is wrong, and it contradicts
the documented `captureTelemetry` contract ("Capture telemetry info regardless
of environment variables"). API-only telemetry must keep working. This is
release-relevant and should be backported.

## How?

`create()` is only ever called on an explicit request (`NIXL_TELEMETRY_ENABLE`
or the agent's `captureTelemetry`), so the fix lives entirely in
`getExporterName()`. Resulting behavior:

| Telemetry requested? | Sink configured? | Result |
| --- | --- | --- |
| yes | `NIXL_TELEMETRY_EXPORTER` set | that exporter |
| yes | `NIXL_TELEMETRY_DIR` set | `BUFFER` |
| yes | neither | `NOP` (collect-only; `get_xfer_telemetry()` works, nothing written) |
| no | — | `telemetry_` stays null → `NIXL_ERR_NO_TELEMETRY` (unchanged) |

Note: the NOP static plugin is registered under the key `"NOP"` (the
`NIXL_REGISTER_STATIC_PLUGIN(Telemetry, NOP)` macro stringifies the name and the
lookup is case-sensitive), so the fallback constant is `"NOP"`. An explicit,
unloadable `NIXL_TELEMETRY_EXPORTER` still throws.

Tests (the C++ core is the source of truth, so coverage is added there rather
than duplicated per binding):
- `telemetry_test.cpp`: replaced `CreateReturnsNullWithoutSink` with
  `CreateFallsBackToNopWithoutSink`.
- `test_transfer.cpp`: flipped `GetXferTelemetryAPI` (`NIXL_TELEMETRY_ENABLE=y` +
  no sink) to `NIXL_SUCCESS`; added `GetXferTelemetryCaptureNoSink` (the vLLM
  scenario: `capture_telemetry=true` + no sink → `getXferTelemetry()` succeeds).
- `test_nixl_api.py`: fixed `test_get_xfer_telemetry_without_sink`, which had
  encoded the buggy "no telemetry without a sink" expectation.

Validation: `telemetryTest.*` (16/16) and `*TestTransferTelemetry*` (20/20
across the 4 UCX instantiations) pass; clang-format-19 clean on changed lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When telemetry is requested but no sink/exporter is configured, telemetry remains active in-process and `getXferTelemetry()` / `get_xfer_telemetry()` succeed instead of failing.
  * Telemetry initialization now uses a collect-only (NOP) fallback when no output destination is available.
* **Documentation**
  * Updated telemetry docs to clarify collect-only fallback behavior, including sink/exporter fallback details and that the run interval has no observable effect without an output destination.
* **Tests**
  * Updated and added C++ and Python regression coverage for “no sink” initialization and capture-only telemetry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->