### PR TITLE
CI: Add job for CI images cleanup

### DIFF
--- a/.ci/cleanup-spec.json
+++ b/.ci/cleanup-spec.json
@@ -11,7 +11,7 @@
               { "name": "manifest.json" },
               { "name": "list.manifest.json" }
             ]},
-            { "created": { "$before": "1d" } }
+            { "modified": { "$before": "1d" } }
           ]
         }
       }
@@ -32,7 +32,7 @@
               { "stat.downloaded": { "$before": "2w" } },
               { "$and": [
                 { "stat.downloads": { "$eq": null } },
-                { "created": { "$before": "2w" } }
+                { "modified": { "$before": "2w" } }
               ]}
             ]}
           ]
@@ -50,7 +50,7 @@
               { "name": "manifest.json" },
               { "name": "list.manifest.json" }
             ]},
-            { "created": { "$before": "3mo" } }
+            { "modified": { "$before": "3mo" } }
           ]
         }
       }
@@ -63,7 +63,7 @@
             { "repo": "sw-nbu-swx-nixl-pypi-local" },
             { "path": { "$match": "verification/**" } },
             { "name": { "$match": "*.whl" } },
-            { "created": { "$before": "3mo" } }
+            { "modified": { "$before": "3mo" } }
           ]
         }
       }

--- a/.ci/cleanup-spec.json
+++ b/.ci/cleanup-spec.json
@@ -1,0 +1,72 @@
+{
+  "files": [
+    {
+      "//": "PR Docker images — older than 1 day",
+      "aql": {
+        "items.find": {
+          "$and": [
+            { "repo": "sw-nbu-swx-nixl-docker-local" },
+            { "path": { "$match": "ci/pr/**" } },
+            { "$or": [
+              { "name": "manifest.json" },
+              { "name": "list.manifest.json" }
+            ]},
+            { "created": { "$before": "1d" } }
+          ]
+        }
+      }
+    },
+    {
+      "//": "CI base Docker images — older than 2 weeks (last pull time)",
+      "aql": {
+        "items.find": {
+          "$and": [
+            { "repo": "sw-nbu-swx-nixl-docker-local" },
+            { "path": { "$match": "ci/**" } },
+            { "path": { "$nmatch": "ci/pr/**" } },
+            { "$or": [
+              { "name": "manifest.json" },
+              { "name": "list.manifest.json" }
+            ]},
+            { "$or": [
+              { "stat.downloaded": { "$before": "2w" } },
+              { "$and": [
+                { "stat.downloads": { "$eq": null } },
+                { "created": { "$before": "2w" } }
+              ]}
+            ]}
+          ]
+        }
+      }
+    },
+    {
+      "//": "Verification Docker images — older than 3 months",
+      "aql": {
+        "items.find": {
+          "$and": [
+            { "repo": "sw-nbu-swx-nixl-docker-local" },
+            { "path": { "$match": "verification/**" } },
+            { "$or": [
+              { "name": "manifest.json" },
+              { "name": "list.manifest.json" }
+            ]},
+            { "created": { "$before": "3mo" } }
+          ]
+        }
+      }
+    },
+    {
+      "//": "Verification PyPI wheels — older than 3 months",
+      "aql": {
+        "items.find": {
+          "$and": [
+            { "repo": "sw-nbu-swx-nixl-pypi-local" },
+            { "path": { "$match": "verification/**" } },
+            { "name": { "$match": "*.whl" } },
+            { "created": { "$before": "3mo" } }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -25,11 +25,12 @@ runs on-demand (`workflow_dispatch`, a PR comment, or a cron schedule).
 | `nixl-ci-build-wheel-nightly` | Jenkins (standalone) | Nightly cron + manual | No — never runs as part of PR CI |
 | `nixl-ci-build-llm-container` | Jenkins (standalone) | Manual only | No — never runs as part of PR CI |
 | `nixl-ci-test-llm-container` | Jenkins (standalone) | Manual, or chained from `build-llm-container` via `RUN_TEST` | No — never runs as part of PR CI |
+| `nixl-ci-cleanup-artifacts` | Jenkins (standalone) | Daily cron (6 AM) + manual | No — never runs as part of PR CI |
 
-> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 10 Jenkins jobs, but only the
+> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 11 Jenkins jobs, but only the
 > 6 that `nixl-ci-dispatcher` fans out to are ever part of the PR CI flow. The
-> other 4 (`build-container`, `build-wheel-nightly`, `build-llm-container`,
-> `test-llm-container`) are entirely standalone — they run only on a nightly
+> other 5 (`build-container`, `build-wheel-nightly`, `build-llm-container`,
+> `test-llm-container`, `cleanup-artifacts`) are entirely standalone — they run only on a nightly
 > cron or when someone triggers them manually from the Jenkins UI, and are
 > never invoked by the dispatcher or by a PR event.
 
@@ -179,6 +180,12 @@ their own nightly/manual trigger. They split into two groups:
 - **Trigger:** Manual only (no cron, no webhook).
 - **What it does:** Builds the 4 LLM inference container variants (`vllm-nixl`, `vllm-cu12-nixl`, `sglang-nixl`, `sglang-cu13-nixl`) for x86_64/aarch64 from a published NIXL wheel set, publishes multi-arch manifests, and optionally (`RUN_TEST`) fires `nixl-ci-test-llm-container` per built variant.
 - **Automatic on every PR:** No — standalone/manual only, used for release verification.
+
+### `nixl-ci-cleanup-artifacts` (standalone)
+- **Trigger:** Daily cron at 6 AM, or manual run with optional `DRY_RUN=true` parameter.
+- **What it does:** Deletes stale Artifactory artifacts based on `.ci/cleanup-spec.json` — PR Docker images older than 1 day, CI base images not pulled in 2 weeks, verification Docker images and PyPI wheels older than 3 months.
+- **Matrix:** `.ci/jenkins/lib/cleanup-matrix.yaml`. Runs on an Ubuntu 24.04 container with `jf` and `jq` installed at runtime.
+- **Automatic on every PR:** No — standalone/scheduled + manual only.
 
 ### `nixl-ci-test-llm-container` (standalone)
 - **Trigger:** Manual, or chained asynchronously from `nixl-ci-build-llm-container` when `RUN_TEST` is enabled.

--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -33,7 +33,6 @@ env:
   REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
   REGISTRY_REPO_PATH: "verification"
   ARTIFACTORY_REGISTRY_URL: "${REGISTRY_HOST_NAME}/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}"
-  ARTIFACTORY_CLEANUP_AGE: "3m" # 3 months
   LOCAL_TAG_BASE: "nixl-ci:build-"
   MAIL_FROM: "jenkins@nvidia.com"
 
@@ -243,7 +242,4 @@ pipeline_stop:
                 ${params.BUILD_NIXL_EP ? "<p>Build NIXL EP: <b>Yes</b></p>" : ''}
             """
         )
-    }
-    withCredentials([usernamePassword(credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-      sh "yum install -y jq > /dev/null && .ci/scripts/artifactory-cleanup-by-time.sh --path ${REGISTRY_REPO_PATH}/${BUILD_TARGET} ${REGISTRY_REPO_NAME} ${ARTIFACTORY_CLEANUP_AGE}"
     }

--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -58,7 +58,6 @@ env:
   REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
   REGISTRY_REPO_PATH: "verification/llm"
   ARTIFACTORY_REGISTRY_URL: "${REGISTRY_HOST_NAME}/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}"
-  ARTIFACTORY_CLEANUP_AGE: '3m' # 3 months
   WHEELS_REPO_NAME: "sw-dynamo-nixl-pypi-local"
   WHEELS_ARTIFACTORY_URL: "https://${REGISTRY_HOST_NAME}/artifactory/${WHEELS_REPO_NAME}"
   WHEELS_DIR: "${WORKSPACE}/llm-wheels"
@@ -462,7 +461,4 @@ pipeline_stop:
           ${publishSucceeded && params.UPDATE_LATEST ? '<p>Latest tag updated: <b>Yes</b></p>' : ''}
         """
       )
-    }
-    withCredentials([usernamePassword(credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')]) {
-      sh "yum install -y jq > /dev/null && .ci/scripts/artifactory-cleanup-by-time.sh --path ${REGISTRY_REPO_PATH} ${REGISTRY_REPO_NAME} ${ARTIFACTORY_CLEANUP_AGE}"
     }

--- a/.ci/jenkins/lib/cleanup-matrix.yaml
+++ b/.ci/jenkins/lib/cleanup-matrix.yaml
@@ -1,0 +1,39 @@
+---
+job: nixl-ci-cleanup-artifacts
+
+failFast: true
+timeout_minutes: 60
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: "{memory: 2Gi, cpu: 500m}"
+  requests: "{memory: 1Gi, cpu: 250m}"
+
+runs_on_dockers:
+  - { name: "ubuntu", url: "docker.io/library/ubuntu:24.04", arch: "x86_64" }
+
+env:
+  ARTIFACTORY_URL: "https://artifactory.nvidia.com/artifactory"
+
+credentials:
+  - {credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'}
+
+pipeline_start:
+  shell: action
+  module: groovy
+  run: |
+    env.DRY_RUN_FLAG=""
+    if ("${DRY_RUN}" == "true") {
+      env.DRY_RUN_FLAG="--dry-run"
+    }
+
+steps:
+  - name: Cleanup Artifactory artifacts
+    parallel: false
+    credentialsId: 'svc-nixl-new-artifactory-token'
+    run: |
+      apt-get update -qq && apt-get install -y -qq jq curl > /dev/null
+      curl -fsSL "https://releases.jfrog.io/artifactory/jfrog-cli/v2-jf/2.72.2/jfrog-cli-linux-amd64/jf" -o /usr/local/bin/jf && chmod +x /usr/local/bin/jf
+      .ci/scripts/artifactory-cleanup-by-time.sh ${DRY_RUN_FLAG} \
+        --spec .ci/cleanup-spec.json

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -882,6 +882,54 @@
               parent-credentials: true
       script-path: "{jjb_jenkinsfile}"
 
+# Template for the Artifactory cleanup job
+# Daily cleanup of NIXL Artifactory artifacts (Docker images + PyPI wheels).
+- job-template:
+    name: "{jjb_proj}-cleanup-artifacts"   # Will be expanded to 'nixl-ci-cleanup-artifacts'
+    folder: "Devops"
+    project-type: pipeline
+    disabled: false
+    properties:
+      - build-discarder:
+          days-to-keep: 14
+          num-to-keep: 14
+      - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}-cleanup-artifacts
+              conf_file=.ci/jenkins/lib/cleanup-matrix.yaml
+    description: Do NOT edit this job through the Web GUI !
+    sandbox: true
+    triggers:
+      - timed: "H 6 * * *"  # Daily at 6 AM
+    parameters:
+      - bool:
+          name: "DRY_RUN"
+          default: false
+          description: "Only list images that would be deleted, without actually deleting them"
+      - string:
+          name: "sha1"
+          default: "{jjb_branch}"    # Default to 'main' branch
+          description: "Commit to be checked, usually set by PR"
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                # Configure refspec to handle branches, PRs, and tags
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
+
 # Project definition that instantiates the job templates
 # This section defines the actual jobs that will be created
 - project:
@@ -905,3 +953,4 @@
         - "{jjb_proj}-dl-gpu-ep"  # Create dl-gpu-ep job for nixl_ep elastic tests on dlcluster.nvidia.com
         - "{jjb_proj}-build-wheel"  # Create build wheel job
         - "{jjb_proj}-build-wheel-nightly"  # Create nightly wheel verification job
+        - "{jjb_proj}-cleanup-artifacts"  # Create Artifactory cleanup job

--- a/.ci/scripts/artifactory-cleanup-by-time.sh
+++ b/.ci/scripts/artifactory-cleanup-by-time.sh
@@ -1,175 +1,73 @@
 #!/bin/bash
-# Artifactory cleanup by time (Docker images)
-# Deletes Docker images in a JFrog Artifactory repository that are older than a given age.
-# Only manifest.json (and list.manifest.json) are queried; image age is based on the
-# manifest's last modified date. The entire image folder is then deleted.
+# Deletes Artifactory artifacts matching the given JFrog CLI file spec.
+# Docker image tag directories are deleted recursively, PyPI wheels are deleted individually.
 #
 # Usage:
 #   export ARTIFACTORY_URL="https://your-instance.jfrog.io/artifactory"
 #   export ARTIFACTORY_USER="user"
 #   export ARTIFACTORY_TOKEN="password-or-api-key"
-#   ./artifactory-cleanup-by-time.sh [OPTIONS] REPO_KEY [AGE]
-#
-# Arguments:
-#   REPO_KEY   Repository key (e.g. sw-nbu-swx-nixl-docker-local)
-#   AGE        Age threshold: delete images whose manifest was last modified before this (default: 4w)
-#              Examples: 4w (weeks), 30d (days), 2m (months)
-#
-# Options:
-#   --dry-run       Only list images that would be deleted, do not delete
-#   --path PATH     Only consider images under this path (AQL path match)
+#   ./artifactory-cleanup-by-time.sh [--dry-run] --spec <cleanup-spec.json>
 #
 # Environment:
-#   ARTIFACTORY_URL       Base Artifactory URL (required)
-#   ARTIFACTORY_USER      Username for API auth (required unless using token only)
+#   ARTIFACTORY_URL       Base Artifactory URL (default: https://artifactory.nvidia.com/artifactory)
+#   ARTIFACTORY_USER      Artifactory username (required)
 #   ARTIFACTORY_TOKEN     Password or API key (required)
 #   ARTIFACTORY_API_KEY   Alternative to ARTIFACTORY_TOKEN
-#
-# Example:
-#   ./artifactory-cleanup-by-time.sh --dry-run sw-nbu-swx-nixl-docker-local 4w
-#   ./artifactory-cleanup-by-time.sh --path "verification/nixl/" sw-nbu-swx-nixl-docker-local 4w
 
 set -e
 
+DRY_RUN_FLAG=""
 DRY_RUN=false
-PATH_FILTER=""
+SPEC=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
-        --path)
-            if [[ $# -lt 2 || "$2" == -* ]]; then
-                echo "Missing value for --path" >&2
-                exit 1
-            fi
-            PATH_FILTER="$2"
-            shift 2
-            ;;
-        -*)
-            echo "Unknown option: $1" >&2
-            exit 1
-            ;;
-        *)
-            break
-            ;;
+        --dry-run) DRY_RUN_FLAG="--dry-run"; DRY_RUN=true; shift ;;
+        --spec)
+            [[ $# -lt 2 ]] && { echo "Missing value for --spec" >&2; exit 1; }
+            SPEC="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
 done
 
-if [[ $# -lt 1 ]]; then
-    echo "Usage: $0 [--dry-run] [--path PATH] REPO_KEY [AGE]" >&2
-    echo "  AGE default: 4w (4 weeks)" >&2
-    exit 1
-fi
-
-REPO_KEY="$1"
-AGE="${2:-4w}"
-
-# Parse age (e.g. 4w, 30d, 2m) and compute cutoff via epoch (portable)
-if [[ "$AGE" =~ ^([0-9]+)([wdm])$ ]]; then
-    NUM="${BASH_REMATCH[1]}"
-    UNIT="${BASH_REMATCH[2]}"
-else
-    echo "Invalid AGE format: $AGE (e.g. 4w, 30d, 2m)" >&2
-    exit 1
-fi
-
-NOW_EPOCH=$(date +%s)
-case "$UNIT" in
-    w) SECS_AGO=$((NUM * 7 * 24 * 3600)) ;;
-    d) SECS_AGO=$((NUM * 24 * 3600)) ;;
-    m) SECS_AGO=$((NUM * 30 * 24 * 3600)) ;;
-    *) echo "Invalid age unit: $UNIT (use w, d, or m)" >&2; exit 1 ;;
-esac
-CUTOFF_EPOCH=$((NOW_EPOCH - SECS_AGO))
-
-if date -u -d "@${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z" &>/dev/null; then
-    CUTOFF=$(date -u -d "@${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z")
-elif date -u -r "${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z" &>/dev/null; then
-    CUTOFF=$(date -u -r "${CUTOFF_EPOCH}" +"%Y-%m-%dT%H:%M:%S.000Z")
-else
-    echo "Cannot convert epoch to ISO date" >&2
-    exit 1
-fi
+[[ -z "$SPEC" ]] && { echo "Usage: $0 [--dry-run] --spec <cleanup-spec.json>" >&2; exit 1; }
+[[ -f "$SPEC" ]] || { echo "Spec file not found: $SPEC" >&2; exit 1; }
 
 ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://artifactory.nvidia.com/artifactory}"
 TOKEN="${ARTIFACTORY_TOKEN:-${ARTIFACTORY_API_KEY:?Set ARTIFACTORY_TOKEN or ARTIFACTORY_API_KEY}}"
-USER="${ARTIFACTORY_USER:-}"
+USER="${ARTIFACTORY_USER:?Set ARTIFACTORY_USER}"
 
-if [[ -n "$USER" ]]; then
-    CURL_AUTH=(-u "$USER:$TOKEN")
-else
-    CURL_AUTH=(-H "X-JFrog-Art-Api: $TOKEN")
-fi
+export JFROG_CLI_LOG_LEVEL=ERROR
 
-# Build AQL: only manifest files; filter by last modified date. Use $and so $or is valid.
-if [[ -n "$PATH_FILTER" ]]; then
-    PATH_MATCH="${PATH_FILTER%/}"
-    AQL='items.find({"$and":[{"repo":"'"$REPO_KEY"'"},{"path":{"$match":"'"$PATH_MATCH"'/*"}},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]},{"modified":{"$lt":"'"$CUTOFF"'"}}]}).include("repo","path","name")'
-else
-    AQL='items.find({"$and":[{"repo":"'"$REPO_KEY"'"},{"$or":[{"name":"manifest.json"},{"name":"list.manifest.json"}]},{"modified":{"$lt":"'"$CUTOFF"'"}}]}).include("repo","path","name")'
-fi
+jf config add artifactory \
+    --artifactory-url "${ARTIFACTORY_URL}" \
+    --password "${TOKEN}" \
+    --user "${USER}" \
+    --interactive=false
 
-echo "Current time (UTC): $(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
-echo "Cutoff: images with manifest last modified before $CUTOFF will be deleted (repo: $REPO_KEY)"
-if [[ -n "$PATH_FILTER" ]]; then
-    echo "Path filter: $PATH_FILTER"
-fi
-if [[ "$DRY_RUN" = true ]]; then echo "DRY RUN: no artifacts will be deleted"; fi
+jf rt ping
 
-RESPONSE=$(curl -s -w "\n%{http_code}" "${CURL_AUTH[@]}" -X POST \
-    "${ARTIFACTORY_URL}/api/search/aql" \
-    -H "Content-Type: text/plain" \
-    -d "$AQL") || { echo "AQL request failed"; exit 1; }
+# For Docker: delete the tag directory (repo/path/) recursively.
+# For PyPI: delete the .whl file directly.
+targets=$(jf rt search --spec "$SPEC" | jq -r '.[] | .path | ltrimstr("/") |
+    if endswith("/manifest.json") or endswith("/list.manifest.json")
+    then split("/")[:-1] | join("/") | . + "/"
+    else .
+    end' | sort -u)
 
-# Split body and HTTP code (last line)
-HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
-
-if ! echo "$RESPONSE_BODY" | jq -e . >/dev/null 2>&1; then
-    echo "Artifactory response is not valid JSON (HTTP $HTTP_CODE). First 500 chars:"
-    echo "$RESPONSE_BODY" | head -c 500
-    echo ""
-    exit 1
-fi
-
-# Check for AQL errors in JSON body
-if echo "$RESPONSE_BODY" | jq -e '.errors' >/dev/null 2>&1; then
-    echo "AQL error:"
-    echo "$RESPONSE_BODY" | jq -r '.errors[]? // .'
-    exit 1
-fi
-
-RESULTS_COUNT=$(echo "$RESPONSE_BODY" | jq -r '(.results // []) | length')
-echo "AQL returned ${RESULTS_COUNT} manifest(s) matching criteria."
-
-# Each result is a manifest file; the image folder is repo/path (parent of manifest). Dedupe by folder.
-COUNT=0
-FAILED=0
-while IFS= read -r image_path; do
-    [[ -z "$image_path" ]] && continue
-    if [[ "$DRY_RUN" = true ]]; then
-        echo "  [dry-run] would delete image: $image_path"
-        COUNT=$((COUNT + 1))
-    else
-        echo "  Deleting image: $image_path"
-        if curl -sSf "${CURL_AUTH[@]}" -X DELETE "${ARTIFACTORY_URL}/${image_path}"; then
-            COUNT=$((COUNT + 1))
+count=$(echo "$targets" | grep -c . || true)
+echo "=== Deleting ${count} artifact(s) (dry-run: $DRY_RUN) ==="
+while IFS= read -r target; do
+    [[ -z "$target" ]] && continue
+    if jf rt del "$target" --recursive --quiet $DRY_RUN_FLAG > /dev/null; then
+        if [ "$DRY_RUN" = true ]; then
+            echo "Would delete: $target"
         else
-            echo "  ERROR: delete failed for $image_path" >&2
-            FAILED=$((FAILED + 1))
+            echo "Deleted: $target"
         fi
+    else
+        echo "WARNING: failed to delete $target" >&2
     fi
-done < <(echo "$RESPONSE_BODY" | jq -r '(.results // [])[] | "\(.repo)/\(.path)"' | sort -u)
+done <<< "$targets"
 
-if [[ "$DRY_RUN" = true ]]; then
-    echo "Done. $COUNT image(s) would be deleted."
-else
-    if [[ "$FAILED" -gt 0 ]]; then
-        echo "Done. $COUNT image(s) deleted, $FAILED failed." >&2
-        exit 1
-    fi
-    echo "Done. $COUNT image(s) deleted."
-fi
+echo "=== Done ==="

--- a/.ci/scripts/artifactory-cleanup-by-time.sh
+++ b/.ci/scripts/artifactory-cleanup-by-time.sh
@@ -14,7 +14,7 @@
 #   ARTIFACTORY_TOKEN     Password or API key (required)
 #   ARTIFACTORY_API_KEY   Alternative to ARTIFACTORY_TOKEN
 
-set -e
+set -eo pipefail
 
 DRY_RUN_FLAG=""
 DRY_RUN=false
@@ -49,14 +49,18 @@ jf rt ping
 
 # For Docker: delete the tag directory (repo/path/) recursively.
 # For PyPI: delete the .whl file directly.
-targets=$(jf rt search --spec "$SPEC" | jq -r '.[] | .path | ltrimstr("/") |
+if ! targets=$(jf rt search --spec "$SPEC" | jq -r '.[] | .path | ltrimstr("/") |
     if endswith("/manifest.json") or endswith("/list.manifest.json")
     then split("/")[:-1] | join("/") | . + "/"
     else .
-    end' | sort -u)
+    end' | sort -u); then
+    echo "ERROR: failed to list artifacts - aborting without cleanup" >&2
+    exit 1
+fi
 
-count=$(echo "$targets" | grep -c . || true)
+count=$(echo "$targets" | grep -c . || echo 0)
 echo "=== Deleting ${count} artifact(s) (dry-run: $DRY_RUN) ==="
+failed=0
 while IFS= read -r target; do
     [[ -z "$target" ]] && continue
     if jf rt del "$target" --recursive --quiet $DRY_RUN_FLAG > /dev/null; then
@@ -67,7 +71,12 @@ while IFS= read -r target; do
         fi
     else
         echo "WARNING: failed to delete $target" >&2
+        failed=$((failed + 1))
     fi
 done <<< "$targets"
 
+if [ "$failed" -gt 0 ]; then
+    echo "=== Done with $failed failure(s) ===" >&2
+    exit 1
+fi
 echo "=== Done ==="


### PR DESCRIPTION
## What?
Add daily job for cleanup CI docker images from artifactory. 
Clean PR docker images older than 1 week and base images older than 3 months.

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily artifact cleanup job with optional dry-run mode and manual execution.
  * Introduced configurable retention rules for PR, CI, and verification Docker images and PyPI packages.
  * Cleanup results can now be previewed without deleting artifacts.

* **Bug Fixes**
  * Centralized artifact cleanup behavior and removed redundant cleanup from container build pipelines.

* **Documentation**
  * Updated CI documentation with the new cleanup job, schedule, scope, and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->