### PR TITLE
fix(plugins): require a unique devId per path-mode file

### DIFF
--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -74,9 +74,15 @@ nixl_status_t nixlGdsEngine::registerMem(const nixlBlobDesc &mem,
                                          nixlBackendMD* &out)
 {
     if (nixl_mem == FILE_SEG) {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            NIXL_ERROR << "GDS path-mode requires a unique devId per file (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         std::unique_ptr<nixlGdsMetadata> md;
         try {
-            md = std::make_unique<nixlGdsMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+            md = std::make_unique<nixlGdsMetadata>(mem.devId, mem.metaInfo);
         }
         catch (const std::system_error &e) {
             NIXL_ERROR << "GDS path-mode open failed: " << e.what();
@@ -95,6 +101,7 @@ nixl_status_t nixlGdsEngine::registerMem(const nixlBlobDesc &mem,
             }
             gds_file_map[fd] = md->handle;
         }
+        resv.commit();
         out = md.release();
         return NIXL_SUCCESS;
     }
@@ -126,6 +133,9 @@ nixl_status_t nixlGdsEngine::deregisterMem (nixlBackendMD* meta)
 {
     nixlGdsMetadata *md = (nixlGdsMetadata *)meta;
     if (md->type == FILE_SEG) {
+        if (!md->file_fd.path().empty()) {
+            path_mode_devids_.release(md->devId);
+        }
         gds_utils->deregisterFileHandle(md->handle);
         gds_file_map.erase(md->handle.fd);
     } else {

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -38,7 +38,9 @@ public:
 
     nixlGdsMetadata() = default;
 
-    explicit nixlGdsMetadata(nixl::FileFd &&fd) : nixlFilePathMD(std::move(fd)), type(FILE_SEG) {}
+    nixlGdsMetadata(uint64_t devid, const std::string &metaInfo)
+        : nixlFilePathMD(devid, metaInfo),
+          type(FILE_SEG) {}
 };
 
 class GdsTransferRequestH {
@@ -90,6 +92,7 @@ class nixlGdsEngine : public nixlBackendEngine {
     private:
         gdsUtil *gds_utils;
         std::unordered_map<int, gdsFileHandle> gds_file_map;
+        nixl::PathModeDevIdRegistry path_mode_devids_;
 
         mutable std::mutex batch_pool_lock;
         mutable std::list<nixlGdsIOBatch*> batch_pool;

--- a/src/plugins/gds_mt/gds_mt_backend.cpp
+++ b/src/plugins/gds_mt/gds_mt_backend.cpp
@@ -43,8 +43,11 @@ const size_t default_thread_count = std::max (1u, std::thread::hardware_concurre
 
 struct FileSegData {
     std::shared_ptr<gdsMtFileHandle> handle;
+    uint64_t devId;
 
-    FileSegData(std::shared_ptr<gdsMtFileHandle> h) : handle(std::move(h)) {}
+    FileSegData(std::shared_ptr<gdsMtFileHandle> h, uint64_t devid)
+        : handle(std::move(h)),
+          devId(devid) {}
 };
 
 struct MemSegData {
@@ -74,9 +77,9 @@ struct GdsMtTransferRequestH {
 
 class nixlGdsMtMetadata : public nixlBackendMD {
 public:
-    explicit nixlGdsMtMetadata (std::shared_ptr<gdsMtFileHandle> file_handle)
-        : nixlBackendMD (true),
-          data_ (FileSegData{std::move (file_handle)}) {}
+    nixlGdsMtMetadata(std::shared_ptr<gdsMtFileHandle> file_handle, uint64_t devid)
+        : nixlBackendMD(true),
+          data_(FileSegData{std::move(file_handle), devid}) {}
 
     explicit nixlGdsMtMetadata (void *addr, size_t size, int flags)
         : nixlBackendMD (true),
@@ -189,6 +192,12 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
                               nixlBackendMD *&out) {
     switch (nixl_mem) {
     case FILE_SEG: {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            NIXL_ERROR << "GDS_MT: path-mode requires a unique devId per file (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         nixl::FileFd file_fd;
         try {
             file_fd = nixl::FileFd(mem.devId, mem.metaInfo);
@@ -217,7 +226,8 @@ nixlGdsMtEngine::registerMem (const nixlBlobDesc &mem,
             }
             gds_mt_file_map_[fd] = handle;
         }
-        out = new nixlGdsMtMetadata(std::move(handle));
+        out = new nixlGdsMtMetadata(std::move(handle), mem.devId);
+        resv.commit();
         return NIXL_SUCCESS;
     }
 
@@ -254,6 +264,9 @@ nixlGdsMtEngine::deregisterMem (nixlBackendMD *meta) {
     if (auto *file_data = std::get_if<FileSegData> (&md->data_)) {
         if (file_data->handle) {
             int key = file_data->handle->file_fd.fd();
+            if (!file_data->handle->file_fd.path().empty()) {
+                path_mode_devids_.release(file_data->devId);
+            }
             md.reset(); // Release metadata first
 
             auto it = gds_mt_file_map_.find (key);

--- a/src/plugins/gds_mt/gds_mt_backend.h
+++ b/src/plugins/gds_mt/gds_mt_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,7 @@ public:
 private:
     gdsMtUtil gds_mt_utils_;
     std::unordered_map<int, std::weak_ptr<gdsMtFileHandle>> gds_mt_file_map_;
+    nixl::PathModeDevIdRegistry path_mode_devids_;
     size_t thread_count_;
     std::unique_ptr<tf::Executor> executor_;
 };

--- a/src/plugins/hf3fs/hf3fs_backend.cpp
+++ b/src/plugins/hf3fs/hf3fs_backend.cpp
@@ -191,9 +191,16 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
         break;
     }
     case FILE_SEG: {
+        auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+        if (!resv.ok()) {
+            HF3FS_LOG_RETURN(NIXL_ERR_INVALID_PARAM,
+                             absl::StrFormat("HF3FS path-mode requires a unique devId per file "
+                                             "(devId=%llu already registered)",
+                                             static_cast<unsigned long long>(mem.devId)));
+        }
         std::unique_ptr<nixlHf3fsFileMetadata> md;
         try {
-            md = std::make_unique<nixlHf3fsFileMetadata>(nixl::FileFd(mem.devId, mem.metaInfo));
+            md = std::make_unique<nixlHf3fsFileMetadata>(mem.devId, mem.metaInfo);
         }
         catch (const std::system_error &e) {
             HF3FS_LOG_RETURN(NIXL_ERR_BACKEND,
@@ -212,6 +219,7 @@ nixl_status_t nixlHf3fsEngine::registerMem (const nixlBlobDesc &mem,
             hf3fs_file_set.insert(fd);
         }
 
+        resv.commit();
         md->handle.fd = fd;
         md->handle.size = mem.len;
         md->handle.metadata = mem.metaInfo;
@@ -230,6 +238,9 @@ nixl_status_t nixlHf3fsEngine::deregisterMem (nixlBackendMD* meta)
     nixlHf3fsMetadata *md = (nixlHf3fsMetadata *)meta;
     if (md->type == NIXL_HF3FS_MEM_TYPE_FILE) {
         nixlHf3fsFileMetadata *file_md = (nixlHf3fsFileMetadata *)md;
+        if (!file_md->file_fd.path().empty()) {
+            path_mode_devids_.release(file_md->devId);
+        }
         hf3fs_file_set.erase(file_md->handle.fd);
         hf3fs_utils->deregisterFileHandle(file_md->handle.fd);
     } else if (md->type != NIXL_HF3FS_MEM_TYPE_DRAM && md->type != NIXL_HF3FS_MEM_TYPE_DRAM_ZC) {

--- a/src/plugins/hf3fs/hf3fs_backend.h
+++ b/src/plugins/hf3fs/hf3fs_backend.h
@@ -58,12 +58,14 @@ class nixlHf3fsFileMetadata : public nixlHf3fsMetadata {
 public:
     hf3fsFileHandle handle;
     nixl::FileFd file_fd;
+    uint64_t devId = 0;
 
     nixlHf3fsFileMetadata() : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE) {}
 
-    explicit nixlHf3fsFileMetadata(nixl::FileFd &&fd)
+    nixlHf3fsFileMetadata(uint64_t devid, const std::string &metaInfo)
         : nixlHf3fsMetadata(NIXL_HF3FS_MEM_TYPE_FILE),
-          file_fd(std::move(fd)) {}
+          file_fd(devid, metaInfo),
+          devId(devid) {}
 };
 
 class nixlHf3fsDramMetadata : public nixlHf3fsMetadata {
@@ -122,6 +124,7 @@ class nixlHf3fsEngine : public nixlBackendEngine {
     private:
         hf3fsUtil *hf3fs_utils;
         std::unordered_set<int> hf3fs_file_set;
+        nixl::PathModeDevIdRegistry path_mode_devids_;
         nixl_hf3fs_mem_config mem_config;
         static long page_size;
 

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -232,13 +232,20 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
     if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) != supported_mems.end()) {
         out = nullptr;
         if (nixl_mem == FILE_SEG) {
+            auto resv = path_mode_devids_.reserve(mem.devId, mem.metaInfo);
+            if (!resv.ok()) {
+                NIXL_ERROR << "POSIX path-mode requires a unique devId per file (devId="
+                           << mem.devId << " already registered)";
+                return NIXL_ERR_INVALID_PARAM;
+            }
             try {
-                out = new nixlPosixFileMD(nixl::FileFd(mem.devId, mem.metaInfo));
+                out = new nixlPosixFileMD(mem.devId, mem.metaInfo);
             }
             catch (const std::system_error &e) {
                 NIXL_ERROR << "POSIX path-mode open failed: " << e.what();
                 return NIXL_ERR_BACKEND;
             }
+            resv.commit();
         }
         return NIXL_SUCCESS;
     }
@@ -248,6 +255,14 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
 
 nixl_status_t
 nixlPosixEngine::deregisterMem(nixlBackendMD *meta) {
+    // non-null meta is always a file MD. Release the path-mode reservation (path() empty in
+    // fd-mode)
+    if (meta) {
+        auto *file_md = static_cast<nixlPosixFileMD *>(meta);
+        if (!file_md->file_fd.path().empty()) {
+            path_mode_devids_.release(file_md->devId);
+        }
+    }
     delete meta;
     return NIXL_SUCCESS;
 }

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -29,7 +29,7 @@
 #include "io_queue.h"
 #include "sync.h"
 
-// POSIX reuses the shared owned-fd base (no extra per-descriptor state).
+// POSIX reuses the shared owned-fd base (path-mode devId stored for dereg).
 using nixlPosixFileMD = nixlFilePathMD;
 
 class nixlPosixBackendReqH : public nixlBackendReqH {
@@ -80,6 +80,7 @@ private:
     std::string_view io_queue_type_;
     mutable std::unique_ptr<nixlPosixIOQueue> io_queue_;
     mutable nixlLock io_queue_lock_;
+    nixl::PathModeDevIdRegistry path_mode_devids_;
 
 public:
     nixlPosixEngine(const nixlBackendInitParams *init_params);

--- a/src/utils/file/file_path_mode.h
+++ b/src/utils/file/file_path_mode.h
@@ -14,13 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef __FILE_PATH_MODE_H
-#define __FILE_PATH_MODE_H
+#ifndef NIXL_SRC_UTILS_FILE_FILE_PATH_MODE_HPP
+#define NIXL_SRC_UTILS_FILE_FILE_PATH_MODE_HPP
 
 #include <sys/types.h>
 
+#include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 #include "backend/backend_engine.h"
 
@@ -37,6 +39,9 @@
 //             | "create"           # | O_CREAT (mode 0644)
 //
 // Unknown tokens: parsePathMeta returns std::nullopt (fail-loud).
+//
+// Path-mode contract: each path-mode file must use a unique devId - the section keys
+// on devId, so two files sharing one collide; backends reject a reused path-mode devId on register.
 
 namespace nixl {
 
@@ -89,15 +94,95 @@ private:
     std::string path_;
 };
 
+// Path-mode contract: each path-mode file registration must use a unique devId
+class PathModeDevIdRegistry {
+public:
+    enum class Ok : bool { No = false, Yes = true };
+    enum class Held : bool { No = false, Yes = true };
+
+    class Reservation {
+    public:
+        Reservation(Reservation &&other) noexcept
+            : reg_(other.reg_),
+              devId_(other.devId_),
+              ok_(other.ok_),
+              held_(other.held_) {
+            other.reg_ = nullptr;
+            other.held_ = Held::No;
+        }
+
+        Reservation(const Reservation &) = delete;
+        Reservation &
+        operator=(const Reservation &) = delete;
+
+        ~Reservation() {
+            if (reg_ && held_ == Held::Yes) {
+                reg_->release(devId_);
+            }
+        }
+
+        // Ok::No: this devId is already registered in path-mode -> caller must reject.
+        bool
+        ok() const noexcept {
+            return static_cast<bool>(ok_);
+        }
+
+        // Keep the hold past this scope; released later via release() on deregister.
+        void
+        commit() noexcept {
+            held_ = Held::No;
+        }
+
+    private:
+        friend class PathModeDevIdRegistry;
+
+        Reservation(PathModeDevIdRegistry *reg, uint64_t devId, Ok ok, Held held)
+            : reg_(reg),
+              devId_(devId),
+              ok_(ok),
+              held_(held) {}
+
+        PathModeDevIdRegistry *reg_;
+        uint64_t devId_;
+        Ok ok_;
+        Held held_;
+    };
+
+    // fd-mode (metaInfo not path-mode) is always ok and untracked.
+    [[nodiscard]] Reservation
+    reserve(uint64_t devId, const std::string &metaInfo) {
+        if (!parsePathMeta(metaInfo)) {
+            return Reservation(this, devId, Ok::Yes, Held::No);
+        }
+        const bool inserted = devids_.insert(devId).second;
+        if (inserted) {
+            return Reservation(this, devId, Ok::Yes, Held::Yes);
+        }
+        return Reservation(this, devId, Ok::No, Held::No);
+    }
+
+    void
+    release(uint64_t devId) {
+        devids_.erase(devId);
+    }
+
+private:
+    std::unordered_set<uint64_t> devids_;
+};
+
 } // namespace nixl
 
 class nixlFilePathMD : public nixlBackendMD {
 public:
     nixl::FileFd file_fd;
+    uint64_t devId = 0;
 
     nixlFilePathMD() : nixlBackendMD(true /*isPrivate*/) {}
 
-    explicit nixlFilePathMD(nixl::FileFd &&fd) : nixlBackendMD(true), file_fd(std::move(fd)) {}
+    nixlFilePathMD(uint64_t devid, const std::string &metaInfo)
+        : nixlBackendMD(true),
+          file_fd(devid, metaInfo),
+          devId(devid) {}
 };
 
-#endif // __FILE_PATH_MODE_H
+#endif // NIXL_SRC_UTILS_FILE_FILE_PATH_MODE_HPP

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -843,6 +843,154 @@ runPathModeCreateCheck() {
     return 0;
 }
 
+// Path-mode requires a unique devId per file: reused devId rejected, distinct OK (addr differs so
+// the dup-descriptor check is not what rejects).
+static int
+runPathModeUniqueDevIdCheck() {
+    constexpr const char *kFileA = "/tmp/nixl_posix_path_mode_devid_a.bin";
+    constexpr const char *kFileB = "/tmp/nixl_posix_path_mode_devid_b.bin";
+    for (const char *p : {kFileA, kFileB}) {
+        if (auto *f = std::fopen(p, "wb")) {
+            std::fputc(0, f);
+            std::fclose(f);
+        } else {
+            return 1;
+        }
+    }
+    auto cleanup = [&]() {
+        std::remove(kFileA);
+        std::remove(kFileB);
+    };
+
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXPathModeDevId", cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend("POSIX", params, be) != NIXL_SUCCESS) {
+        cleanup();
+        return 1;
+    }
+
+    auto pathDesc = [](const char *p, uint64_t devid, uintptr_t addr) {
+        nixlBlobDesc d;
+        d.addr = addr;
+        d.len = 4096;
+        d.devId = devid;
+        d.metaInfo = std::string("rw:") + p;
+        return d;
+    };
+
+    // Two different files sharing one devId within a single list: rejected.
+    {
+        nixl_reg_dlist_t d(FILE_SEG);
+        d.addDesc(pathDesc(kFileA, 0, 0));
+        d.addDesc(pathDesc(kFileB, 0, 4096));
+        if (agent.registerMem(d) == NIXL_SUCCESS) {
+            agent.deregisterMem(d);
+            std::cerr << "path-mode duplicate devId (within list) was not rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+    }
+
+    // devId reused across registrations: rejected, the first stays valid, and the devId
+    // is reusable for a different file once the first is deregistered.
+    {
+        nixl_reg_dlist_t a(FILE_SEG);
+        a.addDesc(pathDesc(kFileA, 0, 0));
+        if (agent.registerMem(a) != NIXL_SUCCESS) {
+            cleanup();
+            return 1;
+        }
+
+        nixl_reg_dlist_t b(FILE_SEG);
+        b.addDesc(pathDesc(kFileB, 0, 4096));
+        if (agent.registerMem(b) == NIXL_SUCCESS) {
+            agent.deregisterMem(b);
+            agent.deregisterMem(a);
+            std::cerr << "path-mode duplicate devId (across calls) was not rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+
+        agent.deregisterMem(a);
+        nixl_reg_dlist_t b2(FILE_SEG);
+        b2.addDesc(pathDesc(kFileB, 0, 0));
+        if (agent.registerMem(b2) != NIXL_SUCCESS) {
+            std::cerr << "devId not freed on deregister" << std::endl;
+            cleanup();
+            return 1;
+        }
+        agent.deregisterMem(b2);
+    }
+
+    // Distinct devIds: both files register together.
+    {
+        nixl_reg_dlist_t d(FILE_SEG);
+        d.addDesc(pathDesc(kFileA, 0, 0));
+        d.addDesc(pathDesc(kFileB, 1, 0));
+        if (agent.registerMem(d) != NIXL_SUCCESS) {
+            std::cerr << "distinct devIds rejected" << std::endl;
+            cleanup();
+            return 1;
+        }
+        agent.deregisterMem(d);
+    }
+
+    cleanup();
+    std::cout << "path-mode unique devId: OK" << std::endl;
+    return 0;
+}
+
+// fd-mode (devId is a real fd, metaInfo not path-mode) is NOT subject to the unique-devId
+// rule, so one fd may back several descriptors (e.g. different offsets in the same file).
+static int
+runFdModeReuseCheck() {
+    constexpr const char *kFile = "/tmp/nixl_posix_fd_mode_reuse.bin";
+    const int fd = open(kFile, O_RDWR | O_CREAT, 0644);
+    if (fd < 0) {
+        return 1;
+    }
+    auto cleanup = [&]() {
+        close(fd);
+        std::remove(kFile);
+    };
+
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXFdModeReuse", cfg);
+    nixl_b_params_t params;
+    nixlBackendH *be = nullptr;
+    if (agent.createBackend("POSIX", params, be) != NIXL_SUCCESS) {
+        cleanup();
+        return 1;
+    }
+
+    auto fdDesc = [&](uintptr_t addr) {
+        nixlBlobDesc d;
+        d.addr = addr;
+        d.len = 4096;
+        d.devId = static_cast<uint64_t>(fd); // fd-mode: devId is the open fd
+        d.metaInfo = ""; // not path-mode
+        return d;
+    };
+
+    // Same fd (devId) under two descriptors at different offsets must register, not be
+    // rejected as a duplicate path-mode devId.
+    nixl_reg_dlist_t d(FILE_SEG);
+    d.addDesc(fdDesc(0));
+    d.addDesc(fdDesc(4096));
+    if (agent.registerMem(d) != NIXL_SUCCESS) {
+        std::cerr << "fd-mode devId reuse was wrongly rejected" << std::endl;
+        cleanup();
+        return 1;
+    }
+    agent.deregisterMem(d);
+
+    cleanup();
+    std::cout << "fd-mode devId reuse: OK" << std::endl;
+    return 0;
+}
+
 int
 main (int argc, char *argv[]) {
     if (page_size <= 0) {
@@ -916,6 +1064,12 @@ main (int argc, char *argv[]) {
     if (run_path_mode_smoke) {
         checkPathModeParser();
         if (int rc = runPathModeCreateCheck(); rc != 0) {
+            return rc;
+        }
+        if (int rc = runPathModeUniqueDevIdCheck(); rc != 0) {
+            return rc;
+        }
+        if (int rc = runFdModeReuseCheck(); rc != 0) {
             return rc;
         }
         if (int rc = nixl_test::runPathModeSmoke(


### PR DESCRIPTION
## Summary

As of now, we dont require unique devIds for that path mode. That can lead to ambiguity:

```
reg([ (0,2000, devid=0, meta="/tmp/a"), (1000,3000, devid=0, meta="/tmp/b") ]) 
transfer( (1000,1000,devid=0), .... )
```
For that transfer it's unclear which file is read (`/tmp/a` or `/tmp/b` ?).

This PR enforces a **unique devId per path-mode file** in each FILE_SEG path-mode backend. It is a focused subset of the registration-time approach discussed in #1744 -- it does **not** touch the common section layer (`nixlLocalSection::addDescList`); the duplicate-descriptor rejection is intentionally out of scope here.

It fixes the double-free & leak problem for path mode, but leaves the problem present for other backends: Fixes https://github.com/ai-dynamo/nixl/issues/1766

## Fix

- New shared helper `nixl::PathModeDevIdRegistry` in `src/utils/file/file_path_mode.h`: a per-engine set of in-use path-mode devIds with an RAII `reserve()` that auto-rolls-back if registration fails before `commit()`. fd-in-devId mode (non-path `metaInfo`) is untracked and unaffected.
- All four FILE_SEG path-mode backends (`posix`, `cuda_gds`, `gds_mt`, `hf3fs`) reserve on register, reject a reused path-mode devId with `NIXL_ERR_INVALID_PARAM`, and release on deregister. The devId is stored on the file MD so deregister can release it.
- No backend lock added: `registerMem` / `deregisterMem` are already serialized by the agent lock.

## Changes

- `src/utils/file/file_path_mode.h`: `PathModeDevIdRegistry` helper; `nixlFilePathMD` gains a `(devId, metaInfo)` ctor and stores `devId`; path-mode unique-devId contract documented.
- `src/plugins/{posix,cuda_gds,gds_mt,hf3fs}`: per-engine path-mode devId registry; devId set via the MD ctor; release on deregister.

## Testing

`test/unit/plugins/posix/nixl_posix_test.cpp`:
- `runPathModeUniqueDevIdCheck`: within-list reuse rejected, cross-call reuse rejected, devId freed on deregister (reusable afterwards), distinct devIds register together. Addresses differ across the colliding descriptors so the rejection is driven by the devId rule, not by any duplicate-descriptor check.
- `runFdModeReuseCheck`: fd-mode (devId is a real fd) is **not** subject to the rule -- one fd may back several descriptors at different offsets.

Built and ran the POSIX unit suite (POSIX-only, `build_tests=true`): all checks pass, including the two above. `cuda_gds` + `gds_mt` compile-checked; `hf3fs` reviewed by inspection (no client dev libs locally).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Path-mode `FILE_SEG` registrations now reserve and enforce uniqueness of `(devId, metaInfo)` consistently across POSIX, CUDA GDS, GDS MT, and HF3FS, rejecting duplicates with `NIXL_ERR_INVALID_PARAM`.
  * Path-mode metadata now carries `devId`, improving deregistration so reserved mappings are released only for actual path-backed segments.

* **Tests**
  * Expanded POSIX unit coverage to validate unique `devId`/`metaInfo` enforcement within and across separate registrations, plus `fd`-mode reuse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->