### PR TITLE
ci: export container on test failure for crash debugging

### DIFF
--- a/.ci/dockerfiles/Dockerfile.gpu-test
+++ b/.ci/dockerfiles/Dockerfile.gpu-test
@@ -27,8 +27,14 @@ ARG WORKSPACE=/workspace/nixl
 WORKDIR ${WORKSPACE}
 COPY --chown="${_UID}":"${_GID}" . .
 
-RUN .gitlab/build.sh ${NIXL_INSTALL_DIR}
-RUN sudo apt-get clean && \
+# Install gdb (for crash debugging), build NIXL, then clean the apt cache — all in one layer.
+# build.sh installs many packages without cleaning up, so the cleanup must run after it and in the
+# same layer to actually shrink the image. gdb is installed before build.sh so its apt-get runs
+# against a clean apt state.
+RUN sudo apt-get update && \
+    sudo apt-get install -y --no-install-recommends gdb gdb-multiarch && \
+    .gitlab/build.sh ${NIXL_INSTALL_DIR} && \
+    sudo apt-get clean && \
     sudo rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["/bin/bash", "-c", "exec \"$@\"", "--"]

--- a/.ci/docs/DebugCoreDumps.md
+++ b/.ci/docs/DebugCoreDumps.md
@@ -1,0 +1,99 @@
+# Debugging Core Dumps from CI Failures
+
+When a GPU CI test step crashes, the pipeline automatically exports the container
+filesystem to a `.sqsh` file on the shared NFS mount. This guide explains how to
+load it and run `gdb` against the crash.
+
+## Step 1: Find the sqsh file
+
+The export path is printed in the Jenkins build log under the step:
+
+```
+exportEnroot: export 'nixl-ci-<ucx_version>-<BUILD_NUMBER>' -> <path>
+```
+
+Files follow this naming convention (the sqsh is named after the container):
+
+```
+/enroot_images/nixl-ci-<ucx_version>-<BUILD_NUMBER>.sqsh
+```
+
+Example: `/enroot_images/nixl-ci-v1.21.x-2209.sqsh`
+
+## What the sqsh contains
+
+`enroot export` produces a fully merged image — the PR base image layers and the
+writable overlay (runtime-compiled Rust binaries, pip-installed Python packages, any
+files written during the test, core dumps) are combined into a single portable file.
+You do not need to pull the PR image from Artifactory separately.
+
+## Step 2: Import the container
+
+Run via `scctl` + `srun` from wherever you have cluster access (no direct node login
+needed). `enroot create` is non-interactive:
+
+```bash
+scctl client connect -- srun -p mizu --ntasks=1 \
+  env ENROOT_DATA_PATH=/enroot-data/enroot-data-148069/user-148069 \
+  enroot create --name nixl-ci-<ucx_version>-<BUILD_NUMBER> \
+  /enroot_images/nixl-ci-<ucx_version>-<BUILD_NUMBER>.sqsh
+```
+
+Example:
+
+```bash
+scctl client connect -- srun -p mizu --ntasks=1 \
+  env ENROOT_DATA_PATH=/enroot-data/enroot-data-148069/user-148069 \
+  enroot create --name nixl-ci-v1.21.x-2209 \
+  /enroot_images/nixl-ci-v1.21.x-2209.sqsh
+```
+
+## Step 3: Start the container
+
+```bash
+scctl client connect -- srun -p mizu --ntasks=1 --pty \
+  env ENROOT_DATA_PATH=/enroot-data/enroot-data-148069/user-148069 \
+  enroot start --rw nixl-ci-v1.21.x-2209
+```
+
+You now have an interactive shell inside the exact environment that failed.
+
+## Step 4: Find core dumps
+
+Core dumps are written to the process working directory at crash time and are
+preserved in the exported sqsh.
+
+Inside the container:
+
+```bash
+find /workspace/nixl /tmp -maxdepth 4 -type f -name "core.*" \
+  ! -path "*/subprojects/*" ! -path "*/nixl_build/*"
+```
+
+Core file naming follows the host `core_pattern`: `core.<binary>.<pid>.<signal>.<timestamp>`
+
+Expected locations by test type:
+- **C++ tests**: `/workspace/nixl/core.<binary>.<pid>.11.<timestamp>`
+- **Rust tests**: `/workspace/nixl/target/debug/core.*`
+- **Python tests**: `/workspace/nixl/` or test working directory
+
+## Step 5: Run gdb
+
+```bash
+# nixl binaries with full debug symbols are in /opt/nixl/bin/
+ls /opt/nixl/bin/
+
+gdb /opt/nixl/bin/<binary> /workspace/nixl/core.<binary>.<pid>.11.<timestamp>
+
+# Inside gdb:
+(gdb) set solib-search-path /opt/nixl/lib:/opt/nixl/lib/x86_64-linux-gnu/plugins
+(gdb) info sharedlibrary
+(gdb) bt
+```
+
+## Debug symbol coverage
+
+| Component | Symbols | Notes |
+|-----------|---------|-------|
+| nixl (`/opt/nixl/`) | Full | Built with `--buildtype=debug` |
+| UCX (`/opt/ucx/`) | None | Built with `make install-strip`; UCX frames show as `??` in backtraces |

--- a/.ci/docs/crash-debug.md
+++ b/.ci/docs/crash-debug.md
@@ -1,0 +1,84 @@
+# CI Crash Debug — DevOps Reference
+
+This document describes how the automatic container export works on crash and what
+operational steps are needed to keep it functioning.
+
+## How it works
+
+When a Slurm run step (`slurmCI` → `slurm.run()` in `swx-jenkins-lib`) exits with a
+non-zero code, the pipeline exports the container's full filesystem to a `.sqsh` file on
+the shared NFS mount. This lets engineers load the exact environment that failed and run
+`gdb` against it without any manual reproduction steps.
+
+The export is driven by a single arg added to each `run` step in `test-matrix.yaml`:
+
+| Arg | Value | Meaning |
+|-----|-------|---------|
+| `exportEnroot` | `"true"` | On step failure, `enroot export` the container to `${ENROOT_MOUNT_PATH}/<containerName>.sqsh` |
+
+`slurm.run()` in `swx-jenkins-lib/vars/slurm.groovy` runs the test with
+`returnStatus: true` (so the export can run after a failure), calls `enroot export` via a
+follow-up `srun` on the same job allocation, then re-raises the failure so the build still
+fails. The output path is `${ENROOT_MOUNT_PATH}/<containerName>.sqsh` — the container name
+is already unique per build, so it doubles as the sqsh filename.
+
+The relevant env vars in `test-matrix.yaml`:
+
+```yaml
+ENROOT_MOUNT_PATH: "/enroot_images"                                  # destination dir for the export
+ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"     # svc-nixl enroot data dir on mizu
+```
+
+`ENROOT_DATA_PATH` must point to the svc-nixl user's enroot data directory on the mizu
+nodes — enroot requires it to locate the container's writable layer. It is forwarded to
+the export `srun` only when set.
+
+## File naming convention
+
+```
+${ENROOT_MOUNT_PATH}/<containerName>.sqsh
+```
+
+`containerName` is `nixl-ci-${ucx_version}-${BUILD_NUMBER}`, so:
+
+```
+/enroot_images/nixl-ci-<ucx_version>-<BUILD_NUMBER>.sqsh
+```
+
+Example: `/enroot_images/nixl-ci-v1.21.x-2209.sqsh`
+
+One file per build per matrix axis. If multiple run steps fail (cpp, python, rust,
+nixlbench), they all target the same sqsh path — the last export wins, which is the
+container after all test layers have been applied.
+
+## NFS mount on mizu
+
+The path `/enroot_images` must be:
+- Mounted on all mizu Slurm compute nodes
+- Writable by `svc-nixl` (UID 148069, GID 30 / `hardware` group)
+
+The export command that runs on the mizu node:
+
+```bash
+srun --jobid=<JOB_ID> --ntasks=1 --oversubscribe \
+  env ENROOT_DATA_PATH=/enroot-data/enroot-data-148069/user-148069 \
+  enroot export --output /enroot_images/nixl-ci-<ucx_version>-<BUILD_NUMBER>.sqsh \
+  pyxis_nixl-ci-<ucx_version>-<BUILD_NUMBER>
+```
+
+## gdb in the container
+
+`gdb` and `gdb-multiarch` are installed in `Dockerfile.gpu-test` so that engineers
+can run gdb directly inside the exported container without installing anything.
+The install runs as `sudo` (before `COPY`/`build.sh`) because the base image
+(`Dockerfile.base`) switches to `USER svc-nixl` before our Dockerfile inherits from it.
+
+## Cleanup
+
+**There is no automated cleanup.** sqsh files accumulate on `/enroot_images` until
+manually removed.
+
+Action items:
+- Set up a cron job on the mizu cluster (or a Jenkins pipeline_stop hook) to delete
+  old files under `/enroot_images/nixl-ci-*.sqsh`
+- Coordinate with the cluster admin who manages the NFS mount

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -44,7 +44,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260625-1"
+  CI_IMAGE_TAG: "20260629-1"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -60,7 +60,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260625-1"
+  CI_IMAGE_TAG: "20260629-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -54,7 +54,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260625-1"
+  CI_IMAGE_TAG: "20260629-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -52,7 +52,9 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260625-1"
+  CI_IMAGE_TAG: "20260629-1"
+  ENROOT_MOUNT_PATH: "/enroot_images"  # NFS mount on mizu nodes; on failure the container is exported here as <containerName>.sqsh
+  ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"  # svc-nixl user on mizu nodes
 
 empty_volumes:
   - {mountPath: /root, memory: false}
@@ -143,6 +145,7 @@ steps:
       dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-test-${ucx_version}:${BUILD_NUMBER}"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      exportEnroot: "true"  # on failure, export the container to ${ENROOT_MOUNT_PATH} for crash debugging
 
   - name: Run Python tests
     containerSelector: "{name: 'build_helper'}"
@@ -158,6 +161,7 @@ steps:
       dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-test-${ucx_version}:${BUILD_NUMBER}"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      exportEnroot: "true"  # on failure, export the container to ${ENROOT_MOUNT_PATH} for crash debugging
 
   - name: Run Rust tests
     containerSelector: "{name: 'build_helper'}"
@@ -173,6 +177,7 @@ steps:
       dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-test-${ucx_version}:${BUILD_NUMBER}"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      exportEnroot: "true"  # on failure, export the container to ${ENROOT_MOUNT_PATH} for crash debugging
 
   - name: Run Nixlbench tests
     containerSelector: "{name: 'build_helper'}"
@@ -188,6 +193,7 @@ steps:
       dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-test-${ucx_version}:${BUILD_NUMBER}"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      exportEnroot: "true"  # on failure, export the container to ${ENROOT_MOUNT_PATH} for crash debugging
 
 pipeline_stop:
   containerSelector: "{name: 'build_helper'}"

--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -42,7 +42,7 @@ env:
   TEST_TIMEOUT: 90
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260625-1"
+  CI_IMAGE_TAG: "20260629-1"
 
 runs_on_dockers:
   # TSan-instrumented dependency image for the tsan build (DEPS_SANITIZE=thread

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -20,6 +20,7 @@
 
 set -e
 set -x
+ulimit -c unlimited
 TEXT_YELLOW="\033[1;33m"
 TEXT_CLEAR="\033[0m"
 

--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -20,6 +20,7 @@
 
 set -e
 set -x
+ulimit -c unlimited
 
 # Parse commandline arguments with first argument being the install directory.
 INSTALL_DIR=$1

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -19,6 +19,7 @@
 
 set -e
 set -x
+ulimit -c unlimited
 
 # Parse commandline arguments with first argument being the install directory.
 INSTALL_DIR=$1

--- a/.gitlab/test_rust.sh
+++ b/.gitlab/test_rust.sh
@@ -20,6 +20,7 @@
 
 set -e
 set -x
+ulimit -c unlimited
 
 # Parse commandline arguments with first argument being the install directory.
 INSTALL_DIR=$1


### PR DESCRIPTION
## What?

When a GPU CI test step fails with a crash, engineers currently have no way to inspect
the exact environment — the container is discarded and the failure is only reproducible
by re-running CI or manually reconstructing the environment.

This PR adds automatic container export on failure. When any run step exits non-zero,
the pipeline exports the full container filesystem (including core dumps, debug symbols,
and runtime-compiled artifacts) to a `.sqsh` file on the shared NFS mount on the mizu
Slurm cluster. Engineers can then import and start the container interactively to run
`gdb` against the crash.

## Changes

**`Dockerfile.gpu-test`** — install `gdb` and `gdb-multiarch` before the `COPY` +
`build.sh` steps. The install runs as `sudo` because the base image switches to a
non-root user (`svc-nixl`, UID 148069) before this Dockerfile inherits from it. Placing
it before `COPY` also avoids apt lock conflicts and improves layer caching.

**`test_{cpp,python,rust,nixlbench}.sh`** — add `ulimit -c unlimited` so core dumps are
written to disk on crash.

**`test-matrix.yaml`** — add `archiveOutputPath` and `archiveOnFailOnly: "true"` to all
four run steps, and three new env vars:
- `DEBUG_MOUNT_PATH: "/enroot_images"` — NFS mount writable by `svc-nixl` on mizu nodes
- `ENROOT_DATA_PATH` — enroot data directory for the `svc-nixl` user on mizu
- `DEBUG_RETENTION_DAYS: "14"` — informational; no automated cleanup yet (see `.ci/docs/crash-debug.md`)

The export is implemented in `swx-jenkins-lib` ([companion PR](https://github.com/Mellanox-lab/swx-jenkins-lib)):
`slurm.run()` now captures the srun exit code with `returnStatus: true`, runs
`enroot export` via a follow-up `srun` on the same job allocation, then re-throws to
preserve the original fail-the-build contract.

**`.ci/docs/crash-debug.md`** — DevOps reference: how the export works, NFS mount
requirements, file naming convention, and cleanup responsibility.

**`docs/DebugCoreDumps.md`** — Engineer guide: how to import and start the container
via `scctl` + `srun`, where core dumps land (`/workspace/nixl/core.<binary>.<pid>.11.<timestamp>`),
how to run `gdb`, and debug symbol coverage.

## File naming
`/enroot_images/nixl-debug-<ucx_version>-<arch>-<BUILD_NUMBER>.sqsh`

## Why?
[HPCINFRA-4441](https://jirasw.nvidia.com/browse/HPCINFRA-4441)

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added GPU CI core-dump debugging guides covering how to export and inspect failing container snapshots, locate core files, and run GDB with the appropriate binaries and debug-symbol expectations.
* **Chores**
  * Updated CI test scripts to allow unlimited core-dump sizes during C++, Python, and Rust test runs.
  * Enhanced GPU CI containers with additional debugging tools for crash analysis.
  * Enabled automatic container export for failing CI steps to improve debug artifact collection, using the configured debug mount path.
  * Refreshed the CI Docker image tag used across test matrices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->