### PR TITLE
feat(examples): add INMEMKV example plugin for shared KV interfaces

### DIFF
--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -189,6 +189,12 @@ if not cuda_available and not rocm_available
     warning('Neither CUDA nor ROCm found. VRAM support will be disabled.')
 endif
 
+if get_option('enable_inmemkv')
+    add_project_arguments('-DNIXLBENCH_ENABLE_INMEMKV=1', language: 'cpp')
+else
+    add_project_arguments('-DNIXLBENCH_ENABLE_INMEMKV=0', language: 'cpp')
+endif
+
 # Subprojects
 subdir('src/utils')
 subdir('src/runtime')

--- a/benchmark/nixlbench/meson_options.txt
+++ b/benchmark/nixlbench/meson_options.txt
@@ -23,3 +23,9 @@ option('nvshmem_inc_path', type: 'string', value: '', description: 'Path to NVSH
 option('nvshmem_lib_path', type: 'string', value: '', description: 'Path to NVSHMEM library directory')
 option('rocm_path', type: 'string', value: '', description: 'Path to the ROCm installation directory (used only when use_rocm=true). Empty falls back to /opt/rocm.')
 option('use_rocm', type: 'boolean', value: false, description: 'Build nixlbench against AMD ROCm/HIP instead of CUDA. Default false; the NVIDIA path is unchanged.')
+option(
+    'enable_inmemkv',
+    type: 'boolean',
+    value: false,
+    description: 'Enable INMEMKV-specific nixlbench support',
+)

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -69,9 +69,7 @@ NB_ARG_STRING(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem
 NB_ARG_STRING(backend,
               XFERBENCH_BACKEND_UCX,
               "Name of NIXL backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ, "
-              "GUSLI, AZURE_BLOB"
-              XFERBENCH_INMEMKV_BACKEND_HELP
-              "] (only used with nixl worker)");
+              "GUSLI, AZURE_BLOB" XFERBENCH_INMEMKV_BACKEND_HELP "] (only used with nixl worker)");
 NB_ARG_STRING(initiator_seg_type,
               XFERBENCH_SEG_TYPE_DRAM,
               "Type of memory segment for initiator [DRAM, VRAM]. Note: Storage backends always "
@@ -837,7 +835,7 @@ xferBenchConfig::isStorageBackend() {
 #if NIXLBENCH_ENABLE_INMEMKV
             || XFERBENCH_BACKEND_INMEMKV == xferBenchConfig::backend
 #endif
-        );
+    );
 }
 
 bool

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -47,6 +47,12 @@
 #define NB_ARG_UINT64(param_name, def_val, help_text) DEFINE_uint64(param_name, def_val, help_text)
 #define NB_ARG_INT32(param_name, def_val, help_text) DEFINE_int32(param_name, def_val, help_text)
 
+#if NIXLBENCH_ENABLE_INMEMKV
+#define XFERBENCH_INMEMKV_BACKEND_HELP ", INMEMKV"
+#else
+#define XFERBENCH_INMEMKV_BACKEND_HELP ""
+#endif
+
 /**********
  * xferBench Config
  **********/
@@ -63,7 +69,9 @@ NB_ARG_STRING(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem
 NB_ARG_STRING(backend,
               XFERBENCH_BACKEND_UCX,
               "Name of NIXL backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ, "
-              "GUSLI, AZURE_BLOB] (only used with nixl worker)");
+              "GUSLI, AZURE_BLOB"
+              XFERBENCH_INMEMKV_BACKEND_HELP
+              "] (only used with nixl worker)");
 NB_ARG_STRING(initiator_seg_type,
               XFERBENCH_SEG_TYPE_DRAM,
               "Type of memory segment for initiator [DRAM, VRAM]. Note: Storage backends always "
@@ -825,7 +833,11 @@ xferBenchConfig::isStorageBackend() {
             XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
-            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
+            XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend
+#if NIXLBENCH_ENABLE_INMEMKV
+            || XFERBENCH_BACKEND_INMEMKV == xferBenchConfig::backend
+#endif
+        );
 }
 
 bool
@@ -833,7 +845,7 @@ xferBenchConfig::isObjStorageBackend() {
     return (XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
-};
+}
 
 
 /**********

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -31,6 +31,10 @@
 #include <utils/common/nixl_time.h>
 #include "runtime/runtime.h"
 
+#ifndef NIXLBENCH_ENABLE_INMEMKV
+#define NIXLBENCH_ENABLE_INMEMKV 0
+#endif
+
 #if HAVE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -94,6 +98,7 @@
 #define XFERBENCH_BACKEND_MOONCAKE "Mooncake"
 #define XFERBENCH_BACKEND_HF3FS "HF3FS"
 #define XFERBENCH_BACKEND_OBJ "OBJ"
+#define XFERBENCH_BACKEND_INMEMKV "INMEMKV"
 #define XFERBENCH_BACKEND_GUSLI "GUSLI"
 #define XFERBENCH_BACKEND_UCCL "UCCL"
 #define XFERBENCH_BACKEND_AZURE_BLOB "AZURE_BLOB"

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -322,8 +322,7 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
         }
 #if NIXLBENCH_ENABLE_INMEMKV
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
-        std::cout << "INMEMKV backend configured (simple in-memory key-value store)"
-                  << std::endl;
+        std::cout << "INMEMKV backend configured (simple in-memory key-value store)" << std::endl;
 #endif
     } else {
         std::cerr << "Unsupported NIXLBench backend: " << xferBenchConfig::backend << std::endl;
@@ -1252,7 +1251,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
         }
     } else
 #endif
-    if (xferBenchConfig::isStorageBackend()) {
+        if (xferBenchConfig::isStorageBackend()) {
         size_t fd_idx = 0;
         uint64_t file_offset = 0;
         for (size_t list_idx = 0; list_idx < local_iovs.size(); list_idx++) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -320,6 +320,11 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
                       << std::endl;
             std::cout << "  Tip: Use --infinia_config_file to specify a config file" << std::endl;
         }
+#if NIXLBENCH_ENABLE_INMEMKV
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
+        std::cout << "INMEMKV backend configured (simple in-memory key-value store)"
+                  << std::endl;
+#endif
     } else {
         std::cerr << "Unsupported NIXLBench backend: " << xferBenchConfig::backend << std::endl;
         exit(EXIT_FAILURE);
@@ -987,6 +992,30 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
             CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
             remote_regs_.emplace_back(*agent, backend_engine, OBJ_SEG, std::move(iov_list));
         }
+#if NIXLBENCH_ENABLE_INMEMKV
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
+        // INMEMKV backend: create DRAM_SEG descriptors with keys in metaInfo
+        struct timeval tv;
+        gettimeofday(&tv, nullptr);
+        uint64_t timestamp = tv.tv_sec * 1000000ULL + tv.tv_usec;
+
+        for (int list_idx = 0; list_idx < num_threads; list_idx++) {
+            std::vector<xferBenchIOV> iov_list;
+            for (i = 0; i < num_devices; i++) {
+                std::string unique_name = "nixlbench_inmemkv" + std::to_string(list_idx) + "_" +
+                    std::to_string(i) + "_" + std::to_string(timestamp);
+
+                // Create a DRAM_SEG descriptor with key in metaInfo
+                xferBenchIOV inmemkv_desc(0, buffer_size, i, unique_name);
+                std::cout << "Creating INMEMKV key: " << unique_name << std::endl;
+                iov_list.push_back(inmemkv_desc);
+            }
+            // Register DRAM_SEG descriptors with keys in metaInfo
+            nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, DRAM_SEG);
+            CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
+            remote_regs_.emplace_back(*agent, backend_engine, DRAM_SEG, std::move(iov_list));
+        }
+#endif
     } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
         // GUSLI backend uses block device descriptors
         if (gusli_devices.empty()) {
@@ -1208,6 +1237,21 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     std::vector<std::vector<xferBenchIOV>> res;
     int desc_str_sz;
 
+#if NIXLBENCH_ENABLE_INMEMKV
+    // INMEMKV uses DRAM_SEG keys in metaInfo and does not populate remote_fds.
+    if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
+        for (auto &iov_list : local_iovs) {
+            std::vector<xferBenchIOV> remote_iov_list;
+            for (auto &iov : iov_list) {
+                xferBenchIOV inmemkv_remote(iov);
+                inmemkv_remote.addr = 0;
+                inmemkv_remote.metaInfo = iov.metaInfo;
+                remote_iov_list.push_back(inmemkv_remote);
+            }
+            res.push_back(remote_iov_list);
+        }
+    } else
+#endif
     if (xferBenchConfig::isStorageBackend()) {
         size_t fd_idx = 0;
         uint64_t file_offset = 0;
@@ -1315,6 +1359,10 @@ prepareTransferDescriptors(nixl_xfer_dlist_t &local_desc,
         remote_desc = nixl_xfer_dlist_t(OBJ_SEG);
     } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
         remote_desc = nixl_xfer_dlist_t(BLK_SEG);
+#if NIXLBENCH_ENABLE_INMEMKV
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
+        remote_desc = nixl_xfer_dlist_t(DRAM_SEG);
+#endif
     } else if (xferBenchConfig::isStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(FILE_SEG);
     }
@@ -1329,6 +1377,10 @@ getRemoteSegType() {
         return OBJ_SEG;
     } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
         return BLK_SEG;
+#if NIXLBENCH_ENABLE_INMEMKV
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_INMEMKV)) {
+        return DRAM_SEG;
+#endif
     } else if (xferBenchConfig::isStorageBackend()) {
         return FILE_SEG;
     }

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/plugins/inmemkv/INMEMKV_ARCHITECTURE.md
+++ b/examples/plugins/inmemkv/INMEMKV_ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# INMEMKV Architecture Guide
+
+This guide explains how the INMEMKV example plugin fits into NIXL and how its layered KV backend design works.
+
+INMEMKV is intentionally small. It demonstrates a KV-style NIXL backend with the fewest moving pieces.
+
+## Big Picture
+
+A NIXL application does not call a backend plugin directly. It creates a `nixlAgent`, asks the agent to use a backend by name, and then uses normal NIXL APIs such as `registerMem`, `createXferReq`, `postXferReq`, and `deregisterMem`.
+
+For INMEMKV, the layers look like this:
+
+```text
+Application (e.g. nixlbench)
+  selects backend "INMEMKV"
+  builds descriptor lists
+  calls nixlAgent APIs
+        |
+        v
+nixlAgent
+  loads/discovers backend plugins
+  creates the backend engine
+  owns local sections and transfer requests
+  routes calls to the backend engine
+        |
+        v
+nixlInMemKVEngine          Plugin entry (extends nixlKVEngine)
+        |
+        v
+nixlKVEngine               Shared thin wrapper (src/plugins/kv/)
+  delegates all data-plane calls to impl_
+        |
+        v
+nixlInMemKVEngineImpl      Plugin-specific logic (inmemkv_engine_impl.*)
+  registerMem, prepXfer, postXfer, ...
+        |
+        v
+InMemKVStore (iKVStore)    Storage put/get/exists (inmemkv_store.*)
+```
+
+### Layer Responsibilities
+
+| Layer | Class | Role |
+|-------|-------|------|
+| NIXL-facing engine | `nixlKVEngine` | Thin wrapper; implements `nixlBackendEngine` |
+| Abstract impl interface | `nixlKVEngineImpl` | Backend-specific logic contract |
+| Concrete impl | `nixlInMemKVEngineImpl` | INMEMKV register/transfer implementation |
+| Storage abstraction | `iKVStore` | put/get/exists storage operations |
+| Shared headers | `src/plugins/kv/` | Reusable across KV backends |
+
+The important separation is:
+
+- The **application** decides what descriptors it wants to register and transfer.
+- The **NIXL core** manages plugin loading, backend instances, metadata lists, and request flow.
+- **`nixlKVEngine`** implements the `nixlBackendEngine` contract and forwards calls.
+- **`nixlKVEngineImpl`** subclasses implement backend-specific behavior.
+- **`iKVStore`** isolates raw put/get/exists storage from NIXL descriptor mapping.
+
+## Shared KV Headers (`src/plugins/kv/`)
+
+### `kv_store.h` — `iKVStore`
+
+Minimal storage interface shared by all KV backends:
+
+```cpp
+class iKVStore {
+    virtual bool put(key, data, len) = 0;
+    virtual bool get(key, data, len, out_len) = 0;
+    virtual bool exists(key) = 0;
+};
+```
+
+INMEMKV uses `InMemKVStore` (`std::unordered_map`). A future REDIS plugin would use `RedisKVStore` (hiredis).
+
+### `kv_engine_impl.h` — `nixlKVEngineImpl`
+
+Abstract interface for KV backend logic. Each KV plugin provides a concrete subclass implementing:
+
+- `getSupportedMems()`
+- `registerMem` / `deregisterMem` / `queryMem`
+- `prepXfer` / `postXfer` / `checkXfer` / `releaseReqH`
+
+Note: `prepXfer` receives `local_agent` explicitly so impl classes do not depend on `nixlBackendEngine` protected members.
+
+### `kv_engine.h` / `kv_engine.cpp` — `nixlKVEngine`
+
+Thin wrapper extending `nixlBackendEngine`. Declares common KV capabilities:
+
+```cpp
+supportsLocal()  == true
+supportsRemote() == false
+supportsNotif()  == false
+```
+
+All data-plane methods delegate to `impl_` in `kv_engine.cpp`.
+
+## Dynamic Plugin Entry Point
+
+`inmemkv_plugin.cpp` is the plugin boundary. NIXL discovers `libplugin_INMEMKV.so` and calls:
+
+```cpp
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *nixl_plugin_init();
+extern "C" NIXL_PLUGIN_EXPORT void nixl_plugin_fini();
+```
+
+`nixl_plugin_init()` returns plugin metadata and an engine factory through `nixlBackendPluginCreator<nixlInMemKVEngine>::create(...)`.
+
+## Plugin Wiring
+
+`inmemkv_backend.cpp` is minimal — it only wires the factory:
+
+```cpp
+nixlInMemKVEngine::nixlInMemKVEngine(const nixlBackendInitParams *init_params)
+    : nixlKVEngine(init_params, createInMemKVEngineImpl(init_params)) {}
+```
+
+The factory function `createInMemKVEngineImpl()` returns a `std::unique_ptr<nixlKVEngineImpl>`.
+
+## Data Model
+
+Each registered memory descriptor is interpreted as a KV key:
+
+1. `mem.metaInfo`, when provided
+2. `std::to_string(mem.devId)`, as a fallback
+
+`nixlInMemKVEngineImpl` keeps:
+
+```cpp
+std::unordered_map<uint64_t, std::string> devIdToKey_;
+std::unique_ptr<iKVStore> store_;
+```
+
+`postXfer()` resolves the key from remote metadata or `devIdToKey_`, then calls `store_->put()` or `store_->get()`.
+
+## Lifecycle
+
+```text
+1. create backend          nixlInMemKVEngine -> nixlKVEngine -> nixlInMemKVEngineImpl
+2. register memory         registerMem() -> nixlInMemKVMetadata + devIdToKey_
+3. prepare transfer        prepXfer() -> allocate request handle
+4. post transfer           postXfer() -> store_->put/get (synchronous)
+5. check transfer          checkXfer() -> NIXL_SUCCESS (already done)
+6. release request handle  releaseReqH()
+7. deregister memory       deregisterMem() -> free metadata
+```
+
+## Step-by-Step Implementation Guide
+
+When adding a new KV backend (e.g. REDIS), follow these steps:
+
+### Step 1: Implement `iKVStore`
+
+Create a storage class in your plugin directory:
+
+```cpp
+class RedisKVStore : public iKVStore { ... };
+```
+
+### Step 2: Implement `nixlKVEngineImpl`
+
+Create `redis_engine_impl.h/.cpp`:
+
+```cpp
+class nixlRedisKVEngineImpl : public nixlKVEngineImpl {
+    std::unique_ptr<iKVStore> store_;
+    // registerMem, prepXfer, postXfer, ...
+};
+```
+
+Copy the descriptor/key mapping logic from `nixlInMemKVEngineImpl` and adapt storage calls.
+
+### Step 3: Create thin engine wrapper
+
+```cpp
+class nixlRedisKVEngine : public nixlKVEngine {
+public:
+    explicit nixlRedisKVEngine(const nixlBackendInitParams *p)
+        : nixlKVEngine(p, std::make_unique<nixlRedisKVEngineImpl>(p)) {}
+};
+```
+
+### Step 4: Register plugin
+
+Use `nixlBackendPluginCreator<nixlRedisKVEngine>` in `redis_plugin.cpp`.
+
+### Step 5: Build
+
+Link `../../../src/plugins/kv/kv_engine.cpp` in your plugin's `meson.build`.
+
+## File Map
+
+```text
+src/plugins/kv/
+  kv_store.h           iKVStore storage interface
+  kv_engine_impl.h     nixlKVEngineImpl abstract interface
+  kv_engine.h          nixlKVEngine thin wrapper declaration
+  kv_engine.cpp        nixlKVEngine delegation implementation
+
+examples/plugins/inmemkv/
+  meson.build               build-tree-only dynamic plugin target
+  inmemkv_plugin.cpp         plugin entry points and backend registration
+  inmemkv_backend.h/.cpp     thin nixlInMemKVEngine wrapper + factory
+  inmemkv_engine_impl.h/.cpp nixlInMemKVEngineImpl (backend logic)
+  inmemkv_store.h/.cpp       InMemKVStore (iKVStore implementation)
+  README.md                  quick start and usage notes
+  INMEMKV_ARCHITECTURE.md    this guide
+```
+
+## Reading Checklist
+
+When learning the code, read in this order:
+
+1. `src/plugins/kv/kv_engine_impl.h` — abstract impl contract
+2. `src/plugins/kv/kv_engine.h` + `kv_engine.cpp` — delegation layer
+3. `inmemkv_plugin.cpp` — how NIXL learns the backend name and factory
+4. `inmemkv_backend.cpp` — factory wiring (3 lines of logic)
+5. `inmemkv_engine_impl.cpp` — `registerMem`, `prepXfer`, `postXfer`
+6. `inmemkv_store.cpp` — raw put/get/exists
+7. Guarded INMEMKV code in nixlbench — how an application prepares descriptors

--- a/examples/plugins/inmemkv/README.md
+++ b/examples/plugins/inmemkv/README.md
@@ -1,0 +1,167 @@
+# INMEMKV Example Plugin
+
+INMEMKV is a small dynamic NIXL backend plugin that implements an in-process key-value store. It is meant to be read as an example of how to write a backend plugin, not as a production storage backend.
+
+## Introduction
+
+The plugin uses a layered design:
+
+```text
+nixlInMemKVEngine          Plugin entry (extends nixlKVEngine)
+    -> nixlKVEngine         Shared thin wrapper (src/plugins/kv/kv_engine.h)
+        -> nixlInMemKVEngineImpl   Plugin logic (inmemkv_engine_impl.*)
+            -> InMemKVStore (iKVStore)   Storage (inmemkv_store.*)
+```
+
+Shared headers under `src/plugins/kv/`:
+
+- `kv_store.h` — `iKVStore` put/get/exists storage interface
+- `kv_engine_impl.h` — `nixlKVEngineImpl` abstract backend logic interface
+- `kv_engine.h` / `kv_engine.cpp` — `nixlKVEngine` delegation wrapper
+
+`InMemKVStore` in this directory provides the in-memory `iKVStore` implementation.
+Each registered descriptor names a key through `metaInfo`; if `metaInfo` is empty,
+INMEMKV falls back to a string form of `devId`. A `NIXL_WRITE` calls `store_->put(...)`.
+A `NIXL_READ` calls `store_->get(...)`.
+
+## What It Demonstrates
+
+- Building a NIXL backend as a dynamic plugin: `libplugin_INMEMKV.so`
+- Exporting the plugin entry points in `inmemkv_plugin.cpp`
+- Implementing a minimal `nixlBackendEngine`
+- Registering and deregistering backend metadata
+- Preparing, posting, checking, and releasing a transfer request
+- Supporting a local-only backend with no service, remote connection, or notification path
+
+INMEMKV intentionally keeps the backend simple:
+
+- Standard C++ only
+- No daemon or external service
+- No persistence
+- No cross-process sharing
+- Synchronous completion in `postXfer`
+- `DRAM_SEG` only
+- `supportsLocal() == true`
+- `supportsRemote() == false`
+- `supportsNotif() == false`
+
+Its architecture is detailed in [INMEMKV architecture](INMEMKV_ARCHITECTURE.md).
+
+## Build
+
+INMEMKV lives under `examples/plugins/inmemkv`. It is built from the **NIXL repository root** (not from `benchmark/nixlbench`). It is gated by `build_examples` (default `true`) and is not installed by `ninja install`.
+
+### Step 1: Configure and build the plugin (NIXL root)
+
+Run all commands from the NIXL repository root, for example `/workspace/nixl`:
+
+```bash
+cd /workspace/nixl
+
+# First-time setup, or reconfigure an existing build directory
+meson setup --reconfigure build \
+    -Dbuild_examples=true \
+    --prefix=/usr/local/nixl \
+    --buildtype=release
+
+# Build the plugin (use the output path as the ninja target)
+ninja -C build examples/plugins/inmemkv/libplugin_INMEMKV.so
+```
+
+After a `meson setup --reconfigure`, you can also use the convenience alias:
+
+```bash
+ninja -C build INMEMKV
+```
+
+Verify the plugin was produced:
+
+```bash
+ls -l build/examples/plugins/inmemkv/libplugin_INMEMKV.so
+```
+
+`ninja: no work to do` means the plugin is already up to date.
+
+### Step 2: Export `NIXL_PLUGIN_DIR`
+
+NIXL discovers dynamic plugins from `NIXL_PLUGIN_DIR`. Export the build-tree plugin directory before starting any process that creates a `nixlAgent`:
+
+```bash
+export NIXL_PLUGIN_DIR=/workspace/nixl/build/examples/plugins/inmemkv
+```
+
+The `export` matters: a plain shell assignment is not inherited by child processes.
+
+## Use With nixlbench
+
+nixlbench is a **separate Meson project** under `benchmark/nixlbench`. Do not pass `-Dbuild_examples` there; use `-Denable_inmemkv` instead.
+
+### Step 3: Build nixlbench
+
+```bash
+cd /workspace/nixl/benchmark/nixlbench
+meson setup build -Denable_inmemkv=true -Dnixl_path=/usr/local/nixl
+ninja -C build
+```
+
+### Step 4: Run
+
+```bash
+export NIXL_PLUGIN_DIR=/workspace/nixl/build/examples/plugins/inmemkv
+./build/nixlbench \
+    --backend INMEMKV \
+    --op_type WRITE \
+    --total_buffer_size 1000000 \
+    --start_block_size 1024 \
+    --max_block_size 4096 \
+    --start_batch_size 1 \
+    --max_batch_size 1 \
+    --warmup_iter 2 \
+    --num_iter 5
+```
+
+nixlbench has a small amount of INMEMKV-specific code because INMEMKV behaves like a storage backend from the benchmark's point of view, but uses `DRAM_SEG` descriptors with keys in `metaInfo` instead of file descriptors and `FILE_SEG` descriptors.
+
+## Code Tour
+
+- `meson.build`: builds `libplugin_INMEMKV.so` as a build-tree-only dynamic plugin.
+- `inmemkv_plugin.cpp`: exports `nixl_plugin_init` and `nixl_plugin_fini`, and registers the backend name `INMEMKV`.
+- `inmemkv_backend.h/.cpp`: thin `nixlInMemKVEngine` wrapper and impl factory.
+- `inmemkv_engine_impl.h/.cpp`: `nixlInMemKVEngineImpl` (registerMem, prep/postXfer, ...).
+- `inmemkv_store.h/.cpp`: `InMemKVStore` implementing shared `iKVStore`.
+- `src/plugins/kv/kv_store.h`: shared storage interface.
+- `src/plugins/kv/kv_engine_impl.h`: shared backend logic interface.
+- `src/plugins/kv/kv_engine.h/.cpp`: shared `nixlKVEngine` delegation layer.
+- `INMEMKV_ARCHITECTURE.md`: explains the plugin lifecycle and the design choices in more detail.
+
+A good reading order is:
+
+1. `inmemkv_plugin.cpp`
+2. `src/plugins/kv/kv_engine_impl.h` and `kv_engine.h`
+3. `inmemkv_backend.h` and `inmemkv_backend.cpp`
+4. `inmemkv_engine_impl.cpp` (`registerMem`, `prepXfer`, `postXfer`, `deregisterMem`)
+5. `INMEMKV_ARCHITECTURE.md`
+
+## Lifecycle Summary
+
+1. NIXL loads `libplugin_INMEMKV.so` from `NIXL_PLUGIN_DIR`.
+2. `nixl_plugin_init()` returns plugin metadata and the engine factory.
+3. The application creates a `nixlAgent` and asks for backend `INMEMKV`.
+4. `registerMem()` records a key and returns backend metadata.
+5. `prepXfer()` validates a `NIXL_WRITE` or `NIXL_READ` and creates a placeholder request handle.
+6. `postXfer()` performs the synchronous PUT or GET.
+7. `checkXfer()` returns `NIXL_SUCCESS` because the work already completed.
+8. `releaseReqH()` frees the placeholder request handle.
+9. `deregisterMem()` removes the key mapping and frees backend metadata.
+
+## Limitations
+
+INMEMKV is deliberately narrow:
+
+- Dynamic example plugin only
+- Build-tree only, not installed
+- Process-local map only
+- No persistence
+- No remote metadata exchange protocol
+- No notifications
+- No internal locking; it assumes serialized backend calls, like other simple backend examples

--- a/examples/plugins/inmemkv/inmemkv_backend.cpp
+++ b/examples/plugins/inmemkv/inmemkv_backend.cpp
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_backend.cpp
+ * @brief Factory wiring for nixlInMemKVEngine; creates nixlInMemKVEngineImpl at construction.
+ */
+
+#include "inmemkv_backend.h"
+#include "inmemkv_engine_impl.h"
+#include <memory>
+
+namespace {
+
+std::unique_ptr<nixlKVEngineImpl>
+createInMemKVEngineImpl(const nixlBackendInitParams *init_params) {
+    return std::make_unique<nixlInMemKVEngineImpl>(init_params);
+}
+
+} // namespace
+
+nixlInMemKVEngine::nixlInMemKVEngine(const nixlBackendInitParams *init_params)
+    : nixlKVEngine(init_params, createInMemKVEngineImpl(init_params)) {}

--- a/examples/plugins/inmemkv/inmemkv_backend.h
+++ b/examples/plugins/inmemkv/inmemkv_backend.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_backend.h
+ * @brief INMEMKV example plugin - thin engine wrapper around nixlKVEngine.
+ *
+ * Architecture:
+ *
+ *   nixlInMemKVEngine          Registered with NIXL; extends nixlKVEngine
+ *        |
+ *        v
+ *   nixlKVEngine               Shared thin wrapper in src/plugins/kv/
+ *        |
+ *        v
+ *   nixlInMemKVEngineImpl      Plugin-specific logic (inmemkv_engine_impl.*)
+ *        |
+ *        v
+ *   InMemKVStore (iKVStore)    In-memory put/get/exists (inmemkv_store.*)
+ *
+ * See INMEMKV_ARCHITECTURE.md and src/plugins/kv/kv_engine_impl.h for details.
+ */
+
+#ifndef NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_BACKEND_H
+#define NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_BACKEND_H
+
+#include "kv_engine.h"
+#include <memory>
+
+/**
+ * @class nixlInMemKVEngine
+ * @brief INMEMKV backend engine registered with the NIXL plugin loader.
+ *
+ * This class is intentionally thin: it wires the shared nixlKVEngine wrapper
+ * to a nixlInMemKVEngineImpl instance at construction time.
+ */
+class nixlInMemKVEngine : public nixlKVEngine {
+public:
+    /**
+     * @brief Constructs the INMEMKV engine and its implementation.
+     * @param init_params NIXL backend initialization parameters.
+     */
+    explicit nixlInMemKVEngine(const nixlBackendInitParams *init_params);
+
+    ~nixlInMemKVEngine() override = default;
+};
+
+#endif // NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_BACKEND_H

--- a/examples/plugins/inmemkv/inmemkv_engine_impl.cpp
+++ b/examples/plugins/inmemkv/inmemkv_engine_impl.cpp
@@ -122,8 +122,7 @@ nixlInMemKVEngineImpl::registerMem(const nixlBlobDesc &mem,
                << ", metaInfo=" << (mem.metaInfo.empty() ? "<empty>" : mem.metaInfo);
 
     const auto supported_mems = getSupportedMems();
-    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) ==
-        supported_mems.end()) {
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) == supported_mems.end()) {
         NIXL_ERROR << "registerMem: unsupported memory type " << nixl_mem;
         return NIXL_ERR_NOT_SUPPORTED;
     }
@@ -175,8 +174,7 @@ nixlInMemKVEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
                                 const nixl_opt_b_args_t *opt_args) const {
     (void)opt_args;
     NIXL_DEBUG << "prepXfer: operation=" << (operation == NIXL_WRITE ? "WRITE" : "READ")
-               << ", local_count=" << local.descCount()
-               << ", remote_count=" << remote.descCount();
+               << ", local_count=" << local.descCount() << ", remote_count=" << remote.descCount();
 
     if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
         NIXL_ERROR << "prepXfer: parameter validation failed";
@@ -239,8 +237,8 @@ nixlInMemKVEngineImpl::postXfer(const nixl_xfer_op_t &operation,
             }
 
             if (bytes_read < data_len) {
-                NIXL_WARN << "postXfer: READ truncated key=" << *key << " (" << bytes_read
-                          << " of " << data_len << " bytes)";
+                NIXL_WARN << "postXfer: READ truncated key=" << *key << " (" << bytes_read << " of "
+                          << data_len << " bytes)";
                 data_len = bytes_read;
             }
             NIXL_DEBUG << "postXfer: READ retrieved " << data_len << " bytes from key=" << *key;

--- a/examples/plugins/inmemkv/inmemkv_engine_impl.cpp
+++ b/examples/plugins/inmemkv/inmemkv_engine_impl.cpp
@@ -1,0 +1,263 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_engine_impl.cpp
+ * @brief nixlInMemKVEngineImpl - INMEMKV-specific nixlKVEngineImpl logic.
+ */
+
+#include "inmemkv_engine_impl.h"
+#include "common/nixl_log.h"
+#include "nixl_types.h"
+#include <absl/strings/str_format.h>
+#include <algorithm>
+#include <memory>
+#include <optional>
+
+namespace {
+
+/** Placeholder request handle for synchronous INMEMKV operations. */
+class nixlInMemKVBackendReqH : public nixlBackendReqH {
+public:
+    nixlInMemKVBackendReqH() = default;
+    ~nixlInMemKVBackendReqH() = default;
+};
+
+/** Backend metadata: maps NIXL devId to KV key string. */
+class nixlInMemKVMetadata : public nixlBackendMD {
+public:
+    nixlInMemKVMetadata(uint64_t dev_id, std::string key)
+        : nixlBackendMD(true),
+          dev_id_(dev_id),
+          key_(std::move(key)) {}
+
+    ~nixlInMemKVMetadata() = default;
+
+    uint64_t dev_id_;
+    std::string key_;
+};
+
+std::string
+descriptorKey(const nixlBlobDesc &desc) {
+    return desc.metaInfo.empty() ? std::to_string(desc.devId) : desc.metaInfo;
+}
+
+bool
+isValidPrepXferParams(const nixl_xfer_op_t &operation,
+                      const nixl_meta_dlist_t &local,
+                      const nixl_meta_dlist_t &remote,
+                      const std::string &remote_agent,
+                      const std::string &local_agent) {
+    (void)remote_agent;
+    (void)local_agent;
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << absl::StrFormat("Error: Invalid operation type: %d", operation);
+        return false;
+    }
+
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat("Error: Local memory type must be DRAM_SEG, got %d",
+                                      local.getType());
+        return false;
+    }
+
+    if (remote.getType() != DRAM_SEG) {
+        NIXL_ERROR << absl::StrFormat("Error: Remote memory type must be DRAM_SEG, got %d",
+                                      remote.getType());
+        return false;
+    }
+
+    return true;
+}
+
+std::optional<std::string>
+lookupKey(const nixlMetaDesc &remote_desc,
+          const std::unordered_map<uint64_t, std::string> &dev_id_to_key) {
+    if (remote_desc.metadataP) {
+        if (auto *inmemkv_md = dynamic_cast<nixlInMemKVMetadata *>(remote_desc.metadataP)) {
+            return inmemkv_md->key_;
+        }
+    }
+
+    const auto key_search = dev_id_to_key.find(remote_desc.devId);
+    if (key_search == dev_id_to_key.end()) {
+        return std::nullopt;
+    }
+
+    return key_search->second;
+}
+
+} // namespace
+
+nixlInMemKVEngineImpl::nixlInMemKVEngineImpl(const nixlBackendInitParams *init_params)
+    : nixlInMemKVEngineImpl(init_params, std::make_unique<InMemKVStore>()) {}
+
+nixlInMemKVEngineImpl::nixlInMemKVEngineImpl(const nixlBackendInitParams *init_params,
+                                             std::unique_ptr<iKVStore> store)
+    : store_(std::move(store)),
+      local_agent_(init_params->localAgent) {
+    NIXL_INFO << "INMEMKV backend initialized (in-memory only)";
+    NIXL_DEBUG << "INMEMKV: local agent = " << local_agent_;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::registerMem(const nixlBlobDesc &mem,
+                                   const nixl_mem_t &nixl_mem,
+                                   nixlBackendMD *&out) {
+    NIXL_DEBUG << "registerMem: type=" << nixl_mem << ", devId=" << mem.devId
+               << ", metaInfo=" << (mem.metaInfo.empty() ? "<empty>" : mem.metaInfo);
+
+    const auto supported_mems = getSupportedMems();
+    if (std::find(supported_mems.begin(), supported_mems.end(), nixl_mem) ==
+        supported_mems.end()) {
+        NIXL_ERROR << "registerMem: unsupported memory type " << nixl_mem;
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    const std::string key = descriptorKey(mem);
+    auto inmemkv_md = std::make_unique<nixlInMemKVMetadata>(mem.devId, key);
+    dev_id_to_key_[mem.devId] = key;
+    NIXL_DEBUG << "registerMem: registered devId=" << mem.devId << " -> key=" << key;
+
+    out = inmemkv_md.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::deregisterMem(nixlBackendMD *meta) {
+    auto *inmemkv_md = static_cast<nixlInMemKVMetadata *>(meta);
+    if (inmemkv_md) {
+        NIXL_DEBUG << "deregisterMem: removing devId=" << inmemkv_md->dev_id_
+                   << ", key=" << inmemkv_md->key_;
+        dev_id_to_key_.erase(inmemkv_md->dev_id_);
+        std::unique_ptr<nixlInMemKVMetadata> ptr(inmemkv_md);
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::queryMem(const nixl_reg_dlist_t &descs,
+                                std::vector<nixl_query_resp_t> &resp) const {
+    resp.reserve(descs.descCount());
+
+    for (auto &desc : descs) {
+        const std::string key = descriptorKey(desc);
+        const bool exists = store_->exists(key);
+
+        NIXL_DEBUG << "queryMem: key=" << key << ", exists=" << exists;
+        resp.emplace_back(exists ? nixl_query_resp_t{nixl_b_params_t{}} : std::nullopt);
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
+                                const nixl_meta_dlist_t &local,
+                                const nixl_meta_dlist_t &remote,
+                                const std::string &remote_agent,
+                                const std::string &local_agent,
+                                nixlBackendReqH *&handle,
+                                const nixl_opt_b_args_t *opt_args) const {
+    (void)opt_args;
+    NIXL_DEBUG << "prepXfer: operation=" << (operation == NIXL_WRITE ? "WRITE" : "READ")
+               << ", local_count=" << local.descCount()
+               << ", remote_count=" << remote.descCount();
+
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
+        NIXL_ERROR << "prepXfer: parameter validation failed";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto req_h = std::make_unique<nixlInMemKVBackendReqH>();
+    handle = req_h.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::postXfer(const nixl_xfer_op_t &operation,
+                                const nixl_meta_dlist_t &local,
+                                const nixl_meta_dlist_t &remote,
+                                const std::string &remote_agent,
+                                const std::string &local_agent,
+                                nixlBackendReqH *&handle,
+                                const nixl_opt_b_args_t *opt_args) const {
+    (void)remote_agent;
+    (void)local_agent;
+    (void)handle;
+    (void)opt_args;
+
+    NIXL_DEBUG << "postXfer: " << (operation == NIXL_WRITE ? "WRITE" : "READ") << " with "
+               << local.descCount() << " descriptor(s)";
+
+    for (int i = 0; i < local.descCount(); ++i) {
+        const auto &local_desc = local[i];
+        const auto &remote_desc = remote[i];
+
+        const auto key = lookupKey(remote_desc, dev_id_to_key_);
+        if (!key) {
+            NIXL_ERROR << "postXfer: key for devId " << remote_desc.devId << " not found";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        const auto data_ptr = reinterpret_cast<uint8_t *>(local_desc.addr);
+        size_t data_len = local_desc.len;
+
+        if (operation == NIXL_WRITE) {
+            const auto write_status = store_->put(*key, data_ptr, data_len);
+            if (write_status != NIXL_SUCCESS) {
+                NIXL_ERROR << "postXfer: WRITE failed for key=" << *key
+                           << ", status=" << write_status;
+                return write_status;
+            }
+            NIXL_DEBUG << "postXfer: WRITE stored " << data_len << " bytes in key=" << *key;
+        } else {
+            size_t bytes_read = 0;
+            const auto read_status = store_->get(*key, data_ptr, data_len, bytes_read);
+            if (read_status == NIXL_ERR_NOT_FOUND) {
+                NIXL_ERROR << "postXfer: READ key not found: " << *key;
+                return NIXL_ERR_NOT_FOUND;
+            }
+            if (read_status != NIXL_SUCCESS) {
+                NIXL_ERROR << "postXfer: READ failed for key=" << *key
+                           << ", status=" << read_status;
+                return read_status;
+            }
+
+            if (bytes_read < data_len) {
+                NIXL_WARN << "postXfer: READ truncated key=" << *key << " (" << bytes_read
+                          << " of " << data_len << " bytes)";
+                data_len = bytes_read;
+            }
+            NIXL_DEBUG << "postXfer: READ retrieved " << data_len << " bytes from key=" << *key;
+        }
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::checkXfer(nixlBackendReqH *handle) const {
+    (void)handle;
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlInMemKVEngineImpl::releaseReqH(nixlBackendReqH *handle) const {
+    delete handle;
+    return NIXL_SUCCESS;
+}

--- a/examples/plugins/inmemkv/inmemkv_engine_impl.h
+++ b/examples/plugins/inmemkv/inmemkv_engine_impl.h
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_engine_impl.h
+ * @brief Concrete nixlKVEngineImpl for the INMEMKV example plugin.
+ *
+ * This class owns the in-memory iKVStore and implements the full KV backend
+ * data path (registerMem through releaseReqH).
+ */
+
+#ifndef NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_ENGINE_IMPL_H
+#define NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_ENGINE_IMPL_H
+
+#include "inmemkv_store.h"
+#include "kv_engine_impl.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+/**
+ * @class nixlInMemKVEngineImpl
+ * @brief INMEMKV-specific implementation of nixlKVEngineImpl.
+ */
+class nixlInMemKVEngineImpl : public nixlKVEngineImpl {
+public:
+    /**
+     * @brief Construct with default InMemKVStore.
+     * @param init_params Used for logging local agent name at initialization.
+     */
+    explicit nixlInMemKVEngineImpl(const nixlBackendInitParams *init_params);
+
+    /**
+     * @brief Construct with an injected store (useful for unit tests).
+     * @param init_params NIXL initialization parameters.
+     * @param store Ownership of the iKVStore instance is transferred.
+     */
+    nixlInMemKVEngineImpl(const nixlBackendInitParams *init_params,
+                          std::unique_ptr<iKVStore> store);
+
+    ~nixlInMemKVEngineImpl() override = default;
+
+    nixl_mem_list_t getSupportedMems() const override {
+        return {DRAM_SEG};
+    }
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const override;
+
+    nixl_status_t checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t releaseReqH(nixlBackendReqH *handle) const override;
+
+private:
+    std::unique_ptr<iKVStore> store_;
+    std::unordered_map<uint64_t, std::string> dev_id_to_key_;
+    std::string local_agent_;
+};
+
+#endif // NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_ENGINE_IMPL_H

--- a/examples/plugins/inmemkv/inmemkv_engine_impl.h
+++ b/examples/plugins/inmemkv/inmemkv_engine_impl.h
@@ -54,14 +54,16 @@ public:
 
     ~nixlInMemKVEngineImpl() override = default;
 
-    nixl_mem_list_t getSupportedMems() const override {
+    nixl_mem_list_t
+    getSupportedMems() const override {
         return {DRAM_SEG};
     }
 
     nixl_status_t
     registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
 
-    nixl_status_t deregisterMem(nixlBackendMD *meta) override;
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
 
     nixl_status_t
     queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
@@ -84,9 +86,11 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const override;
 
-    nixl_status_t checkXfer(nixlBackendReqH *handle) const override;
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
 
-    nixl_status_t releaseReqH(nixlBackendReqH *handle) const override;
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
 
 private:
     std::unique_ptr<iKVStore> store_;

--- a/examples/plugins/inmemkv/inmemkv_plugin.cpp
+++ b/examples/plugins/inmemkv/inmemkv_plugin.cpp
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_plugin.cpp
+ * @brief Dynamic plugin registration for the INMEMKV example backend.
+ *
+ * Exports nixl_plugin_init() / nixl_plugin_fini() so NIXL can load
+ * libplugin_INMEMKV.so from NIXL_PLUGIN_DIR at runtime.
+ */
+
+#include "backend/backend_plugin.h"
+#include "common/nixl_log.h"
+#include "inmemkv_backend.h"
+#include "nixl_types.h"
+
+using inmemkv_plugin_t = nixlBackendPluginCreator<nixlInMemKVEngine>;
+
+/**
+ * @brief Plugin initialization entry point for dynamic loading.
+ * @return Pointer to the registered backend plugin object.
+ */
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
+nixl_plugin_init() {
+    return inmemkv_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION,
+        "INMEMKV",
+        "0.1.0",
+        {},
+        {DRAM_SEG}
+    );
+}
+
+/**
+ * @brief Plugin cleanup entry point for dynamic unloading.
+ */
+extern "C" NIXL_PLUGIN_EXPORT void
+nixl_plugin_fini() {}

--- a/examples/plugins/inmemkv/inmemkv_plugin.cpp
+++ b/examples/plugins/inmemkv/inmemkv_plugin.cpp
@@ -36,13 +36,7 @@ using inmemkv_plugin_t = nixlBackendPluginCreator<nixlInMemKVEngine>;
  */
 extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
 nixl_plugin_init() {
-    return inmemkv_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION,
-        "INMEMKV",
-        "0.1.0",
-        {},
-        {DRAM_SEG}
-    );
+    return inmemkv_plugin_t::create(NIXL_PLUGIN_API_VERSION, "INMEMKV", "0.1.0", {}, {DRAM_SEG});
 }
 
 /**

--- a/examples/plugins/inmemkv/inmemkv_store.cpp
+++ b/examples/plugins/inmemkv/inmemkv_store.cpp
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_store.cpp
+ * @brief InMemKVStore put/get/exists implementation.
+ */
+
+#include "inmemkv_store.h"
+#include <algorithm>
+#include <cstring>
+
+nixl_status_t
+InMemKVStore::put(std::string_view key, const uint8_t *data, size_t len) {
+    auto &value = store_[std::string(key)];
+    value.resize(len);
+    if (len > 0) {
+        std::memcpy(value.data(), data, len);
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+InMemKVStore::get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const {
+    auto it = store_.find(std::string(key));
+    if (it == store_.end()) {
+        bytes_read = 0;
+        return NIXL_ERR_NOT_FOUND;
+    }
+
+    bytes_read = std::min(it->second.size(), len);
+    if (bytes_read > 0) {
+        std::memcpy(buffer, it->second.data(), bytes_read);
+    }
+    return NIXL_SUCCESS;
+}
+
+bool
+InMemKVStore::exists(std::string_view key) const {
+    return store_.find(std::string(key)) != store_.end();
+}

--- a/examples/plugins/inmemkv/inmemkv_store.h
+++ b/examples/plugins/inmemkv/inmemkv_store.h
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file inmemkv_store.h
+ * @brief In-memory implementation of the shared iKVStore interface for INMEMKV.
+ */
+
+#ifndef NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_STORE_H
+#define NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_STORE_H
+
+#include "kv_store.h"
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @class InMemKVStore
+ * @brief In-memory implementation of iKVStore using unordered_map.
+ */
+class InMemKVStore : public iKVStore {
+public:
+    nixl_status_t put(std::string_view key, const uint8_t *data, size_t len) override;
+
+    nixl_status_t get(std::string_view key,
+                      uint8_t *buffer,
+                      size_t len,
+                      size_t &bytes_read) const override;
+
+    bool exists(std::string_view key) const override;
+
+private:
+    mutable std::unordered_map<std::string, std::vector<uint8_t>> store_;
+};
+
+#endif // NIXL_EXAMPLES_PLUGINS_INMEMKV_INMEMKV_STORE_H

--- a/examples/plugins/inmemkv/inmemkv_store.h
+++ b/examples/plugins/inmemkv/inmemkv_store.h
@@ -35,14 +35,14 @@
  */
 class InMemKVStore : public iKVStore {
 public:
-    nixl_status_t put(std::string_view key, const uint8_t *data, size_t len) override;
+    nixl_status_t
+    put(std::string_view key, const uint8_t *data, size_t len) override;
 
-    nixl_status_t get(std::string_view key,
-                      uint8_t *buffer,
-                      size_t len,
-                      size_t &bytes_read) const override;
+    nixl_status_t
+    get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const override;
 
-    bool exists(std::string_view key) const override;
+    bool
+    exists(std::string_view key) const override;
 
 private:
     mutable std::unordered_map<std::string, std::vector<uint8_t>> store_;

--- a/examples/plugins/inmemkv/meson.build
+++ b/examples/plugins/inmemkv/meson.build
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+inmemkv_sources = [
+    '../../../src/plugins/kv/kv_engine.cpp',
+    'inmemkv_backend.cpp',
+    'inmemkv_backend.h',
+    'inmemkv_engine_impl.cpp',
+    'inmemkv_engine_impl.h',
+    'inmemkv_store.cpp',
+    'inmemkv_store.h',
+    'inmemkv_plugin.cpp',
+]
+
+inmemkv_example_plugin = shared_library(
+    'INMEMKV',
+    inmemkv_sources,
+    dependencies: [nixl_infra, nixl_common_dep],
+    cpp_args: ['-fPIC'],
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    install: false,
+    name_prefix: 'libplugin_')
+
+# Convenience alias so "ninja -C build INMEMKV" works.
+alias_target('INMEMKV', inmemkv_example_plugin)

--- a/examples/plugins/meson.build
+++ b/examples/plugins/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if get_option('build_examples')
-    subdir('cpp')
-    subdir('plugins')
-endif
-
-subdir('device')
+subdir('inmemkv')

--- a/meson.build
+++ b/meson.build
@@ -439,7 +439,7 @@ if get_option('buildtype') == 'debug'
     run_command('truncate', '-s 0', plugfile, check: true)
 endif
 
-nixl_inc_dirs = include_directories('src/api/cpp', 'src/api/cpp/backend', 'src/infra', 'src/core', 'src/core/telemetry')
+nixl_inc_dirs = include_directories('src/api/cpp', 'src/api/cpp/backend', 'src/infra', 'src/core', 'src/core/telemetry', 'src/plugins/kv')
 nixl_gpu_inc_dirs = include_directories('src/api/gpu/ucx')
 plugins_inc_dirs = include_directories('src/plugins')
 utils_inc_dirs = include_directories('src/utils')
@@ -469,6 +469,9 @@ if get_option('install_headers')
   install_headers('src/core/transfer_request.h', install_dir: prefix_inc)
   install_headers('src/core/agent_data.h', install_dir: prefix_inc)
   install_headers('src/infra/mem_section.h', install_dir: prefix_inc)
+  install_headers('src/plugins/kv/kv_store.h', install_dir: prefix_inc + '/plugins/kv')
+  install_headers('src/plugins/kv/kv_engine_impl.h', install_dir: prefix_inc + '/plugins/kv')
+  install_headers('src/plugins/kv/kv_engine.h', install_dir: prefix_inc + '/plugins/kv')
   install_headers('src/core/telemetry/telemetry_event.h', install_dir: prefix_inc)
 
   if ucx_gpu_device_api_available

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine.cpp
+ * @brief nixlKVEngine delegation layer; forwards nixlBackendEngine calls to impl_.
+ */
+
+#include "kv_engine.h"
+
+nixlKVEngine::nixlKVEngine(const nixlBackendInitParams *init_params,
+                           std::unique_ptr<nixlKVEngineImpl> impl)
+    : nixlBackendEngine(init_params),
+      impl_(std::move(impl)) {}
+
+nixlKVEngine::~nixlKVEngine() = default;
+
+nixl_mem_list_t
+nixlKVEngine::getSupportedMems() const {
+    return impl_->getSupportedMems();
+}
+
+nixl_status_t
+nixlKVEngine::registerMem(const nixlBlobDesc &mem,
+                          const nixl_mem_t &nixl_mem,
+                          nixlBackendMD *&out) {
+    return impl_->registerMem(mem, nixl_mem, out);
+}
+
+nixl_status_t
+nixlKVEngine::deregisterMem(nixlBackendMD *meta) {
+    return impl_->deregisterMem(meta);
+}
+
+nixl_status_t
+nixlKVEngine::queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const {
+    return impl_->queryMem(descs, resp);
+}
+
+nixl_status_t
+nixlKVEngine::prepXfer(const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       const std::string &remote_agent,
+                       nixlBackendReqH *&handle,
+                       const nixl_opt_b_args_t *opt_args) const {
+    return impl_->prepXfer(operation, local, remote, remote_agent, localAgent, handle, opt_args);
+}
+
+nixl_status_t
+nixlKVEngine::postXfer(const nixl_xfer_op_t &operation,
+                       const nixl_meta_dlist_t &local,
+                       const nixl_meta_dlist_t &remote,
+                       const std::string &remote_agent,
+                       nixlBackendReqH *&handle,
+                       const nixl_opt_b_args_t *opt_args) const {
+    return impl_->postXfer(operation, local, remote, remote_agent, handle, opt_args);
+}
+
+nixl_status_t
+nixlKVEngine::checkXfer(nixlBackendReqH *handle) const {
+    return impl_->checkXfer(handle);
+}
+
+nixl_status_t
+nixlKVEngine::releaseReqH(nixlBackendReqH *handle) const {
+    return impl_->releaseReqH(handle);
+}

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -71,7 +71,7 @@ nixlKVEngine::postXfer(const nixl_xfer_op_t &operation,
                        const std::string &remote_agent,
                        nixlBackendReqH *&handle,
                        const nixl_opt_b_args_t *opt_args) const {
-    return impl_->postXfer(operation, local, remote, remote_agent, handle, opt_args);
+    return impl_->postXfer(operation, local, remote, remote_agent, localAgent, handle, opt_args);
 }
 
 nixl_status_t

--- a/src/plugins/kv/kv_engine.cpp
+++ b/src/plugins/kv/kv_engine.cpp
@@ -21,11 +21,14 @@
  */
 
 #include "kv_engine.h"
+#include <cassert>
 
 nixlKVEngine::nixlKVEngine(const nixlBackendInitParams *init_params,
                            std::unique_ptr<nixlKVEngineImpl> impl)
     : nixlBackendEngine(init_params),
-      impl_(std::move(impl)) {}
+      impl_(std::move(impl)) {
+    assert(impl_ && "nixlKVEngine requires a non-null nixlKVEngineImpl");
+}
 
 nixlKVEngine::~nixlKVEngine() = default;
 

--- a/src/plugins/kv/kv_engine.h
+++ b/src/plugins/kv/kv_engine.h
@@ -26,8 +26,8 @@
  * register the resulting engine with nixlBackendPluginCreator.
  */
 
-#ifndef NIXL_KV_ENGINE_H
-#define NIXL_KV_ENGINE_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_ENGINE_H
+#define NIXL_SRC_PLUGINS_KV_KV_ENGINE_H
 
 #include "kv_engine_impl.h"
 #include <memory>
@@ -92,8 +92,18 @@ public:
         return NIXL_SUCCESS;
     }
 
+    /**
+     * @brief Passes local metadata through unchanged.
+     *
+     * Local-only KV backends do not transform metadata. input must be the
+     * nixlBackendMD* returned by registerMem().
+     */
     nixl_status_t
     loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        if (input == nullptr) {
+            output = nullptr;
+            return NIXL_ERR_INVALID_PARAM;
+        }
         output = input;
         return NIXL_SUCCESS;
     }
@@ -124,4 +134,4 @@ private:
     std::unique_ptr<nixlKVEngineImpl> impl_;
 };
 
-#endif // NIXL_KV_ENGINE_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_ENGINE_H

--- a/src/plugins/kv/kv_engine.h
+++ b/src/plugins/kv/kv_engine.h
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine.h
+ * @brief Shared thin wrapper base class for KV-style NIXL backend engines.
+ *
+ * nixlKVEngine implements nixlBackendEngine and forwards all data-plane calls
+ * to a nixlKVEngineImpl instance supplied by each plugin.
+ *
+ * Plugin authors subclass nixlKVEngine (or use it directly with a factory) and
+ * register the resulting engine with nixlBackendPluginCreator.
+ */
+
+#ifndef NIXL_KV_ENGINE_H
+#define NIXL_KV_ENGINE_H
+
+#include "kv_engine_impl.h"
+#include <memory>
+
+/**
+ * @class nixlKVEngine
+ * @brief Thin nixlBackendEngine wrapper that delegates to nixlKVEngineImpl.
+ *
+ * Common KV backend capabilities (local-only, no notifications) are declared here
+ * so individual plugins only need to supply a concrete nixlKVEngineImpl.
+ */
+class nixlKVEngine : public nixlBackendEngine {
+public:
+    /**
+     * @brief Construct a KV engine with a plugin-specific implementation.
+     * @param init_params NIXL initialization parameters.
+     * @param impl Concrete nixlKVEngineImpl (ownership transferred).
+     */
+    nixlKVEngine(const nixlBackendInitParams *init_params, std::unique_ptr<nixlKVEngineImpl> impl);
+
+    ~nixlKVEngine() override;
+
+    bool
+    supportsRemote() const override {
+        return false;
+    }
+
+    bool
+    supportsLocal() const override {
+        return true;
+    }
+
+    bool
+    supportsNotif() const override {
+        return false;
+    }
+
+    nixl_mem_list_t
+    getSupportedMems() const override;
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+    nixl_status_t
+    connect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    disconnect(const std::string &remote_agent) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    unloadMD(nixlBackendMD *input) override {
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    loadLocalMD(nixlBackendMD *input, nixlBackendMD *&output) override {
+        output = input;
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+private:
+    std::unique_ptr<nixlKVEngineImpl> impl_;
+};
+
+#endif // NIXL_KV_ENGINE_H

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -54,7 +54,8 @@ class nixlKVEngineImpl {
 public:
     virtual ~nixlKVEngineImpl() = default;
 
-    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically DRAM_SEG). */
+    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically
+     * DRAM_SEG). */
     virtual nixl_mem_list_t
     getSupportedMems() const = 0;
 

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -35,8 +35,8 @@
  * on NIXL descriptor/key mapping while iKVStore handles put/get/exists.
  */
 
-#ifndef NIXL_KV_ENGINE_IMPL_H
-#define NIXL_KV_ENGINE_IMPL_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H
+#define NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H
 
 #include "backend/backend_engine.h"
 #include <string>
@@ -97,4 +97,4 @@ public:
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };
 
-#endif // NIXL_KV_ENGINE_IMPL_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_ENGINE_IMPL_H

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -54,24 +54,54 @@ class nixlKVEngineImpl {
 public:
     virtual ~nixlKVEngineImpl() = default;
 
-    /** @return Memory segment types supported by this KV backend (typically DRAM_SEG). */
+    /** @brief Memory segment types supported by this KV backend. @return Segment list (typically DRAM_SEG). */
     virtual nixl_mem_list_t
     getSupportedMems() const = 0;
 
+    /**
+     * @brief Registers a local memory descriptor as a KV key.
+     *
+     * @param mem Descriptor blob including key metadata (metaInfo or devId).
+     * @param nixl_mem Memory segment type; must be supported by getSupportedMems().
+     * @param out On success, receives a newly allocated nixlBackendMD* owned by the caller
+     *            until deregisterMem().
+     * @return NIXL_SUCCESS on success, or an error status on invalid input or backend failure.
+     */
     virtual nixl_status_t
     registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) = 0;
 
+    /**
+     * @brief Deregisters backend metadata created by registerMem().
+     *
+     * @param meta Metadata pointer returned by registerMem(); must be non-null.
+     * @return NIXL_SUCCESS on success, or an error status if meta is invalid.
+     */
     virtual nixl_status_t
     deregisterMem(nixlBackendMD *meta) = 0;
 
+    /**
+     * @brief Queries whether registered keys exist in the backing store.
+     *
+     * @param descs Registered descriptors to query.
+     * @param resp Output vector; each entry is set when the key exists, or std::nullopt otherwise.
+     * @return NIXL_SUCCESS on success, or an error status on backend failure.
+     */
     virtual nixl_status_t
     queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const = 0;
 
     /**
-     * @brief Prepare a transfer request.
+     * @brief Prepares a transfer request and allocates a backend request handle.
      *
-     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     * @param operation Transfer operation (NIXL_WRITE or NIXL_READ).
+     * @param local Local descriptor metadata list.
+     * @param remote Remote descriptor metadata list.
+     * @param remote_agent Remote agent name (unused for local-only KV backends).
+     * @param local_agent Local agent name from nixlKVEngine::localAgent (passed explicitly
      *                    so impl does not depend on nixlBackendEngine protected members).
+     * @param handle On success, receives a newly allocated nixlBackendReqH* owned by the caller
+     *               until releaseReqH().
+     * @param opt_args Optional backend arguments; may be nullptr.
+     * @return NIXL_SUCCESS on success, or an error status on invalid parameters.
      */
     virtual nixl_status_t
     prepXfer(const nixl_xfer_op_t &operation,
@@ -83,10 +113,17 @@ public:
              const nixl_opt_b_args_t *opt_args) const = 0;
 
     /**
-     * @brief Execute a prepared transfer request.
+     * @brief Executes a prepared transfer request.
      *
-     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     * @param operation Transfer operation (NIXL_WRITE or NIXL_READ).
+     * @param local Local descriptor metadata list.
+     * @param remote Remote descriptor metadata list.
+     * @param remote_agent Remote agent name (unused for local-only KV backends).
+     * @param local_agent Local agent name from nixlKVEngine::localAgent (passed explicitly
      *                    so impl does not depend on nixlBackendEngine protected members).
+     * @param handle Request handle allocated by prepXfer(); must be non-null.
+     * @param opt_args Optional backend arguments; may be nullptr.
+     * @return NIXL_SUCCESS on success, or an error status on transfer or backend failure.
      */
     virtual nixl_status_t
     postXfer(const nixl_xfer_op_t &operation,
@@ -97,9 +134,21 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 
+    /**
+     * @brief Checks transfer completion status for a request handle.
+     *
+     * @param handle Request handle from prepXfer(); must be non-null.
+     * @return NIXL_SUCCESS when the transfer is complete, or an in-progress/error status.
+     */
     virtual nixl_status_t
     checkXfer(nixlBackendReqH *handle) const = 0;
 
+    /**
+     * @brief Releases a request handle allocated by prepXfer().
+     *
+     * @param handle Request handle to release; must be non-null.
+     * @return NIXL_SUCCESS on success.
+     */
     virtual nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const = 0;
 };

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -82,11 +82,18 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 
+    /**
+     * @brief Execute a prepared transfer request.
+     *
+     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     *                    so impl does not depend on nixlBackendEngine protected members).
+     */
     virtual nixl_status_t
     postXfer(const nixl_xfer_op_t &operation,
              const nixl_meta_dlist_t &local,
              const nixl_meta_dlist_t &remote,
              const std::string &remote_agent,
+             const std::string &local_agent,
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args) const = 0;
 

--- a/src/plugins/kv/kv_engine_impl.h
+++ b/src/plugins/kv/kv_engine_impl.h
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_engine_impl.h
+ * @brief Abstract implementation interface for KV-style NIXL backend engines.
+ *
+ * Architecture:
+ *
+ *   nixlBackendEngine          NIXL agent-facing protocol (registerMem, prepXfer, ...)
+ *        ^
+ *        |  nixlKVEngine        Thin wrapper; delegates lifecycle calls to impl_
+ *        |
+ *   nixlKVEngineImpl           Vendor/backend-specific logic (this header)
+ *        ^
+ *        |
+ *   nixlInMemKVEngineImpl      Example: in-process map via iKVStore
+ *   nixlRedisKVEngineImpl      Future: Redis via hiredis implementing iKVStore
+ *
+ * Storage is further factored through iKVStore (kv_store.h) so impl classes focus
+ * on NIXL descriptor/key mapping while iKVStore handles put/get/exists.
+ */
+
+#ifndef NIXL_KV_ENGINE_IMPL_H
+#define NIXL_KV_ENGINE_IMPL_H
+
+#include "backend/backend_engine.h"
+#include <string>
+#include <vector>
+
+/**
+ * @class nixlKVEngineImpl
+ * @brief Abstract implementation interface for KV-style backend engines.
+ *
+ * Each KV plugin (INMEMKV example, REDIS src plugin, etc.) provides a concrete
+ * subclass that implements register/deregister, query, and synchronous transfer
+ * operations against its chosen iKVStore backend.
+ */
+class nixlKVEngineImpl {
+public:
+    virtual ~nixlKVEngineImpl() = default;
+
+    /** @return Memory segment types supported by this KV backend (typically DRAM_SEG). */
+    virtual nixl_mem_list_t
+    getSupportedMems() const = 0;
+
+    virtual nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) = 0;
+
+    virtual nixl_status_t
+    deregisterMem(nixlBackendMD *meta) = 0;
+
+    virtual nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const = 0;
+
+    /**
+     * @brief Prepare a transfer request.
+     *
+     * @param local_agent Agent name from nixlKVEngine::localAgent (passed explicitly
+     *                    so impl does not depend on nixlBackendEngine protected members).
+     */
+    virtual nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const = 0;
+
+    virtual nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const = 0;
+
+    virtual nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const = 0;
+
+    virtual nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const = 0;
+};
+
+#endif // NIXL_KV_ENGINE_IMPL_H

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -59,7 +59,7 @@ public:
      * @param buffer Output buffer for stored value bytes.
      * @param len Maximum number of bytes to read into buffer.
      * @param bytes_read Set to min(stored_len, len) on success.
-     * @return NIXL_SUCCESS on success, or NIXL_ERR_BACKEND when key does not exist.
+     * @return NIXL_SUCCESS on success, or NIXL_ERR_NOT_FOUND when key does not exist.
      */
     virtual nixl_status_t
     get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -23,8 +23,8 @@
  * backend-specific storage while sharing this synchronous put/get/exists API.
  */
 
-#ifndef NIXL_KV_STORE_H
-#define NIXL_KV_STORE_H
+#ifndef NIXL_SRC_PLUGINS_KV_KV_STORE_H
+#define NIXL_SRC_PLUGINS_KV_KV_STORE_H
 
 #include "nixl_types.h"
 #include <cstddef>
@@ -41,20 +41,37 @@ class iKVStore {
 public:
     virtual ~iKVStore() = default;
 
+    /**
+     * @brief Stores value bytes for key.
+     *
+     * @param key Storage key.
+     * @param data Pointer to value bytes to store.
+     * @param len Number of bytes to copy from data.
+     * @return NIXL_SUCCESS on success, or a backend error code on failure.
+     */
     virtual nixl_status_t
     put(std::string_view key, const uint8_t *data, size_t len) = 0;
 
     /**
      * @brief Reads value for key into buffer.
      *
-     * bytes_read is set to min(stored_len, len) on success.
-     * Returns NIXL_ERR_BACKEND when key does not exist.
+     * @param key Storage key.
+     * @param buffer Output buffer for stored value bytes.
+     * @param len Maximum number of bytes to read into buffer.
+     * @param bytes_read Set to min(stored_len, len) on success.
+     * @return NIXL_SUCCESS on success, or NIXL_ERR_BACKEND when key does not exist.
      */
     virtual nixl_status_t
     get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;
 
+    /**
+     * @brief Checks whether key is present in the store.
+     *
+     * @param key Storage key.
+     * @return true if key exists, false otherwise.
+     */
     virtual bool
     exists(std::string_view key) const = 0;
 };
 
-#endif // NIXL_KV_STORE_H
+#endif // NIXL_SRC_PLUGINS_KV_KV_STORE_H

--- a/src/plugins/kv/kv_store.h
+++ b/src/plugins/kv/kv_store.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file kv_store.h
+ * @brief Shared minimal key-value storage interface for NIXL KV backends.
+ *
+ * Implementations (e.g. INMEMKV example plugin, REDIS src plugin) provide
+ * backend-specific storage while sharing this synchronous put/get/exists API.
+ */
+
+#ifndef NIXL_KV_STORE_H
+#define NIXL_KV_STORE_H
+
+#include "nixl_types.h"
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+/**
+ * @brief Minimal key-value storage interface for KV-style NIXL backends.
+ *
+ * This interface intentionally keeps only the smallest synchronous API
+ * needed by current KV backend flows (INMEMKV, REDIS, etc.).
+ */
+class iKVStore {
+public:
+    virtual ~iKVStore() = default;
+
+    virtual nixl_status_t
+    put(std::string_view key, const uint8_t *data, size_t len) = 0;
+
+    /**
+     * @brief Reads value for key into buffer.
+     *
+     * bytes_read is set to min(stored_len, len) on success.
+     * Returns NIXL_ERR_BACKEND when key does not exist.
+     */
+    virtual nixl_status_t
+    get(std::string_view key, uint8_t *buffer, size_t len, size_t &bytes_read) const = 0;
+
+    virtual bool
+    exists(std::string_view key) const = 0;
+};
+
+#endif // NIXL_KV_STORE_H


### PR DESCRIPTION
## What?
This PR adds an INMEMKV example dynamic backend under examples/plugins/inmemkv/, built as libplugin_INMEMKV.so. It shows how to implement the shared KV layer (iKVStore, nixlKVEngineImpl, nixlKVEngine) with a minimal in-process key-value store.

It also adds optional nixlbench support behind -Denable_inmemkv=true so benchmarks can run with --backend INMEMKV.

Plugin layering:
- nixlInMemKVEngine — thin nixlKVEngine wrapper
- nixlInMemKVEngineImpl — registerMem / queryMem / xfer lifecycle
- InMemKVStore — iKVStore with sync put / get / exists

Behavior:
- DRAM_SEG only; keys from descriptor metaInfo (fallback: devId)
- NIXL_WRITE → put, NIXL_READ → get
- Local-only: no remote agent, notifications, or persistence
Docs: README.md, INMEMKV_ARCHITECTURE.md

## Why?
The shared KV interfaces in src/plugins/kv/ need a small, runnable reference so authors can see how to wire a KV backend without reading production plugins (e.g. REDIS) end-to-end.

INMEMKV is intentionally minimal: standard C++, no external service, synchronous completion — suitable for learning, tests, and local validation of the KV abstraction.

## How?
Build (NIXL root):
- examples/meson.build adds subdir('plugins') when build_examples=true
- examples/plugins/inmemkv/meson.build builds libplugin_INMEMKV.so (not installed; load via NIXL_PLUGIN_DIR)
Plugin registration:
- inmemkv_plugin.cpp exports nixl_plugin_init() / nixl_plugin_fini() and registers backend name INMEMKV
Engine implementation:
- nixlInMemKVEngineImpl implements the full nixlKVEngineImpl surface
- registerMem creates per-descriptor metadata and maps devId → key
- postXfer / checkXfer perform sync store operations and complete immediately
nixlbench (optional):
- New Meson option enable_inmemkv (default false)
- When enabled, nixlbench treats INMEMKV as a storage-style backend: DRAM remote descriptors with keys in metaInfo, no file fds

Depends on: KV interface PR (pr_nixl_kv_plugin_interface) — this PR should target that branch, not main directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an **INMEMKV** in-memory key-value backend with a loadable plugin for **local-only** operations.
  * Extended benchmarking/worker backend selection so **INMEMKV** is available when explicitly enabled.

* **Documentation**
  * Added an **INMEMKV** plugin architecture guide and a README with build/run steps and lifecycle notes.

* **Chores**
  * Introduced a Meson option to enable/disable INMEMKV and made related examples build conditional.
  * Added/install KV plugin interface headers for plugin development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->