### PR TITLE
ci: switch back to avoid build C++ tests in release builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -445,11 +445,11 @@ plugins_inc_dirs = include_directories('src/plugins')
 utils_inc_dirs = include_directories('src/utils')
 
 subdir('src')
-# Build tests whenever build_tests is set. (Previously also required a non-release
-# buildtype, but CI builds the image as --buildtype=release and test_cpp.sh runs the
-# installed test binaries, e.g. /usr/local/nixl/bin/desc_example — so release builds
-# must include them.)
-if get_option('build_tests')
+# Do not build tests in release builds: they carry latent -Werror debt (assert()
+# is a no-op under NDEBUG, so checked-only vars go unused and assert(0) defaults fall
+# off non-void functions) and aren't needed for the release wheel. Build them only in
+# non-release buildtypes. (Reverts the #1803 unconditional gate, matching #896.)
+if get_option('build_tests') and get_option('buildtype') != 'release'
   subdir('test')
 endif
 


### PR DESCRIPTION
Restore the buildtype guard on the build_tests gate (reverts the #1803 change). The unit tests carry latent -Werror debt that only surfaces in release builds (-O3 -DNDEBUG, where assert() is a no-op so checked-only vars go unused and assert(0) defaults fall off non-void functions), and they aren't needed for the release wheel. Build them only in non-release buildtypes — the alternative to fixing each test's -Werror violations.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified test build configuration to exclude tests from release builds when test building is enabled, while maintaining test builds for development builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->