### PR TITLE
posix: fix in-flight io handling in AIO doCheckCompleted

### DIFF
--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -138,7 +138,8 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
             ssize_t ret = aio_return(&io->aio_);
             if (ret < 0 || ret != static_cast<ssize_t>(io->aio_.aio_nbytes)) {
                 NIXL_ERROR << "aio_return failed: " << nixl_strerror(-ret);
-                ios_in_flight_.push_front(io);
+                ios_in_flight_.erase(it);
+                free_ios_.push_back(io);
                 return NIXL_ERR_BACKEND;
             }
             if (io->clb_) {
@@ -150,11 +151,10 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
             return NIXL_IN_PROG;
         } else {
             NIXL_ERROR << "aio_error failed: " << nixl_strerror(-status);
-            ios_in_flight_.push_front(io);
+            ios_in_flight_.erase(it);
+            free_ios_.push_back(io);
             return NIXL_ERR_BACKEND;
         }
-
-        it++;
 
         num_ios--;
         if (num_ios == 0) {


### PR DESCRIPTION
## What?

`nixlPosixIOQueueAIO::doCheckCompleted()` (`src/plugins/posix/posix_aio_io_queue.cpp`)
mishandled the `ios_in_flight_` list in two ways:

**1. Duplicate on the error paths.** The success path reclaims a completed I/O
with `it = ios_in_flight_.erase(it); free_ios_.push_back(io);`, but the two
*error* paths instead called `ios_in_flight_.push_front(io)` without first
erasing `io` (still `== *it`), inserting a second copy of the same pointer.

**2. Double iterator advance.** `it = ios_in_flight_.erase(it)` already returns
the next iterator, yet the loop did a second `it++` at the bottom — skipping one
in-flight I/O per completion, and incrementing a past-the-end iterator when the
erased element was the last one. (Thanks to the review for flagging this.)

This PR reclaims the failed slot on the error paths (erase + `free_ios_.push_back`,
matching the success path and the io_uring backend) and drops the redundant `it++`.

## Why?

The `nixlPosixIOQueue` is owned by `nixlPosixEngine` and reused across every
transfer. Bug 1's duplicate therefore persists: the same pool `Entry` is returned
to `free_ios_` twice and handed to two in-flight IOs that alias one `aiocb`/buffer
(a memory-safety hazard, not just a leak). Bug 2 silently drops completed IOs and
is undefined behaviour on the last element. POSIX-AIO is also the **default** queue
selected by `getDefaultIoQueueType()` when neither liburing nor libaio is present,
so this is the fallback path on stock systems.

### Reproduction

A self-contained reproducer replaying the exact `enqueue -> post -> doCheckCompleted`
list bookkeeping (`g++ -std=c++17 -fsanitize=address,undefined`):

```
[A] error path:             BEFORE in_flight 2->3, Entry #0 duplicated  | AFTER 2->1, no duplicate
[B] 2 successful completions: BEFORE processed 1/2 (one IO skipped)      | AFTER 2/2, none skipped
```

## How (verification)

- Compiled the modified plugin **in-tree** with `-Dsanitizer=address,undefined`
  (meson/ninja build of `posix_aio_io_queue.cpp.o`, exit 0).
- Confirmed both before/after behaviours with the reproducer above.

The `nixlPosixIOQueueAIO` class is local to the `.cpp` and the method is `private`,
so it isn't directly reachable from a GoogleTest without exposing internals. Happy
to add an integration test, or a small test seam to unit-test the queue, if you'd
prefer one.

## Related Issues

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for failed asynchronous I/O completions, ensuring errored requests are released correctly.
  * Prevents errored I/O entries from staying marked as in-flight, improving recovery and allowing resources to be reused more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->