### PR TITLE
POC/CI: run GPU tests on a pre-cluster via a generic trigger pipeline

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -1,12 +1,12 @@
 ---
 #
-# DLCluster GPU Test Matrix Configuration for dlcluster.nvidia.com
+# Pre-Cluster GPU Test Matrix Configuration
 #
 # Key Components:
 # - Job Configuration: Defines timeout, failure behavior, and server resources
 # - Docker Images: Specifies the container images used for different build stages
-# - Matrix Axes: Defines build variations for dlcluster testing (multi-node, multi-GPU)
-# - Run Steps: Sequential steps for running dlcluster GPU tests
+# - Matrix Axes: Defines build variations for pre-cluster testing (multi-node, multi-GPU)
+# - Run Steps: Sequential steps - build image, then trigger the pre-cluster pipeline and wait
 #
 # When Modified:
 # - Adding/removing Docker images: Affects available test environments
@@ -38,23 +38,20 @@ kubernetes:
 
 credentials:
   - {credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
+  - {credentialsId: 'lyris-trigger-token', type: string, variable: 'PRECLUSTER_TRIGGER_TOKEN'}
+  - {credentialsId: 'lyris-api-token', type: string, variable: 'PRECLUSTER_API_TOKEN'}
 
 env:
   ARTIFACTORY_PATH: /sw-nbu-swx-nixl-docker-local/ci
   NIXL_INSTALL_DIR: /opt/nixl
   NIXL_BUILD_DIR: nixl_build
-  SLURM_NODES: 1
-  SLURM_PARTITION: gb200nvl72_ci
-  SLURM_HEAD_NODE: dlcluster.nvidia.com
-  SLURM_HEAD_USER: svc-nixl
-  SLURM_ACCOUNT: 'oberon-gb-ci'
-  SLURM_JOB_TIMEOUT: '01:30:00'
-  SLURM_IMMEDIATE_TIMEOUT: 3600
-  SSH_CREDENTIALS_ID: 'svc-nixl-ssh_key'
-  JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
-  TEST_TIMEOUT: 50
+  TEST_TIMEOUT: 120
   STORAGE_DRIVER: overlay
   CI_IMAGE_TAG: "20260707-1"
+  # Target pre-cluster (GitLab runner tag) + its Slurm partition
+  PRECLUSTER: lyris
+  PRECLUSTER_PARTITION: gb200
+  PRECLUSTER_PIPELINE_REF: main
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}
@@ -110,104 +107,56 @@ steps:
       -f .ci/dockerfiles/Dockerfile.gpu-test .
       podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE}
 
-  - name: Allocate DL Environment
-    containerSelector: "{name: 'build_helper_dl'}"
-    parallel: false
-    shell: action
-    module: slurmCI
-    run: allocation
-    args:
-      partition: "${SLURM_PARTITION}"
-      headNode: "${SLURM_HEAD_NODE}"
-      headUser: "${SLURM_HEAD_USER}"
-      nodes: "${SLURM_NODES}"
-      jobTimeout: "${SLURM_JOB_TIMEOUT}"
-      immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
-      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
-      credentialsId: "${SSH_CREDENTIALS_ID}"
-      extraArgs: [
-        "--account=${SLURM_ACCOUNT}"
-      ]
-
-  - name: Run DL Python tests
+  # Runs all four tests in ONE pre-cluster allocation and downloads per-test
+  # results into ./results/. Gates on infra only (trigger_and_wait exits 90 on
+  # allocation/runner failure); per-test pass/fail is gated by the stages below.
+  - name: Run DL tests on pre-cluster
     containerSelector: "{name: 'build_helper_dl'}"
     timeout: "${TEST_TIMEOUT}"
     parallel: false
-    shell: action
-    module: slurmCI
-    run: run
-    args:
-      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
-      testScript: ".gitlab/test_python.sh ${NIXL_INSTALL_DIR}"
-      headNode: "${SLURM_HEAD_NODE}"
-      headUser: "${SLURM_HEAD_USER}"
-      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}"
-      credentialsId: "${SSH_CREDENTIALS_ID}"
-      containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+    credentialsId: ['lyris-trigger-token', 'lyris-api-token']
+    run: |
+      set -x
+      # test-cmds: "name<TAB>command" per line; per-test env inlined as a prefix.
+      printf "python\t.gitlab/test_python.sh ${NIXL_INSTALL_DIR}\n" > tc.txt
+      printf "rust\t.gitlab/test_rust.sh ${NIXL_INSTALL_DIR}\n" >> tc.txt
+      printf "cpp\tUCX_IB_REG_METHODS=rcache .gitlab/test_cpp.sh ${NIXL_INSTALL_DIR}\n" >> tc.txt
+      printf "nixlbench\tHAS_GPU=false .gitlab/test_nixlbench.sh ${NIXL_INSTALL_DIR}\n" >> tc.txt
+      TRIGGER_TOKEN=${PRECLUSTER_TRIGGER_TOKEN} GITLAB_TOKEN=${PRECLUSTER_API_TOKEN} \
+      .ci/scripts/trigger_and_wait.sh \
+        --ref ${PRECLUSTER_PIPELINE_REF} \
+        --cluster ${PRECLUSTER} \
+        --partition ${PRECLUSTER_PARTITION} \
+        --image "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}" \
+        --test-cmds-file tc.txt \
+        --retries 2
 
-  - name: Run DL Rust tests
+  # Per-test result stages: surface each test's pass/fail from the single run
+  # above (they read ./results/<name>.rc, they do not re-run anything).
+  - name: Python
     containerSelector: "{name: 'build_helper_dl'}"
-    timeout: "${TEST_TIMEOUT}"
     parallel: false
-    shell: action
-    module: slurmCI
-    run: run
-    args:
-      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
-      testScript: ".gitlab/test_rust.sh ${NIXL_INSTALL_DIR}"
-      headNode: "${SLURM_HEAD_NODE}"
-      headUser: "${SLURM_HEAD_USER}"
-      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}"
-      credentialsId: "${SSH_CREDENTIALS_ID}"
-      containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+    run: |
+      cat results/python.log 2>/dev/null || true
+      exit "$(cat results/python.rc 2>/dev/null || echo 1)"
 
-  - name: Run DL CPP tests
+  - name: Rust
     containerSelector: "{name: 'build_helper_dl'}"
-    timeout: "${TEST_TIMEOUT}"
     parallel: false
-    shell: action
-    module: slurmCI
-    run: run
-    args:
-      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
-      testScript: ".gitlab/test_cpp.sh ${NIXL_INSTALL_DIR}"
-      headNode: "${SLURM_HEAD_NODE}"
-      headUser: "${SLURM_HEAD_USER}"
-      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}"
-      credentialsId: "${SSH_CREDENTIALS_ID}"
-      containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
-      slurmEnv: [
-        'UCX_IB_REG_METHODS=rcache'
-      ]
+    run: |
+      cat results/rust.log 2>/dev/null || true
+      exit "$(cat results/rust.rc 2>/dev/null || echo 1)"
 
-  - name: Run DL Nixlbench tests
+  - name: CPP
     containerSelector: "{name: 'build_helper_dl'}"
-    timeout: "${TEST_TIMEOUT}"
     parallel: false
-    shell: action
-    module: slurmCI
-    run: run
-    args:
-      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
-      testScript: ".gitlab/test_nixlbench.sh ${NIXL_INSTALL_DIR}"
-      headNode: "${SLURM_HEAD_NODE}"
-      headUser: "${SLURM_HEAD_USER}"
-      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}"
-      credentialsId: "${SSH_CREDENTIALS_ID}"
-      containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
-      slurmEnv: [
-        'HAS_GPU=false'
-      ]
+    run: |
+      cat results/cpp.log 2>/dev/null || true
+      exit "$(cat results/cpp.rc 2>/dev/null || echo 1)"
 
-pipeline_stop:
-  containerSelector: "{name: 'build_helper_dl'}"
-  parallel: false
-  shell: action
-  module: slurmCI
-  run: stopAllForBuild
-  args:
-    credentialsId: "${SSH_CREDENTIALS_ID}"
-    headNode: "${SLURM_HEAD_NODE}"
-    headUser: "${SLURM_HEAD_USER}"
-    jobIdDir: "${JOB_ID_FILE_ROOT}"
+  - name: Nixlbench
+    containerSelector: "{name: 'build_helper_dl'}"
+    parallel: false
+    run: |
+      cat results/nixlbench.log 2>/dev/null || true
+      exit "$(cat results/nixlbench.rc 2>/dev/null || echo 1)"

--- a/.ci/scripts/trigger_and_wait.sh
+++ b/.ci/scripts/trigger_and_wait.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Trigger the generic `slurm-exec` pipeline, wait for it, and fetch its results.
+#
+# Usage:
+#   TRIGGER_TOKEN=... GITLAB_TOKEN=... \
+#   trigger_and_wait.sh --ref <branch> --partition <partition> \
+#                       --image <pyxis-image> --test-cmds-file <file> \
+#                       [--cluster <runner-tag>] [--allow-fail "<names>"] [--retries N]
+#
+# --cluster selects the target pre-cluster by GitLab runner tag (default: lyris).
+#
+# Downloads the job artifacts into ./results/ (per-test <name>.rc / <name>.log,
+# summary.txt, junit.xml). Exit code: 0 = pipeline ran (read ./results/ for
+# per-test pass/fail), 90 = infra failure (allocation/runner/queue) after
+# retries. Per-test gating is left to the caller (each test has its own .rc).
+set -uo pipefail
+
+PROJECT_API="https://gitlab-master.nvidia.com/api/v4/projects/231686"
+PROJECT_WEB="https://gitlab-master.nvidia.com/nbu-swx/ai/precluster-poc"
+POLL_INTERVAL=30
+
+# --- arguments ---
+ref=""; partition=""; image=""; test_cmds_file=""; allow_fail=""; retries=2
+cluster="lyris"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ref)            ref=$2;            shift 2 ;;
+    --cluster)        cluster=$2;        shift 2 ;;
+    --partition)      partition=$2;      shift 2 ;;
+    --image)          image=$2;          shift 2 ;;
+    --test-cmds-file) test_cmds_file=$2; shift 2 ;;
+    --allow-fail)     allow_fail=$2;     shift 2 ;;   # passed through to the pipeline (optional)
+    --retries)        retries=$2;        shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+: "${TRIGGER_TOKEN:?}" "${GITLAB_TOKEN:?}"
+: "${ref:?}" "${partition:?}" "${image:?}" "${test_cmds_file:?}"
+
+# GitLab API GET (path relative to the project), prints the response body.
+api_get() { curl -sS -H "PRIVATE-TOKEN: $GITLAB_TOKEN" "$PROJECT_API$1"; }
+# Extract one field from JSON on stdin, e.g. json_field "['status']".
+json_field() { python3 -c "import sys,json;print(json.load(sys.stdin)$1)"; }
+
+test_cmds_b64=$(base64 -w0 < "$test_cmds_file" 2>/dev/null || base64 < "$test_cmds_file" | tr -d '\n')
+
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+
+  # 1. trigger the pipeline with the test inputs as variables
+  trigger_resp=$(curl -sS -X POST \
+    -F "token=$TRIGGER_TOKEN" -F "ref=$ref" \
+    -F "variables[CLUSTER]=$cluster" \
+    -F "variables[PARTITION]=$partition" \
+    -F "variables[IMAGE]=$image" \
+    -F "variables[TEST_CMDS]=$test_cmds_b64" \
+    -F "variables[ALLOW_FAIL]=$allow_fail" \
+    "$PROJECT_API/trigger/pipeline")
+  pipeline_id=$(printf '%s' "$trigger_resp" | json_field "['id']" 2>/dev/null)
+  case "$pipeline_id" in
+    ''|*[!0-9]*)
+      echo "ERROR: pipeline trigger failed (bad token/ref?): $trigger_resp" >&2
+      exit 2 ;;
+  esac
+  echo "pipeline=$pipeline_id attempt=$attempt"
+  echo "GitLab pipeline: $PROJECT_WEB/-/pipelines/$pipeline_id"
+
+  # 2. poll until it reaches a terminal state
+  while :; do
+    status=$(api_get "/pipelines/$pipeline_id" | json_field "['status']")
+    case "$status" in success|failed|canceled|skipped) break ;; esac
+    sleep "$POLL_INTERVAL"
+  done
+
+  # 3. download the slurm-exec job artifacts (results/) - kept even on failure
+  job_id=$(api_get "/pipelines/$pipeline_id/jobs" \
+    | python3 -c "import sys,json;print(next(j['id'] for j in json.load(sys.stdin) if j['name']=='slurm-exec'))")
+  echo "GitLab slurm-exec job (full logs + artifacts): $PROJECT_WEB/-/jobs/$job_id"
+  rm -rf results results.zip
+  api_get "/jobs/$job_id/artifacts" > results.zip || true
+  python3 -c "import zipfile;zipfile.ZipFile('results.zip').extractall()" 2>/dev/null || true
+
+  # 4. classify: config error -> fail fast (retrying won't help); infra failure
+  # -> retry then give up (90); otherwise hand off to the caller
+  if grep -q '^CONFIG_ERROR' results/summary.txt 2>/dev/null; then
+    cat results/summary.txt >&2
+    echo "configuration error - not retrying" >&2
+    exit 2
+  fi
+  if [ "$status" = canceled ] || [ ! -f results/summary.txt ] \
+     || grep -q '^INFRA_FAILURE' results/summary.txt 2>/dev/null; then
+    if [ "$attempt" -le "$retries" ]; then echo "infra failure, retrying"; continue; fi
+    echo "infra failure after $retries retries"; exit 90
+  fi
+  cat results/summary.txt
+  exit 0
+done


### PR DESCRIPTION
## What?

Run the `nixl-ci-dl-gpu` GPU tests on an NVIDIA pre-cluster (Lyris by default) instead of dlcluster. Jenkins still owns the image build, the test matrix, and result reporting; only the GPU execution step changes.

## Why?

Pre-cluster onboarding forbids CI service accounts (personal credentials only), and the sanctioned execution path is a project runner on the cluster frontend - so the old `svc-nixl` SSH + `salloc`/`srun` model can't be lifted as-is.

## How?

- A new step triggers the generic `slurm-exec` GitLab pipeline (via vendored `.ci/scripts/trigger_and_wait.sh`), which runs all four tests in one allocation and reports back. The target cluster is a trigger variable (`PRECLUSTER`, default `lyris`) that maps to a GitLab runner tag, so pointing at another pre-cluster later is a config change, not a rewrite.
- Removed the dlcluster `salloc`/`srun`/`scancel` steps, the `svc-nixl` SSH credential, and the dlcluster `SLURM_*` env. Per-test env kept inline (cpp `UCX_IB_REG_METHODS=rcache`, nixlbench `HAS_GPU=false`).
- Logs flow back as GitLab job artifacts: `trigger_and_wait.sh` downloads `results/`, and the per-test Jenkins stages `cat` each `<name>.log` and gate on its `.rc` - plus a clickable GitLab pipeline/job link in the console.

## Status

- The execution pipeline lives in precluster-poc (GitLab MR !1, **merged to `main`**); this PR points `PRECLUSTER_PIPELINE_REF` at `main`.
- Validated end-to-end on Jenkins: Python / Rust / Nixlbench green. CPP is red pending the cluster loading `nvidia_peermem` (GPUDirect memory registration) - an environment gap, not a code issue.
