### PR TITLE
ci: stop non-etcd sanitizer stages from spawning the etcd/gRPC comm thread

### DIFF
--- a/.gitlab/test_sanitizer.sh
+++ b/.gitlab/test_sanitizer.sh
@@ -123,10 +123,25 @@ export UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:suppressions=${SAN_SUPP
 export TSAN_OPTIONS="halt_on_error=1:suppressions=${SAN_SUPP_DIR}/tsan.supp"
 export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 cd "${INSTALL_DIR}"
+# etcd-dependent stages run first, while start_etcd_server's NIXL_ETCD_ENDPOINTS
+# is still exported. A nixlAgent auto-starts an etcd comm thread whenever that var
+# is set (detectEtcd() in nixl_agent.cpp); that thread opens a gRPC channel whose
+# WorkStealingThreadPool calls pthread_create, which flakily trips the GCC 13.3
+# libsanitizer thread-registry CHECK (the same toolchain bug gusli /
+# MetadataExchange are excluded for). nixl_etcd_example is the only install-dir
+# binary that needs etcd, so run it here, then drop the var.
+run_stage "nixl_etcd_example" ./bin/nixl_etcd_example
+
+# No remaining test needs etcd. Unset the endpoints so no agent starts the
+# etcd/gRPC comm thread: this is what makes nixl_posix_test (a local file backend
+# with no metadata exchange) and the other single-process binaries deterministic
+# under the sanitizers, instead of flakily aborting inside libsanitizer's
+# pthread_create interceptor.
+unset NIXL_ETCD_ENDPOINTS NIXL_ETCD_NAMESPACE NIXL_ETCD_PEER_URLS
+
 run_stage "desc_example" ./bin/desc_example
 run_stage "agent_example" ./bin/agent_example
 run_stage "nixl_example" ./bin/nixl_example
-run_stage "nixl_etcd_example" ./bin/nixl_etcd_example
 run_stage "ucx_backend_test" ./bin/ucx_backend_test
 run_stage "nixl_posix_test" ./bin/nixl_posix_test -n 128 -s 1048576
 # nixl_gusli_test is excluded from the sanitizer run entirely: under TSan it


### PR DESCRIPTION
## Summary

`nixl_posix_test` (and other single-process install-dir binaries) failed **flakily** under the ASan/UBSan sanitizer pipeline, aborting with no useful output on the teed logs. This fixes it without dropping any coverage by stopping those binaries from opening an unnecessary etcd/gRPC connection under the sanitizers.

## Root cause

The failure is the **GCC 13.3 libsanitizer thread-registry bug** — the same toolchain issue `nixl_gusli_test` and `MetadataExchangeTestFixture` are already excluded for — but the *trigger* was incidental:

1. `start_etcd_server` (run for the gtest metadata-exchange tests) `export`s `NIXL_ETCD_ENDPOINTS` for the **rest of the script**.
2. `detectEtcd()` (`nixl_agent.cpp`) makes **every** `nixlAgent` start an etcd comm thread whenever that var is set.
3. That thread opens a gRPC channel whose `WorkStealingThreadPool` calls `pthread_create`, which flakily trips the libsanitizer CHECK.

A POSIX **local file-backend** test has no need for metadata exchange — the etcd connection was purely a side effect of the leaked env var.

Captured backtrace (via a temporary diagnostic that wrote sanitizer reports to files):

```
AddressSanitizer: CHECK failed: sanitizer_thread_registry.cpp:161
  #5  pthread_create (asan interceptor)
  #6  grpc_core::Thread::Thread
  #7  grpc ... WorkStealingThreadPool::StartThread
  #19 grpc_channel_create
  #22 etcd::detail::create_grpc_channel
  #23 etcd::SyncClient::SyncClient
  #25 nixlEtcdClient                       (nixl_listener.cpp:222)
  #27 nixlAgentData::commWorkerInternal     (nixl_listener.cpp:464)
  #28 nixlAgentData::commWorker             (nixl_listener.cpp:451)
```

Across a single 20-iteration diagnostic run the per-iteration exit codes were ~45% crashes (`rc=134` SIGABRT / `rc=139` SIGSEGV), the rest clean — consistent with a flaky toolchain race, not a NIXL bug.

## Fix

- Run the only etcd-dependent install-dir binary (`nixl_etcd_example`) **first**, while the endpoints are still set.
- `unset NIXL_ETCD_ENDPOINTS NIXL_ETCD_NAMESPACE NIXL_ETCD_PEER_URLS` before the remaining single-process binaries.

With no endpoints set, those agents never start the comm thread, so they never reach the libsanitizer `pthread_create` path — making the stages **deterministic** while keeping full coverage (nothing is excluded; `nixl_posix_test` still runs its complete `-n 128 -s 1048576` suite).

## Notes

- `nixl_etcd_example` genuinely needs gRPC threads, so it remains the one stage still exposed to the same toolchain bug (it's the standalone equivalent of the already-excluded `MetadataExchange`). It's isolated up front now; if it proves flaky it can be excluded the same way.
- No product code changes — CI script only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the sanitizer test sequence to run the etcd-backed example earlier in the workflow.
  * Prevented leftover etcd-related settings from affecting later test steps, improving test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->