### PR TITLE
test/mooncake: fix -Werror build failures in mooncake_backend_test

### DIFF
--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -153,6 +153,7 @@ memType2Str(nixl_mem_t mem_type) {
     default:
         std::cout << "Unsupported memory type!" << std::endl;
         assert(0);
+        return std::string("UNKNOWN");
     }
 }
 
@@ -267,6 +268,7 @@ getValidationPtr(nixl_mem_t mem_type, void *addr, size_t len) {
     default:
         std::cout << "Unsupported memory type!" << std::endl;
         assert(0);
+        return nullptr;
     }
 }
 
@@ -293,12 +295,13 @@ allocateWrongGPUTest(nixlBackendEngine *mooncake, int dev_id) {
     nixlBackendMD *md;
     void *buf;
 
+    desc.len = 1 * 1024 * 1024;
     allocateBuffer(VRAM_SEG, dev_id, desc.len, buf);
 
     desc.devId = dev_id;
     desc.addr = (uint64_t)buf;
 
-    int ret = mooncake->registerMem(desc, VRAM_SEG, md);
+    [[maybe_unused]] int ret = mooncake->registerMem(desc, VRAM_SEG, md);
 
     assert(ret == NIXL_ERR_NOT_SUPPORTED);
 
@@ -320,7 +323,7 @@ allocateAndRegister(nixlBackendEngine *mooncake,
     desc.len = len;
     desc.devId = dev_id;
 
-    int ret = mooncake->registerMem(desc, mem_type, md);
+    [[maybe_unused]] int ret = mooncake->registerMem(desc, mem_type, md);
 
     assert(ret == NIXL_SUCCESS);
 }
@@ -354,7 +357,7 @@ loadRemote(nixlBackendEngine *mooncake,
     // assert(info.metaInfo.size() > 0);
 
     // We get the data from the cetnral location and populate the backend, and receive remote_meta
-    int ret = mooncake->loadRemoteMD(info, mem_type, agent, rmd);
+    [[maybe_unused]] int ret = mooncake->loadRemoteMD(info, mem_type, agent, rmd);
     assert(NIXL_SUCCESS == ret);
 }
 
@@ -493,7 +496,7 @@ test_intra_agent_transfer(bool p_thread, nixlBackendEngine *mooncake, nixl_mem_t
     std::cout << std::endl << std::endl;
 
     std::string agent1("Agent1");
-    nixl_status_t ret1;
+    [[maybe_unused]] nixl_status_t ret1;
 
     int iter = 10;
 
@@ -576,7 +579,7 @@ test_inter_agent_transfer(bool p_thread,
                           nixlBackendEngine *mooncake2,
                           nixl_mem_t dst_mem_type,
                           int dst_dev_id) {
-    int ret;
+    [[maybe_unused]] int ret;
     int iter = 10;
 
     std::cout << std::endl << std::endl;
@@ -616,7 +619,7 @@ test_inter_agent_transfer(bool p_thread,
     int ret_gen = 0;
     notif_list_t target_notif_gen;
     while (ret_gen == 0) {
-        int ret3_gen = mooncake2->getNotifs(target_notif_gen);
+        [[maybe_unused]] int ret3_gen = mooncake2->getNotifs(target_notif_gen);
         ret_gen = target_notif_gen.size();
         assert(ret3_gen == NIXL_SUCCESS);
     }


### PR DESCRIPTION
## Problem

`mooncake_backend_test.cpp` no longer compiles under the release CI flags (`-O3 -DNDEBUG -Werror`), which breaks **`nixl-ci-gpu`**, **`nixl-ci-non-gpu`** and **`nixl-ci-dl-gpu`** on every PR (the `non-gpu`/`dl-gpu` failures surface via the editable `pip install` that recompiles the C++ tree).

`-DNDEBUG` strips `assert()`, so:
- status locals that are only read by `assert()` become *unused* (`-Werror=unused-variable` / `-Werror=unused-but-set-variable`);
- the two `switch` statements whose `default` ends in `assert(0)` fall off the end of a non-void function (`-Werror=return-type`);
- `allocateWrongGPUTest()` passes an uninitialized `desc.len` to `allocateBuffer()` (`-Werror=uninitialized`).

The test file is unchanged since Aug 2025 — a recent CI base-image/compiler bump turned these long-standing warnings into hard errors.

```
mooncake_backend_test.cpp:301: error: unused variable 'ret' [-Werror=unused-variable]
mooncake_backend_test.cpp:154: error: control reaches end of non-void function [-Werror=return-type]
mooncake_backend_test.cpp:296: error: 'desc...len' is used uninitialized [-Werror=uninitialized]
... (and similar at 323, 357, 496, 579, 619, 268)
```

## Fix
- Mark assert-only locals `[[maybe_unused]]` (`ret`, `ret1`, `ret3_gen`).
- Return a fallback after `assert(0)` in `memType2Str()` and `getValidationPtr()` so the non-void paths are covered under `NDEBUG`.
- Initialize `desc.len` before `allocateBuffer()` in `allocateWrongGPUTest()`.

No behavioral change in debug builds; release builds now compile clean.

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compiler “unused variable” warnings in Mooncake backend unit tests by marking test-only variables as intentionally unused.
  * Improved robustness in unsupported memory-type test helpers by adding explicit fallback return values after existing assertions.
  * Updated the test source header copyright year range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->