### PR TITLE
ci: add native GitHub Actions pipeline + nSpect/scan GitLab trigger

### DIFF
--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -139,12 +139,20 @@ steps:
       set -x
       export NPROC=$NPROC
       export GRPC_NPROC=$GRPC_NPROC
+      # --cuda-version matches BASE_TAG (13.0-devel-manylinux); it drives the cu13 torch
+      # index and meta-wheel split in Dockerfile.manylinux.
+      # --no-infinia: this blossom runner authenticates only to artifactory.nvidia.com and
+      # cannot pull the private INFINIA libs image, so build the wheel without the INFINIA
+      # plugin (all other plugins are unaffected). The GHA pipeline (.github/workflows/ci.yml)
+      # builds bundled INFINIA via its ECR login; this Jenkins path does not.
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
+        --cuda-version 13.0 \
         --wheel-base "manylinux_${manylinux}" \
         --python-versions "${python_version}" \
         --arch ${arch} \
+        --no-infinia \
         --dockerfile contrib/Dockerfile.manylinux
 
 # =============================================================================

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,12 @@
+# Self-hosted runner labels used by this repo's workflows so actionlint does
+# not flag them as unknown. The prod-nixl-*/stg-nixl-* runners are velonix ARC
+# runner scale sets (see velonix flux-apps/.../runner-scale-sets/nixl).
+self-hosted-runner:
+  labels:
+    - gitlab
+    - blossom
+    - prod-nixl-builder-amd-v1
+    - prod-nixl-builder-arm-v1
+    - prod-nixl-tester-gpu-v1
+    - stg-nixl-builder-amd-v1
+    - stg-nixl-builder-arm-v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,447 @@
+name: NIXL CI
+
+# Native GitHub Actions replacement for the GitLab pipeline that previously ran
+# in nixl-ci (.gitlab-ci.yml). Builds run on self-hosted velonix ARC runners
+# (prod-nixl-builder-amd-v1 / prod-nixl-builder-arm-v1), which provide an
+# in-pod Docker daemon (dind sidecar), so the build/test docker commands below
+# work just as they did under GitLab.
+#
+# Repository configuration required (Settings -> Secrets and variables -> Actions):
+#   Variables:
+#     NIXL_ECR_IMAGE        - ECR image base, e.g.
+#                             210086341041.dkr.ecr.us-west-2.amazonaws.com/nixl-ci
+#     ENABLE_GPU_CI         - set to "true" to enable the (currently deferred)
+#                             GPU test/verify jobs once GPU runners exist.
+#   Secrets:
+#     GITLAB_REGISTRY_USER  - user for gitlab-master.nvidia.com:5005 (manylinux
+#     GITLAB_REGISTRY_TOKEN   base images + wheeltamer scan image)
+#     ARTIFACTORY_URL       - JFrog Artifactory base URL (release uploads)
+#     ARTIFACTORY_PYPI_TOKEN
+#     ARTIFACTORY_CARGO_TOKEN
+#   (The runtime-container push reuses ARTIFACTORY_URL + ARTIFACTORY_PYPI_TOKEN — same
+#    sw-dynamo project as the wheel upload — with docker login as user 'nmailhot'.)
+# AWS/ECR push auth comes from the runner pod's IRSA service account, not a secret.
+
+on:
+  pull_request:
+  push:
+    branches: [main, 'release/**']
+  workflow_dispatch:
+    inputs:
+      release_build:
+        description: "Build/publish release artifacts (maps to GitLab RELEASE_BUILD)"
+        type: boolean
+        default: false
+      security_scan:
+        description: "Run the wheel security scan (maps to GitLab SECURITY_SCAN)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref. PRs cancel-in-progress (latest push
+# wins); release/** + main pushes do NOT cancel, so an in-flight RC upload isn't
+# interrupted mid-publish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  AWS_REGION: us-west-2
+  REPO_NAME: nixl
+  WHL_PYTHON_VERSIONS: "3.10,3.11,3.12,3.13,3.14"
+  IMAGE_BASE: ${{ vars.NIXL_ECR_IMAGE }}
+  # Release flag, normalized to a plain "true"/"false" string usable in shells.
+  # True on a push to a release/** branch (e.g. a PR merged into release/1.3.0 triggers
+  # RC generation on the merge commit) or an explicit workflow_dispatch release_build.
+  RELEASE_BUILD: ${{ github.event.inputs.release_build == true || github.event.inputs.release_build == 'true' || startsWith(github.ref, 'refs/heads/release/') }}
+
+jobs:
+  # ----------------------------------------------------------------------------
+  # version: replicate the GitLab before_script version computation.
+  # ----------------------------------------------------------------------------
+  version:
+    # Don't run fork-PR code on the self-hosted IRSA-backed builders (they have ECR write
+    # access and this workflow publishes). Allow push/dispatch + same-repo (collaborator)
+    # PRs; skip pull_requests from forks. build/uploads inherit this via `needs`. (CodeRabbit.)
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-amd-v1
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Compute version
+        id: compute
+        run: |
+          set -e
+          git fetch --tags --force || true
+          RELEASE_TAG=$(git tag --sort=-v:refname | head -n 1 | sed 's/^v//' | tr -d '\n')
+          if [ -z "$RELEASE_TAG" ]; then RELEASE_TAG="0.0.1"; fi
+          if [ "${RELEASE_BUILD}" != "true" ]; then
+            BASE_VERSION=$(echo "$RELEASE_TAG" | awk -F. '{$NF = $NF + 1;} 1' OFS=.)
+            VERSION="${BASE_VERSION}.dev${{ github.run_id }}+$(git rev-parse --short HEAD)"
+          else
+            # Use the static package version (pyproject.toml), NOT the latest git tag.
+            # Leftover/RC tags (e.g. v1.3.0-rc2) must not override the real release
+            # version, and VERSION must match the wheel + Artifactory upload path.
+            VERSION=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')
+            # Fail fast if a release/<x.y.z> branch disagrees with pyproject — otherwise the
+            # wrong version would flow into the wheels, Artifactory paths, and nSpect register.
+            case "${GITHUB_REF_NAME}" in
+              release/*)
+                BRANCH_VER="${GITHUB_REF_NAME#release/}"
+                case "${VERSION}" in
+                  "${BRANCH_VER}"*) : ;;
+                  *) echo "::error::pyproject version '${VERSION}' does not match release branch '${BRANCH_VER}'"; exit 1 ;;
+                esac
+                ;;
+            esac
+          fi
+          echo -n "$VERSION" > version.txt
+          echo "Computed VERSION=$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: version
+          path: version.txt
+          retention-days: 1
+
+  # ----------------------------------------------------------------------------
+  # build: five container builds (the GitLab build stage), pushed to ECR with a
+  # unique per-variant tag; dist/ extracted and uploaded as an artifact.
+  # ----------------------------------------------------------------------------
+  build:
+    needs: version
+    # Same fork-PR guard as `version` (explicit; not just inherited via needs).
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-${{ matrix.runner }}-v1
+    timeout-minutes: 120  # ARM manylinux builds everything from source (~60min); was timing out at the push step
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: build-nixl
+            dockerfile: contrib/Dockerfile
+            base_image: nvcr.io/nvidia/cuda-dl-base
+            base_image_tag: 25.06-cuda12.9-devel-ubuntu24.04
+            whl_base: manylinux_2_39
+            cuda_version: "12.9"
+            arch: x86_64
+            runner: amd
+          # Option B: manylinux jobs build on the public PyPA manylinux_2_28 base
+          # (Dockerfile.manylinux) and pull CUDA from a public NGC image — no GitLab.
+          # VERIFY the nvcr.io/nvidia/cuda el8/ubi8 devel tags below actually exist.
+          - name: build-nixl-manylinux
+            dockerfile: contrib/Dockerfile.manylinux
+            base_image: nvcr.io/nvidia/cuda
+            base_image_tag: 12.9.1-devel-ubi8
+            whl_base: manylinux_2_28
+            cuda_version: "12.9"
+            arch: x86_64
+            runner: amd
+          - name: build-nixl-manylinux-cuda13
+            dockerfile: contrib/Dockerfile.manylinux
+            base_image: nvcr.io/nvidia/cuda
+            base_image_tag: 13.0.1-devel-ubi8
+            whl_base: manylinux_2_28
+            cuda_version: "13.0"
+            arch: x86_64
+            runner: amd
+          - name: build-nixl-arm-manylinux
+            dockerfile: contrib/Dockerfile.manylinux
+            base_image: nvcr.io/nvidia/cuda
+            base_image_tag: 12.9.1-devel-ubi8
+            whl_base: manylinux_2_28
+            cuda_version: "12.9"
+            arch: aarch64
+            runner: arm
+          - name: build-nixl-arm-manylinux-cuda13
+            dockerfile: contrib/Dockerfile.manylinux
+            base_image: nvcr.io/nvidia/cuda
+            base_image_tag: 13.0.1-devel-ubi8
+            whl_base: manylinux_2_28
+            cuda_version: "13.0"
+            arch: aarch64
+            runner: arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Log in to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Build and push image
+        run: |
+          set -e
+          IMAGE_NAME="${IMAGE_BASE}:${{ matrix.name }}-${{ github.sha }}-${{ github.run_id }}"
+          echo "IMAGE_NAME=$IMAGE_NAME" >> "$GITHUB_ENV"
+          chmod +x contrib/build-container.sh
+          bash contrib/build-container.sh \
+            --base-image "${{ matrix.base_image }}" \
+            --base-image-tag "${{ matrix.base_image_tag }}" \
+            --cuda-version "${{ matrix.cuda_version }}" \
+            --wheel-base "${{ matrix.whl_base }}" \
+            --python-versions "${WHL_PYTHON_VERSIONS}" \
+            --tag "${IMAGE_NAME}" \
+            --os "ubuntu24" \
+            --arch "${{ matrix.arch }}" \
+            --dockerfile "${{ matrix.dockerfile }}"
+          docker push "$IMAGE_NAME"
+      - name: Extract build artifacts
+        run: |
+          set -e
+          CN="nixl-extract-${{ github.run_id }}-${{ strategy.job-index }}"
+          docker rm -f "$CN" || true
+          docker create --name "$CN" "$IMAGE_NAME"
+          # Don't mask a build that produced no wheels: fail if dist is absent/empty.
+          docker cp "$CN:/workspace/nixl/dist" ./dist
+          docker cp "$CN:/usr/local/nixl" ./nixl_install || true
+          docker rm -f "$CN" || true
+          ls dist/*.whl >/dev/null 2>&1 || { echo "ERROR: no wheels in dist/"; exit 1; }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.name }}
+          path: dist
+          retention-days: 1
+          if-no-files-found: error
+
+  # ----------------------------------------------------------------------------
+  # upload: GitLab upload stage. Release-only. Wheels -> Artifactory (JFrog CLI),
+  # crates -> Artifactory cargo registry (manual approval via environment).
+  # ----------------------------------------------------------------------------
+  upload-x86-wheels:
+    needs: build
+    if: ${{ github.event.inputs.release_build == 'true' || startsWith(github.ref, 'refs/heads/release/') }}
+    environment: release   # manual-approval gate before publishing to Artifactory
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-amd-v1
+    timeout-minutes: 30
+    env:
+      ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+      ARTIFACTORY_PYPI_TOKEN: ${{ secrets.ARTIFACTORY_PYPI_TOKEN }}
+      ARCH: x86_64
+    steps:
+      - name: Download x86 wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-build-nixl-manylinux*
+          path: dist
+          merge-multiple: true
+      - name: Upload wheels to Artifactory
+        run: |
+          set -e
+          cd dist
+          ls -la *.whl
+          WHEEL_VERSION=$(ls nixl*.whl | head -n 1 | cut -d'-' -f2)
+          CN="upload_nixl_build_${{ github.run_id }}"
+          docker rm -f "$CN" || true
+          docker create --name "$CN" -w /workspace -e CI=true -e JFROG_CLI_LOG_LEVEL=INFO \
+            -e ARTIFACTORY_PYPI_TOKEN -e ARTIFACTORY_URL \
+            releases-docker.jfrog.io/jfrog/jfrog-cli-v2-jf bash -c "
+              TARGET_PROPS=\"CI_PIPELINE_ID=${{ github.run_id }};component_name=nixl;os=linux;arch=${ARCH};version=${WHEEL_VERSION}\" &&
+              jf rt upload '*.whl' 'sw-dynamo-nixl-pypi-local/release/${WHEEL_VERSION}/${{ github.run_id }}/${ARCH}/' \
+                --target-props=\"\$TARGET_PROPS\" \
+                --access-token \"\$ARTIFACTORY_PYPI_TOKEN\" --url \"\$ARTIFACTORY_URL\" \
+                --flat --fail-no-op=true --detailed-summary
+            "
+          docker cp . "$CN:/workspace/"
+          docker start -a "$CN"
+      - name: Cleanup
+        if: always()
+        run: docker rm -f "upload_nixl_build_${{ github.run_id }}" || true
+
+  upload-arm-wheels:
+    needs: build
+    if: ${{ github.event.inputs.release_build == 'true' || startsWith(github.ref, 'refs/heads/release/') }}
+    environment: release   # manual-approval gate before publishing to Artifactory
+    # amd runner: the jfrog-cli-v2-jf image is amd64-only. This job only uploads the
+    # already-built arm wheel files (downloaded as artifacts), so the host arch is irrelevant.
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-amd-v1
+    timeout-minutes: 30
+    env:
+      ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+      ARTIFACTORY_PYPI_TOKEN: ${{ secrets.ARTIFACTORY_PYPI_TOKEN }}
+      ARCH: aarch64
+    steps:
+      - name: Download arm wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dist-build-nixl-arm-manylinux*
+          path: dist
+          merge-multiple: true
+      - name: Upload wheels to Artifactory
+        run: |
+          set -e
+          cd dist
+          ls -la *.whl
+          WHEEL_VERSION=$(ls nixl*.whl | head -n 1 | cut -d'-' -f2)
+          CN="upload_arm_nixl_build_${{ github.run_id }}"
+          docker rm -f "$CN" || true
+          docker create --name "$CN" -w /workspace -e CI=true -e JFROG_CLI_LOG_LEVEL=INFO \
+            -e ARTIFACTORY_PYPI_TOKEN -e ARTIFACTORY_URL \
+            releases-docker.jfrog.io/jfrog/jfrog-cli-v2-jf bash -c "
+              TARGET_PROPS=\"CI_PIPELINE_ID=${{ github.run_id }};component_name=nixl;os=linux;arch=${ARCH};version=${WHEEL_VERSION}\" &&
+              jf rt upload '*.whl' 'sw-dynamo-nixl-pypi-local/release/${WHEEL_VERSION}/${{ github.run_id }}/${ARCH}/' \
+                --target-props=\"\$TARGET_PROPS\" \
+                --access-token \"\$ARTIFACTORY_PYPI_TOKEN\" --url \"\$ARTIFACTORY_URL\" \
+                --flat --fail-no-op=true --detailed-summary
+            "
+          docker cp . "$CN:/workspace/"
+          docker start -a "$CN"
+      - name: Cleanup
+        if: always()
+        run: docker rm -f "upload_arm_nixl_build_${{ github.run_id }}" || true
+
+  upload-crates:
+    needs: build
+    # GitLab marked this job `when: manual` on release builds. The `release`
+    # environment provides the equivalent manual approval gate (configure
+    # required reviewers under Settings -> Environments -> release).
+    if: ${{ github.event.inputs.release_build == 'true' || startsWith(github.ref, 'refs/heads/release/') }}
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-amd-v1
+    environment: release
+    env:
+      ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+      ARTIFACTORY_CARGO_TOKEN: ${{ secrets.ARTIFACTORY_CARGO_TOKEN }}
+    steps:
+      - name: Log in to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Publish crates to Artifactory
+        run: |
+          set -e
+          IMAGE_NAME="${IMAGE_BASE}:build-nixl-${{ github.sha }}-${{ github.run_id }}"
+          docker run -e ARTIFACTORY_CARGO_TOKEN -e ARTIFACTORY_URL \
+            -e CI_PIPELINE_ID="${{ github.run_id }}" "$IMAGE_NAME" /bin/bash -c "set -e &&
+            grep '^version = ' Cargo.toml &&
+            sed -i -E 's/^(version = \"([^\"]+)\")/version = \"\2-rc.${{ github.run_id }}\"/' Cargo.toml &&
+            grep '^version = ' Cargo.toml &&
+            cargo check --manifest-path src/bindings/rust/Cargo.toml &&
+            cargo publish --manifest-path src/bindings/rust/Cargo.toml \
+              --token \"Bearer \$ARTIFACTORY_CARGO_TOKEN\" \
+              --index \"sparse+\$ARTIFACTORY_URL/api/cargo/sw-dynamo-nixl-cargo-local/index/\" \
+              --no-verify --allow-dirty"
+
+  # ----------------------------------------------------------------------------
+  # push-container: release-gated runtime-container push to Artifactory. A SEPARATE
+  # job (not the ungated `build`) so it sits behind the manual-approval `release`
+  # environment like the wheel/crate uploads — nothing publishes before approval.
+  # Pulls the already-built build-nixl image from ECR and retags it.
+  # ----------------------------------------------------------------------------
+  push-container:
+    needs: [version, build]
+    if: ${{ github.event.inputs.release_build == 'true' || startsWith(github.ref, 'refs/heads/release/') }}
+    runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-amd-v1
+    environment: release
+    timeout-minutes: 30
+    env:
+      # Prefer Docker-scoped service-account creds; fall back to the shared sw-dynamo creds
+      # (ARTIFACTORY_DOCKER_USERNAME var / ARTIFACTORY_DOCKER_TOKEN secret when configured).
+      ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+      ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_DOCKER_TOKEN || secrets.ARTIFACTORY_PYPI_TOKEN }}
+      AF_USERNAME: ${{ vars.ARTIFACTORY_DOCKER_USERNAME || 'nmailhot' }}
+      AF_REPO: sw-dynamo-nixl-docker-local
+      UCX_REF: v1.21.x
+      # build-nixl runtime-container variant (matches that build-matrix entry).
+      BASE_IMAGE_TAG: 25.06-cuda12.9-devel-ubuntu24.04
+      ARCH: x86_64
+      RELEASE_VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Log in to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Retag the build-nixl image from ECR and push to Artifactory
+        run: |
+          set -e
+          ECR_IMAGE="${IMAGE_BASE}:build-nixl-${GITHUB_SHA}-${GITHUB_RUN_ID}"
+          docker pull "$ECR_IMAGE"
+          # 8-char nixl + UCX commit SHAs (matches the Jenkins tag scheme).
+          NIXL_SHA="$(git rev-parse --short=8 HEAD)"
+          if [[ "$UCX_REF" =~ ^[a-f0-9]{8,40}$ ]]; then
+            UCX_SHA="${UCX_REF:0:8}"
+          else
+            UCX_SHA="$(git ls-remote https://github.com/openucx/ucx.git "$UCX_REF" | head -n1 | cut -c1-8)"
+          fi
+          [ -n "$UCX_SHA" ] || { echo "ERROR: could not resolve UCX_REF=$UCX_REF"; exit 1; }
+          SUFFIX="${RELEASE_VERSION:+-v${RELEASE_VERSION}}"
+          TAG="${BASE_IMAGE_TAG}-nixl-${NIXL_SHA}-ucx-${UCX_SHA}-${ARCH}${SUFFIX}"
+          AF_HOST="$(printf '%s' "$ARTIFACTORY_URL" | sed -E 's#^https?://##; s#/.*##')"
+          AF_IMAGE="${AF_HOST}/${AF_REPO}/nixl:${TAG}"
+          echo "$ARTIFACTORY_TOKEN" | docker login "$AF_HOST" -u "$AF_USERNAME" --password-stdin
+          # Drop the registry creds from the runner's docker config on exit (CodeRabbit).
+          trap 'docker logout "$AF_HOST" >/dev/null 2>&1 || true' EXIT
+          docker tag "$ECR_IMAGE" "$AF_IMAGE"
+          docker push "$AF_IMAGE"
+          # Set item properties (parity with the Jenkins push step); non-fatal.
+          PROPS="component_name=nixl;NIXL_VERSION=${NIXL_SHA};UCX_VERSION=${UCX_SHA};arch=${ARCH};BASE_IMAGE_TAG=${BASE_IMAGE_TAG};version=${RELEASE_VERSION}"
+          curl -fsSL -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" -X PUT \
+            "${ARTIFACTORY_URL}/api/storage/${AF_REPO}/nixl/${TAG}?properties=${PROPS}" \
+            || echo "WARN: failed to set Artifactory properties (non-fatal)"
+
+  # ----------------------------------------------------------------------------
+  # trigger-gitlab-nspect: on a push to a release/** branch (i.e. a PR merged into
+  # release/<x.y.z>), kick the nixl-ci GitLab pipeline to run the wheel security
+  # scan + nSpect registration against the wheels just uploaded to Artifactory.
+  # nSpect tooling/creds live GitLab-side, so this is a thin trigger. It runs on
+  # the gitlab_ci_runners group (the only runners that can reach gitlab-master).
+  # Required secrets (release environment): GITLAB_NIXL_PIPELINE_URL,
+  # GITLAB_NIXL_TRIGGER_TOKEN. Repo var NIXL_CI_REF picks the nixl-ci branch to
+  # trigger (defaults to main).
+  # ----------------------------------------------------------------------------
+  trigger-gitlab-nspect:
+    needs: [version, upload-x86-wheels, upload-arm-wheels]
+    if: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+    runs-on:
+      group: gitlab_ci_runners
+    environment: release
+    env:
+      GITLAB_TRIGGER_URL: ${{ secrets.GITLAB_NIXL_PIPELINE_URL }}
+      GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_NIXL_TRIGGER_TOKEN }}
+      NSPECT_ID: NSPECT-WO64-8O3P
+      NIXL_CI_REF: ${{ vars.NIXL_CI_REF || 'main' }}
+      WHEEL_VERSION: ${{ needs.version.outputs.version }}
+      # security_scan dispatch input gates the wheel scan; defaults true on release/** pushes.
+      ENABLE_WHEEL_SCAN: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.security_scan == 'true' }}
+    steps:
+      - name: Trigger nixl-ci nSpect + scan pipeline
+        run: |
+          set -euo pipefail
+          # Trigger token via @file so it never lands in process listings / set -x.
+          TOKEN_FILE=$(mktemp); trap 'rm -f "${TOKEN_FILE}"' EXIT; chmod 600 "${TOKEN_FILE}"
+          printf '%s' "${GITLAB_TRIGGER_TOKEN}" > "${TOKEN_FILE}"
+          RESPONSE=$(curl -fsSL --request POST \
+            --form "token=<${TOKEN_FILE}" \
+            --form "ref=${NIXL_CI_REF}" \
+            --form "variables[PIPELINE_TYPE]=rc" \
+            --form "variables[DRY_RUN]=false" \
+            --form "variables[NSPECT_ID]=${NSPECT_ID}" \
+            --form "variables[NSPECT_RELEASE_VERSION]=${WHEEL_VERSION}" \
+            --form "variables[NSPECT_REGISTERED]=false" \
+            --form "variables[WHEEL_VERSION]=${WHEEL_VERSION}" \
+            --form "variables[RC_TAG]=${GITHUB_REF_NAME}" \
+            --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}" \
+            --form "variables[COMMIT_SHA]=${GITHUB_SHA}" \
+            --form "variables[ENABLE_WHEEL_SCAN]=${ENABLE_WHEEL_SCAN}" \
+            "${GITLAB_TRIGGER_URL}")
+          PIPELINE_ID=$(echo "${RESPONSE}" | jq -r '.id // empty')
+          PIPELINE_URL=$(echo "${RESPONSE}" | jq -r '.web_url // empty')
+          if [ -z "${PIPELINE_ID}" ]; then
+            echo "::error::Failed to trigger nixl-ci GitLab pipeline"
+            echo "Response: ${RESPONSE}"
+            exit 1
+          fi
+          echo "Triggered nixl-ci nSpect pipeline ${PIPELINE_ID}: ${PIPELINE_URL}"
+          {
+            echo "## nixl-ci nSpect + scan pipeline"
+            echo "| Field | Value |"
+            echo "|--|--|"
+            echo "| Pipeline | ${PIPELINE_URL:-$PIPELINE_ID} |"
+            echo "| nSpect ID | ${NSPECT_ID} |"
+            echo "| Version | ${WHEEL_VERSION} |"
+            echo "| Commit | ${GITHUB_SHA} |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,8 @@ jobs:
     # Same fork-PR guard as `version` (explicit; not just inherited via needs).
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ${{ vars.NIXL_RUNNER_PREFIX || 'prod' }}-nixl-builder-${{ matrix.runner }}-v1
-    timeout-minutes: 120  # ARM manylinux builds everything from source (~60min); was timing out at the push step
+    timeout-minutes: 240  # manylinux builds everything from source AND now builds the NIXL-EP wheel
+                          # for 3 torch versions x 5 python versions (#1775); cu13 hit the old 120m cap.
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,69 @@ pip install nixl
 
 This installs both CUDA 12 and CUDA 13 backends. At runtime, the correct backend is selected automatically based on the CUDA version reported by PyTorch.
 
+### Building the wheels
+
+The release wheels are built inside a manylinux container by
+[`contrib/build-container.sh`](contrib/build-container.sh), with the same parameters used by
+the release pipeline (`.github/workflows/ci.yml`, the `build` job). Keep the commands below in
+sync with that workflow.
+
+> **Note:** by default the `contrib/Dockerfile.manylinux` build below pulls an
+> **NVIDIA-internal** INFINIA (DDN) libs image. To build the same wheels **without** the INFINIA
+> plugin — works anywhere, no internal image required — add `--no-infinia`; see
+> [Building without INFINIA](#building-without-infinia).
+
+```bash
+# CUDA 12, x86_64 — produces the cu12 manylinux_2_28 release wheels
+# (NVIDIA-internal: pulls the INFINIA libs image)
+./contrib/build-container.sh \
+  --base-image nvcr.io/nvidia/cuda \
+  --base-image-tag 12.9.1-devel-ubi8 \
+  --cuda-version 12.9 \
+  --wheel-base manylinux_2_28 \
+  --python-versions "3.10,3.11,3.12,3.13,3.14" \
+  --os ubuntu24 \
+  --arch x86_64 \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --tag nixl-wheel-build:cu12-x86_64
+
+# CUDA 13:  --base-image-tag 13.0.1-devel-ubi8  --cuda-version 13.0
+# aarch64:  --arch aarch64   (build on an arm64 host)
+```
+
+The wheels are written to `/workspace/nixl/dist` inside the image; extract them with:
+
+```bash
+cid=$(docker create nixl-wheel-build:cu12-x86_64)
+docker cp "$cid:/workspace/nixl/dist" ./dist
+docker rm "$cid"
+ls dist/*.whl
+```
+
+#### Building without INFINIA
+
+The INFINIA (DDN) plugin links against DDN's proprietary `libred` libraries, which are not
+publicly redistributable, so by default the manylinux build pulls an NVIDIA-internal image. To
+build the same wheels **without** INFINIA — no internal image required — add `--no-infinia`,
+which substitutes an empty INFINIA stage (meson then finds no `red_client` and drops the plugin):
+
+```bash
+./contrib/build-container.sh \
+  --base-image nvcr.io/nvidia/cuda \
+  --base-image-tag 12.9.1-devel-ubi8 \
+  --cuda-version 12.9 \
+  --wheel-base manylinux_2_28 \
+  --python-versions "3.10,3.11,3.12,3.13,3.14" \
+  --os ubuntu24 \
+  --arch x86_64 \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --no-infinia \
+  --tag nixl-wheel-build:cu12-x86_64
+```
+
+Extract the wheels the same way (`docker create` / `docker cp .../dist`). This produces the
+full nixl wheel minus the INFINIA backend; all other plugins are unaffected.
+
 ## Prerequisites for source build (Linux)
 
 NIXL requires a C++20 compatible compiler (GCC >= 11 or Clang >= 14).

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -291,16 +291,19 @@ ENV PYTHONPATH=/workspace/nixl/build/examples/device/ep
 RUN cd src/bindings/rust && cargo build --release --locked
 
 # Build wheel using the build-wheel.sh script for better UCX plugin bundling and library management
+# build-wheel.sh requires --torch-versions with --build-nixl-ep (main #1775); pass it here too —
+# the runtime Dockerfile wasn't updated by #1775, so this keeps the NIXL EP build working.
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 RUN export PATH=$VIRTUAL_ENV/bin:$PATH && \
     mkdir -p dist && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAG="--build-nixl-ep"; else EP_BUILD_FLAG=""; fi && \
+    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; else EP_BUILD_FLAGS=""; fi && \
     ./contrib/build-wheel.sh \
     --python-version $DEFAULT_PYTHON_VERSION \
     --platform manylinux_2_39_$ARCH \
     --ucx-plugins-dir $UCX_PLUGIN_DIR \
     --nixl-plugins-dir $NIXL_PLUGIN_DIR \
     --output-dir /workspace/nixl/dist \
-    $EP_BUILD_FLAG
+    $EP_BUILD_FLAGS
 
 RUN cp build/src/bindings/python/nixl-meta/nixl-*.whl dist/
 RUN uv pip install dist/nixl*cp${DEFAULT_PYTHON_VERSION//./}*.whl dist/nixl-*-none-any.whl

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -14,12 +14,110 @@
 # limitations under the License.
 
 
-ARG BASE_IMAGE
-ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
-
-ARG DEFAULT_PYTHON_VERSION="3.14"
+# === Manylinux wheel build (public PyPA base + NGC CUDA) =====================
+# Build wheels on the PUBLIC PyPA manylinux_2_28 image and bring CUDA in from a
+# public NGC CUDA image, instead of the internal
+# gitlab-master.nvidia.com:5005/dl/dgx/cuda manylinux image (NOT reachable from
+# the velonix AWS runners — no DNS/PrivateLink). Mirrors dynamo's
+# container/templates/wheel_builder.Dockerfile pattern. Key moving parts:
+# gcc-toolset for CUDA, the CUDA COPY, and the DOCA el8 rpms.
+# ARCH must be declared before the FROM lines that interpolate it.
 ARG ARCH="x86_64"
+
+# Pin the manylinux base to a specific PyPA release so the toolchain (gcc, CMake,
+# bundled CPython) is reproducible; the implicit :latest would drift between builds.
+# Declared in the global pre-FROM scope because it's interpolated in a FROM line below.
+ARG MANYLINUX_VERSION="2026.06.06-1"
+
+# CUDA toolkit provider: a public NGC CUDA *devel* image, el8/ubi8 to match the
+# AlmaLinux-8 manylinux base (e.g. nvcr.io/nvidia/cuda:12.9.1-devel-ubi8).
+# Reachable from the AWS runners; replaces the internal GitLab base image.
+ARG BASE_IMAGE="nvcr.io/nvidia/cuda"
+ARG BASE_IMAGE_TAG
+# INFINIA libs image — declared here in the global (pre-first-FROM) scope because an ARG
+# used in a FROM line is only visible if declared before the first FROM. See the INFINIA
+# block below for what this is and how it's mirrored.
+ARG INFINIA_LIBS_IMAGE="210086341041.dkr.ecr.us-west-2.amazonaws.com/nixl/infinia-libs:v2.4.0-beta.1"
+# INFINIA build variant: "bundled" (default) pulls the private libs image above; "none" uses
+# an empty stub so external builds WITHOUT access to that image can skip INFINIA — meson then
+# finds no red_client and silently drops the plugin. build-container.sh exposes --no-infinia.
+ARG INFINIA_VARIANT=bundled
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS cuda
+
+# --- INFINIA plugin libs (DDN "red") — bundled by default; skippable via INFINIA_VARIANT=none ---
+# The INFINIA plugin only builds when libred_client.so is found at /opt/ddn/red/lib
+# (src/plugins/meson.build does cc.find_library('red_client', dirs:['/opt/ddn/red/lib'])
+# and silently skips the plugin otherwise — which is what the stage below provides).
+# The libs live in harbor.mellanox.com/nixl/infinia-libs (NOT reachable from the AWS CI
+# runners), so mirror that image into ECR — one time per INFINIA version, from a host
+# that sees both harbor and AWS:
+#   docker pull harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1
+#   ECR=210086341041.dkr.ecr.us-west-2.amazonaws.com/nixl/infinia-libs
+#   docker tag harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1 $ECR:v2.4.0-beta.1
+#   aws ecr get-login-password --region us-west-2 | docker login --username AWS \
+#     --password-stdin 210086341041.dkr.ecr.us-west-2.amazonaws.com
+#   docker push $ECR:v2.4.0-beta.1
+# The dedicated nixl/infinia-libs ECR repo (no-delete lifecycle) is provisioned in
+# velonix terraform/aws/envs/staging/ecr.tf. The runner's existing IRSA already grants
+# pull (account-wide ECR), so no workflow/IAM change is needed. Bump the tag when DDN
+# bumps the INFINIA version (and re-run the mirror push). The ARG is declared in the
+# global pre-FROM block at the top of this file (required to use it in a FROM line).
+FROM ${INFINIA_LIBS_IMAGE} AS infinia-bundled
+# Empty stub for INFINIA_VARIANT=none: a public base carrying an empty /infinia/${ARCH}/ so the
+# COPY below still succeeds without the private image. With variant=none BuildKit prunes the
+# infinia-bundled stage above and never pulls it; meson finds no red_client and skips INFINIA.
+FROM quay.io/pypa/manylinux_2_28_${ARCH}:${MANYLINUX_VERSION} AS infinia-none
+ARG ARCH
+RUN mkdir -p /infinia/${ARCH}
+# Select the source the COPY pulls from based on the INFINIA_VARIANT build arg.
+FROM infinia-${INFINIA_VARIANT} AS infinia
+
+# Manylinux build base — official PyPA image (public on quay.io; velonix also has
+# a quay ECR pull-through). AlmaLinux 8 / glibc 2.28 => manylinux_2_28 wheels.
+FROM quay.io/pypa/manylinux_2_28_${ARCH}:${MANYLINUX_VERSION}
+
+# Re-declare args needed inside this build stage (args before the first FROM are
+# only visible to FROM lines).
+ARG ARCH="x86_64"
+ARG DEFAULT_PYTHON_VERSION="3.14"
+
+# CUDA version (e.g. 12.9 / 13.0) — was provided as an ENV by the old GitLab base;
+# now passed explicitly. Used for the torch cuXXX index and the cu12/cu13 wheel split.
+ARG CUDA_VERSION
+ENV CUDA_VERSION=${CUDA_VERSION}
+
+# Bring the CUDA toolkit onto the manylinux base (dynamo wheel_builder pattern).
+COPY --from=cuda /usr/local/cuda /usr/local/cuda
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}
+
+# INFINIA libs (paired with the `infinia` stage above). The mirrored image lays the libs
+# out per-arch under /infinia/${ARCH}/ (lib/ + include/); copying that to /opt/ddn/red
+# puts libred_client.so / libred_async.so + headers where meson looks, so it auto-detects
+# and builds the INFINIA plugin into the wheel (default -Dinfinia_path=/opt/ddn/red).
+# NOTE: libred_client/libred_async are DDN proprietary and are intentionally NOT
+# redistributed — contrib/build-wheel.sh already auditwheel --excludes them, so the wheel
+# ships only the INFINIA plugin (libplugin_INFINIA.so), which loads libred_* at runtime
+# from a customer's DDN install via its RUNPATH (/opt/ddn/red/lib). The plugin's other
+# transitive deps (liburing.so.2, libldap.so.2, etc.) are why this Dockerfile installs/
+# builds them above: they must resolve at link time even though libred itself is excluded.
+ARG INFINIA_DEST=/opt/ddn/red
+COPY --from=infinia /infinia/${ARCH}/ ${INFINIA_DEST}/
+
+# CUDA needs gcc <= 14. The PyPA manylinux base + system "Development Tools" can
+# pull in a gcc that CUDA rejects, so pin gcc-toolset-14 on PATH ahead of the
+# system gcc (same approach as dynamo's wheel_builder). gcc-toolset-14 is added to
+# the dnf install list below.
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH:-}
+
+# The PyPA manylinux_2_28 image ships CMake 4.x, which removed support for
+# cmake_minimum_required(VERSION < 3.5). Some bundled deps (e.g. gRPC's c-ares)
+# still declare ancient minimums. This tells CMake 4.x to accept them. (Harmless
+# on the older CMake that the previous GitLab base shipped.)
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+# === end Option B header ======================================================
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG HWLOC_VERSION="2.12.2"
 ARG BUILD_TYPE="release"
@@ -29,7 +127,7 @@ ARG GRPC_TAG="v1.73.0"
 ARG NPROC
 
 RUN yum groupinstall -y 'Development Tools' &&  \
-    dnf install -y almalinux-release-synergy && \
+    dnf install -y almalinux-release-synergy epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y \
     boost \
@@ -42,9 +140,14 @@ RUN yum groupinstall -y 'Development Tools' &&  \
     gflags \
     glibc-headers \
     gcc-c++ \
+    gcc-toolset-14 \
     libaio \
     libaio-devel \
     libtool-ltdl \
+    libuuid-devel \
+    jansson \
+    libjose \
+    xxhash-libs \
     ninja-build \
     openssl \
     openssl-devel \
@@ -96,6 +199,51 @@ ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:/usr/local/openssl3/lib:$LD_LIBRA
 ENV OPENSSL_ROOT_DIR="/usr/local/openssl3"
 ENV OPENSSL_LIBRARIES="/usr/local/openssl3/lib64:/usr/local/openssl3/lib"
 ENV OPENSSL_INCLUDE_DIR="/usr/local/openssl3/include"
+
+# --- INFINIA (libred_client) transitive deps not packaged at the right soname on EL8 ---
+# liburing 2.x: EL8 only ships liburing.so.1 (1.0.7); libred_client needs liburing.so.2.
+# Pinned to 2.14 to match subprojects/liburing.wrap (the version NIXL's own build uses); this
+# system install is found ahead of that meson wrap and also satisfies the prebuilt libred_client's
+# transitive liburing.so.2 link/runtime need (the wrap is an internal subproject not on the
+# system linker/loader path, so it can't resolve libred's NEEDED — hence the system build here).
+# Build/install ONLY the library (make -C src): liburing 2.14's examples (e.g. zcrx.c) pull in
+# linux/udmabuf.h, which isn't in the manylinux_2_28 (EL8) kernel headers, so a full `make` fails.
+RUN cd /tmp && \
+    LIBURING_VERSION=2.14 && \
+    wget -q "https://github.com/axboe/liburing/archive/refs/tags/liburing-${LIBURING_VERSION}.tar.gz" && \
+    echo "5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c  liburing-${LIBURING_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf "liburing-${LIBURING_VERSION}.tar.gz" && \
+    cd "liburing-liburing-${LIBURING_VERSION}" && \
+    ./configure --prefix=/usr/local && \
+    make -j"${NPROC:-$(nproc)}" -C src && \
+    make -C src install && \
+    echo "/usr/local/lib"   >  /etc/ld.so.conf.d/usrlocal.conf && \
+    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usrlocal.conf && \
+    ldconfig && \
+    rm -rf /tmp/liburing*
+
+# OpenLDAP 2.6 client libs: EL8 ships 2.4 (libldap-2.4.so.2); libred_client needs the
+# 2.6 soname libldap.so.2 (+ liblber.so.2). Build client libs only, against openssl3.
+RUN cd /tmp && \
+    OPENLDAP_VERSION=2.6.8 && \
+    wget -q "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz" && \
+    echo "48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e  openldap-${OPENLDAP_VERSION}.tgz" | sha256sum -c - && \
+    tar -xzf "openldap-${OPENLDAP_VERSION}.tgz" && \
+    cd "openldap-${OPENLDAP_VERSION}" && \
+    ./configure --prefix=/usr/local --enable-shared --disable-static --disable-slapd \
+        --without-cyrus-sasl --with-tls=openssl \
+        CPPFLAGS="-I/usr/local/openssl3/include" \
+        LDFLAGS="-L/usr/local/openssl3/lib64 -L/usr/local/openssl3/lib" && \
+    make depend && \
+    make -j"${NPROC:-$(nproc)}" && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/openldap-${OPENLDAP_VERSION}*
+
+# Let the linker (gcc LIBRARY_PATH) and loader/auditwheel (LD_LIBRARY_PATH) find the
+# INFINIA libs at /opt/ddn/red/lib and the source-built transitive deps in /usr/local.
+ENV LD_LIBRARY_PATH="/opt/ddn/red/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+ENV LIBRARY_PATH="/opt/ddn/red/lib:/usr/local/lib:/usr/local/lib64:${LIBRARY_PATH:-}"
 
 WORKDIR /workspace
 
@@ -357,14 +505,13 @@ RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && 
 # Create the wheel
 # No need to specifically add path to libcuda.so here, meson finds the stubs and links them
 ARG WHL_PYTHON_VERSIONS="3.10,3.11,3.12,3.13,3.14"
-ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG WHL_PLATFORM="manylinux_2_28_$ARCH"
+# Torch versions for the NIXL EP wheel: build-wheel.sh requires --torch-versions with
+# --build-nixl-ep and derives the torch CUDA index from nvcc internally (main #1775),
+# so no manual UV_INDEX export is needed here.
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 RUN IFS=',' read -ra PYTHON_VERSIONS <<< "$WHL_PYTHON_VERSIONS" && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then \
-        EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; \
-    else \
-        EP_BUILD_FLAGS=""; \
-    fi && \
+    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; else EP_BUILD_FLAGS=""; fi && \
     rm -rf dist && mkdir -p dist && \
     for PYTHON_VERSION in "${PYTHON_VERSIONS[@]}"; do \
         export PATH=$VIRTUAL_ENV/bin:$PATH && \

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -41,6 +41,13 @@ OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
+# CUDA toolkit version (e.g. 12.9 / 13.0). Option B (manylinux on public PyPA base)
+# no longer inherits this from the base image's ENV, so it's passed in. Defaults to
+# 13.0 to match the default BASE_IMAGE_TAG (cuda13.0); override with --cuda-version.
+CUDA_VERSION=${CUDA_VERSION:-13.0}
+# INFINIA build variant passed to Dockerfile.manylinux: "bundled" pulls the private DDN libs
+# image; "none" (via --no-infinia) skips it so external builds without access still work.
+INFINIA_VARIANT=${INFINIA_VARIANT:-bundled}
 
 get_options() {
     while :; do
@@ -92,6 +99,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --cuda-version)
+            if [ "$2" ]; then
+                CUDA_VERSION=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --tag)
             if [ "$2" ]; then
                 TAG="--tag $2"
@@ -126,6 +141,9 @@ get_options() {
             ;;
         --build-nixl-ep)
             BUILD_NIXL_EP=true
+            ;;
+        --no-infinia)
+            INFINIA_VARIANT=none
             ;;
         --arch)
             if [ "$2" ]; then
@@ -187,6 +205,7 @@ show_help() {
     echo "usage: build-container.sh"
     echo "  [--base base image]"
     echo "  [--base-image-tag base image tag]"
+    echo "  [--cuda-version CUDA version, e.g. 12.9 (manylinux builds)]"
     echo "  [--wheel-base base platform for wheel builds]"
     echo "  [--no-cache disable docker build cache]"
     echo "  [--os [ubuntu24|ubuntu22] to select Ubuntu version]"
@@ -195,6 +214,7 @@ show_help() {
     echo "  [--python-versions python versions to build for, comma separated]"
     echo "  [--ucx-ref ucx git reference (branch, tag, or sha)]"
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
+    echo "  [--no-infinia skip the INFINIA plugin (manylinux: don't pull the private DDN libs image)]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     exit 0
@@ -216,7 +236,22 @@ if [ -d "$NIXL_DIR/build" ]; then
     exit 1
 fi
 
+# The manylinux build path requires CUDA_VERSION in MAJOR.MINOR form (e.g. 12.9, 13.0):
+# Dockerfile.manylinux derives the torch index (cu<major><minor>) and the cu12/cu13
+# meta-wheel split from it. Empty yields a broken index (https://download.pytorch.org/
+# whl/cu) and a skipped meta-wheel; a major-only value like "12" yields a nonexistent
+# "cu12" index instead of e.g. "cu129". Validate the shape (not just presence) up front.
+case "$DOCKER_FILE" in
+    *manylinux*)
+        if ! echo "$CUDA_VERSION" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "ERROR: --cuda-version must be MAJOR.MINOR for manylinux builds (e.g. --cuda-version 12.9); got '${CUDA_VERSION}'" >&2
+            exit 1
+        fi
+        ;;
+esac
+
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
+BUILD_ARGS+=" --build-arg CUDA_VERSION=$CUDA_VERSION"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"
@@ -226,7 +261,13 @@ BUILD_ARGS+=" --build-arg NPROC=$NPROC"
 BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
+BUILD_ARGS+=" --build-arg INFINIA_VARIANT=$INFINIA_VARIANT"
 
 show_build_options
 
+# Disable buildx's default provenance/sbom attestations (the attestation-manifest export
+# was tipping the ARM build over the job timeout; CI images don't need them). Use the env
+# var, which buildx honors and the classic docker build frontend ignores -- unlike the
+# --provenance/--sbom flags, which classic docker rejects as unknown.
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -262,6 +262,15 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 BUILD_ARGS+=" --build-arg INFINIA_VARIANT=$INFINIA_VARIANT"
+# With --no-infinia the COPY pulls from the empty infinia-none stub, never the private
+# infinia-bundled image. BuildKit prunes the unreferenced bundled FROM, but not every
+# builder does (e.g. podman/buildah in some configs may still resolve it), and the
+# default points at a private registry the builder may not be able to auth to. Repoint
+# the bundled image at the (already-pulled, already-authed) base image so an infinia-free
+# build never depends on the private registry, regardless of stage-pruning behavior.
+if [ "$INFINIA_VARIANT" = "none" ]; then
+    BUILD_ARGS+=" --build-arg INFINIA_LIBS_IMAGE=$BASE_IMAGE:$BASE_IMAGE_TAG"
+fi
 
 show_build_options
 


### PR DESCRIPTION
Add the nixl GitHub Actions CI that replaces the GitLab build pipeline (runs on the velonix AWS runners):
- version: compute release/dev version (pyproject on release/** builds)
- build: matrix of manylinux wheel builds (cu12/cu13, x86/arm) + the runtime container, images pushed to ECR, dist/ extracted as artifacts
- upload-x86-wheels / upload-arm-wheels / upload-crates: release-only uploads to internal Artifactory (JFrog CLI / cargo), manual-approval environment
- trigger-gitlab-nspect: on release/** builds, triggers the nixl-ci GitLab pipeline that runs nSpect registration + wheel scans (NSPECT-WO64-8O3P)

Follow-on to #1832 (INFINIA wheel build). Pushing the built container to the Artifactory docker registry is a separate follow-up PR.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions CI workflow for pull requests, main, and release branches, plus manual release-build with optional security scanning.
  * Release builds now compute and publish version metadata, build multi-architecture container variants, and publish wheels/crates to Artifactory (crates use an auto release-candidate suffix).
  * On release branch pushes, the workflow triggers the related GitLab pipeline and summarizes key results in the run output.
* **Bug Fixes**
  * Improved the manylinux build to install only the necessary liburing components for the target environment.
* **Chores**
  * Added repository runner-label configuration so workflow runner labels are recognized by actionlint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->