### PR TITLE
tracing: add the NVTX trace backend plugin (libtrace_backend_nvtx.so)

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -15,13 +15,8 @@ requested.
 
 The first backend is **NVTX** (NVIDIA Tools Extension), which makes NIXL operations
 visible as ranges on an [NVIDIA Nsight Systems](https://docs.nvidia.com/nsight-systems/)
-timeline; it ships as `libtrace_backend_nvtx.so` in a follow-up change. Additional
-backends (e.g. MLCommons **Chakra** execution traces) are planned and plug into the
-same call sites.
-
-> Scope: this page describes the tracing facade and the backend-plugin mechanism.
-> No backend ships in the base; backend-specific usage (NVTX profiling with Nsight
-> Systems, etc.) is documented alongside each backend plugin.
+timeline; it ships as `libtrace_backend_nvtx.so`. Additional backends (e.g. MLCommons
+**Chakra** execution traces) are planned and plug into the same call sites.
 
 Tracing is independent of the [telemetry](telemetry.md) system: telemetry collects
 numeric metrics/events, while tracing records spans/markers for profiling and
@@ -117,19 +112,61 @@ dependencies (`addCtrlDep`/`addDataDep`) is backend-specific and documented with
 backend (e.g. NVTX surfaces attributes as `key=value` marks inside the range and
 ignores dependencies; offline backends such as Chakra record them).
 
-## Running the tracing tests
+## Profiling with NVTX / Nsight Systems
 
-The facade unit tests run as part of the normal gtest suite (CTest); they exercise
-the fan-out, attribute, and inert/no-backend paths against mock backends, so they
-need no backend plugin:
+NVTX is a lazy, online API: when no profiler is attached, ranges are near-zero-cost
+no-op stubs. Run the process under `nsys` to capture the ranges into a `.nsys-rep`
+you can open in the Nsight Systems GUI. The NVTX backend is sourced from the CUDA
+toolkit's header-only `nvtx3` (CUDA-toolkit-only — there is no non-CUDA build).
 
 ```bash
-ninja -C build test/gtest/unit/unit
-./build/test/gtest/unit/unit --gtest_filter='Tracing.*'
+# Build with tracing + the NVTX backend plugin (both on by default)
+meson setup build -Dbuildtype=debug -Dwith_trace=true -Dtrace_backends=nvtx
+ninja -C build
+
+# Profile a tracing-enabled run (here: the tracing gtest)
+NIXL_TRACE_BACKENDS=nvtx nsys profile --trace=nvtx,cuda,osrt --force-overwrite true \
+    --output /tmp/nixl_nvtx \
+    ./build/test/gtest/gtest --tests_plugin_dirs=build/test/gtest/mocks \
+    --gtest_filter='*Tracing*'
+
+# Summarize from the CLI, or open /tmp/nixl_nvtx.nsys-rep in Nsight Systems:
+nsys stats --report nvtx_sum --format csv /tmp/nixl_nvtx.nsys-rep | grep 'nixl::'
 ```
 
-Real-agent tracing tests and an `nsys` timeline-capture test ship with the NVTX
-backend.
+Each agent uses its **own NVTX domain named after the agent**, so ranges appear as
+`<agent_name>:<span_name>`, e.g.:
+
+```text
+agent_0:nixl::postXferReq.write
+agent_0:nixl::createXferReq
+agent_0:nixl::registerMem
+agent_1:nixl::registerMem
+```
+
+For GPU transfers the host-side NVTX ranges line up on the Nsight timeline with the
+GPU activity Nsight captures via CUDA tracing (`--trace=cuda,nvtx`), i.e. a GPU-aware
+view by correlation. In-kernel / device-side tracing is out of scope (NVTX cannot run
+in `__device__` code).
+
+## Running the tracing tests
+
+The facade unit tests run against mock backends (no plugin needed); the real-agent
+`TestTransferTracing` tests load the NVTX plugin and exercise live UCX transfers with
+NVTX active:
+
+```bash
+ninja -C build test/gtest/unit/unit test/gtest/gtest
+# facade unit suite (no backend plugin needed):
+./build/test/gtest/unit/unit --gtest_filter='Tracing.*'
+# real-agent NVTX suite (loads libtrace_backend_nvtx.so from the build tree):
+./build/test/gtest/gtest --tests_plugin_dirs=build/test/gtest/mocks \
+    --gtest_filter='*TestTransferTracing*'
+```
+
+When `nsys` is available, a `tracing_nsys` CTest additionally profiles the real-agent
+test and writes `build/test/gtest/artifacts/nixl_nvtx.nsys-rep` (skipped automatically
+if profiling is not permitted in the environment).
 
 ## Correlation
 
@@ -149,8 +186,8 @@ backend.
 
 ## Planned work
 
-- **NVTX backend plugin** (`libtrace_backend_nvtx.so`) — ranges/marks on the Nsight
-  Systems timeline, plus an `nsys` capture test (immediate follow-up).
+- **NVTX completeness** — structured, typed NVTX payload attributes (vs the current
+  `key=value` marks), hot-path registered-string labels, and broader call-site coverage.
 - **Chakra backend** — serialize MLCommons Chakra execution traces (one ET per rank),
   recording the span attributes and dependencies the NVTX backend ignores.
 - **Cross-rank correlation** — propagate a global request id on the wire so sender and

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -116,11 +116,17 @@ ignores dependencies; offline backends such as Chakra record them).
 
 NVTX is a lazy, online API: when no profiler is attached, ranges are near-zero-cost
 no-op stubs. Run the process under `nsys` to capture the ranges into a `.nsys-rep`
-you can open in the Nsight Systems GUI. The NVTX backend is sourced from the CUDA
-toolkit's header-only `nvtx3` (CUDA-toolkit-only — there is no non-CUDA build).
+you can open in the Nsight Systems GUI.
+
+The NVTX backend plugin is **optional at build time**: it is built only when the CUDA
+toolkit's header-only `nvtx3` headers are present, and is silently skipped otherwise
+(there is no separate non-CUDA NVTX build). When it isn't built, requesting it at
+runtime (`NIXL_TRACE_BACKENDS=nvtx`) just logs a warning and tracing stays off — the
+rest of NIXL is unaffected.
 
 ```bash
-# Build with tracing + the NVTX backend plugin (both on by default)
+# Build with tracing + the NVTX backend plugin (both on by default; the NVTX
+# plugin is built when the CUDA-toolkit nvtx3 headers are found, else skipped)
 meson setup build -Dbuildtype=debug -Dwith_trace=true -Dtrace_backends=nvtx
 ninja -C build
 

--- a/meson.build
+++ b/meson.build
@@ -426,7 +426,13 @@ nixl_trace_enabled = get_option('with_trace')
 nixl_trace_nvtx_enabled = false
 
 if nixl_trace_enabled
-    add_project_arguments('-DNIXL_TRACE_ENABLED', language: ['cpp', 'cuda'])
+    # 'cuda' is only an enabled language when cuda_dep.found() (add_languages('CUDA')
+    # above); passing it unconditionally breaks a non-CUDA with_trace configure.
+    nixl_trace_arg_langs = ['cpp']
+    if cuda_dep.found()
+        nixl_trace_arg_langs += ['cuda']
+    endif
+    add_project_arguments('-DNIXL_TRACE_ENABLED', language: nixl_trace_arg_langs)
 
     requested_trace_backends = []
     foreach b : get_option('trace_backends').split(',')

--- a/meson.build
+++ b/meson.build
@@ -418,15 +418,45 @@ if get_option('buildtype') == 'release'
 endif
 
 # ---- Tracing (nixl::trace) -------------------------------------------------
-# The tracing facade + plugin loader are compiled into libnixl when with_trace is
-# set. Tracing backends (NVTX, ...) ship as separate on-demand .so plugins under
-# src/plugins/tracing, added in a follow-up PR; only the facade lands here.
+# Two gates: build/packaging (which backend plugins are built, as separate .so
+# modules under src/plugins/tracing) and runtime (which built plugins the caller
+# activates via NIXL_TRACE_BACKENDS / nsys auto-load). The facade itself is
+# always compiled into libnixl.
 nixl_trace_enabled = get_option('with_trace')
+nixl_trace_nvtx_enabled = false
 
 if nixl_trace_enabled
     add_project_arguments('-DNIXL_TRACE_ENABLED', language: ['cpp', 'cuda'])
+
+    requested_trace_backends = []
+    foreach b : get_option('trace_backends').split(',')
+        b_stripped = b.strip()
+        if b_stripped != ''
+            requested_trace_backends += [b_stripped]
+        endif
+    endforeach
+
+    # NVTX: header-only; ships with the CUDA toolkit (nvtx3). Detect-then-disable
+    # gracefully so non-CUDA / werror builds stay green. Built as a separately
+    # loaded plugin (src/plugins/tracing/nvtx), not linked into libnixl; nvtx_inc_dep
+    # is consumed there.
+    if 'nvtx' in requested_trace_backends
+        if cuda_dep.found()
+            nvtx_inc_dep = cuda_dep.partial_dependency(includes: true, compile_args: true)
+            if cpp.has_header('nvtx3/nvToolsExt.h', dependencies: nvtx_inc_dep)
+                nixl_trace_nvtx_enabled = true
+                message('nixl::trace: NVTX backend plugin enabled (CUDA-bundled nvtx3 headers)')
+            else
+                warning('nixl::trace: nvtx requested but nvtx3 headers not found; NVTX backend disabled')
+            endif
+        else
+            warning('nixl::trace: nvtx requested but CUDA not found; NVTX backend disabled')
+        endif
+    endif
+
     summary({
-        'Tracing facade' : nixl_trace_enabled,
+        'Tracing facade'      : nixl_trace_enabled,
+        'NVTX backend plugin' : nixl_trace_nvtx_enabled,
     }, section: 'Tracing', bool_yn: true)
 endif
 

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -141,3 +141,7 @@ if enabled_plugins.get('GPUNETIO')
 endif
 
 subdir('telemetry')
+
+if nixl_trace_enabled
+    subdir('tracing')
+endif

--- a/src/plugins/tracing/meson.build
+++ b/src/plugins/tracing/meson.build
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tracing-backend plugins (nixl::trace). Each backend is a separate .so loaded
+# on demand by nixlPluginManager; gating happens in the root meson.build.
+if nixl_trace_nvtx_enabled
+    subdir('nvtx')
+endif

--- a/src/plugins/tracing/nvtx/meson.build
+++ b/src/plugins/tracing/nvtx/meson.build
@@ -13,10 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Entered only when the NVTX backend was detected (nixl_trace_nvtx_enabled, set
-# in the root meson.build). nvtx_inc_dep comes from that detection. Built as an
-# on-demand `.so` plugin (prefix libtrace_backend_) like NIXL's data backends
-# and telemetry exporters, not linked into libnixl.
+# Reached only when nixl_trace_nvtx_enabled is set (root meson.build), which also
+# provides nvtx_inc_dep.
 shared_library(
     'libtrace_backend_nvtx',
     'nvtx_plugin.cpp',

--- a/src/plugins/tracing/nvtx/meson.build
+++ b/src/plugins/tracing/nvtx/meson.build
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Entered only when the NVTX backend was detected (nixl_trace_nvtx_enabled, set
+# in the root meson.build). nvtx_inc_dep comes from that detection. Built as an
+# on-demand `.so` plugin (prefix libtrace_backend_) like NIXL's data backends
+# and telemetry exporters, not linked into libnixl.
+shared_library(
+    'libtrace_backend_nvtx',
+    'nvtx_plugin.cpp',
+    'nvtx_backend.cpp',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, nvtx_inc_dep],
+    install: true,
+    install_dir: plugin_install_dir,
+    name_prefix: '',
+)
+message('Building NVTX trace backend plugin')

--- a/src/plugins/tracing/nvtx/meson.build
+++ b/src/plugins/tracing/nvtx/meson.build
@@ -20,7 +20,9 @@ shared_library(
     'nvtx_plugin.cpp',
     'nvtx_backend.cpp',
     include_directories: [nixl_inc_dirs, utils_inc_dirs],
-    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, nvtx_inc_dep],
+    # dl_dep: nvtx3 injection thunks call dlopen/dlsym/dlclose, so with --no-undefined
+    # libdl must be linked where dl* isn't merged into libc (e.g. the manylinux wheel build).
+    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, nvtx_inc_dep, dl_dep],
     install: true,
     install_dir: plugin_install_dir,
     name_prefix: '',

--- a/src/plugins/tracing/nvtx/nvtx_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_backend.cpp
@@ -1,0 +1,173 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_backend.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include <nvtx3/nvToolsExt.h>
+
+namespace nixl::trace {
+namespace {
+
+    // Map an operation kind to a stable ARGB color so the Nsight timeline is
+    // visually distinguishable.
+    [[nodiscard]] constexpr std::uint32_t
+    colorFor(const Kind kind) noexcept {
+        switch (kind) {
+        case Kind::CommSend:
+            return 0xFF2E7D32u; // green
+        case Kind::CommRecv:
+            return 0xFF1565C0u; // blue
+        case Kind::CommColl:
+            return 0xFF6A1B9Au; // purple
+        case Kind::MemoryR:
+            return 0xFFEF6C00u; // orange
+        case Kind::MemoryW:
+            return 0xFFF9A825u; // amber
+        case Kind::Compute:
+            return 0xFF00838Fu; // teal
+        case Kind::Metadata:
+            return 0xFF757575u; // gray
+        case Kind::Generic:
+        default:
+            return 0xFF455A64u; // blue-gray
+        }
+    }
+
+    // NVTX copies the message at submit time, so a null-terminated C string that
+    // outlives the call is sufficient.
+    [[nodiscard]] nvtxEventAttributes_t
+    makeEvent(const char *msg, Kind kind) {
+        nvtxEventAttributes_t ev{};
+        ev.version = NVTX_VERSION;
+        ev.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+        ev.colorType = NVTX_COLOR_ARGB;
+        ev.color = colorFor(kind);
+        ev.messageType = NVTX_MESSAGE_TYPE_ASCII;
+        ev.message.ascii = msg;
+        return ev;
+    }
+
+    // A single NVTX range. The matching push happens in the backend's beginSpan();
+    // the pop happens here on destruction (per-thread, per-domain LIFO).
+    class NvtxSpan final : public SpanBackend {
+    public:
+        explicit NvtxSpan(nvtxDomainHandle_t domain) noexcept : domain_(domain) {}
+
+        ~NvtxSpan() override {
+            nvtxDomainRangePop(domain_);
+        }
+
+        // An NVTX range's message/color are fixed at push time, so attributes
+        // (added afterwards) are surfaced as "key=value" marks inside the range.
+        // They show on the Nsight timeline; a structured NVTX payload schema is a
+        // future enhancement. Dependencies have no NVTX representation (no-op).
+        void
+        addAttribute(std::string_view key, std::string_view value) override {
+            emitAttr(key, value);
+        }
+
+        void
+        addAttribute(std::string_view key, std::int64_t value) override {
+            emitAttr(key, std::to_string(value));
+        }
+
+        void
+        addAttribute(std::string_view key, double value) override {
+            emitAttr(key, std::to_string(value));
+        }
+
+        void
+        addCtrlDep(SpanId) override {}
+
+        void
+        addDataDep(SpanId) override {}
+
+        [[nodiscard]] SpanId
+        id() const noexcept override {
+            return {};
+        }
+
+    private:
+        // Surface one attribute as a "key=value" mark inside the active range.
+        void
+        emitAttr(std::string_view key, std::string_view value) {
+            std::string kv;
+            kv.reserve(key.size() + value.size() + 1);
+            kv.append(key).append("=").append(value);
+            const nvtxEventAttributes_t ev = makeEvent(kv.c_str(), Kind::Metadata);
+            nvtxDomainMarkEx(domain_, &ev);
+        }
+
+        nvtxDomainHandle_t domain_;
+    };
+
+    class NvtxTraceBackend final : public TraceBackend {
+    public:
+        explicit NvtxTraceBackend(std::string_view domain)
+            : domainName_(domain),
+              domain_(nvtxDomainCreateA(domainName_.c_str())) {}
+
+        ~NvtxTraceBackend() override {
+            nvtxDomainDestroy(domain_);
+        }
+
+        [[nodiscard]] std::unique_ptr<SpanBackend>
+        beginSpan(std::string_view name, Kind kind) override {
+            const std::string msg(name);
+            const nvtxEventAttributes_t ev = makeEvent(msg.c_str(), kind);
+            // Allocate before pushing so a throwing allocation cannot leave the
+            // NVTX range stack unbalanced (the span's dtor performs the pop).
+            auto span = std::make_unique<NvtxSpan>(domain_);
+            nvtxDomainRangePushEx(domain_, &ev);
+            return span;
+        }
+
+        void
+        mark(std::string_view name, Kind kind) override {
+            const std::string msg(name);
+            const nvtxEventAttributes_t ev = makeEvent(msg.c_str(), kind);
+            nvtxDomainMarkEx(domain_, &ev);
+        }
+
+        void
+        pushCorrelationId(std::uint64_t) override {}
+
+        void
+        popCorrelationId() override {}
+
+        [[nodiscard]] std::string_view
+        name() const noexcept override {
+            return "nvtx";
+        }
+
+    private:
+        const std::string domainName_;
+        nvtxDomainHandle_t domain_;
+    };
+
+} // namespace
+
+std::unique_ptr<TraceBackend>
+createNvtxBackend(const nixlTraceBackendInitParams &init_params) {
+    return std::make_unique<NvtxTraceBackend>(init_params.agentName);
+}
+
+} // namespace nixl::trace

--- a/src/plugins/tracing/nvtx/nvtx_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_backend.cpp
@@ -17,6 +17,8 @@
 
 #include "nvtx_backend.h"
 
+#include "common/nixl_log.h"
+
 #include <cstdint>
 #include <string>
 #include <string_view>
@@ -167,7 +169,13 @@ namespace {
 
 std::unique_ptr<TraceBackend>
 createNvtxBackend(const nixlTraceBackendInitParams &init_params) {
-    return std::make_unique<NvtxTraceBackend>(init_params.agentName);
+    try {
+        return std::make_unique<NvtxTraceBackend>(init_params.agentName);
+    }
+    catch (const std::exception &e) {
+        NIXL_ERROR << "Failed to create NVTX trace backend: " << e.what();
+        return nullptr;
+    }
 }
 
 } // namespace nixl::trace

--- a/src/plugins/tracing/nvtx/nvtx_backend.h
+++ b/src/plugins/tracing/nvtx/nvtx_backend.h
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_BACKEND_H
+#define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_BACKEND_H
+
+#include <memory>
+
+#include "tracing/trace_plugin.h"
+
+namespace nixl::trace {
+
+/**
+ * @brief Create the NVTX trace backend. Header-only nvtx3 under the hood; ranges
+ *        are cheap no-op stubs until a profiler (Nsight Systems) is attached via
+ *        NVTX_INJECTION64_PATH. Each agent gets its own NVTX domain named after
+ *        @p init_params.agentName. This is the factory the plugin hands to the
+ *        core via nixl_trace_plugin_init().
+ */
+[[nodiscard]] std::unique_ptr<TraceBackend>
+createNvtxBackend(const nixlTraceBackendInitParams &init_params);
+
+} // namespace nixl::trace
+
+#endif // NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_BACKEND_H

--- a/src/plugins/tracing/nvtx/nvtx_plugin.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_plugin.cpp
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_backend.h"
+#include "tracing/trace_plugin.h"
+
+// Loaded by nixlPluginManager (prefix `libtrace_backend_`). The factory itself
+// (createNvtxBackend) builds one NVTX domain per agent on demand.
+extern "C" NIXL_TRACE_PLUGIN_EXPORT nixlTracePlugin *
+nixl_trace_plugin_init() {
+    static nixlTracePlugin plugin(
+        nixl_trace_plugin_api_version::V1, "nvtx", "0.1.0", &nixl::trace::createNvtxBackend);
+    return &plugin;
+}
+
+extern "C" NIXL_TRACE_PLUGIN_EXPORT void
+nixl_trace_plugin_fini() {}

--- a/src/plugins/tracing/nvtx/nvtx_plugin.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_plugin.cpp
@@ -18,8 +18,7 @@
 #include "nvtx_backend.h"
 #include "tracing/trace_plugin.h"
 
-// Loaded by nixlPluginManager (prefix `libtrace_backend_`). The factory itself
-// (createNvtxBackend) builds one NVTX domain per agent on demand.
+// Loaded by nixlPluginManager via the `libtrace_backend_` prefix.
 extern "C" NIXL_TRACE_PLUGIN_EXPORT nixlTracePlugin *
 nixl_trace_plugin_init() {
     static nixlTracePlugin plugin(

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -128,6 +128,21 @@ if get_option('sanitizer') != 'none'
 endif
 test('gtest', test_exe, args: gtest_args, env: sanitizer_env, suite: 'sanitizer')
 
+# Best-effort NVTX capture: when nsys is available, profile the tracing tests
+# and write a .nsys-rep that CI can publish as an artifact. Skips (exit 77) when
+# profiling is denied, so it never fails CI on its own.
+if nixl_trace_nvtx_enabled
+    nsys_prog = find_program('nsys', required: false)
+    if nsys_prog.found()
+        nsys_wrapper = find_program(meson.current_source_dir() / 'run_nsys_tracing.sh')
+        test('tracing_nsys',
+             nsys_wrapper,
+             args: [nsys_prog.full_path(), test_exe, meson.current_build_dir(), plugin_dirs_arg],
+             is_parallel: false,
+             timeout: 600)
+    endif
+endif
+
 if get_option('b_sanitize').split(',').contains('thread')
     test_env = environment()
     test_env.set('TSAN_OPTIONS', 'halt_on_error=1')

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Best-effort NVTX capture for CI artifacts. Profiles the tracing gtest under
-# Nsight Systems and writes a .nsys-rep. If profiling is unavailable (e.g. perf
-# permissions are denied inside a container), the test is skipped (exit 77)
-# rather than failing -- the same tests also run in the normal gtest job, which
-# is what gates correctness.
+# Nsight Systems and writes a .nsys-rep. Only a genuine "profiling unavailable"
+# condition (e.g. perf permissions denied inside a container) is reported as a
+# skip (exit 77); any other nsys/gtest failure -- or a successful run that did
+# not actually produce the .nsys-rep -- is propagated as a real failure so this
+# capture test still catches regressions on the profiled path.
 #
 # Usage: run_nsys_tracing.sh <nsys> <gtest_exe> <out_dir> [extra gtest args...]
 set -u
@@ -25,17 +26,30 @@ shift
 
 mkdir -p "${OUT_DIR}/artifacts"
 OUT="${OUT_DIR}/artifacts/nixl_nvtx"
+LOG="${OUT}.log"
 
 "${NSYS}" profile --trace=nvtx,osrt --force-overwrite true --output "${OUT}" \
-    "${GTEST}" "$@" --gtest_filter='*Tracing*'
+    "${GTEST}" "$@" --gtest_filter='*Tracing*' >"${LOG}" 2>&1
 rc=$?
 
 if [ "${rc}" -ne 0 ]; then
-    echo "tracing_nsys: nsys profiling unavailable or failed (rc=${rc}); skipping"
-    exit 77
+    # Distinguish "profiling not permitted here" (a legitimate skip) from a real
+    # nsys/gtest failure, which must fail the test.
+    if grep -qiE 'denied|not permitted|permission|unsupported|insufficient|capabilit' "${LOG}"; then
+        echo "tracing_nsys: nsys profiling unavailable (rc=${rc}); skipping"
+        sed 's/^/  nsys: /' "${LOG}" >&2
+        exit 77
+    fi
+    echo "tracing_nsys: nsys/gtest run failed (rc=${rc})" >&2
+    cat "${LOG}" >&2
+    exit "${rc}"
 fi
 
-if [ -f "${OUT}.nsys-rep" ]; then
-    echo "tracing_nsys: wrote ${OUT}.nsys-rep"
+if [ ! -f "${OUT}.nsys-rep" ]; then
+    echo "tracing_nsys: profiling reported success but ${OUT}.nsys-rep was not created" >&2
+    cat "${LOG}" >&2
+    exit 1
 fi
+
+echo "tracing_nsys: wrote ${OUT}.nsys-rep"
 exit 0

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Best-effort NVTX capture for CI artifacts. Profiles the tracing gtest under
+# Nsight Systems and writes a .nsys-rep. If profiling is unavailable (e.g. perf
+# permissions are denied inside a container), the test is skipped (exit 77)
+# rather than failing -- the same tests also run in the normal gtest job, which
+# is what gates correctness.
+#
+# Usage: run_nsys_tracing.sh <nsys> <gtest_exe> <out_dir> [extra gtest args...]
+set -u
+
+if [ "$#" -lt 3 ]; then
+    echo "usage: $0 <nsys> <gtest_exe> <out_dir> [gtest args...]" >&2
+    exit 2
+fi
+
+NSYS="$1"
+shift
+GTEST="$1"
+shift
+OUT_DIR="$1"
+shift
+
+mkdir -p "${OUT_DIR}/artifacts"
+OUT="${OUT_DIR}/artifacts/nixl_nvtx"
+
+"${NSYS}" profile --trace=nvtx,osrt --force-overwrite true --output "${OUT}" \
+    "${GTEST}" "$@" --gtest_filter='*Tracing*'
+rc=$?
+
+if [ "${rc}" -ne 0 ]; then
+    echo "tracing_nsys: nsys profiling unavailable or failed (rc=${rc}); skipping"
+    exit 77
+fi
+
+if [ -f "${OUT}.nsys-rep" ]; then
+    echo "tracing_nsys: wrote ${OUT}.nsys-rep"
+fi
+exit 0

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -20,10 +20,12 @@
 
 #include "nixl.h"
 #include "nixl_types.h"
+#include "plugin_manager.h"
 
 #include <absl/strings/str_format.h>
 #include <absl/time/clock.h>
 #include <gtest/gtest.h>
+#include <filesystem>
 #include <memory>
 #include <optional>
 #include <string>
@@ -675,5 +677,138 @@ NIXL_INSTANTIATE_TEST(ucx_telemetry_threadpool_no_pt,
                       6,
                       4,
                       "");
+
+// End-to-end test with real agents and the NVTX trace backend active. It passes
+// standalone (NVTX ranges are no-op stubs with no profiler attached) and is also
+// the binary profiled under nsys to capture the NVTX timeline as an artifact.
+class TestTransferTracing : public TestTransfer {
+protected:
+    // The NVTX backend is an on-demand plugin (libtrace_backend_nvtx.so); point
+    // the manager at its build-tree location once for the whole suite. Guarded so
+    // a build without the NVTX plugin doesn't log a missing-directory error, and
+    // added a single time so re-entry across instantiations doesn't warn about a
+    // duplicate directory.
+    static void
+    SetUpTestSuite() {
+        static bool added = false;
+        if (added) {
+            return;
+        }
+        const std::string nvtx_plugin_dir = std::string(BUILD_DIR) + "/src/plugins/tracing/nvtx";
+        if (std::filesystem::exists(nvtx_plugin_dir)) {
+            nixlPluginManager::getInstance().addPluginDirectory(nvtx_plugin_dir);
+            added = true;
+        }
+    }
+
+    void
+    SetUp() override {
+        // Activate NVTX tracing before the agents are created (the constructor
+        // reads NIXL_TRACE_BACKENDS). Keep telemetry off.
+        env.addVar("NIXL_TELEMETRY_ENABLE", "n");
+        env.addVar("NIXL_TRACE_BACKENDS", "nvtx");
+        for (size_t i = 0; i < 2; i++) {
+            addAgent(i);
+        }
+    }
+
+    void
+    runTracingTransferTest() {
+        constexpr size_t size = 4096;
+        constexpr size_t count = 4;
+        // A few iterations so the captured NVTX timeline shows repeated ranges.
+        constexpr size_t repeat = 8;
+        constexpr size_t num_threads = 1;
+
+        std::vector<MemBuffer> src_buffers, dst_buffers;
+        createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
+        createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+
+        exchangeMD(0, 1);
+        doTransfer(getAgent(0),
+                   getAgentName(0),
+                   getAgent(1),
+                   getAgentName(1),
+                   size,
+                   count,
+                   repeat,
+                   num_threads,
+                   DRAM_SEG,
+                   src_buffers,
+                   DRAM_SEG,
+                   dst_buffers);
+        invalidateMD(0, 1);
+        deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
+        deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
+    }
+};
+
+TEST_P(TestTransferTracing, NvtxTransferLoop) {
+    runTracingTransferTest();
+}
+
+// Exercises the genNotif/getNotifs trace call sites under active NVTX.
+TEST_P(TestTransferTracing, NvtxNotifications) {
+    doNotificationTest(getAgent(0),
+                       getAgentName(0),
+                       getAgent(1),
+                       getAgentName(1),
+                       /*repeat=*/4,
+                       /*num_threads=*/1);
+}
+
+// Single clean pass through every traced agent op in lifecycle order, so the
+// nsys capture is an easy-to-narrate demo timeline (see the demo plan in
+// docs/proposals/shared-tracing-api-plan.md). makeConnection is invoked
+// explicitly: the loop/notif tests connect implicitly via exchangeMD, so the
+// Connection span would otherwise never appear on the timeline.
+TEST_P(TestTransferTracing, NvtxDemoWalkthrough) {
+    constexpr size_t size = 4096;
+    constexpr size_t count = 1;
+
+    std::vector<MemBuffer> src_buffers, dst_buffers;
+    createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
+    createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+
+    exchangeMD(0, 1);
+
+    ASSERT_EQ(getAgent(0).makeConnection(getAgentName(1)), NIXL_SUCCESS);
+
+    doTransfer(getAgent(0),
+               getAgentName(0),
+               getAgent(1),
+               getAgentName(1),
+               size,
+               count,
+               /*repeat=*/1,
+               /*num_threads=*/1,
+               DRAM_SEG,
+               src_buffers,
+               DRAM_SEG,
+               dst_buffers);
+
+    ASSERT_EQ(getAgent(0).genNotif(getAgentName(1), "nixl::demo"), NIXL_SUCCESS);
+    // Drain the notification until it is actually delivered, so no UCX active
+    // message is left in flight at teardown (a canceled AM logs a warning).
+    constexpr int max_drain_polls = 1000;
+    constexpr std::chrono::milliseconds drain_poll_interval{10};
+    nixl_notifs_t notif_map;
+    for (int i = 0; i < max_drain_polls; ++i) {
+        ASSERT_EQ(getAgent(0).getNotifs(notif_map), NIXL_SUCCESS);
+        ASSERT_EQ(getAgent(1).getNotifs(notif_map), NIXL_SUCCESS);
+        if (!notif_map[getAgentName(0)].empty()) {
+            break;
+        }
+        std::this_thread::sleep_for(drain_poll_interval);
+    }
+    ASSERT_FALSE(notif_map[getAgentName(0)].empty());
+
+    invalidateMD(0, 1);
+    deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
+    deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
+}
+
+NIXL_INSTANTIATE_TEST(ucx_tracing, TestTransferTracing, "UCX", true, 2, 0, "");
+NIXL_INSTANTIATE_TEST(ucx_tracing_no_pt, TestTransferTracing, "UCX", false, 2, 0, "");
 
 } // namespace gtest

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -683,6 +683,9 @@ NIXL_INSTANTIATE_TEST(ucx_telemetry_threadpool_no_pt,
 // the binary profiled under nsys to capture the NVTX timeline as an artifact.
 class TestTransferTracing : public TestTransfer {
 protected:
+    // False when this build did not produce libtrace_backend_nvtx.so.
+    static bool nvtxPluginAvailable_;
+
     // The NVTX backend is an on-demand plugin (libtrace_backend_nvtx.so); point
     // the manager at its build-tree location once for the whole suite. Guarded so
     // a build without the NVTX plugin doesn't log a missing-directory error, and
@@ -692,17 +695,25 @@ protected:
     SetUpTestSuite() {
         static bool added = false;
         if (added) {
+            nvtxPluginAvailable_ = true;
             return;
         }
         const std::string nvtx_plugin_dir = std::string(BUILD_DIR) + "/src/plugins/tracing/nvtx";
         if (std::filesystem::exists(nvtx_plugin_dir)) {
             nixlPluginManager::getInstance().addPluginDirectory(nvtx_plugin_dir);
             added = true;
+            nvtxPluginAvailable_ = true;
+        } else {
+            nvtxPluginAvailable_ = false;
         }
     }
 
     void
     SetUp() override {
+        // Nothing to validate without the plugin -- skip instead of running blind.
+        if (!nvtxPluginAvailable_) {
+            GTEST_SKIP() << "NVTX trace plugin (libtrace_backend_nvtx.so) was not built";
+        }
         // Activate NVTX tracing before the agents are created (the constructor
         // reads NIXL_TRACE_BACKENDS). Keep telemetry off.
         env.addVar("NIXL_TELEMETRY_ENABLE", "n");
@@ -742,6 +753,8 @@ protected:
         deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
     }
 };
+
+bool TestTransferTracing::nvtxPluginAvailable_ = false;
 
 TEST_P(TestTransferTracing, NvtxTransferLoop) {
     runTracingTransferTest();


### PR DESCRIPTION
## What?
Adds **NVTX** as the first `nixl::trace` backend, packaged as an on-demand `.so`
plugin. Builds on the tracing facade + plugin loader that landed in #1765 (now in
`main`); this PR only adds the backend, its build wiring, the real-agent tests, and
the NVTX usage docs.

- `src/plugins/tracing/nvtx/` → `libtrace_backend_nvtx.so` (`nvtx_backend.{h,cpp}` +
  `nvtx_plugin.cpp`), built like NIXL's data-backend / telemetry-exporter plugins.
- Meson wiring: root `meson.build` NVTX (`nvtx3`) detection, `src/plugins/tracing/`
  subdir, and the `tracing_nsys` capture test in `test/gtest/meson.build`.
- Real-agent `TestTransferTracing` e2e tests + `run_nsys_tracing.sh`.
- `docs/tracing.md`: the NVTX/Nsight profiling sections.

## Why?
#1765 shipped the facade and a `nixlPluginManager` trace-plugin loader but **no
backend** — `makeTracer("nvtx")` returned a null tracer. This PR provides the actual
NVTX backend so NIXL operations show up as ranges on an NVIDIA Nsight Systems
timeline. Packaging it as a plugin keeps NVTX/CUDA out of `libnixl` (the toolkit's
header-only `nvtx3` is `dlopen`'d only when `nvtx` is requested), matching how data
backends and telemetry exporters ship.

## How?
- The plugin implements the `trace_plugin.h` contract: `nixl_trace_plugin_init()`
  returns a `nixlTracePlugin` whose `create_backend` factory builds an
  `NvtxTraceBackend` (one NVTX domain per agent). `nixlPluginManager::loadTracePlugin()`
  (already in `main`) discovers/loads it by the `libtrace_backend_` prefix; no facade
  or call-site changes.
- **CUDA-toolkit-only:** the plugin builds when the toolkit's `nvtx3` headers are
  present and is silently skipped otherwise (graceful disable; runtime
  `NIXL_TRACE_BACKENDS=nvtx` then warns + yields a null tracer). There is no non-CUDA
  build / vendored fallback.
- Spans push/pop NVTX ranges (colored by `Kind`); attributes are surfaced as
  `key=value` marks inside the range; ranges are near-zero-cost no-op stubs until a
  profiler attaches. For GPU transfers the host-side ranges correlate with CUDA
  activity on the Nsight timeline (`--trace=cuda,nvtx`).

## Testing
- Real-agent `TestTransferTracing` (UCX + NVTX active, loaded from the build tree):
  `NvtxTransferLoop`, `NvtxNotifications`, `NvtxDemoWalkthrough` — **6/6**.
- The facade unit suite (mock fan-out, inert/no-plugin path) already landed in #1765
  and stays green — **8/8**.
- `nsys`-gated `tracing_nsys` CTest writes a `.nsys-rep` artifact (auto-skips where
  profiling is denied).

## Follow-ups
NVTX completeness (structured payload attributes, registered-string labels, broader
call sites); the Chakra backend. Cross-process/request "distributed tracing" is a
separate NIXL-architecture effort, not part of this thin facade.

Stacks on #1765. Tracks Linear NIX-1559.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an NVTX-based tracing backend with per-agent NVTX domains, timeline-friendly ranges/metadata marks, and a loadable NVTX plugin.
  * Improved tracing enablement so NVTX backend builds/activates only when required tooling/headers are available.
* **Tests**
  * Added end-to-end NVTX transfer/notification tests and a demo-style walkthrough that run when the NVTX plugin is present.
  * Added an Nsight Systems–driven test that produces an `.nsys-rep` artifact when profiling is available.
* **Documentation**
  * Updated NVTX tracing docs with profiling, build, and test/run instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->