### PR TITLE
ci: fix DL EP test setup

### DIFF
--- a/.gitlab/test_ep.sh
+++ b/.gitlab/test_ep.sh
@@ -40,23 +40,9 @@ export NIXL_PLUGIN_DIR=${INSTALL_DIR}/lib/$ARCH-linux-gnu/plugins
 export NIXL_PREFIX=${INSTALL_DIR}
 export NIXL_DEBUG_LOGGING=yes
 
-# The PR image installs the CUDA-versioned bindings (nixl_ep_cu*) under
-# ${INSTALL_DIR}/lib/python3/dist-packages via meson's --prefix, which is not
-# on Python's default sys.path. Expose it so the nixl_ep dispatcher can load
-# nixl_ep_cu13 at runtime.
-export PYTHONPATH="${INSTALL_DIR}/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}"
-
-# Install the nixl meta wheel (provides the nixl_ep dispatcher package that
-# re-exports from nixl_ep_cu13). The wheel is staged in dist/ by the PR image
-# build; without this install `import nixl_ep` fails with ModuleNotFoundError.
-# The CUDA backend is already installed from source in the PR image, so avoid
-# fetching matching nixl-cu* release wheels that may not be published yet.
-if [ -n "$VIRTUAL_ENV" ] && grep -q '^uv =' "$VIRTUAL_ENV/pyvenv.cfg" 2>/dev/null; then
-    pip3="uv pip"
-else
-    pip3="python3 -m pip"
-fi
-$pip3 install --break-system-packages --no-deps dist/nixl-*none-any.whl
+# Make `import nixl_ep` resolve the source-tree dispatcher, which loads the
+# CUDA-versioned backend (nixl_ep_cu*) from the source install under ${INSTALL_DIR}.
+export PYTHONPATH="${PWD}/src/bindings/python/nixl-meta:${INSTALL_DIR}/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}"
 
 echo "==== Show system info ===="
 env
@@ -64,29 +50,6 @@ nvidia-smi topo -m || true
 ibv_devinfo || true
 uname -a || true
 cat /sys/devices/virtual/dmi/id/product_name || true
-
-echo "==== NVIDIA Peermem check ===="
-if ! lsmod | grep -q nvidia_peermem; then
-    echo "nvidia_peermem module not loaded"
-fi
-
-if [ -f /sys/kernel/mm/memory_peers/nv_mem/version ]; then
-    cat /sys/kernel/mm/memory_peers/nv_mem/version
-else
-    echo "/sys/kernel/mm/memory_peers/nv_mem/version not found "
-fi
-
-if [ -f /sys/module/nvidia_peermem/version ]; then
-    cat /sys/module/nvidia_peermem/version
-else
-    echo "/sys/module/nvidia_peermem/version not found"
-fi
-
-if [ -f /sys/module/nv_peer_mem/version ]; then
-    cat /sys/module/nv_peer_mem/version
-else
-    echo "/sys/module/nv_peer_mem/version not found"
-fi
 
 echo "==== Running elastic EP tests ===="
 EP_SRC_DIR="examples/device/ep"

--- a/.gitlab/test_ep.sh
+++ b/.gitlab/test_ep.sh
@@ -49,12 +49,14 @@ export PYTHONPATH="${INSTALL_DIR}/lib/python3/dist-packages${PYTHONPATH:+:$PYTHO
 # Install the nixl meta wheel (provides the nixl_ep dispatcher package that
 # re-exports from nixl_ep_cu13). The wheel is staged in dist/ by the PR image
 # build; without this install `import nixl_ep` fails with ModuleNotFoundError.
+# The CUDA backend is already installed from source in the PR image, so avoid
+# fetching matching nixl-cu* release wheels that may not be published yet.
 if [ -n "$VIRTUAL_ENV" ] && grep -q '^uv =' "$VIRTUAL_ENV/pyvenv.cfg" 2>/dev/null; then
     pip3="uv pip"
 else
     pip3="python3 -m pip"
 fi
-$pip3 install --break-system-packages dist/nixl-*none-any.whl
+$pip3 install --break-system-packages --no-deps dist/nixl-*none-any.whl
 
 echo "==== Show system info ===="
 env


### PR DESCRIPTION
Fix the new DL EP CI job by resolving `nixl_ep` through `PYTHONPATH` instead of installing the local `nixl` meta wheel with pip. This avoids pip trying to resolve unpublished matching backend wheels such as `nixl-cu13==1.3.1`.

In this DL EP CI path, the EP backend is already built from source into the PR image. This change makes `import nixl_ep` resolve the source-tree `nixl_ep` package, which then loads the CUDA-versioned backend from the source install under `${INSTALL_DIR}`. This avoids mixing a pip-installed meta wheel with source-installed backend artifacts.

The PR also removes the NVIDIA peermem diagnostic logging block from `test_ep.sh`, since peermem is not needed for this EP test.