### PR TITLE
ci: trigger CI triage agent on build failure

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -15,7 +15,7 @@
 // It is used to update the commit status and upload logs
 @Library('blossom-github-lib@master')
 @Library('ci-demo')  // External library for matrix build functionality
-@Library('swx-jenkins-lib')  // External library for matrix build functionality
+@Library('swx-jenkins-lib') // External library for matrix build functionality
 
 // Initialize the build matrix
 // The matrix class handles the parallel execution of different build configurations
@@ -48,6 +48,22 @@ try {
 } catch (Exception ex) {
     currentBuild.result = 'FAILURE'
     println ex
+    // On failure, kick off an automated CI triage investigation.
+    if (params.githubData) {
+        try {
+            // ciTriage (swx-jenkins-lib) POSTs to the agent on the flyweight executor.
+            withCredentials([string(credentialsId: 'ci-triage-nixl-url', variable: 'CI_TRIAGE_URL')]) {
+                ciTriage(
+                    url:       env.CI_TRIAGE_URL,
+                    commitSha: githubHelper.getMergedSHA(),
+                    prNumber:  githubHelper.getPRNumber(),
+                    insecure:  true,   // the ingress wildcard CA isn't in the controller trust store
+                )
+            }
+        } catch (Exception triageEx) {
+            echo "CI triage trigger failed (non-fatal): ${triageEx}"
+        }
+    }
     throw ex
 } finally {
     if (params.githubData) {


### PR DESCRIPTION
## What?
When a build fails and we have the GitHub context (PR/commit), POST to the CI triage agent's /triage endpoint to kick off an automated investigation. The agent fetches the Jenkins console log itself (job_name + build_number) and posts its diagnosis back to the PR.

- Added in the Jenkinsfile catch, gated on params.githubData, fully wrapped in try/catch so a triage-trigger failure never masks the real build failure.
- Uses the httpRequest step on the flyweight executor (no node{}): the matrix's k8s workers are torn down by the time the catch runs, and a bare node{} would cold-start a fresh pod or hang since the controller has no executors.
- validResponseCodes 100:599 so the agent's HTTP status never fails the build; ignoreSslErrors because the ingress wildcard CA isn't in the agents' trust store.
- Payload: trigger=jenkins, job_name, build_number, build_url, commit_sha (merged SHA), branch, pr_number — every field /triage requires.
- Endpoint overridable via env.CI_TRIAGE_URL (default is the nixl ingress).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI failure handling so failed builds can attempt an automatic triage notification when the necessary build context is available.
  * Triage notification failures are now non-blocking, ensuring the original build failure remains the primary outcome and the pipeline doesn’t get interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->