### PR TITLE
telemetry: expose error counts in exporters

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -68,6 +68,11 @@ stream:
   `agent_memory_deregistered_last_bytes` -- on both exporters. This is purely an
   exporter-side derivation: no new event type is emitted and the buffer format is
   unchanged.
+- **Error counters**: the Prometheus and DOCA exporters expose error events as
+  `agent_errors_total{status="<status>"}`. The `status` label is bounded by the
+  fixed `AGENT_ERR_*` event set: `not_posted`, `invalid_param`, `backend`,
+  `not_found`, `mismatch`, `not_allowed`, `repost_active`, `unknown`,
+  `not_supported`, `remote_disconnect`, `canceled`, and `no_telemetry`.
 
 ### Metric naming convention
 

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -17,6 +17,7 @@
 #ifndef NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_EVENT_H
 
+#include <array>
 #include <cstdint>
 #include <string_view>
 
@@ -104,7 +105,62 @@ telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
     }
     return "unknown_event";
 }
+
+constexpr std::array<nixl_telemetry_event_type_t, 12> telemetryErrorEventTypes{{
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED,
+    nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM,
+    nixl_telemetry_event_type_t::AGENT_ERR_BACKEND,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND,
+    nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED,
+    nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE,
+    nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED,
+    nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT,
+    nixl_telemetry_event_type_t::AGENT_ERR_CANCELED,
+    nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY,
+}};
+
+[[nodiscard]] constexpr const char *
+telemetryErrorStatusLabel(const nixl_telemetry_event_type_t type) noexcept {
+    switch (type) {
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED:
+        return "not_posted";
+    case nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM:
+        return "invalid_param";
+    case nixl_telemetry_event_type_t::AGENT_ERR_BACKEND:
+        return "backend";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND:
+        return "not_found";
+    case nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH:
+        return "mismatch";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED:
+        return "not_allowed";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE:
+        return "repost_active";
+    case nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN:
+        return "unknown";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED:
+        return "not_supported";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
+        return "remote_disconnect";
+    case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
+        return "canceled";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
+        return "no_telemetry";
+    case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
+    case nixl_telemetry_event_type_t::AGENT_RX_BYTES:
+    case nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM:
+    case nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM:
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED:
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED:
+    case nixl_telemetry_event_type_t::AGENT_XFER_TIME:
+    case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
+        return nullptr;
+    }
+    return nullptr;
 }
+} // namespace nixlEnumStrings
 
 /**
  * @struct nixlTelemetryEvent

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -106,7 +106,7 @@ telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
     return "unknown_event";
 }
 
-constexpr std::array<nixl_telemetry_event_type_t, 12> telemetryErrorEventTypes{{
+constexpr std::array<nixl_telemetry_event_type_t, 12> telemetry_error_event_types{{
     nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED,
     nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM,
     nixl_telemetry_event_type_t::AGENT_ERR_BACKEND,

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -58,6 +58,21 @@ enum class nixl_telemetry_event_type_t : uint32_t {
 [[nodiscard]] nixl_telemetry_event_type_t
 nixlTelemetryEventTypeForStatus(nixl_status_t s);
 
+inline constexpr std::array telemetry_error_event_types = {
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED,
+    nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM,
+    nixl_telemetry_event_type_t::AGENT_ERR_BACKEND,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND,
+    nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED,
+    nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE,
+    nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN,
+    nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED,
+    nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT,
+    nixl_telemetry_event_type_t::AGENT_ERR_CANCELED,
+    nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY,
+};
+
 namespace nixlEnumStrings {
 [[nodiscard]] constexpr std::string_view
 telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
@@ -105,21 +120,6 @@ telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
     }
     return "unknown_event";
 }
-
-inline constexpr std::array<nixl_telemetry_event_type_t, 12> telemetry_error_event_types{{
-    nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED,
-    nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM,
-    nixl_telemetry_event_type_t::AGENT_ERR_BACKEND,
-    nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND,
-    nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH,
-    nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED,
-    nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE,
-    nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN,
-    nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED,
-    nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT,
-    nixl_telemetry_event_type_t::AGENT_ERR_CANCELED,
-    nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY,
-}};
 
 [[nodiscard]] constexpr const char *
 telemetryErrorStatusLabel(const nixl_telemetry_event_type_t type) noexcept {

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -106,7 +106,7 @@ telemetryEventTypeStr(const nixl_telemetry_event_type_t type) noexcept {
     return "unknown_event";
 }
 
-constexpr std::array<nixl_telemetry_event_type_t, 12> telemetry_error_event_types{{
+inline constexpr std::array<nixl_telemetry_event_type_t, 12> telemetry_error_event_types{{
     nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED,
     nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM,
     nixl_telemetry_event_type_t::AGENT_ERR_BACKEND,

--- a/src/plugins/telemetry/doca/README.md
+++ b/src/plugins/telemetry/doca/README.md
@@ -71,11 +71,12 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_requests_num` | Yes | No | No |
 | `agent_xfer_time` | No | Yes | No |
 | `agent_xfer_post_time` | No | Yes | No |
-| Error event types (`agent_err_*`) | No | No | No |
+| Error event types (`agent_err_*`) | Yes | No | No |
 
 **Counter, Gauge, Histogram** - as implemented by the DOCA Telemetry Exporter
 
 - **Counter**: Instance lifetime count of the related value. Summed over the separate events' values.
+- Error events are exposed as one labeled counter: `agent_errors_total{status="..."}`. The `status` label is bounded by the fixed `AGENT_ERR_*` event set.
 - **Gauge**: Shows the value per the last event (transaction) and can grow or decrease as each event updates it. The byte events publish both a cumulative counter and a last-operation gauge: `agent_tx_bytes` / `agent_rx_bytes` carry the running total, while `agent_tx_last_bytes` / `agent_rx_last_bytes` (the `agent_<subject>_last_<unit>` convention) carry the byte size of the latest TX/RX request. The memory gauges follow the same convention -- `agent_memory_registered_last_bytes` / `agent_memory_deregistered_last_bytes` -- and report the byte size of the last (de)registration.
 - **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details.
 

--- a/src/plugins/telemetry/doca/README.md
+++ b/src/plugins/telemetry/doca/README.md
@@ -86,3 +86,4 @@ Each telemetry metric is provided with the following labels:
 
 - Hostname where the agent runs
 - Agent name (as provided during initialization, may be deprecated in future versions)
+- `status` (only on `agent_errors_total`): the error kind, bounded by the fixed `AGENT_ERR_*` event set

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -95,46 +95,6 @@ isCounterEvent(nixl_telemetry_event_type_t event_type) noexcept {
     return false;
 }
 
-[[nodiscard]] constexpr const char *
-errorStatusLabel(nixl_telemetry_event_type_t event_type) noexcept {
-    switch (event_type) {
-    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED:
-        return "not_posted";
-    case nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM:
-        return "invalid_param";
-    case nixl_telemetry_event_type_t::AGENT_ERR_BACKEND:
-        return "backend";
-    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND:
-        return "not_found";
-    case nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH:
-        return "mismatch";
-    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED:
-        return "not_allowed";
-    case nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE:
-        return "repost_active";
-    case nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN:
-        return "unknown";
-    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED:
-        return "not_supported";
-    case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
-        return "remote_disconnect";
-    case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
-        return "canceled";
-    case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
-        return "no_telemetry";
-    case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
-    case nixl_telemetry_event_type_t::AGENT_RX_BYTES:
-    case nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM:
-    case nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM:
-    case nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED:
-    case nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED:
-    case nixl_telemetry_event_type_t::AGENT_XFER_TIME:
-    case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
-        return nullptr;
-    }
-    return nullptr;
-}
-
 // Gauge series name for an event, or nullptr if the event has no gauge.
 [[nodiscard]] constexpr const char *
 gaugeMetricName(nixl_telemetry_event_type_t event_type) noexcept {
@@ -371,7 +331,8 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
         const std::lock_guard lock(g_metrics_mutex);
         const char *label_values[] = {agent_name_.c_str()};
 
-        if (const char *const status = errorStatusLabel(event.eventType_)) {
+        if (const char *const status =
+                nixlEnumStrings::telemetryErrorStatusLabel(event.eventType_)) {
             const auto result = appendErrorCounterSample(event, status);
             if (result != DOCA_SUCCESS) {
                 NIXL_ERROR << "Failed to add error counter: " << result;

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -95,6 +95,46 @@ isCounterEvent(nixl_telemetry_event_type_t event_type) noexcept {
     return false;
 }
 
+[[nodiscard]] constexpr const char *
+errorStatusLabel(nixl_telemetry_event_type_t event_type) noexcept {
+    switch (event_type) {
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED:
+        return "not_posted";
+    case nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM:
+        return "invalid_param";
+    case nixl_telemetry_event_type_t::AGENT_ERR_BACKEND:
+        return "backend";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND:
+        return "not_found";
+    case nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH:
+        return "mismatch";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED:
+        return "not_allowed";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE:
+        return "repost_active";
+    case nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN:
+        return "unknown";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED:
+        return "not_supported";
+    case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
+        return "remote_disconnect";
+    case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
+        return "canceled";
+    case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
+        return "no_telemetry";
+    case nixl_telemetry_event_type_t::AGENT_TX_BYTES:
+    case nixl_telemetry_event_type_t::AGENT_RX_BYTES:
+    case nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM:
+    case nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM:
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED:
+    case nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED:
+    case nixl_telemetry_event_type_t::AGENT_XFER_TIME:
+    case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
+        return nullptr;
+    }
+    return nullptr;
+}
+
 // Gauge series name for an event, or nullptr if the event has no gauge.
 [[nodiscard]] constexpr const char *
 gaugeMetricName(nixl_telemetry_event_type_t event_type) noexcept {
@@ -147,6 +187,7 @@ struct DocaSharedContext {
     doca_telemetry_exporter_schema *schema = nullptr;
     doca_telemetry_exporter_source *source = nullptr;
     doca_telemetry_exporter_label_set_id_t label_set_id = 0;
+    doca_telemetry_exporter_label_set_id_t error_label_set_id = 0;
     bool source_started = false;
     bool metrics_context_created = false;
 
@@ -215,6 +256,13 @@ DocaSharedContext::DocaSharedContext(const std::string &bind_address) {
             doca_telemetry_exporter_metrics_add_label_names(source, label_names, 1, &label_set_id);
         if (result != DOCA_SUCCESS) {
             throw std::runtime_error("Failed to create DOCA label set");
+        }
+
+        const char *error_label_names[] = {"agent_name", "status"};
+        result = doca_telemetry_exporter_metrics_add_label_names(
+            source, error_label_names, 2, &error_label_set_id);
+        if (result != DOCA_SUCCESS) {
+            throw std::runtime_error("Failed to create DOCA error label set");
         }
 
         doca_telemetry_exporter_metrics_set_flush_interval_ms(source, 1000);
@@ -292,6 +340,21 @@ nixlTelemetryDocaExporter::appendCounterSample(const nixlTelemetryEvent &event,
 }
 
 doca_error_t
+nixlTelemetryDocaExporter::appendErrorCounterSample(const nixlTelemetryEvent &event,
+                                                    const char *status) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    const char *label_values[] = {agent_name_.c_str(), status};
+    return doca_telemetry_exporter_metrics_add_counter_increment(ctx_->source,
+                                                                 docaTimestamp(),
+                                                                 "agent_errors_total",
+                                                                 event.value_,
+                                                                 ctx_->error_label_set_id,
+                                                                 label_values);
+#pragma GCC diagnostic pop
+}
+
+doca_error_t
 nixlTelemetryDocaExporter::appendGaugeSample(const nixlTelemetryEvent &event,
                                              const char *metric_name,
                                              const char *label_values[]) {
@@ -307,6 +370,15 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
         const std::lock_guard lock(g_metrics_mutex);
         const char *label_values[] = {agent_name_.c_str()};
+
+        if (const char *const status = errorStatusLabel(event.eventType_)) {
+            const auto result = appendErrorCounterSample(event, status);
+            if (result != DOCA_SUCCESS) {
+                NIXL_ERROR << "Failed to add error counter: " << result;
+                return NIXL_ERR_UNKNOWN;
+            }
+            return NIXL_SUCCESS;
+        }
 
         // Idempotent gauge first, non-idempotent counter increment last.
         if (const char *const gauge_name = gaugeMetricName(event.eventType_)) {

--- a/src/plugins/telemetry/doca/doca_exporter.h
+++ b/src/plugins/telemetry/doca/doca_exporter.h
@@ -52,6 +52,9 @@ private:
     [[nodiscard]] doca_error_t
     appendCounterSample(const nixlTelemetryEvent &event, const char *label_values[]);
 
+    [[nodiscard]] doca_error_t
+    appendErrorCounterSample(const nixlTelemetryEvent &event, const char *status);
+
     // Appends a gauge sample to the time-series (absolute last-operation value).
     [[nodiscard]] doca_error_t
     appendGaugeSample(const nixlTelemetryEvent &event,

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -92,3 +92,4 @@ Each telemetry metrics is provided with the following labels:
 
 - Hostname where the agent runs
 - Agent name (as custom provided during initialization, can be deprecated in the next versions)
+- `status` (only on `agent_errors_total`): the error kind, bounded by the fixed `AGENT_ERR_*` event set

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -77,11 +77,12 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_requests_num` | Yes | No | No |
 | `agent_xfer_time` | Yes | No | No |
 | `agent_xfer_post_time` | Yes | No | No |
-| Error event types (`agent_err_*`) | No | No | No |
+| Error event types (`agent_err_*`) | Yes | No | No |
 
 **Counter, Gauge, Histogram** - as implemented by the Prometheus exporter
 
 - **Counter**: Instance lifetime count of the related value. Summed over the separate events' values. Counter metrics have suffix '_total'
+- Error events are exposed as one labeled counter: `agent_errors_total{status="..."}`. The `status` label is bounded by the fixed `AGENT_ERR_*` event set.
 - **Gauge**: Shows the value per the last event (transaction) and can grow or decrease as each event updates it. The byte gauges follow the `agent_<subject>_last_<unit>` convention (the `_last` qualifier precedes the unit, keeping it distinct from the cumulative `_total` counter of the same base name): `agent_tx_last_bytes` / `agent_rx_last_bytes` carry the byte size of the latest TX/RX request, while `agent_tx_bytes_total` / `agent_rx_bytes_total` carry the running total. The memory gauges follow the same convention -- `agent_memory_registered_last_bytes` / `agent_memory_deregistered_last_bytes` -- and report the byte size of the last (de)registration, distinct from the cumulative `agent_memory_registered_total` / `agent_memory_deregistered_total` counters.
 - **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details.
 

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -155,7 +155,7 @@ nixlTelemetryPrometheusExporter::registerErrorCounters() {
                        .Help("Cumulative error count by status")
                        .Register(*registry_);
 
-    for (const auto event_type : nixlEnumStrings::telemetryErrorEventTypes) {
+    for (const auto event_type : nixlEnumStrings::telemetry_error_event_types) {
         const char *const status = nixlEnumStrings::telemetryErrorStatusLabel(event_type);
         auto &metric =
             family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}, {"status", status}});

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -155,7 +155,7 @@ nixlTelemetryPrometheusExporter::registerErrorCounters() {
                        .Help("Cumulative error count by status")
                        .Register(*registry_);
 
-    for (const auto event_type : nixlEnumStrings::telemetry_error_event_types) {
+    for (const auto event_type : telemetry_error_event_types) {
         const char *const status = nixlEnumStrings::telemetryErrorStatusLabel(event_type);
         auto &metric =
             family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}, {"status", status}});

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -18,7 +18,6 @@
 #include "common/configuration.h"
 #include "common/nixl_log.h"
 
-#include <array>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -52,26 +51,6 @@ std::mutex s_mutex;
 std::weak_ptr<prometheus::Exposer> s_exposer_weak;
 std::weak_ptr<prometheus::Registry> s_registry_weak;
 std::unordered_set<std::string> s_agent_names;
-
-struct ErrorMetric {
-    nixl_telemetry_event_type_t event_type;
-    const char *status;
-};
-
-constexpr std::array<ErrorMetric, 12> error_metrics{{
-    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED, "not_posted"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, "invalid_param"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_BACKEND, "backend"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND, "not_found"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH, "mismatch"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED, "not_allowed"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE, "repost_active"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN, "unknown"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED, "not_supported"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT, "remote_disconnect"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_CANCELED, "canceled"},
-    {nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY, "no_telemetry"},
-}};
 } // namespace
 
 nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
@@ -176,12 +155,11 @@ nixlTelemetryPrometheusExporter::registerErrorCounters() {
                        .Help("Cumulative error count by status")
                        .Register(*registry_);
 
-    for (const auto &error_metric : error_metrics) {
-        auto &metric = family.Add({{"hostname", hostname_},
-                                   {"agent_name", agent_name_},
-                                   {"status", error_metric.status}});
-        const std::string event_name(
-            nixlEnumStrings::telemetryEventTypeStr(error_metric.event_type));
+    for (const auto event_type : nixlEnumStrings::telemetryErrorEventTypes) {
+        const char *const status = nixlEnumStrings::telemetryErrorStatusLabel(event_type);
+        auto &metric =
+            family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}, {"status", status}});
+        const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event_type));
         const auto inserted = counters_.try_emplace(event_name, &family, &metric).second;
         if (!inserted) {
             family.Remove(&metric);

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -18,6 +18,7 @@
 #include "common/configuration.h"
 #include "common/nixl_log.h"
 
+#include <array>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -51,6 +52,26 @@ std::mutex s_mutex;
 std::weak_ptr<prometheus::Exposer> s_exposer_weak;
 std::weak_ptr<prometheus::Registry> s_registry_weak;
 std::unordered_set<std::string> s_agent_names;
+
+struct ErrorMetric {
+    nixl_telemetry_event_type_t event_type;
+    const char *status;
+};
+
+constexpr std::array<ErrorMetric, 12> error_metrics{{
+    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED, "not_posted"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, "invalid_param"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_BACKEND, "backend"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_FOUND, "not_found"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_MISMATCH, "mismatch"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_ALLOWED, "not_allowed"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_REPOST_ACTIVE, "repost_active"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_UNKNOWN, "unknown"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_NOT_SUPPORTED, "not_supported"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT, "remote_disconnect"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_CANCELED, "canceled"},
+    {nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY, "no_telemetry"},
+}};
 } // namespace
 
 nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
@@ -125,6 +146,7 @@ nixlTelemetryPrometheusExporter::initializeMetrics() {
     registerCounter("agent_memory_deregistered", "Cumulative memory deregistered");
     registerCounter("agent_xfer_time", "Start to Complete (per request)");
     registerCounter("agent_xfer_post_time", "Start to posting to Back-End (per request)");
+    registerErrorCounters();
 
     registerGauge("agent_tx_bytes", "agent_tx_last_bytes", "Bytes sent by the last request");
     registerGauge("agent_rx_bytes", "agent_rx_last_bytes", "Bytes received by the last request");
@@ -145,6 +167,27 @@ nixlTelemetryPrometheusExporter::registerCounter(const std::string &name, const 
         family.Remove(&metric);
     }
     NIXL_ASSERT(inserted);
+}
+
+void
+nixlTelemetryPrometheusExporter::registerErrorCounters() {
+    auto &family = prometheus::BuildCounter()
+                       .Name("agent_errors_total")
+                       .Help("Cumulative error count by status")
+                       .Register(*registry_);
+
+    for (const auto &error_metric : error_metrics) {
+        auto &metric = family.Add({{"hostname", hostname_},
+                                   {"agent_name", agent_name_},
+                                   {"status", error_metric.status}});
+        const std::string event_name(
+            nixlEnumStrings::telemetryEventTypeStr(error_metric.event_type));
+        const auto inserted = counters_.try_emplace(event_name, &family, &metric).second;
+        if (!inserted) {
+            family.Remove(&metric);
+        }
+        NIXL_ASSERT(inserted);
+    }
 }
 
 void

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.h
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.h
@@ -107,6 +107,9 @@ private:
     void
     registerCounter(const std::string &name, const std::string &help);
 
+    void
+    registerErrorCounters();
+
     // event_name is the lookup key exportEvent() uses (the telemetry event
     // name); metric_name is the exposed Prometheus series name. They differ for
     // last-operation gauges, e.g. the AGENT_TX_BYTES event ("agent_tx_bytes")

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -213,6 +213,32 @@ TEST_F(docaNixlExporterTest, ByteEventsEmitCumulativeCountersAndLastGauges) {
         << "rx last-op gauge must reflect only the final pushed value (15), not a sum";
 }
 
+TEST_F(docaNixlExporterTest, ErrorCountersUseBoundedStatusLabel) {
+    constexpr char agentName[] = "nixl_doca_error_counter_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    ASSERT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, 1}),
+              NIXL_SUCCESS);
+    ASSERT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, 1}),
+              NIXL_SUCCESS);
+    ASSERT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_BACKEND, 1}),
+              NIXL_SUCCESS);
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const std::string metric = "agent_errors_total";
+    const nixl::doca_test::labelSet invalidParamLabels{{"agent_name", agentName},
+                                                       {"status", "invalid_param"}};
+    const nixl::doca_test::labelSet backendLabels{{"agent_name", agentName}, {"status", "backend"}};
+
+    const auto metrics =
+        scrapeUntilValue(port_, metric, 2.0, std::chrono::seconds(12), invalidParamLabels);
+    EXPECT_EQ(metrics.latestValue(metric, invalidParamLabels), std::optional<double>(2.0))
+        << "invalid_param errors must accumulate under a bounded status label";
+    EXPECT_EQ(metrics.latestValue(metric, backendLabels), std::optional<double>(1.0))
+        << "backend errors must use a distinct status label on the same metric";
+}
+
 int
 main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -237,6 +237,12 @@ TEST_F(docaNixlExporterTest, ErrorCountersUseBoundedStatusLabel) {
         << "invalid_param errors must accumulate under a bounded status label";
     EXPECT_EQ(metrics.latestValue(metric, backendLabels), std::optional<double>(1.0))
         << "backend errors must use a distinct status label on the same metric";
+
+    for (const auto &[id, samples] : metrics.series()) {
+        (void)samples;
+        EXPECT_NE(id.name.rfind("agent_err_", 0), 0)
+            << "legacy per-type error counter must not be published: " << id.name;
+    }
 }
 
 int

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -496,8 +496,9 @@ TEST_F(prometheusTelemetryTest, ErrorCountersUseBoundedStatusLabel) {
     EXPECT_EQ(backend_sample.value, 1.0);
     EXPECT_FALSE(backend_sample.labels["hostname"].empty());
 
-    EXPECT_EQ(body.find("\nagent_err_invalid_param_total{"), std::string::npos)
-        << "Error counters must use the bounded status label, not per-type families";
-    EXPECT_EQ(body.find("\nagent_err_backend_total{"), std::string::npos)
-        << "Error counters must use the bounded status label, not per-type families";
+    std::istringstream metrics_stream(body);
+    for (std::string line; std::getline(metrics_stream, line);) {
+        EXPECT_NE(line.rfind("agent_err_", 0), 0u)
+            << "legacy per-type error counter must not be published: " << line;
+    }
 }

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -148,10 +148,22 @@ parsePrometheusSampleLine(const std::string &line,
 }
 
 bool
-findAgentMetricSample(const std::string &body,
-                      const std::string &metric_name,
-                      const std::string &agent_name,
-                      PrometheusSample &sample) {
+labelsContain(const std::unordered_map<std::string, std::string> &labels,
+              const std::unordered_map<std::string, std::string> &required_labels) {
+    for (const auto &[key, expected_value] : required_labels) {
+        const auto it = labels.find(key);
+        if (it == labels.end() || it->second != expected_value) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+findMetricSample(const std::string &body,
+                 const std::string &metric_name,
+                 const std::unordered_map<std::string, std::string> &required_labels,
+                 PrometheusSample &sample) {
     std::istringstream body_lines(body);
     std::string line;
     while (std::getline(body_lines, line)) {
@@ -165,16 +177,25 @@ findAgentMetricSample(const std::string &body,
             continue;
         }
 
-        const auto agent_it = labels.find("agent_name");
-        const auto hostname_it = labels.find("hostname");
-        if (agent_it != labels.end() && agent_it->second == agent_name &&
-            hostname_it != labels.end() && !hostname_it->second.empty()) {
+        if (labelsContain(labels, required_labels)) {
             sample.labels = labels;
             sample.value = value;
             return true;
         }
     }
     return false;
+}
+
+bool
+findAgentMetricSample(const std::string &body,
+                      const std::string &metric_name,
+                      const std::string &agent_name,
+                      PrometheusSample &sample) {
+    if (!findMetricSample(body, metric_name, {{"agent_name", agent_name}}, sample)) {
+        return false;
+    }
+    const auto hostname_it = sample.labels.find("hostname");
+    return hostname_it != sample.labels.end() && !hostname_it->second.empty();
 }
 
 bool
@@ -251,7 +272,7 @@ TEST_F(prometheusTelemetryTest, AgentMetricsAppearInScrape) {
     const std::string body = waitForMetricsBody(port_);
     ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
 
-    // The 8 counter families that initializeMetrics() must publish.
+    // The counter families that initializeMetrics() must publish.
     const std::vector<std::string> expected_counters = {
         "agent_tx_bytes_total",
         "agent_rx_bytes_total",
@@ -261,6 +282,7 @@ TEST_F(prometheusTelemetryTest, AgentMetricsAppearInScrape) {
         "agent_memory_deregistered_total",
         "agent_xfer_time_total",
         "agent_xfer_post_time_total",
+        "agent_errors_total",
     };
     for (const auto &c : expected_counters) {
         EXPECT_NE(body.find(c), std::string::npos)
@@ -278,6 +300,8 @@ TEST_F(prometheusTelemetryTest, AgentMetricsAppearInScrape) {
         << "Missing agent_tx_last_bytes gauge";
     EXPECT_NE(body.find("\nagent_rx_last_bytes{"), std::string::npos)
         << "Missing agent_rx_last_bytes gauge";
+    EXPECT_EQ(body.find("\nagent_err_invalid_param_total{"), std::string::npos)
+        << "Error counters must use the labeled agent_errors_total series";
 
     // Each metric must carry the two labels the exporter attaches.
     EXPECT_NE(body.find("agent_name=\"" + agent_name + "\""), std::string::npos)
@@ -433,4 +457,45 @@ TEST_F(prometheusTelemetryTest, ByteCounterSumsWhileLastGaugeTracksFinalOp) {
         << "agent_rx_last_bytes gauge for this agent is not in scrape body";
     EXPECT_EQ(rx_last_sample.value, 1500.0)
         << "rx last-op gauge must equal the final exported value (1500), not the sum";
+}
+
+TEST_F(prometheusTelemetryTest, ErrorCountersUseBoundedStatusLabel) {
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const std::string agent_name = "prometheus_error_counter_agent";
+    const nixlTelemetryExporterInitParams params{agent_name, 4096};
+    auto exporter = handle->createExporter(params);
+    ASSERT_NE(exporter, nullptr);
+
+    EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, 1}),
+              NIXL_SUCCESS);
+    EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_INVALID_PARAM, 1}),
+              NIXL_SUCCESS);
+    EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_ERR_BACKEND, 1}),
+              NIXL_SUCCESS);
+
+    const std::string body = waitForMetricsBody(port_);
+    ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
+
+    PrometheusSample invalid_param_sample;
+    ASSERT_TRUE(findMetricSample(body,
+                                 "agent_errors_total",
+                                 {{"agent_name", agent_name}, {"status", "invalid_param"}},
+                                 invalid_param_sample))
+        << "agent_errors_total{status=\"invalid_param\"} for this agent is not in scrape body";
+    EXPECT_EQ(invalid_param_sample.value, 2.0);
+    EXPECT_FALSE(invalid_param_sample.labels["hostname"].empty());
+
+    PrometheusSample backend_sample;
+    ASSERT_TRUE(findMetricSample(body,
+                                 "agent_errors_total",
+                                 {{"agent_name", agent_name}, {"status", "backend"}},
+                                 backend_sample))
+        << "agent_errors_total{status=\"backend\"} for this agent is not in scrape body";
+    EXPECT_EQ(backend_sample.value, 1.0);
+    EXPECT_FALSE(backend_sample.labels["hostname"].empty());
+
+    EXPECT_EQ(body.find("\nagent_err_invalid_param_total{"), std::string::npos)
+        << "Error counters must use the bounded status label, not per-type families";
 }

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -498,4 +498,6 @@ TEST_F(prometheusTelemetryTest, ErrorCountersUseBoundedStatusLabel) {
 
     EXPECT_EQ(body.find("\nagent_err_invalid_param_total{"), std::string::npos)
         << "Error counters must use the bounded status label, not per-type families";
+    EXPECT_EQ(body.find("\nagent_err_backend_total{"), std::string::npos)
+        << "Error counters must use the bounded status label, not per-type families";
 }


### PR DESCRIPTION
## What?

Expose existing `AGENT_ERR_*` telemetry events from both telemetry exporters as a bounded labeled counter:

`agent_errors_total{status="..."}`

This adds error-count export support to the native Prometheus exporter and the DOCA telemetry exporter. Core telemetry event types, event names, and the shared-memory buffer format are unchanged.

## Why?

The agent already emits per-error telemetry events via `updateErrorCount`, but the active exporter paths did not expose them. This makes error counts visible through the exporter metrics surface without adding new core events or changing `TELEMETRY_VERSION`.

## How?

Prometheus registers one `agent_errors_total` counter family with `hostname`, `agent_name`, and `status` labels, then maps each existing `AGENT_ERR_*` event to the corresponding bounded `status` value.

DOCA adds a second label set for `agent_name` + `status` and routes `AGENT_ERR_*` events through a dedicated `agent_errors_total` counter path.

Tests cover both exporters:
- Prometheus scrape test verifies `invalid_param` and `backend` accumulate under separate `status` labels.
- DOCA scrape test verifies the same labeled counter behavior after flush.

Validation:
- `ninja -C build install`
- `build/test/gtest/gtest --gtest_filter='telemetryTest.*:prometheusTelemetryTest.*'`
- `meson test -C build doca_test doca_nixl_test`
- diff-scoped `clang-format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry docs and “Metrics & Events” guidance to describe agent error telemetry as a single labeled counter: `agent_errors_total{status="..."}`, with `status` constrained to the predefined `AGENT_ERR_*` set.
* **New Features**
  * Prometheus and DOCA exporters now aggregate agent error events into `agent_errors_total` using the bounded `status` label (and include `hostname`/`agent_name`), removing legacy per-error-type `agent_err_*` counter families.
* **Tests**
  * Added/updated end-to-end and scrape-parsing tests to validate per-`status` totals and confirm legacy `agent_err_*` series are not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->