### PR TITLE
tracing: NVTX completeness + cross-thread correlation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -445,13 +445,18 @@ if nixl_trace_enabled
     # NVTX: header-only; ships with the CUDA toolkit (nvtx3). Detect-then-disable
     # gracefully so non-CUDA / werror builds stay green. Built as a separately
     # loaded plugin (src/plugins/tracing/nvtx), not linked into libnixl; nvtx_inc_dep
-    # is consumed there.
+    # is consumed there. PR7 structured payloads require nvToolsExtPayload.h (not
+    # present in all CUDA toolkit images); skip the plugin when either header is absent.
     if 'nvtx' in requested_trace_backends
         if cuda_dep.found()
             nvtx_inc_dep = cuda_dep.partial_dependency(includes: true, compile_args: true)
-            if cpp.has_header('nvtx3/nvToolsExt.h', dependencies: nvtx_inc_dep)
+            has_nvtx_base = cpp.has_header('nvtx3/nvToolsExt.h', dependencies: nvtx_inc_dep)
+            has_nvtx_payload = cpp.has_header('nvtx3/nvToolsExtPayload.h', dependencies: nvtx_inc_dep)
+            if has_nvtx_base and has_nvtx_payload
                 nixl_trace_nvtx_enabled = true
                 message('nixl::trace: NVTX backend plugin enabled (CUDA-bundled nvtx3 headers)')
+            elif has_nvtx_base and not has_nvtx_payload
+                warning('nixl::trace: nvtx requested but nvtx3/nvToolsExtPayload.h not found; NVTX backend disabled')
             else
                 warning('nixl::trace: nvtx requested but nvtx3 headers not found; NVTX backend disabled')
             endif

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1082,6 +1082,9 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
         return NIXL_ERR_INVALID_PARAM;
     }
 
+    // Request-handle address is a stable id shared with the completion below,
+    // so the two link even when posted and polled from different threads.
+    NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), reinterpret_cast<std::uint64_t>(req_hndl));
     NIXL_TRACE_SCOPE(trace_span,
                      data->tracer_.get(),
                      req_hndl->backendOp == NIXL_WRITE ? "nixl::postXferReq.write" :
@@ -1213,6 +1216,8 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
             }
         }
         if (req_hndl->status == NIXL_SUCCESS) {
+            NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(),
+                                         reinterpret_cast<std::uint64_t>(req_hndl));
             NIXL_TRACE_MARK(
                 data->tracer_.get(), "nixl::xfer.complete", nixl::trace::Kind::Metadata);
         }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1542,6 +1542,9 @@ nixlAgent::getLocalPartialMD(const nixl_reg_dlist_t &descs,
 nixl_status_t
 nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
                          std::string &agent_name) {
+    NIXL_TRACE_SCOPE(
+        trace_span, data->tracer_.get(), "nixl::loadRemoteMD", nixl::trace::Kind::Metadata);
+
     nixlSerDes sd;
     nixl_blob_t conn_info;
     nixl_backend_t nixl_backend;
@@ -1567,6 +1570,7 @@ nixlAgent::loadRemoteMD (const nixl_blob_t &remote_metadata,
     }
 
     NIXL_DEBUG << "Loading remote metadata for agent: " << remote_agent;
+    NIXL_TRACE_ATTR(trace_span, "remote_agent", std::string_view{remote_agent});
 
     size_t conn_cnt;
     ret = sd.getBuf("Conns", &conn_cnt, sizeof(conn_cnt));
@@ -1715,6 +1719,10 @@ nixlAgent::sendLocalPartialMD(const nixl_reg_dlist_t &descs,
 nixl_status_t
 nixlAgent::fetchRemoteMD (const std::string remote_name,
                           const nixl_opt_args_t* extra_params) {
+    NIXL_TRACE_SCOPE(
+        trace_span, data->tracer_.get(), "nixl::fetchRemoteMD", nixl::trace::Kind::Metadata);
+    NIXL_TRACE_ATTR(trace_span, "remote_agent", std::string_view{remote_name});
+
     // If IP is provided, use socket-based communication
     if (extra_params && !extra_params->ipAddr.empty()) {
         data->enqueueCommWork(std::make_tuple(SOCK_FETCH, extra_params->ipAddr, extra_params->port, ""));
@@ -1810,6 +1818,11 @@ nixlAgent::prepMemView(const nixl_remote_dlist_t &dlist,
                        const nixl_opt_args_t *extra_params) const {
     const auto desc_count = static_cast<size_t>(dlist.descCount());
     const auto mem_type = dlist.getType();
+    NIXL_TRACE_SCOPE(
+        trace_span, data->tracer_.get(), "nixl::prepMemView", nixl::trace::Kind::MemoryR);
+    NIXL_TRACE_ATTR(trace_span, "mem_type", static_cast<std::int64_t>(mem_type));
+    NIXL_TRACE_ATTR(trace_span, "desc_count", static_cast<std::int64_t>(desc_count));
+
     nixl_remote_meta_dlist_t remote_meta_dlist{mem_type};
     nixlBackendEngine *engine{nullptr};
 
@@ -1879,6 +1892,11 @@ nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
                        nixlMemViewH &mvh,
                        const nixl_opt_args_t *extra_params) const {
     const auto mem_type = dlist.getType();
+    NIXL_TRACE_SCOPE(
+        trace_span, data->tracer_.get(), "nixl::prepMemView", nixl::trace::Kind::MemoryR);
+    NIXL_TRACE_ATTR(trace_span, "mem_type", static_cast<std::int64_t>(mem_type));
+    NIXL_TRACE_ATTR(trace_span, "desc_count", static_cast<std::int64_t>(dlist.descCount()));
+
     nixl_meta_dlist_t meta_dlist{mem_type};
     nixlBackendEngine *engine{nullptr};
 
@@ -1914,6 +1932,9 @@ nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
 
 void
 nixlAgent::releaseMemView(nixlMemViewH mvh) const {
+    NIXL_TRACE_SCOPE(
+        trace_span, data->tracer_.get(), "nixl::releaseMemView", nixl::trace::Kind::Generic);
+
     NIXL_SHARED_LOCK_GUARD(data->lock);
 
     const auto it = data->mvhToEngine.find(mvh);

--- a/src/core/tracing/trace.h
+++ b/src/core/tracing/trace.h
@@ -185,6 +185,38 @@ private:
     std::vector<std::unique_ptr<TraceBackend>> backends_;
 };
 
+/**
+ * @brief RAII guard that keeps a correlation id active on the tracer for its
+ *        lifetime, so every span/mark created while it is in scope is tagged
+ *        with that id. Null-tracer-safe. Used to link spans emitted on different
+ *        threads (e.g. postXferReq on the caller thread vs. the completion on
+ *        the polling thread) to the same logical request.
+ */
+class CorrelationScope {
+public:
+    CorrelationScope(Tracer *tracer, std::uint64_t id) noexcept : tracer_(tracer) {
+        if (tracer_ != nullptr) {
+            tracer_->pushCorrelationId(id);
+        }
+    }
+
+    ~CorrelationScope() {
+        if (tracer_ != nullptr) {
+            tracer_->popCorrelationId();
+        }
+    }
+
+    CorrelationScope(const CorrelationScope &) = delete;
+    CorrelationScope &
+    operator=(const CorrelationScope &) = delete;
+    CorrelationScope(CorrelationScope &&) = delete;
+    CorrelationScope &
+    operator=(CorrelationScope &&) = delete;
+
+private:
+    Tracer *tracer_;
+};
+
 /** @brief Inputs used to build the composite tracer from enabled backends. */
 struct TracerConfig {
     /** @brief Agent name; used e.g. as the NVTX domain name. */

--- a/src/core/tracing/trace.h
+++ b/src/core/tracing/trace.h
@@ -194,7 +194,7 @@ private:
  */
 class CorrelationScope {
 public:
-    CorrelationScope(Tracer *tracer, std::uint64_t id) noexcept : tracer_(tracer) {
+    [[nodiscard]] CorrelationScope(Tracer *tracer, std::uint64_t id) : tracer_(tracer) {
         if (tracer_ != nullptr) {
             tracer_->pushCorrelationId(id);
         }

--- a/src/core/tracing/trace_macros.h
+++ b/src/core/tracing/trace_macros.h
@@ -50,6 +50,11 @@
         }                                                       \
     } while (0)
 
+// Declare before NIXL_TRACE_SCOPE so the span is created while the id is active.
+// One per scope.
+#define NIXL_TRACE_CORRELATION_SCOPE(tracer_ptr, id) \
+    ::nixl::trace::CorrelationScope nixl_trace_correlation_scope_((tracer_ptr), (id))
+
 #define NIXL_TRACE_ATTR(span, attr_key, attr_value)        \
     do {                                                   \
         if ((span).active()) {                             \
@@ -67,6 +72,9 @@
     } while (0)
 #define NIXL_TRACE_ATTR(span, attr_key, attr_value) \
     do {                                            \
+    } while (0)
+#define NIXL_TRACE_CORRELATION_SCOPE(tracer_ptr, id) \
+    do {                                             \
     } while (0)
 
 #endif // NIXL_TRACE_ENABLED

--- a/src/plugins/tracing/nvtx/meson.build
+++ b/src/plugins/tracing/nvtx/meson.build
@@ -19,6 +19,10 @@ shared_library(
     'libtrace_backend_nvtx',
     'nvtx_plugin.cpp',
     'nvtx_backend.cpp',
+    'nvtx_payload_schemas.cpp',
+    'nvtx_events.cpp',
+    'nvtx_span.cpp',
+    'nvtx_trace_backend.cpp',
     include_directories: [nixl_inc_dirs, utils_inc_dirs],
     # dl_dep: nvtx3 injection thunks call dlopen/dlsym/dlclose, so with --no-undefined
     # libdl must be linked where dl* isn't merged into libc (e.g. the manylinux wheel build).

--- a/src/plugins/tracing/nvtx/nvtx_events.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_events.cpp
@@ -81,14 +81,6 @@ namespace {
         return ev;
     }
 
-    [[nodiscard]] nvtxEventAttributes_t
-    makeEvent(const char *ascii_name, const Kind kind) {
-        nvtxEventAttributes_t ev = makeEventBase(kind);
-        ev.messageType = NVTX_MESSAGE_TYPE_ASCII;
-        ev.message.ascii = ascii_name;
-        return ev;
-    }
-
     [[nodiscard]] nvtxStringHandle_t
     lookupRegistered(std::string_view name,
                      const std::vector<nvtxStringHandle_t> &handles) noexcept {
@@ -115,13 +107,17 @@ registerSpanNames(const nvtxDomainHandle_t domain) {
 nvtxEventAttributes_t
 eventForName(const std::string_view name,
              const Kind kind,
-             const std::vector<nvtxStringHandle_t> &registered_handles,
-             std::string &fallback_storage) {
-    if (const nvtxStringHandle_t registered = lookupRegistered(name, registered_handles)) {
-        return makeEvent(registered, kind);
+             const nvtxDomainHandle_t domain,
+             const std::vector<nvtxStringHandle_t> &registered_handles) {
+    nvtxStringHandle_t handle = lookupRegistered(name, registered_handles);
+    if (handle == nullptr) {
+        // Not one of the fixed nixl::* names: register it now so the event still
+        // carries the real label. Registered strings need no caller-owned storage
+        // (unlike an ASCII message), keeping the call sites simple.
+        const std::string owned(name);
+        handle = nvtxDomainRegisterStringA(domain, owned.c_str());
     }
-    fallback_storage.assign(name);
-    return makeEvent(fallback_storage.c_str(), kind);
+    return makeEvent(handle, kind);
 }
 
 } // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_events.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_events.cpp
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_events.h"
+
+#include <cstdint>
+#include <iterator>
+
+namespace nixl::trace::nvtx_internal {
+namespace {
+
+    constexpr const char *kRegisteredSpanNames[] = {
+        "nixl::registerMem",
+        "nixl::deregisterMem",
+        "nixl::makeConnection",
+        "nixl::makeXferReq",
+        "nixl::createXferReq",
+        "nixl::postXferReq.write",
+        "nixl::postXferReq.read",
+        "nixl::genNotif",
+        "nixl::getNotifs",
+        "nixl::xfer.complete",
+        "nixl::loadRemoteMD",
+        "nixl::fetchRemoteMD",
+        "nixl::prepMemView",
+        "nixl::releaseMemView",
+    };
+
+    [[nodiscard]] constexpr std::uint32_t
+    colorFor(const Kind kind) noexcept {
+        switch (kind) {
+        case Kind::Generic:
+            return 0xFF455A64u; // blue-gray
+        case Kind::Compute:
+            return 0xFF00838Fu; // teal
+        case Kind::MemoryR:
+            return 0xFFEF6C00u; // orange
+        case Kind::MemoryW:
+            return 0xFFF9A825u; // amber
+        case Kind::CommSend:
+            return 0xFF2E7D32u; // green
+        case Kind::CommRecv:
+            return 0xFF1565C0u; // blue
+        case Kind::CommColl:
+            return 0xFF6A1B9Au; // purple
+        case Kind::Metadata:
+            return 0xFF757575u; // gray
+        }
+        return 0xFF455A64u; // blue-gray fallback for out-of-range Kind values
+    }
+
+    [[nodiscard]] nvtxEventAttributes_t
+    makeEventBase(const Kind kind) {
+        nvtxEventAttributes_t ev{};
+        ev.version = NVTX_VERSION;
+        ev.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+        ev.colorType = NVTX_COLOR_ARGB;
+        ev.color = colorFor(kind);
+        return ev;
+    }
+
+    [[nodiscard]] nvtxEventAttributes_t
+    makeEvent(const nvtxStringHandle_t registered_name, const Kind kind) {
+        nvtxEventAttributes_t ev = makeEventBase(kind);
+        ev.messageType = NVTX_MESSAGE_TYPE_REGISTERED;
+        ev.message.registered = registered_name;
+        return ev;
+    }
+
+    [[nodiscard]] nvtxEventAttributes_t
+    makeEvent(const char *ascii_name, const Kind kind) {
+        nvtxEventAttributes_t ev = makeEventBase(kind);
+        ev.messageType = NVTX_MESSAGE_TYPE_ASCII;
+        ev.message.ascii = ascii_name;
+        return ev;
+    }
+
+    [[nodiscard]] nvtxStringHandle_t
+    lookupRegistered(std::string_view name,
+                     const std::vector<nvtxStringHandle_t> &handles) noexcept {
+        for (std::size_t i = 0; i < std::size(kRegisteredSpanNames); ++i) {
+            if (name == kRegisteredSpanNames[i]) {
+                return handles[i];
+            }
+        }
+        return nullptr;
+    }
+
+} // namespace
+
+std::vector<nvtxStringHandle_t>
+registerSpanNames(const nvtxDomainHandle_t domain) {
+    std::vector<nvtxStringHandle_t> handles;
+    handles.reserve(std::size(kRegisteredSpanNames));
+    for (const char *name : kRegisteredSpanNames) {
+        handles.push_back(nvtxDomainRegisterStringA(domain, name));
+    }
+    return handles;
+}
+
+nvtxEventAttributes_t
+eventForName(const std::string_view name,
+             const Kind kind,
+             const std::vector<nvtxStringHandle_t> &registered_handles,
+             std::string &fallback_storage) {
+    if (const nvtxStringHandle_t registered = lookupRegistered(name, registered_handles)) {
+        return makeEvent(registered, kind);
+    }
+    fallback_storage.assign(name);
+    return makeEvent(fallback_storage.c_str(), kind);
+}
+
+} // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_events.h
+++ b/src/plugins/tracing/nvtx/nvtx_events.h
@@ -31,12 +31,14 @@ namespace nixl::trace::nvtx_internal {
 [[nodiscard]] std::vector<nvtxStringHandle_t>
 registerSpanNames(nvtxDomainHandle_t domain);
 
-/** @brief Build NVTX event attributes for a span/mark name and operation kind. */
+/** @brief Build NVTX event attributes for a span/mark name and operation kind.
+ *         Uses a pre-registered string handle; an unknown name is registered on
+ *         @p domain on demand, so the event always carries a registered label. */
 [[nodiscard]] nvtxEventAttributes_t
 eventForName(std::string_view name,
              Kind kind,
-             const std::vector<nvtxStringHandle_t> &registered_handles,
-             std::string &fallback_storage);
+             nvtxDomainHandle_t domain,
+             const std::vector<nvtxStringHandle_t> &registered_handles);
 
 } // namespace nixl::trace::nvtx_internal
 

--- a/src/plugins/tracing/nvtx/nvtx_events.h
+++ b/src/plugins/tracing/nvtx/nvtx_events.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_EVENTS_H
+#define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_EVENTS_H
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nvtx3/nvToolsExt.h>
+
+#include "tracing/trace.h"
+
+namespace nixl::trace::nvtx_internal {
+
+/** @brief Register fixed `nixl::*` span/mark names on @p domain (hot-path labels). */
+[[nodiscard]] std::vector<nvtxStringHandle_t>
+registerSpanNames(nvtxDomainHandle_t domain);
+
+/** @brief Build NVTX event attributes for a span/mark name and operation kind. */
+[[nodiscard]] nvtxEventAttributes_t
+eventForName(std::string_view name,
+             Kind kind,
+             const std::vector<nvtxStringHandle_t> &registered_handles,
+             std::string &fallback_storage);
+
+} // namespace nixl::trace::nvtx_internal
+
+#endif // NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_EVENTS_H

--- a/src/plugins/tracing/nvtx/nvtx_payload_schemas.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_payload_schemas.cpp
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_payload_schemas.h"
+
+#include <cstddef>
+#include <iterator>
+
+#include <nvtx3/nvToolsExtPayload.h>
+
+namespace nixl::trace::nvtx_internal {
+namespace {
+
+    struct Int64Attr {
+        const char *key;
+        std::int64_t value;
+    };
+
+    struct DoubleAttr {
+        const char *key;
+        double value;
+    };
+
+    struct StrAttr {
+        const char *key;
+        const char *value;
+    };
+
+    [[nodiscard]] nvtxPayloadSchemaAttr_t
+    makeStaticSchemaAttr(const char *name,
+                         nvtxPayloadSchemaEntry_t *entries,
+                         const std::size_t num_entries,
+                         const std::size_t static_size) {
+        nvtxPayloadSchemaAttr_t attr{};
+        attr.fieldMask = NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME |
+            NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
+            NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_STATIC_SIZE;
+        attr.name = name;
+        attr.type = NVTX_PAYLOAD_SCHEMA_TYPE_STATIC;
+        attr.entries = entries;
+        attr.numEntries = num_entries;
+        attr.payloadStaticSize = static_size;
+        return attr;
+    }
+
+    nvtxPayloadSchemaEntry_t kInt64AttrSchemaEntries[] = {
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
+         "key",
+         nullptr,
+         0,
+         offsetof(Int64Attr, key),
+         nullptr,
+         nullptr},
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_INT64,
+         "value",
+         nullptr,
+         0,
+         offsetof(Int64Attr, value),
+         nullptr,
+         nullptr},
+    };
+
+    nvtxPayloadSchemaEntry_t kDoubleAttrSchemaEntries[] = {
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
+         "key",
+         nullptr,
+         0,
+         offsetof(DoubleAttr, key),
+         nullptr,
+         nullptr},
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
+         "value",
+         nullptr,
+         0,
+         offsetof(DoubleAttr, value),
+         nullptr,
+         nullptr},
+    };
+
+    nvtxPayloadSchemaEntry_t kStrAttrSchemaEntries[] = {
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
+         "key",
+         nullptr,
+         0,
+         offsetof(StrAttr, key),
+         nullptr,
+         nullptr},
+        {0,
+         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
+         "value",
+         nullptr,
+         0,
+         offsetof(StrAttr, value),
+         nullptr,
+         nullptr},
+    };
+
+    const nvtxPayloadSchemaAttr_t kInt64AttrSchemaAttr =
+        makeStaticSchemaAttr("nixl.trace.int64_attr",
+                             kInt64AttrSchemaEntries,
+                             std::size(kInt64AttrSchemaEntries),
+                             sizeof(Int64Attr));
+
+    const nvtxPayloadSchemaAttr_t kDoubleAttrSchemaAttr =
+        makeStaticSchemaAttr("nixl.trace.double_attr",
+                             kDoubleAttrSchemaEntries,
+                             std::size(kDoubleAttrSchemaEntries),
+                             sizeof(DoubleAttr));
+
+    const nvtxPayloadSchemaAttr_t kStrAttrSchemaAttr =
+        makeStaticSchemaAttr("nixl.trace.str_attr",
+                             kStrAttrSchemaEntries,
+                             std::size(kStrAttrSchemaEntries),
+                             sizeof(StrAttr));
+
+} // namespace
+
+PayloadSchemaIds
+registerPayloadSchemas(const nvtxDomainHandle_t domain) {
+    PayloadSchemaIds ids;
+    ids.int64_attr = nvtxPayloadSchemaRegister(domain, &kInt64AttrSchemaAttr);
+    ids.double_attr = nvtxPayloadSchemaRegister(domain, &kDoubleAttrSchemaAttr);
+    ids.str_attr = nvtxPayloadSchemaRegister(domain, &kStrAttrSchemaAttr);
+    return ids;
+}
+
+} // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_payload_schemas.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_payload_schemas.cpp
@@ -25,26 +25,29 @@
 namespace nixl::trace::nvtx_internal {
 namespace {
 
-    struct Int64Attr {
-        const char *key;
-        std::int64_t value;
-    };
+    // All three schemas describe the shared AttrPayload layout: a "key" C-string
+    // followed by a "value" whose only difference is the NVTX entry type.
+    [[nodiscard]] nvtxPayloadSchemaEntry_t
+    keyEntry() {
+        return {0,
+                NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
+                "key",
+                nullptr,
+                0,
+                offsetof(AttrPayload, key),
+                nullptr,
+                nullptr};
+    }
 
-    struct DoubleAttr {
-        const char *key;
-        double value;
-    };
-
-    struct StrAttr {
-        const char *key;
-        const char *value;
-    };
+    [[nodiscard]] nvtxPayloadSchemaEntry_t
+    valueEntry(const std::uint64_t entry_type) {
+        return {0, entry_type, "value", nullptr, 0, offsetof(AttrPayload, value), nullptr, nullptr};
+    }
 
     [[nodiscard]] nvtxPayloadSchemaAttr_t
     makeStaticSchemaAttr(const char *name,
                          nvtxPayloadSchemaEntry_t *entries,
-                         const std::size_t num_entries,
-                         const std::size_t static_size) {
+                         const std::size_t num_entries) {
         nvtxPayloadSchemaAttr_t attr{};
         attr.fieldMask = NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NAME |
             NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_FIELD_NUM_ENTRIES |
@@ -53,93 +56,30 @@ namespace {
         attr.type = NVTX_PAYLOAD_SCHEMA_TYPE_STATIC;
         attr.entries = entries;
         attr.numEntries = num_entries;
-        attr.payloadStaticSize = static_size;
+        attr.payloadStaticSize = sizeof(AttrPayload);
         return attr;
     }
 
-    nvtxPayloadSchemaEntry_t kInt64AttrSchemaEntries[] = {
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
-         "key",
-         nullptr,
-         0,
-         offsetof(Int64Attr, key),
-         nullptr,
-         nullptr},
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_INT64,
-         "value",
-         nullptr,
-         0,
-         offsetof(Int64Attr, value),
-         nullptr,
-         nullptr},
-    };
-
-    nvtxPayloadSchemaEntry_t kDoubleAttrSchemaEntries[] = {
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
-         "key",
-         nullptr,
-         0,
-         offsetof(DoubleAttr, key),
-         nullptr,
-         nullptr},
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE,
-         "value",
-         nullptr,
-         0,
-         offsetof(DoubleAttr, value),
-         nullptr,
-         nullptr},
-    };
-
-    nvtxPayloadSchemaEntry_t kStrAttrSchemaEntries[] = {
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
-         "key",
-         nullptr,
-         0,
-         offsetof(StrAttr, key),
-         nullptr,
-         nullptr},
-        {0,
-         NVTX_PAYLOAD_ENTRY_TYPE_CSTRING,
-         "value",
-         nullptr,
-         0,
-         offsetof(StrAttr, value),
-         nullptr,
-         nullptr},
-    };
-
-    const nvtxPayloadSchemaAttr_t kInt64AttrSchemaAttr =
-        makeStaticSchemaAttr("nixl.trace.int64_attr",
-                             kInt64AttrSchemaEntries,
-                             std::size(kInt64AttrSchemaEntries),
-                             sizeof(Int64Attr));
-
-    const nvtxPayloadSchemaAttr_t kDoubleAttrSchemaAttr =
-        makeStaticSchemaAttr("nixl.trace.double_attr",
-                             kDoubleAttrSchemaEntries,
-                             std::size(kDoubleAttrSchemaEntries),
-                             sizeof(DoubleAttr));
-
-    const nvtxPayloadSchemaAttr_t kStrAttrSchemaAttr =
-        makeStaticSchemaAttr("nixl.trace.str_attr",
-                             kStrAttrSchemaEntries,
-                             std::size(kStrAttrSchemaEntries),
-                             sizeof(StrAttr));
+    [[nodiscard]] std::uint64_t
+    registerSchema(const nvtxDomainHandle_t domain,
+                   const char *name,
+                   const std::uint64_t value_type) {
+        nvtxPayloadSchemaEntry_t entries[] = {keyEntry(), valueEntry(value_type)};
+        const nvtxPayloadSchemaAttr_t attr =
+            makeStaticSchemaAttr(name, entries, std::size(entries));
+        return nvtxPayloadSchemaRegister(domain, &attr);
+    }
 
 } // namespace
 
 PayloadSchemaIds
 registerPayloadSchemas(const nvtxDomainHandle_t domain) {
     PayloadSchemaIds ids;
-    ids.int64_attr = nvtxPayloadSchemaRegister(domain, &kInt64AttrSchemaAttr);
-    ids.double_attr = nvtxPayloadSchemaRegister(domain, &kDoubleAttrSchemaAttr);
-    ids.str_attr = nvtxPayloadSchemaRegister(domain, &kStrAttrSchemaAttr);
+    ids.int64_attr = registerSchema(domain, "nixl.trace.int64_attr", NVTX_PAYLOAD_ENTRY_TYPE_INT64);
+    ids.double_attr =
+        registerSchema(domain, "nixl.trace.double_attr", NVTX_PAYLOAD_ENTRY_TYPE_DOUBLE);
+    ids.string_attr =
+        registerSchema(domain, "nixl.trace.string_attr", NVTX_PAYLOAD_ENTRY_TYPE_CSTRING);
     return ids;
 }
 

--- a/src/plugins/tracing/nvtx/nvtx_payload_schemas.h
+++ b/src/plugins/tracing/nvtx/nvtx_payload_schemas.h
@@ -14,23 +14,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_PAYLOAD_SCHEMAS_H
+#define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_PAYLOAD_SCHEMAS_H
 
-#include "nvtx_backend.h"
+#include <cstdint>
 
-#include "common/nixl_log.h"
-#include "nvtx_trace_backend.h"
+#include <nvtx3/nvToolsExt.h>
 
-namespace nixl::trace {
+namespace nixl::trace::nvtx_internal {
 
-std::unique_ptr<TraceBackend>
-createNvtxBackend(const nixlTraceBackendInitParams &init_params) {
-    try {
-        return std::make_unique<nvtx_internal::NvtxTraceBackend>(init_params.agentName);
-    }
-    catch (const std::exception &e) {
-        NIXL_ERROR << "Failed to create NVTX trace backend: " << e.what();
-        return nullptr;
-    }
-}
+/** @brief Domain-registered schema IDs for typed span attribute payloads. */
+struct PayloadSchemaIds {
+    std::uint64_t int64_attr{};
+    std::uint64_t double_attr{};
+    std::uint64_t str_attr{};
+};
 
-} // namespace nixl::trace
+/** @brief Register the static attribute payload schemas on @p domain. */
+[[nodiscard]] PayloadSchemaIds
+registerPayloadSchemas(nvtxDomainHandle_t domain);
+
+} // namespace nixl::trace::nvtx_internal
+
+#endif // NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_PAYLOAD_SCHEMAS_H

--- a/src/plugins/tracing/nvtx/nvtx_payload_schemas.h
+++ b/src/plugins/tracing/nvtx/nvtx_payload_schemas.h
@@ -23,11 +23,27 @@
 
 namespace nixl::trace::nvtx_internal {
 
+/**
+ * @brief Record backing every typed attribute payload: a key plus a value at a
+ *        fixed offset. Each schema (int64/double/string) describes the value
+ *        with its own NVTX entry type but identical offsets, so one struct backs
+ *        all three (only one value member is live per record).
+ */
+struct AttrPayload {
+    const char *key;
+
+    union {
+        std::int64_t int64_value;
+        double double_value;
+        const char *string_value;
+    } value;
+};
+
 /** @brief Domain-registered schema IDs for typed span attribute payloads. */
 struct PayloadSchemaIds {
     std::uint64_t int64_attr{};
     std::uint64_t double_attr{};
-    std::uint64_t str_attr{};
+    std::uint64_t string_attr{};
 };
 
 /** @brief Register the static attribute payload schemas on @p domain. */

--- a/src/plugins/tracing/nvtx/nvtx_span.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_span.cpp
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_span.h"
+
+#include <utility>
+
+#include <nvtx3/nvToolsExt.h>
+#include <nvtx3/nvToolsExtPayload.h>
+
+namespace nixl::trace::nvtx_internal {
+namespace {
+
+    struct Int64Attr {
+        const char *key;
+        std::int64_t value;
+    };
+
+    struct DoubleAttr {
+        const char *key;
+        double value;
+    };
+
+    struct StrAttr {
+        const char *key;
+        const char *value;
+    };
+
+} // namespace
+
+struct NvtxSpan::StoredPayload {
+    nvtxPayloadData_t data{};
+    std::string key_storage;
+    std::string value_storage;
+    Int64Attr int64{};
+    DoubleAttr dbl{};
+    StrAttr str{};
+};
+
+NvtxSpan::NvtxSpan(const nvtxDomainHandle_t domain, const PayloadSchemaIds schema_ids) noexcept
+    : domain_(domain),
+      schemaIds_(schema_ids) {}
+
+NvtxSpan::~NvtxSpan() {
+    if (payloads_.empty()) {
+        nvtxDomainRangePop(domain_);
+        return;
+    }
+
+    std::vector<nvtxPayloadData_t> refs;
+    refs.reserve(payloads_.size());
+    for (const auto &stored : payloads_) {
+        refs.push_back(stored->data);
+    }
+    nvtxRangePopPayload(domain_, refs.data(), refs.size());
+}
+
+void
+NvtxSpan::addAttribute(const std::string_view key, const std::string_view value) {
+    emitStrAttr(key, value);
+}
+
+void
+NvtxSpan::addAttribute(const std::string_view key, const std::int64_t value) {
+    emitInt64Attr(key, value);
+}
+
+void
+NvtxSpan::addAttribute(const std::string_view key, const double value) {
+    emitDoubleAttr(key, value);
+}
+
+void
+NvtxSpan::emitInt64Attr(const std::string_view key, const std::int64_t value) {
+    auto stored = std::make_unique<StoredPayload>();
+    stored->key_storage.assign(key);
+    stored->int64.key = stored->key_storage.c_str();
+    stored->int64.value = value;
+    stored->data = {schemaIds_.int64_attr, sizeof(Int64Attr), &stored->int64};
+    payloads_.push_back(std::move(stored));
+}
+
+void
+NvtxSpan::emitDoubleAttr(const std::string_view key, const double value) {
+    auto stored = std::make_unique<StoredPayload>();
+    stored->key_storage.assign(key);
+    stored->dbl.key = stored->key_storage.c_str();
+    stored->dbl.value = value;
+    stored->data = {schemaIds_.double_attr, sizeof(DoubleAttr), &stored->dbl};
+    payloads_.push_back(std::move(stored));
+}
+
+void
+NvtxSpan::emitStrAttr(const std::string_view key, const std::string_view value) {
+    auto stored = std::make_unique<StoredPayload>();
+    stored->key_storage.assign(key);
+    stored->value_storage.assign(value);
+    stored->str.key = stored->key_storage.c_str();
+    stored->str.value = stored->value_storage.c_str();
+    stored->data = {schemaIds_.str_attr, sizeof(StrAttr), &stored->str};
+    payloads_.push_back(std::move(stored));
+}
+
+} // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_span.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_span.cpp
@@ -17,39 +17,12 @@
 
 #include "nvtx_span.h"
 
-#include <utility>
+#include <vector>
 
 #include <nvtx3/nvToolsExt.h>
 #include <nvtx3/nvToolsExtPayload.h>
 
 namespace nixl::trace::nvtx_internal {
-namespace {
-
-    struct Int64Attr {
-        const char *key;
-        std::int64_t value;
-    };
-
-    struct DoubleAttr {
-        const char *key;
-        double value;
-    };
-
-    struct StrAttr {
-        const char *key;
-        const char *value;
-    };
-
-} // namespace
-
-struct NvtxSpan::StoredPayload {
-    nvtxPayloadData_t data{};
-    std::string key_storage;
-    std::string value_storage;
-    Int64Attr int64{};
-    DoubleAttr dbl{};
-    StrAttr str{};
-};
 
 NvtxSpan::NvtxSpan(const nvtxDomainHandle_t domain, const PayloadSchemaIds schema_ids) noexcept
     : domain_(domain),
@@ -63,56 +36,40 @@ NvtxSpan::~NvtxSpan() {
 
     std::vector<nvtxPayloadData_t> refs;
     refs.reserve(payloads_.size());
-    for (const auto &stored : payloads_) {
-        refs.push_back(stored->data);
+    for (const StoredPayload &stored : payloads_) {
+        refs.push_back(stored.data);
     }
     nvtxRangePopPayload(domain_, refs.data(), refs.size());
 }
 
+NvtxSpan::StoredPayload &
+NvtxSpan::addPayload(const std::string_view key) {
+    StoredPayload &payload = payloads_.emplace_back();
+    payload.key.assign(key);
+    payload.record.key = payload.key.c_str();
+    return payload;
+}
+
 void
 NvtxSpan::addAttribute(const std::string_view key, const std::string_view value) {
-    emitStrAttr(key, value);
+    StoredPayload &payload = addPayload(key);
+    payload.string_value.assign(value);
+    payload.record.value.string_value = payload.string_value.c_str();
+    payload.data = {schemaIds_.string_attr, sizeof(AttrPayload), &payload.record};
 }
 
 void
 NvtxSpan::addAttribute(const std::string_view key, const std::int64_t value) {
-    emitInt64Attr(key, value);
+    StoredPayload &payload = addPayload(key);
+    payload.record.value.int64_value = value;
+    payload.data = {schemaIds_.int64_attr, sizeof(AttrPayload), &payload.record};
 }
 
 void
 NvtxSpan::addAttribute(const std::string_view key, const double value) {
-    emitDoubleAttr(key, value);
-}
-
-void
-NvtxSpan::emitInt64Attr(const std::string_view key, const std::int64_t value) {
-    auto stored = std::make_unique<StoredPayload>();
-    stored->key_storage.assign(key);
-    stored->int64.key = stored->key_storage.c_str();
-    stored->int64.value = value;
-    stored->data = {schemaIds_.int64_attr, sizeof(Int64Attr), &stored->int64};
-    payloads_.push_back(std::move(stored));
-}
-
-void
-NvtxSpan::emitDoubleAttr(const std::string_view key, const double value) {
-    auto stored = std::make_unique<StoredPayload>();
-    stored->key_storage.assign(key);
-    stored->dbl.key = stored->key_storage.c_str();
-    stored->dbl.value = value;
-    stored->data = {schemaIds_.double_attr, sizeof(DoubleAttr), &stored->dbl};
-    payloads_.push_back(std::move(stored));
-}
-
-void
-NvtxSpan::emitStrAttr(const std::string_view key, const std::string_view value) {
-    auto stored = std::make_unique<StoredPayload>();
-    stored->key_storage.assign(key);
-    stored->value_storage.assign(value);
-    stored->str.key = stored->key_storage.c_str();
-    stored->str.value = stored->value_storage.c_str();
-    stored->data = {schemaIds_.str_attr, sizeof(StrAttr), &stored->str};
-    payloads_.push_back(std::move(stored));
+    StoredPayload &payload = addPayload(key);
+    payload.record.value.double_value = value;
+    payload.data = {schemaIds_.double_attr, sizeof(AttrPayload), &payload.record};
 }
 
 } // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_span.h
+++ b/src/plugins/tracing/nvtx/nvtx_span.h
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_SPAN_H
+#define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_SPAN_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nvtx3/nvToolsExt.h>
+
+#include "nvtx_payload_schemas.h"
+#include "tracing/trace.h"
+
+namespace nixl::trace::nvtx_internal {
+
+/** @brief One active NVTX range; typed attributes are attached on pop. */
+class NvtxSpan final : public SpanBackend {
+public:
+    NvtxSpan(nvtxDomainHandle_t domain, PayloadSchemaIds schema_ids) noexcept;
+
+    ~NvtxSpan() override;
+
+    void
+    addAttribute(std::string_view key, std::string_view value) override;
+    void
+    addAttribute(std::string_view key, std::int64_t value) override;
+    void
+    addAttribute(std::string_view key, double value) override;
+
+    void
+    addCtrlDep(SpanId) override {}
+
+    void
+    addDataDep(SpanId) override {}
+
+    [[nodiscard]] SpanId
+    id() const noexcept override {
+        return {};
+    }
+
+private:
+    struct StoredPayload;
+
+    void
+    emitInt64Attr(std::string_view key, std::int64_t value);
+    void
+    emitDoubleAttr(std::string_view key, double value);
+    void
+    emitStrAttr(std::string_view key, std::string_view value);
+
+    nvtxDomainHandle_t domain_;
+    PayloadSchemaIds schemaIds_;
+    std::vector<std::unique_ptr<StoredPayload>> payloads_;
+};
+
+} // namespace nixl::trace::nvtx_internal
+
+#endif // NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_SPAN_H

--- a/src/plugins/tracing/nvtx/nvtx_span.h
+++ b/src/plugins/tracing/nvtx/nvtx_span.h
@@ -18,19 +18,22 @@
 #define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_SPAN_H
 
 #include <cstdint>
-#include <memory>
+#include <list>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #include <nvtx3/nvToolsExt.h>
+#include <nvtx3/nvToolsExtPayload.h>
 
 #include "nvtx_payload_schemas.h"
 #include "tracing/trace.h"
 
 namespace nixl::trace::nvtx_internal {
 
-/** @brief One active NVTX range; typed attributes are attached on pop. */
+/**
+ * @brief One active NVTX range. Attributes are buffered as typed payloads and
+ *        attached to the range when it is popped in the destructor.
+ */
 class NvtxSpan final : public SpanBackend {
 public:
     NvtxSpan(nvtxDomainHandle_t domain, PayloadSchemaIds schema_ids) noexcept;
@@ -56,18 +59,23 @@ public:
     }
 
 private:
-    struct StoredPayload;
+    // Backing storage for one attribute payload. Held in a std::list so nodes
+    // never move: record.key / value.string_value point into these strings and
+    // must stay valid until the range is popped.
+    struct StoredPayload {
+        std::string key;
+        std::string string_value; // only used for string attributes
+        AttrPayload record{};
+        nvtxPayloadData_t data{};
+    };
 
-    void
-    emitInt64Attr(std::string_view key, std::int64_t value);
-    void
-    emitDoubleAttr(std::string_view key, double value);
-    void
-    emitStrAttr(std::string_view key, std::string_view value);
+    // Append a payload with its key set; caller fills the value + schema id.
+    [[nodiscard]] StoredPayload &
+    addPayload(std::string_view key);
 
     nvtxDomainHandle_t domain_;
     PayloadSchemaIds schemaIds_;
-    std::vector<std::unique_ptr<StoredPayload>> payloads_;
+    std::list<StoredPayload> payloads_;
 };
 
 } // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
@@ -64,8 +64,7 @@ NvtxTraceBackend::~NvtxTraceBackend() {
 
 std::unique_ptr<SpanBackend>
 NvtxTraceBackend::beginSpan(const std::string_view name, const Kind kind) {
-    std::string fallback;
-    nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    nvtxEventAttributes_t ev = eventForName(name, kind, domain_, registeredHandles_);
     applyCorrelation(ev);
     auto span = std::make_unique<NvtxSpan>(domain_, schemaIds_);
     nvtxDomainRangePushEx(domain_, &ev);
@@ -74,8 +73,7 @@ NvtxTraceBackend::beginSpan(const std::string_view name, const Kind kind) {
 
 void
 NvtxTraceBackend::mark(const std::string_view name, const Kind kind) {
-    std::string fallback;
-    nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    nvtxEventAttributes_t ev = eventForName(name, kind, domain_, registeredHandles_);
     applyCorrelation(ev);
     nvtxDomainMarkEx(domain_, &ev);
 }

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "nvtx_trace_backend.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "nvtx_events.h"
+#include "nvtx_span.h"
+
+namespace nixl::trace::nvtx_internal {
+
+NvtxTraceBackend::NvtxTraceBackend(const std::string_view domain)
+    : domainName_(domain),
+      domain_(nvtxDomainCreateA(domainName_.c_str())),
+      schemaIds_(registerPayloadSchemas(domain_)),
+      registeredHandles_(registerSpanNames(domain_)) {}
+
+NvtxTraceBackend::~NvtxTraceBackend() {
+    nvtxDomainDestroy(domain_);
+}
+
+std::unique_ptr<SpanBackend>
+NvtxTraceBackend::beginSpan(const std::string_view name, const Kind kind) {
+    std::string fallback;
+    const nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    auto span = std::make_unique<NvtxSpan>(domain_, schemaIds_);
+    nvtxDomainRangePushEx(domain_, &ev);
+    return span;
+}
+
+void
+NvtxTraceBackend::mark(const std::string_view name, const Kind kind) {
+    std::string fallback;
+    const nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    nvtxDomainMarkEx(domain_, &ev);
+}
+
+} // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
@@ -17,14 +17,40 @@
 
 #include "nvtx_trace_backend.h"
 
+#include <cstdint>
 #include <memory>
+#include <stack>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "nvtx_events.h"
 #include "nvtx_span.h"
 
 namespace nixl::trace::nvtx_internal {
+namespace {
+
+    using CorrelationStack = std::stack<std::uint64_t, std::vector<std::uint64_t>>;
+
+    // static thread_local is shared across backend instances on a thread, which
+    // is safe here: push/pop are balanced within a single agent call, so the
+    // stack is empty between calls.
+    [[nodiscard]] CorrelationStack &
+    correlationStack() noexcept {
+        static thread_local CorrelationStack stack;
+        return stack;
+    }
+
+    void
+    applyCorrelation(nvtxEventAttributes_t &ev) noexcept {
+        const CorrelationStack &stack = correlationStack();
+        if (!stack.empty()) {
+            ev.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64;
+            ev.payload.ullValue = stack.top();
+        }
+    }
+
+} // namespace
 
 NvtxTraceBackend::NvtxTraceBackend(const std::string_view domain)
     : domainName_(domain),
@@ -39,7 +65,8 @@ NvtxTraceBackend::~NvtxTraceBackend() {
 std::unique_ptr<SpanBackend>
 NvtxTraceBackend::beginSpan(const std::string_view name, const Kind kind) {
     std::string fallback;
-    const nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    applyCorrelation(ev);
     auto span = std::make_unique<NvtxSpan>(domain_, schemaIds_);
     nvtxDomainRangePushEx(domain_, &ev);
     return span;
@@ -48,8 +75,22 @@ NvtxTraceBackend::beginSpan(const std::string_view name, const Kind kind) {
 void
 NvtxTraceBackend::mark(const std::string_view name, const Kind kind) {
     std::string fallback;
-    const nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    nvtxEventAttributes_t ev = eventForName(name, kind, registeredHandles_, fallback);
+    applyCorrelation(ev);
     nvtxDomainMarkEx(domain_, &ev);
+}
+
+void
+NvtxTraceBackend::pushCorrelationId(const std::uint64_t id) {
+    correlationStack().push(id);
+}
+
+void
+NvtxTraceBackend::popCorrelationId() {
+    CorrelationStack &stack = correlationStack();
+    if (!stack.empty()) {
+        stack.pop();
+    }
 }
 
 } // namespace nixl::trace::nvtx_internal

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.cpp
@@ -30,20 +30,20 @@
 namespace nixl::trace::nvtx_internal {
 namespace {
 
-    using CorrelationStack = std::stack<std::uint64_t, std::vector<std::uint64_t>>;
+    using correlation_stack_t = std::stack<std::uint64_t, std::vector<std::uint64_t>>;
 
     // static thread_local is shared across backend instances on a thread, which
     // is safe here: push/pop are balanced within a single agent call, so the
     // stack is empty between calls.
-    [[nodiscard]] CorrelationStack &
+    [[nodiscard]] correlation_stack_t &
     correlationStack() noexcept {
-        static thread_local CorrelationStack stack;
+        static thread_local correlation_stack_t stack;
         return stack;
     }
 
     void
     applyCorrelation(nvtxEventAttributes_t &ev) noexcept {
-        const CorrelationStack &stack = correlationStack();
+        const correlation_stack_t &stack = correlationStack();
         if (!stack.empty()) {
             ev.payloadType = NVTX_PAYLOAD_TYPE_UNSIGNED_INT64;
             ev.payload.ullValue = stack.top();
@@ -87,7 +87,7 @@ NvtxTraceBackend::pushCorrelationId(const std::uint64_t id) {
 
 void
 NvtxTraceBackend::popCorrelationId() {
-    CorrelationStack &stack = correlationStack();
+    correlation_stack_t &stack = correlationStack();
     if (!stack.empty()) {
         stack.pop();
     }

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.h
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_TRACE_BACKEND_H
+#define NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_TRACE_BACKEND_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <nvtx3/nvToolsExt.h>
+
+#include "nvtx_payload_schemas.h"
+#include "tracing/trace.h"
+
+namespace nixl::trace::nvtx_internal {
+
+class NvtxTraceBackend final : public TraceBackend {
+public:
+    explicit NvtxTraceBackend(std::string_view domain);
+    ~NvtxTraceBackend() override;
+
+    [[nodiscard]] std::unique_ptr<SpanBackend>
+    beginSpan(std::string_view name, Kind kind) override;
+
+    void
+    mark(std::string_view name, Kind kind) override;
+
+    void
+    pushCorrelationId(std::uint64_t) override {}
+
+    void
+    popCorrelationId() override {}
+
+    [[nodiscard]] std::string_view
+    name() const noexcept override {
+        return "nvtx";
+    }
+
+private:
+    const std::string domainName_;
+    nvtxDomainHandle_t domain_;
+    PayloadSchemaIds schemaIds_;
+    std::vector<nvtxStringHandle_t> registeredHandles_;
+};
+
+} // namespace nixl::trace::nvtx_internal
+
+#endif // NIXL_SRC_PLUGINS_TRACING_NVTX_NVTX_TRACE_BACKEND_H

--- a/src/plugins/tracing/nvtx/nvtx_trace_backend.h
+++ b/src/plugins/tracing/nvtx/nvtx_trace_backend.h
@@ -42,10 +42,10 @@ public:
     mark(std::string_view name, Kind kind) override;
 
     void
-    pushCorrelationId(std::uint64_t) override {}
+    pushCorrelationId(std::uint64_t id) override;
 
     void
-    popCorrelationId() override {}
+    popCorrelationId() override;
 
     [[nodiscard]] std::string_view
     name() const noexcept override {

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -55,7 +55,7 @@ fi
 NVTX_RANGES="$(nsys stats --force-export=true --report nvtx_sum --format csv "${OUT}.nsys-rep" 2>/dev/null \
     | grep 'nixl::' | sed 's/.*,//' | sort -u)"
 for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write; do
-    if ! echo "${NVTX_RANGES}" | grep -q "${expected}"; then
+    if ! echo "${NVTX_RANGES}" | grep -Fq -- "${expected}"; then
         echo "tracing_nsys: expected NVTX range '${expected}' missing from capture" >&2
         echo "${NVTX_RANGES}" | sed 's/^/  seen: /' >&2
         exit 1

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -51,5 +51,16 @@ if [ ! -f "${OUT}.nsys-rep" ]; then
     exit 1
 fi
 
+# Sanity-check expected NVTX ranges and the new metadata-exchange span.
+NVTX_RANGES="$(nsys stats --force-export=true --report nvtx_sum --format csv "${OUT}.nsys-rep" 2>/dev/null \
+    | grep 'nixl::' | sed 's/.*,//' | sort -u)"
+for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write; do
+    if ! echo "${NVTX_RANGES}" | grep -q "${expected}"; then
+        echo "tracing_nsys: expected NVTX range '${expected}' missing from capture" >&2
+        echo "${NVTX_RANGES}" | sed 's/^/  seen: /' >&2
+        exit 1
+    fi
+done
+
 echo "tracing_nsys: wrote ${OUT}.nsys-rep"
 exit 0

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -770,6 +770,22 @@ TEST_P(TestTransferTracing, NvtxNotifications) {
                        /*num_threads=*/1);
 }
 
+// Exercises loadRemoteMD via direct metadata blob exchange (exchangeMD path).
+TEST_P(TestTransferTracing, NvtxMetadataExchange) {
+    constexpr size_t size = 4096;
+    constexpr size_t count = 1;
+
+    std::vector<MemBuffer> src_buffers, dst_buffers;
+    createRegisteredMem(getAgent(0), size, count, DRAM_SEG, src_buffers);
+    createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
+
+    exchangeMD(0, 1);
+
+    invalidateMD(0, 1);
+    deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
+    deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);
+}
+
 // Single clean pass through every traced agent op in lifecycle order, so the
 // nsys capture is an easy-to-narrate demo timeline (see the demo plan in
 // docs/proposals/shared-tracing-api-plan.md). makeConnection is invoked

--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -38,6 +38,8 @@ struct CallLog {
     std::vector<std::pair<std::string, std::string>> strAttrs;
     std::vector<std::pair<std::string, std::int64_t>> intAttrs;
     std::vector<std::pair<std::string, double>> dblAttrs;
+    std::vector<std::uint64_t> pushedCorrelationIds;
+    int correlationPops = 0;
 };
 
 class MockSpan final : public nixl::trace::SpanBackend {
@@ -98,10 +100,14 @@ public:
     }
 
     void
-    pushCorrelationId(std::uint64_t) override {}
+    pushCorrelationId(std::uint64_t id) override {
+        log_->pushedCorrelationIds.push_back(id);
+    }
 
     void
-    popCorrelationId() override {}
+    popCorrelationId() override {
+        ++log_->correlationPops;
+    }
 
     [[nodiscard]] std::string_view
     name() const noexcept override {
@@ -255,4 +261,46 @@ TEST(Tracing, RequestedBackendWithoutPluginIsInert) {
     span.addAttribute("bytes", std::int64_t{1024});
     span.addAttribute("peer", std::string_view{"peer_agent"});
     EXPECT_EQ(span.id().value, 0u);
+}
+
+// Cross-thread correlation: push/pop must fan out to every backend, so a
+// correlation id set at the request boundary reaches all active backends.
+TEST(Tracing, CorrelationIdFansOutToAllBackends) {
+    CallLog a, b;
+    auto tracer = makeMockTracer(a, b);
+
+    tracer->pushCorrelationId(0xABCDu);
+    tracer->popCorrelationId();
+
+    ASSERT_EQ(a.pushedCorrelationIds.size(), 1u);
+    ASSERT_EQ(b.pushedCorrelationIds.size(), 1u);
+    EXPECT_EQ(a.pushedCorrelationIds[0], 0xABCDu);
+    EXPECT_EQ(b.pushedCorrelationIds[0], 0xABCDu);
+    EXPECT_EQ(a.correlationPops, 1);
+    EXPECT_EQ(b.correlationPops, 1);
+}
+
+// CorrelationScope is the RAII guard used at call sites: it pushes on
+// construction and pops on destruction, across every backend.
+TEST(Tracing, CorrelationScopeBalancesPushPop) {
+    CallLog a, b;
+    auto tracer = makeMockTracer(a, b);
+
+    {
+        const nixl::trace::CorrelationScope scope(tracer.get(), 0x1234u);
+        const auto span = tracer->beginSpan("op");
+    }
+
+    ASSERT_EQ(a.pushedCorrelationIds.size(), 1u);
+    EXPECT_EQ(a.pushedCorrelationIds[0], 0x1234u);
+    EXPECT_EQ(a.correlationPops, 1);
+    EXPECT_EQ(b.pushedCorrelationIds.size(), 1u);
+    EXPECT_EQ(b.correlationPops, 1);
+}
+
+// A null tracer (no active backend) must make CorrelationScope a safe no-op.
+TEST(Tracing, CorrelationScopeNullTracerIsInert) {
+    nixl::trace::Tracer *tracer = nullptr;
+    { const nixl::trace::CorrelationScope scope(tracer, 0x1u); }
+    SUCCEED();
 }


### PR DESCRIPTION
## What?

Complete the NVTX trace backend (NIX-1540 / PR7) and add cross-thread request
correlation (NIX-1538 / PR5b): typed attribute payloads on ranges,
registered-string span labels, broader agent call sites, and a shared
correlation id linking a transfer's post to its completion across threads.

## Why?

PR1/PR2 (#1765 + #1845) made NVTX functional but incomplete: attributes were
lossy `key=value` marks, span names were allocated per `beginSpan`, and
`loadRemoteMD` / `prepMemView` were missing from the timeline. Separately, an
async transfer showed up as two unrelated events — `postXferReq` on the caller
thread and completion on the polling thread — with no way to tell they belong to
the same request. This PR closes both gaps so a single nsys capture shows the
full NIXL agent lifecycle with inspectable typed metadata and post↔complete
correlation.

## How?

**NVTX completeness**
* **Structured payloads:** register static NVTX payload schemas (int64/double/string
  key/value); accumulate attrs on `NvtxSpan` and attach via `nvtxRangePopPayload`.
* **Registered strings:** `nvtxDomainRegisterStringA` for all fixed `nixl::*` names.
* **Plugin modules:** `nvtx_payload_schemas`, `nvtx_events`, `nvtx_span`,
  `nvtx_trace_backend` (+ thin `createNvtxBackend` factory).
* **Call sites:** `loadRemoteMD`, `fetchRemoteMD`, `prepMemView`, `releaseMemView`
  in `nixl_agent.cpp`.

**Cross-thread correlation** (tracing-only; no core-struct change)
* `CorrelationScope` RAII guard + `NIXL_TRACE_CORRELATION_SCOPE` on the facade;
  `Tracer::push/popCorrelationId` fan out to backends (previously no-ops).
* NVTX keeps a per-thread correlation-id stack and stamps the active id as the
  event's `uint64` payload on both ranges and marks.
* Correlation id is the transfer-request handle address, so `postXferReq` and the
  `xfer.complete` mark share it even when posted and polled from different threads.

**Out of scope:** NIX-1576 (nsys auto-enable, merged separately in #1867); UCX
backend-internal sub-spans (NIX-1538 / PR5a, de-scoped); Chakra.

## Test plan

* `ninja -C build/trace src/plugins/tracing/nvtx/libtrace_backend_nvtx.so`
* `./build/trace/test/gtest/unit/unit --gtest_filter='Tracing.*'` (11 pass, incl.
  3 correlation tests)
* `./build/trace/test/gtest/gtest --tests_plugin_dirs=... --gtest_filter='*TestTransferTracing*'` (8 pass)
* `meson test -C build/trace tracing_nsys`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced NVTX tracing with richer, typed span attributes and dedicated timeline markers for remote metadata exchange and the memory-view lifecycle.
  * Added correlation scopes to automatically propagate tracing correlation IDs for more consistent cross-thread linking.
* **Bug Fixes**
  * Improved NVTX correlation-id propagation to better link related events across threads.
* **Tests**
  * Strengthened NVTX capture validation to ensure expected ranges are present.
  * Added an NVTX transfer test covering metadata exchange via the direct blob exchange path.
* **Build/Chores**
  * Updated NVTX backend detection to require both headers needed for payload support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->