### PR TITLE
Allow rndv-based PUT/GET protocol without error handling

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -438,6 +438,10 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         config.modify("MAX_HCA_PER_GPU", "auto");
     }
 
+    if (ucpVersion_ >= UCP_VERSION(1, 22)) {
+        config.modify("RNDV_PIPELINE_ERROR_HANDLING", "y");
+    }
+
     const auto &hw_info = nixl::hwInfo::instance();
     if (hw_info.numEfaDevices != 0) {
         config.modify("ADDRESS_VERSION", "v2");


### PR DESCRIPTION
## What?
Allow RNDV, even if it does not fully support error handling.

## Why?
Needed to enable GET and PUT rendezvous-based protocols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection and transfer reliability when using newer UCX versions by enabling additional error-handling support during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->