### PR TITLE
build(manylinux): bundle the INFINIA plugin into release wheels

### DIFF
--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -139,12 +139,19 @@ steps:
       set -x
       export NPROC=$NPROC
       export GRPC_NPROC=$GRPC_NPROC
+      # --cuda-version matches BASE_TAG (13.0-devel-manylinux); it drives the cu13 torch
+      # index and meta-wheel split in Dockerfile.manylinux.
+      # --no-infinia: this blossom runner authenticates only to artifactory.nvidia.com and
+      # cannot pull the private INFINIA libs image, so build the wheel without the INFINIA
+      # plugin (all other plugins are unaffected).
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
+        --cuda-version 13.0 \
         --wheel-base "manylinux_${manylinux}" \
         --python-versions "${python_version}" \
         --arch ${arch} \
+        --no-infinia \
         --dockerfile contrib/Dockerfile.manylinux
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -45,6 +45,69 @@ pip install nixl
 
 This installs both CUDA 12 and CUDA 13 backends. At runtime, the correct backend is selected automatically based on the CUDA version reported by PyTorch.
 
+### Building the wheels
+
+The release wheels are built inside a manylinux container by
+[`contrib/build-container.sh`](contrib/build-container.sh), with the same parameters used by
+the release pipeline (`.github/workflows/ci.yml`, the `build` job). Keep the commands below in
+sync with that workflow.
+
+> **Note:** by default the `contrib/Dockerfile.manylinux` build below pulls an
+> **NVIDIA-internal** INFINIA (DDN) libs image. To build the same wheels **without** the INFINIA
+> plugin — works anywhere, no internal image required — add `--no-infinia`; see
+> [Building without INFINIA](#building-without-infinia).
+
+```bash
+# CUDA 12, x86_64 — produces the cu12 manylinux_2_28 release wheels
+# (NVIDIA-internal: pulls the INFINIA libs image)
+./contrib/build-container.sh \
+  --base-image nvcr.io/nvidia/cuda \
+  --base-image-tag 12.9.1-devel-ubi8 \
+  --cuda-version 12.9 \
+  --wheel-base manylinux_2_28 \
+  --python-versions "3.10,3.11,3.12,3.13,3.14" \
+  --os ubuntu24 \
+  --arch x86_64 \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --tag nixl-wheel-build:cu12-x86_64
+
+# CUDA 13:  --base-image-tag 13.0.1-devel-ubi8  --cuda-version 13.0
+# aarch64:  --arch aarch64   (build on an arm64 host)
+```
+
+The wheels are written to `/workspace/nixl/dist` inside the image; extract them with:
+
+```bash
+cid=$(docker create nixl-wheel-build:cu12-x86_64)
+docker cp "$cid:/workspace/nixl/dist" ./dist
+docker rm "$cid"
+ls dist/*.whl
+```
+
+#### Building without INFINIA
+
+The INFINIA (DDN) plugin links against DDN's proprietary `libred` libraries, which are not
+publicly redistributable, so by default the manylinux build pulls an NVIDIA-internal image. To
+build the same wheels **without** INFINIA — no internal image required — add `--no-infinia`,
+which substitutes an empty INFINIA stage (meson then finds no `red_client` and drops the plugin):
+
+```bash
+./contrib/build-container.sh \
+  --base-image nvcr.io/nvidia/cuda \
+  --base-image-tag 12.9.1-devel-ubi8 \
+  --cuda-version 12.9 \
+  --wheel-base manylinux_2_28 \
+  --python-versions "3.10,3.11,3.12,3.13,3.14" \
+  --os ubuntu24 \
+  --arch x86_64 \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --no-infinia \
+  --tag nixl-wheel-build:cu12-x86_64
+```
+
+Extract the wheels the same way (`docker create` / `docker cp .../dist`). This produces the
+full nixl wheel minus the INFINIA backend; all other plugins are unaffected.
+
 ## Prerequisites for source build (Linux)
 
 NIXL requires a C++20 compatible compiler (GCC >= 11 or Clang >= 14).

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -14,12 +14,110 @@
 # limitations under the License.
 
 
-ARG BASE_IMAGE
-ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
-
-ARG DEFAULT_PYTHON_VERSION="3.14"
+# === Manylinux wheel build (public PyPA base + NGC CUDA) =====================
+# Build wheels on the PUBLIC PyPA manylinux_2_28 image and bring CUDA in from a
+# public NGC CUDA image, instead of the internal
+# gitlab-master.nvidia.com:5005/dl/dgx/cuda manylinux image (NOT reachable from
+# the velonix AWS runners — no DNS/PrivateLink). Mirrors dynamo's
+# container/templates/wheel_builder.Dockerfile pattern. Key moving parts:
+# gcc-toolset for CUDA, the CUDA COPY, and the DOCA el8 rpms.
+# ARCH must be declared before the FROM lines that interpolate it.
 ARG ARCH="x86_64"
+
+# Pin the manylinux base to a specific PyPA release so the toolchain (gcc, CMake,
+# bundled CPython) is reproducible; the implicit :latest would drift between builds.
+# Declared in the global pre-FROM scope because it's interpolated in a FROM line below.
+ARG MANYLINUX_VERSION="2026.06.06-1"
+
+# CUDA toolkit provider: a public NGC CUDA *devel* image, el8/ubi8 to match the
+# AlmaLinux-8 manylinux base (e.g. nvcr.io/nvidia/cuda:12.9.1-devel-ubi8).
+# Reachable from the AWS runners; replaces the internal GitLab base image.
+ARG BASE_IMAGE="nvcr.io/nvidia/cuda"
+ARG BASE_IMAGE_TAG
+# INFINIA libs image — declared here in the global (pre-first-FROM) scope because an ARG
+# used in a FROM line is only visible if declared before the first FROM. See the INFINIA
+# block below for what this is and how it's mirrored.
+ARG INFINIA_LIBS_IMAGE="210086341041.dkr.ecr.us-west-2.amazonaws.com/nixl/infinia-libs:v2.4.0-beta.1"
+# INFINIA build variant: "bundled" (default) pulls the private libs image above; "none" uses
+# an empty stub so external builds WITHOUT access to that image can skip INFINIA — meson then
+# finds no red_client and silently drops the plugin. build-container.sh exposes --no-infinia.
+ARG INFINIA_VARIANT=bundled
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS cuda
+
+# --- INFINIA plugin libs (DDN "red") — bundled by default; skippable via INFINIA_VARIANT=none ---
+# The INFINIA plugin only builds when libred_client.so is found at /opt/ddn/red/lib
+# (src/plugins/meson.build does cc.find_library('red_client', dirs:['/opt/ddn/red/lib'])
+# and silently skips the plugin otherwise — which is what the stage below provides).
+# The libs live in harbor.mellanox.com/nixl/infinia-libs (NOT reachable from the AWS CI
+# runners), so mirror that image into ECR — one time per INFINIA version, from a host
+# that sees both harbor and AWS:
+#   docker pull harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1
+#   ECR=210086341041.dkr.ecr.us-west-2.amazonaws.com/nixl/infinia-libs
+#   docker tag harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1 $ECR:v2.4.0-beta.1
+#   aws ecr get-login-password --region us-west-2 | docker login --username AWS \
+#     --password-stdin 210086341041.dkr.ecr.us-west-2.amazonaws.com
+#   docker push $ECR:v2.4.0-beta.1
+# The dedicated nixl/infinia-libs ECR repo (no-delete lifecycle) is provisioned in
+# velonix terraform/aws/envs/staging/ecr.tf. The runner's existing IRSA already grants
+# pull (account-wide ECR), so no workflow/IAM change is needed. Bump the tag when DDN
+# bumps the INFINIA version (and re-run the mirror push). The ARG is declared in the
+# global pre-FROM block at the top of this file (required to use it in a FROM line).
+FROM ${INFINIA_LIBS_IMAGE} AS infinia-bundled
+# Empty stub for INFINIA_VARIANT=none: a public base carrying an empty /infinia/${ARCH}/ so the
+# COPY below still succeeds without the private image. With variant=none BuildKit prunes the
+# infinia-bundled stage above and never pulls it; meson finds no red_client and skips INFINIA.
+FROM quay.io/pypa/manylinux_2_28_${ARCH}:${MANYLINUX_VERSION} AS infinia-none
+ARG ARCH
+RUN mkdir -p /infinia/${ARCH}
+# Select the source the COPY pulls from based on the INFINIA_VARIANT build arg.
+FROM infinia-${INFINIA_VARIANT} AS infinia
+
+# Manylinux build base — official PyPA image (public on quay.io; velonix also has
+# a quay ECR pull-through). AlmaLinux 8 / glibc 2.28 => manylinux_2_28 wheels.
+FROM quay.io/pypa/manylinux_2_28_${ARCH}:${MANYLINUX_VERSION}
+
+# Re-declare args needed inside this build stage (args before the first FROM are
+# only visible to FROM lines).
+ARG ARCH="x86_64"
+ARG DEFAULT_PYTHON_VERSION="3.14"
+
+# CUDA version (e.g. 12.9 / 13.0) — was provided as an ENV by the old GitLab base;
+# now passed explicitly. Used for the torch cuXXX index and the cu12/cu13 wheel split.
+ARG CUDA_VERSION
+ENV CUDA_VERSION=${CUDA_VERSION}
+
+# Bring the CUDA toolkit onto the manylinux base (dynamo wheel_builder pattern).
+COPY --from=cuda /usr/local/cuda /usr/local/cuda
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}
+
+# INFINIA libs (paired with the `infinia` stage above). The mirrored image lays the libs
+# out per-arch under /infinia/${ARCH}/ (lib/ + include/); copying that to /opt/ddn/red
+# puts libred_client.so / libred_async.so + headers where meson looks, so it auto-detects
+# and builds the INFINIA plugin into the wheel (default -Dinfinia_path=/opt/ddn/red).
+# NOTE: libred_client/libred_async are DDN proprietary and are intentionally NOT
+# redistributed — contrib/build-wheel.sh already auditwheel --excludes them, so the wheel
+# ships only the INFINIA plugin (libplugin_INFINIA.so), which loads libred_* at runtime
+# from a customer's DDN install via its RUNPATH (/opt/ddn/red/lib). The plugin's other
+# transitive deps (liburing.so.2, libldap.so.2, etc.) are why this Dockerfile installs/
+# builds them above: they must resolve at link time even though libred itself is excluded.
+ARG INFINIA_DEST=/opt/ddn/red
+COPY --from=infinia /infinia/${ARCH}/ ${INFINIA_DEST}/
+
+# CUDA needs gcc <= 14. The PyPA manylinux base + system "Development Tools" can
+# pull in a gcc that CUDA rejects, so pin gcc-toolset-14 on PATH ahead of the
+# system gcc (same approach as dynamo's wheel_builder). gcc-toolset-14 is added to
+# the dnf install list below.
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH:-}
+
+# The PyPA manylinux_2_28 image ships CMake 4.x, which removed support for
+# cmake_minimum_required(VERSION < 3.5). Some bundled deps (e.g. gRPC's c-ares)
+# still declare ancient minimums. This tells CMake 4.x to accept them. (Harmless
+# on the older CMake that the previous GitLab base shipped.)
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+# === end Option B header ======================================================
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG HWLOC_VERSION="2.12.2"
 ARG BUILD_TYPE="release"
@@ -29,7 +127,7 @@ ARG GRPC_TAG="v1.73.0"
 ARG NPROC
 
 RUN yum groupinstall -y 'Development Tools' &&  \
-    dnf install -y almalinux-release-synergy && \
+    dnf install -y almalinux-release-synergy epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y \
     boost \
@@ -42,9 +140,14 @@ RUN yum groupinstall -y 'Development Tools' &&  \
     gflags \
     glibc-headers \
     gcc-c++ \
+    gcc-toolset-14 \
     libaio \
     libaio-devel \
     libtool-ltdl \
+    libuuid-devel \
+    jansson \
+    libjose \
+    xxhash-libs \
     ninja-build \
     openssl \
     openssl-devel \
@@ -96,6 +199,51 @@ ENV LD_LIBRARY_PATH="/usr/local/openssl3/lib64:/usr/local/openssl3/lib:$LD_LIBRA
 ENV OPENSSL_ROOT_DIR="/usr/local/openssl3"
 ENV OPENSSL_LIBRARIES="/usr/local/openssl3/lib64:/usr/local/openssl3/lib"
 ENV OPENSSL_INCLUDE_DIR="/usr/local/openssl3/include"
+
+# --- INFINIA (libred_client) transitive deps not packaged at the right soname on EL8 ---
+# liburing 2.x: EL8 only ships liburing.so.1 (1.0.7); libred_client needs liburing.so.2.
+# Pinned to 2.14 to match subprojects/liburing.wrap (the version NIXL's own build uses); this
+# system install is found ahead of that meson wrap and also satisfies the prebuilt libred_client's
+# transitive liburing.so.2 link/runtime need (the wrap is an internal subproject not on the
+# system linker/loader path, so it can't resolve libred's NEEDED — hence the system build here).
+# Build/install ONLY the library (make -C src): liburing 2.14's examples (e.g. zcrx.c) pull in
+# linux/udmabuf.h, which isn't in the manylinux_2_28 (EL8) kernel headers, so a full `make` fails.
+RUN cd /tmp && \
+    LIBURING_VERSION=2.14 && \
+    wget -q "https://github.com/axboe/liburing/archive/refs/tags/liburing-${LIBURING_VERSION}.tar.gz" && \
+    echo "5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c  liburing-${LIBURING_VERSION}.tar.gz" | sha256sum -c - && \
+    tar -xzf "liburing-${LIBURING_VERSION}.tar.gz" && \
+    cd "liburing-liburing-${LIBURING_VERSION}" && \
+    ./configure --prefix=/usr/local && \
+    make -j"${NPROC:-$(nproc)}" -C src && \
+    make -C src install && \
+    echo "/usr/local/lib"   >  /etc/ld.so.conf.d/usrlocal.conf && \
+    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usrlocal.conf && \
+    ldconfig && \
+    rm -rf /tmp/liburing*
+
+# OpenLDAP 2.6 client libs: EL8 ships 2.4 (libldap-2.4.so.2); libred_client needs the
+# 2.6 soname libldap.so.2 (+ liblber.so.2). Build client libs only, against openssl3.
+RUN cd /tmp && \
+    OPENLDAP_VERSION=2.6.8 && \
+    wget -q "https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz" && \
+    echo "48969323e94e3be3b03c6a132942dcba7ef8d545f2ad35401709019f696c3c4e  openldap-${OPENLDAP_VERSION}.tgz" | sha256sum -c - && \
+    tar -xzf "openldap-${OPENLDAP_VERSION}.tgz" && \
+    cd "openldap-${OPENLDAP_VERSION}" && \
+    ./configure --prefix=/usr/local --enable-shared --disable-static --disable-slapd \
+        --without-cyrus-sasl --with-tls=openssl \
+        CPPFLAGS="-I/usr/local/openssl3/include" \
+        LDFLAGS="-L/usr/local/openssl3/lib64 -L/usr/local/openssl3/lib" && \
+    make depend && \
+    make -j"${NPROC:-$(nproc)}" && \
+    make install && \
+    ldconfig && \
+    rm -rf /tmp/openldap-${OPENLDAP_VERSION}*
+
+# Let the linker (gcc LIBRARY_PATH) and loader/auditwheel (LD_LIBRARY_PATH) find the
+# INFINIA libs at /opt/ddn/red/lib and the source-built transitive deps in /usr/local.
+ENV LD_LIBRARY_PATH="/opt/ddn/red/lib:/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH"
+ENV LIBRARY_PATH="/opt/ddn/red/lib:/usr/local/lib:/usr/local/lib64:${LIBRARY_PATH:-}"
 
 WORKDIR /workspace
 

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -41,6 +41,13 @@ OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
+# CUDA toolkit version (e.g. 12.9 / 13.0). Option B (manylinux on public PyPA base)
+# no longer inherits this from the base image's ENV, so it's passed in. Defaults to
+# 13.0 to match the default BASE_IMAGE_TAG (cuda13.0); override with --cuda-version.
+CUDA_VERSION=${CUDA_VERSION:-13.0}
+# INFINIA build variant passed to Dockerfile.manylinux: "bundled" pulls the private DDN libs
+# image; "none" (via --no-infinia) skips it so external builds without access still work.
+INFINIA_VARIANT=${INFINIA_VARIANT:-bundled}
 
 get_options() {
     while :; do
@@ -92,6 +99,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --cuda-version)
+            if [ "$2" ]; then
+                CUDA_VERSION=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --tag)
             if [ "$2" ]; then
                 TAG="--tag $2"
@@ -126,6 +141,9 @@ get_options() {
             ;;
         --build-nixl-ep)
             BUILD_NIXL_EP=true
+            ;;
+        --no-infinia)
+            INFINIA_VARIANT=none
             ;;
         --arch)
             if [ "$2" ]; then
@@ -187,6 +205,7 @@ show_help() {
     echo "usage: build-container.sh"
     echo "  [--base base image]"
     echo "  [--base-image-tag base image tag]"
+    echo "  [--cuda-version CUDA version, e.g. 12.9 (manylinux builds)]"
     echo "  [--wheel-base base platform for wheel builds]"
     echo "  [--no-cache disable docker build cache]"
     echo "  [--os [ubuntu24|ubuntu22] to select Ubuntu version]"
@@ -195,6 +214,7 @@ show_help() {
     echo "  [--python-versions python versions to build for, comma separated]"
     echo "  [--ucx-ref ucx git reference (branch, tag, or sha)]"
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
+    echo "  [--no-infinia skip the INFINIA plugin (manylinux: don't pull the private DDN libs image)]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     exit 0
@@ -216,7 +236,22 @@ if [ -d "$NIXL_DIR/build" ]; then
     exit 1
 fi
 
+# The manylinux build path requires CUDA_VERSION in MAJOR.MINOR form (e.g. 12.9, 13.0):
+# Dockerfile.manylinux derives the torch index (cu<major><minor>) and the cu12/cu13
+# meta-wheel split from it. Empty yields a broken index (https://download.pytorch.org/
+# whl/cu) and a skipped meta-wheel; a major-only value like "12" yields a nonexistent
+# "cu12" index instead of e.g. "cu129". Validate the shape (not just presence) up front.
+case "$DOCKER_FILE" in
+    *manylinux*)
+        if ! echo "$CUDA_VERSION" | grep -qE '^[0-9]+\.[0-9]+$'; then
+            echo "ERROR: --cuda-version must be MAJOR.MINOR for manylinux builds (e.g. --cuda-version 12.9); got '${CUDA_VERSION}'" >&2
+            exit 1
+        fi
+        ;;
+esac
+
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
+BUILD_ARGS+=" --build-arg CUDA_VERSION=$CUDA_VERSION"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"
@@ -226,7 +261,13 @@ BUILD_ARGS+=" --build-arg NPROC=$NPROC"
 BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
+BUILD_ARGS+=" --build-arg INFINIA_VARIANT=$INFINIA_VARIANT"
 
 show_build_options
 
+# Disable buildx's default provenance/sbom attestations (the attestation-manifest export
+# was tipping the ARM build over the job timeout; CI images don't need them). Use the env
+# var, which buildx honors and the classic docker build frontend ignores -- unlike the
+# --provenance/--sbom flags, which classic docker rejects as unknown.
+export BUILDX_NO_DEFAULT_ATTESTATIONS=1
 docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -262,6 +262,15 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 BUILD_ARGS+=" --build-arg INFINIA_VARIANT=$INFINIA_VARIANT"
+# With --no-infinia the COPY pulls from the empty infinia-none stub, never the private
+# infinia-bundled image. BuildKit prunes the unreferenced bundled FROM, but not every
+# builder does (e.g. podman/buildah in some configs may still resolve it), and the
+# default points at a private registry the builder may not be able to auth to. Repoint
+# the bundled image at the (already-pulled, already-authed) base image so an infinia-free
+# build never depends on the private registry, regardless of stage-pruning behavior.
+if [ "$INFINIA_VARIANT" = "none" ]; then
+    BUILD_ARGS+=" --build-arg INFINIA_LIBS_IMAGE=$BASE_IMAGE:$BASE_IMAGE_TAG"
+fi
 
 show_build_options
 


### PR DESCRIPTION
Re-apply only the INFINIA wheel-build changes from #1841 onto release/1.3.1 (the native GitHub Actions pipeline was reverted separately):

- contrib/Dockerfile.manylinux: build wheels on the public PyPA manylinux_2_28 base + NGC CUDA (the internal GitLab base isn't reachable from the AWS runners), pull the DDN "red" libs from a mirrored ECR image into /opt/ddn/red so meson auto-detects red_client and builds the INFINIA plugin, and source-build the liburing 2.14 / OpenLDAP 2.6 transitive deps EL8 lacks at the right soname. INFINIA_VARIANT=none yields an empty stub for external builds without the private image.
- contrib/build-container.sh: --cuda-version (MAJOR.MINOR, validated for manylinux) and --no-infinia (INFINIA_VARIANT=none); disable buildx provenance/sbom attestations via env var.
- README: document the manylinux wheel build and the --no-infinia path.

Excludes the #1775-derived changes carried in #1841 (the contrib/Dockerfile EP/torch-versions edit and the manylinux wheel-build EP_BUILD_FLAGS reformat), since #1775 isn't on release/1.3.1 and its build-wheel.sh doesn't accept --torch-versions.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
