### PR TITLE
Build: pass --torch-versions in the EP wheel step of contrib/Dockerfile

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -33,6 +33,7 @@ ARG NIXL_PREFIX="/usr/local/nixl"
 ARG NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/$ARCH-linux-gnu/plugins"
 ARG NPROC
 ARG WHL_DEFAULT_PYTHON_VERSIONS="3.12"
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG LIBFABRIC_INSTALL_PATH="/usr/local"
 ARG BUILD_TYPE="release"
@@ -296,7 +297,7 @@ RUN cd src/bindings/rust && cargo build --release --locked
 
 # Build wheel using the build-wheel.sh script for better UCX plugin bundling and library management
 RUN mkdir -p dist && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAG="--build-nixl-ep"; else EP_BUILD_FLAG=""; fi && \
+    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAG="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; else EP_BUILD_FLAG=""; fi && \
     ./contrib/build-wheel.sh \
     --python-version $DEFAULT_PYTHON_VERSION \
     --platform manylinux_2_39_$ARCH \


### PR DESCRIPTION
## What?
The EP container build (`BUILD_NIXL_EP=true`) dies at the wheel step:
```
ERROR: --build-nixl-ep requires --torch-versions
```

## Why?
#1775 made `--torch-versions` mandatory alongside `--build-nixl-ep` and updated `Dockerfile.manylinux`, but `contrib/Dockerfile` was left calling `--build-nixl-ep` on its own. So every EP container build has errored here since #1775 merged.

## Fix
Mirror the manylinux default so the wheel step completes:
```dockerfile
ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
...
EP_BUILD_FLAG="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"
```

## Test
`nixl-ci-build-container` [#34](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-container/34/) passed on `cuda-dl-base` with `BUILD_NIXL_EP=True` - the EP wheel step now builds all three torch versions instead of erroring on the missing flag.