### PR TITLE
build: fix build-container flow (pass --torch-versions in Dockerfile and set explicit EP meson overrides)

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -33,6 +33,7 @@ ARG NIXL_PREFIX="/usr/local/nixl"
 ARG NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/$ARCH-linux-gnu/plugins"
 ARG NPROC
 ARG WHL_DEFAULT_PYTHON_VERSIONS="3.12"
+ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG LIBFABRIC_INSTALL_PATH="/usr/local"
 ARG BUILD_TYPE="release"
@@ -296,14 +297,14 @@ RUN cd src/bindings/rust && cargo build --release --locked
 
 # Build wheel using the build-wheel.sh script for better UCX plugin bundling and library management
 RUN mkdir -p dist && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAG="--build-nixl-ep"; else EP_BUILD_FLAG=""; fi && \
+    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; else EP_BUILD_FLAGS=""; fi && \
     ./contrib/build-wheel.sh \
     --python-version $DEFAULT_PYTHON_VERSION \
     --platform manylinux_2_39_$ARCH \
     --ucx-plugins-dir $UCX_PLUGIN_DIR \
     --nixl-plugins-dir $NIXL_PLUGIN_DIR \
     --output-dir /workspace/nixl/dist \
-    $EP_BUILD_FLAG
+    $EP_BUILD_FLAGS
 
 RUN cp build/src/bindings/python/nixl-meta/nixl-*.whl dist/
 RUN uv pip install --system \

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -131,9 +131,11 @@ nixl_ep_rpath += ':' + join_paths(nixl_lib_dir, 'plugins')
 # For now, nixl ep cannot be built with -G due to register usage limits;
 # build the EP target as release even in a global debug build (same flags
 # we ship in release wheels), and add -g back so we keep debug symbols.
+# Override buildtype, optimization, and debug explicitly so a global
+# buildtype=debug cannot leak --device-debug (-G) onto the EP nvcc line.
 nixl_ep_override_options = []
 if get_option('buildtype') == 'debug'
-    nixl_ep_override_options = ['buildtype=release']
+    nixl_ep_override_options = ['buildtype=release', 'optimization=3', 'debug=false']
     nixl_ep_cpp_args += ['-g']
 endif
 


### PR DESCRIPTION
Fixes for nixl-ci-build-container flow

## What?
1. contrib/Dockerfile: add a new WHL_TORCH_VERSIONS build arg (default 2.11,2.12,2.13, mirroring Dockerfile.manylinux) and forward it to contrib/build-wheel.sh via --torch-versions when BUILD_NIXL_EP=true.
2. examples/device/ep/meson.build: extend the EP target's override_options from ['buildtype=release'] to ['buildtype=release', 'optimization=3', 'debug=false'].

## Why?
After #1802 + #1775 landed, nixl-ci-build-container (debug, BUILD_NIXL_EP=true) has been failing in two distinct places:
1. Wheel step failure: #1775 added --torch-versions support to contrib/build-wheel.sh and updated Dockerfile.manylinux, but contrib/Dockerfile was still calling --build-nixl-ep alone. Every EP container build errored at the wheel step with --build-nixl-ep requires --torch-versions.
2. EP nvcc compile failure: #1802 sets nixl_ep target with override_options = ['buildtype=release'] so a global --buildtype=debug doesn't drop -G onto the EP nvcc line. In practice --device-debug still reached the EP .cu compiles on nixl-ci-build-containe compilation path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring which Torch versions are included when building the wheel, with a sensible default set.

* **Bug Fixes**
  * Improved EP builds in debug environments by forcing release-style compilation settings, helping avoid debug flags affecting CUDA compilation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->