### PR TITLE
ci: split Dockerfile.manylinux into wheel_base/wheel stages to cache deps

### DIFF
--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -7,6 +7,7 @@ CI_FILES=(
     ".ci/dockerfiles/Dockerfile.build_helper"
     ".gitlab/build.sh"
     ".ci/scripts/common.sh"
+    "contrib/Dockerfile.manylinux"
 )
 
 # YAML files containing CI_IMAGE_TAG
@@ -15,6 +16,7 @@ TEST_MATRIX_YAML=".ci/jenkins/lib/test-matrix.yaml"
 TEST_DL_MATRIX_YAML=".ci/jenkins/lib/test-dl-matrix.yaml"
 TEST_DL_EP_MATRIX_YAML=".ci/jenkins/lib/test-dl-ep-matrix.yaml"
 SANITIZER_MATRIX_YAML=".ci/jenkins/lib/test-sanitizer-matrix.yaml"
+WHEEL_BUILD_MATRIX_YAML=".ci/jenkins/lib/build-wheel-matrix.yaml"
 
 # Function to extract CI_IMAGE_TAG from a YAML file
 get_ci_image_tag() {
@@ -64,18 +66,21 @@ current_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "")
 current_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "")
 current_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "")
 current_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "")
+current_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "")
 
 previous_build_image_tag=$(get_ci_image_tag "$BUILD_MATRIX_YAML" "HEAD~1")
 previous_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "HEAD~1")
 previous_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "HEAD~1")
 previous_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "HEAD~1")
 previous_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "HEAD~1")
+previous_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "HEAD~1")
 
 echo "Build Matrix CI_IMAGE_TAG:     $previous_build_image_tag -> $current_build_image_tag"
 echo "Test Matrix CI_IMAGE_TAG:      $previous_test_image_tag -> $current_test_image_tag"
 echo "Test DL Matrix CI_IMAGE_TAG:   $previous_test_dl_image_tag -> $current_test_dl_image_tag"
 echo "Test DL EP Matrix CI_IMAGE_TAG: $previous_test_dl_ep_image_tag -> $current_test_dl_ep_image_tag"
 echo "Sanitizer Matrix CI_IMAGE_TAG: $previous_sanitizer_image_tag -> $current_sanitizer_image_tag"
+echo "Wheel Build Matrix CI_IMAGE_TAG: $previous_wheel_build_image_tag -> $current_wheel_build_image_tag"
 
 # Check if CI_IMAGE_TAG was changed in all files
 build_tag_changed=false
@@ -83,6 +88,7 @@ test_tag_changed=false
 test_dl_tag_changed=false
 test_dl_ep_tag_changed=false
 sanitizer_tag_changed=false
+wheel_build_tag_changed=false
 
 if [ "$current_build_image_tag" != "$previous_build_image_tag" ]; then
     echo "✓ CI_IMAGE_TAG in build-matrix.yaml was updated"
@@ -109,7 +115,12 @@ if [ "$current_sanitizer_image_tag" != "$previous_sanitizer_image_tag" ]; then
     sanitizer_tag_changed=true
 fi
 
-if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$test_dl_tag_changed" = false ] || [ "$test_dl_ep_tag_changed" = false ] || [ "$sanitizer_tag_changed" = false ]; then
+if [ "$current_wheel_build_image_tag" != "$previous_wheel_build_image_tag" ]; then
+    echo "✓ CI_IMAGE_TAG in build-wheel-matrix.yaml was updated"
+    wheel_build_tag_changed=true
+fi
+
+if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$test_dl_tag_changed" = false ] || [ "$test_dl_ep_tag_changed" = false ] || [ "$sanitizer_tag_changed" = false ] || [ "$wheel_build_tag_changed" = false ]; then
     echo ""
     echo "❌ ERROR: You have changed CI files but forgot to increase CI_IMAGE_TAG!"
     echo ""
@@ -128,6 +139,7 @@ if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$te
     echo "  - $TEST_DL_MATRIX_YAML (line 52)"
     echo "  - $TEST_DL_EP_MATRIX_YAML"
     echo "  - $SANITIZER_MATRIX_YAML"
+    echo "  - $WHEEL_BUILD_MATRIX_YAML"
     echo ""
     exit 1
 fi

--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -19,8 +19,20 @@ The CI pipeline consists of four main components:
 ┌─────────────────┐    ┌──────────────────┐    ┌──────────────────┐    ┌─────────────────┐
 │   Jenkins       │    │  build-          │    │   Dockerfile     │    │   build-        │
 │   Matrix Job    │───▶│  container.sh    │───▶│   .manylinux     │───▶│   wheel.sh      │
-│  (podman runner)│    │  (docker build)  │    │  (full build)    │    │  (wheel pkg)    │
+│  (podman runner)│    │  --wheel-base-   │    │   wheel stage    │    │  (wheel pkg)    │
+│                 │    │  image <url>     │    │   only (~16 steps│    │                 │
 └─────────────────┘    └──────────────────┘    └──────────────────┘    └─────────────────┘
+                                                        ▲
+                                               pulls pre-built image
+                                               from Artifactory
+                                          ┌──────────────────┐
+                                          │  wheel_base stage│
+                                          │  (UCX, gRPC,     │
+                                          │  Rust, DOCA, …)  │
+                                          │  built & pushed  │
+                                          │  by CI-demo when │
+                                          │  Dockerfile changes│
+                                          └──────────────────┘
 ```
 
 ## 1. Jenkins Matrix Configuration
@@ -48,27 +60,35 @@ The job builds wheels for multiple combinations:
 ```yaml
 runs_on_dockers:
   - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+  - { file: 'contrib/Dockerfile.manylinux', name: "nixl-wheel-base-manylinux_2_28",
+      tag: "${CI_IMAGE_TAG}", build_args: '... --target wheel_base' }
 ```
 
-The CI runner uses podman-in-container. `build-container.sh` is called inside this container and executes `docker build` (symlinked to podman) to build the wheel image using `contrib/Dockerfile.manylinux`.
+The CI runner uses podman-in-container. `build-container.sh` is called inside this container and executes `docker build` (symlinked to podman). The `nixl-wheel-base-manylinux_2_28` entry is never used as a runner — CI-demo builds and pushes it to Artifactory whenever `CI_IMAGE_TAG` changes, so that each PR build can pull the pre-built `wheel_base` layer instead of compiling all dependencies from scratch.
 
 ## 2. Docker Build Environment (`contrib/Dockerfile.manylinux`)
 
 ### Multi-Stage Build Architecture
 
-The Dockerfile uses a multi-stage build approach with two main stages:
+The Dockerfile has two stages:
+
+- **`wheel_base`** — builds all slow dependencies (hwloc, OpenSSL, Abseil, gRPC, etcd, curl, AWS SDK, libxml2, Azure SDK, Rust, DOCA, gdrcopy, libfabric, Python/uv, UCX). Built and pushed to Artifactory by CI-demo when `CI_IMAGE_TAG` changes. This stage is never rebuilt per-PR.
+- **`wheel`** — `FROM $wheel_base AS wheel` — builds NIXL itself and runs `build-wheel.sh`. The `wheel_base` ARG is overridden to the Artifactory URL so this stage pulls the pre-built image as its base; only ~16 steps run per PR.
 
 ```dockerfile
-# Stage 1: Base stage with all dependencies and build environment
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} as wheel-base
+ARG wheel_base=wheel_base   # overridden to Artifactory URL in CI
 
-# ... (dependency installation and build setup)
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS wheel_base
+# ... installs UCX, gRPC, Rust, DOCA, gdrcopy, etc.
 
-# Stage 2: Default stage that builds and generates wheels
-FROM wheel-base
-# ... (NIXL build and wheel generation)
+FROM $wheel_base AS wheel
+ARG ARCH="x86_64"
+ARG BUILD_TYPE="release"
+ARG BUILD_NIXL_EP="true"
+ARG UCX_SONAME_SUFFIX=""
+# ... builds NIXL and generates wheels
 ```
 
 **Base Image**: `artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda:13.0-devel-manylinux--25.09`
@@ -76,38 +96,35 @@ FROM wheel-base
 ### Stage Usage Patterns
 
 #### CI Pipeline Usage (via build-container.sh)
-In the CI pipeline, `build-container.sh` is called with Artifactory base image and the target arch/Python version:
+In the PR CI pipeline, `build-container.sh` is called with `--wheel-base-image` pointing to the pre-built `wheel_base` image in Artifactory:
 
 ```bash
 ./contrib/build-container.sh \
   --base-image 'artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda' \
   --base-image-tag '13.0-devel-manylinux--25.09' \
-  --wheel-base "manylinux_${manylinux}" \
+  --wheel-base "manylinux_2_28" \
   --python-versions "${python_version}" \
   --arch ${arch} \
-  --dockerfile contrib/Dockerfile.manylinux
+  --torch-versions "2.13" \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --wheel-base-image "${registry_host}${registry_path}/${arch}/${WHEEL_BASE_IMAGE_NAME}:${CI_IMAGE_TAG}"
 ```
 
-The script invokes `docker build` (symlinked to podman) with `BUILD_ARGS` assembled from those parameters, running a full Dockerfile.manylinux build that produces wheels inside the container.
+`--wheel-base-image` causes the script to pass `--build-arg wheel_base=<url> --target wheel`, so only the `wheel` stage runs and the pre-built deps are pulled from Artifactory rather than recompiled.
 
-#### User Usage (Default Stage)
-Users can build the complete image without specifying a target:
+`--torch-versions "2.13"` limits PR builds to the latest torch version. The nightly job omits this flag, building the full matrix.
+
+#### User Usage (Full Build)
+Users can build the complete image locally without specifying a target:
 
 ```bash
-docker build -f contrib/Dockerfile.manylinux .
+./contrib/build-container.sh --dockerfile contrib/Dockerfile.manylinux
 ```
 
-This will:
-- Use the `wheel-base` stage as foundation
-- Build NIXL from source
-- Generate wheels for all configured Python versions
-- Install the wheel for testing
+This builds both stages from scratch without the `--wheel-base-image` override.
 
-**User Benefits:**
-- Self-contained build environment
-- Pre-built wheels ready for distribution
-- Complete testing environment
-- No need to run separate build steps
+#### Nightly Build
+The nightly job (`nixl-ci-build-wheel-nightly`) omits `--torch-versions` and `--wheel-base-image`, so it builds all torch versions and runs the full two-stage build.
 
 ### Key Dependencies Installed
 
@@ -250,13 +267,14 @@ Sets up the podman container runtime and authenticates with Artifactory:
 
 ### Step 2: Build Wheel
 
-Builds the full NIXL container image (including wheel generation) via `build-container.sh`:
+Builds only the `wheel` stage of `Dockerfile.manylinux` by pulling the pre-built `wheel_base` from Artifactory:
 
-- Calls `contrib/build-container.sh` with the Artifactory base image, target arch, manylinux platform, and Python version
-- The script invokes `docker build` (podman) with `contrib/Dockerfile.manylinux`, which:
-  - Installs all system dependencies (UCX, gRPC, CUDA tools, Rust toolchain, etc.)
+- Calls `contrib/build-container.sh` with `--wheel-base-image <artifactory-url>` and `--torch-versions "2.13"`
+- The script invokes `docker build --target wheel --build-arg wheel_base=<url>` (podman), which:
+  - Pulls the pre-built `nixl-wheel-base-manylinux_2_28:${CI_IMAGE_TAG}` image (all deps already compiled)
   - Builds NIXL from source with meson/ninja
   - Runs `build-wheel.sh` to produce the Python wheel with auditwheel repair
+- Only ~16 Docker steps run per PR build (instead of the full ~53-step build)
 - Wheels are written to the `dist/` directory inside the container image
 
 
@@ -412,6 +430,7 @@ uv pip install --force-reinstall dist/nixl-*.whl
 
 ### Updating Dependencies
 - Modify `contrib/Dockerfile.manylinux` for system package updates
+- **Bump `CI_IMAGE_TAG`** in all six matrix YAMLs (including `.ci/jenkins/lib/build-wheel-matrix.yaml`) — `Dockerfile.manylinux` is in the `CI_FILES` list, so the `cidemo-init.sh` check will fail the PR otherwise
 - Update Python versions in matrix configuration
 - Test new dependencies in isolated environment
 
@@ -424,7 +443,7 @@ uv pip install --force-reinstall dist/nixl-*.whl
 ### Performance Optimization
 - Adjust `NPROC` build argument for parallel compilation
 - Monitor resource usage and adjust Kubernetes limits
-- Consider caching strategies for faster builds
+- Dependencies are cached in the `wheel_base` image; rebuilding it only requires bumping `CI_IMAGE_TAG`
 
 ## 10. Build Configuration Tools
 

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -165,6 +165,11 @@ their own nightly/manual trigger. They split into two groups:
 - **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
 - **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all six) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
 
+### `nixl-ci-build-wheel` (dispatcher-triggered)
+- **Config:** `.ci/jenkins/lib/build-wheel-matrix.yaml`
+- **What it does:** Builds NIXL Python wheels for each Python version × architecture combination. Uses a two-stage `contrib/Dockerfile.manylinux` build: the `wheel_base` stage (all slow deps: UCX, gRPC, Rust, etc.) is pre-built and cached in Artifactory under `CI_IMAGE_TAG`; PR builds pull this pre-built image and run only the `wheel` stage (~16 steps). PR builds also pass `--torch-versions` (set via the `TORCH_VERSIONS` env in the matrix file) to limit the torch extension builds to the latest version.
+- **`CI_IMAGE_TAG`:** Same convention as the other five matrix files. `contrib/Dockerfile.manylinux` is part of the `CI_FILES` list in `cidemo-init.sh`, so changing it (or any other CI file) without bumping `CI_IMAGE_TAG` in all six matrix YAMLs will fail the pre-commit check.
+
 ### `nixl-ci-build-container` (standalone)
 - **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the DLFW PyTorch daily image, ~3–4 AM), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).
 - **What it does:** Builds and pushes x86_64/aarch64 NIXL/NIXLBench container images to Artifactory.

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -45,7 +45,7 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "20260709-1"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -80,6 +80,16 @@ kubernetes:
 # build-container.sh runs podman/docker inside this container to build the wheel image
 runs_on_dockers:
   - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+  # wheel_base: built and pushed by CI-demo when Dockerfile.manylinux changes.
+  # No step selects this container, so it is never used as a runner — only as a cached deps image.
+  # name/tag cannot use matrix axes (${manylinux}, ${arch}) — those resolve only inside steps.
+  # manylinux is hardcoded to 2_28 (the only matrix value); arch is handled by ci-demo per node.
+  - {
+      file: 'contrib/Dockerfile.manylinux',
+      name: "${WHEEL_BASE_IMAGE_NAME}",
+      tag: "${CI_IMAGE_TAG}",
+      build_args: '--build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_IMAGE_TAG=${BASE_TAG} --build-arg ARCH=${arch} --build-arg NPROC=${NPROC} --build-arg GRPC_NPROC=${GRPC_NPROC} --target wheel_base'
+    }
 
 # =============================================================================
 # Build Matrix Configuration
@@ -88,8 +98,6 @@ runs_on_dockers:
 # Each combination runs in parallel
 matrix:
   axes:
-    manylinux:
-      - "2_28"
     # Python versions supported by NIXL
     # Each version gets its own wheel with appropriate ABI tags
     python_version:
@@ -106,10 +114,14 @@ matrix:
 # =============================================================================
 # Global environment variables for the build process
 env:
-  NPROC: 16
+  NPROC: 32
   GRPC_NPROC: 10
   BASE_IMAGE: "${registry_host}/sw-nbu-swx-nixl-docker-local/base/cuda"
   BASE_TAG: '13.0-devel-manylinux--25.09'
+  CI_IMAGE_TAG: "20260709-1"
+  WHL_BASE: "manylinux_2_28"
+  TORCH_VERSIONS: "2.13"
+  WHEEL_BASE_IMAGE_NAME: "nixl-wheel-base-manylinux_2_28"
 
 steps:
   # =============================================================================
@@ -120,6 +132,7 @@ steps:
   - name: Prepare
     credentialsId: 'svc-nixl-new-artifactory-token'
     parallel: false
+    containerSelector: "{name: 'manylinux'}"
     run: |
       # Setup podman and dependencies
       rm -f /etc/containers/storage.conf /usr/share/containers/storage.conf
@@ -135,6 +148,7 @@ steps:
   # This step uses the build-wheel.sh script to package everything into wheels
   - name: Build Wheel
     parallel: false
+    containerSelector: "{name: 'manylinux'}"
     run: |
       set -x
       export NPROC=$NPROC
@@ -142,13 +156,15 @@ steps:
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
-        --wheel-base "manylinux_${manylinux}" \
+        --wheel-base "${WHL_BASE}" \
         --python-versions "${python_version}" \
         --arch ${arch} \
-        --dockerfile contrib/Dockerfile.manylinux
+        --torch-versions "${TORCH_VERSIONS}" \
+        --dockerfile contrib/Dockerfile.manylinux \
+        --wheel-base-image "${registry_host}${registry_path}/${arch}/${WHEEL_BASE_IMAGE_NAME}:${CI_IMAGE_TAG}"
 
 # =============================================================================
 # Task Naming Convention
 # =============================================================================
 # Unique identifier for each matrix combination
-taskName: '${name}_${manylinux}/${arch}/python_${python_version}'
+taskName: '${name}/${arch}/python_${python_version}'

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -60,7 +60,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "20260709-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -54,7 +54,7 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "20260709-1"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -52,7 +52,7 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "20260709-1"
   ENROOT_MOUNT_PATH: "/enroot_images"  # NFS mount on mizu nodes; on failure the container is exported here as <containerName>.sqsh
   ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"  # svc-nixl user on mizu nodes
 

--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -42,7 +42,7 @@ env:
   TEST_TIMEOUT: 40
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "20260709-1"
 
 runs_on_dockers:
   # TSan-instrumented dependency image for the tsan build (DEPS_SANITIZE=thread

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -16,7 +16,11 @@
 
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
+# When overridden to an Artifactory URL, the wheel stage pulls the pre-built deps
+# image instead of building them locally. Default keeps the single-stage local build.
+ARG wheel_base=wheel_base
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS wheel_base
 
 ARG DEFAULT_PYTHON_VERSION="3.14"
 ARG ARCH="x86_64"
@@ -347,6 +351,13 @@ RUN cd /usr/local/src && \
      make -j &&                      \
      make -j install-strip &&        \
      ldconfig
+
+FROM $wheel_base AS wheel
+
+ARG ARCH="x86_64"
+ARG BUILD_TYPE="release"
+ARG BUILD_NIXL_EP="true"
+ARG UCX_SONAME_SUFFIX=""
 
 COPY . /workspace/nixl
 WORKDIR /workspace/nixl

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -119,6 +119,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --torch-versions)
+            if [ "$2" ]; then
+                WHL_TORCH_VERSIONS=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --ucx-repo)
             if [ "$2" ]; then
                 UCX_REPO=$2
@@ -152,6 +160,14 @@ get_options() {
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+        --wheel-base-image)
+            if [ "$2" ]; then
+                WHEEL_BASE_IMAGE=$2
                 shift
             else
                 missing_requirement $1
@@ -230,6 +246,8 @@ show_help() {
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
+    echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
+    echo "  [--wheel-base-image pre-built wheel base image URL; skips wheel_base stage and builds only the wheel stage]"
     exit 0
 }
 
@@ -251,6 +269,7 @@ fi
 
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
+BUILD_ARGS+="${WHL_TORCH_VERSIONS:+ --build-arg WHL_TORCH_VERSIONS=$WHL_TORCH_VERSIONS}"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"
 BUILD_ARGS+=" --build-arg UCX_REPO=$UCX_REPO"
@@ -262,6 +281,11 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 
+if [ -n "$WHEEL_BASE_IMAGE" ]; then
+    BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"
+    BUILD_TARGET="--target wheel"
+fi
+
 show_build_options
 
-docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT
+docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${BUILD_TARGET:-} $BUILD_CONTEXT


### PR DESCRIPTION
## What?
Add a wheel_base Docker build target covering all dependency compilation (hwloc, OpenSSL, Abseil, gRPC, AWS/Azure SDKs, Rust, DOCA, libfabric, UCX, etc.). The wheel stage starts FROM wheel_base and only runs the NIXL build and wheel creation steps.

In CI the wheel_base image is built and pushed to Artifactory by ci-demo when Dockerfile.manylinux changes (via the new runs_on_dockers entry). The build-wheel pipeline then passes --wheel-base-image to build-container.sh which pulls the cached image and runs --target wheel, skipping the expensive dep compilation on every PR.

Local docker builds are unaffected: wheel_base ARG defaults to the local stage name so docker build ./contrib/Dockerfile.manylinux builds the full image as before.

Also removes the now-redundant manylinux matrix axis (was single-valued 2_28, hardcoded in the image name and wheel-base arg), and wires cidemo-init.sh to enforce a CI_IMAGE_TAG bump in build-wheel-matrix.yaml whenever Dockerfile.manylinux changes.

## Why?
Lower nixl-ci-build-wheel pipeline times, and to justify adding #1777 later on which adds time to this pipeline


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wheel builds now use a single cached wheel-base (manylinux_2_28) and support selecting a prebuilt dependencies image, alongside optional Torch version selection.
  * The wheel build matrix is simplified to vary only by Python version and architecture for more consistent builds.
* **Bug Fixes**
  * CI validation now more reliably enforces required image tag updates for both standard CI changes and wheel Dockerfile changes, with clearer guidance when updates are missing.
* **Documentation**
  * Updated CI docs to reflect the new cached wheel-base flow and how to refresh it via the wheel cache image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->