### PR TITLE
ci: skip ucx_backend_multi under TSan and lower sanitizer stage timeout to 40m

### DIFF
--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -39,7 +39,7 @@ kubernetes:
 env:
   NIXL_CI_NON_GPU: 1
   NIXL_INSTALL_DIR: /opt/nixl
-  TEST_TIMEOUT: 90
+  TEST_TIMEOUT: 40
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
   CI_IMAGE_TAG: "20260625-1"

--- a/.gitlab/test_sanitizer.sh
+++ b/.gitlab/test_sanitizer.sh
@@ -149,7 +149,17 @@ run_stage "nixl_posix_test" ./bin/nixl_posix_test -n 128 -s 1048576
 # library's block-device/direct-IO memory model vs the TSan runtime), and under
 # ASan its GUSLIc thread init flakily trips the GCC 13.3 libsanitizer
 # thread-registry crash. Both are toolchain / third-party issues, not NIXL bugs.
-run_stage "ucx_backend_multi" ./bin/ucx_backend_multi
+# ucx_backend_multi is skipped under TSan only: this multi-threaded UCX
+# connect/disconnect stress test rarely hangs to the stage timeout under
+# ThreadSanitizer. Its two threads own separate engines and coordinate a
+# one-sided connect/disconnect via busy-wait spin loops with asymmetric progress
+# pumping; TSan's scheduling perturbation occasionally leaves a UCX wireup step
+# un-progressed and the peers deadlock. TSan also can't see UCX's own
+# synchronization (all of libucp/uct/ucs is suppressed in tsan.supp), so the test
+# adds little TSan value. It still runs under ASan/UBSan, where it is reliable.
+if [ "${SAN_LABEL}" != "tsan" ]; then
+    run_stage "ucx_backend_multi" ./bin/ucx_backend_multi
+fi
 run_stage "serdes_test" ./bin/serdes_test
 run_stage "test_plugin" ./bin/test_plugin
 


### PR DESCRIPTION
## What?
ucx_backend_multi rarely hangs to the stage timeout under ThreadSanitizer. It is a multi-threaded UCX connect/disconnect stress test whose two threads own separate engines and coordinate a one-sided connect/disconnect via busy-wait spin loops with asymmetric progress pumping; TSan's scheduling perturbation occasionally leaves a UCX wireup step un-progressed and the peers deadlock. TSan also cannot see UCX's own synchronization (all of libucp/uct/ucs is already suppressed in tsan.supp), so the test adds little TSan value. Skip it under TSan only, keyed on SAN_LABEL; it still runs under ASan/UBSan, where it is reliable.

Also lower TEST_TIMEOUT from 90 to 40 minutes: sanitizer runs average 15-30 min, so 90 let a hung stage burn far longer than needed before being killed. 40m keeps comfortable headroom over the normal runtime while failing hangs faster.

## Why?
test-sanitizers pipeline on rare occasions hangs until timeout, this restores stability

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced sanitizer test job timeouts to shorten waiting time in CI.
  * Updated sanitizer execution so one backend stage is skipped under ThreadSanitizer, preventing failures in that configuration.
  * Improved reliability of sanitizer-related test runs without changing normal build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->