### PR TITLE
telemetry: key Prometheus exporter maps by event-type enum

### DIFF
--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -117,31 +117,39 @@ nixlTelemetryPrometheusExporter::~nixlTelemetryPrometheusExporter() {
 // Events are defined in the telemetry.cpp file
 void
 nixlTelemetryPrometheusExporter::initializeMetrics() {
-    registerCounter("agent_tx_bytes", "Number of bytes sent by the agent");
-    registerCounter("agent_rx_bytes", "Number of bytes received by the agent");
-    registerCounter("agent_tx_requests_num", "Number of requests sent by the agent");
-    registerCounter("agent_rx_requests_num", "Number of requests received by the agent");
-    registerCounter("agent_memory_registered", "Cumulative memory registered");
-    registerCounter("agent_memory_deregistered", "Cumulative memory deregistered");
-    registerCounter("agent_xfer_time", "Start to Complete (per request)");
-    registerCounter("agent_xfer_post_time", "Start to posting to Back-End (per request)");
+    using event_type_t = nixl_telemetry_event_type_t;
+
+    registerCounter(event_type_t::AGENT_TX_BYTES, "Number of bytes sent by the agent");
+    registerCounter(event_type_t::AGENT_RX_BYTES, "Number of bytes received by the agent");
+    registerCounter(event_type_t::AGENT_TX_REQUESTS_NUM, "Number of requests sent by the agent");
+    registerCounter(event_type_t::AGENT_RX_REQUESTS_NUM,
+                    "Number of requests received by the agent");
+    registerCounter(event_type_t::AGENT_MEMORY_REGISTERED, "Cumulative memory registered");
+    registerCounter(event_type_t::AGENT_MEMORY_DEREGISTERED, "Cumulative memory deregistered");
+    registerCounter(event_type_t::AGENT_XFER_TIME, "Start to Complete (per request)");
+    registerCounter(event_type_t::AGENT_XFER_POST_TIME,
+                    "Start to posting to Back-End (per request)");
     registerErrorCounters();
 
-    registerGauge("agent_tx_bytes", "agent_tx_last_bytes", "Bytes sent by the last request");
-    registerGauge("agent_rx_bytes", "agent_rx_last_bytes", "Bytes received by the last request");
-    registerGauge("agent_memory_registered",
+    registerGauge(
+        event_type_t::AGENT_TX_BYTES, "agent_tx_last_bytes", "Bytes sent by the last request");
+    registerGauge(
+        event_type_t::AGENT_RX_BYTES, "agent_rx_last_bytes", "Bytes received by the last request");
+    registerGauge(event_type_t::AGENT_MEMORY_REGISTERED,
                   "agent_memory_registered_last_bytes",
                   "Memory registered by the last operation");
-    registerGauge("agent_memory_deregistered",
+    registerGauge(event_type_t::AGENT_MEMORY_DEREGISTERED,
                   "agent_memory_deregistered_last_bytes",
                   "Memory deregistered by the last operation");
 }
 
 void
-nixlTelemetryPrometheusExporter::registerCounter(const std::string &name, const std::string &help) {
+nixlTelemetryPrometheusExporter::registerCounter(const nixl_telemetry_event_type_t event_type,
+                                                 const std::string &help) {
+    const std::string name(nixlEnumStrings::telemetryEventTypeStr(event_type));
     auto &family = prometheus::BuildCounter().Name(name + "_total").Help(help).Register(*registry_);
     auto &metric = family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}});
-    const auto inserted = counters_.try_emplace(name, &family, &metric).second;
+    const auto inserted = counters_.try_emplace(event_type, &family, &metric).second;
     if (!inserted) {
         family.Remove(&metric);
     }
@@ -159,8 +167,7 @@ nixlTelemetryPrometheusExporter::registerErrorCounters() {
         const char *const status = nixlEnumStrings::telemetryErrorStatusLabel(event_type);
         auto &metric =
             family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}, {"status", status}});
-        const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event_type));
-        const auto inserted = counters_.try_emplace(event_name, &family, &metric).second;
+        const auto inserted = counters_.try_emplace(event_type, &family, &metric).second;
         if (!inserted) {
             family.Remove(&metric);
         }
@@ -169,12 +176,12 @@ nixlTelemetryPrometheusExporter::registerErrorCounters() {
 }
 
 void
-nixlTelemetryPrometheusExporter::registerGauge(const std::string &event_name,
+nixlTelemetryPrometheusExporter::registerGauge(const nixl_telemetry_event_type_t event_type,
                                                const std::string &metric_name,
                                                const std::string &help) {
     auto &family = prometheus::BuildGauge().Name(metric_name).Help(help).Register(*registry_);
     auto &metric = family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}});
-    const auto inserted = gauges_.try_emplace(event_name, &family, &metric).second;
+    const auto inserted = gauges_.try_emplace(event_type, &family, &metric).second;
     if (!inserted) {
         family.Remove(&metric);
     }
@@ -183,17 +190,13 @@ nixlTelemetryPrometheusExporter::registerGauge(const std::string &event_name,
 
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
-    // TODO(C++20): use std::string_view for lookup keys and transparent hash/equal_to
-    // on counters_/gauges_ to avoid allocating a std::string per event when feasible.
     try {
-        const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
-
-        const auto counter = counters_.find(event_name);
+        const auto counter = counters_.find(event.eventType_);
         if (counter != counters_.end()) {
             counter->second.metric->Increment(event.value_);
         }
 
-        const auto gauge = gauges_.find(event_name);
+        const auto gauge = gauges_.find(event.eventType_);
         if (gauge != gauges_.end()) {
             gauge->second.metric->Set(static_cast<double>(event.value_));
         }

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.h
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.h
@@ -98,24 +98,24 @@ private:
     std::shared_ptr<prometheus::Exposer> exposer_;
     std::shared_ptr<prometheus::Registry> registry_;
 
-    std::unordered_map<std::string, CounterEntry> counters_;
-    std::unordered_map<std::string, GaugeEntry> gauges_;
+    std::unordered_map<nixl_telemetry_event_type_t, CounterEntry> counters_;
+    std::unordered_map<nixl_telemetry_event_type_t, GaugeEntry> gauges_;
 
     void
     initializeMetrics();
 
     void
-    registerCounter(const std::string &name, const std::string &help);
+    registerCounter(nixl_telemetry_event_type_t event_type, const std::string &help);
 
     void
     registerErrorCounters();
 
-    // event_name is the lookup key exportEvent() uses (the telemetry event
-    // name); metric_name is the exposed Prometheus series name. They differ for
-    // last-operation gauges, e.g. the AGENT_TX_BYTES event ("agent_tx_bytes")
-    // drives a gauge published as "agent_tx_last_bytes".
+    // event_type is the lookup key exportEvent() uses; metric_name is the
+    // exposed Prometheus series name. They differ for last-operation gauges,
+    // e.g. the AGENT_TX_BYTES event drives a gauge published as
+    // "agent_tx_last_bytes".
     void
-    registerGauge(const std::string &event_name,
+    registerGauge(nixl_telemetry_event_type_t event_type,
                   const std::string &metric_name,
                   const std::string &help);
 };


### PR DESCRIPTION
## What?

Re-key the Prometheus exporter's `counters_` / `gauges_` maps on the
`nixl_telemetry_event_type_t` enum instead of `std::string`. `exportEvent()`
now looks up metrics directly by `event.eventType_` with no per-event string
construction on the hot path; series names are still derived from
`telemetryEventTypeStr()` at registration time only. Removes the
`// TODO(C++20)` in `exportEvent()`.

## Why?

Addresses the review question on #1851 ("why construct a string per event?",
`prometheus_exporter.cpp`). `exportEvent()` allocated a `std::string` from the
`string_view` returned by `telemetryEventTypeStr()` on every event just to
index the maps.

The originally-ticketed fix (transparent `string_view` hash) was rejected: it
relies on heterogeneous `unordered_map` lookup, which is C++20-only
(`#if __cplusplus > 201703L`), and the project still builds under C++17 (the
`cpp_std` meson option is overridable and ASan/CI configs use `c++17`). Keying
by the enum is allocation-free for every event, uses a cheaper integer hash,
and compiles cleanly under both the C++17 and C++20 build configs.

Refs NIX-1588.

## How?

- `counters_` / `gauges_` become
  `std::unordered_map<nixl_telemetry_event_type_t, ...>` (`std::hash` supports
  enums in C++17).
- `registerCounter` takes the enum and derives the `*_total` family name via
  `telemetryEventTypeStr(event_type)`; `registerGauge` / `registerErrorCounters`
  key by the enum.
- Behavior-preserving: identical series names, labels, and values. Verified by
  the existing `prometheusTelemetryTest` suite (4 tests) under both C++17 and
  C++20 builds; no new tests needed since observable output is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry metric registration and export reliability by using consistent event-type handling.
  * Reduced the chance of missing or mismatched Prometheus counters and gauges during metric export.
  * Kept exported metric names and behavior unchanged while making metric lookup more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->