### PR TITLE
ci: link libasan into the nvcc-linked gtest binary under sanitizer builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -285,6 +285,21 @@ if cuda_dep.found()
     add_project_arguments('-std=c++20', language: 'cuda')
 
     add_project_link_arguments(nvcc_flags_link, language: 'cuda')
+
+    # When a sanitizer is enabled, forward its runtime to the nvcc-driven link so
+    # mixed C++/CUDA executables get libasan/libubsan/libtsan directly on their
+    # link line. The gtest binary is the case that bites: it compiles the
+    # device_api .cu sources, so meson links it with nvcc, but the sanitizer flag
+    # (added for language 'cpp' above) never reaches that link -- while its C++
+    # TUs were compiled with -fsanitize. Result: "undefined reference to
+    # __asan_unregister_globals ... libasan.so: DSO missing from command line".
+    # nvcc's -Xcompiler treats commas as argument separators, so forward each
+    # sanitizer part on its own -Xcompiler instead of -fsanitize=address,undefined.
+    if sanitizer != 'none'
+        foreach _san_part : sanitizer_parts
+            add_project_link_arguments('-Xcompiler=-fsanitize=' + _san_part, language: 'cuda')
+        endforeach
+    endif
     message('nvcc version: ' + nvcc.version())
     message('CUDA targets: ' + ', '.join(selected_cuda_archs) + ' + ' + nvcc_ptx_arch)
     if nvcc.version().version_compare('>=12.8')


### PR DESCRIPTION
## Summary

The `asan_ubsan` sanitizer build broke at link time:

```
undefined reference to symbol '__asan_unregister_globals'
libasan.so.8: error adding symbols: DSO missing from command line
```

## Root cause

The sanitizer flag is added only for `language: 'cpp'` in `meson.build`. The gtest binary compiles the `device_api` `.cu` sources, so meson links it with **nvcc** — and that link never received `-fsanitize`, while the binary's C++ TUs *were* compiled with it and reference the ASan runtime. libasan was only pulled in indirectly (via `libnixl.so`'s `DT_NEEDED`), which `ld.bfd` refuses to use for a direct symbol reference.

It surfaced now (not a code change) because the rebuilt CI base image began providing the UCX GPU Device API + DOCA GPUNETIO, which turns the `device_api` `.cu` tests on and flips gtest from a C++ link to an nvcc link.

## Fix

Forward the sanitizer runtime to the nvcc link via `-Xcompiler`, one part at a time (nvcc's `-Xcompiler` splits on commas, so `-fsanitize=address,undefined` can't be passed whole). Scoped to `-Dsanitizer != none` and to CUDA link args only, so it's a no-op for normal builds and fixes both the asan_ubsan and tsan variants (libasan / libtsan land directly on the link line).

No product code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA build handling when sanitizers are enabled.
  * CUDA-linked builds now include the needed sanitizer runtime flags more reliably, helping mixed C++/CUDA projects link successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->