### PR TITLE
[codex] fix SGLang CUDA 12 CI parameter wiring

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -5,12 +5,13 @@
 #
 #   - vllm-nixl-<ver>         : Dockerfile.vllm   + vllm/vllm-openai:latest
 #   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu129
-#   - sglang-nixl-<ver>       : Dockerfile.sglang + lmsysorg/sglang:latest
+#   - sglang-nixl-<ver>       : Dockerfile.sglang + pinned CUDA 12 image
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
-# For RC0 builds the upstream defaults are used. For subsequent RCs (or
-# re-spins) BASE_IMAGE_* parameters pin each variant to the RC0 image so the
-# verification stays isolated to the NIXL change.
+# Each variant uses its configured BASE_IMAGE_* default. SGLang CUDA 12 stays
+# pinned because the upstream latest tag currently resolves to CUDA 13. For
+# subsequent RCs (or re-spins), the parameters can pin each variant to its RC0
+# image so verification stays isolated to the NIXL change.
 #
 # Wheels are pulled from Artifactory at:
 #   sw-dynamo-nixl-pypi-local/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/<arch>/
@@ -96,7 +97,7 @@ pipeline_start:
     echo "WHEEL_BUILD_ID:     ${params.WHEEL_BUILD_ID}"
     echo "BASE_IMAGE_VLLM:        ${params.BASE_IMAGE_VLLM}"
     echo "BASE_IMAGE_VLLM_CU12:   ${params.BASE_IMAGE_VLLM_CU12}"
-    echo "BASE_IMAGE_SGLANG:      ${params.BASE_IMAGE_SGLANG}"
+    echo "BASE_IMAGE_SGLANG_CU12: ${params.BASE_IMAGE_SGLANG_CU12}"
     echo "BASE_IMAGE_SGLANG_CU13: ${params.BASE_IMAGE_SGLANG_CU13}"
     echo "ENABLE_VLLM:        ${env.ENABLE_VLLM}"
     echo "ENABLE_VLLM_CU12:   ${env.ENABLE_VLLM_CU12}"
@@ -234,7 +235,9 @@ steps:
         *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
       esac
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"
-      BASE="${BASE_IMAGE_SGLANG:-docker.io/lmsysorg/sglang:latest}"
+      # The upstream latest tag currently resolves to CUDA 13, so keep the
+      # CUDA 12 lane pinned while still allowing an explicit job override.
+      BASE="${BASE_IMAGE_SGLANG_CU12:-artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/sglang-nixl:1.3.0-rc0-v1}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \

--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -87,7 +87,7 @@ pipeline_start:
     def target = params.BUILD_TARGET
     env.ENABLE_VLLM = (target == 'vllm'        || target == 'all') ? 'true' : 'false'
     env.ENABLE_VLLM_CU12 = (target == 'vllm-cu12'   || target == 'all') ? 'true' : 'false'
-    env.ENABLE_SGLANG = (target == 'sglang'      || target == 'all') ? 'true' : 'false'
+    env.ENABLE_SGLANG_CU12 = (target == 'sglang-cu12' || target == 'sglang' || target == 'all') ? 'true' : 'false'
     env.ENABLE_SGLANG_CU13 = (target == 'sglang-cu13' || target == 'all') ? 'true' : 'false'
 
     echo "BUILD_TARGET:       ${target}"
@@ -101,7 +101,7 @@ pipeline_start:
     echo "BASE_IMAGE_SGLANG_CU13: ${params.BASE_IMAGE_SGLANG_CU13}"
     echo "ENABLE_VLLM:        ${env.ENABLE_VLLM}"
     echo "ENABLE_VLLM_CU12:   ${env.ENABLE_VLLM_CU12}"
-    echo "ENABLE_SGLANG:      ${env.ENABLE_SGLANG}"
+    echo "ENABLE_SGLANG_CU12: ${env.ENABLE_SGLANG_CU12}"
     echo "ENABLE_SGLANG_CU13: ${env.ENABLE_SGLANG_CU13}"
 
 steps:
@@ -137,7 +137,7 @@ steps:
         # multi-arch tag is what consumers pull and what we ultimately publish.
         [[ "${ENABLE_VLLM}"        == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}"
         [[ "${ENABLE_VLLM_CU12}"   == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}"
-        [[ "${ENABLE_SGLANG}"      == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}"
+        [[ "${ENABLE_SGLANG_CU12}" == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}"
         [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_tag_free "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}"
         true
       fi
@@ -221,8 +221,8 @@ steps:
       podman save --format oci-archive -o "${STAGE_DIR}/vllm-cu12-nixl.tar" "${IMAGE}"
       ls -lh "${STAGE_DIR}/vllm-cu12-nixl.tar"
 
-  - name: Build SGLang
-    enable: ${ENABLE_SGLANG}
+  - name: Build SGLang CU12
+    enable: ${ENABLE_SGLANG_CU12}
     containerSelector: "{name: 'podman'}"
     parallel: true
     run: |
@@ -300,7 +300,7 @@ steps:
 
       [[ "${ENABLE_VLLM}"        == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/vllm-nixl:${IMAGE_TAG}-${arch}"       vllm
       [[ "${ENABLE_VLLM_CU12}"   == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/vllm-cu12-nixl:${IMAGE_TAG}-${arch}"  vllm
-      [[ "${ENABLE_SGLANG}"      == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"     sglang
+      [[ "${ENABLE_SGLANG_CU12}" == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-nixl:${IMAGE_TAG}-${arch}"     sglang
       [[ "${ENABLE_SGLANG_CU13}" == "true" ]] && check_image "${ARTIFACTORY_REGISTRY_URL}/sglang-cu13-nixl:${IMAGE_TAG}-${arch}" sglang
       true
 
@@ -319,7 +319,7 @@ pipeline_stop:
     def variants = []
     if (target == 'vllm'        || target == 'all') variants << 'vllm-nixl'
     if (target == 'vllm-cu12'   || target == 'all') variants << 'vllm-cu12-nixl'
-    if (target == 'sglang'      || target == 'all') variants << 'sglang-nixl'
+    if (target == 'sglang-cu12' || target == 'sglang' || target == 'all') variants << 'sglang-nixl'
     if (target == 'sglang-cu13' || target == 'all') variants << 'sglang-cu13-nixl'
 
     // Flipped to true only after every variant publishes AND the properties

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -640,7 +640,7 @@
       • Publishes multi-arch manifests after both arches succeed<br/>
       • Wheels pulled from <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/</code><br/>
       • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ under <code>llm/{{vllm-nixl,vllm-cu12-nixl,sglang-nixl,sglang-cu13-nixl}}</code><br/>
-      • For <b>rc0</b> leave the <code>BASE_IMAGE_*</code> params empty to use upstream defaults<br/>
+      • Review the per-variant <code>BASE_IMAGE_*</code> defaults; SGLang CUDA 12 is pinned because upstream <code>latest</code> resolves to CUDA 13<br/>
       • For <b>rcN, N&gt;0</b> set each <code>BASE_IMAGE_*</code> to the matching rc0 image to isolate the verification to the NIXL change<br/>
       <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
     concurrent: true
@@ -699,12 +699,13 @@
             Leave empty to use upstream <code>docker.io/vllm/vllm-openai:latest-cu129</code> (rc0 default).<br/>
             For <b>rcN, N&gt;0</b> pin to the rc0 vllm-cu12 image.
       - string:
-          name: "BASE_IMAGE_SGLANG"
-          default: ""
+          name: "BASE_IMAGE_SGLANG_CU12"
+          default: "artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/sglang-nixl:1.3.0-rc0-v1"
           description: >
-            Optional override for the sglang (cu12) base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/lmsysorg/sglang:latest</code>).<br/>
-            For <b>rcN, N&gt;0</b> pin to the rc0 image.
+            Base image for the sglang CUDA 12 build-arg.<br/>
+            Defaults to the pinned CUDA 12 rc0 image because upstream
+            <code>docker.io/lmsysorg/sglang:latest</code> currently resolves to CUDA 13.<br/>
+            Override this value to test a different CUDA 12 image.
       - string:
           name: "BASE_IMAGE_SGLANG_CU13"
           default: ""

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -652,14 +652,14 @@
             - "all"
             - "vllm"
             - "vllm-cu12"
-            - "sglang"
+            - "sglang-cu12"
             - "sglang-cu13"
           description: >
             Which image variants to build:<br/>
             • <b>all</b>: build all 4 variants (default)<br/>
             • <b>vllm</b>: only vllm-nixl<br/>
             • <b>vllm-cu12</b>: only vllm-cu12-nixl<br/>
-            • <b>sglang</b>: only sglang-nixl (cu12)<br/>
+            • <b>sglang-cu12</b>: only sglang-nixl (cu12)<br/>
             • <b>sglang-cu13</b>: only sglang-cu13-nixl
       - string:
           name: "NIXL_VERSION"


### PR DESCRIPTION
## What changed

- Rename the SGLang CUDA 12 Jenkins parameter from `BASE_IMAGE_SGLANG` to `BASE_IMAGE_SGLANG_CU12` so it matches the job input.
- Pin the Jenkins default and matrix fallback to `artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/sglang-nixl:1.3.0-rc0-v1`.
- Keep the parameter overridable for future CUDA 12 images.
- Expose `sglang-cu12` as the build target and map it to `ENABLE_SGLANG_CU12`, while retaining `sglang` as a backward-compatible alias.

## Why

The build matrix read `BASE_IMAGE_SGLANG`, while the Jenkins job supplied `BASE_IMAGE_SGLANG_CU12`. As a result, the requested image was ignored and the lane fell back to `docker.io/lmsysorg/sglang:latest`, which currently resolves to CUDA 13.

The matrix also enabled the CUDA 12 step only for `BUILD_TARGET=sglang`. Submitting the explicit `sglang-cu12` target therefore disabled the build step entirely.

## Impact

The SGLang CUDA 12 lane now uses the requested CUDA 12 image instead of accidentally building on CUDA 13.

## Validation

- Parsed both modified YAML files with PyYAML.
- Verified the Jenkins parameter and matrix variable names match.
- Verified `BUILD_TARGET=sglang-cu12` enables the CUDA 12 build and publish path.
- Verified the exact pinned image is present as both the Jenkins default and matrix fallback.
- Verified no legacy `BASE_IMAGE_SGLANG` CUDA 12 references remain.
- Ran `git diff --check`.
