### PR TITLE
BINDINGS/RUST: Remove explicit `g++` compiler in `cc` builder

### DIFF
--- a/src/bindings/rust/build.rs
+++ b/src/bindings/rust/build.rs
@@ -240,7 +240,6 @@ fn create_builder() -> cc::Build {
     let mut builder = cc::Build::new();
     builder
         .cpp(true)
-        .compiler("g++")
         .flag("-std=c++20")
         .flag("-fPIC")
         .flag("-Wno-unused-parameter")


### PR DESCRIPTION
## What?

Remove the hard-coded `g++` compiler from the Rust binding build configuration and allow the `cc` crate to select the compiler.

## Why?

Hard-coding `g++` limits portability and can break builds on systems where:

  - The C++ compiler has a different name, such as `clang++`.
  - The compiler is provided through a cross-compilation toolchain.
  - The user or build environment specifies a compiler via `CXX` or target-specific configuration.
The `cc` crate already provides platform-aware compiler discovery and honors the relevant environment settings. Relying on that behavior makes the build more flexible without changing the C++ standard, flags, or generated output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build setup for Rust bindings to use the default or externally configured C++ compiler.
  * Existing C++ language settings and compilation flags remain unchanged, preserving the current build behavior while allowing compiler selection to follow the surrounding environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->