### PR TITLE
telemetry: avoid DOCA counter event name allocation

### DIFF
--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -290,12 +290,8 @@ nixlTelemetryDocaExporter::appendCounterSample(const nixlTelemetryEvent &event,
     // Counter events carry a per-operation delta; increment so the exported
     // counter is a monotonic cumulative total (add_counter would instead push
     // each delta as an absolute value, yielding a non-monotonic series).
-    return doca_telemetry_exporter_metrics_add_counter_increment(ctx_->source,
-                                                                 docaTimestamp(),
-                                                                 event_name,
-                                                                 event.value_,
-                                                                 ctx_->label_set_id,
-                                                                 label_values);
+    return doca_telemetry_exporter_metrics_add_counter_increment(
+        ctx_->source, docaTimestamp(), event_name, event.value_, ctx_->label_set_id, label_values);
 #pragma GCC diagnostic pop
 }
 

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -286,13 +286,13 @@ nixlTelemetryDocaExporter::appendCounterSample(const nixlTelemetryEvent &event,
                                                const char *label_values[]) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    const std::string event_name(nixlEnumStrings::telemetryEventTypeStr(event.eventType_));
+    const char *event_name = nixlEnumStrings::telemetryEventTypeStr(event.eventType_).data();
     // Counter events carry a per-operation delta; increment so the exported
     // counter is a monotonic cumulative total (add_counter would instead push
     // each delta as an absolute value, yielding a non-monotonic series).
     return doca_telemetry_exporter_metrics_add_counter_increment(ctx_->source,
                                                                  docaTimestamp(),
-                                                                 event_name.c_str(),
+                                                                 event_name,
                                                                  event.value_,
                                                                  ctx_->label_set_id,
                                                                  label_values);


### PR DESCRIPTION
## What?
Removes a per-event `std::string` allocation in the DOCA telemetry exporter's counter
hot path. In `nixlTelemetryDocaExporter::appendCounterSample`, the event name is now
taken directly from `nixlEnumStrings::telemetryEventTypeStr(event.eventType_).data()`
instead of constructing a temporary `std::string` just to call `.c_str()`.
`telemetryEventTypeStr` is `constexpr` and returns a `std::string_view` backed entirely
by null-terminated string literals (every case plus the `"unknown_event"` default), so
`.data()` is a valid C string for the DOCA Metrics API. The `-Wdeprecated-declarations`
pragma around the experimental DOCA call is kept as-is.
## Why?
Pure hot-path overhead: a heap allocation on every exported counter event with no
behavioral benefit. This is the DOCA twin of the already-merged Prometheus Perf-5
(#1878 / NIX-1588), which removed the equivalent allocation on the Prometheus side.
Tracking: NIX-1591.
Behavior-preserving — identical series names, labels, and values. Covered by the existing
`doca_nixl_test` (`test/doca-telemetry/telemetry_doca_nixl_test.cpp`), which asserts counter
series names and cumulative values via the OpenMetrics scrape parser. All 5 tests pass.
## How?
Scope is a single site: the gauge path already takes a `const char *` (`gaugeMetricName`)
and the error path uses the `"agent_errors_total"` literal, so `appendCounterSample` was the
only allocation site. Exporter-side only — independent of the queue-architecture decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved telemetry export performance by reducing unnecessary string copying when reporting counter increments.
  * Streamlined how event/metric names are passed to the telemetry counter reporting call, aligning formatting with the updated data flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->