### PR TITLE
Build: skip the DOCA SDK install when the base ships only the DOCA runtime

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -50,7 +50,9 @@ RUN apt-get update -y && \
     build-essential
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip only the DOCA SDK install when the base image already ships it.
+# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
+# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
+# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -59,6 +61,8 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
+    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -50,10 +50,9 @@ RUN apt-get update -y && \
     build-essential
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip the DOCA SDK install when the base image already ships it. When the base ships
-# only the DOCA runtime at another version, the pinned repo's SDK can't install against
-# it (apt refuses the downgrade), so install the SDK from the online DOCA repo matching
-# the installed runtime instead.
+# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
+# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
+# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -62,16 +61,9 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
+    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
-        if dpkg -s doca-sdk-common >/dev/null 2>&1; then \
-            DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
-            DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
-            DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
-            echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
-            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
-            apt-get update; \
-        fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi
 

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -50,9 +50,10 @@ RUN apt-get update -y && \
     build-essential
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
-# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
-# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
+# Skip the DOCA SDK install when the base image already ships it. When the base ships
+# only the DOCA runtime at another version, the pinned repo's SDK can't install against
+# it (apt refuses the downgrade), so install the SDK from the online DOCA repo matching
+# the installed runtime instead.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -61,9 +62,16 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
-    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
-        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
+        if dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+            DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
+            DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
+            DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
+            echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
+            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
+            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            apt-get update; \
+        fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi
 

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -67,9 +67,10 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
             DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
             DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
             DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
+            DOCA_REPO="https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH}" && \
             echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
-            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            wget --tries=3 --waitretry=5 --no-verbose ${DOCA_REPO}/doca_keyring.gpg -O /etc/apt/keyrings/doca_online_keyring.gpg && \
+            echo "deb [signed-by=/etc/apt/keyrings/doca_online_keyring.gpg] ${DOCA_REPO} ./" > /etc/apt/sources.list.d/doca-online.list && \
             apt-get update; \
         fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \

--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -67,10 +67,9 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
             DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
             DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
             DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
-            DOCA_REPO="https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH}" && \
             echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose ${DOCA_REPO}/doca_keyring.gpg -O /etc/apt/keyrings/doca_online_keyring.gpg && \
-            echo "deb [signed-by=/etc/apt/keyrings/doca_online_keyring.gpg] ${DOCA_REPO} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
+            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
             apt-get update; \
         fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -74,7 +74,9 @@ RUN apt-get update -y && \
     libxml2-dev
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip only the DOCA SDK install when the base image already ships it.
+# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
+# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
+# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -83,6 +85,8 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
+    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -91,9 +91,10 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
             DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
             DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
             DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
+            DOCA_REPO="https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH}" && \
             echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
-            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            wget --tries=3 --waitretry=5 --no-verbose ${DOCA_REPO}/doca_keyring.gpg -O /etc/apt/keyrings/doca_online_keyring.gpg && \
+            echo "deb [signed-by=/etc/apt/keyrings/doca_online_keyring.gpg] ${DOCA_REPO} ./" > /etc/apt/sources.list.d/doca-online.list && \
             apt-get update; \
         fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -74,10 +74,9 @@ RUN apt-get update -y && \
     libxml2-dev
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip the DOCA SDK install when the base image already ships it. When the base ships
-# only the DOCA runtime at another version, the pinned repo's SDK can't install against
-# it (apt refuses the downgrade), so install the SDK from the online DOCA repo matching
-# the installed runtime instead.
+# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
+# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
+# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -86,16 +85,9 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
+    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
-        if dpkg -s doca-sdk-common >/dev/null 2>&1; then \
-            DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
-            DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
-            DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
-            echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
-            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
-            apt-get update; \
-        fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -91,10 +91,9 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
             DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
             DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
             DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
-            DOCA_REPO="https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH}" && \
             echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
-            wget --tries=3 --waitretry=5 --no-verbose ${DOCA_REPO}/doca_keyring.gpg -O /etc/apt/keyrings/doca_online_keyring.gpg && \
-            echo "deb [signed-by=/etc/apt/keyrings/doca_online_keyring.gpg] ${DOCA_REPO} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
+            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
             apt-get update; \
         fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -74,9 +74,10 @@ RUN apt-get update -y && \
     libxml2-dev
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
-# Skip the DOCA SDK install when the base image already ships the SDK, and also when it
-# ships only the DOCA runtime at another version: the pinned repo's SDK can't install
-# against it (apt refuses the downgrade), and the GPUNETIO plugin is optional in meson.
+# Skip the DOCA SDK install when the base image already ships it. When the base ships
+# only the DOCA runtime at another version, the pinned repo's SDK can't install against
+# it (apt refuses the downgrade), so install the SDK from the online DOCA repo matching
+# the installed runtime instead.
 RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
     MELLANOX_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
     wget --tries=3 --waitretry=5 --no-verbose https://www.mellanox.com/downloads/DOCA/DOCA_v3.3.0/host/doca-host_3.3.0-088000-26.01-${MELLANOX_OS}_${ARCH_SUFFIX}.deb -O doca-host.deb && \
@@ -85,9 +86,16 @@ RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "am
     apt-get upgrade -y && \
     if dpkg -s doca-sdk-gpunetio >/dev/null 2>&1; then \
         echo "DOCA SDK already installed in base image, skipping SDK install"; \
-    elif dpkg -s doca-sdk-common >/dev/null 2>&1; then \
-        echo "Base image ships DOCA runtime $(dpkg-query -W -f='${Version}' doca-sdk-common) without the GPUNETIO SDK, skipping SDK install to avoid a version mismatch"; \
     else \
+        if dpkg -s doca-sdk-common >/dev/null 2>&1; then \
+            DOCA_VER="$(dpkg-query -W -f='${Version}' doca-sdk-common | cut -d. -f1,2).0" && \
+            DOCA_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z)" && \
+            DOCA_ARCH=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64-sbsa"; else echo "x86_64"; fi) && \
+            echo "Base image ships the DOCA ${DOCA_VER} runtime without the SDK, installing the SDK from the matching online repo" && \
+            wget --tries=3 --waitretry=5 --no-verbose https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub -O /etc/apt/keyrings/GPG-KEY-Mellanox.asc && \
+            echo "deb [signed-by=/etc/apt/keyrings/GPG-KEY-Mellanox.asc] https://linux.mellanox.com/public/repo/doca/${DOCA_VER}/${DOCA_OS}/${DOCA_ARCH} ./" > /etc/apt/sources.list.d/doca-online.list && \
+            apt-get update; \
+        fi && \
         apt-get install -y --no-install-recommends doca-sdk-gpunetio libdoca-sdk-gpunetio-dev libdoca-sdk-verbs-dev libdoca-sdk-telemetry-exporter-dev collectx-clxapidev; \
     fi
 

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -128,6 +128,20 @@ BUILD_DEPS=(
 # be used unambiguously as a path component.
 slug() { echo "${1//./}"; }
 
+# The base image's torch major.minor, printed only when the EP build can use
+# it (>= 2.7). pytorch bases ship torch built for CUDA versions that have no
+# public wheel index, so it is the fallback when the cu index has nothing.
+system_torch_version() {
+    python3 -c '
+import sys
+import torch
+major, minor = (int(x) for x in torch.__version__.split(".")[:2])
+if (major, minor) < (2, 7):
+    sys.exit(1)
+print(f"{major}.{minor}")
+' 2>/dev/null
+}
+
 # Cache torch channel per version for this script run. Populated by
 # ensure_torch_venv(); cleared when the venv is torn down after a build.
 declare -A TORCH_CHANNEL_CACHE
@@ -190,6 +204,18 @@ ensure_torch_venv() {
     fi
     if [ -n "$CHANNEL" ] && torch_venv_ready "$VENV_PATH"; then
         return 0
+    fi
+
+    # Prefer the base image's torch when its major.minor matches VER; the
+    # venv sees it through system site-packages, no index download needed.
+    if [ "$(system_torch_version)" = "$VER" ]; then
+        rm -rf "$VENV_PATH"
+        if uv venv "$VENV_PATH" --python "$PYTHON_VERSION" --system-site-packages && \
+           torch_venv_ready "$VENV_PATH"; then
+            TORCH_CHANNEL_CACHE[$VER]="system"
+            return 0
+        fi
+        rm -rf "$VENV_PATH"
     fi
 
     rm -rf "$VENV_PATH"
@@ -320,9 +346,21 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         echo "=== Skipping torch versions (no wheel on index for Python ${PYTHON_VERSION} + ${CU_TAG}): ${SKIPPED[*]} ==="
     fi
     if [ ${#TORCH_ARRAY[@]} -eq 0 ]; then
-        echo "ERROR: none of the requested torch versions (${TORCH_REQUESTED[*]}) are available for Python ${PYTHON_VERSION} + ${CU_TAG}"
-        exit 1
+        # Nothing on the cu index (no public wheels for this CUDA yet). Fall
+        # back to the base image's torch; failing that, build without nixl_ep
+        # rather than failing the whole wheel.
+        SYS_VER=$(system_torch_version || true)
+        if [ -n "$SYS_VER" ] && ensure_torch_venv "$SYS_VER"; then
+            echo "=== No requested torch available on the ${CU_TAG} index, using the base image's torch ${SYS_VER} ==="
+            TORCH_ARRAY=("$SYS_VER")
+        else
+            echo "WARNING: no torch is installable for Python ${PYTHON_VERSION} + ${CU_TAG}; building the wheel WITHOUT nixl_ep"
+            BUILD_NIXL_EP="false"
+        fi
     fi
+fi
+
+if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     echo "=== Building for torch versions: ${TORCH_ARRAY[*]} ==="
 
     FIRST_TORCH="${TORCH_ARRAY[0]}"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -128,20 +128,6 @@ BUILD_DEPS=(
 # be used unambiguously as a path component.
 slug() { echo "${1//./}"; }
 
-# The base image's torch major.minor, printed only when the EP build can use
-# it (>= 2.7). pytorch bases ship torch built for CUDA versions that have no
-# public wheel index, so it is the fallback when the cu index has nothing.
-system_torch_version() {
-    python3 -c '
-import sys
-import torch
-major, minor = (int(x) for x in torch.__version__.split(".")[:2])
-if (major, minor) < (2, 7):
-    sys.exit(1)
-print(f"{major}.{minor}")
-' 2>/dev/null
-}
-
 # Cache torch channel per version for this script run. Populated by
 # ensure_torch_venv(); cleared when the venv is torn down after a build.
 declare -A TORCH_CHANNEL_CACHE
@@ -204,18 +190,6 @@ ensure_torch_venv() {
     fi
     if [ -n "$CHANNEL" ] && torch_venv_ready "$VENV_PATH"; then
         return 0
-    fi
-
-    # Prefer the base image's torch when its major.minor matches VER; the
-    # venv sees it through system site-packages, no index download needed.
-    if [ "$(system_torch_version)" = "$VER" ]; then
-        rm -rf "$VENV_PATH"
-        if uv venv "$VENV_PATH" --python "$PYTHON_VERSION" --system-site-packages && \
-           torch_venv_ready "$VENV_PATH"; then
-            TORCH_CHANNEL_CACHE[$VER]="system"
-            return 0
-        fi
-        rm -rf "$VENV_PATH"
     fi
 
     rm -rf "$VENV_PATH"
@@ -346,21 +320,9 @@ if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
         echo "=== Skipping torch versions (no wheel on index for Python ${PYTHON_VERSION} + ${CU_TAG}): ${SKIPPED[*]} ==="
     fi
     if [ ${#TORCH_ARRAY[@]} -eq 0 ]; then
-        # Nothing on the cu index (no public wheels for this CUDA yet). Fall
-        # back to the base image's torch; failing that, build without nixl_ep
-        # rather than failing the whole wheel.
-        SYS_VER=$(system_torch_version || true)
-        if [ -n "$SYS_VER" ] && ensure_torch_venv "$SYS_VER"; then
-            echo "=== No requested torch available on the ${CU_TAG} index, using the base image's torch ${SYS_VER} ==="
-            TORCH_ARRAY=("$SYS_VER")
-        else
-            echo "WARNING: no torch is installable for Python ${PYTHON_VERSION} + ${CU_TAG}; building the wheel WITHOUT nixl_ep"
-            BUILD_NIXL_EP="false"
-        fi
+        echo "ERROR: none of the requested torch versions (${TORCH_REQUESTED[*]}) are available for Python ${PYTHON_VERSION} + ${CU_TAG}"
+        exit 1
     fi
-fi
-
-if [ "$BUILD_NIXL_EP" = "true" ] && [ -n "$TORCH_VERSIONS" ]; then
     echo "=== Building for torch versions: ${TORCH_ARRAY[*]} ==="
 
     FIRST_TORCH="${TORCH_ARRAY[0]}"


### PR DESCRIPTION
## What?
When the base image ships the DOCA runtime (`doca-sdk-common`) without the GPUNETIO SDK, skip the SDK install instead of failing. Full-SDK bases still skip as before; DOCA-less bases still install from the pinned 3.3 repo.

## Why?
The daily DLFW pytorch base moved to the DOCA 3.4 runtime while our repo pin is 3.3. Installing the 3.3 `-dev` packages against the 3.4 runtime is an apt dependency conflict, so every DLFW container build fails (nightly [#69](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-container/69/)).

## How?
GPUNETIO is an optional meson plugin and disables cleanly when the SDK is absent (`doca-sdk-common` is the runtime only - it does not provide the GPUNETIO SDK). Installing a version-matched SDK from the online DOCA repo is possible but adds moving parts (repo URL scheme, keyring, version derivation) for one optional plugin; if GPUNETIO on DLFW bases turns out to be needed, that can be a follow-up.

Earlier revisions of this PR carried a torch fallback in `build-wheel.sh` for bases without public torch wheels - dropped, superseded by #1896 (the image no longer builds wheels).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build behavior for DOCA-based images by skipping a pinned SDK install when the base image already includes a compatible runtime package. This helps avoid version conflicts and build failures.
  * Expanded the build’s detection logic to handle more base-image scenarios cleanly, reducing unnecessary installation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->