### PR TITLE
ci: version the dispatcher pipeline and drop flaky uploadLogs

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -137,8 +137,11 @@ Step by step, matching the jobs in `blossom-ci.yml`:
 ## Jenkins jobs
 
 All 10 Jenkins jobs are defined in `.ci/jenkins/pipeline/proj-jjb.yaml`
-(Jenkins Job Builder config) and run through the shared pipeline entry point
-`.ci/jenkins/pipeline/Jenkinsfile`. None of them run directly off GitHub
+(Jenkins Job Builder config). The dispatcher runs its own pipeline,
+`.ci/jenkins/pipeline/Jenkinsfile.dispatcher`, checked out from the PR merge
+ref (`refs/pull/<n>/merge`) on webhook runs, or from any branch/commit passed
+in `sha1` on manual runs; all other jobs run through the shared pipeline
+entry point `.ci/jenkins/pipeline/Jenkinsfile`. None of them run directly off GitHub
 events — they only start via the Jenkins webhook fired by Blossom-CI, or via
 their own nightly/manual trigger. They split into two groups:
 
@@ -159,7 +162,8 @@ their own nightly/manual trigger. They split into two groups:
   - `nixl-ci-dl-gpu-ep` — `.ci/jenkins/lib/test-dl-ep-matrix.yaml` (nixl_ep elastic tests on dlcluster.nvidia.com)
   - `nixl-ci-build-wheel` — `.ci/jenkins/lib/build-wheel-matrix.yaml`
   - `nixl-ci-test-sanitizers` — `.ci/jenkins/lib/test-sanitizer-matrix.yaml` (ASan/UBSan + TSan)
-- **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. Each sub-job also aborts any stale in-flight run for the same PR before starting.
+- **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
+- **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all six) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
 
 ### `nixl-ci-build-container` (standalone)
 - **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the DLFW PyTorch daily image, ~3–4 AM), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).

--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -73,6 +73,5 @@ try {
             currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE,
             env.JOB_BASE_NAME
         )
-        githubHelper.uploadLogs(this, env.JOB_NAME, env.BUILD_NUMBER, null, null)
     }
 }

--- a/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
@@ -1,0 +1,138 @@
+#!/usr/bin/groovy
+
+/*
+ * Dispatcher pipeline for the NIXL CI.
+ * This is the entry point triggered by the GitHub webhook (via the
+ * nixl-ci-dispatcher job). It aborts stale runs for the same PR, updates the
+ * commit status, and fans out to the leaf jobs (non-gpu, gpu, dl-gpu, ...).
+ *
+ * This file is checked out from the PR merge ref (refs/pull/<n>/merge, see the
+ * sha1 webhook parameter in proj-jjb.yaml) - the PR merged into its base branch.
+ * Once a release branch is cut, PRs into it run that branch's dispatcher and
+ * changes on main do not affect it. PR content can only be executed here via a
+ * /build comment from an authorized member (Blossom auth gate). Manual runs may
+ * pass any branch/commit/ref in sha1.
+ *
+ * KNOWN LIMITATION: GitHub does not maintain refs/pull/<n>/merge for PRs that
+ * conflict with their base branch, so /build on a conflicting PR fails at SCM
+ * checkout before this script runs and no commit status is posted. Such PRs
+ * cannot be tested (getMergedSHA would fail regardless) - resolve the conflict
+ * and comment /build again.
+ * NOTE: This file should not be changed by none devops team members
+ */
+
+@Library('blossom-github-lib@master')  // Use custom GitHub library
+import ipp.blossom.*
+
+// Authenticate with GitHub using stored credentials
+withCredentials([usernamePassword(credentialsId: 'svc-nixl-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
+  githubHelper = GithubHelper.getInstance("${GIT_PASSWORD}", VARIABLE_FROM_POST)
+}
+
+// Abort previous dispatcher runs for the same PR and their leaf jobs
+def currentPrNumber = githubHelper.getPRNumber()?.toString()
+if (currentPrNumber) {
+  try {
+    def staleBuilds = Jenkins.instance.getItemByFullName(env.JOB_NAME).builds.findAll {
+      it.isBuilding() && it.number < currentBuild.number
+    }.findAll { b ->
+      def gd = b.getAction(hudson.model.ParametersAction)?.getParameters()?.find { it.name == 'VARIABLE_FROM_POST' }?.value
+      // JsonSlurper is created per call: it is not Serializable, and holding it in
+      // a local across the sleep below fails the pipeline state checkpoint.
+      def otherPr = gd ? new groovy.json.JsonSlurper().parseText(gd)?.issue?.number?.toString() : null
+      otherPr == currentPrNumber
+    }
+
+    if (staleBuilds) {
+      echo "PR #${currentPrNumber}: found ${staleBuilds.size()} stale dispatcher(s) to abort"
+    }
+
+    // Targets to kill as [jobFullName, buildNumber] pairs - holding Run objects
+    // across the sleep below breaks the pipeline state checkpoint (WorkflowRun is
+    // not serializable). Leaf builds are collected from each stale dispatcher's
+    // console log and listed first, so they are killed before their dispatcher.
+    def targets = []
+    staleBuilds.each { b ->
+      b.getLog(1000).each { line ->
+        def m = (line =~ /Starting building: (\S+) #(\d+)/)
+        if (m) {
+          targets.add([m[0][1], m[0][2] as int])
+        }
+      }
+    }
+    targets.addAll(staleBuilds.collect { [env.JOB_NAME, it.number] })
+    staleBuilds = null
+
+    for (int attempt = 1; attempt <= 3; attempt++) {
+      def alive = targets.findAll { t ->
+        Jenkins.instance.getItemByFullName(t[0])?.getBuildByNumber(t[1])?.isBuilding()
+      }
+      if (!alive) break
+      alive.each { t ->
+        echo "${attempt > 1 ? 'Retry ' + attempt + ': ' : ''}Killing ${t[0]} #${t[1]}"
+        Jenkins.instance.getItemByFullName(t[0])?.getBuildByNumber(t[1])?.doKill()
+      }
+      if (attempt < 3) sleep 5
+    }
+  } catch(Exception e) {
+    echo "Could not abort previous builds: ${e.message}"
+  }
+}
+
+def blueOceanJobPath = env.JOB_NAME.replace('/', '%2F')
+def blueOceanUrl = "${JENKINS_URL}blue/organizations/jenkins/${blueOceanJobPath}/detail/${env.JOB_BASE_NAME}/${env.BUILD_NUMBER}/pipeline/"
+// Update GitHub commit status
+githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI started", GitHubCommitState.PENDING)
+currentBuild.description = githubHelper.getBuildDescription()
+
+// Leaf jobs to dispatch, keyed by parallel-branch name
+def leafJobs = [
+    'non-gpu':    'nixl-ci-non-gpu',
+    'gpu':        'nixl-ci-gpu',
+    'dl-gpu':     'nixl-ci-dl-gpu',
+    'dl-gpu-ep':  'nixl-ci-dl-gpu-ep',
+    'wheel':      'nixl-ci-build-wheel',
+    'sanitizers': 'nixl-ci-test-sanitizers',
+]
+
+try {
+    // Restrict the fan-out to the LEAF_JOBS parameter (comma-separated branch
+    // names). Webhook runs use the default (all jobs); a leaf job can be disabled
+    // temporarily by editing the parameter default in the job config, without a PR.
+    def requested = params.LEAF_JOBS?.trim() ? params.LEAF_JOBS.split(',').collect { it.trim() }.findAll { it } : []
+    def unknown = requested.findAll { !leafJobs.containsKey(it) }
+    if (unknown) {
+        error "Unknown LEAF_JOBS entries: ${unknown.join(', ')} (valid: ${leafJobs.keySet().join(', ')})"
+    }
+    if (requested) {
+        def skipped = leafJobs.keySet() - (requested as Set)
+        if (skipped) {
+            echo "LEAF_JOBS: skipping ${skipped.join(', ')}"
+        }
+        leafJobs = leafJobs.subMap(requested)
+    }
+
+    // Compute the merged SHA once so all leaf jobs test the same commit
+    def mergedSHA = githubHelper.getMergedSHA()
+
+    // Leaf jobs report their own GitHub statuses; the dispatcher build stays
+    // SUCCESS unless dispatching itself fails. catchError paints a failed
+    // leaf's branch red without failing the build, and all branches run to
+    // completion regardless of sibling failures.
+    parallel(leafJobs.collectEntries { branchName, jobName ->
+        [(branchName): {
+            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                build job: jobName, parameters: [
+                    string(name: 'sha1', value: mergedSHA),
+                    string(name: 'githubData', value: VARIABLE_FROM_POST)
+                ], wait: true
+            }
+        }]
+    })
+
+    githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.SUCCESS)
+} catch(Exception ex) {
+    println ex
+    githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.FAILURE)
+    throw ex
+}

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -38,6 +38,13 @@
             - type: JSONPath
               key: VARIABLE_FROM_POST
               value: $
+            # Full PR merge ref (refs/pull/<n>/merge) built from the PR number in the
+            # /build comment payload via the Jayway JSONPath concat function, so the
+            # dispatcher runs the PR merged into its base branch (release branches stay
+            # frozen) while manual runs can pass any branch/commit in sha1.
+            - type: JSONPath
+              key: sha1
+              value: '$.concat("refs/pull/", $.issue.number, "/merge")'
     description: Do NOT edit this job through the Web GUI !  # Manual edits will be overwritten
     concurrent: true    # Allow multiple builds to run simultaneously
     sandbox: false
@@ -46,111 +53,35 @@
             name: "VARIABLE_FROM_POST"
             default: ""
             description: ""
-    # Pipeline script that handles the build process
-    dsl: |
-        @Library('blossom-github-lib@master')  // Use custom GitHub library
-        import ipp.blossom.*
-
-        // Authenticate with GitHub using stored credentials
-        withCredentials([usernamePassword(credentialsId: 'svc-nixl-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {{
-          githubHelper = GithubHelper.getInstance("${{GIT_PASSWORD}}", VARIABLE_FROM_POST)
-        }}
-
-        // Abort previous dispatcher runs for the same PR and their leaf jobs
-        def currentPrNumber = githubHelper.getPRNumber()?.toString()
-        if (currentPrNumber) {{
-          def slurper = new groovy.json.JsonSlurper()
-          try {{
-            def staleBuilds = Jenkins.instance.getItemByFullName(env.JOB_NAME).builds.findAll {{
-              it.isBuilding() && it.number < currentBuild.number
-            }}.findAll {{ b ->
-              def gd = b.getAction(hudson.model.ParametersAction)?.getParameters()?.find {{ it.name == 'VARIABLE_FROM_POST' }}?.value
-              def otherPr = gd ? slurper.parseText(gd)?.issue?.number?.toString() : null
-              otherPr == currentPrNumber
-            }}
-
-            if (staleBuilds) {{
-              echo "PR #${{currentPrNumber}}: found ${{staleBuilds.size()}} stale dispatcher(s) to abort"
-            }}
-
-            // Collect leaf builds from each stale dispatcher's console log
-            def leafBuilds = []
-            staleBuilds.each {{ b ->
-              b.getLog(1000).each {{ line ->
-                def m = (line =~ /Starting building: (\S+) #(\d+)/)
-                if (m) {{
-                  def child = Jenkins.instance.getItemByFullName(m[0][1])?.getBuildByNumber(m[0][2] as int)
-                  if (child) leafBuilds.add(child)
-                }}
-              }}
-            }}
-
-            // Kill leaf jobs first (unblocks dispatcher), then dispatchers
-            def allTargets = leafBuilds + staleBuilds
-            for (int attempt = 1; attempt <= 3; attempt++) {{
-              def alive = allTargets.findAll {{ it.isBuilding() }}
-              if (!alive) break
-              alive.each {{ target ->
-                echo "${{attempt > 1 ? 'Retry ' + attempt + ': ' : ''}}Killing ${{target.fullDisplayName}}"
-                target.doKill()
-              }}
-              if (attempt < 3) sleep 5
-            }}
-          }} catch(Exception e) {{
-            echo "Could not abort previous builds: ${{e.message}}"
-          }}
-        }}
-
-        def blueOceanUrl = "${{JENKINS_URL}}blue/organizations/jenkins/${{env.JOB_BASE_NAME}}/detail/${{env.JOB_BASE_NAME}}/${{env.BUILD_NUMBER}}/pipeline/"
-        // Update GitHub commit status
-        githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI started", GitHubCommitState.PENDING)
-        currentBuild.description = githubHelper.getBuildDescription()
-
-        try {{
-            parallel 'non-gpu': {{
-                def jobName = 'nixl-ci-non-gpu'
-                build job: jobName, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}, 'gpu': {{
-                def jobName = 'nixl-ci-gpu'
-                build job: jobName, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}, 'dl-gpu': {{
-                def jobName = 'nixl-ci-dl-gpu'
-                build job: jobName, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}, 'dl-gpu-ep': {{
-                def jobName = 'nixl-ci-dl-gpu-ep'
-                build job: jobName, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}, wheel: {{
-                def buildJob = 'nixl-ci-build-wheel'
-                build job: buildJob, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}, sanitizers: {{
-                def jobName = 'nixl-ci-test-sanitizers'
-                build job: jobName, parameters: [
-                    string(name: 'sha1', value: githubHelper.getMergedSHA()),
-                    string(name: 'githubData', value: VARIABLE_FROM_POST)
-                ], propagate: false, wait: true
-            }}
-
-            githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.SUCCESS)
-        }} catch(Exception ex) {{
-            println ex
-            githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.FAILURE)
-            throw ex
-        }}
+        - string:
+            name: "sha1"
+            default: "{jjb_branch}"    # Default to 'main' branch for manual runs
+            description: "Ref to check out the dispatcher pipeline from. Set to refs/pull/<n>/merge by the webhook; manual runs may pass a branch name, commit SHA, or any ref"
+        - string:
+            name: "LEAF_JOBS"
+            default: "non-gpu,gpu,dl-gpu,dl-gpu-ep,wheel,sanitizers"
+            description: "Comma-separated list of leaf jobs to dispatch. Edit the default here (via job config) to temporarily disable a leaf job for all runs without a code change; JJB redeploy restores the full list"
+    # SCM configuration - checks out whatever ref sha1 holds: the PR merge ref
+    # (set by the webhook) so a PR into a release branch runs that branch's
+    # dispatcher, or a branch/commit for manual runs.
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                # Configure refspec to handle branches, PRs, and tags
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_dispatcher_jenkinsfile}"  # Dispatcher pipeline definition
 
 # Template for the main build job that performs the actual build process
 - job-template:
@@ -955,6 +886,7 @@
     jjb_proj: 'nixl-ci'           # Project prefix for job names
     jjb_git: 'https://github.com/ai-dynamo/nixl.git'  # Repository URL
     jjb_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile'  # Main pipeline definition
+    jjb_dispatcher_jenkinsfile: '.ci/jenkins/pipeline/Jenkinsfile.dispatcher'  # Dispatcher pipeline definition
     jjb_branch: 'main'            # Default branch
     jjb_gh_url: 'https://github.com/ai-dynamo/nixl'  # GitHub web URL
     jjb_gh_refspec: '+refs/heads/*:refs/remotes/origin/* +$sha1:refs/remotes/origin/$sha1'


### PR DESCRIPTION
## What?
Move the dispatcher logic out of the inline dsl block in `proj-jjb.yaml` into `.ci/jenkins/pipeline/Jenkinsfile.dispatcher`, checked out via pipeline-scm. The build is triggered by a /build issue-comment webhook, so the dispatcher is
checked out from the PR merge ref (refs/pull/<n>/merge, derived from the PR number in the payload). This runs the PR merged into its base branch, so a PR into a release branch runs that branch's dispatcher and changes on main no
longer disturb it.

Also remove githubHelper.uploadLogs from the main Jenkinsfile: it sometimes
hangs and kills the runner.


## Why?
CI improvements for release branches
CI stability for Blossom-CI issues

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a Jenkins CI dispatcher pipeline that fans out selected leaf jobs in parallel and checks that all complete successfully.
  * Updated the dispatcher job template to run the dispatcher script from the pull request merge ref (or a provided `sha1`) via SCM.

* **Bug Fixes**
  * The dispatcher now aborts stale in-progress dispatcher runs (and any leaf builds they started) before starting a new dispatch.
  * Streamlined GitHub commit status updates during dispatcher cleanup and start/end reporting.

* **Documentation**
  * Refined the Jenkins CI overview, including how `LEAF_JOBS` temporarily restricts which leaf jobs run.

* **Chores**
  * Stopped uploading pipeline logs to GitHub during cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->