### PR TITLE
ci: remove uploadLogs from jenkinsfile

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -73,6 +73,5 @@ try {
             currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE,
             env.JOB_BASE_NAME
         )
-        githubHelper.uploadLogs(this, env.JOB_NAME, env.BUILD_NUMBER, null, null)
     }
 }


### PR DESCRIPTION
## What?
uploadLogs takes too many resources and sufficate the runner, causing CI to stop

## Why?
CI stability

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the CI completion flow so it no longer uploads build logs at the end of a run.
  * Commit status updates still report test completion as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->