### PR TITLE
CI: pin CUDA-ambiguous LLM base image defaults

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -4,8 +4,8 @@
 # pre-built NIXL wheel set.
 #
 #   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu129
-#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:v0.24.0
-#   - sglang-cu12-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:v0.5.14-cu129-runtime
+#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu130
+#   - sglang-cu12-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu129-runtime
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
 # For RC0 builds the upstream defaults are used. For subsequent RCs (or
@@ -184,9 +184,9 @@ steps:
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-cu13-nixl:${IMAGE_TAG}-${arch}"
       # Podman enforces short-name resolution, so always pass a fully-qualified
       # BASE_IMAGE. Falls back to the upstream docker.io image when no override.
-      # Pinned tag: vllm-openai:latest makes no CUDA promise, so the cu13 lane
-      # could silently change CUDA version when upstream moves latest.
-      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:v0.24.0}"
+      # Use the CUDA-pinned latest tag: plain :latest carries no CUDA promise,
+      # while :latest-cu130 locks CUDA 13 yet still tracks the newest vLLM.
+      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:latest-cu130}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \
@@ -240,9 +240,9 @@ steps:
         *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
       esac
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/sglang-cu12-nixl:${IMAGE_TAG}-${arch}"
-      # Pin the cu12 default to an immutable CUDA 12 tag; sglang:latest tracks
-      # the newest CUDA (currently 13), which would build a cu13 image here.
-      BASE="${BASE_IMAGE_SGLANG_CU12:-docker.io/lmsysorg/sglang:v0.5.14-cu129-runtime}"
+      # Use the CUDA-pinned latest tag: plain :latest is a CUDA 13 image now,
+      # while :latest-cu129-runtime locks CUDA 12 yet still tracks newest SGLang.
+      BASE="${BASE_IMAGE_SGLANG_CU12:-docker.io/lmsysorg/sglang:latest-cu129-runtime}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \

--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -4,8 +4,8 @@
 # pre-built NIXL wheel set.
 #
 #   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu129
-#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest
-#   - sglang-cu12-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest
+#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:v0.24.0
+#   - sglang-cu12-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:v0.5.14-cu129-runtime
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
 # For RC0 builds the upstream defaults are used. For subsequent RCs (or
@@ -184,7 +184,9 @@ steps:
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-cu13-nixl:${IMAGE_TAG}-${arch}"
       # Podman enforces short-name resolution, so always pass a fully-qualified
       # BASE_IMAGE. Falls back to the upstream docker.io image when no override.
-      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:latest}"
+      # Pinned tag: vllm-openai:latest makes no CUDA promise, so the cu13 lane
+      # could silently change CUDA version when upstream moves latest.
+      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:v0.24.0}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \
@@ -238,7 +240,9 @@ steps:
         *)       echo "Unsupported arch: ${arch}"; exit 1 ;;
       esac
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/sglang-cu12-nixl:${IMAGE_TAG}-${arch}"
-      BASE="${BASE_IMAGE_SGLANG_CU12:-docker.io/lmsysorg/sglang:latest}"
+      # Pin the cu12 default to an immutable CUDA 12 tag; sglang:latest tracks
+      # the newest CUDA (currently 13), which would build a cu13 image here.
+      BASE="${BASE_IMAGE_SGLANG_CU12:-docker.io/lmsysorg/sglang:v0.5.14-cu129-runtime}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -627,7 +627,7 @@
           default: ""
           description: >
             Optional override for the vllm-cu13 base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses the pinned default <code>docker.io/vllm/vllm-openai:v0.24.0</code>).<br/>
+            Leave empty for <b>rc0</b> (uses the CUDA 13 default <code>docker.io/vllm/vllm-openai:latest-cu130</code>).<br/>
             For <b>rcN, N&gt;0</b> set to the corresponding rc0 image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/vllm-cu13-nixl:1.1.0-rc0</code>
       - string:
@@ -635,7 +635,7 @@
           default: ""
           description: >
             Optional override for the sglang-cu12 base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses the pinned default <code>docker.io/lmsysorg/sglang:v0.5.14-cu129-runtime</code>).<br/>
+            Leave empty for <b>rc0</b> (uses the CUDA 12 default <code>docker.io/lmsysorg/sglang:latest-cu129-runtime</code>).<br/>
             For <b>rcN, N&gt;0</b> pin to the rc0 sglang-cu12-nixl image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/sglang-cu12-nixl:1.1.0-rc0</code>
       - string:

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -627,7 +627,7 @@
           default: ""
           description: >
             Optional override for the vllm-cu13 base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/vllm/vllm-openai:latest</code>).<br/>
+            Leave empty for <b>rc0</b> (uses the pinned default <code>docker.io/vllm/vllm-openai:v0.24.0</code>).<br/>
             For <b>rcN, N&gt;0</b> set to the corresponding rc0 image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/vllm-cu13-nixl:1.1.0-rc0</code>
       - string:
@@ -635,7 +635,7 @@
           default: ""
           description: >
             Optional override for the sglang-cu12 base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses Dockerfile default <code>docker.io/lmsysorg/sglang:latest</code>).<br/>
+            Leave empty for <b>rc0</b> (uses the pinned default <code>docker.io/lmsysorg/sglang:v0.5.14-cu129-runtime</code>).<br/>
             For <b>rcN, N&gt;0</b> pin to the rc0 sglang-cu12-nixl image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/sglang-cu12-nixl:1.1.0-rc0</code>
       - string:


### PR DESCRIPTION
## What?
Pin the default base images of two LLM lanes to CUDA-locked `latest-cuXXX` tags, so every lane defaults to the same tag family:
- vllm-cu13: `vllm/vllm-openai:latest-cu130` (CUDA 13.0.2)
- sglang-cu12: `lmsysorg/sglang:latest-cu129-runtime` (CUDA 12.9.1)

## Why?
Fixes HPCINFRA-4541, Issue 2 (the rename/override half landed in #1839).
- Both lanes defaulted to plain `latest` tags, which make no CUDA promise.
- `sglang:latest` is already a CUDA 13 image, so the cu12 lane built CUDA 13.
- `vllm-openai:latest` is CUDA 13 today but changes whenever upstream moves it - same trap waiting to spring.
- `latest-cuXXX` tags lock CUDA per lane while still tracking the newest framework release, matching the rc0 "use upstream latest" intent.

## How?
- One-line default change per lane, plus matching help text.
- All four lanes now use the `latest-cuXXX` family (cu12->cu129, cu13->cu130); the other two already did.

Tested with empty `BASE_IMAGE_*` overrides so the new defaults fire; both lanes pull the pinned tag on both arches:
- [build #21](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-llm-container/21/) (vllm-cu13) - `FROM docker.io/vllm/vllm-openai:latest-cu130`
- [build #22](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-llm-container/22/) (sglang-cu12) - `FROM docker.io/lmsysorg/sglang:latest-cu129-runtime`