### PR TITLE
Build: install python bindings from source in the container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ To see all the options supported by the container use:
 $ ./contrib/build-container.sh -h
 ```
 
-The container also includes a prebuilt python wheel in /workspace/dist if required for installing/distributing. Also, the wheel can be built with a separate script (see below).
+The container has the NIXL python bindings preinstalled (built from source against the container's own PyTorch). For a redistributable python wheel, use the wheel build script below or install the published `nixl` package.
 
 ### Building the python wheel
 The contrib folder also includes a script to build the python wheel with the UCX dependencies. Note, that UCX and other NIXL dependencies are required to be installed.

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -35,7 +35,6 @@ ARG NIXL_PREFIX="/usr/local/nixl"
 ARG NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/$ARCH-linux-gnu/plugins"
 ARG NPROC
 ARG WHL_DEFAULT_PYTHON_VERSIONS="3.12"
-ARG WHL_TORCH_VERSIONS="2.11,2.12,2.13"
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG LIBFABRIC_INSTALL_PATH="/usr/local"
 ARG BUILD_TYPE="release"
@@ -316,21 +315,10 @@ ENV PYTHONPATH=/workspace/nixl/build/examples/device/ep
 
 RUN cd src/bindings/rust && cargo build --release --locked
 
-# Build wheel using the build-wheel.sh script for better UCX plugin bundling and library management
-RUN mkdir -p dist && \
-    if [ "$BUILD_NIXL_EP" = "true" ]; then EP_BUILD_FLAGS="--build-nixl-ep --torch-versions $WHL_TORCH_VERSIONS"; else EP_BUILD_FLAGS=""; fi && \
-    if [ -n "$UCX_SONAME_SUFFIX" ]; then \
-        UCX_PLUGIN_SONAME_FLAG="--plugin-soname-suffix $UCX_SONAME_SUFFIX"; \
-    else UCX_PLUGIN_SONAME_FLAG=""; fi && \
-    ./contrib/build-wheel.sh \
-    --python-version $DEFAULT_PYTHON_VERSION \
-    --platform manylinux_2_39_$ARCH \
-    --ucx-plugins-dir $UCX_PLUGIN_DIR \
-    --nixl-plugins-dir $NIXL_PLUGIN_DIR \
-    --output-dir /workspace/nixl/dist \
-    $UCX_PLUGIN_SONAME_FLAG \
-    $EP_BUILD_FLAGS
-
-RUN cp build/src/bindings/python/nixl-meta/nixl-*.whl dist/
-RUN uv pip install --system \
-    dist/nixl*cp${DEFAULT_PYTHON_VERSION//./}*.whl dist/nixl-*-none-any.whl
+# Install the python bindings from source, built against the container's own
+# torch - works on any base, no dependency on public torch wheels.
+# Redistributable wheels are produced by the wheel CI pipelines, not here.
+RUN CUDA_MAJOR=$(echo "${CUDA_VERSION}" | cut -d. -f1) && \
+    ./contrib/tomlutil.py --wheel-name "nixl-cu${CUDA_MAJOR}" pyproject.toml && \
+    uv pip install --system --no-build-isolation . && \
+    uv pip install --system build/src/bindings/python/nixl-meta/nixl-*.whl


### PR DESCRIPTION
## What?
- Replace the in-image wheel build (`build-wheel.sh`) with `pip install .` from source + the meson-generated meta wheel.
- Bindings build against the container's own torch - no dependency on public torch wheels.
- README updated: the image ships preinstalled bindings; redistributable wheels come from the wheel pipelines.

## Why?
- Newer bases (CUDA 13.3) have no public torch wheels yet, so the container image build fails.
- The image only needs a working `import nixl`; the multi-torch wheel matrix duplicates what the wheel pipelines publish.

## Test
Manual `nixl-ci-build-container` runs on this PR (nixl target, EP on, x86_64 + aarch64):
- `cuda-dl-base:25.10-cuda13.0` - **PASS** ([#76](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-container/76/)) - current default keeps working
- `cuda-dl-base:26.06-cuda13.3` - **PASS** ([#77](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-build-container/77/)) - previously impossible (no cu133 torch wheels); verified `nixl-cu13` + `nixl` meta installed, no torch-index access
- `dl/dgx/pytorch:main-py3-devel` - blocked by a pre-existing DOCA 3.3/3.4 apt conflict - handled at https://github.com/ai-dynamo/nixl/pull/1888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker build guide to reflect that the container now includes the Python bindings preinstalled.
  * Removed outdated instructions about using a separate prebuilt wheel package.
* **Build/Packaging**
  * Simplified the container image setup so Python wheels are built and installed directly during image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->