### PR TITLE
telemetry/doca: add IPC->DTS delivery backend (NIX-1599)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -14,6 +14,7 @@ Custom telemetry exporter plug-ins can be created according to [src/plugins/tele
 2. **Shared Memory Buffer**: Statically-linked built in implementation of telemetry exporter. Uses shared memory cyclic buffer for efficient event storage and export.
 3. **Telemetry Readers**: C++ and Python applications to read and display telemetry data from the cyclic buffer.
 4. **Prometheus exporter**: EXPERIMENTAL (beta) Prometheus compatible telemetry exporter, see [src/plugins/telemetry/prometheus/README.md](../src/plugins/telemetry/prometheus/README.md).
+5. **DOCA exporter**: EXPERIMENTAL DOCA/CollectX telemetry exporter. Drives one or more delivery backends (`NIXL_TELEMETRY_DOCA_BACKENDS`, default `scrape`): a local Prometheus scrape endpoint and/or `ipc` push to the DOCA Telemetry Service (DTS) for single-endpoint multi-process aggregation. See [src/plugins/telemetry/doca/README.md](../src/plugins/telemetry/doca/README.md).
 
 ### Event Structure
 

--- a/src/plugins/telemetry/doca/README.md
+++ b/src/plugins/telemetry/doca/README.md
@@ -52,6 +52,23 @@ export NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL="y"
 
 When multiple agents run in the same process, the first agent to initialize creates the DOCA server and its port/address settings take effect. Subsequent agents share that endpoint and are distinguished by the `agent_name` label.
 
+### Delivery backends (scrape and/or IPC to DTS)
+
+The exporter can drive **one or more** delivery backends at once, selected by a comma-separated list. By default it serves its own Prometheus scrape endpoint (`scrape`); under multi-process runs this collides on the shared port, so it can instead (or additionally) push metrics over IPC to the DOCA Telemetry Service (DTS), which aggregates all NIXL processes behind a single endpoint (no per-process listening socket):
+
+```bash
+# Comma-separated set; default "scrape". Examples: "scrape", "ipc", "scrape,ipc".
+export NIXL_TELEMETRY_DOCA_BACKENDS="ipc"
+# Optional: directory of DTS IPC sockets (default: /opt/mellanox/doca/services/telemetry/ipc_sockets)
+export NIXL_TELEMETRY_DOCA_IPC_SOCKETS_DIR="/path/to/ipc_sockets"
+```
+
+- `scrape` — opens the local Prometheus HTTP endpoint (uses the port/local vars above).
+- `ipc` — pushes over IPC to DTS; no HTTP endpoint of its own. If DTS is not reachable the exporter logs a warning and continues (metrics are not exported until DTS is available) rather than failing.
+- An unrecognized token is a hard error (surfaces a likely config typo rather than silently degrading); an unset or empty value defaults to `scrape`.
+
+Other CollectX outputs (Remote Write, OTLP, Fluent Bit) are **DTS-side onward backends**, not exporter flags — reach them by enabling `ipc` and configuring DTS. Deploying DTS alongside NIXL is a separate operational step.
+
 You can alter where to look for plug-in .so files
 NOTE: the same var is used for backend plug-ins search
 

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -21,6 +21,8 @@
 
 #include <doca_telemetry_exporter.h>
 #include <doca_error.h>
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_split.h>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -47,6 +49,10 @@ constexpr uint64_t histogramFlushIntervalMs = 1000;
 
 const char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
 const char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
+const char docaBackendsVar[] = "NIXL_TELEMETRY_DOCA_BACKENDS";
+const char docaIpcSocketsDirVar[] = "NIXL_TELEMETRY_DOCA_IPC_SOCKETS_DIR";
+const char docaBackendScrape[] = "scrape";
+const char docaBackendIpc[] = "ipc";
 
 const std::string docaExporterLocalAddress = "http://127.0.0.1";
 const std::string docaExporterPublicAddress = "http://0.0.0.0";
@@ -58,6 +64,42 @@ getBindAddress() {
         nixl::config::getValueDefaulted(docaPrometheusPortVar, docaPrometheusExporterDefaultPort);
     return (local ? docaExporterLocalAddress : docaExporterPublicAddress) + ":" +
         std::to_string(port);
+}
+
+struct DocaBackends {
+    bool scrape = false;
+    bool ipc = false;
+};
+
+[[nodiscard]] DocaBackends
+parseBackends() {
+    const std::string spec =
+        nixl::config::getValueDefaulted<std::string>(docaBackendsVar, docaBackendScrape);
+    DocaBackends backends;
+    for (const absl::string_view raw : absl::StrSplit(spec, ',')) {
+        const absl::string_view token = absl::StripAsciiWhitespace(raw);
+        if (token.empty()) {
+            continue;
+        }
+        if (token == docaBackendScrape) {
+            backends.scrape = true;
+        } else if (token == docaBackendIpc) {
+            backends.ipc = true;
+        } else {
+            throw std::runtime_error(std::string(docaBackendsVar) + ": unknown backend '" +
+                                     std::string(token) + "'; valid backends are '" +
+                                     docaBackendScrape + "', '" + docaBackendIpc + "'");
+        }
+    }
+    if (!backends.scrape && !backends.ipc) {
+        backends.scrape = true;
+    }
+    return backends;
+}
+
+[[nodiscard]] std::string
+getIpcSocketsDir() {
+    return nixl::config::getValueDefaulted<std::string>(docaIpcSocketsDirVar, std::string());
 }
 
 [[nodiscard]] std::string
@@ -88,10 +130,13 @@ std::mutex g_metrics_mutex;
 /**
  * @brief Process-wide shared DOCA context
  *
- * DOCA only supports one metrics context per process, so all agents share
- * this context. The underlying CLX Metrics API is not thread-safe, so all
- * metric recording calls (metrics_add_counter / metrics_add_gauge) are
- * serialised by a dedicated mutex (g_metrics_mutex).
+ * All agents in a process share one context. The exporter drives process-global
+ * CollectX state -- the Prometheus endpoint via the PROMETHEUS_ENDPOINT env var
+ * (one HTTP server) and a fixed schema name -- so independently-configured
+ * per-agent contexts would collide; sharing one avoids that. The underlying CLX
+ * Metrics API is not thread-safe, so all metric recording calls
+ * (metrics_add_counter / metrics_add_gauge) are serialised by a dedicated mutex
+ * (g_metrics_mutex).
  */
 struct DocaSharedContext {
     doca_telemetry_exporter_schema *schema = nullptr;
@@ -100,6 +145,9 @@ struct DocaSharedContext {
     doca_telemetry_exporter_label_set_id_t error_label_set_id = 0;
     bool source_started = false;
     bool metrics_context_created = false;
+    const bool scrape_enabled;
+    const bool ipc_enabled;
+    std::string backend_desc;
 
     // Base histograms are templates created once on the shared source; observing
     // against one with concrete label values yields a concrete histogram id. The
@@ -110,7 +158,10 @@ struct DocaSharedContext {
         base_histograms{};
     std::unordered_set<doca_telemetry_exporter_histogram_id_t> histogram_ids;
 
-    explicit DocaSharedContext(const std::string &bind_address);
+    DocaSharedContext(bool enable_scrape,
+                      bool enable_ipc,
+                      const std::string &bind_address,
+                      const std::string &ipc_sockets_dir);
     ~DocaSharedContext();
 
     DocaSharedContext(const DocaSharedContext &) = delete;
@@ -122,21 +173,42 @@ private:
     cleanup();
 };
 
-DocaSharedContext::DocaSharedContext(const std::string &bind_address) {
+DocaSharedContext::DocaSharedContext(bool enable_scrape,
+                                     bool enable_ipc,
+                                     const std::string &bind_address,
+                                     const std::string &ipc_sockets_dir)
+    : scrape_enabled(enable_scrape),
+      ipc_enabled(enable_ipc) {
     const std::string hostname = getHostname();
+
+    if (scrape_enabled) {
+        backend_desc = "scrape on " + bind_address;
+    }
+    if (ipc_enabled) {
+        backend_desc += (backend_desc.empty() ? "" : ", ") + std::string("ipc->DTS");
+    }
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
     try {
-        // DOCA reads its HTTP bind address from this env var. setenv is not
-        // thread-safe per POSIX, but the caller holds g_ctx_mutex and this runs
-        // only once during first-agent init (before heavy threading).
-        setenv("PROMETHEUS_ENDPOINT", bind_address.c_str(), 1);
+        if (scrape_enabled) {
+            // DOCA reads its HTTP bind address from this env var. setenv is not
+            // thread-safe per POSIX, but the caller holds g_ctx_mutex and this runs
+            // only once during first-agent init (before heavy threading).
+            setenv("PROMETHEUS_ENDPOINT", bind_address.c_str(), 1);
+        }
 
         doca_error_t result = doca_telemetry_exporter_schema_init("nixl_telemetry", &schema);
         if (result != DOCA_SUCCESS) {
             throw std::runtime_error("Failed to initialize DOCA schema");
+        }
+
+        if (ipc_enabled) {
+            doca_telemetry_exporter_schema_set_ipc_enabled(schema);
+            if (!ipc_sockets_dir.empty()) {
+                doca_telemetry_exporter_schema_set_ipc_sockets_dir(schema, ipc_sockets_dir.c_str());
+            }
         }
 
         result = doca_telemetry_exporter_schema_start(schema);
@@ -157,6 +229,21 @@ DocaSharedContext::DocaSharedContext(const std::string &bind_address) {
             throw std::runtime_error("Failed to start DOCA source");
         }
         source_started = true;
+
+        if (ipc_enabled) {
+            doca_telemetry_exporter_ipc_status_t ipc_status =
+                DOCA_TELEMETRY_EXPORTER_IPC_STATUS_FAILED;
+            const doca_error_t ipc_result =
+                doca_telemetry_exporter_check_ipc_status(source, &ipc_status);
+            if (ipc_result != DOCA_SUCCESS ||
+                ipc_status != DOCA_TELEMETRY_EXPORTER_IPC_STATUS_CONNECTED) {
+                NIXL_WARN << "DOCA telemetry IPC not connected to DTS (status " << ipc_status
+                          << "); metrics will not be exported until DTS is reachable via "
+                          << (ipc_sockets_dir.empty() ?
+                                  std::string("the default DOCA sockets dir") :
+                                  ipc_sockets_dir);
+            }
+        }
 
         result = doca_telemetry_exporter_metrics_create_context(source);
         if (result != DOCA_SUCCESS) {
@@ -241,17 +328,28 @@ nixlTelemetryDocaExporter::nixlTelemetryDocaExporter(
     const nixlTelemetryExporterInitParams &init_params)
     : nixlTelemetryExporter(init_params),
       agent_name_(init_params.agentName) {
+    const DocaBackends backends = parseBackends();
     const std::string bind_address = getBindAddress();
+    const std::string ipc_sockets_dir = getIpcSocketsDir();
 
     const std::lock_guard lock(g_ctx_mutex);
     ctx_ = g_ctx_weak.lock();
     if (!ctx_) {
-        ctx_ = std::make_shared<DocaSharedContext>(bind_address);
+        ctx_ = std::make_shared<DocaSharedContext>(
+            backends.scrape, backends.ipc, bind_address, ipc_sockets_dir);
         g_ctx_weak = ctx_;
-        NIXL_INFO << "DOCA Telemetry exporter initialized on " << bind_address;
+        NIXL_INFO << "DOCA Telemetry exporter initialized (" << ctx_->backend_desc << ")";
     } else {
+        if (backends.scrape != ctx_->scrape_enabled || backends.ipc != ctx_->ipc_enabled) {
+            NIXL_WARN << "DOCA Telemetry exporter for agent '" << agent_name_
+                      << "' requested different backends than the shared process-wide DOCA "
+                         "context (already created as "
+                      << ctx_->backend_desc
+                      << "); NIXL uses one shared context per process, so the first agent's "
+                         "backend selection is kept and this request is ignored";
+        }
         NIXL_INFO << "DOCA Telemetry exporter for agent '" << agent_name_
-                  << "' sharing existing server on " << bind_address;
+                  << "' sharing existing context (" << ctx_->backend_desc << ")";
     }
 }
 

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -17,12 +17,11 @@
 #include "doca_exporter.h"
 #include "common/configuration.h"
 #include "common/nixl_log.h"
+#include "common/str_util.h"
 #include "histogram_buckets.h"
 
 #include <doca_telemetry_exporter.h>
 #include <doca_error.h>
-#include <absl/strings/ascii.h>
-#include <absl/strings/str_split.h>
 #include <array>
 #include <cstdint>
 #include <cstdlib>
@@ -76,11 +75,7 @@ parseBackends() {
     const std::string spec =
         nixl::config::getValueDefaulted<std::string>(docaBackendsVar, docaBackendScrape);
     DocaBackends backends;
-    for (const absl::string_view raw : absl::StrSplit(spec, ',')) {
-        const absl::string_view token = absl::StripAsciiWhitespace(raw);
-        if (token.empty()) {
-            continue;
-        }
+    for (const std::string &token : nixl::str::splitStrippedSet(spec)) {
         if (token == docaBackendScrape) {
             backends.scrape = true;
         } else if (token == docaBackendIpc) {

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -16,6 +16,7 @@
  */
 #include "doca_exporter.h"
 #include "common/configuration.h"
+#include "common/exception.h"
 #include "common/nixl_log.h"
 #include "common/str_util.h"
 #include "histogram_buckets.h"
@@ -65,36 +66,45 @@ getBindAddress() {
         std::to_string(port);
 }
 
-struct DocaBackends {
+struct DocaExporterConfig {
     bool scrape = false;
     bool ipc = false;
+    std::string bind_address;
+    std::string ipc_sockets_dir;
 };
-
-[[nodiscard]] DocaBackends
-parseBackends() {
-    const std::string spec =
-        nixl::config::getValueDefaulted<std::string>(docaBackendsVar, docaBackendScrape);
-    DocaBackends backends;
-    for (const std::string &token : nixl::str::splitStrippedSet(spec)) {
-        if (token == docaBackendScrape) {
-            backends.scrape = true;
-        } else if (token == docaBackendIpc) {
-            backends.ipc = true;
-        } else {
-            throw std::runtime_error(std::string(docaBackendsVar) + ": unknown backend '" +
-                                     std::string(token) + "'; valid backends are '" +
-                                     docaBackendScrape + "', '" + docaBackendIpc + "'");
-        }
-    }
-    if (!backends.scrape && !backends.ipc) {
-        backends.scrape = true;
-    }
-    return backends;
-}
 
 [[nodiscard]] std::string
 getIpcSocketsDir() {
     return nixl::config::getValueDefaulted<std::string>(docaIpcSocketsDirVar, std::string());
+}
+
+[[nodiscard]] DocaExporterConfig
+parseExporterConfig() {
+    DocaExporterConfig config;
+    const std::string spec =
+        nixl::config::getValueDefaulted<std::string>(docaBackendsVar, docaBackendScrape);
+    for (const std::string &token : nixl::str::splitStrippedSet(spec)) {
+        if (token == docaBackendScrape) {
+            config.scrape = true;
+        } else if (token == docaBackendIpc) {
+            config.ipc = true;
+        } else {
+            nixl::throwRuntimeError(docaBackendsVar,
+                                    ": unknown backend '",
+                                    token,
+                                    "'; valid backends are '",
+                                    docaBackendScrape,
+                                    "', '",
+                                    docaBackendIpc,
+                                    "'");
+        }
+    }
+    if (!config.scrape && !config.ipc) {
+        config.scrape = true;
+    }
+    config.bind_address = getBindAddress();
+    config.ipc_sockets_dir = getIpcSocketsDir();
+    return config;
 }
 
 [[nodiscard]] std::string
@@ -153,10 +163,7 @@ struct DocaSharedContext {
         base_histograms{};
     std::unordered_set<doca_telemetry_exporter_histogram_id_t> histogram_ids;
 
-    DocaSharedContext(bool enable_scrape,
-                      bool enable_ipc,
-                      const std::string &bind_address,
-                      const std::string &ipc_sockets_dir);
+    explicit DocaSharedContext(const DocaExporterConfig &config);
     ~DocaSharedContext();
 
     DocaSharedContext(const DocaSharedContext &) = delete;
@@ -168,13 +175,12 @@ private:
     cleanup();
 };
 
-DocaSharedContext::DocaSharedContext(bool enable_scrape,
-                                     bool enable_ipc,
-                                     const std::string &bind_address,
-                                     const std::string &ipc_sockets_dir)
-    : scrape_enabled(enable_scrape),
-      ipc_enabled(enable_ipc) {
+DocaSharedContext::DocaSharedContext(const DocaExporterConfig &config)
+    : scrape_enabled(config.scrape),
+      ipc_enabled(config.ipc) {
     const std::string hostname = getHostname();
+    const std::string &bind_address = config.bind_address;
+    const std::string &ipc_sockets_dir = config.ipc_sockets_dir;
 
     if (scrape_enabled) {
         backend_desc = "scrape on " + bind_address;
@@ -323,19 +329,16 @@ nixlTelemetryDocaExporter::nixlTelemetryDocaExporter(
     const nixlTelemetryExporterInitParams &init_params)
     : nixlTelemetryExporter(init_params),
       agent_name_(init_params.agentName) {
-    const DocaBackends backends = parseBackends();
-    const std::string bind_address = getBindAddress();
-    const std::string ipc_sockets_dir = getIpcSocketsDir();
+    const DocaExporterConfig config = parseExporterConfig();
 
     const std::lock_guard lock(g_ctx_mutex);
     ctx_ = g_ctx_weak.lock();
     if (!ctx_) {
-        ctx_ = std::make_shared<DocaSharedContext>(
-            backends.scrape, backends.ipc, bind_address, ipc_sockets_dir);
+        ctx_ = std::make_shared<DocaSharedContext>(config);
         g_ctx_weak = ctx_;
         NIXL_INFO << "DOCA Telemetry exporter initialized (" << ctx_->backend_desc << ")";
     } else {
-        if (backends.scrape != ctx_->scrape_enabled || backends.ipc != ctx_->ipc_enabled) {
+        if (config.scrape != ctx_->scrape_enabled || config.ipc != ctx_->ipc_enabled) {
             NIXL_WARN << "DOCA Telemetry exporter for agent '" << agent_name_
                       << "' requested different backends than the shared process-wide DOCA "
                          "context (already created as "

--- a/src/plugins/telemetry/doca/meson.build
+++ b/src/plugins/telemetry/doca/meson.build
@@ -22,7 +22,7 @@ shared_library(
     'doca_plugin.cpp',
     'doca_exporter.cpp',
     include_directories: [nixl_inc_dirs, utils_inc_dirs, include_directories('../common')],
-    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, doca_telemetry_dep, doca_common_dep],
+    dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, absl_strings_dep, doca_telemetry_dep, doca_common_dep],
     install: true,
     install_dir: plugin_install_dir,
     name_prefix: '',

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -57,7 +57,7 @@ if build_doca_tests
             include_directories(doca_exporter_dir),
             include_directories('../../src/plugins/telemetry/common'),
         ],
-        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep],
+        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep, absl_strings_dep],
         cpp_args: ['-Wno-deprecated-declarations'],
         install: true,
     )

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -38,6 +38,9 @@ namespace {
 
 constexpr char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
 constexpr char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
+constexpr char docaBackendsVar[] = "NIXL_TELEMETRY_DOCA_BACKENDS";
+constexpr char docaIpcSocketsDirVar[] = "NIXL_TELEMETRY_DOCA_IPC_SOCKETS_DIR";
+constexpr char absentDtsSocketsDir[] = "/tmp/nixl_dts_absent_sockets";
 
 } // namespace
 
@@ -59,6 +62,8 @@ protected:
         // Pair with SetUp so the fixture does not leak process-wide env state.
         ::unsetenv(docaPrometheusLocalVar);
         ::unsetenv(docaPrometheusPortVar);
+        ::unsetenv(docaBackendsVar);
+        ::unsetenv(docaIpcSocketsDirVar);
     }
 
     uint16_t port_ = 0;
@@ -386,6 +391,107 @@ TEST_F(docaNixlExporterTest, XferTimeHistogramRecordsObservations) {
     EXPECT_EQ(buckets[100.0], 2.0);
     EXPECT_EQ(buckets[250.0], 3.0);
     EXPECT_EQ(buckets[1000.0], 4.0);
+}
+
+// IPC->DTS backend (NIX-1599 part 1): with NIXL_TELEMETRY_DOCA_BACKENDS=ipc and no
+// DTS reachable at the sockets dir, the exporter must construct, accept events, and
+// flush without throwing -- IPC failure degrades to a WARN, never a crash (the same
+// graceful stance as the scrape-endpoint bind failure). End-to-end aggregation
+// through a live DTS is deferred to NIX-1600.
+TEST_F(docaNixlExporterTest, IpcBackendDegradesGracefullyWithoutDts) {
+    ASSERT_EQ(::setenv(docaBackendsVar, "ipc", 1), 0);
+    ASSERT_EQ(::setenv(docaIpcSocketsDirVar, absentDtsSocketsDir, 1), 0);
+
+    constexpr char agentName[] = "nixl_doca_ipc_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+
+    ASSERT_NO_THROW({
+        nixlTelemetryDocaExporter exporter(params);
+        EXPECT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_TX_BYTES, 1024}),
+                  NIXL_SUCCESS);
+        EXPECT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+        EXPECT_TRUE(loopbackConnection::httpGet(port_, "/metrics").empty())
+            << "ipc-only backend must not serve a Prometheus scrape endpoint on port " << port_;
+    });
+}
+
+// An unrecognized backend token is a hard error (a likely config typo) rather
+// than silently degrading to a value the user did not intend.
+TEST_F(docaNixlExporterTest, UnknownBackendIsRejected) {
+    ASSERT_EQ(::setenv(docaBackendsVar, "scrape,bogus", 1), 0);
+
+    const nixlTelemetryExporterInitParams params{"nixl_doca_bad_backend_test", 4096};
+    EXPECT_THROW(nixlTelemetryDocaExporter exporter(params), std::runtime_error);
+}
+
+// Multiple backends can be enabled at once. With "scrape,ipc" and no DTS, the scrape
+// endpoint must still serve metrics (the enabled scrape backend is independent of the
+// failed ipc one, which only WARNs) -- proving backends compose rather than being a
+// single mutually-exclusive choice.
+TEST_F(docaNixlExporterTest, MultipleBackendsScrapeServesWhenIpcHasNoDts) {
+    ASSERT_EQ(::setenv(docaBackendsVar, "scrape,ipc", 1), 0);
+    ASSERT_EQ(::setenv(docaIpcSocketsDirVar, absentDtsSocketsDir, 1), 0);
+
+    constexpr char agentName[] = "nixl_doca_multi_backend_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    const std::string metric =
+        nixlEnumStrings::telemetryMetricDescriptor(nixl_telemetry_event_type_t::AGENT_TX_BYTES)
+            .counterName;
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+
+    ASSERT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_TX_BYTES, 909}),
+              NIXL_SUCCESS);
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const auto metrics = scrapeUntilValue(port_, metric, 909.0, std::chrono::seconds(12), labels);
+    EXPECT_EQ(metrics.latestValue(metric, labels), std::optional<double>(909.0))
+        << "scrape must still serve metrics when ipc is also enabled but has no DTS";
+}
+
+// Opt-in end-to-end against a LIVE DTS (NIX-1599/NIX-1600). DISABLED_ so it never
+// runs in normal CI; it needs a running DOCA Telemetry Service with IPC enabled and
+// a Prometheus endpoint. Point it at the DTS ipc-sockets-dir and prometheus port,
+// then run:
+//   NIXL_DTS_IPC_SOCKETS_DIR=/dev/shm/nixl_dts/ipc_sockets NIXL_DTS_PROM_PORT=9100
+//   doca_nixl_test --gtest_also_run_disabled_tests --gtest_filter='*IpcDeliversToLiveDts'
+// Pushes over IPC, then scrapes the DTS endpoint and asserts our unified series
+// surfaces there with the exact pushed total.
+TEST_F(docaNixlExporterTest, DISABLED_IpcDeliversToLiveDts) {
+    const char *const socketsDir = ::getenv("NIXL_DTS_IPC_SOCKETS_DIR");
+    ASSERT_NE(socketsDir, nullptr)
+        << "set NIXL_DTS_IPC_SOCKETS_DIR to the running DTS ipc-sockets-dir";
+    const char *const portEnv = ::getenv("NIXL_DTS_PROM_PORT");
+    const uint16_t promPort = portEnv ? static_cast<uint16_t>(std::stoi(portEnv)) : 9100;
+
+    ASSERT_EQ(::setenv(docaBackendsVar, "ipc", 1), 0);
+    ASSERT_EQ(::setenv(docaIpcSocketsDirVar, socketsDir, 1), 0);
+
+    constexpr char agentName[] = "nixl_doca_ipc_e2e";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    const std::string metric =
+        nixlEnumStrings::telemetryMetricDescriptor(nixl_telemetry_event_type_t::AGENT_TX_BYTES)
+            .counterName;
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+
+    constexpr std::array<uint64_t, 3> deltas{1000, 2000, 4000};
+    uint64_t expected_total = 0;
+    for (const uint64_t delta : deltas) {
+        ASSERT_EQ(exporter.exportEvent({nixl_telemetry_event_type_t::AGENT_TX_BYTES, delta}),
+                  NIXL_SUCCESS);
+        expected_total += delta;
+    }
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const auto metrics = scrapeUntilValue(
+        promPort, metric, static_cast<double>(expected_total), std::chrono::seconds(30), labels);
+    EXPECT_EQ(metrics.latestValue(metric, labels), std::optional<double>(expected_total))
+        << metric << "{agent_name=" << agentName << "} not served by DTS at :" << promPort
+        << " -- IPC delivery or DTS Prometheus re-export failed";
 }
 
 int


### PR DESCRIPTION
## What?
Add an IPC->DTS delivery mode to the DOCA/CollectX telemetry exporter. Delivery backends
are now selected by `NIXL_TELEMETRY_DOCA_BACKENDS` — a comma-separated **set** (default
`scrape`; e.g. `scrape`, `ipc`, `scrape,ipc`), parsed with `absl::StrSplit` +
`absl::StripAsciiWhitespace` (the same idiom `nixl::trace` uses for `NIXL_TRACE_BACKENDS`),
plus `NIXL_TELEMETRY_DOCA_IPC_SOCKETS_DIR` for the shared socket folder:
- `scrape` — opens the local Prometheus HTTP endpoint (existing behavior).
- `ipc` — pushes metrics over IPC to the DOCA Telemetry Service (DTS); no HTTP endpoint of
  its own. If DTS is unreachable the exporter logs a WARN and continues (no crash).
- The two compose; unknown tokens warn+ignore; an empty/unknown set falls back to `scrape`.

Default is unchanged (`scrape`), so this is backward-compatible. Exporter-side only — no
`TELEMETRY_VERSION` bump. Remote-write / OTLP remain DTS-side onward backends (reached via
`ipc`), not exporter flags.

## Why?
Under multi-process runs (TP/DP/PP/EP) every NIXL process opens its own scrape endpoint and
they collide on the shared port, so only one rank exports (NIX-1557). Pushing over IPC to a
single per-node DTS aggregates all processes behind one Prometheus endpoint with no
per-process listener — the strategic DOCA-path fix. NIX-1590 (per-rank port offset) stays the
near-term mitigation; DTS deployment (K8s DaemonSet/sidecar, multi-process aggregation,
per-rank identity) is the follow-up NIX-1600. Tracking: NIX-1599. Builds on the unified
exporter descriptor from #1894 (NIX-1598).

## How?
All wiring is in the `DocaSharedContext` ctor. In `ipc` mode it skips
`setenv(PROMETHEUS_ENDPOINT)`, calls `doca_telemetry_exporter_schema_set_ipc_enabled`
(+ `set_ipc_sockets_dir` when configured) between `schema_init` and `schema_start`, and after
`source_start` calls `check_ipc_status`, logging WARN-and-continue when not `CONNECTED`. Links
`absl_strings` into the plugin + test. Adds DOCA-gated unit tests (backend gating,
multi-backend, graceful degradation without DTS) and an opt-in `DISABLED_` end-to-end test
that pushes over IPC and scrapes a live DTS. Validated end-to-end (client DOCA 3.3 → DTS 3.5):
`agent_tx_bytes_total=7000` + `agent_tx_last_bytes=4000` observed at the DTS endpoint. Docs:
DOCA plugin README + `docs/telemetry.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental DOCA/CollectX telemetry delivery backends with environment-driven selection for `scrape` and/or `ipc`, plus optional IPC socket directory control.
* **Bug Fixes**
  * If IPC can’t reach the telemetry service, the process continues running and metrics exporting via other enabled backends still works.
  * If no known backend is selected, the exporter defaults to `scrape`; unknown backend tokens now fail fast.
* **Documentation**
  * Updated telemetry documentation and the DOCA exporter README with backend configuration and runtime behavior details.
* **Tests**
  * Added end-to-end coverage for backend selection, IPC-only endpoint behavior, scrape+IPC mixed operation, and a disabled live IPC integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->