### PR TITLE
telemetry: downgrade Prometheus bind-collision from ERROR to WARN

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -132,6 +132,7 @@ Telemetry is configured by environment variables:
 - When telemetry is requested but no output sink is configured (neither `NIXL_TELEMETRY_EXPORTER` nor `NIXL_TELEMETRY_DIR`), it falls back to the collect-only NOP exporter: events are collected in-process so `getXferTelemetry()` / `get_xfer_telemetry()` works, but nothing is written out.
 - If telemetry is enabled but no exporter is set, or the exporter name is empty, then the sink depends on `NIXL_TELEMETRY_DIR` as explained below (falling back to NOP when it is unset).
 - Set `NIXL_TELEMETRY_EXPORTER=NOP` to explicitly keep telemetry active (events are collected and `getXferTelemetry()` works) while discarding all output. It needs no sink and writes nothing, so it can be used to measure the overhead of the telemetry collection path in isolation.
+- Exporters that expose a scrape endpoint (e.g. Prometheus) bind one port per process. Under multi-process runs (e.g. tensor/data parallelism) every rank tries to bind the same port; only one wins. Losing that race is benign and non-fatal: the affected process logs a single warning and runs without a telemetry sink instead of failing agent construction. See [src/plugins/telemetry/prometheus/README.md](../src/plugins/telemetry/prometheus/README.md).
 
 ## Cyclic Buffer
 

--- a/src/api/cpp/telemetry/telemetry_exporter.h
+++ b/src/api/cpp/telemetry/telemetry_exporter.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/api/cpp/telemetry/telemetry_exporter.h
+++ b/src/api/cpp/telemetry/telemetry_exporter.h
@@ -20,9 +20,15 @@
 #include "nixl_types.h"
 #include "telemetry_event.h"
 
+#include <stdexcept>
 #include <string>
 
 inline constexpr char telemetryExporterVar[] = "NIXL_TELEMETRY_EXPORTER";
+
+class nixlTelemetryBindFailed : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
 
 /**
  * @struct nixlTelemetryExporterInitParams

--- a/src/api/cpp/telemetry/telemetry_exporter.h
+++ b/src/api/cpp/telemetry/telemetry_exporter.h
@@ -25,6 +25,12 @@
 
 inline constexpr char telemetryExporterVar[] = "NIXL_TELEMETRY_EXPORTER";
 
+/**
+ * @brief Thrown by a telemetry exporter when its scrape endpoint could not bind
+ *        its port -- typically a benign multi-process collision. Callers may
+ *        catch it to continue without a telemetry sink instead of treating the
+ *        failure as fatal.
+ */
 class nixlTelemetryBindFailed : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;

--- a/src/api/cpp/telemetry/telemetry_plugin.h
+++ b/src/api/cpp/telemetry/telemetry_plugin.h
@@ -83,6 +83,9 @@ private:
         try {
             return std::make_unique<exporterType>(init_params);
         }
+        catch (const nixlTelemetryBindFailed &) {
+            throw;
+        }
         catch (const std::exception &e) {
             NIXL_ERROR << "Failed to create exporter: " << e.what();
             return nullptr;

--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -91,11 +91,13 @@ resolveMaxBufferedEvents();
 
 [[nodiscard]] std::unique_ptr<nixlTelemetry>
 nixlTelemetry::create(const std::string &agent_name) {
-    // create() is only called when telemetry is explicitly requested (see
-    // nixlAgent's constructor), so it always produces an active instance:
-    // getExporterName() falls back to the collect-only NOP sink when no output
-    // sink is configured.
-    return std::make_unique<nixlTelemetry>(agent_name, getExporterName());
+    try {
+        return std::make_unique<nixlTelemetry>(agent_name, getExporterName());
+    }
+    catch (const nixlTelemetryBindFailed &e) {
+        NIXL_WARN << e.what() << "; this process will run without a telemetry sink";
+        return nullptr;
+    }
 }
 
 nixlTelemetry::nixlTelemetry(const std::string &agent_name, const std::string &exporter_name)

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -54,12 +54,14 @@ public:
      * @brief Creates a telemetry instance that records transfer events.
      *
      * Only called when telemetry is explicitly requested (NIXL_TELEMETRY_ENABLE
-     * or the agent's captureTelemetry config), so it always returns a non-null
-     * instance. With an output sink configured it exports events there; without
-     * one it falls back to the collect-only NOP sink, which still records events
-     * in process (so getXferTelemetry() returns data) but writes nothing.
+     * or the agent's captureTelemetry config). With an output sink configured it
+     * exports events there; without one it falls back to the collect-only NOP
+     * sink, which still records events in process (so getXferTelemetry() returns
+     * data) but writes nothing.
      * @param agent_name Non-empty agent name.
-     * @return A non-null telemetry instance.
+     * @return A telemetry instance, or nullptr if the exporter's scrape endpoint
+     *         could not bind its port (a benign multi-process collision): that
+     *         rank then runs without a telemetry sink instead of failing.
      * @throws std::invalid_argument / std::runtime_error on genuine
      *         configuration or plugin-load errors.
      */

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -65,6 +65,10 @@ NOTE: the same var is used for backend plug-ins search
 export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 ```
 
+### Multi-process runs
+
+The exporter opens one HTTP scrape endpoint per process. Under multi-process runs (e.g. tensor or data parallelism) every rank process tries to bind the same `NIXL_TELEMETRY_PROMETHEUS_PORT`; only one wins. Losing that race is benign and non-fatal: the affected process logs a single warning and runs **without** a telemetry sink (agent construction still succeeds, the model still runs). Only the process that bound the port exports metrics. Aggregating every rank behind one endpoint is a separate, larger effort.
+
 ### Metrics & Events
 
 | Event Name | Counter | Gauge | Histogram |

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -84,7 +84,20 @@ nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
             registry_.reset();
             exposer_.reset();
             registry_ = std::make_shared<prometheus::Registry>();
-            exposer_ = std::make_shared<prometheus::Exposer>(bind_address);
+            try {
+                exposer_ = std::make_shared<prometheus::Exposer>(bind_address);
+            }
+            catch (const std::exception &e) {
+                // civetweb reports a failed port bind with this exact text; other
+                // startup failures (threads, ACL, OOM, ...) don't, so they stay fatal.
+                const std::string reason = e.what();
+                if (reason.find("Failed to setup server ports") == std::string::npos) {
+                    throw;
+                }
+                throw nixlTelemetryBindFailed("Prometheus telemetry endpoint '" + bind_address +
+                                              "' could not be bound (likely already in use by "
+                                              "another process)");
+            }
             exposer_->RegisterCollectable(registry_);
             s_exposer_weak = exposer_;
             s_registry_weak = registry_;

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -88,8 +88,9 @@ nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
                 exposer_ = std::make_shared<prometheus::Exposer>(bind_address);
             }
             catch (const std::exception &e) {
-                // civetweb reports a failed port bind with this exact text; other
-                // startup failures (threads, ACL, OOM, ...) don't, so they stay fatal.
+                // civetweb reports a failed port bind with this exact text (verified
+                // against prometheus-cpp v1.3.0 / civetweb 1.16); other startup
+                // failures (threads, ACL, OOM, ...) don't, so they stay fatal.
                 const std::string reason = e.what();
                 if (reason.find("Failed to setup server ports") == std::string::npos) {
                     throw;

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -296,6 +296,9 @@ public:
     ScopedFd(const ScopedFd &) = delete;
     ScopedFd &
     operator=(const ScopedFd &) = delete;
+    ScopedFd(ScopedFd &&) = delete;
+    ScopedFd &
+    operator=(ScopedFd &&) = delete;
 
     int
     get() const {

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -283,6 +283,29 @@ scrapeCoreOverflow(uint16_t port,
     return result; // ok stays false: full accounting was not observed in time
 }
 
+class ScopedFd {
+public:
+    explicit ScopedFd(int fd) : fd_(fd) {}
+
+    ~ScopedFd() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    ScopedFd(const ScopedFd &) = delete;
+    ScopedFd &
+    operator=(const ScopedFd &) = delete;
+
+    int
+    get() const {
+        return fd_;
+    }
+
+private:
+    int fd_ = -1;
+};
+
 int
 occupyLocalPort(uint16_t port) {
     const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
@@ -752,21 +775,19 @@ TEST_F(prometheusTelemetryTest, CoreAddXferStatsOverflowConservation) {
 }
 
 TEST_F(prometheusTelemetryTest, BindCollisionThrowsBindFailed) {
-    const int occupier = occupyLocalPort(port_);
-    ASSERT_GE(occupier, 0) << "could not occupy 127.0.0.1:" << port_;
+    const ScopedFd occupier(occupyLocalPort(port_));
+    ASSERT_GE(occupier.get(), 0) << "could not occupy 127.0.0.1:" << port_;
 
     auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
     ASSERT_NE(handle, nullptr);
 
     const nixlTelemetryExporterInitParams params{"prometheus_bind_collision_agent", 4096};
     EXPECT_THROW(handle->createExporter(params), nixlTelemetryBindFailed);
-
-    ::close(occupier);
 }
 
 TEST_F(prometheusTelemetryTest, BindCollisionCreateIsNonFatalWarn) {
-    const int occupier = occupyLocalPort(port_);
-    ASSERT_GE(occupier, 0) << "could not occupy 127.0.0.1:" << port_;
+    const ScopedFd occupier(occupyLocalPort(port_));
+    ASSERT_GE(occupier.get(), 0) << "could not occupy 127.0.0.1:" << port_;
 
     gtest::ScopedEnv exporter_env;
     exporter_env.addVar(telemetryExporterVar, "prometheus");
@@ -782,6 +803,4 @@ TEST_F(prometheusTelemetryTest, BindCollisionCreateIsNonFatalWarn) {
     EXPECT_EQ(sink.bindWarnings(), 1) << "the collision must log exactly one WARNING";
     EXPECT_EQ(sink.otherProblems(), 0) << "the collision must not log an ERROR or other problem";
     EXPECT_EQ(ignore_bind_warning.getIgnoredCount(), 1u);
-
-    ::close(occupier);
 }

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -31,8 +31,10 @@
 #include <unistd.h>
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
 #include <cstring>
 #include <functional>
 #include <set>
@@ -339,32 +341,28 @@ public:
 
     void
     Send(const absl::LogEntry &entry) override {
-        const std::lock_guard<std::mutex> lock(mutex_);
         const std::string msg(entry.text_message());
         if (entry.log_severity() == absl::LogSeverity::kWarning &&
             msg.find("could not be bound") != std::string::npos) {
-            ++bindWarnings_;
+            bindWarnings_.fetch_add(1, std::memory_order_relaxed);
         } else if (entry.log_severity() >= absl::LogSeverity::kWarning) {
-            ++otherProblems_;
+            otherProblems_.fetch_add(1, std::memory_order_relaxed);
         }
     }
 
-    int
+    std::size_t
     bindWarnings() const {
-        const std::lock_guard<std::mutex> lock(mutex_);
-        return bindWarnings_;
+        return bindWarnings_.load(std::memory_order_relaxed);
     }
 
-    int
+    std::size_t
     otherProblems() const {
-        const std::lock_guard<std::mutex> lock(mutex_);
-        return otherProblems_;
+        return otherProblems_.load(std::memory_order_relaxed);
     }
 
 private:
-    mutable std::mutex mutex_;
-    int bindWarnings_ = 0;
-    int otherProblems_ = 0;
+    std::atomic<std::size_t> bindWarnings_{0};
+    std::atomic<std::size_t> otherProblems_{0};
 };
 
 } // namespace
@@ -803,7 +801,8 @@ TEST_F(prometheusTelemetryTest, BindCollisionCreateIsNonFatalWarn) {
     EXPECT_EQ(telemetry, nullptr)
         << "a scrape-port collision must disable telemetry, not fail agent construction";
 
-    EXPECT_EQ(sink.bindWarnings(), 1) << "the collision must log exactly one WARNING";
-    EXPECT_EQ(sink.otherProblems(), 0) << "the collision must not log an ERROR or other problem";
+    EXPECT_EQ(sink.bindWarnings(), std::size_t{1}) << "the collision must log exactly one WARNING";
+    EXPECT_EQ(sink.otherProblems(), std::size_t{0})
+        << "the collision must not log an ERROR or other problem";
     EXPECT_EQ(ignore_bind_warning.getIgnoredCount(), 1u);
 }

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -23,6 +23,8 @@
 
 #include "open_metrics_text_parser.h"
 
+#include <absl/log/log_sink_registry.h>
+
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -280,6 +282,64 @@ scrapeCoreOverflow(uint16_t port,
     } while (std::chrono::steady_clock::now() < deadline);
     return result; // ok stays false: full accounting was not observed in time
 }
+
+int
+occupyLocalPort(uint16_t port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = ::inet_addr("127.0.0.1");
+    if (::bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0 ||
+        ::listen(fd, 1) != 0) {
+        ::close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+class SeverityCountingLogSink : public absl::LogSink {
+public:
+    SeverityCountingLogSink() {
+        absl::AddLogSink(this);
+    }
+
+    ~SeverityCountingLogSink() override {
+        absl::RemoveLogSink(this);
+    }
+
+    void
+    Send(const absl::LogEntry &entry) override {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        const std::string msg(entry.text_message());
+        if (entry.log_severity() == absl::LogSeverity::kWarning &&
+            msg.find("could not be bound") != std::string::npos) {
+            ++bindWarnings_;
+        } else if (entry.log_severity() >= absl::LogSeverity::kWarning) {
+            ++otherProblems_;
+        }
+    }
+
+    int
+    bindWarnings() const {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        return bindWarnings_;
+    }
+
+    int
+    otherProblems() const {
+        const std::lock_guard<std::mutex> lock(mutex_);
+        return otherProblems_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    int bindWarnings_ = 0;
+    int otherProblems_ = 0;
+};
 
 } // namespace
 
@@ -689,4 +749,39 @@ TEST_F(prometheusTelemetryTest, CoreAddXferStatsOverflowConservation) {
     EXPECT_GT(scrape.dropped, 0.0) << "flooding the staging queue must drop xfer batches";
     EXPECT_EQ(std::fmod(scrape.dropped, static_cast<double>(kEventsPerCall)), 0.0)
         << "addXferStats drops the whole 4-event batch, so drops are multiples of 4";
+}
+
+TEST_F(prometheusTelemetryTest, BindCollisionThrowsBindFailed) {
+    const int occupier = occupyLocalPort(port_);
+    ASSERT_GE(occupier, 0) << "could not occupy 127.0.0.1:" << port_;
+
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const nixlTelemetryExporterInitParams params{"prometheus_bind_collision_agent", 4096};
+    EXPECT_THROW(handle->createExporter(params), nixlTelemetryBindFailed);
+
+    ::close(occupier);
+}
+
+TEST_F(prometheusTelemetryTest, BindCollisionCreateIsNonFatalWarn) {
+    const int occupier = occupyLocalPort(port_);
+    ASSERT_GE(occupier, 0) << "could not occupy 127.0.0.1:" << port_;
+
+    gtest::ScopedEnv exporter_env;
+    exporter_env.addVar(telemetryExporterVar, "prometheus");
+
+    gtest::LogIgnoreGuard ignore_bind_warning("could not be bound");
+    SeverityCountingLogSink sink;
+
+    std::unique_ptr<nixlTelemetry> telemetry;
+    EXPECT_NO_THROW(telemetry = nixlTelemetry::create("prometheus_bind_collision_create_agent"));
+    EXPECT_EQ(telemetry, nullptr)
+        << "a scrape-port collision must disable telemetry, not fail agent construction";
+
+    EXPECT_EQ(sink.bindWarnings(), 1) << "the collision must log exactly one WARNING";
+    EXPECT_EQ(sink.otherProblems(), 0) << "the collision must not log an ERROR or other problem";
+    EXPECT_EQ(ignore_bind_warning.getIgnoredCount(), 1u);
+
+    ::close(occupier);
 }


### PR DESCRIPTION
## What?

Make a NIXL Prometheus telemetry scrape-port bind collision **benign and non-fatal**:
the losing process logs a single `WARNING` and continues **without** a telemetry sink,
instead of logging a per-rank `ERROR` and throwing out of the `nixlAgent` constructor.

- New dedicated exception `nixlTelemetryBindFailed` (in `telemetry_exporter.h`).
- The Prometheus exporter translates **only** the civetweb port-bind failure
  (`"Failed to setup server ports"`) into it; every other startup failure
  (thread creation, ACL, OOM, ...) is rethrown unchanged and stays a genuine `ERROR`.
- The plugin creator rethrows `nixlTelemetryBindFailed`; `nixlTelemetry::create()`
  catches it, logs one `NIXL_WARN`, and returns `nullptr`, so the agent runs with
  telemetry disabled.
- gtest coverage for both the thrown type and the non-fatal WARN path.
- Docs: multi-process note in `src/plugins/telemetry/prometheus/README.md` and
  `docs/telemetry.md`.

Scope: native Prometheus only. DOCA is out of scope (its bind happens inside CollectX
after `setenv`, and is harder to catch cleanly).

## Why?

Reported in [ai-dynamo/nixl#1838](https://github.com/ai-dynamo/nixl/issues/1838) (NIX-1557):
under multi-process runs (TP/DP/…) every rank binds the same
`NIXL_TELEMETRY_PROMETHEUS_PORT`; only one wins. On `main` this was worse than mere log
spam — the losing ranks **threw `std::runtime_error` out of the agent constructor**
(`makeExporter` throws on the null exporter and the `create()` call site is unguarded),
a fatal regression from 1.2.0, which continued without a telemetry sink. This restores
non-fatal behavior and removes the alarming ERROR spam.

Tracked as NIX-1604 (the graceful-bind half carved out of NIX-1590; the disputed per-rank
port offset is separate and on hold).

## How?

The benign case is distinguished from real failures by a **dedicated exception type**
rather than a blanket ERROR→WARN downgrade (which would also silence genuine
misconfiguration). Net user-visible effect: at most one `WARN` per losing rank, no `ERROR`,
no crash; the process that won the port still exports normally.

Example log on a losing rank:

    W ... telemetry.cpp:98] Prometheus telemetry endpoint '0.0.0.0:9090' could not be bound (likely already in use by another process); this process will run without a telemetry sink

### Test plan

- `ninja -C build && meson test -C build gtest` (telemetry suites)
- New: `prometheusTelemetryTest.BindCollisionThrowsBindFailed`,
  `prometheusTelemetryTest.BindCollisionCreateIsNonFatalWarn`
- Verified green locally: core telemetry (21), Prometheus (10, incl. the 2 new),
  descriptor contract + UCX transfer-telemetry (21).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry now safely handles Prometheus scrape-port binding conflicts in multi-process runs without crashing.
  * If the Prometheus exporter can’t bind its scrape port, telemetry startup becomes non-fatal (telemetry creation returns `nullptr`) and execution continues.
  * Logs a single, binding-related warning when the collision occurs.

* **Documentation**
  * Updated telemetry and Prometheus exporter docs with expected multi-process port contention behavior.

* **Tests**
  * Added/extended regression tests to deterministically simulate scrape-port bind collisions and verify warning counts and non-fatal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->