### PR TITLE
nixlbench: fix HIP/toml++ include ordering on GCC

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -27,11 +27,6 @@
 #include <omp.h>
 #include <set>
 
-#if HAVE_CUDA
-#include <cuda_runtime.h>
-#elif HAVE_ROCM
-#include <hip/hip_runtime.h>
-#endif
 #include <fcntl.h>
 #include <filesystem>
 #include <gflags/gflags.h>

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -21,12 +21,6 @@
 #include <cctype>
 #include <chrono>
 #include <cstring>
-#if HAVE_CUDA
-#include <cuda.h>
-#include <cuda_runtime.h>
-#elif HAVE_ROCM
-#include <hip/hip_runtime.h>
-#endif
 #include <fcntl.h>
 #include <filesystem>
 #include <iomanip>


### PR DESCRIPTION
## What?

Remove the unnecessary and error-inducing conditional includes in nixlbench source files.

## Why?

ROCm's host_defines.h defines an empty __noinline__ macro on GCC, which breaks toml++'s TOML_HAS_ATTR(__noinline__) check when hip/hip_runtime.h is included before toml++/toml.hpp. utils.h already includes toml++ first and then conditionally includes the GPU headers, so the early redundant includes in utils.cpp and nixl_worker.cpp are both the source of the breakage and unnecessary.

This enables nixlbench to be build on ROCm-based systems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up platform-specific runtime header handling in benchmark components.
  * This change has no expected impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->