### PR TITLE
chore: update NIXL attributions to 1.3.1 (#1901)

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -9288,7 +9288,7 @@ NetworkX is distributed with the 3-clause BSD license.
   - `Source Code`: https://github.com/networkx/networkx
 
 
-## nixl (1.3.0)
+## nixl (1.3.1)
 
 ### Licenses
 License: `Apache-2.0`
@@ -9509,7 +9509,7 @@ License: `Apache-2.0`
 
 
 
-## nixl-cu13 (1.3.0)
+## nixl-cu13 (1.3.1)
 
 ### Licenses
 License: `Apache-2.0`


### PR DESCRIPTION
Bump the nixl and nixl-cu13 self-version headers in ATTRIBUTIONS-Python.md from 1.3.0 to 1.3.1 to match the released package version (pyproject is already at 1.3.1). No third-party dependency attributions changed for the 1.3.1 patch release.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
* Updated license attribution entries for two packages to reflect the latest versions.
* Kept the same Apache 2.0 license details while refreshing the recorded package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
