### PR TITLE
fix(mooncake): use openSegmentNoCache to flush stale segment metadata

### DIFF
--- a/src/plugins/mooncake/mooncake_backend.cpp
+++ b/src/plugins/mooncake/mooncake_backend.cpp
@@ -134,7 +134,7 @@ nixl_status_t
 nixlMooncakeEngine::loadRemoteConnInfo(const std::string &remote_agent,
                                        const std::string &remote_conn_info) {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto segment_id = openSegment(engine_, remote_conn_info.c_str());
+    auto segment_id = openSegmentNoCache(engine_, remote_conn_info.c_str());
     if (segment_id < 0) return NIXL_ERR_BACKEND;
     connected_agents_[remote_agent].segment_id = segment_id;
     return NIXL_SUCCESS;


### PR DESCRIPTION
## What?
When NIXL opens a remote segment in Mooncake TransferEngine, the cached metadata for the same segment may not be refreshed, which can lead to data corruption. `openSegmentNoCache` first calls `syncSegmentCache()` before `openSegment()`, ensuring the latest metadata is used.

## Why?
This is the minimal version of the fix previously proposed in #1114. The old PR also contained CI/build script and test changes that have since become outdated or are better handled separately, so this PR contains only the core one-line fix.

## How?
- `src/plugins/mooncake/mooncake_backend.cpp`: `openSegment` → `openSegmentNoCache` in `loadRemoteConnInfo`.

## Notes
- Supersedes #1114.
- I have dropped the `.gitlab/build.sh` and test changes from the original PR; the current build script already uses Ninja + `NPROC`, and the test changes can be proposed separately if still needed.
- Please run `/ok to test` and `/build` when ready. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote connection handling so segments are opened more reliably during setup, helping reduce connection-related issues and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->