### PR TITLE
Refactoring: derive nixlUcxThreadPoolEngine from nixlUcxThreadEngine

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -363,7 +363,11 @@ nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_param
     : nixlUcxEngine(init_params) {
     const size_t num_threads =
         nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    numSharedWorkers_ = getWorkers().size() - num_threads;
+    const size_t num_workers = getWorkers().size();
+    if (num_threads > num_workers) {
+        throw std::invalid_argument("num_threads exceeds available UCX workers");
+    }
+    numSharedWorkers_ = num_workers - num_threads;
 
     const size_t shared_count = init_params.enableProgTh ? numSharedWorkers_ : 0;
     if (shared_count == 0) {
@@ -650,13 +654,15 @@ private:
 
 nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params)
     : nixlUcxThreadEngine(init_params) {
-    const size_t num_threads =
-        nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    NIXL_ASSERT(getSharedWorkersSize() > 0);
+    if (getSharedWorkersSize() == 0) {
+        throw std::invalid_argument("thread-pool engine requires at least one shared worker");
+    }
 
     splitBatchSize_ =
         nixl::getBackendParamDefaulted(init_params.customParams, "split_batch_size", 1024u);
 
+    const size_t num_threads =
+        nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
     if (num_threads > 0) {
         io_.reset(new asio::io_context());
         dedicatedThreads_.reserve(num_threads);

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -769,8 +769,7 @@ nixlUcxEngine::create(const nixlBackendInitParams &init_params) {
     return std::unique_ptr<nixlUcxEngine>(engine);
 }
 
-nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params,
-                             size_t num_dedicated_workers)
+nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t num_dedicated_workers)
     : nixlBackendEngine(&init_params),
       sharedWorkerIndex_(1) {
     std::vector<std::string> devs; /* Empty vector */

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -779,8 +779,11 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
         devs = absl::StrSplit(*opt, ", ");
     }
 
-    numSharedWorkers_ = nixl::getBackendParamDefaulted(custom_params, "num_workers", 1u);
-    const size_t num_workers = numSharedWorkers_ + num_dedicated_workers;
+    size_t num_workers = nixl::getBackendParamDefaulted(custom_params, "num_workers", 1u);
+    if (num_workers <= num_dedicated_workers) {
+        num_workers = num_dedicated_workers + 1;
+    }
+    numSharedWorkers_ = num_workers - num_dedicated_workers;
 
     const size_t num_device_channels =
         nixl::getBackendParamDefaulted(custom_params, "ucx_num_device_channels", 4u);

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -361,20 +361,28 @@ private:
 
 nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_params)
     : nixlUcxEngine(init_params) {
+    const size_t num_threads =
+        nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
+    const size_t shared_count = init_params.enableProgTh ? getWorkers().size() - num_threads : 0;
+    if (shared_count == 0) {
+        return;
+    }
+
     if (!nixlUcxMtLevelIsSupported(nixl::ucx::mt_mode_t::WORKER)) {
         throw std::invalid_argument("UCX library does not support multi-threading");
     }
 
-    size_t num_workers = getWorkers().size();
-    thread_ = std::make_unique<nixlUcxSharedThread>(this, num_workers, init_params.pthrDelay);
-    for (size_t i = 0; i < num_workers; i++) {
+    thread_ = std::make_unique<nixlUcxSharedThread>(this, shared_count, init_params.pthrDelay);
+    for (size_t i = 0; i < shared_count; i++) {
         thread_->addWorker(getWorkers()[i].get(), i);
     }
     thread_->start();
 }
 
 nixlUcxThreadEngine::~nixlUcxThreadEngine() {
-    thread_->join();
+    if (thread_) {
+        thread_->join();
+    }
 }
 
 void
@@ -387,6 +395,10 @@ nixl_status_t
 nixlUcxThreadEngine::getNotifs(notif_list_t &notif_list) {
     if (!notif_list.empty()) {
         return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (!thread_) {
+        progressLoop();
     }
 
     const std::lock_guard lock(notifMutex_);
@@ -635,7 +647,7 @@ private:
 };
 
 nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params)
-    : nixlUcxEngine(init_params) {
+    : nixlUcxThreadEngine(init_params) {
     const size_t num_threads =
         nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
     numSharedWorkers_ = getWorkers().size() - num_threads;
@@ -643,15 +655,6 @@ nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &in
 
     splitBatchSize_ =
         nixl::getBackendParamDefaulted(init_params.customParams, "split_batch_size", 1024u);
-
-    if (init_params.enableProgTh) {
-        sharedThread_ =
-            std::make_unique<nixlUcxSharedThread>(this, numSharedWorkers_, init_params.pthrDelay);
-        for (size_t i = 0; i < numSharedWorkers_; i++) {
-            sharedThread_->addWorker(getWorkers()[i].get(), i);
-        }
-        sharedThread_->start();
-    }
 
     if (num_threads > 0) {
         io_.reset(new asio::io_context());
@@ -666,10 +669,6 @@ nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &in
 }
 
 nixlUcxThreadPoolEngine::~nixlUcxThreadPoolEngine() {
-    if (sharedThread_) {
-        sharedThread_->join();
-    }
-
     if (io_) {
         io_->stop();
         for (auto &thread : dedicatedThreads_) {
@@ -755,27 +754,6 @@ nixlUcxThreadPoolEngine::sendXferRange(const nixl_xfer_op_t &operation,
     future.wait();
     NIXL_TRACE << "sent " << *comp_handle << " with status: " << status.load();
     return status.load();
-}
-
-void
-nixlUcxThreadPoolEngine::appendNotif(std::string &&remote_name, std::string &&msg) {
-    const std::lock_guard lock(notifMutex_);
-    notifList_.emplace_back(std::move(remote_name), std::move(msg));
-}
-
-nixl_status_t
-nixlUcxThreadPoolEngine::getNotifs(notif_list_t &notif_list) {
-    if (!notif_list.empty()) {
-        return NIXL_ERR_INVALID_PARAM;
-    }
-
-    if (!sharedThread_) {
-        progressLoop();
-    }
-
-    const std::lock_guard lock(notifMutex_);
-    notifList_.swap(notif_list);
-    return NIXL_SUCCESS;
 }
 
 /****************************************

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -359,18 +359,10 @@ private:
     std::vector<pollfd> pollFds_;
 };
 
-nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_params)
-    : nixlUcxEngine(init_params) {
-    const size_t num_threads =
-        nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    const size_t num_workers = getWorkers().size();
-    if (num_threads > num_workers) {
-        throw std::invalid_argument("num_threads exceeds available UCX workers");
-    }
-    numSharedWorkers_ = num_workers - num_threads;
-
-    const size_t shared_count = init_params.enableProgTh ? numSharedWorkers_ : 0;
-    if (shared_count == 0) {
+nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_params,
+                                         size_t num_dedicated_workers)
+    : nixlUcxEngine(init_params, num_dedicated_workers) {
+    if (!init_params.enableProgTh) {
         return;
     }
 
@@ -378,9 +370,10 @@ nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_param
         throw std::invalid_argument("UCX library does not support multi-threading");
     }
 
+    const size_t shared_count = getSharedWorkers().size();
     thread_ = std::make_unique<nixlUcxSharedThread>(this, shared_count, init_params.pthrDelay);
     for (size_t i = 0; i < shared_count; i++) {
-        thread_->addWorker(getWorkers()[i].get(), i);
+        thread_->addWorker(getSharedWorkers()[i].get(), i);
     }
     thread_->start();
 }
@@ -652,26 +645,20 @@ private:
     std::vector<nixlUcxChunkBackendReqH *> requests_;
 };
 
-nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params)
-    : nixlUcxThreadEngine(init_params) {
-    if (getSharedWorkersSize() == 0) {
-        throw std::invalid_argument("thread-pool engine requires at least one shared worker");
-    }
-
+nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params,
+                                                 size_t num_threads)
+    : nixlUcxThreadEngine(init_params, num_threads) {
     splitBatchSize_ =
         nixl::getBackendParamDefaulted(init_params.customParams, "split_batch_size", 1024u);
 
-    const size_t num_threads =
-        nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    if (num_threads > 0) {
-        io_.reset(new asio::io_context());
-        dedicatedThreads_.reserve(num_threads);
-        for (size_t i = 0; i < num_threads; ++i) {
-            size_t worker_id = getSharedWorkersSize() + i;
-            dedicatedThreads_.emplace_back(std::make_unique<nixlUcxDedicatedThread>(this, *io_));
-            dedicatedThreads_.back()->addWorker(getWorker(worker_id).get(), worker_id);
-            dedicatedThreads_.back()->start();
-        }
+    const auto dedicated_workers = getDedicatedWorkers();
+    io_.reset(new asio::io_context());
+    dedicatedThreads_.reserve(dedicated_workers.size());
+    for (size_t i = 0; i < dedicated_workers.size(); ++i) {
+        const size_t worker_id = getSharedWorkersSize() + i;
+        dedicatedThreads_.emplace_back(std::make_unique<nixlUcxDedicatedThread>(this, *io_));
+        dedicatedThreads_.back()->addWorker(dedicated_workers[i].get(), worker_id);
+        dedicatedThreads_.back()->start();
     }
 }
 
@@ -699,9 +686,9 @@ nixlUcxThreadPoolEngine::prepXfer(const nixl_xfer_op_t &operation,
     size_t chunk_size = std::max(batch_size / dedicatedThreads_.size(), splitBatchSize_);
     size_t num_chunks = (batch_size + chunk_size - 1) / chunk_size;
 
-    size_t worker_id = getWorkerId();
+    size_t worker_id = getSharedWorkerId();
     const auto comp_handle = new nixlUcxCompositeBackendReqH(
-        getWorker(worker_id).get(), worker_id, chunk_size, num_chunks);
+        getSharedWorker(worker_id).get(), worker_id, chunk_size, num_chunks);
     NIXL_TRACE << "created " << *comp_handle;
     handle = comp_handle;
     return NIXL_SUCCESS;
@@ -773,7 +760,7 @@ nixlUcxEngine::create(const nixlBackendInitParams &init_params) {
     const size_t num_threads =
         nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
     if (num_threads > 0) {
-        engine = new nixlUcxThreadPoolEngine(init_params);
+        engine = new nixlUcxThreadPoolEngine(init_params, num_threads);
     } else if (init_params.enableProgTh) {
         engine = new nixlUcxThreadEngine(init_params);
     } else {
@@ -782,7 +769,8 @@ nixlUcxEngine::create(const nixlBackendInitParams &init_params) {
     return std::unique_ptr<nixlUcxEngine>(engine);
 }
 
-nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
+nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params,
+                             size_t num_dedicated_workers)
     : nixlBackendEngine(&init_params),
       sharedWorkerIndex_(1) {
     std::vector<std::string> devs; /* Empty vector */
@@ -792,15 +780,12 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
         devs = absl::StrSplit(*opt, ", ");
     }
 
-    size_t num_workers = nixl::getBackendParamDefaulted(custom_params, "num_workers", 1u);
-    const size_t num_threads = nixl::getBackendParamDefaulted(custom_params, "num_threads", 0u);
+    numSharedWorkers_ = nixl::getBackendParamDefaulted(custom_params, "num_workers", 1u);
+    const size_t num_workers = numSharedWorkers_ + num_dedicated_workers;
+
     const size_t num_device_channels =
         nixl::getBackendParamDefaulted(custom_params, "ucx_num_device_channels", 4u);
 
-    if (num_workers <= num_threads) {
-        /* There must be at least one shared worker */
-        num_workers = num_threads + 1;
-    }
 
     ucp_err_handling_mode_t err_handling_mode = UCP_ERR_HANDLING_MODE_PEER;
     if (const auto opt = nixl::getBackendParamOptional<std::string>(
@@ -820,13 +805,14 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params)
 
     uc->warnAboutHardwareSupportMismatch();
 
+    workers_.reserve(num_workers);
     for (size_t i = 0; i < num_workers; i++) {
-        uws.emplace_back(std::make_unique<nixlUcxWorker>(*uc, err_handling_mode));
+        workers_.emplace_back(std::make_unique<nixlUcxWorker>(*uc, err_handling_mode));
     }
 
-    auto &uw = uws.front();
-    workerAddr = uw->epAddr();
-    uw->regAmCallback(nixl::ucx::am_cb_op_t::NOTIF_STR, notifAmCb, this);
+    auto &worker = workers_.front();
+    workerAddr = worker->epAddr();
+    worker->regAmCallback(nixl::ucx::am_cb_op_t::NOTIF_STR, notifAmCb, this);
 }
 
 nixl_mem_list_t nixlUcxEngine::getSupportedMems () const {
@@ -893,12 +879,12 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
 
     nixlSerDes::_stringToBytes(addr.data(), remote_conn_info, size);
     std::shared_ptr<nixlUcxConnection> conn = std::make_shared<nixlUcxConnection>();
-    for (auto &uw : uws) {
-        std::unique_ptr<nixlUcxEp> result = uw->connect(addr.data(), size);
-        if (!result) {
+    for (const auto &uw : workers_) {
+        std::unique_ptr<nixlUcxEp> ep = uw->connect(addr.data(), size);
+        if (!ep) {
             return NIXL_ERR_BACKEND;
         }
-        conn->eps.push_back(std::move(result));
+        conn->eps.push_back(std::move(ep));
     }
 
     remoteConnMap.insert({remote_agent, conn});
@@ -978,7 +964,7 @@ nixlUcxEngine::internalMDHelper (const nixl_blob_t &blob,
         }
         // nixlSerDes::_stringToBytes() was used to "unpack" blob here.
         output = new nixlUcxPublicMetadata(
-            it->second, makePublicMetadataRkeys(it->second, uws.size(), blob.data()));
+            it->second, makePublicMetadataRkeys(it->second, getAllWorkersSize(), blob.data()));
         return NIXL_SUCCESS;
     }
     catch (const std::runtime_error &e) {
@@ -1017,7 +1003,7 @@ nixl_status_t nixlUcxEngine::unloadMD (nixlBackendMD* input) {
 *****************************************/
 
 size_t
-nixlUcxEngine::getWorkerId(const nixl_opt_b_args_t *opt_args) const noexcept {
+nixlUcxEngine::getSharedWorkerId(const nixl_opt_b_args_t *opt_args) const noexcept {
     if (opt_args) {
         const std::optional<size_t> worker_id = getWorkerIdFromOptArgs(*opt_args);
         if (worker_id) {
@@ -1072,9 +1058,9 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    const size_t worker_id = getWorkerId(opt_args);
+    const size_t worker_id = getSharedWorkerId(opt_args);
     /* TODO: try to get from a pool first */
-    handle = new nixlUcxBackendReqH(getWorker(worker_id).get(), worker_id);
+    handle = new nixlUcxBackendReqH(getSharedWorker(worker_id).get(), worker_id);
 
     return NIXL_SUCCESS;
 }
@@ -1332,7 +1318,7 @@ unsigned
 nixlUcxEngine::progress() {
     // TODO: add listen for connection handling if necessary
     unsigned ret = 0;
-    for (auto &uw : uws) {
+    for (const auto &uw : getSharedWorkers()) {
         ret += uw->progress();
     }
     return ret;
@@ -1434,7 +1420,7 @@ nixlUcxEngine::genNotif(const std::string &remote_agent, const std::string &msg)
         return NIXL_ERR_NOT_FOUND;
     }
 
-    const nixl_status_t ret = notifSendPriv(remote_agent, msg, conn->getEp(getWorkerId()));
+    const nixl_status_t ret = notifSendPriv(remote_agent, msg, conn->getEp(getSharedWorkerId()));
     if (ret == NIXL_IN_PROG) {
         return NIXL_SUCCESS;
     }
@@ -1445,9 +1431,9 @@ nixl_status_t
 nixlUcxEngine::prepMemView(const nixl_remote_meta_dlist_t &dlist,
                            nixlMemViewH &mvh,
                            const nixl_opt_b_args_t *opt_args) const {
-    const size_t worker_id = getWorkerId(opt_args);
+    const size_t worker_id = getSharedWorkerId(opt_args);
     try {
-        mvh = nixl::ucx::createMemList(dlist, worker_id, *getWorker(worker_id));
+        mvh = nixl::ucx::createMemList(dlist, worker_id, *getSharedWorker(worker_id));
         return NIXL_SUCCESS;
     }
     catch (const std::exception &e) {
@@ -1460,9 +1446,9 @@ nixl_status_t
 nixlUcxEngine::prepMemView(const nixl_meta_dlist_t &dlist,
                            nixlMemViewH &mvh,
                            const nixl_opt_b_args_t *opt_args) const {
-    const size_t worker_id = getWorkerId(opt_args);
+    const size_t worker_id = getSharedWorkerId(opt_args);
     try {
-        mvh = nixl::ucx::createMemList(dlist, *getWorker(worker_id));
+        mvh = nixl::ucx::createMemList(dlist, *getSharedWorker(worker_id));
         return NIXL_SUCCESS;
     }
     catch (const std::exception &e) {

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -363,7 +363,9 @@ nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_param
     : nixlUcxEngine(init_params) {
     const size_t num_threads =
         nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    const size_t shared_count = init_params.enableProgTh ? getWorkers().size() - num_threads : 0;
+    numSharedWorkers_ = getWorkers().size() - num_threads;
+
+    const size_t shared_count = init_params.enableProgTh ? numSharedWorkers_ : 0;
     if (shared_count == 0) {
         return;
     }
@@ -650,8 +652,7 @@ nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &in
     : nixlUcxThreadEngine(init_params) {
     const size_t num_threads =
         nixl::getBackendParamDefaulted(init_params.customParams, "num_threads", 0u);
-    numSharedWorkers_ = getWorkers().size() - num_threads;
-    NIXL_ASSERT(numSharedWorkers_ > 0);
+    NIXL_ASSERT(getSharedWorkersSize() > 0);
 
     splitBatchSize_ =
         nixl::getBackendParamDefaulted(init_params.customParams, "split_batch_size", 1024u);
@@ -660,7 +661,7 @@ nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &in
         io_.reset(new asio::io_context());
         dedicatedThreads_.reserve(num_threads);
         for (size_t i = 0; i < num_threads; ++i) {
-            size_t worker_id = numSharedWorkers_ + i;
+            size_t worker_id = getSharedWorkersSize() + i;
             dedicatedThreads_.emplace_back(std::make_unique<nixlUcxDedicatedThread>(this, *io_));
             dedicatedThreads_.back()->addWorker(getWorker(worker_id).get(), worker_id);
             dedicatedThreads_.back()->start();

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -963,7 +963,7 @@ nixlUcxEngine::internalMDHelper (const nixl_blob_t &blob,
         }
         // nixlSerDes::_stringToBytes() was used to "unpack" blob here.
         output = new nixlUcxPublicMetadata(
-            it->second, makePublicMetadataRkeys(it->second, getAllWorkersSize(), blob.data()));
+            it->second, makePublicMetadataRkeys(it->second, workers_.size(), blob.data()));
         return NIXL_SUCCESS;
     }
     catch (const std::runtime_error &e) {

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -261,12 +261,6 @@ public:
         return tls;
     }
 
-    static bool
-    isProgressThread(const nixlUcxEngine *engine) noexcept {
-        nixlUcxThread *thread = tlsThread();
-        return thread && thread->engine_ == engine;
-    }
-
     friend std::ostream &
     operator<<(std::ostream &os, const nixlUcxThread &thread) {
         return os << "thread " << &thread << "{engine: " << thread.engine_ << ", worker_ids: ["
@@ -850,10 +844,6 @@ nixlUcxEngine::~nixlUcxEngine() {
 /****************************************
  * Connection management
 *****************************************/
-
-nixl_status_t nixlUcxEngine::checkConn(const std::string &remote_agent) {
-    return remoteConnMap.count(remote_agent) ? NIXL_SUCCESS : NIXL_ERR_NOT_FOUND;
-}
 
 nixl_status_t nixlUcxEngine::getConnInfo(std::string &str) const {
     str = workerAddr;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -223,6 +223,9 @@ protected:
 
     [[nodiscard]] const std::unique_ptr<nixlUcxWorker> &
     getSharedWorker(size_t worker_id) const {
+        if (worker_id >= numSharedWorkers_) [[unlikely]] {
+            throw std::out_of_range("Worker ID out of range");
+        }
         return workers_[worker_id];
     }
 
@@ -232,11 +235,6 @@ protected:
     [[nodiscard]] size_t
     getSharedWorkersSize() const {
         return numSharedWorkers_;
-    }
-
-    [[nodiscard]] size_t
-    getAllWorkersSize() const {
-        return workers_.size();
     }
 
     virtual void

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -18,6 +18,7 @@
 #define NIXL_SRC_PLUGINS_UCX_UCX_BACKEND_H
 
 #include <vector>
+#include <span>
 #include <cstring>
 #include <iostream>
 #include <thread>
@@ -208,22 +209,34 @@ public:
     void releaseMemView(nixlMemViewH) const override;
 
 protected:
-    const std::vector<std::unique_ptr<nixlUcxWorker>> &
-    getWorkers() const {
-        return uws;
+    using worker_span_t = std::span<const std::unique_ptr<nixlUcxWorker>>;
+
+    [[nodiscard]] worker_span_t
+    getSharedWorkers() const {
+        return {workers_.data(), numSharedWorkers_};
     }
 
-    const std::unique_ptr<nixlUcxWorker> &
-    getWorker(size_t worker_id) const {
-        return uws[worker_id];
+    [[nodiscard]] worker_span_t
+    getDedicatedWorkers() const {
+        return {workers_.data() + numSharedWorkers_, workers_.size() - numSharedWorkers_};
+    }
+
+    [[nodiscard]] const std::unique_ptr<nixlUcxWorker> &
+    getSharedWorker(size_t worker_id) const {
+        return workers_[worker_id];
     }
 
     [[nodiscard]] size_t
-    getWorkerId(const nixl_opt_b_args_t *opt_args = nullptr) const noexcept;
+    getSharedWorkerId(const nixl_opt_b_args_t *opt_args = nullptr) const noexcept;
 
-    virtual size_t
+    [[nodiscard]] size_t
     getSharedWorkersSize() const {
-        return uws.size();
+        return numSharedWorkers_;
+    }
+
+    [[nodiscard]] size_t
+    getAllWorkersSize() const {
+        return workers_.size();
     }
 
     virtual void
@@ -238,7 +251,8 @@ protected:
                   size_t start_idx,
                   size_t end_idx) const;
 
-    nixlUcxEngine(const nixlBackendInitParams &init_params);
+    nixlUcxEngine(const nixlBackendInitParams &init_params,
+                  size_t num_dedicated_workers = 0);
 
     notif_list_t notifList_;
 
@@ -289,7 +303,8 @@ private:
 
     /* UCX data */
     std::unique_ptr<nixlUcxContext> uc;
-    std::vector<std::unique_ptr<nixlUcxWorker>> uws;
+    std::vector<std::unique_ptr<nixlUcxWorker>> workers_;
+    size_t numSharedWorkers_;
     std::string workerAddr;
     mutable std::atomic<size_t> sharedWorkerIndex_;
 
@@ -306,7 +321,8 @@ class nixlUcxThread;
  */
 class nixlUcxThreadEngine : public nixlUcxEngine {
 public:
-    nixlUcxThreadEngine(const nixlBackendInitParams &init_params);
+    nixlUcxThreadEngine(const nixlBackendInitParams &init_params,
+                        size_t num_dedicated_workers = 0);
     ~nixlUcxThreadEngine();
 
     nixl_status_t
@@ -316,15 +332,9 @@ protected:
     void
     appendNotif(std::string &&remote_name, std::string &&msg) override;
 
-    size_t
-    getSharedWorkersSize() const override {
-        return numSharedWorkers_;
-    }
-
 private:
     std::unique_ptr<nixlUcxThread> thread_;
     std::mutex notifMutex_;
-    size_t numSharedWorkers_;
 };
 
 namespace asio {
@@ -333,7 +343,8 @@ class io_context;
 
 class nixlUcxThreadPoolEngine : public nixlUcxThreadEngine {
 public:
-    nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params);
+    nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params,
+                            size_t num_threads);
     ~nixlUcxThreadPoolEngine();
 
     nixl_status_t

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -251,8 +251,7 @@ protected:
                   size_t start_idx,
                   size_t end_idx) const;
 
-    nixlUcxEngine(const nixlBackendInitParams &init_params,
-                  size_t num_dedicated_workers = 0);
+    nixlUcxEngine(const nixlBackendInitParams &init_params, size_t num_dedicated_workers = 0);
 
     notif_list_t notifList_;
 
@@ -321,8 +320,7 @@ class nixlUcxThread;
  */
 class nixlUcxThreadEngine : public nixlUcxEngine {
 public:
-    nixlUcxThreadEngine(const nixlBackendInitParams &init_params,
-                        size_t num_dedicated_workers = 0);
+    nixlUcxThreadEngine(const nixlBackendInitParams &init_params, size_t num_dedicated_workers = 0);
     ~nixlUcxThreadEngine();
 
     nixl_status_t
@@ -343,8 +341,7 @@ class io_context;
 
 class nixlUcxThreadPoolEngine : public nixlUcxThreadEngine {
 public:
-    nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params,
-                            size_t num_threads);
+    nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params, size_t num_threads);
     ~nixlUcxThreadPoolEngine();
 
     nixl_status_t

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -312,14 +312,14 @@ public:
     nixl_status_t
     getNotifs(notif_list_t &notif_list) override;
 
+protected:
+    void
+    appendNotif(std::string &&remote_name, std::string &&msg) override;
+
     size_t
     getSharedWorkersSize() const override {
         return numSharedWorkers_;
     }
-
-protected:
-    void
-    appendNotif(std::string &&remote_name, std::string &&msg) override;
 
 private:
     std::unique_ptr<nixlUcxThread> thread_;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -300,7 +300,9 @@ private:
 class nixlUcxThread;
 
 /**
- * Represents an engine with a single progress thread for all shared workers
+ * Engine with an optional single progress thread that progresses all shared
+ * workers. The thread is started only when there are shared workers; with none
+ * (shared_count == 0) no progress thread is created and progress is synchronous.
  */
 class nixlUcxThreadEngine : public nixlUcxEngine {
 public:

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -302,7 +302,7 @@ class nixlUcxThread;
 /**
  * Engine with an optional single progress thread that progresses all shared
  * workers. The thread is started only when there are shared workers; with none
- * (shared_count == 0) no progress thread is created and progress is synchronous.
+ * shared workers no progress thread is created and progress is synchronous.
  */
 class nixlUcxThreadEngine : public nixlUcxEngine {
 public:
@@ -312,6 +312,11 @@ public:
     nixl_status_t
     getNotifs(notif_list_t &notif_list) override;
 
+    size_t
+    getSharedWorkersSize() const override {
+        return numSharedWorkers_;
+    }
+
 protected:
     void
     appendNotif(std::string &&remote_name, std::string &&msg) override;
@@ -319,6 +324,7 @@ protected:
 private:
     std::unique_ptr<nixlUcxThread> thread_;
     std::mutex notifMutex_;
+    size_t numSharedWorkers_;
 };
 
 namespace asio {
@@ -338,11 +344,6 @@ public:
              nixlBackendReqH *&handle,
              const nixl_opt_b_args_t *opt_args = nullptr) const override;
 
-    size_t
-    getSharedWorkersSize() const override {
-        return numSharedWorkers_;
-    }
-
 protected:
     nixl_status_t
     sendXferRange(const nixl_xfer_op_t &operation,
@@ -356,7 +357,6 @@ protected:
 private:
     std::unique_ptr<asio::io_context> io_;
     std::vector<std::unique_ptr<nixlUcxThread>> dedicatedThreads_;
-    size_t numSharedWorkers_;
     size_t splitBatchSize_;
 };
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -192,10 +192,6 @@ public:
     nixl_status_t
     genNotif(const std::string &remote_agent, const std::string &msg) const override;
 
-    // public function for UCX worker to mark connections as connected
-    nixl_status_t
-    checkConn(const std::string &remote_agent);
-
     nixl_status_t
     prepMemView(const nixl_remote_meta_dlist_t &,
                 nixlMemViewH &,

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -323,7 +323,7 @@ namespace asio {
 class io_context;
 }
 
-class nixlUcxThreadPoolEngine : public nixlUcxEngine {
+class nixlUcxThreadPoolEngine : public nixlUcxThreadEngine {
 public:
     nixlUcxThreadPoolEngine(const nixlBackendInitParams &init_params);
     ~nixlUcxThreadPoolEngine();
@@ -341,13 +341,7 @@ public:
         return numSharedWorkers_;
     }
 
-    nixl_status_t
-    getNotifs(notif_list_t &notif_list) override;
-
 protected:
-    void
-    appendNotif(std::string &&remote_name, std::string &&msg) override;
-
     nixl_status_t
     sendXferRange(const nixl_xfer_op_t &operation,
                   const nixl_meta_dlist_t &local,
@@ -359,10 +353,8 @@ protected:
 
 private:
     std::unique_ptr<asio::io_context> io_;
-    std::unique_ptr<nixlUcxThread> sharedThread_;
     std::vector<std::unique_ptr<nixlUcxThread>> dedicatedThreads_;
     size_t numSharedWorkers_;
-    std::mutex notifMutex_;
     size_t splitBatchSize_;
 };
 


### PR DESCRIPTION
## What?
To unify the code and reuse the same functions
It's pre-requisite for completions API PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UCX backend thread lifecycle so the shared progress thread is created and joined only when enabled and shared workers are available.
  * Notification retrieval now properly runs progress when the shared progress thread is not active.

* **Refactor**
  * Updated the UCX thread-pool engine to inherit from the shared thread-engine, centralizing shared-worker sizing and notification behavior and removing pool-specific notification overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->