### PR TITLE
telemetry: remove dead core buffer flush path (NIX-1592)

### DIFF
--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -125,11 +125,6 @@ nixlTelemetry::~nixlTelemetry() {
         NIXL_DEBUG << "Failed to cancel telemetry write timer: " << e.what();
         // continue anyway since it's not critical
     }
-
-    if (buffer_) {
-        flushPendingEvents();
-        buffer_.reset();
-    }
 }
 
 namespace {

--- a/src/core/telemetry/telemetry.h
+++ b/src/core/telemetry/telemetry.h
@@ -17,7 +17,6 @@
 #ifndef NIXL_SRC_CORE_TELEMETRY_TELEMETRY_H
 #define NIXL_SRC_CORE_TELEMETRY_TELEMETRY_H
 
-#include "common/cyclic_buffer.h"
 #include "telemetry/telemetry_exporter.h"
 #include "telemetry_event.h"
 #include "mem_section.h"
@@ -123,7 +122,6 @@ private:
     const std::string agentName_;
     const size_t maxBufferedEvents_;
     const std::unique_ptr<nixlTelemetryExporter> exporter_;
-    std::unique_ptr<sharedRingBuffer<nixlTelemetryEvent>> buffer_;
     std::vector<nixlTelemetryEvent> events_;
     std::mutex mutex_;
     asio::thread_pool pool_;

--- a/test/gtest/telemetry_test.cpp
+++ b/test/gtest/telemetry_test.cpp
@@ -31,6 +31,7 @@
 #include "telemetry.h"
 #include "telemetry_event.h"
 #include "nixl_types.h"
+#include "common/cyclic_buffer.h"
 #include "common.h"
 #include "backend/backend_engine.h"
 #include "mocks/gmock_engine.h"


### PR DESCRIPTION
## What?
Remove the unused `nixlTelemetry::buffer_` member and its unreachable destructor branch (the `if (buffer_)` flush/reset). Also drop the now-unneeded `#include "common/cyclic_buffer.h"` from `telemetry.h`, and add it directly to `telemetry_test.cpp`, which uses `sharedRingBuffer` and had been relying on the transitive include through `telemetry.h`.

## Why?
The core `buffer_` member was live when telemetry was introduced (#562): `nixlTelemetry` itself owned the shared-memory ring buffer, pushed events to it, and flushed on destruction. #1088 moved the BUFFER sink into the plugin-based `nixlTelemetryBufferExporter` (which owns its own buffer) but left the core member and destructor branch orphaned. Since #1088 the core `buffer_` is never assigned, so it is always null and the destructor branch is dead code. Removing it keeps the core telemetry owner aligned with the current exporter model and avoids implying a shutdown flush that does not actually happen.

Behavior-preserving: no change to event ordering, drop accounting, exporter error handling, BUFFER cyclic-ring behavior, or the periodic `flushPendingEvents()` task.

## How?
- `src/core/telemetry/telemetry.h`: remove the `buffer_` member and the `common/cyclic_buffer.h` include.
- `src/core/telemetry/telemetry.cpp`: remove the dead destructor branch; keep `#include "buffer_exporter.h"` (still needed for `telemetryDirVar`) and the shutdown ordering (disable task, stop/join pool, cancel timer).
- `test/gtest/telemetry_test.cpp`: include `common/cyclic_buffer.h` directly.

## Testing
- `ninja -C build` — clean build.
- Full gtest suite: 111/111 passed, including all 17 `telemetryTest` cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry shutdown behavior to avoid extra work during teardown.
  * Added more resilient handling when background scheduling cannot be canceled, helping prevent shutdown-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->