### PR TITLE
telemetry: add transfer-duration histograms to Prometheus and DOCA exporters

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -70,6 +70,16 @@ stream:
   a `_total` counter alongside a last-op gauge (`agent_xfer_time` /
   `agent_xfer_post_time`). This is purely an exporter-side derivation: no new event
   type is emitted and the buffer format is unchanged.
+- **Latency histograms**: the transfer-time events additionally feed distribution
+  histograms `agent_xfer_time_us` / `agent_xfer_post_time_us` (microseconds) on
+  both the Prometheus and DOCA exporters, at parity (same names, buckets, labels).
+  Each is exposed as the standard `_bucket{le="..."}` / `_sum` / `_count` series
+  alongside the existing counter and gauge. Bucket boundaries default to a
+  microsecond range covering ~10us..~10s and are overridable via
+  `NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US` (a comma-separated list of
+  strictly-increasing positive microsecond upper bounds; absent/empty/invalid
+  falls back to the defaults). Like the other views this is an exporter-side
+  derivation with no new event type.
 - **Error counters**: the Prometheus and DOCA exporters expose error events as
   `agent_errors_total{status="<status>"}`. The `status` label is bounded by the
   fixed `AGENT_ERR_*` event set: `not_posted`, `invalid_param`, `backend`,
@@ -126,6 +136,7 @@ Telemetry is configured by environment variables:
 | `NIXL_TELEMETRY_BUFFER_SIZE` | Number of events in buffer | `4096` |
 | `NIXL_TELEMETRY_RUN_INTERVAL` | Flush interval (ms) | `100` |
 | `NIXL_TELEMETRY_EXPORTER` | Name of the exporter plugin to use | - |
+| `NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US` | Comma-separated microsecond bucket bounds for the transfer-time histograms (Prometheus/DOCA) | built-in µs defaults |
 
 - `NIXL_TELEMETRY_ENABLE` can be set to `y`/`yes`/`on`/`true`/`enable`/`1` to be enabled, and `n`/`no`/`off`/`false`/`disable`/`0` (or not set) to be disabled. Matching is case insensitive.
 - Telemetry is requested either via `NIXL_TELEMETRY_ENABLE` or via the agent config flag `captureTelemetry` (`capture_telemetry=True` in Python). It is fully off only when it is not requested.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -77,9 +77,10 @@ stream:
   alongside the existing counter and gauge. Bucket boundaries default to a
   microsecond range covering ~10us..~10s and are overridable via
   `NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US` (a comma-separated list of
-  strictly-increasing positive microsecond upper bounds; absent/empty/invalid
-  falls back to the defaults). Like the other views this is an exporter-side
-  derivation with no new event type.
+  strictly-increasing positive microsecond upper bounds; when absent or empty the
+  built-in defaults are used, while a non-empty but invalid value is rejected and
+  the exporter fails to initialize rather than silently using the defaults). Like
+  the other views this is an exporter-side derivation with no new event type.
 - **Error counters**: the Prometheus and DOCA exporters expose error events as
   `agent_errors_total{status="<status>"}`. The `status` label is bounded by the
   fixed `AGENT_ERR_*` event set: `not_posted`, `invalid_param`, `backend`,

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -91,6 +91,8 @@ struct nixlTelemetryMetricDescriptor {
     const char *counterHelp;
     const char *gaugeName;
     const char *gaugeHelp;
+    const char *histogramName;
+    const char *histogramHelp;
 };
 
 namespace nixlEnumStrings {
@@ -188,10 +190,10 @@ telemetryErrorStatusLabel(const nixl_telemetry_event_type_t type) noexcept {
  * @brief Exporter-side Prometheus series descriptor for a telemetry event.
  *
  * Both the native Prometheus and DOCA/CollectX exporters derive their series
- * from this single mapping, so they emit identical output. A null @c counterName
- * or @c gaugeName means the event has no cumulative counter or no last-operation
- * gauge, respectively. Error events (@c AGENT_ERR_*) and any unmapped value
- * return an all-null descriptor.
+ * from this single mapping, so they emit identical output. A null @c counterName,
+ * @c gaugeName, or @c histogramName means the event has no cumulative counter, no
+ * last-operation gauge, or no distribution histogram, respectively. Error events
+ * (@c AGENT_ERR_*) and any unmapped value return an all-null descriptor.
  *
  * @param type Telemetry event type.
  * @return Counter/gauge series names and HELP strings for @p type.
@@ -203,45 +205,63 @@ telemetryMetricDescriptor(const nixl_telemetry_event_type_t type) noexcept {
         return {"agent_tx_bytes_total",
                 "Number of bytes sent by the agent",
                 "agent_tx_last_bytes",
-                "Bytes sent by the last request"};
+                "Bytes sent by the last request",
+                nullptr,
+                nullptr};
     case nixl_telemetry_event_type_t::AGENT_RX_BYTES:
         return {"agent_rx_bytes_total",
                 "Number of bytes received by the agent",
                 "agent_rx_last_bytes",
-                "Bytes received by the last request"};
+                "Bytes received by the last request",
+                nullptr,
+                nullptr};
     case nixl_telemetry_event_type_t::AGENT_TX_REQUESTS_NUM:
         return {"agent_tx_requests_num_total",
                 "Number of requests sent by the agent",
+                nullptr,
+                nullptr,
                 nullptr,
                 nullptr};
     case nixl_telemetry_event_type_t::AGENT_RX_REQUESTS_NUM:
         return {"agent_rx_requests_num_total",
                 "Number of requests received by the agent",
                 nullptr,
+                nullptr,
+                nullptr,
                 nullptr};
     case nixl_telemetry_event_type_t::AGENT_MEMORY_REGISTERED:
         return {"agent_memory_registered_total",
                 "Cumulative memory registered",
                 "agent_memory_registered_last_bytes",
-                "Memory registered by the last operation"};
+                "Memory registered by the last operation",
+                nullptr,
+                nullptr};
     case nixl_telemetry_event_type_t::AGENT_MEMORY_DEREGISTERED:
         return {"agent_memory_deregistered_total",
                 "Cumulative memory deregistered",
                 "agent_memory_deregistered_last_bytes",
-                "Memory deregistered by the last operation"};
+                "Memory deregistered by the last operation",
+                nullptr,
+                nullptr};
     case nixl_telemetry_event_type_t::AGENT_XFER_TIME:
         return {"agent_xfer_time_total",
                 "Cumulative sum of transfer time from start to completion",
                 "agent_xfer_time",
-                "Transfer time of the last request"};
+                "Transfer time of the last request",
+                "agent_xfer_time_us",
+                "Distribution of transfer time from start to completion, in microseconds"};
     case nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME:
         return {"agent_xfer_post_time_total",
                 "Cumulative sum of time from start to posting to the back-end",
                 "agent_xfer_post_time",
-                "Post time of the last request"};
+                "Post time of the last request",
+                "agent_xfer_post_time_us",
+                "Distribution of time from start to posting to the back-end, in microseconds"};
     case nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED:
         return {"agent_telemetry_events_dropped_total",
                 "Cumulative telemetry events dropped at the producer-side staging queue",
+                nullptr,
+                nullptr,
                 nullptr,
                 nullptr};
     case nixl_telemetry_event_type_t::AGENT_ERR_NOT_POSTED:
@@ -256,9 +276,9 @@ telemetryMetricDescriptor(const nixl_telemetry_event_type_t type) noexcept {
     case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
     case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
     case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
-        return {nullptr, nullptr, nullptr, nullptr};
+        return {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
     }
-    return {nullptr, nullptr, nullptr, nullptr};
+    return {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 } // namespace nixlEnumStrings
 

--- a/src/core/telemetry/telemetry_event.h
+++ b/src/core/telemetry/telemetry_event.h
@@ -276,7 +276,7 @@ telemetryMetricDescriptor(const nixl_telemetry_event_type_t type) noexcept {
     case nixl_telemetry_event_type_t::AGENT_ERR_REMOTE_DISCONNECT:
     case nixl_telemetry_event_type_t::AGENT_ERR_CANCELED:
     case nixl_telemetry_event_type_t::AGENT_ERR_NO_TELEMETRY:
-        return {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+        break;
     }
     return {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }

--- a/src/plugins/telemetry/README.md
+++ b/src/plugins/telemetry/README.md
@@ -35,8 +35,8 @@ NIXL generates the following telemetry events:
 | `agent_rx_bytes` | Counter | Total bytes received |
 | `agent_tx_requests_num` | Counter | Number of transmit requests |
 | `agent_rx_requests_num` | Counter | Number of receive requests |
-| `agent_xfer_time` | Gauge | Transfer time in microseconds |
-| `agent_xfer_post_time` | Gauge | Post time in microseconds |
+| `agent_xfer_time` | Counter, Gauge, Histogram | Transfer time (start->completion) in microseconds; also a latency histogram `agent_xfer_time_us` |
+| `agent_xfer_post_time` | Counter, Gauge, Histogram | Post time (start->backend-post) in microseconds; also a latency histogram `agent_xfer_post_time_us` |
 | `agent_telemetry_events_dropped` | Counter | Telemetry events dropped at the producer-side staging queue |
 
 ## Quick Start

--- a/src/plugins/telemetry/common/histogram_buckets.h
+++ b/src/plugins/telemetry/common/histogram_buckets.h
@@ -32,6 +32,10 @@ namespace nixl::telemetry {
 
 inline constexpr char histogramBucketsUsVar[] = "NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US";
 
+/**
+ * @brief Built-in microsecond histogram bucket upper bounds (~10us..~10s).
+ * @return Shared default boundaries, used when the env override is absent or invalid.
+ */
 [[nodiscard]] inline const std::vector<double> &
 defaultHistogramBucketsUs() {
     static const std::vector<double> buckets = {10,
@@ -55,10 +59,12 @@ defaultHistogramBucketsUs() {
     return buckets;
 }
 
-// Parses a comma-separated list of strictly-increasing positive doubles. Returns
-// an empty vector when the spec is malformed so the caller can fall back to the
-// defaults (matching the config layer's "fall back only when absent" intent while
-// keeping the validation local to the telemetry plugins).
+/**
+ * @brief Parse a comma-separated list of strictly-increasing positive doubles.
+ * @param spec Comma-separated bucket specification (whitespace around tokens is trimmed).
+ * @return Parsed boundaries, or an empty vector when @p spec is malformed so the caller
+ *         can fall back to the defaults (validation kept local to the telemetry plugins).
+ */
 [[nodiscard]] inline std::vector<double>
 parseHistogramBucketsUs(const std::string &spec) {
     std::vector<double> buckets;
@@ -76,10 +82,12 @@ parseHistogramBucketsUs(const std::string &spec) {
     return buckets;
 }
 
-// Resolves the histogram bucket boundaries (microsecond upper bounds) shared by
-// both duration histograms in both exporters. Reads the env var; on absent,
-// empty, or invalid input it WARNs (only when something was provided) and returns
-// the built-in microsecond defaults.
+/**
+ * @brief Resolve the histogram bucket boundaries (microsecond upper bounds) shared by
+ *        both duration histograms in both exporters.
+ * @return The parsed env override when valid; otherwise the built-in microsecond defaults.
+ *         Emits a WARN only when a non-empty override was provided but is invalid.
+ */
 [[nodiscard]] inline std::vector<double>
 resolveHistogramBucketsUs() {
     const auto spec = nixl::config::getValueOptional<std::string>(histogramBucketsUsVar);

--- a/src/plugins/telemetry/common/histogram_buckets.h
+++ b/src/plugins/telemetry/common/histogram_buckets.h
@@ -30,7 +30,7 @@
 
 namespace nixl::telemetry {
 
-constexpr char histogramBucketsUsVar[] = "NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US";
+inline constexpr char histogramBucketsUsVar[] = "NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US";
 
 [[nodiscard]] inline const std::vector<double> &
 defaultHistogramBucketsUs() {

--- a/src/plugins/telemetry/common/histogram_buckets.h
+++ b/src/plugins/telemetry/common/histogram_buckets.h
@@ -18,13 +18,12 @@
 #define NIXL_SRC_PLUGINS_TELEMETRY_COMMON_HISTOGRAM_BUCKETS_H
 
 #include "common/configuration.h"
-#include "common/nixl_log.h"
 
 #include <cmath>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
-#include <absl/strings/ascii.h>
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 
@@ -60,17 +59,18 @@ defaultHistogramBucketsUs() {
 }
 
 /**
- * @brief Parse a comma-separated list of strictly-increasing positive doubles.
- * @param spec Comma-separated bucket specification (whitespace around tokens is trimmed).
- * @return Parsed boundaries, or an empty vector when @p spec is malformed so the caller
- *         can fall back to the defaults (validation kept local to the telemetry plugins).
+ * @brief Parse a comma-separated list of strictly-increasing positive numbers.
+ * @param spec Comma-separated bucket specification. Values are real numbers (fractional
+ *             microseconds are allowed), and leading/trailing whitespace around each token
+ *             is tolerated (absl::SimpleAtod ignores it).
+ * @return Parsed boundaries, or an empty vector when @p spec is malformed (non-numeric,
+ *         non-finite, non-positive, or not strictly increasing).
  */
 [[nodiscard]] inline std::vector<double>
 parseHistogramBucketsUs(const std::string &spec) {
     std::vector<double> buckets;
     double previous = 0.0;
-    for (const absl::string_view raw : absl::StrSplit(spec, ',')) {
-        const absl::string_view token = absl::StripAsciiWhitespace(raw);
+    for (const absl::string_view token : absl::StrSplit(spec, ',')) {
         double value = 0.0;
         if (!absl::SimpleAtod(token, &value) || !std::isfinite(value) || value <= 0.0 ||
             value <= previous) {
@@ -85,8 +85,10 @@ parseHistogramBucketsUs(const std::string &spec) {
 /**
  * @brief Resolve the histogram bucket boundaries (microsecond upper bounds) shared by
  *        both duration histograms in both exporters.
- * @return The parsed env override when valid; otherwise the built-in microsecond defaults.
- *         Emits a WARN only when a non-empty override was provided but is invalid.
+ * @return The parsed env override when set and valid; the built-in microsecond defaults
+ *         when the override is absent or empty.
+ * @throws std::invalid_argument when a non-empty override is provided but malformed, so a
+ *         user who specified buckets is not silently given the defaults instead.
  */
 [[nodiscard]] inline std::vector<double>
 resolveHistogramBucketsUs() {
@@ -95,12 +97,11 @@ resolveHistogramBucketsUs() {
         return defaultHistogramBucketsUs();
     }
 
-    std::vector<double> buckets = parseHistogramBucketsUs(*spec);
+    const std::vector<double> buckets = parseHistogramBucketsUs(*spec);
     if (buckets.empty()) {
-        NIXL_WARN << histogramBucketsUsVar
-                  << " must be a comma-separated list of strictly-increasing positive numbers; "
-                     "falling back to default microsecond buckets";
-        return defaultHistogramBucketsUs();
+        throw std::invalid_argument(
+            std::string(histogramBucketsUsVar) +
+            " must be a comma-separated list of strictly-increasing positive numbers");
     }
     return buckets;
 }

--- a/src/plugins/telemetry/common/histogram_buckets.h
+++ b/src/plugins/telemetry/common/histogram_buckets.h
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_PLUGINS_TELEMETRY_COMMON_HISTOGRAM_BUCKETS_H
+#define NIXL_SRC_PLUGINS_TELEMETRY_COMMON_HISTOGRAM_BUCKETS_H
+
+#include "common/configuration.h"
+#include "common/nixl_log.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <absl/strings/ascii.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_split.h>
+
+namespace nixl::telemetry {
+
+constexpr char histogramBucketsUsVar[] = "NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US";
+
+[[nodiscard]] inline const std::vector<double> &
+defaultHistogramBucketsUs() {
+    static const std::vector<double> buckets = {10,
+                                                25,
+                                                50,
+                                                100,
+                                                250,
+                                                500,
+                                                1000,
+                                                2500,
+                                                5000,
+                                                10000,
+                                                25000,
+                                                50000,
+                                                100000,
+                                                250000,
+                                                500000,
+                                                1000000,
+                                                5000000,
+                                                10000000};
+    return buckets;
+}
+
+// Parses a comma-separated list of strictly-increasing positive doubles. Returns
+// an empty vector when the spec is malformed so the caller can fall back to the
+// defaults (matching the config layer's "fall back only when absent" intent while
+// keeping the validation local to the telemetry plugins).
+[[nodiscard]] inline std::vector<double>
+parseHistogramBucketsUs(const std::string &spec) {
+    std::vector<double> buckets;
+    double previous = 0.0;
+    for (const absl::string_view raw : absl::StrSplit(spec, ',')) {
+        const absl::string_view token = absl::StripAsciiWhitespace(raw);
+        double value = 0.0;
+        if (!absl::SimpleAtod(token, &value) || !std::isfinite(value) || value <= 0.0 ||
+            value <= previous) {
+            return {};
+        }
+        buckets.push_back(value);
+        previous = value;
+    }
+    return buckets;
+}
+
+// Resolves the histogram bucket boundaries (microsecond upper bounds) shared by
+// both duration histograms in both exporters. Reads the env var; on absent,
+// empty, or invalid input it WARNs (only when something was provided) and returns
+// the built-in microsecond defaults.
+[[nodiscard]] inline std::vector<double>
+resolveHistogramBucketsUs() {
+    const auto spec = nixl::config::getValueOptional<std::string>(histogramBucketsUsVar);
+    if (!spec || spec->empty()) {
+        return defaultHistogramBucketsUs();
+    }
+
+    std::vector<double> buckets = parseHistogramBucketsUs(*spec);
+    if (buckets.empty()) {
+        NIXL_WARN << histogramBucketsUsVar
+                  << " must be a comma-separated list of strictly-increasing positive numbers; "
+                     "falling back to default microsecond buckets";
+        return defaultHistogramBucketsUs();
+    }
+    return buckets;
+}
+
+} // namespace nixl::telemetry
+
+#endif // NIXL_SRC_PLUGINS_TELEMETRY_COMMON_HISTOGRAM_BUCKETS_H

--- a/src/plugins/telemetry/doca/README.md
+++ b/src/plugins/telemetry/doca/README.md
@@ -90,7 +90,7 @@ The default bucket boundaries for the transfer-time histograms can be overridden
 export NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US="10,100,1000,10000,100000"
 ```
 
-An absent, empty, or invalid value falls back to the built-in defaults.
+An absent or empty value uses the built-in defaults. A non-empty but invalid value (non-numeric, non-positive, or not strictly increasing) is rejected and the exporter fails to initialize, rather than silently falling back to the defaults.
 
 ### Metric labels
 

--- a/src/plugins/telemetry/doca/README.md
+++ b/src/plugins/telemetry/doca/README.md
@@ -69,8 +69,8 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_bytes` | Yes | Yes | No |
 | `agent_tx_requests_num` | Yes | No | No |
 | `agent_rx_requests_num` | Yes | No | No |
-| `agent_xfer_time` | Yes | Yes | No |
-| `agent_xfer_post_time` | Yes | Yes | No |
+| `agent_xfer_time` | Yes | Yes | Yes |
+| `agent_xfer_post_time` | Yes | Yes | Yes |
 | `agent_telemetry_events_dropped` | Yes | No | No |
 | Error event types (`agent_err_*`) | Yes | No | No |
 
@@ -80,7 +80,17 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 - Error events are exposed as one labeled counter: `agent_errors_total{status="..."}`. The `status` label is bounded by the fixed `AGENT_ERR_*` event set.
 - `agent_telemetry_events_dropped_total` is the cumulative count of telemetry events dropped at the producer-side staging queue (when the queue is full and an event cannot be enqueued for export). It does not count BUFFER cyclic-ring loss. Emitted through the standard counter path (identical to `agent_tx_bytes`), not any DOCA-native "dropped metrics" feature.
 - **Gauge**: Shows the value per the last event (transaction) and can grow or decrease as each event updates it. The byte events publish both a cumulative counter and a last-operation gauge: `agent_tx_bytes_total` / `agent_rx_bytes_total` carry the running total, while `agent_tx_last_bytes` / `agent_rx_last_bytes` (the `agent_<subject>_last_<unit>` convention) carry the byte size of the latest TX/RX request. The memory gauges follow the same convention -- `agent_memory_registered_last_bytes` / `agent_memory_deregistered_last_bytes` -- and report the byte size of the last (de)registration. The transfer-time events likewise publish both a cumulative `_total` counter and a last-operation gauge (`agent_xfer_time` / `agent_xfer_post_time`).
-- **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details.
+- **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details. The transfer-time events additionally publish latency-distribution histograms `agent_xfer_time_us` and `agent_xfer_post_time_us` (microseconds), exposed as the usual `_bucket{le="..."}` / `_sum` / `_count` series alongside the existing counter and gauge, at parity with the native Prometheus exporter. Bucket boundaries default to a microsecond range covering ~10us..~10s and can be overridden (see below).
+
+### Histogram buckets
+
+The default bucket boundaries for the transfer-time histograms can be overridden with a comma-separated list of strictly-increasing positive microsecond upper bounds (shared with the native Prometheus exporter):
+
+```bash
+export NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US="10,100,1000,10000,100000"
+```
+
+An absent, empty, or invalid value falls back to the built-in defaults.
 
 ### Metric labels
 

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -377,12 +377,15 @@ nixlTelemetryDocaExporter::flush() {
     // snapshotted into the export buffer via histogram_flush before the general
     // metrics flush transmits the buffer. Order matters: snapshot histograms
     // first, then flush everything (counters/gauges + histogram snapshots) out.
+    // A single histogram failure must not skip the remaining snapshots or the
+    // general flush, so aggregate the outcome and report it after both phases.
+    bool histogram_flush_failed = false;
     for (const auto histogram_id : ctx_->histogram_ids) {
         const auto histogram_result = doca_telemetry_exporter_metrics_histogram_flush(
             ctx_->source, histogram_id, DOCA_TELEMETRY_EXPORTER_HISTOGRAM_TIMESTAMP_UPDATE, false);
         if (histogram_result != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to flush DOCA histogram: " << histogram_result;
-            return NIXL_ERR_UNKNOWN;
+            histogram_flush_failed = true;
         }
     }
 
@@ -391,6 +394,6 @@ nixlTelemetryDocaExporter::flush() {
         NIXL_ERROR << "Failed to flush DOCA metrics: " << result;
         return NIXL_ERR_UNKNOWN;
     }
-    return NIXL_SUCCESS;
+    return histogram_flush_failed ? NIXL_ERR_UNKNOWN : NIXL_SUCCESS;
 #pragma GCC diagnostic pop
 }

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -17,6 +17,7 @@
 #include "doca_exporter.h"
 #include "common/configuration.h"
 #include "common/nixl_log.h"
+#include "histogram_buckets.h"
 
 #include <doca_telemetry_exporter.h>
 #include <doca_error.h>
@@ -27,6 +28,9 @@
 #include <mutex>
 #include <stdexcept>
 #include <unistd.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace {
 const uint16_t docaPrometheusExporterDefaultPort = 9091;
@@ -86,6 +90,14 @@ struct DocaSharedContext {
     doca_telemetry_exporter_label_set_id_t error_label_set_id = 0;
     bool source_started = false;
     bool metrics_context_created = false;
+
+    // Base histograms are templates created once on the shared source; observing
+    // against one with concrete label values yields a concrete histogram id. The
+    // general metrics flush does not push histograms, so track those concrete ids
+    // to flush them explicitly.
+    std::unordered_map<nixl_telemetry_event_type_t, doca_telemetry_exporter_base_histogram_id_t>
+        base_histograms;
+    std::unordered_set<doca_telemetry_exporter_histogram_id_t> histogram_ids;
 
     explicit DocaSharedContext(const std::string &bind_address);
     ~DocaSharedContext();
@@ -162,6 +174,26 @@ DocaSharedContext::DocaSharedContext(const std::string &bind_address) {
         }
 
         doca_telemetry_exporter_metrics_set_flush_interval_ms(source, 1000);
+
+        const std::vector<double> histogram_buckets = nixl::telemetry::resolveHistogramBucketsUs();
+        for (const auto event_type : telemetry_metric_event_types) {
+            const auto descriptor = nixlEnumStrings::telemetryMetricDescriptor(event_type);
+            if (descriptor.histogramName == nullptr) {
+                continue;
+            }
+            doca_telemetry_exporter_base_histogram_id_t base_id = 0;
+            result = doca_telemetry_exporter_metrics_add_base_histogram(source,
+                                                                        descriptor.histogramName,
+                                                                        histogram_buckets.data(),
+                                                                        histogram_buckets.size(),
+                                                                        label_set_id,
+                                                                        1000,
+                                                                        &base_id);
+            if (result != DOCA_SUCCESS) {
+                throw std::runtime_error("Failed to create DOCA base histogram");
+            }
+            base_histograms.emplace(event_type, base_id);
+        }
     }
     catch (...) {
         cleanup();
@@ -261,6 +293,25 @@ nixlTelemetryDocaExporter::appendGaugeSample(const nixlTelemetryEvent &event,
 #pragma GCC diagnostic pop
 }
 
+doca_error_t
+nixlTelemetryDocaExporter::appendHistogramSample(const nixlTelemetryEvent &event,
+                                                 const char *label_values[]) {
+    const auto base = ctx_->base_histograms.find(event.eventType_);
+    if (base == ctx_->base_histograms.end()) {
+        return DOCA_SUCCESS;
+    }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    doca_telemetry_exporter_histogram_id_t histogram_id = 0;
+    const doca_error_t result = doca_telemetry_exporter_metrics_base_histogram_observe(
+        ctx_->source, base->second, label_values, static_cast<double>(event.value_), &histogram_id);
+    if (result == DOCA_SUCCESS) {
+        ctx_->histogram_ids.insert(histogram_id);
+    }
+    return result;
+#pragma GCC diagnostic pop
+}
+
 nixl_status_t
 nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
@@ -288,6 +339,14 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
             }
         }
 
+        doca_error_t histogram_result = DOCA_SUCCESS;
+        if (descriptor.histogramName != nullptr) {
+            histogram_result = appendHistogramSample(event, label_values);
+            if (histogram_result != DOCA_SUCCESS) {
+                NIXL_ERROR << "Failed to observe histogram: " << histogram_result;
+            }
+        }
+
         doca_error_t counter_result = DOCA_SUCCESS;
         if (descriptor.counterName != nullptr) {
             counter_result = appendCounterSample(event, descriptor.counterName, label_values);
@@ -296,7 +355,8 @@ nixlTelemetryDocaExporter::exportEvent(const nixlTelemetryEvent &event) {
             }
         }
 
-        if (gauge_result != DOCA_SUCCESS || counter_result != DOCA_SUCCESS) {
+        if (gauge_result != DOCA_SUCCESS || counter_result != DOCA_SUCCESS ||
+            histogram_result != DOCA_SUCCESS) {
             return NIXL_ERR_UNKNOWN;
         }
         return NIXL_SUCCESS;
@@ -312,6 +372,20 @@ nixlTelemetryDocaExporter::flush() {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     const std::lock_guard lock(g_metrics_mutex);
+
+    // Observing only accumulates a histogram in the metrics-API cache; it must be
+    // snapshotted into the export buffer via histogram_flush before the general
+    // metrics flush transmits the buffer. Order matters: snapshot histograms
+    // first, then flush everything (counters/gauges + histogram snapshots) out.
+    for (const auto histogram_id : ctx_->histogram_ids) {
+        const auto histogram_result = doca_telemetry_exporter_metrics_histogram_flush(
+            ctx_->source, histogram_id, DOCA_TELEMETRY_EXPORTER_HISTOGRAM_TIMESTAMP_UPDATE, false);
+        if (histogram_result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to flush DOCA histogram: " << histogram_result;
+            return NIXL_ERR_UNKNOWN;
+        }
+    }
+
     const auto result = doca_telemetry_exporter_metrics_flush(ctx_->source);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to flush DOCA metrics: " << result;

--- a/src/plugins/telemetry/doca/doca_exporter.cpp
+++ b/src/plugins/telemetry/doca/doca_exporter.cpp
@@ -26,14 +26,24 @@
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <unistd.h>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace {
 const uint16_t docaPrometheusExporterDefaultPort = 9091;
+
+// Number of distinct telemetry event types, used to size direct-indexed arrays
+// keyed by nixl_telemetry_event_type_t.
+constexpr size_t numTelemetryEventTypes =
+    static_cast<size_t>(nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED) + 1;
+
+// Per-histogram flush interval (ms) passed to add_base_histogram; the exporter
+// also flushes explicitly at scrape time, so this only bounds staleness if an
+// explicit flush is missed.
+constexpr uint64_t histogramFlushIntervalMs = 1000;
 
 const char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
 const char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
@@ -94,9 +104,10 @@ struct DocaSharedContext {
     // Base histograms are templates created once on the shared source; observing
     // against one with concrete label values yields a concrete histogram id. The
     // general metrics flush does not push histograms, so track those concrete ids
-    // to flush them explicitly.
-    std::unordered_map<nixl_telemetry_event_type_t, doca_telemetry_exporter_base_histogram_id_t>
-        base_histograms;
+    // to flush them explicitly. Indexed directly by event type (small dense enum)
+    // to avoid a hash lookup on the observe path.
+    std::array<std::optional<doca_telemetry_exporter_base_histogram_id_t>, numTelemetryEventTypes>
+        base_histograms{};
     std::unordered_set<doca_telemetry_exporter_histogram_id_t> histogram_ids;
 
     explicit DocaSharedContext(const std::string &bind_address);
@@ -187,12 +198,12 @@ DocaSharedContext::DocaSharedContext(const std::string &bind_address) {
                                                                         histogram_buckets.data(),
                                                                         histogram_buckets.size(),
                                                                         label_set_id,
-                                                                        1000,
+                                                                        histogramFlushIntervalMs,
                                                                         &base_id);
             if (result != DOCA_SUCCESS) {
                 throw std::runtime_error("Failed to create DOCA base histogram");
             }
-            base_histograms.emplace(event_type, base_id);
+            base_histograms[static_cast<size_t>(event_type)] = base_id;
         }
     }
     catch (...) {
@@ -296,15 +307,17 @@ nixlTelemetryDocaExporter::appendGaugeSample(const nixlTelemetryEvent &event,
 doca_error_t
 nixlTelemetryDocaExporter::appendHistogramSample(const nixlTelemetryEvent &event,
                                                  const char *label_values[]) {
-    const auto base = ctx_->base_histograms.find(event.eventType_);
-    if (base == ctx_->base_histograms.end()) {
+    const auto &base = ctx_->base_histograms[static_cast<size_t>(event.eventType_)];
+    if (!base.has_value()) {
         return DOCA_SUCCESS;
     }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     doca_telemetry_exporter_histogram_id_t histogram_id = 0;
     const doca_error_t result = doca_telemetry_exporter_metrics_base_histogram_observe(
-        ctx_->source, base->second, label_values, static_cast<double>(event.value_), &histogram_id);
+        ctx_->source, *base, label_values, static_cast<double>(event.value_), &histogram_id);
+    // The same (base, label_values) pair always yields the same concrete id, so
+    // the set de-dups: flush() then flushes each concrete histogram exactly once.
     if (result == DOCA_SUCCESS) {
         ctx_->histogram_ids.insert(histogram_id);
     }

--- a/src/plugins/telemetry/doca/doca_exporter.h
+++ b/src/plugins/telemetry/doca/doca_exporter.h
@@ -62,6 +62,14 @@ private:
     appendGaugeSample(const nixlTelemetryEvent &event,
                       const char *metric_name,
                       const char *label_values[]);
+
+    // Records the per-operation value into the base histogram registered for this
+    // event's type (created once on the shared context). Tracks the concrete
+    // histogram id so flush() can push it, since the general metrics flush does
+    // not cover histograms. A no-op returning DOCA_SUCCESS when the event has no
+    // histogram.
+    [[nodiscard]] doca_error_t
+    appendHistogramSample(const nixlTelemetryEvent &event, const char *label_values[]);
 };
 
 #endif // NIXL_SRC_PLUGINS_TELEMETRY_DOCA_EXPORTER_H

--- a/src/plugins/telemetry/doca/meson.build
+++ b/src/plugins/telemetry/doca/meson.build
@@ -21,7 +21,7 @@ shared_library(
     'libtelemetry_exporter_doca',
     'doca_plugin.cpp',
     'doca_exporter.cpp',
-    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    include_directories: [nixl_inc_dirs, utils_inc_dirs, include_directories('../common')],
     dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, doca_telemetry_dep, doca_common_dep],
     install: true,
     install_dir: plugin_install_dir,

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -100,7 +100,7 @@ The default bucket boundaries for the transfer-time histograms can be overridden
 export NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US="10,100,1000,10000,100000"
 ```
 
-An absent, empty, or invalid value falls back to the built-in defaults.
+An absent or empty value uses the built-in defaults. A non-empty but invalid value (non-numeric, non-positive, or not strictly increasing) is rejected and the exporter fails to initialize, rather than silently falling back to the defaults.
 
 ### Metric labels
 

--- a/src/plugins/telemetry/prometheus/README.md
+++ b/src/plugins/telemetry/prometheus/README.md
@@ -75,8 +75,8 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 | `agent_rx_bytes` | Yes | Yes | No |
 | `agent_tx_requests_num` | Yes | No | No |
 | `agent_rx_requests_num` | Yes | No | No |
-| `agent_xfer_time` | Yes | Yes | No |
-| `agent_xfer_post_time` | Yes | Yes | No |
+| `agent_xfer_time` | Yes | Yes | Yes |
+| `agent_xfer_post_time` | Yes | Yes | Yes |
 | `agent_telemetry_events_dropped` | Yes | No | No |
 | Error event types (`agent_err_*`) | Yes | No | No |
 
@@ -86,7 +86,17 @@ export NIXL_PLUGIN_DIR="path/to/dir/with/.so/files"
 - Error events are exposed as one labeled counter: `agent_errors_total{status="..."}`. The `status` label is bounded by the fixed `AGENT_ERR_*` event set.
 - `agent_telemetry_events_dropped_total` is the cumulative count of telemetry events dropped at the producer-side staging queue (when the queue is full and an event cannot be enqueued for export). It does not count BUFFER cyclic-ring loss.
 - **Gauge**: Shows the value per the last event (transaction) and can grow or decrease as each event updates it. The byte gauges follow the `agent_<subject>_last_<unit>` convention (the `_last` qualifier precedes the unit, keeping it distinct from the cumulative `_total` counter of the same base name): `agent_tx_last_bytes` / `agent_rx_last_bytes` carry the byte size of the latest TX/RX request, while `agent_tx_bytes_total` / `agent_rx_bytes_total` carry the running total. The memory gauges follow the same convention -- `agent_memory_registered_last_bytes` / `agent_memory_deregistered_last_bytes` -- and report the byte size of the last (de)registration, distinct from the cumulative `agent_memory_registered_total` / `agent_memory_deregistered_total` counters. The transfer-time events likewise publish both a cumulative `_total` counter and a last-operation gauge (`agent_xfer_time` / `agent_xfer_post_time`).
-- **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details.
+- **Histogram**: Counts the number of observations per pre-defined bins. Please see [Prometheus histograms documentation](https://prometheus.io/docs/practices/histograms/) for more details. The transfer-time events additionally publish latency-distribution histograms `agent_xfer_time_us` and `agent_xfer_post_time_us` (microseconds), exposed as the usual `_bucket{le="..."}` / `_sum` / `_count` series alongside the existing counter and gauge. Bucket boundaries default to a microsecond range covering ~10us..~10s and can be overridden (see below).
+
+### Histogram buckets
+
+The default bucket boundaries for the transfer-time histograms can be overridden with a comma-separated list of strictly-increasing positive microsecond upper bounds:
+
+```bash
+export NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US="10,100,1000,10000,100000"
+```
+
+An absent, empty, or invalid value falls back to the built-in defaults.
 
 ### Metric labels
 

--- a/src/plugins/telemetry/prometheus/meson.build
+++ b/src/plugins/telemetry/prometheus/meson.build
@@ -47,7 +47,7 @@ if prometheus_found
         'libtelemetry_exporter_prometheus',
         'prometheus_plugin.cpp',
         'prometheus_exporter.cpp',
-        include_directories: [nixl_inc_dirs, utils_inc_dirs],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, include_directories('../common')],
         dependencies: [nixl_infra, nixl_common_dep, absl_log_dep, prometheus_core_dep, prometheus_pull_dep],
         install: true,
         install_dir: plugin_install_dir,

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -17,6 +17,7 @@
 #include "prometheus_exporter.h"
 #include "common/configuration.h"
 #include "common/nixl_log.h"
+#include "histogram_buckets.h"
 
 #include <fstream>
 #include <iostream>
@@ -99,6 +100,7 @@ nixlTelemetryPrometheusExporter::nixlTelemetryPrometheusExporter(
     catch (...) {
         counters_.clear();
         gauges_.clear();
+        histograms_.clear();
         s_agent_names.erase(agent_name_);
         throw;
     }
@@ -108,6 +110,7 @@ nixlTelemetryPrometheusExporter::~nixlTelemetryPrometheusExporter() {
     const std::lock_guard lock(s_mutex);
     counters_.clear();
     gauges_.clear();
+    histograms_.clear();
     s_agent_names.erase(agent_name_);
     exposer_.reset();
     registry_.reset();
@@ -117,6 +120,7 @@ nixlTelemetryPrometheusExporter::~nixlTelemetryPrometheusExporter() {
 // Events are defined in the telemetry.cpp file
 void
 nixlTelemetryPrometheusExporter::initializeMetrics() {
+    const std::vector<double> histogram_buckets = nixl::telemetry::resolveHistogramBucketsUs();
     for (const auto event_type : telemetry_metric_event_types) {
         const auto descriptor = nixlEnumStrings::telemetryMetricDescriptor(event_type);
         if (descriptor.counterName != nullptr) {
@@ -124,6 +128,10 @@ nixlTelemetryPrometheusExporter::initializeMetrics() {
         }
         if (descriptor.gaugeName != nullptr) {
             registerGauge(event_type, descriptor.gaugeName, descriptor.gaugeHelp);
+        }
+        if (descriptor.histogramName != nullptr) {
+            registerHistogram(
+                event_type, descriptor.histogramName, descriptor.histogramHelp, histogram_buckets);
         }
     }
     registerErrorCounters();
@@ -174,6 +182,21 @@ nixlTelemetryPrometheusExporter::registerGauge(const nixl_telemetry_event_type_t
     NIXL_ASSERT(inserted);
 }
 
+void
+nixlTelemetryPrometheusExporter::registerHistogram(const nixl_telemetry_event_type_t event_type,
+                                                   const std::string &metric_name,
+                                                   const std::string &help,
+                                                   const std::vector<double> &buckets) {
+    auto &family = prometheus::BuildHistogram().Name(metric_name).Help(help).Register(*registry_);
+    auto &metric = family.Add({{"hostname", hostname_}, {"agent_name", agent_name_}},
+                              prometheus::Histogram::BucketBoundaries(buckets));
+    const auto inserted = histograms_.try_emplace(event_type, &family, &metric).second;
+    if (!inserted) {
+        family.Remove(&metric);
+    }
+    NIXL_ASSERT(inserted);
+}
+
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
@@ -185,6 +208,11 @@ nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
         const auto gauge = gauges_.find(event.eventType_);
         if (gauge != gauges_.end()) {
             gauge->second.metric->Set(static_cast<double>(event.value_));
+        }
+
+        const auto histogram = histograms_.find(event.eventType_);
+        if (histogram != histograms_.end()) {
+            histogram->second.metric->Observe(static_cast<double>(event.value_));
         }
 
         return NIXL_SUCCESS;

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.cpp
@@ -214,19 +214,19 @@ nixlTelemetryPrometheusExporter::registerHistogram(const nixl_telemetry_event_ty
 nixl_status_t
 nixlTelemetryPrometheusExporter::exportEvent(const nixlTelemetryEvent &event) {
     try {
-        const auto counter = counters_.find(event.eventType_);
-        if (counter != counters_.end()) {
-            counter->second.metric->Increment(event.value_);
+        const auto counter_it = counters_.find(event.eventType_);
+        if (counter_it != counters_.end()) {
+            counter_it->second.metric->Increment(event.value_);
         }
 
-        const auto gauge = gauges_.find(event.eventType_);
-        if (gauge != gauges_.end()) {
-            gauge->second.metric->Set(static_cast<double>(event.value_));
+        const auto gauge_it = gauges_.find(event.eventType_);
+        if (gauge_it != gauges_.end()) {
+            gauge_it->second.metric->Set(static_cast<double>(event.value_));
         }
 
-        const auto histogram = histograms_.find(event.eventType_);
-        if (histogram != histograms_.end()) {
-            histogram->second.metric->Observe(static_cast<double>(event.value_));
+        const auto histogram_it = histograms_.find(event.eventType_);
+        if (histogram_it != histograms_.end()) {
+            histogram_it->second.metric->Observe(static_cast<double>(event.value_));
         }
 
         return NIXL_SUCCESS;

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.h
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.h
@@ -21,6 +21,7 @@
 #include "telemetry_event.h"
 #include "nixl_types.h"
 
+#include <cassert>
 #include <string>
 #include <memory>
 #include <unordered_map>
@@ -66,8 +67,9 @@ private:
         CounterEntry &
         operator=(CounterEntry &&) = delete;
 
-        ~CounterEntry() {
-            if (family && metric) family->Remove(metric);
+        ~CounterEntry() noexcept {
+            assert(family && metric);
+            family->Remove(metric);
         }
 
         prometheus::Family<prometheus::Counter> *family = nullptr;
@@ -86,8 +88,9 @@ private:
         GaugeEntry &
         operator=(GaugeEntry &&) = delete;
 
-        ~GaugeEntry() {
-            if (family && metric) family->Remove(metric);
+        ~GaugeEntry() noexcept {
+            assert(family && metric);
+            family->Remove(metric);
         }
 
         prometheus::Family<prometheus::Gauge> *family = nullptr;
@@ -107,10 +110,9 @@ private:
         HistogramEntry &
         operator=(HistogramEntry &&) = delete;
 
-        ~HistogramEntry() {
-            if (family && metric) {
-                family->Remove(metric);
-            }
+        ~HistogramEntry() noexcept {
+            assert(family && metric);
+            family->Remove(metric);
         }
 
         prometheus::Family<prometheus::Histogram> *family = nullptr;

--- a/src/plugins/telemetry/prometheus/prometheus_exporter.h
+++ b/src/plugins/telemetry/prometheus/prometheus_exporter.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 #include <prometheus/registry.h>
 #include <prometheus/exposer.h>
@@ -93,6 +94,29 @@ private:
         prometheus::Gauge *metric = nullptr;
     };
 
+    struct HistogramEntry {
+        HistogramEntry(prometheus::Family<prometheus::Histogram> *family,
+                       prometheus::Histogram *metric)
+            : family(family),
+              metric(metric) {}
+
+        HistogramEntry(const HistogramEntry &) = delete;
+        HistogramEntry &
+        operator=(const HistogramEntry &) = delete;
+        HistogramEntry(HistogramEntry &&) = delete;
+        HistogramEntry &
+        operator=(HistogramEntry &&) = delete;
+
+        ~HistogramEntry() {
+            if (family && metric) {
+                family->Remove(metric);
+            }
+        }
+
+        prometheus::Family<prometheus::Histogram> *family = nullptr;
+        prometheus::Histogram *metric = nullptr;
+    };
+
     const std::string agent_name_;
     const std::string hostname_;
     std::shared_ptr<prometheus::Exposer> exposer_;
@@ -100,6 +124,7 @@ private:
 
     std::unordered_map<nixl_telemetry_event_type_t, CounterEntry> counters_;
     std::unordered_map<nixl_telemetry_event_type_t, GaugeEntry> gauges_;
+    std::unordered_map<nixl_telemetry_event_type_t, HistogramEntry> histograms_;
 
     void
     initializeMetrics();
@@ -120,6 +145,12 @@ private:
     registerGauge(nixl_telemetry_event_type_t event_type,
                   const std::string &metric_name,
                   const std::string &help);
+
+    void
+    registerHistogram(nixl_telemetry_event_type_t event_type,
+                      const std::string &metric_name,
+                      const std::string &help,
+                      const std::vector<double> &buckets);
 };
 
 #endif // NIXL_SRC_PLUGINS_TELEMETRY_PROMETHEUS_EXPORTER_H

--- a/test/doca-telemetry/histogram_parity.h
+++ b/test/doca-telemetry/histogram_parity.h
@@ -1,0 +1,109 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_DOCA_TELEMETRY_HISTOGRAM_PARITY_H
+#define NIXL_TEST_DOCA_TELEMETRY_HISTOGRAM_PARITY_H
+
+#include "timeseries.h"
+
+#include <cstdlib>
+#include <iomanip>
+#include <set>
+#include <sstream>
+#include <string>
+
+namespace nixl::telemetry_test {
+
+using seriesLines = std::set<std::string>;
+
+// Reduce a label value to a canonical form so two exporters that render the same
+// number differently compare equal. prometheus-cpp writes histogram boundaries as
+// "1000000" while DOCA/CollectX writes "1e+06"; both are the same double. A value
+// that is not fully numeric (agent_name, hostname, status, ...) is returned
+// unchanged.
+[[nodiscard]] inline std::string
+canonicalLabelValue(const std::string &raw) {
+    char *end = nullptr;
+    const double value = std::strtod(raw.c_str(), &end);
+    if (raw.empty() || end != raw.c_str() + raw.size()) {
+        return raw;
+    }
+    std::ostringstream out;
+    out << std::setprecision(17) << value;
+    return out.str();
+}
+
+// Every histogram series emitted for `agent_name`, rendered as a canonical
+// "name{sorted labels} value" line: numeric label values canonicalized (so
+// "1e+06" and "1000000" match) and timestamps dropped (values only). Returned as
+// a set of strings so two exporters' payloads compare with a plain EXPECT_EQ that
+// gtest can print -- the same technique the descriptor-series parity tests use. A
+// histogram <base> is exactly the series <base>_bucket / <base>_sum /
+// <base>_count, so the families are discovered by their _bucket component and no
+// metric name is hard-coded.
+[[nodiscard]] inline seriesLines
+histogramSeriesLines(const nixl::doca_test::timeSeries &metrics, const std::string &agent_name) {
+    const auto endsWith = [](const std::string &name, const std::string &suffix) {
+        return name.size() > suffix.size() &&
+            name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+
+    std::set<std::string> bases;
+    for (const auto &[id, samples] : metrics.series()) {
+        (void)samples;
+        if (endsWith(id.name, "_bucket")) {
+            bases.insert(id.name.substr(0, id.name.size() - std::string("_bucket").size()));
+        }
+    }
+
+    seriesLines lines;
+    for (const auto &[id, samples] : metrics.series()) {
+        const auto agent_it = id.labels.find("agent_name");
+        if (agent_it == id.labels.end() || agent_it->second != agent_name || samples.empty()) {
+            continue;
+        }
+
+        bool is_histogram = false;
+        for (const std::string suffix : {"_bucket", "_sum", "_count"}) {
+            if (endsWith(id.name, suffix) &&
+                bases.count(id.name.substr(0, id.name.size() - suffix.size())) != 0) {
+                is_histogram = true;
+                break;
+            }
+        }
+        if (!is_histogram) {
+            continue;
+        }
+
+        std::ostringstream line;
+        line << id.name << '{';
+        bool first = true;
+        for (const auto &[label, value] : id.labels) {
+            if (!first) {
+                line << ',';
+            }
+            line << label << "=\"" << canonicalLabelValue(value) << '"';
+            first = false;
+        }
+        line << "} " << samples.back().value;
+        lines.insert(line.str());
+    }
+    return lines;
+}
+
+} // namespace nixl::telemetry_test
+
+#endif // NIXL_TEST_DOCA_TELEMETRY_HISTOGRAM_PARITY_H

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -55,6 +55,7 @@ if build_doca_tests
             nixl_inc_dirs,
             utils_inc_dirs,
             include_directories(doca_exporter_dir),
+            include_directories('../../src/plugins/telemetry/common'),
         ],
         dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep],
         cpp_args: ['-Wno-deprecated-declarations'],
@@ -63,4 +64,53 @@ if build_doca_tests
 
     test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false)
     message('Building standalone DOCA telemetry exporter tests')
+
+    cmake = import('cmake')
+    cmake_opts = cmake.subproject_options()
+    cmake_opts.add_cmake_defines({
+        'ENABLE_PULL': 'ON',
+        'ENABLE_PUSH': 'OFF',
+        'ENABLE_COMPRESSION': 'OFF',
+        'ENABLE_TESTING': 'OFF',
+        'USE_THIRDPARTY_LIBRARIES': 'ON',
+        'BUILD_SHARED_LIBS': 'ON',
+        'CMAKE_POSITION_INDEPENDENT_CODE': 'ON',
+        'CMAKE_LINK_DEPENDS_USE_LINKER': 'OFF',
+        'CMAKE_C_FLAGS': '-Wno-unused-but-set-variable',
+        'CMAKE_CXX_FLAGS': '-Wno-unused-but-set-variable'
+    })
+    prometheus_sub = cmake.subproject('prometheus-cpp', required: false, options: cmake_opts)
+    if prometheus_sub.found()
+        prometheus_core_dep = prometheus_sub.dependency('core')
+        prometheus_pull_dep = prometheus_sub.dependency('pull')
+        prometheus_exporter_dir = '../../src/plugins/telemetry/prometheus'
+        histogram_parity_test_exe = executable('histogram_parity_test',
+            sources: [
+                'telemetry_histogram_parity_test.cpp',
+                doca_exporter_dir / 'doca_exporter.cpp',
+                prometheus_exporter_dir / 'prometheus_exporter.cpp',
+            ],
+            include_directories: [
+                nixl_inc_dirs,
+                utils_inc_dirs,
+                include_directories(doca_exporter_dir),
+                include_directories(prometheus_exporter_dir),
+                include_directories('../../src/plugins/telemetry/common'),
+            ],
+            dependencies: [
+                gtest_dep,
+                doca_telemetry_dep,
+                doca_common_dep,
+                nixl_infra,
+                nixl_common_dep,
+                absl_log_dep,
+                prometheus_core_dep,
+                prometheus_pull_dep,
+            ],
+            cpp_args: ['-Wno-deprecated-declarations'],
+            install: true,
+        )
+        test('histogram_parity_test', histogram_parity_test_exe, is_parallel: false)
+        message('Building Prometheus/DOCA histogram parity test')
+    endif
 endif

--- a/test/doca-telemetry/telemetry_doca_nixl_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_nixl_test.cpp
@@ -23,6 +23,7 @@
 #include <array>
 #include <cstdint>
 #include <cstdlib>
+#include <map>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -263,6 +264,12 @@ TEST_F(docaNixlExporterTest, ScrapeEmitsExactlyTheDescriptorSeries) {
         if (descriptor.gaugeName != nullptr) {
             expected.insert(descriptor.gaugeName);
         }
+        if (descriptor.histogramName != nullptr) {
+            const std::string base = descriptor.histogramName;
+            expected.insert(base + "_bucket");
+            expected.insert(base + "_sum");
+            expected.insert(base + "_count");
+        }
         ASSERT_EQ(exporter.exportEvent(nixlTelemetryEvent(eventType, 7)), NIXL_SUCCESS);
     }
     expected.insert("agent_errors_total");
@@ -270,10 +277,11 @@ TEST_F(docaNixlExporterTest, ScrapeEmitsExactlyTheDescriptorSeries) {
               NIXL_SUCCESS);
     ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
 
-    const nixl::doca_test::labelSet errorLabels{{"agent_name", agentName},
-                                                {"status", "invalid_param"}};
-    const auto metrics =
-        scrapeUntilValue(port_, "agent_errors_total", 1.0, std::chrono::seconds(12), errorLabels);
+    // Anchor on a histogram series (flushed with everything else in one metrics
+    // flush): once it is served, every other descriptor series is present too.
+    const nixl::doca_test::labelSet histogramLabels{{"agent_name", agentName}};
+    const auto metrics = scrapeUntilValue(
+        port_, "agent_xfer_time_us_count", 1.0, std::chrono::seconds(12), histogramLabels);
 
     std::set<std::string> actual;
     for (const auto &[id, samples] : metrics.series()) {
@@ -319,6 +327,65 @@ TEST_F(docaNixlExporterTest, DroppedEventsCounterAccumulates) {
         << metric << "{agent_name=" << agentName << "} not served at the endpoint after flush";
     EXPECT_EQ(*observed, static_cast<double>(expected_total))
         << "dropped-events counter must equal the sum of all emitted deltas (7+4+13)";
+}
+
+// AGENT_XFER_TIME events drive the agent_xfer_time_us DOCA histogram. After
+// flush (which snapshots the cached histogram into the export buffer before the
+// general metrics flush transmits it), the endpoint must serve _count = number
+// of observations, _sum = their total, and cumulative _bucket{le} counts. Values
+// land in distinct default buckets so the per-bucket counts are unambiguous.
+TEST_F(docaNixlExporterTest, XferTimeHistogramRecordsObservations) {
+    constexpr char agentName[] = "nixl_doca_histogram_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+
+    constexpr std::array<uint64_t, 4> values{5, 30, 200, 700}; // sum 935
+    for (const uint64_t v : values) {
+        ASSERT_EQ(exporter.exportEvent(
+                      nixlTelemetryEvent(nixl_telemetry_event_type_t::AGENT_XFER_TIME, v)),
+                  NIXL_SUCCESS);
+    }
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const auto metrics =
+        scrapeUntilValue(port_, "agent_xfer_time_us_count", 4.0, std::chrono::seconds(12), labels);
+
+    EXPECT_EQ(metrics.latestValue("agent_xfer_time_us_count", labels), std::optional<double>(4.0))
+        << "histogram _count must equal the number of observations";
+    EXPECT_EQ(metrics.latestValue("agent_xfer_time_us_sum", labels), std::optional<double>(935.0))
+        << "histogram _sum must equal the sum of observations";
+
+    // Build le(double) -> cumulative count from the bucket series for this agent
+    // so the assertions do not depend on the exact `le` string formatting.
+    std::map<double, double> buckets;
+    for (const auto &[id, samples] : metrics.series()) {
+        if (id.name != "agent_xfer_time_us_bucket") {
+            continue;
+        }
+        const auto agent = id.labels.find("agent_name");
+        const auto le = id.labels.find("le");
+        if (agent == id.labels.end() || agent->second != agentName || le == id.labels.end() ||
+            samples.empty()) {
+            continue;
+        }
+        try {
+            size_t pos = 0;
+            const double boundary = std::stod(le->second, &pos);
+            if (pos == le->second.size()) {
+                buckets[boundary] = samples.back().value;
+            }
+        }
+        catch (const std::exception &) {
+        }
+    }
+
+    // 5<=10 (1); +30<=100 (2); +200<=250 (3); +700<=1000 (4).
+    EXPECT_EQ(buckets[10.0], 1.0);
+    EXPECT_EQ(buckets[100.0], 2.0);
+    EXPECT_EQ(buckets[250.0], 3.0);
+    EXPECT_EQ(buckets[1000.0], 4.0);
 }
 
 int

--- a/test/doca-telemetry/telemetry_histogram_parity_test.cpp
+++ b/test/doca-telemetry/telemetry_histogram_parity_test.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "histogram_parity.h"
+#include "scrape_util.h"
+
+#include "doca_exporter.h"
+#include "prometheus_exporter.h"
+#include "telemetry_event.h"
+
+#include <array>
+#include <cstdlib>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using nixl::doca_test::loopbackConnection;
+using nixl::doca_test::scrapeUntilValue;
+using nixl::telemetry_test::histogramSeriesLines;
+
+namespace {
+
+constexpr char prometheusPortVar[] = "NIXL_TELEMETRY_PROMETHEUS_PORT";
+constexpr char prometheusLocalVar[] = "NIXL_TELEMETRY_PROMETHEUS_LOCAL";
+constexpr char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
+constexpr char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
+
+} // namespace
+
+class histogramExporterParityTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        prometheus_port_ = loopbackConnection::findFreePort();
+        doca_port_ = loopbackConnection::findFreePort();
+        ASSERT_NE(prometheus_port_, 0);
+        ASSERT_NE(doca_port_, 0);
+        ASSERT_NE(prometheus_port_, doca_port_);
+
+        ASSERT_EQ(::setenv(prometheusLocalVar, "y", 1), 0);
+        ASSERT_EQ(::setenv(prometheusPortVar, std::to_string(prometheus_port_).c_str(), 1), 0);
+        ASSERT_EQ(::setenv(docaPrometheusLocalVar, "y", 1), 0);
+        ASSERT_EQ(::setenv(docaPrometheusPortVar, std::to_string(doca_port_).c_str(), 1), 0);
+    }
+
+    void
+    TearDown() override {
+        ::unsetenv(prometheusLocalVar);
+        ::unsetenv(prometheusPortVar);
+        ::unsetenv(docaPrometheusLocalVar);
+        ::unsetenv(docaPrometheusPortVar);
+    }
+
+    uint16_t prometheus_port_ = 0;
+    uint16_t doca_port_ = 0;
+};
+
+TEST_F(histogramExporterParityTest, XferDurationHistogramPayloadMatchesAcrossExporters) {
+    constexpr char agentName[] = "histogram_parity_agent";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+
+    nixlTelemetryPrometheusExporter prometheus_exporter(params);
+    nixlTelemetryDocaExporter doca_exporter(params);
+
+    constexpr std::array<uint64_t, 4> xfer_time_values{5, 30, 200, 700};
+    for (const uint64_t value : xfer_time_values) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_XFER_TIME, value);
+        ASSERT_EQ(prometheus_exporter.exportEvent(event), NIXL_SUCCESS);
+        ASSERT_EQ(doca_exporter.exportEvent(event), NIXL_SUCCESS);
+    }
+
+    constexpr std::array<uint64_t, 4> xfer_post_time_values{2, 15, 80, 300};
+    for (const uint64_t value : xfer_post_time_values) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_XFER_POST_TIME, value);
+        ASSERT_EQ(prometheus_exporter.exportEvent(event), NIXL_SUCCESS);
+        ASSERT_EQ(doca_exporter.exportEvent(event), NIXL_SUCCESS);
+    }
+
+    ASSERT_EQ(doca_exporter.flush(), NIXL_SUCCESS);
+
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+    const auto doca_metrics = scrapeUntilValue(
+        doca_port_, "agent_xfer_time_us_count", 4.0, std::chrono::seconds(12), labels);
+    ASSERT_EQ(doca_metrics.latestValue("agent_xfer_time_us_count", labels),
+              std::optional<double>(4.0));
+
+    const std::string prometheus_body = loopbackConnection::httpGet(prometheus_port_, "/metrics");
+    ASSERT_FALSE(prometheus_body.empty()) << "empty Prometheus /metrics body";
+
+    const auto prometheus_metrics =
+        nixl::doca_test::timeSeries(nixl::doca_test::open_metrics_text::parse(prometheus_body));
+    const auto prometheus_histograms = histogramSeriesLines(prometheus_metrics, agentName);
+    const auto doca_histograms = histogramSeriesLines(doca_metrics, agentName);
+
+    ASSERT_FALSE(doca_histograms.empty())
+        << "DOCA exporter published no histogram series; the parity check would be vacuous";
+
+    EXPECT_EQ(prometheus_histograms, doca_histograms);
+}
+
+int
+main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -112,7 +112,7 @@ endif
 
 test_exe = executable('gtest',
     sources : gtest_sources,
-    include_directories: [nixl_inc_dirs, utils_inc_dirs, device_api_inc, include_directories('../doca-telemetry')],
+    include_directories: [nixl_inc_dirs, utils_inc_dirs, device_api_inc, include_directories('../doca-telemetry'), include_directories('../../src/plugins/telemetry/common')],
     cpp_args : cpp_flags,
     dependencies : [nixl_dep, nixl_common_dep, cuda_dependencies, device_api_dep, gtest_dep, gmock_dep, absl_strings_dep, absl_time_dep, ucx_hw_warning_dep, file_utils_interface],
     link_with: [nixl_build_lib],

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -89,6 +89,7 @@ gtest_sources = [
     'query_mem.cpp',
     'telemetry_test.cpp',
     'telemetry_prometheus_test.cpp',
+    'telemetry_histogram_test.cpp',
     'telemetry_benchmark.cpp',
     'nixl_duration_test.cpp',
     'configuration.cpp'

--- a/test/gtest/prometheus_telemetry_fixture.h
+++ b/test/gtest/prometheus_telemetry_fixture.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_TEST_GTEST_PROMETHEUS_TELEMETRY_FIXTURE_H
+#define NIXL_TEST_GTEST_PROMETHEUS_TELEMETRY_FIXTURE_H
+
+#include "common.h"
+#include "plugin_manager.h"
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+
+// Shared fixture for the native Prometheus telemetry exporter tests, which live
+// in both telemetry_prometheus_test.cpp and telemetry_histogram_test.cpp. Because
+// both files drive this single fixture class, gtest groups them into one test
+// suite and runs SetUpTestSuite exactly once, so the plugin directory is
+// registered a single time for the whole process (registering it per-test, or
+// twice from two suites, trips the plugin manager's "already registered" warning
+// which the gtest main treats as a failure).
+class prometheusTelemetryTest : public ::testing::Test {
+protected:
+    static void
+    SetUpTestSuite() {
+        nixlPluginManager::getInstance().addPluginDirectory(std::string(BUILD_DIR) +
+                                                            "/src/plugins/telemetry/prometheus");
+    }
+
+    void
+    SetUp() override {
+        port_ = gtest::PortAllocator::next_tcp_port();
+        env_.addVar("NIXL_TELEMETRY_PROMETHEUS_LOCAL", "y");
+        env_.addVar("NIXL_TELEMETRY_PROMETHEUS_PORT", std::to_string(port_));
+    }
+
+    void
+    TearDown() override {
+        env_.popVar();
+        env_.popVar();
+    }
+
+    gtest::ScopedEnv env_;
+    uint16_t port_ = 0;
+};
+
+#endif // NIXL_TEST_GTEST_PROMETHEUS_TELEMETRY_FIXTURE_H

--- a/test/gtest/telemetry_histogram_test.cpp
+++ b/test/gtest/telemetry_histogram_test.cpp
@@ -1,0 +1,214 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "prometheus_telemetry_fixture.h"
+
+#include "plugin_manager.h"
+#include "telemetry/telemetry_exporter.h"
+#include "telemetry_event.h"
+
+#include "histogram_buckets.h"
+#include "loopback_connection.h"
+#include "open_metrics_text_parser.h"
+#include "timeseries.h"
+
+#include <array>
+#include <chrono>
+#include <limits>
+#include <optional>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using nixl::doca_test::loopbackConnection;
+using nixl::doca_test::timeSeries;
+
+// Poll /metrics until it serves a non-empty body (the exposer may not be ready
+// the instant the exporter is constructed), then parse it into the time-series
+// model shared with the doca-telemetry tests.
+timeSeries
+scrapeMetrics(uint16_t port) {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    do {
+        const std::string body = loopbackConnection::httpGet(port, "/metrics");
+        if (!body.empty()) {
+            return timeSeries(nixl::doca_test::open_metrics_text::parse(body));
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return timeSeries(nixl::doca_test::seriesMap{});
+}
+
+// Cumulative count at the exact `le` boundary of this agent's bucket series.
+// Parses `le` as a double so the check does not depend on boundary formatting.
+std::optional<double>
+bucketCount(const timeSeries &metrics,
+            const std::string &bucket_metric,
+            const std::string &agent_name,
+            double le) {
+    for (const auto &[id, samples] : metrics.series()) {
+        if (id.name != bucket_metric || samples.empty()) {
+            continue;
+        }
+        const auto agent = id.labels.find("agent_name");
+        const auto le_it = id.labels.find("le");
+        if (agent == id.labels.end() || agent->second != agent_name || le_it == id.labels.end()) {
+            continue;
+        }
+        try {
+            size_t pos = 0;
+            if (std::stod(le_it->second, &pos) == le && pos == le_it->second.size()) {
+                return samples.back().value;
+            }
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return std::nullopt;
+}
+
+// The full set of `le` boundaries emitted for this agent's bucket series
+// ("+Inf" becomes +infinity).
+std::set<double>
+bucketBoundaries(const timeSeries &metrics,
+                 const std::string &bucket_metric,
+                 const std::string &agent_name) {
+    std::set<double> boundaries;
+    for (const auto &[id, samples] : metrics.series()) {
+        (void)samples;
+        if (id.name != bucket_metric) {
+            continue;
+        }
+        const auto agent = id.labels.find("agent_name");
+        const auto le_it = id.labels.find("le");
+        if (agent == id.labels.end() || agent->second != agent_name || le_it == id.labels.end()) {
+            continue;
+        }
+        if (le_it->second == "+Inf") {
+            boundaries.insert(std::numeric_limits<double>::infinity());
+            continue;
+        }
+        try {
+            size_t pos = 0;
+            const double le = std::stod(le_it->second, &pos);
+            if (pos == le_it->second.size()) {
+                boundaries.insert(le);
+            }
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return boundaries;
+}
+
+} // namespace
+
+// AGENT_XFER_TIME events drive the agent_xfer_time_us histogram: _count is the
+// number of observations, _sum is their total, and each cumulative _bucket{le}
+// counts the observations at or below that boundary. Values land in distinct
+// default buckets so the per-bucket counts are unambiguous.
+TEST_F(prometheusTelemetryTest, XferTimeHistogramRecordsObservations) {
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const std::string agent_name = "prometheus_histogram_agent";
+    const nixlTelemetryExporterInitParams params{agent_name, 4096};
+    auto exporter = handle->createExporter(params);
+    ASSERT_NE(exporter, nullptr);
+
+    constexpr std::array<uint64_t, 4> values{5, 30, 200, 700}; // sum 935
+    for (const uint64_t v : values) {
+        EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_XFER_TIME, v}),
+                  NIXL_SUCCESS);
+    }
+
+    const auto metrics = scrapeMetrics(port_);
+    const nixl::doca_test::labelSet labels{{"agent_name", agent_name}};
+
+    EXPECT_EQ(metrics.latestValue("agent_xfer_time_us_count", labels), std::optional<double>(4.0))
+        << "histogram _count must equal the number of observations";
+    EXPECT_EQ(metrics.latestValue("agent_xfer_time_us_sum", labels), std::optional<double>(935.0))
+        << "histogram _sum must equal the sum of observations";
+
+    // Cumulative counts at representative default boundaries: 5<=10 (1); +30<=100
+    // (2); +200<=250 (3); +700<=1000 (4).
+    EXPECT_EQ(bucketCount(metrics, "agent_xfer_time_us_bucket", agent_name, 10.0),
+              std::optional<double>(1.0));
+    EXPECT_EQ(bucketCount(metrics, "agent_xfer_time_us_bucket", agent_name, 100.0),
+              std::optional<double>(2.0));
+    EXPECT_EQ(bucketCount(metrics, "agent_xfer_time_us_bucket", agent_name, 250.0),
+              std::optional<double>(3.0));
+    EXPECT_EQ(bucketCount(metrics, "agent_xfer_time_us_bucket", agent_name, 1000.0),
+              std::optional<double>(4.0));
+}
+
+// NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US replaces the default boundaries for the xfer
+// histograms. prometheus-cpp always appends the implicit +Inf bucket, so the
+// emitted boundary set is the configured list plus +Inf.
+TEST_F(prometheusTelemetryTest, HistogramBucketsEnvOverride) {
+    gtest::ScopedEnv bucket_env;
+    bucket_env.addVar(nixl::telemetry::histogramBucketsUsVar, "100,200,300");
+
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const std::string agent_name = "prometheus_histogram_env_agent";
+    const nixlTelemetryExporterInitParams params{agent_name, 4096};
+    auto exporter = handle->createExporter(params);
+    ASSERT_NE(exporter, nullptr);
+
+    const auto metrics = scrapeMetrics(port_);
+    const std::set<double> expected{100.0, 200.0, 300.0, std::numeric_limits<double>::infinity()};
+    EXPECT_EQ(bucketBoundaries(metrics, "agent_xfer_time_us_bucket", agent_name), expected)
+        << "histogram buckets must reflect NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US plus +Inf";
+}
+
+TEST(histogramBucketsTest, ValidListIsParsedInOrder) {
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "1, 2.5, 10, 100");
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              (std::vector<double>{1.0, 2.5, 10.0, 100.0}));
+}
+
+TEST(histogramBucketsTest, NonNumericThrows) {
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,not_a_number,30");
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
+}
+
+TEST(histogramBucketsTest, UnsortedThrows) {
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,5,20");
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
+}
+
+TEST(histogramBucketsTest, NonPositiveThrows) {
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "0,10,20");
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
+}
+
+TEST(histogramBucketsTest, AbsentUsesDefaults) {
+    ::unsetenv(nixl::telemetry::histogramBucketsUsVar);
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              nixl::telemetry::defaultHistogramBucketsUs());
+}

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -21,7 +21,11 @@
 #include "telemetry/telemetry_exporter.h"
 #include "telemetry_event.h"
 
+#include "histogram_buckets.h"
 #include "open_metrics_text_parser.h"
+
+#include <limits>
+#include <optional>
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
@@ -190,6 +194,78 @@ findMetricSample(const std::string &body,
         }
     }
     return false;
+}
+
+// Cumulative count of a histogram bucket whose `le` label parses to exactly
+// `le`, for this agent. Parses `le` as a double so the assertion does not depend
+// on how prometheus-cpp formats the boundary (e.g. "10" vs "10.0").
+std::optional<double>
+histogramBucketValue(const std::string &body,
+                     const std::string &bucket_metric,
+                     const std::string &agent_name,
+                     double le) {
+    std::istringstream body_lines(body);
+    std::string line;
+    while (std::getline(body_lines, line)) {
+        if (line.rfind(bucket_metric + "{", 0) != 0) {
+            continue;
+        }
+        std::unordered_map<std::string, std::string> labels;
+        double value = 0;
+        if (!parsePrometheusSampleLine(line, bucket_metric, labels, value)) {
+            continue;
+        }
+        const auto agent_it = labels.find("agent_name");
+        const auto le_it = labels.find("le");
+        if (agent_it == labels.end() || agent_it->second != agent_name || le_it == labels.end()) {
+            continue;
+        }
+        try {
+            size_t pos = 0;
+            if (std::stod(le_it->second, &pos) == le && pos == le_it->second.size()) {
+                return value;
+            }
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return std::nullopt;
+}
+
+// The full set of `le` boundaries emitted for a histogram bucket series of this
+// agent (parsed as doubles; "+Inf" becomes +infinity).
+std::set<double>
+histogramBucketBoundaries(const std::string &body,
+                          const std::string &bucket_metric,
+                          const std::string &agent_name) {
+    std::set<double> boundaries;
+    std::istringstream body_lines(body);
+    std::string line;
+    while (std::getline(body_lines, line)) {
+        if (line.rfind(bucket_metric + "{", 0) != 0) {
+            continue;
+        }
+        std::unordered_map<std::string, std::string> labels;
+        double value = 0;
+        if (!parsePrometheusSampleLine(line, bucket_metric, labels, value)) {
+            continue;
+        }
+        const auto agent_it = labels.find("agent_name");
+        const auto le_it = labels.find("le");
+        if (agent_it == labels.end() || agent_it->second != agent_name || le_it == labels.end()) {
+            continue;
+        }
+        try {
+            size_t pos = 0;
+            const double le = std::stod(le_it->second, &pos);
+            if (pos == le_it->second.size()) {
+                boundaries.insert(le);
+            }
+        }
+        catch (const std::exception &) {
+        }
+    }
+    return boundaries;
 }
 
 bool
@@ -411,6 +487,12 @@ TEST_F(prometheusTelemetryTest, ScrapeEmitsExactlyTheDescriptorSeries) {
         if (descriptor.gaugeName != nullptr) {
             expected.insert(descriptor.gaugeName);
         }
+        if (descriptor.histogramName != nullptr) {
+            const std::string base = descriptor.histogramName;
+            expected.insert(base + "_bucket");
+            expected.insert(base + "_sum");
+            expected.insert(base + "_count");
+        }
     }
     expected.insert("agent_errors_total");
 
@@ -427,6 +509,112 @@ TEST_F(prometheusTelemetryTest, ScrapeEmitsExactlyTheDescriptorSeries) {
 
     EXPECT_EQ(actual, expected)
         << "native Prometheus scrape must emit exactly the shared-descriptor series set";
+}
+
+// AGENT_XFER_TIME events drive the agent_xfer_time_us histogram: _count is the
+// number of observations, _sum is their total, and each cumulative _bucket{le}
+// counts the observations at or below that boundary. Values are chosen to land in
+// distinct default buckets so the per-bucket counts are unambiguous.
+TEST_F(prometheusTelemetryTest, XferTimeHistogramRecordsObservations) {
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const std::string agent_name = "prometheus_histogram_agent";
+    const nixlTelemetryExporterInitParams params{agent_name, 4096};
+    auto exporter = handle->createExporter(params);
+    ASSERT_NE(exporter, nullptr);
+
+    constexpr std::array<uint64_t, 4> values{5, 30, 200, 700}; // sum 935
+    for (const uint64_t v : values) {
+        EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_XFER_TIME, v}),
+                  NIXL_SUCCESS);
+    }
+
+    const std::string body = waitForMetricsBody(port_);
+    ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
+
+    PrometheusSample count_sample;
+    ASSERT_TRUE(findAgentMetricSample(body, "agent_xfer_time_us_count", agent_name, count_sample))
+        << "agent_xfer_time_us_count for this agent is not in scrape body";
+    EXPECT_EQ(count_sample.value, 4.0) << "histogram _count must equal the number of observations";
+
+    PrometheusSample sum_sample;
+    ASSERT_TRUE(findAgentMetricSample(body, "agent_xfer_time_us_sum", agent_name, sum_sample))
+        << "agent_xfer_time_us_sum for this agent is not in scrape body";
+    EXPECT_EQ(sum_sample.value, 935.0) << "histogram _sum must equal the sum of observations";
+
+    // Cumulative counts at representative default boundaries: 5<=10 (1); +30<=100
+    // (2); +200<=250 (3); +700<=1000 (4).
+    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 10.0),
+              std::optional<double>(1.0));
+    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 100.0),
+              std::optional<double>(2.0));
+    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 250.0),
+              std::optional<double>(3.0));
+    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 1000.0),
+              std::optional<double>(4.0));
+}
+
+// NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US replaces the default boundaries for the xfer
+// histograms. prometheus-cpp always appends the implicit +Inf bucket, so the
+// emitted boundary set is the configured list plus +Inf.
+TEST_F(prometheusTelemetryTest, HistogramBucketsEnvOverride) {
+    gtest::ScopedEnv bucket_env;
+    bucket_env.addVar(nixl::telemetry::histogramBucketsUsVar, "100,200,300");
+
+    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
+    ASSERT_NE(handle, nullptr);
+
+    const std::string agent_name = "prometheus_histogram_env_agent";
+    const nixlTelemetryExporterInitParams params{agent_name, 4096};
+    auto exporter = handle->createExporter(params);
+    ASSERT_NE(exporter, nullptr);
+
+    const std::string body = waitForMetricsBody(port_);
+    ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
+
+    const std::set<double> boundaries =
+        histogramBucketBoundaries(body, "agent_xfer_time_us_bucket", agent_name);
+    const std::set<double> expected{100.0, 200.0, 300.0, std::numeric_limits<double>::infinity()};
+    EXPECT_EQ(boundaries, expected)
+        << "histogram buckets must reflect NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US plus +Inf";
+}
+
+TEST(histogramBucketsTest, ValidListIsParsedInOrder) {
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "1, 2.5, 10, 100");
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              (std::vector<double>{1.0, 2.5, 10.0, 100.0}));
+}
+
+TEST(histogramBucketsTest, NonNumericFallsBackToDefaults) {
+    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,not_a_number,30");
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              nixl::telemetry::defaultHistogramBucketsUs());
+}
+
+TEST(histogramBucketsTest, UnsortedFallsBackToDefaults) {
+    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,5,20");
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              nixl::telemetry::defaultHistogramBucketsUs());
+}
+
+TEST(histogramBucketsTest, NonPositiveFallsBackToDefaults) {
+    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+    gtest::ScopedEnv env;
+    env.addVar(nixl::telemetry::histogramBucketsUsVar, "0,10,20");
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              nixl::telemetry::defaultHistogramBucketsUs());
+}
+
+TEST(histogramBucketsTest, AbsentUsesDefaults) {
+    ::unsetenv(nixl::telemetry::histogramBucketsUsVar);
+    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
+              nixl::telemetry::defaultHistogramBucketsUs());
 }
 
 // Drives the hot path to surface the dangling-pointer consequence of the

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -17,15 +17,12 @@
 
 #include "common.h"
 #include "plugin_manager.h"
+#include "prometheus_telemetry_fixture.h"
 #include "telemetry.h"
 #include "telemetry/telemetry_exporter.h"
 #include "telemetry_event.h"
 
-#include "histogram_buckets.h"
 #include "open_metrics_text_parser.h"
-
-#include <limits>
-#include <optional>
 
 #include <absl/log/log_sink_registry.h>
 
@@ -204,73 +201,6 @@ findMetricSample(const std::string &body,
     return false;
 }
 
-// Invokes `on_sample(le, value)` for every histogram bucket line of `bucket_metric`
-// belonging to `agent_name`, parsing the `le` label as a double so callers do not
-// depend on how prometheus-cpp formats the boundary (e.g. "10" vs "10.0").
-template<typename Fn>
-void
-forEachBucketSample(const std::string &body,
-                    const std::string &bucket_metric,
-                    const std::string &agent_name,
-                    Fn &&on_sample) {
-    std::istringstream body_lines(body);
-    std::string line;
-    while (std::getline(body_lines, line)) {
-        if (line.rfind(bucket_metric + "{", 0) != 0) {
-            continue;
-        }
-        std::unordered_map<std::string, std::string> labels;
-        double value = 0;
-        if (!parsePrometheusSampleLine(line, bucket_metric, labels, value)) {
-            continue;
-        }
-        const auto agent_it = labels.find("agent_name");
-        const auto le_it = labels.find("le");
-        if (agent_it == labels.end() || agent_it->second != agent_name || le_it == labels.end()) {
-            continue;
-        }
-        try {
-            size_t pos = 0;
-            const double le = std::stod(le_it->second, &pos);
-            if (pos == le_it->second.size()) {
-                on_sample(le, value);
-            }
-        }
-        catch (const std::exception &) {
-        }
-    }
-}
-
-// Cumulative count of a histogram bucket whose `le` label parses to exactly `le`,
-// for this agent.
-std::optional<double>
-histogramBucketValue(const std::string &body,
-                     const std::string &bucket_metric,
-                     const std::string &agent_name,
-                     double le) {
-    std::optional<double> result;
-    forEachBucketSample(body, bucket_metric, agent_name, [&](double boundary, double value) {
-        if (boundary == le) {
-            result = value;
-        }
-    });
-    return result;
-}
-
-// The full set of `le` boundaries emitted for a histogram bucket series of this
-// agent ("+Inf" becomes +infinity).
-std::set<double>
-histogramBucketBoundaries(const std::string &body,
-                          const std::string &bucket_metric,
-                          const std::string &agent_name) {
-    std::set<double> boundaries;
-    forEachBucketSample(body, bucket_metric, agent_name, [&](double le, double value) {
-        (void)value;
-        boundaries.insert(le);
-    });
-    return boundaries;
-}
-
 bool
 findAgentMetricSample(const std::string &body,
                       const std::string &metric_name,
@@ -442,35 +372,6 @@ private:
 
 } // namespace
 
-class prometheusTelemetryTest : public ::testing::Test {
-protected:
-    // Register the freshly built plugin directory exactly once for the whole
-    // test suite. Doing it in SetUp() instead would re-register on every
-    // test and trip the plugin manager's "already registered" warning, which
-    // the gtest main() treats as a test failure.
-    static void
-    SetUpTestSuite() {
-        nixlPluginManager::getInstance().addPluginDirectory(std::string(BUILD_DIR) +
-                                                            "/src/plugins/telemetry/prometheus");
-    }
-
-    void
-    SetUp() override {
-        port_ = gtest::PortAllocator::next_tcp_port();
-        env_.addVar("NIXL_TELEMETRY_PROMETHEUS_LOCAL", "y");
-        env_.addVar("NIXL_TELEMETRY_PROMETHEUS_PORT", std::to_string(port_));
-    }
-
-    void
-    TearDown() override {
-        env_.popVar();
-        env_.popVar();
-    }
-
-    gtest::ScopedEnv env_;
-    uint16_t port_ = 0;
-};
-
 // Regression test for a bug where the pre-registered per-agent metric
 // families were immediately wiped from the shared prometheus::Registry by
 // the dtor of a temporary CounterEntry/GaugeEntry created during
@@ -592,106 +493,6 @@ TEST_F(prometheusTelemetryTest, ScrapeEmitsExactlyTheDescriptorSeries) {
 
     EXPECT_EQ(actual, expected)
         << "native Prometheus scrape must emit exactly the shared-descriptor series set";
-}
-
-// AGENT_XFER_TIME events drive the agent_xfer_time_us histogram: _count is the
-// number of observations, _sum is their total, and each cumulative _bucket{le}
-// counts the observations at or below that boundary. Values are chosen to land in
-// distinct default buckets so the per-bucket counts are unambiguous.
-TEST_F(prometheusTelemetryTest, XferTimeHistogramRecordsObservations) {
-    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
-    ASSERT_NE(handle, nullptr);
-
-    const std::string agent_name = "prometheus_histogram_agent";
-    const nixlTelemetryExporterInitParams params{agent_name, 4096};
-    auto exporter = handle->createExporter(params);
-    ASSERT_NE(exporter, nullptr);
-
-    constexpr std::array<uint64_t, 4> values{5, 30, 200, 700}; // sum 935
-    for (const uint64_t v : values) {
-        EXPECT_EQ(exporter->exportEvent({nixl_telemetry_event_type_t::AGENT_XFER_TIME, v}),
-                  NIXL_SUCCESS);
-    }
-
-    const std::string body = waitForMetricsBody(port_);
-    ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
-
-    PrometheusSample count_sample;
-    ASSERT_TRUE(findAgentMetricSample(body, "agent_xfer_time_us_count", agent_name, count_sample))
-        << "agent_xfer_time_us_count for this agent is not in scrape body";
-    EXPECT_EQ(count_sample.value, 4.0) << "histogram _count must equal the number of observations";
-
-    PrometheusSample sum_sample;
-    ASSERT_TRUE(findAgentMetricSample(body, "agent_xfer_time_us_sum", agent_name, sum_sample))
-        << "agent_xfer_time_us_sum for this agent is not in scrape body";
-    EXPECT_EQ(sum_sample.value, 935.0) << "histogram _sum must equal the sum of observations";
-
-    // Cumulative counts at representative default boundaries: 5<=10 (1); +30<=100
-    // (2); +200<=250 (3); +700<=1000 (4).
-    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 10.0),
-              std::optional<double>(1.0));
-    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 100.0),
-              std::optional<double>(2.0));
-    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 250.0),
-              std::optional<double>(3.0));
-    EXPECT_EQ(histogramBucketValue(body, "agent_xfer_time_us_bucket", agent_name, 1000.0),
-              std::optional<double>(4.0));
-}
-
-// NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US replaces the default boundaries for the xfer
-// histograms. prometheus-cpp always appends the implicit +Inf bucket, so the
-// emitted boundary set is the configured list plus +Inf.
-TEST_F(prometheusTelemetryTest, HistogramBucketsEnvOverride) {
-    gtest::ScopedEnv bucket_env;
-    bucket_env.addVar(nixl::telemetry::histogramBucketsUsVar, "100,200,300");
-
-    auto handle = nixlPluginManager::getInstance().loadTelemetryPlugin("prometheus");
-    ASSERT_NE(handle, nullptr);
-
-    const std::string agent_name = "prometheus_histogram_env_agent";
-    const nixlTelemetryExporterInitParams params{agent_name, 4096};
-    auto exporter = handle->createExporter(params);
-    ASSERT_NE(exporter, nullptr);
-
-    const std::string body = waitForMetricsBody(port_);
-    ASSERT_FALSE(body.empty()) << "Got empty /metrics response on port " << port_;
-
-    const std::set<double> boundaries =
-        histogramBucketBoundaries(body, "agent_xfer_time_us_bucket", agent_name);
-    const std::set<double> expected{100.0, 200.0, 300.0, std::numeric_limits<double>::infinity()};
-    EXPECT_EQ(boundaries, expected)
-        << "histogram buckets must reflect NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US plus +Inf";
-}
-
-TEST(histogramBucketsTest, ValidListIsParsedInOrder) {
-    gtest::ScopedEnv env;
-    env.addVar(nixl::telemetry::histogramBucketsUsVar, "1, 2.5, 10, 100");
-    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
-              (std::vector<double>{1.0, 2.5, 10.0, 100.0}));
-}
-
-TEST(histogramBucketsTest, NonNumericThrows) {
-    gtest::ScopedEnv env;
-    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,not_a_number,30");
-    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
-}
-
-TEST(histogramBucketsTest, UnsortedThrows) {
-    gtest::ScopedEnv env;
-    env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,5,20");
-    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
-}
-
-TEST(histogramBucketsTest, NonPositiveThrows) {
-    gtest::ScopedEnv env;
-    env.addVar(nixl::telemetry::histogramBucketsUsVar, "0,10,20");
-    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
-}
-
-TEST(histogramBucketsTest, AbsentUsesDefaults) {
-    ::unsetenv(nixl::telemetry::histogramBucketsUsVar);
-    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
-              nixl::telemetry::defaultHistogramBucketsUs());
 }
 
 // Drives the hot path to surface the dangling-pointer consequence of the

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -62,7 +62,9 @@ struct PrometheusSample {
 std::string
 httpGet(uint16_t port, const std::string &path) {
     const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) return {};
+    if (fd < 0) {
+        return {};
+    }
 
     const struct timeval tv{3, 0};
     ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
@@ -85,7 +87,9 @@ httpGet(uint16_t port, const std::string &path) {
     char buf[4096];
     while (true) {
         const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
-        if (n <= 0) break;
+        if (n <= 0) {
+            break;
+        }
         response.append(buf, n);
     }
     ::close(fd);
@@ -200,49 +204,15 @@ findMetricSample(const std::string &body,
     return false;
 }
 
-// Cumulative count of a histogram bucket whose `le` label parses to exactly
-// `le`, for this agent. Parses `le` as a double so the assertion does not depend
-// on how prometheus-cpp formats the boundary (e.g. "10" vs "10.0").
-std::optional<double>
-histogramBucketValue(const std::string &body,
-                     const std::string &bucket_metric,
-                     const std::string &agent_name,
-                     double le) {
-    std::istringstream body_lines(body);
-    std::string line;
-    while (std::getline(body_lines, line)) {
-        if (line.rfind(bucket_metric + "{", 0) != 0) {
-            continue;
-        }
-        std::unordered_map<std::string, std::string> labels;
-        double value = 0;
-        if (!parsePrometheusSampleLine(line, bucket_metric, labels, value)) {
-            continue;
-        }
-        const auto agent_it = labels.find("agent_name");
-        const auto le_it = labels.find("le");
-        if (agent_it == labels.end() || agent_it->second != agent_name || le_it == labels.end()) {
-            continue;
-        }
-        try {
-            size_t pos = 0;
-            if (std::stod(le_it->second, &pos) == le && pos == le_it->second.size()) {
-                return value;
-            }
-        }
-        catch (const std::exception &) {
-        }
-    }
-    return std::nullopt;
-}
-
-// The full set of `le` boundaries emitted for a histogram bucket series of this
-// agent (parsed as doubles; "+Inf" becomes +infinity).
-std::set<double>
-histogramBucketBoundaries(const std::string &body,
-                          const std::string &bucket_metric,
-                          const std::string &agent_name) {
-    std::set<double> boundaries;
+// Invokes `on_sample(le, value)` for every histogram bucket line of `bucket_metric`
+// belonging to `agent_name`, parsing the `le` label as a double so callers do not
+// depend on how prometheus-cpp formats the boundary (e.g. "10" vs "10.0").
+template<typename Fn>
+void
+forEachBucketSample(const std::string &body,
+                    const std::string &bucket_metric,
+                    const std::string &agent_name,
+                    Fn &&on_sample) {
     std::istringstream body_lines(body);
     std::string line;
     while (std::getline(body_lines, line)) {
@@ -263,12 +233,41 @@ histogramBucketBoundaries(const std::string &body,
             size_t pos = 0;
             const double le = std::stod(le_it->second, &pos);
             if (pos == le_it->second.size()) {
-                boundaries.insert(le);
+                on_sample(le, value);
             }
         }
         catch (const std::exception &) {
         }
     }
+}
+
+// Cumulative count of a histogram bucket whose `le` label parses to exactly `le`,
+// for this agent.
+std::optional<double>
+histogramBucketValue(const std::string &body,
+                     const std::string &bucket_metric,
+                     const std::string &agent_name,
+                     double le) {
+    std::optional<double> result;
+    forEachBucketSample(body, bucket_metric, agent_name, [&](double boundary, double value) {
+        if (boundary == le) {
+            result = value;
+        }
+    });
+    return result;
+}
+
+// The full set of `le` boundaries emitted for a histogram bucket series of this
+// agent ("+Inf" becomes +infinity).
+std::set<double>
+histogramBucketBoundaries(const std::string &body,
+                          const std::string &bucket_metric,
+                          const std::string &agent_name) {
+    std::set<double> boundaries;
+    forEachBucketSample(body, bucket_metric, agent_name, [&](double le, double value) {
+        (void)value;
+        boundaries.insert(le);
+    });
     return boundaries;
 }
 
@@ -765,10 +764,8 @@ TEST_F(prometheusTelemetryTest, ExportEventIncrementReflectedInScrape) {
     ASSERT_FALSE(after_peer_teardown_body.empty())
         << "Got empty /metrics response on port " << port_;
     PrometheusSample remaining_sample;
-    ASSERT_TRUE(findAgentMetricSample(after_peer_teardown_body,
-                                      "agent_tx_bytes_total",
-                                      agent_name,
-                                      remaining_sample))
+    ASSERT_TRUE(findAgentMetricSample(
+        after_peer_teardown_body, "agent_tx_bytes_total", agent_name, remaining_sample))
         << "First agent metrics were removed when peer exporter was destroyed";
     EXPECT_EQ(remaining_sample.value, static_cast<double>(kIncrement * kEventCount));
     EXPECT_FALSE(hasAnyAgentMetricSample(after_peer_teardown_body, peer_agent_name))

--- a/test/gtest/telemetry_prometheus_test.cpp
+++ b/test/gtest/telemetry_prometheus_test.cpp
@@ -670,28 +670,22 @@ TEST(histogramBucketsTest, ValidListIsParsedInOrder) {
               (std::vector<double>{1.0, 2.5, 10.0, 100.0}));
 }
 
-TEST(histogramBucketsTest, NonNumericFallsBackToDefaults) {
-    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+TEST(histogramBucketsTest, NonNumericThrows) {
     gtest::ScopedEnv env;
     env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,not_a_number,30");
-    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
-              nixl::telemetry::defaultHistogramBucketsUs());
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
 }
 
-TEST(histogramBucketsTest, UnsortedFallsBackToDefaults) {
-    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+TEST(histogramBucketsTest, UnsortedThrows) {
     gtest::ScopedEnv env;
     env.addVar(nixl::telemetry::histogramBucketsUsVar, "10,5,20");
-    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
-              nixl::telemetry::defaultHistogramBucketsUs());
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
 }
 
-TEST(histogramBucketsTest, NonPositiveFallsBackToDefaults) {
-    gtest::LogIgnoreGuard ignore(std::string(nixl::telemetry::histogramBucketsUsVar));
+TEST(histogramBucketsTest, NonPositiveThrows) {
     gtest::ScopedEnv env;
     env.addVar(nixl::telemetry::histogramBucketsUsVar, "0,10,20");
-    EXPECT_EQ(nixl::telemetry::resolveHistogramBucketsUs(),
-              nixl::telemetry::defaultHistogramBucketsUs());
+    EXPECT_THROW(nixl::telemetry::resolveHistogramBucketsUs(), std::invalid_argument);
 }
 
 TEST(histogramBucketsTest, AbsentUsesDefaults) {


### PR DESCRIPTION
## What?

This PR adds latency histograms for transfer-time telemetry events:

- `agent_xfer_time_us` — transfer duration from start to completion.
- `agent_xfer_post_time_us` — time from start to backend post.

Both Prometheus and DOCA/CollectX exporters publish standard `_bucket`, `_sum`, and `_count` series. Existing counters and last-operation gauges remain unchanged.

## Why?

NIX-1364 requires visibility into transfer-latency distributions. Existing cumulative counters and last-value gauges cannot expose tail latency, regressions within latency bands, or the number of transfers within a range.

The histograms provide this information without adding telemetry event types or changing the telemetry buffer format.

## How?

Histogram names and help text are defined in the shared `nixlTelemetryMetricDescriptor`, keeping both exporters and parity tests consistent.

Each exporter uses its native histogram implementation:

- Prometheus: `prometheus::BuildHistogram` and `Observe`.
- DOCA/CollectX: `add_base_histogram`, `base_histogram_observe`, and `histogram_flush`.

Default buckets cover approximately 10 microseconds to 10 seconds. `NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US` can override them with a comma-separated list of strictly increasing positive microsecond bounds. An absent or empty value uses the defaults; a malformed non-empty value is rejected and causes exporter initialization to fail.

DOCA observations remain cached until each concrete histogram is flushed. The exporter therefore calls `histogram_flush` for every histogram ID before `metrics_flush`.

A cross-exporter compliance test sends identical samples through both exporters, scrapes their endpoints, and compares all histogram buckets, sums, and counts after normalizing timestamps and numeric label formatting.

## Tests

- `ninja -C build test/gtest/gtest`
- `ctest --test-dir build -R gtest --output-on-failure`
- `ninja -C build test/doca-telemetry/doca_nixl_test`
- `ctest --test-dir build -R doca_nixl_test --output-on-failure`
- `ninja -C build test/doca-telemetry/histogram_parity_test`
- `ctest --test-dir build -R histogram_parity_test --output-on-failure`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added histogram support for transfer-time telemetry in both Prometheus and DOCA exporters.
  * Exposed latency-distribution series for `agent_xfer_time` and `agent_xfer_post_time` as `*_bucket`, `*_sum`, and `*_count` (with `*_us` metric variants).
  * Added `NIXL_TELEMETRY_HISTOGRAM_BUCKETS_US` to configure histogram bucket upper bounds, using built-in defaults and rejecting malformed non-empty overrides.
* **Documentation**
  * Updated telemetry, Prometheus, and DOCA docs to reflect histogram outputs and bucket configuration.
* **Tests**
  * Added histogram validation (including bucket boundary checks) and cross-exporter histogram parity tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->