### PR TITLE
test: scope timeout to function body in test_empty_notif_tag

### DIFF
--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -170,7 +170,7 @@ def test_metadata_pass(two_agents):
     utils.free_passthru(addr)
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(5, func_only=True)
 def test_empty_notif_tag(two_connected_agents):
     agent1, agent2 = two_connected_agents
 


### PR DESCRIPTION
## Summary

- `@pytest.mark.timeout(5)` on `test_empty_notif_tag` was applied to fixture setup as well as the test body
- The `two_connected_agents` fixture creates two UCX backends (~10s each in CI), blowing past the 5s budget during setup
- `func_only=True` excludes fixture setup/teardown from the timeout so the 5s correctly guards only the `send_notif`/`check_remote_xfer_done` loop

Fixes the flaky `Failed: Timeout (>5.0s) from pytest-timeout` CI failure reported in #1898 by the triage bot.

## Test plan

- [x] `test_empty_notif_tag` passes in CI without timeout during fixture setup
- [x] Notification loop still times out if it hangs (5s budget still enforced on test body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a timeout configuration to enforce function-only timing for a specific test, improving consistency of test duration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->