### PR TITLE
Build wheels with the UCX spcx external plugin bundled

### DIFF
--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -126,6 +126,16 @@ This builds both stages from scratch without the `--wheel-base-image` override.
 #### Nightly Build
 The nightly job (`nixl-ci-build-wheel-nightly`) omits `--torch-versions` and `--wheel-base-image`, so it builds all torch versions and runs the full two-stage build.
 
+#### Optional: UCX spcx external plugin
+`build-container.sh --build-ucx-spcx-plugin` opt-in flag fetches the internal `ucx-spcx-plugin` source on the host into the build context, compiles it against the just-built UCX inside the Dockerfile, and installs it into the UCX plugins dir where `wheel_add_ucx_plugins.py` bundles it like any other UCX module. It requires `--dockerfile contrib/Dockerfile.manylinux` and two environment variables — neither is hardcoded so the repo location and token stay out of the source and image layers:
+
+| Env var | Purpose | Jenkins credential | Credential type |
+|---|---|---|---|
+| `NIXL_SPCX_PLUGIN_REPO_URL` | Git URL of the plugin repo | `ucx-plugin-gitlab-url` | Secret text |
+| `NIXL_GITLAB_TOKEN` | GitLab token (`read_repository` scope) used via a git credential helper so it never appears in URLs, argv, or git error output | `svc-nixl-gitlab-token` | Username/Password (token in password field) |
+
+The plugin ref defaults to `main` and is selectable with `--ucx-spcx-plugin-ref`. This flag is not enabled in the PR CI pipeline; it is consumed by the QA/release invocations of `build-container.sh`, which bind both credentials into the environment.
+
 ### Key Dependencies Installed
 
 #### System Packages

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ subprojects/*
 
 # Infinia DDN libs staged into the build context by build-container.sh --build-infinia
 /infinia-libs/
+
+# ucx-spcx-plugin source fetched into the build context by build-container.sh
+ucx-spcx-plugin-src/

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -358,6 +358,7 @@ ARG ARCH="x86_64"
 ARG BUILD_TYPE="release"
 ARG BUILD_NIXL_EP="true"
 ARG UCX_SONAME_SUFFIX=""
+ARG NPROC=1
 
 COPY . /workspace/nixl
 WORKDIR /workspace/nixl
@@ -381,6 +382,36 @@ RUN if [ "$BUILD_INFINIA" = "true" ]; then \
         dnf install -y libuuid-devel && \
         mkdir -p /opt/ddn/red && \
         cp -a /workspace/nixl/infinia-libs/. /opt/ddn/red/; \
+    fi
+
+# Opt-in: build the internal ucx-spcx-plugin against the just-built UCX and
+# install it into the UCX plugins dir, where the wheel bundling
+# (wheel_add_ucx_plugins.py) picks it up like any other UCX module. The
+# plugin source is cloned into the build context (ucx-spcx-plugin-src/) by
+# build-container.sh --build-ucx-spcx-plugin.
+# FlexIO SDK + dpacc (build-time dependencies of the plugin's DPA transport) come from
+# the doca-host repo installed above; libflexio is compile-against only —
+# it is not bundled into the wheel, at runtime it comes from the target
+# machine's DOCA/FlexIO installation (like libmlx5 from rdma-core).
+ARG BUILD_UCX_SPCX_PLUGIN=false
+RUN if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then \
+        rpm -ivh --nodeps /usr/share/doca-host-3.3.0/repo/Packages/flexio-sdk-*rpm && \
+        rpm -ivh --nodeps /usr/share/doca-host-3.3.0/repo/Packages/dpacc-[0-9]*rpm && \
+        ldconfig && \
+        cd ucx-spcx-plugin-src && \
+        export ACLOCAL_PATH="/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}" && \
+        ./autogen.sh /usr/local/src/ucx && \
+        ./configure --prefix=/usr --libdir=/usr/lib64 \
+            --enable-shared --disable-static \
+            --with-ucx-src=/usr/local/src/ucx \
+            --with-ucx-build=/usr/local/src/ucx \
+            --with-cuda=/usr/local/cuda \
+            --with-flexio=/opt/mellanox/flexio \
+            --with-dpacc=/opt/mellanox/doca/tools/dpacc \
+            LDFLAGS="-L/usr/lib64/ucx -L/usr/lib64" && \
+        make -j"${NPROC}" && \
+        make install && \
+        cd /workspace/nixl && rm -rf ucx-spcx-plugin-src; \
     fi
 
 RUN rm -rf build && \

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -46,6 +46,8 @@ GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
 BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
+BUILD_UCX_SPCX_PLUGIN="false"
+UCX_SPCX_PLUGIN_REF="main"
 
 get_options() {
     while :; do
@@ -159,6 +161,17 @@ get_options() {
         --build-nixl-ep)
             BUILD_NIXL_EP=true
             ;;
+        --build-ucx-spcx-plugin)
+            BUILD_UCX_SPCX_PLUGIN="true"
+            ;;
+        --ucx-spcx-plugin-ref)
+            if [ "$2" ]; then
+                UCX_SPCX_PLUGIN_REF=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
@@ -244,6 +257,11 @@ show_build_options() {
     else
         echo "Infinia DDN plugin: Disabled"
     fi
+    if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then
+        echo "UCX spcx plugin: Enabled (ref: ${UCX_SPCX_PLUGIN_REF})"
+    else
+        echo "UCX spcx plugin: Disabled"
+    fi
     echo "Build Type: ${BUILD_TYPE}"
 }
 
@@ -262,6 +280,8 @@ show_help() {
     echo "  [--ucx-soname-suffix suffix to pass to UCX --with-soname-suffix]"
     echo "  [--private-ucx shortcut for --ucx-soname-suffix ${PRIVATE_UCX_SONAME_SUFFIX}; requires a UCX ref with --with-soname-suffix and --enable-module-deepbind]"
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
+    echo "  [--build-ucx-spcx-plugin build and bundle the UCX spcx external plugin (requires NIXL_GITLAB_TOKEN and NIXL_SPCX_PLUGIN_REPO_URL in the environment) (requires --dockerfile contrib/Dockerfile.manylinux)]"
+    echo "  [--ucx-spcx-plugin-ref git ref of ucx-spcx-plugin to build (default: ${UCX_SPCX_PLUGIN_REF})]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
@@ -301,6 +321,43 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 BUILD_ARGS+=" --build-arg BUILD_INFINIA=$BUILD_INFINIA"
+BUILD_ARGS+=" --build-arg BUILD_UCX_SPCX_PLUGIN=$BUILD_UCX_SPCX_PLUGIN"
+
+# The plugin source is fetched on the host and placed inside the build
+# context (ucx-spcx-plugin-src/), where the Dockerfile's plugin RUN builds
+# it from the copied context. This keeps credentials and BuildKit-specific
+# syntax out of the Dockerfile entirely, so the default build works with
+# any docker builder. The token stays out of URLs and argv (git credential
+# helper reading the environment) so git errors cannot leak it.
+SPCX_SRC_DIR="$BUILD_CONTEXT/ucx-spcx-plugin-src"
+rm -rf "$SPCX_SRC_DIR"
+if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then
+    case "$DOCKER_FILE" in
+        *Dockerfile.manylinux) ;;
+        *) error "ERROR:" "--build-ucx-spcx-plugin requires --dockerfile contrib/Dockerfile.manylinux (the default Dockerfile does not consume it)" ;;
+    esac
+    if [ -z "${NIXL_GITLAB_TOKEN:-}" ]; then
+        error "ERROR:" "--build-ucx-spcx-plugin requires the NIXL_GITLAB_TOKEN environment variable"
+    fi
+    if [ -z "${NIXL_SPCX_PLUGIN_REPO_URL:-}" ]; then
+        error "ERROR:" "--build-ucx-spcx-plugin requires the NIXL_SPCX_PLUGIN_REPO_URL environment variable"
+    fi
+    trap 'rm -rf "$SPCX_SRC_DIR"' EXIT
+    mkdir -p "$SPCX_SRC_DIR"
+    (
+        set -e
+        cd "$SPCX_SRC_DIR"
+        git init -q
+        git remote add origin "$NIXL_SPCX_PLUGIN_REPO_URL"
+        # shellcheck disable=SC2016
+        GIT_TERMINAL_PROMPT=0 git -c credential.helper= \
+            -c credential.helper='!f() { echo "username=oauth2"; echo "password=${NIXL_GITLAB_TOKEN}"; }; f' \
+            fetch -q --depth 1 origin "$UCX_SPCX_PLUGIN_REF"
+        git checkout -q FETCH_HEAD
+        echo "ucx-spcx-plugin ref ${UCX_SPCX_PLUGIN_REF} -> commit $(git rev-parse HEAD)"
+        rm -rf .git
+    ) || error "ERROR:" "failed to fetch ucx-spcx-plugin at ref ${UCX_SPCX_PLUGIN_REF}"
+fi
 
 if [ -n "$WHEEL_BASE_IMAGE" ]; then
     BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"


### PR DESCRIPTION
## What

Adds opt-in support for building the internal `ucx-spcx-plugin` (UCX external plugin, `libuct_ib_mlx5_ext.so`) as part of the NIXL wheel image build and bundling it into the `nixl-cuXX` wheel.

## How

- **`contrib/Dockerfile.manylinux`**: a dedicated RUN right after the UCX build (same pattern as the UCX build itself) clones the plugin from internal GitLab at `UCX_SPCX_PLUGIN_REF` (branch, tag, or full sha; default `main`), builds it against the just-built UCX (`--with-ucx=/usr --with-ucx-src=/usr/local/src/ucx`, shared-only like UCX), and make-installs it directly into `/usr/lib64/ucx` via `--libdir`. Gated by `BUILD_UCX_SPCX_PLUGIN` (default `false`).
- **Wheel bundling — no changes**: `build-wheel.sh` and `wheel_add_ucx_plugins.py` are untouched; the plugin sits in the UCX plugins dir and rides the existing bundling/RPATH-patching like any other UCX module.
- **`contrib/build-container.sh`**: new `--build-ucx-spcx-plugin` / `--ucx-spcx-plugin-ref` options; the GitLab token is taken from `NIXL_GITLAB_TOKEN` and handed to the docker build as a file-based `--secret` (always supplied, empty when the feature is off, so the unconditional secret mount works identically on docker and podman).
- **DPA/FlexIO readiness**: the image pre-installs the FlexIO SDK (`libflexio`) and `dpacc` from the already-configured doca-host repo; when the plugin's upcoming DPA transport lands and links `libflexio`, the Dockerfile bundles it next to the plugin automatically so the wheel ships it — no further changes needed here.

## Token hygiene

The token never appears in image layers, `docker history`, argv, or git error output: it travels env → 0600 temp file → build secret → env inside the plugin RUN only, and the clone uses a git credential helper reading it from the environment (credential-free URL, `GIT_TERMINAL_PROMPT=0`).

## Behavior when disabled

Flag off ⇒ the wheel build is byte-identical to today; the plugin RUN is a no-op and the wheel RUN is unchanged from main.

## Testing

- Feature leg built end-to-end locally (x86_64, CUDA 13, Python 3.12): plugin cloned/built/installed by the inline RUN, wheel contains `nixl_cu13.libs/ucx/libuct_ib_mlx5_ext.so.0.0.0` (shared-only, no static archive) alongside `libplugin_UCX.so`; clean-venv `pip install` verified; `docker history` clean of the token.
- Regression: with the flag off the wheel RUN is byte-identical to main (verified by diff); default builds don't reach any new code path.
- Build fixes discovered during E2E are baked in: UCX installs to `/usr` in this image (its configure default), `ACLOCAL_PATH` so the plugin's autogen finds `pkg.m4` with the image's source-built autotools, and explicit `-L/usr/lib64/ucx -L/usr/lib64` link dirs (the plugin's configure assumes a `lib/` layout).

## Why?
[HPCINFRA-4539](https://jirasw.nvidia.com/browse/HPCINFRA-4539)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in build flow to include the UCX SPX plugin in manylinux container builds.
  * Introduced build options/flags to enable the plugin and select the plugin revision.
  * Updated build help/output to show plugin status and required prerequisites when enabled.
* **Chores**
  * Prevented the temporary plugin source directory from being committed.
  * Ensured the downloaded plugin sources are cleaned up after the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->