### PR TITLE
chore: Update release version for NIXL (1.3.1 -> 1.4.0)

### DIFF
--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -436,7 +436,7 @@
       - string:
           name: "NIXL_VERSION"
           default: "{jjb_branch}"
-          description: "NIXL version to use (tag like 1.3.1, branch name, or commit hash)"
+          description: "NIXL version to use (tag like 1.4.0, branch name, or commit hash)"
       - string:
           name: "UCX_VERSION"
           default: "v1.22.x"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nixl-sys"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "1.3.1"
+version = "1.4.0"
 edition = "2021"
 description = "Low-level bindings to NIXL - NVIDIA Inference Xfer Library"
 authors = ["NIXL Developers <nixl-developers@nvidia.com>"]

--- a/benchmark/nixlbench/meson.build
+++ b/benchmark/nixlbench/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('nixlbench', 'CPP', version: '1.3.1',
+project('nixlbench', 'CPP', version: '1.4.0',
     default_options: ['buildtype=release',
                 'werror=true',
                 'cpp_std=c++20',

--- a/examples/rust/Cargo.lock
+++ b/examples/rust/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "nixl-sys"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "bindgen",
  "cc",

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('nixl', 'CPP', version: '1.3.1',
+project('nixl', 'CPP', version: '1.4.0',
     default_options: ['buildtype=release',
                 'werror=true',
                 'cpp_std=c++20',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "mesonpy"
 
 [project]
 name = "nixl-cu12"
-version = "1.3.1"
+version = "1.4.0"
 description = "NIXL Python API"
 readme = "README.md"
 license = "MIT AND Apache-2.0"


### PR DESCRIPTION
Bump the release/1.4.0 branch version from 1.3.1 to 1.4.0 across pyproject.toml, meson.build, benchmark/nixlbench/meson.build, Cargo.toml, both Cargo.lock nixl-sys entries, and the proj-jjb version-hint string — the same file set as the canonical version-bump commit (#1807). The branch still carried 1.3.1, so builds produced 1.3.1 wheels.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project version to **1.4.0** across the workspace and build metadata.
  * Updated the build pipeline example version reference to match the new release.
  * Kept package and benchmark version information in sync with the release update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->