### PR TITLE
fix(libfabric): disable FI_MORE batching on EFA

### DIFF
--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -394,18 +394,23 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
-        // WRITE: group 16 consecutive descs to same rail for FI_MORE batching.
-        // READ: per-descriptor round-robin (FI_MORE has no benefit for reads).
+        // EFA defers an FI_MORE batch until a closing post. NIXL locks each descriptor post
+        // separately, so CQ progress or another posting thread can run before that closing post
+        // and prevent it from being submitted. Do not use FI_MORE on EFA until NIXL can submit a
+        // complete batch under one endpoint owner.
         constexpr int FI_MORE_BATCH_SIZE = 16;
-        const bool batch_write = (op_type == nixlLibfabricReq::WRITE);
+        const auto &provider_name = rails_[selected_rails.front()]->provider_name;
+        const bool is_efa_provider = provider_name == "efa" || provider_name == "efa-direct";
+        const bool batch_write = (op_type == nixlLibfabricReq::WRITE) && !is_efa_provider;
+        const int batch_size = batch_write ? FI_MORE_BATCH_SIZE : 1;
         const size_t rr_idx =
-            batch_write ? (base_offset + desc_idx / FI_MORE_BATCH_SIZE) : (base_offset + desc_idx);
+            batch_write ? (base_offset + desc_idx / batch_size) : (base_offset + desc_idx);
         const size_t rail_id = selected_rails[rr_idx % selected_rails.size()];
         const size_t remote_ep_id =
             remote_selected_endpoints[rr_idx % remote_selected_endpoints.size()];
-        const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
+        const int pos_in_group = desc_idx % batch_size;
         const bool is_last_in_group =
-            (pos_in_group == FI_MORE_BATCH_SIZE - 1) || (desc_idx == desc_count - 1);
+            (pos_in_group == batch_size - 1) || (desc_idx == desc_count - 1);
         const uint64_t fi_flags = (batch_write && !is_last_in_group) ? FI_MORE : 0;
         NIXL_DEBUG << "rail " << rail_id << ", remote_ep_id " << remote_ep_id;
         // Allocate request


### PR DESCRIPTION
## What?

Backport the EFA-specific LIBFABRIC posting fix to `release/1.3.1`.

For the `efa` and `efa-direct` providers, this disables `FI_MORE` on non-striped WRITEs and restores per-descriptor rail/end-point round robin. Other providers retain the existing 16-descriptor `FI_MORE` batching behavior.

Addresses #1921. Related: #1862.

## Why?

NIXL 1.3.1 can hang a cross-node EFA transfer after a complete 16-descriptor boundary when the progress thread is enabled. NIXL posts each descriptor under a separate endpoint lock while using `FI_MORE` to keep a 16-WRITE batch open. CQ progress can acquire the same endpoint lock before the closing post; in the reproduced failure it remained inside EFA CQ progress while the posting thread blocked on that lock.

The sender therefore never closes the current batch or sends the transfer notification. SGLang decode waits in `KVPoll.WaitingForInput` and eventually returns an empty response.

## How?

Detect the selected LIBFABRIC provider before choosing the batching policy:

- `efa` / `efa-direct`: effective batch size 1, no `FI_MORE`
- all other providers: unchanged batch size 16 and `FI_MORE` behavior
- READ and striped-transfer behavior: unchanged

This branch is based directly on `release/1.3.1` and changes one source file. The release branch's pre-patch rail-manager source is byte-identical to the parent of the tested `f29b589b` backport. This PR is functionally identical to `f29b589b`, with one clang-format-only whitespace adjustment.

## Validation

Built only `libplugin_LIBFABRIC.so` from the tested backport in the exact arm64 RC image, leaving NIXL core, Python bindings, EFA/libfabric, CUDA, and all other plugins unchanged.

Standalone cross-node GB200/EFA, VRAM-to-VRAM, progress thread enabled:

- 4 concurrent producers × 100 waves: 400/400 transfers passed; 38,400/38,400 descriptors verified
- 16 concurrent producers × 20 waves: 320/320 transfers passed; 30,720/30,720 descriptors verified
- every wave observed the requested simultaneous `postXferReq` concurrency
- all notifications and target bytes verified; both peers exited 0

Full Dynamo/SGLang TP2 prefill/decode stack with `Qwen/Qwen3-30B-A3B-FP8`:

- progress thread enabled on both workers
- `SGLANG_DISAGGREGATION_QUEUE_SIZE=4`
- 2,862/2,862 requests passed at concurrency 1, 4, 8, and 16
- primary concurrency-16 soak: 1,600/1,600 passed at 26.33 requests/s
- zero empty responses, transfer timeouts, assertions, or pod restarts
- post-soak sentinel passed

EFA hardware counters during an isolated 800-request concurrency-16 window:

- prefill `rdma_write_bytes`: +25,168,384,000
- decode `rdma_write_recv_bytes`: +25,168,384,000
- RDMA errors, RX drops, retransmitted bytes, retransmission-timeout events, newly impaired connections, and unresponsive-remote events: zero delta

Local checks on this clean release backport:

- NIXL pre-commit hooks: passed
- clang-format-19 changed-line check: passed
- `git diff --check`: passed
