### PR TITLE
build: fix ucx: add UCS_BIT_GET fallback for UCX < 1.19

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -32,7 +32,7 @@
 #include "serdes/serdes.h"
 
 #ifndef UCS_BIT_GET
-#define UCS_BIT_GET(_mask, _bit) (!!((_mask) & UCS_BIT(_bit)))
+#define UCS_BIT_GET(_value, _i)  (!!((_value) & UCS_BIT(_i)))
 #endif
 
 [[nodiscard]] nixl_b_params_t

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -30,6 +30,7 @@
 #include "common/nixl_log.h"
 #include "config.h"
 #include "serdes/serdes.h"
+
 #ifndef UCS_BIT_GET
 #define UCS_BIT_GET(_mask, _bit) (!!((_mask) & UCS_BIT(_bit)))
 #endif

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -32,7 +32,7 @@
 #include "serdes/serdes.h"
 
 #ifndef UCS_BIT_GET
-#define UCS_BIT_GET(_value, _i)  (!!((_value) & UCS_BIT(_i)))
+#define UCS_BIT_GET(_value, _i) (!!((_value) & UCS_BIT(_i)))
 #endif
 
 [[nodiscard]] nixl_b_params_t

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -30,6 +30,9 @@
 #include "common/nixl_log.h"
 #include "config.h"
 #include "serdes/serdes.h"
+#ifndef UCS_BIT_GET
+#define UCS_BIT_GET(_mask, _bit) (!!((_mask) & UCS_BIT(_bit)))
+#endif
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {


### PR DESCRIPTION
## What?
Add `#ifndef UCS_BIT_GET` fallback in `ucx_utils.cpp` for UCX < 1.19.
## Why?
`UCS_BIT_GET` is used unconditionally (no version guard), but the macro only exists in UCX 1.22+. Ubuntu 24.04 et al apt provides UCX 1.16, causing compile failure. meson.build does not enforce a minimum UCX version.

## How?
     #ifndef UCS_BIT_GET
     #define UCS_BIT_GET(_mask, _bit) (!!((_mask) & UCS_BIT(_bit)))
     #endif

     Matches UCX 1.22 upstream definition. #ifndef guard ensures no conflict with newer UCX.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of UCX feature/flag checks by adding a guarded fallback for bit-get support when it isn’t provided by external UCX headers.
  * Ensures bitmask-based flag evaluation continues to work reliably across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

cc @brminich