### PR TITLE
EXAMPLES/DEVICE/EP: Added missing const to Buffer::query_mask_buffer.

### DIFF
--- a/examples/device/ep/csrc/kernels/api.cuh
+++ b/examples/device/ep/csrc/kernels/api.cuh
@@ -244,7 +244,11 @@ void combine(void* combined_x,
 
 void barrier(gpu_nixl_ctx* nixl_ctx, int* mask_buffer_ptr, uint64_t timeout_cycles, cudaStream_t stream);
 
-void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* output_mask_tensor, cudaStream_t stream);
+void
+query_mask_buffer(const int *mask_buffer_ptr,
+                  int num_ranks,
+                  int *output_mask_tensor,
+                  cudaStream_t stream);
 
 void update_mask_buffer(int* mask_buffer_ptr, int rank_to_mask, bool mask, cudaStream_t stream);
 

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -1087,8 +1087,9 @@ LAUNCH_KERNEL(&cfg, combine_func, \
 #undef COMBINE_LAUNCH_CASE
 }
 
-template <int kNumThreads> __launch_bounds__(kNumThreads, 1)
-__global__ void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* mask_tensor) {
+template<int kNumThreads>
+__launch_bounds__(kNumThreads, 1) __global__
+    void query_mask_buffer(const int *mask_buffer_ptr, int num_ranks, int *mask_tensor) {
     const auto num_sms = static_cast<int>(gridDim.x);
     const auto sm_id = static_cast<int>(blockIdx.x);
     const auto num_threads = num_sms * kNumThreads;
@@ -1098,7 +1099,11 @@ __global__ void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* mask
     }
 }
 
-void query_mask_buffer(int* mask_buffer_ptr, int num_ranks, int* mask_tensor, cudaStream_t stream) {
+void
+query_mask_buffer(const int *mask_buffer_ptr,
+                  int num_ranks,
+                  int *mask_tensor,
+                  cudaStream_t stream) {
     constexpr int num_sms = 1;
     constexpr int kNumThreads = 1024;
     SETUP_LAUNCH_CONFIG(num_sms, kNumThreads, stream);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1281,13 +1281,16 @@ void Buffer::update_mask_buffer(int rank_to_mask, bool mask) {
     ep_kernels::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, at::cuda::getCurrentCUDAStream());
 }
 
-void Buffer::query_mask_buffer(const torch::Tensor& mask_status) {
+void
+Buffer::query_mask_buffer(const torch::Tensor &mask_status) const {
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
-    EP_HOST_ASSERT(mask_status.numel() == max_num_ranks && mask_status.scalar_type() == torch::kInt32);
+    EP_HOST_ASSERT(mask_status.numel() == max_num_ranks &&
+                   mask_status.scalar_type() == torch::kInt32);
 
-    ep_kernels::query_mask_buffer(mask_buffer_ptr, max_num_ranks,
-                                    reinterpret_cast<int*>(mask_status.data_ptr()),
-                                    at::cuda::getCurrentCUDAStream());
+    ep_kernels::query_mask_buffer(mask_buffer_ptr,
+                                  max_num_ranks,
+                                  mask_status.data_ptr<int>(),
+                                  at::cuda::getCurrentCUDAStream());
 }
 
 void Buffer::clean_mask_buffer() {

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -258,7 +258,8 @@ public:
 
     void update_mask_buffer(int rank_to_mask, bool mask);
 
-    void query_mask_buffer(const torch::Tensor& mask_status);
+    void
+    query_mask_buffer(const torch::Tensor &mask_status) const;
 
     void clean_mask_buffer();
 


### PR DESCRIPTION
## What?
Added missing `const` to the declaration of `Buffer::query_mask_buffer`.
Added missing `const` to a parameter of `ep_kernels::query_mask_buffer`.

## Why?
To improve the readability of the code, following C++ core guidelines.
Spotted by the PR (https://github.com/ai-dynamo/nixl/pull/1793), need to reduce the size of the PR, removing unrelated changes.