### PR TITLE
util: add reusable comma-separated env-list parser (NIX-1621)

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -22,9 +22,6 @@
 #include <optional>
 #include <set>
 
-#include <absl/strings/ascii.h>
-#include <absl/strings/str_split.h>
-
 #include "nixl.h"
 #include "serdes/serdes.h"
 #include "backend/backend_engine.h"
@@ -35,6 +32,7 @@
 #include "common/nixl_log.h"
 #include "common/operators.h"
 #include "common/hw_info.h"
+#include "common/str_util.h"
 #include "telemetry.h"
 #include "telemetry_event.h"
 #include "tracing/trace.h"
@@ -129,12 +127,8 @@ resolveTraceBackends(const std::optional<std::string> &explicit_spec, bool under
     if (explicit_spec) {
         // Trim entries so a padded value like "chakra, nvtx" matches backend
         // names; the set dedups them.
-        for (const absl::string_view raw : absl::StrSplit(*explicit_spec, ',')) {
-            const absl::string_view name = absl::StripAsciiWhitespace(raw);
-            if (!name.empty()) {
-                backends.emplace(name);
-            }
-        }
+        const auto names = nixl::str::splitStripped(*explicit_spec);
+        backends.insert(names.begin(), names.end());
         // Set-but-empty (or all-blank) is an explicit "off" that must beat the
         // nsys auto-enable below.
         explicit_off = backends.empty();

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -127,8 +127,7 @@ resolveTraceBackends(const std::optional<std::string> &explicit_spec, bool under
     if (explicit_spec) {
         // Trim entries so a padded value like "chakra, nvtx" matches backend
         // names; the set dedups them.
-        const auto names = nixl::str::splitStripped(*explicit_spec);
-        backends.insert(names.begin(), names.end());
+        backends = nixl::str::splitStrippedSet(*explicit_spec);
         // Set-but-empty (or all-blank) is an explicit "off" that must beat the
         // nsys auto-enable below.
         explicit_off = backends.empty();

--- a/src/utils/common/str_util.h
+++ b/src/utils/common/str_util.h
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_UTILS_COMMON_STR_UTIL_H
+#define NIXL_UTILS_COMMON_STR_UTIL_H
+
+#include <string>
+#include <vector>
+
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_split.h>
+#include <absl/strings/string_view.h>
+
+namespace nixl::str {
+
+[[nodiscard]] inline std::vector<std::string>
+splitStripped(absl::string_view s, char delim = ',') {
+    std::vector<std::string> tokens;
+    for (const absl::string_view raw : absl::StrSplit(s, delim)) {
+        const absl::string_view token = absl::StripAsciiWhitespace(raw);
+        if (!token.empty()) {
+            tokens.emplace_back(token);
+        }
+    }
+    return tokens;
+}
+
+} // namespace nixl::str
+
+#endif // NIXL_UTILS_COMMON_STR_UTIL_H

--- a/src/utils/common/str_util.h
+++ b/src/utils/common/str_util.h
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NIXL_UTILS_COMMON_STR_UTIL_H
-#define NIXL_UTILS_COMMON_STR_UTIL_H
+#ifndef NIXL_SRC_UTILS_COMMON_STR_UTIL_H
+#define NIXL_SRC_UTILS_COMMON_STR_UTIL_H
 
 #include <string>
 #include <vector>
@@ -26,6 +26,13 @@
 
 namespace nixl::str {
 
+/**
+ * @brief Split @p s on @p delim into non-empty, whitespace-stripped tokens.
+ *
+ * @param s String to split.
+ * @param delim Delimiter character (default ',').
+ * @return Tokens in input order, ASCII-whitespace-trimmed; empty tokens dropped.
+ */
 [[nodiscard]] inline std::vector<std::string>
 splitStripped(absl::string_view s, char delim = ',') {
     std::vector<std::string> tokens;
@@ -40,4 +47,4 @@ splitStripped(absl::string_view s, char delim = ',') {
 
 } // namespace nixl::str
 
-#endif // NIXL_UTILS_COMMON_STR_UTIL_H
+#endif // NIXL_SRC_UTILS_COMMON_STR_UTIL_H

--- a/src/utils/common/str_util.h
+++ b/src/utils/common/str_util.h
@@ -17,6 +17,7 @@
 #ifndef NIXL_SRC_UTILS_COMMON_STR_UTIL_H
 #define NIXL_SRC_UTILS_COMMON_STR_UTIL_H
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,25 @@ splitStripped(absl::string_view s, char delim = ',') {
         const absl::string_view token = absl::StripAsciiWhitespace(raw);
         if (!token.empty()) {
             tokens.emplace_back(token);
+        }
+    }
+    return tokens;
+}
+
+/**
+ * @brief Like splitStripped(), but returns the tokens deduplicated and sorted.
+ *
+ * @param s String to split.
+ * @param delim Delimiter character (default ',').
+ * @return Unique ASCII-whitespace-trimmed tokens; empty tokens dropped.
+ */
+[[nodiscard]] inline std::set<std::string>
+splitStrippedSet(absl::string_view s, char delim = ',') {
+    std::set<std::string> tokens;
+    for (const absl::string_view raw : absl::StrSplit(s, delim)) {
+        const absl::string_view token = absl::StripAsciiWhitespace(raw);
+        if (!token.empty()) {
+            tokens.emplace(token);
         }
     }
     return tokens;

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -29,6 +29,9 @@ unit_test_deps += [agent_unit_test_dep]
 subdir('descriptors')
 unit_test_deps += [descriptors_unit_test_dep]
 
+subdir('util')
+unit_test_deps += [util_unit_test_dep]
+
 subdir('tracing')
 unit_test_deps += [tracing_unit_test_dep]
 

--- a/test/gtest/unit/util/meson.build
+++ b/test/gtest/unit/util/meson.build
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+util_unit_test_dep = declare_dependency(
+    sources: [
+        'str_util_test.cpp',
+    ],
+    include_directories: [nixl_inc_dirs, gtest_inc_dirs],
+    dependencies: [nixl_common_dep],
+)

--- a/test/gtest/unit/util/str_util_test.cpp
+++ b/test/gtest/unit/util/str_util_test.cpp
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "common/str_util.h"
+
+namespace {
+
+using nixl::str::splitStripped;
+
+TEST(StrSplitStripped, SplitsAndTrimsTokens) {
+    EXPECT_EQ(splitStripped("nvtx,chakra"), (std::vector<std::string>{"nvtx", "chakra"}));
+    EXPECT_EQ(splitStripped(" nvtx , chakra "), (std::vector<std::string>{"nvtx", "chakra"}));
+    EXPECT_EQ(splitStripped("\tnvtx\t"), (std::vector<std::string>{"nvtx"}));
+}
+
+TEST(StrSplitStripped, PreservesOrderAndDuplicates) {
+    EXPECT_EQ(splitStripped("chakra,nvtx"), (std::vector<std::string>{"chakra", "nvtx"}));
+    EXPECT_EQ(splitStripped("nvtx,nvtx"), (std::vector<std::string>{"nvtx", "nvtx"}));
+}
+
+TEST(StrSplitStripped, DropsEmptyAndWhitespaceOnlyTokens) {
+    EXPECT_TRUE(splitStripped("").empty());
+    EXPECT_TRUE(splitStripped("   ").empty());
+    EXPECT_TRUE(splitStripped(",").empty());
+    EXPECT_TRUE(splitStripped(" , ").empty());
+    EXPECT_EQ(splitStripped(",nvtx,,chakra,"), (std::vector<std::string>{"nvtx", "chakra"}));
+}
+
+TEST(StrSplitStripped, HonorsCustomDelimiter) {
+    EXPECT_EQ(splitStripped("a:b: c ", ':'), (std::vector<std::string>{"a", "b", "c"}));
+    EXPECT_EQ(splitStripped("a,b", ':'), (std::vector<std::string>{"a,b"}));
+}
+
+} // namespace

--- a/test/gtest/unit/util/str_util_test.cpp
+++ b/test/gtest/unit/util/str_util_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
 #include <string>
 #include <vector>
 
@@ -25,6 +26,7 @@
 namespace {
 
 using nixl::str::splitStripped;
+using nixl::str::splitStrippedSet;
 
 TEST(StrSplitStripped, SplitsAndTrimsTokens) {
     EXPECT_EQ(splitStripped("nvtx,chakra"), (std::vector<std::string>{"nvtx", "chakra"}));
@@ -48,6 +50,23 @@ TEST(StrSplitStripped, DropsEmptyAndWhitespaceOnlyTokens) {
 TEST(StrSplitStripped, HonorsCustomDelimiter) {
     EXPECT_EQ(splitStripped("a:b: c ", ':'), (std::vector<std::string>{"a", "b", "c"}));
     EXPECT_EQ(splitStripped("a,b", ':'), (std::vector<std::string>{"a,b"}));
+}
+
+TEST(StrSplitStrippedSet, DeduplicatesAndSorts) {
+    EXPECT_EQ(splitStrippedSet("nvtx,chakra"), (std::set<std::string>{"chakra", "nvtx"}));
+    EXPECT_EQ(splitStrippedSet(" nvtx , nvtx , chakra "),
+              (std::set<std::string>{"chakra", "nvtx"}));
+    EXPECT_EQ(splitStrippedSet("chakra,chakra,chakra"), (std::set<std::string>{"chakra"}));
+}
+
+TEST(StrSplitStrippedSet, DropsEmptyAndWhitespaceOnlyTokens) {
+    EXPECT_TRUE(splitStrippedSet("").empty());
+    EXPECT_TRUE(splitStrippedSet(" , ").empty());
+    EXPECT_EQ(splitStrippedSet(",nvtx,,nvtx,"), (std::set<std::string>{"nvtx"}));
+}
+
+TEST(StrSplitStrippedSet, HonorsCustomDelimiter) {
+    EXPECT_EQ(splitStrippedSet("a:b: a ", ':'), (std::set<std::string>{"a", "b"}));
 }
 
 } // namespace


### PR DESCRIPTION
## What?
Adds a small, header-only helper `nixl::str::splitStripped(absl::string_view, char delim = ',')`
in `src/utils/common/str_util.h` that splits a delimited string into non-empty,
whitespace-stripped tokens (order-preserving, duplicates kept). Refactors
`resolveTraceBackends()` in `src/core/nixl_agent.cpp` (`NIXL_TRACE_BACKENDS`) to use it,
replacing the open-coded `absl::StrSplit(',')` + `absl::StripAsciiWhitespace` + skip-empty
loop with a range-insert into the backend set. Adds unit tests
(`test/gtest/unit/util/str_util_test.cpp`).

## Why?
Follow-up from the PR #1897 review (NIX-1621): the same comma-separated env-list parsing
idiom is open-coded in several places (tracing backends, DOCA exporter backends, histogram
buckets, per-metric activation). This lands the shared helper and converts the one call site
that exists on `main` today (`resolveTraceBackends`). Kept intentionally minimal and
behavior-preserving so the remaining call sites can adopt it independently as their PRs land;
if this merges first the helper is already available to cherry-pick on rebase, avoiding a
separate follow-up PR.

Ref: https://linear.app/nvidia/issue/NIX-1621

## How?
`splitStripped` centralizes the `StrSplit` + `StripAsciiWhitespace` + skip-empty logic and
returns a `std::vector<std::string>`; deduplication stays a caller concern (`resolveTraceBackends`
still collects into a `std::set`, so the set-but-empty "off" semantics and nsys auto-enable
precedence are unchanged). No `TELEMETRY_VERSION`/API change. Existing tracing tests
(`Tracing.ResolveBackends*`) plus 4 new `StrSplitStripped` cases pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved trace backend configuration parsing to trim ASCII whitespace, ignore empty entries, and correctly handle repeated delimiters while keeping the prior NVTX enable/disable behavior.
- **New Features**
  - Added shared string-splitting utilities to split/trim and optionally return a deduplicated set.
- **Tests**
  - Added unit tests for the new split behaviors (ordering vs. deduplication, whitespace-only handling, and custom delimiters).
  - Updated the unit-test build setup to include the new utility tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->