### PR TITLE
contrib: exclude rdma-core libs from wheel packaging

### DIFF
--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -97,7 +97,7 @@ if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then
     echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'"
     exit 1
 fi
-AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca* --exclude libred_client* --exclude libred_async* --exclude liblz4*"
+AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca* --exclude libred_client* --exclude libred_async* --exclude liblz4* --exclude libibverbs* --exclude libmlx5*"
 
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
 CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | tr -d .)"

--- a/contrib/build-wheel.sh
+++ b/contrib/build-wheel.sh
@@ -97,7 +97,7 @@ if [ "$CUDA_MAJOR" -ne 12 ] && [ "$CUDA_MAJOR" -ne 13 ]; then
     echo "Invalid CUDA_MAJOR: '$CUDA_MAJOR'"
     exit 1
 fi
-AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libcuobjclient* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca* --exclude libred_client* --exclude libred_async* --exclude liblz4*"
+AUDITWHEEL_EXCLUDES="--exclude libcuda* --exclude libcufile* --exclude libcuobjclient* --exclude libssl* --exclude libcrypto* --exclude libefa* --exclude libhwloc* --exclude libfabric* --exclude libtorch* --exclude libc10* --exclude libdoca* --exclude libred_client* --exclude libred_async* --exclude liblz4* --exclude libibverbs* --exclude libmlx5*"
 
 PKG_NAME="nixl-cu${CUDA_MAJOR}"
 CU_TAG="cu$(nvcc --version | grep -Eo 'release [0-9]+\.[0-9]+' | cut -d' ' -f2 | tr -d .)"


### PR DESCRIPTION
Add libibverbs and libmlx5 to AUDITWHEEL_EXCLUDES so auditwheel does not bundle host RDMA userspace libraries into NIXL wheels. This avoids loading a wheel-private libibverbs alongside the system libibverbs used by other RDMA consumers such as NCCL, and lets UCX resolve rdma-core providers from the host environment.

## What?

The NIXL wheel currently bundles two rdma-core shared libraries — `libibverbs` and `libmlx5` — because they are not listed in `AUDITWHEEL_EXCLUDES` in `contrib/build-wheel.sh`. After `auditwheel repair`, these appear as renamed files in the wheel, for
example:

```
nixl_cu13.libs/libibverbs-1de1263b.so.1.14.48.0
nixl_cu13.libs/libmlx5-79ef1d27.so.1.24.48.0
```
(Verified from `nixl-cu13==1.3.1` on PyPI.)

These libraries should be excluded from the wheel and resolved from the host system at runtime.

## Why?

### 1. rdma-core must match the host kernel's RDMA subsystem

rdma-core libraries (`libibverbs`, provider plugins like `libmlx5`, etc.) communicate directly with kernel RDMA drivers via `/dev/infiniband/` device nodes and kernel ABI. Bundling a fixed version in the wheel can produce silent failures or undefined behavior when deployed on hosts running a different kernel RDMA stack.

Furthermore, different deployment environments require different RDMA stacks — some use upstream rdma-core, while others require MLNX_OFED >= 5.0 for features like GPUDirect RDMA or SHARP. Bundling a specific rdma-core version in the wheel forces a single choice and prevents users from selecting the RDMA stack that matches their hardware and deployment requirements.

### 2. Dual-libibverbs conflict when NCCL and UCX coexist

NCCL is not bundled with the wheel, so when a process uses NCCL's IB net plugin, it resolves `libibverbs.so` from the system at runtime. Meanwhile, the UCX transport module `libuct_ib.so` inside the wheel has been patched by `auditwheel` to load the bundled `libibverbs-<hash>.so`.

If a process uses both NCCL and NIXL simultaneously:

```
UCX path:  wheel's libuct_ib.so → wheel's libibverbs-<hash>.so  (bundled copy)
NCCL path: NCCL IB net plugin  → system libibverbs.so.1         (system copy)
```

Two independent instances of `libibverbs` in the same process maintain separate device lists and internal state, which can cause unpredictable RDMA behavior.

### 3. Bundling `libmlx5` locks out non-Mellanox RDMA providers

The wheel currently bundles `libmlx5.so` (a Mellanox/NVIDIA-specific userspace driver) as a build-time artifact. On hosts with non-Mellanox RDMA hardware — such as Alibaba eRDMA, Intel/Cornelis OPX, Broadcom, or other ibverbs-capable devices. These hosts provide their own vendor-specific provider libraries (e.g., `liberdma.so`, `libhfi1.so`) through the system's rdma-core installation.

By excluding rdma-core from the wheel, NIXL would use whatever ibverbs providers the host system offers, enabling RDMA support across a wider range of hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the wheel repair process to further prevent selected high-speed hardware communication libraries from being bundled into repaired wheel packages (by adding additional exclusion patterns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->