### PR TITLE
ci: right-size run-step and job timeouts

### DIFF
--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -20,7 +20,9 @@ job: nixl-ci-gpu
 # Fail job if one of the steps fails or continue
 failFast: false
 
-timeout_minutes: 240
+# Job cap. Axes run in parallel, so this bounds the longest single axis:
+# docker build (~11) + allocation wait (up to immediateTimeout 60) + run steps (110) + stop (~5).
+timeout_minutes: 200
 
 registry_host: artifactory.nvidia.com
 registry_auth: svc-nixl-new-artifactory-token
@@ -133,7 +135,7 @@ steps:
 
   - name: Run CPP tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: 120
+    timeout: 60
     parallel: false
     shell: action
     module: slurmCI
@@ -149,7 +151,7 @@ steps:
 
   - name: Run Python tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: 10
+    timeout: 20
     parallel: false
     shell: action
     module: slurmCI
@@ -165,7 +167,7 @@ steps:
 
   - name: Run Rust tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: 10
+    timeout: 15
     parallel: false
     shell: action
     module: slurmCI
@@ -181,7 +183,7 @@ steps:
 
   - name: Run Nixlbench tests
     containerSelector: "{name: 'build_helper'}"
-    timeout: 50
+    timeout: 25
     parallel: false
     shell: action
     module: slurmCI


### PR DESCRIPTION
## What?
The on-failure enroot export (~5 min for a multi-GB container) runs inside each run step's timeout(), so the tight Python/Rust steps could SIGTERM the export mid-mksquashfs. Meanwhile CPP (120) and Nixlbench (50) were far larger than their real runtimes, and the four timeouts summed to 190 min — more than the Slurm allocation's --time (SLURM_JOB_TIMEOUT = 140 min), so a slow run could lose the allocation before the Jenkins timeouts even fired.

Right-size run steps to observed durations plus export headroom:
  CPP        120 -> 60   (~35 min observed)
  Python      10 -> 15   (~7 min observed; UCX createBackend can be slow)
  Rust        10 -> 10   (~1.5 min observed; already has headroom)
  Nixlbench   50 -> 25   (~10 min observed)

Sum is now 110 min, under the 140-min allocation. Axes run in parallel, so the job cap only needs to cover the longest single axis (docker ~11 + allocation wait up to 60 + steps 110 + stop ~5 ~= 186), so drop timeout_minutes 240 -> 200. Durations taken from three nixl-ci-gpu runs.

## Why?
The export capability would sometime fail on timeout if tests took all the test allocated time

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GPU CI test time limits to improve overall execution efficiency.
  * Adjusted time allocations across C++, Python, Rust, and Nixlbench test phases to better fit workload expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->