### PR TITLE
test/gtest: fail on unexpected NVTX tracing skips

### DIFF
--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -85,27 +85,20 @@ if $TEST_LIBFABRIC ; then
 fi
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
-mkdir -p /tmp/telemetry_test
-NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test ./bin/agent_example &
-sleep 5
-./bin/telemetry_reader /tmp/telemetry_test/Agent001 &
-telePID=$!
-sleep 15
-kill -s INT $telePID
-
-# POSIX test disabled until we solve io_uring and Docker compatibility
 
 ./bin/nixl_posix_test -n 128 -s 1048576
-./bin/nixl_gusli_test -n 4 -s 16
+
 ./bin/ucx_backend_multi
 ./bin/serdes_test
-# TODO: Enable Mooncake test once data corruption issue is resolved
-# if $HAS_GPU ; then
-#     ./bin/mooncake_backend_test
-# fi
 
 # shellcheck disable=SC2154
+echo SEPARATE
 gtest-parallel --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
+echo TOGETHER
+./bin/gtest --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
+echo DONE
+exit 42
+
 ./bin/test_plugin
 
 # DOCA telemetry exporter tests: present only when built with the DOCA SDK

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -104,6 +104,12 @@ kill -s INT $telePID
 #     ./bin/mooncake_backend_test
 # fi
 
+cuda_nvcc=$(command -v nvcc || echo /usr/local/cuda/bin/nvcc)
+cuda_major=$("$cuda_nvcc" --version 2>/dev/null | grep -oP 'release \K[0-9]+' | head -1 || true)
+if [ -n "$cuda_major" ] && [ "$cuda_major" -lt 13 ]; then
+    export NIXL_CI_ALLOW_NVTX_SKIP=1
+fi
+
 # shellcheck disable=SC2154
 gtest-parallel --output_dir=/tmp --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
 echo NIXL_CI_NON_GPU $NIXL_CI_NON_GPU

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -106,6 +106,8 @@ kill -s INT $telePID
 
 # shellcheck disable=SC2154
 gtest-parallel --output_dir=/tmp --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
+echo NIXL_CI_NON_GPU $NIXL_CI_NON_GPU
+echo TEST_LIBFABRIC $TEST_LIBFABRIC
 grep -r Skipped /tmp/gtest-parallel-logs
 
 ./bin/test_plugin

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -85,19 +85,28 @@ if $TEST_LIBFABRIC ; then
 fi
 ./bin/nixl_etcd_example
 ./bin/ucx_backend_test
+mkdir -p /tmp/telemetry_test
+NIXL_TELEMETRY_ENABLE=y NIXL_TELEMETRY_DIR=/tmp/telemetry_test ./bin/agent_example &
+sleep 5
+./bin/telemetry_reader /tmp/telemetry_test/Agent001 &
+telePID=$!
+sleep 15
+kill -s INT $telePID
+
+# POSIX test disabled until we solve io_uring and Docker compatibility
 
 ./bin/nixl_posix_test -n 128 -s 1048576
-
+./bin/nixl_gusli_test -n 4 -s 16
 ./bin/ucx_backend_multi
 ./bin/serdes_test
+# TODO: Enable Mooncake test once data corruption issue is resolved
+# if $HAS_GPU ; then
+#     ./bin/mooncake_backend_test
+# fi
 
 # shellcheck disable=SC2154
-echo SEPARATE
-gtest-parallel --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
-echo TOGETHER
-./bin/gtest --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
-echo DONE
-exit 42
+gtest-parallel --output_dir=/tmp --workers=1 --serialize_test_cases ./bin/gtest -- --min-tcp-port="$min_gtest_port" --max-tcp-port="$max_gtest_port"
+grep -r Skipped /tmp/gtest-parallel-logs
 
 ./bin/test_plugin
 

--- a/test/gtest/main.cpp
+++ b/test/gtest/main.cpp
@@ -85,6 +85,8 @@ namespace {
         "HardwareWarningTest.NoWarningWhenIbAndCudaSupported",
         "ucxDeviceApi*"};
 
+    const std::set<std::string> nvtx_skips = {"*TestTransferTracing*"};
+
     std::mutex mutex;
     std::vector<std::string> required_but_skipped;
 
@@ -167,6 +169,11 @@ RunAllTests() {
     if (var && (var == std::string("false"))) {
         stc->allowForSkip(non_efa_skips);
         std::cerr << "ALLOWING EFA tests to be skipped" << std::endl;
+    }
+
+    if (std::getenv("NIXL_CI_ALLOW_NVTX_SKIP") != nullptr) {
+        stc->allowForSkip(nvtx_skips);
+        std::cerr << "ALLOWING NVTX tracing tests to be skipped" << std::endl;
     }
 
     return RUN_ALL_TESTS();

--- a/test/gtest/main.cpp
+++ b/test/gtest/main.cpp
@@ -16,10 +16,15 @@
  */
 #include "plugin_manager.h"
 #include "common.h"
+
+#include <fnmatch.h>
+
 #include <gtest/gtest.h>
 #include <cstdlib>
 #include <iostream>
 #include <list>
+#include <mutex>
+#include <set>
 #include <sstream>
 #include <vector>
 #include <string>
@@ -68,6 +73,66 @@ void ParseArguments(int argc, char **argv) {
 }
 
 namespace {
+    const std::set<std::string> non_efa_skips = {
+        "HardwareWarningTest.EfaHardwareMismatchWarning",
+        "HardwareWarningTest.EfaHardwareMismatchNoWarning",
+        "LoadedPluginTestFixture.LibfabricPluginAdvertisesPostThreadOptions",
+        "LibfabricLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0"
+    };
+
+    const std::set<std::string> non_gpu_skips = {
+        "HardwareWarningTest.WarnWhenGpuPresentButCudaNotSupported",
+        "HardwareWarningTest.WarnWhenIbPresentButRdmaNotSupported",
+        "HardwareWarningTest.NoWarningWhenIbAndCudaSupported",
+        "ucxDeviceApi*"
+    };
+
+    std::mutex mutex;
+    std::vector<std::string> required_but_skipped;
+
+} // namespace
+
+class SkippedTestsChecker
+    : public testing::EmptyTestEventListener {
+public:
+    void
+    allowForSkip(const std::set<std::string> &set) {
+        allowed_for_skip_.insert(set.begin(), set.end());
+    }
+
+private:
+    std::set<std::string> allowed_for_skip_ = {
+#if !defined( LOAD_ALL_PLUGINS )
+        "UcxLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0",
+        "GdsLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0",
+        "LoadedPluginTestFixture.LibfabricPluginAdvertisesPostThreadOptions",
+        "LibfabricLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0"
+#endif
+    };
+    std::vector<std::string> required_skipped_;
+
+    void
+    OnTestEnd(const testing::TestInfo &info) override {
+        if (const auto *result = info.result()) {
+            if (result->Skipped()) {
+                const std::string s = info.test_suite_name();
+                const std::string n = info.name();
+                const std::string name = s + "." + n;
+
+                for (const std::string &allowed : allowed_for_skip_) {
+                    if (::fnmatch(allowed.c_str(), name.c_str(), 0) == 0) {
+                        return;
+                    }
+                }
+                const std::scoped_lock ml(mutex);
+                required_but_skipped.push_back(name);
+            }
+        }
+    }
+};
+
+
+namespace {
     const std::regex
         ib_regex("IB device\\(s\\) were detected, but accelerated IB support was not found");
     const std::regex aws_regex("UCX version is less than 1.19, CUDA support is limited, including"
@@ -81,6 +146,12 @@ int
 RunAllTests() {
     LogProblemCounter lpc;
     std::list<LogIgnoreGuard> ligs;
+    auto *stc = new SkippedTestsChecker;
+    {
+        auto *instance = testing::UnitTest::GetInstance();
+        auto &listeners = instance->listeners();
+        listeners.Append(stc); // Takes ownership and deletes "when the program finishes".
+    }
 
     // TODO: Remove after the CI issues spuriously triggering this message are fixed.
     ligs.emplace_back(ib_regex);
@@ -90,7 +161,15 @@ RunAllTests() {
     }
 
     if (std::getenv("NIXL_CI_NON_GPU") != nullptr) {
+        stc->allowForSkip(non_gpu_skips);
+        std::cerr << "ALLOWING GPU tests to be skipped" << std::endl;
         ligs.emplace_back(non_gpu_regex);
+    }
+
+    const char *var = std::getenv("TEST_LIBFABRIC");
+    if (var && (var == std::string("false"))) {
+        stc->allowForSkip(non_efa_skips);
+        std::cerr << "ALLOWING EFA tests to be skipped" << std::endl;
     }
 
     return RUN_ALL_TESTS();
@@ -99,12 +178,21 @@ RunAllTests() {
 int RunTests(int argc, char **argv) {
     testing::InitGoogleTest(&argc, argv);
     ParseArguments(argc, argv);
-    const int result = RunAllTests();
+
+    int result = RunAllTests();
+
+    if (const size_t skipped = required_but_skipped.size(); skipped > 0) {
+        std::cerr << "ATTENTION: Required tests skipped without skip being allowed" << std::endl;
+        for (const std::string &name : required_but_skipped) {
+            std::cerr << "ATTENTION: Skipped " << name << std::endl;
+        }
+        result |= 1;
+    }
 
     if (const size_t problems = LogProblemCounter::getProblemCount(); problems > 0) {
         std::cerr << "ATTENTION: Unexpected NIXL warning(s) and/or error(s) detected!" << std::endl;
         std::cerr << "ATTENTION: Problem count is " << problems << std::endl;
-        return 42;
+        result |= 1;
     }
     return result;
 }

--- a/test/gtest/main.cpp
+++ b/test/gtest/main.cpp
@@ -77,23 +77,20 @@ namespace {
         "HardwareWarningTest.EfaHardwareMismatchWarning",
         "HardwareWarningTest.EfaHardwareMismatchNoWarning",
         "LoadedPluginTestFixture.LibfabricPluginAdvertisesPostThreadOptions",
-        "LibfabricLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0"
-    };
+        "LibfabricLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0"};
 
     const std::set<std::string> non_gpu_skips = {
         "HardwareWarningTest.WarnWhenGpuPresentButCudaNotSupported",
         "HardwareWarningTest.WarnWhenIbPresentButRdmaNotSupported",
         "HardwareWarningTest.NoWarningWhenIbAndCudaSupported",
-        "ucxDeviceApi*"
-    };
+        "ucxDeviceApi*"};
 
     std::mutex mutex;
     std::vector<std::string> required_but_skipped;
 
 } // namespace
 
-class SkippedTestsChecker
-    : public testing::EmptyTestEventListener {
+class SkippedTestsChecker : public testing::EmptyTestEventListener {
 public:
     void
     allowForSkip(const std::set<std::string> &set) {
@@ -102,7 +99,7 @@ public:
 
 private:
     std::set<std::string> allowed_for_skip_ = {
-#if !defined( LOAD_ALL_PLUGINS )
+#if !defined(LOAD_ALL_PLUGINS)
         "UcxLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0",
         "GdsLoadPluginInstantiation/LoadSinglePluginTestFixture.SimpleLifeCycleTest/0",
         "LoadedPluginTestFixture.LibfabricPluginAdvertisesPostThreadOptions",

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -62,6 +62,7 @@ cpp_flags = []
 
 if cuda_dep.found()
     cpp_flags += '-DHAVE_CUDA'
+    cuda_flags += '-DHAVE_CUDA'
     cuda_dependencies = [cuda_dep]
 else
     cuda_dependencies = []
@@ -115,6 +116,7 @@ test_exe = executable('gtest',
     sources : gtest_sources,
     include_directories: [nixl_inc_dirs, utils_inc_dirs, device_api_inc, include_directories('../doca-telemetry'), include_directories('../../src/plugins/telemetry/common')],
     cpp_args : cpp_flags,
+    cuda_args : cuda_flags,
     dependencies : [nixl_dep, nixl_common_dep, cuda_dependencies, device_api_dep, gtest_dep, gmock_dep, absl_strings_dep, absl_time_dep, ucx_hw_warning_dep, file_utils_interface],
     link_with: [nixl_build_lib],
     install : true

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -59,6 +59,7 @@ endif
 plugin_dirs_arg = '--tests_plugin_dirs=' + mocks_dep.get_variable('path')
 
 cpp_flags = []
+cuda_flags = []
 
 if cuda_dep.found()
     cpp_flags += '-DHAVE_CUDA'


### PR DESCRIPTION
## What?
- `test/gtest/main.cpp`: allowlist the NVTX tracing gtests (`*TestTransferTracing*`, covering `TestTransferTracing` and `TestTransferTracingNsysAuto`) for skipping **only** when `NIXL_CI_ALLOW_NVTX_SKIP` is set — integrating with the `SkippedTestsChecker` from #1909.
- `.gitlab/test_cpp.sh`: export `NIXL_CI_ALLOW_NVTX_SKIP=1` before `bin/gtest` **only** when the container's CUDA major `< 13`.

## Why?
- NIX-1623. The NVTX tracing gtests `GTEST_SKIP()` when `libtrace_backend_nvtx.so` was not built. With skips now treated as failures, a broken build that silently omits the plugin must **fail**, not skip — via an outside-declared switch (like `NIXL_CI_NON_GPU`).
- The NVTX plugin needs `nvtx3/nvToolsExtPayload.h`, absent only on CUDA < 13 images (in CI, `cuda-dl-base 25.06-cuda12.9`; `cuda 13.0.1` and `pytorch 26.06` build it — confirmed from the `nixl-ci-non-gpu` meson logs). CUDA is present in all CI images, so this is **not** GPU-vs-non-GPU.

## How?
- Fail-closed: unset (default) → an NVTX skip fails the run; set → tolerated.
- The `test_cpp.sh` CUDA-major gate is the single entry point that launches `bin/gtest` for the non-gpu, GPU, and DL jobs, so every CUDA-13.x leg (GPU/DL/sanitizer + the non-gpu 13.0.1 & pytorch legs) keeps NVTX skips fatal; only the cuda12.9 non-gpu legs allow the skip. No matrix `env` change, and no reliance on per-image `${name}` interpolation.
- Stacked on #1909 (`ColinNV:log_ci_cpp`), which adds `SkippedTestsChecker` — merge that first, then this.
- Validated locally on a real build: env unset → `exit 1` with `ATTENTION: Required tests skipped`; env set → `exit 0`; plugin present → tests run and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation to detect and report required tests that were unexpectedly skipped.
  * Test results now consistently indicate failures when warnings or required skips are detected.
  * Added environment-aware handling for GPU, CUDA, NVTX, and libfabric test availability.
  * Enhanced test logs to identify skipped tests and provide clearer diagnostics.

* **Build Improvements**
  * Improved CUDA-aware test compilation when CUDA support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->