### PR TITLE
libfabric: PT-owns-endpoint with MPSC lock-free ring

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -260,16 +260,28 @@ nixlLibfabricCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &wa
 
     was_updated = false;
 
-    if (expected_dev == -1) return -1;
-    if (myDevId_ != -1 && expected_dev != myDevId_) return -1;
+    if (expected_dev == -1) {
+        return -1;
+    }
+    if (myDevId_ != -1 && expected_dev != myDevId_) {
+        return -1;
+    }
 
     ret = cudaQueryAddr(address, is_dev, dev, ctx, pci_bus_id);
-    if (ret) return ret;
-    if (!is_dev) return 0;
-    if (dev != expected_dev) return -1;
+    if (ret) {
+        return ret;
+    }
+    if (!is_dev) {
+        return 0;
+    }
+    if (dev != expected_dev) {
+        return -1;
+    }
 
     if (pthrCudaCtx_) {
-        if (pthrCudaCtx_ != ctx) return -1;
+        if (pthrCudaCtx_ != ctx) {
+            return -1;
+        }
         return 0;
     }
 
@@ -283,15 +295,41 @@ nixlLibfabricCudaCtx::cudaUpdateCtxPtr(void *address, int expected_dev, bool &wa
 int
 nixlLibfabricCudaCtx::cudaSetCtx() {
     CUresult result;
-    if (NULL == pthrCudaCtx_) return 0;
+    if (NULL == pthrCudaCtx_) {
+        return 0;
+    }
 
     result = cuCtxSetCurrent(pthrCudaCtx_);
     return (CUDA_SUCCESS == result);
 }
 
+class nixlLibfaricCudaCtxEngineMediator : public LibfabricUtils::nixlLibfaricCudaCtxMediator {
+public:
+    nixlLibfaricCudaCtxEngineMediator(nixlLibfabricEngine *engine) : engine_(engine) {}
+
+    ~nixlLibfaricCudaCtxEngineMediator() override {}
+
+    nixl_status_t
+    cudaSetCtx(bool &use_cuda_addr_wa) override {
+        if (engine_ == nullptr) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        return engine_->vramApplyCtxEx(use_cuda_addr_wa);
+    }
+
+private:
+    nixlLibfabricEngine *engine_;
+};
+
 void
 nixlLibfabricEngine::vramInitCtx() {
     cudaCtx_ = std::make_unique<nixlLibfabricCudaCtx>();
+
+    // install a mediator so that the progress thread can also use this
+    // NOTE: the mediator is stateless and therefore it cannot be involved in a race
+    std::unique_ptr<LibfabricUtils::nixlLibfaricCudaCtxMediator> mediator;
+    mediator.reset(new (std::nothrow) nixlLibfaricCudaCtxEngineMediator(this));
+    setCudaCtxMediator(std::move(mediator));
 }
 
 int
@@ -328,6 +366,18 @@ void
 nixlLibfabricEngine::vramFiniCtx() {
     const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
     cudaCtx_.reset();
+    LibfabricUtils::clearCudaCtxMediator();
+}
+
+nixl_status_t
+nixlLibfabricEngine::vramApplyCtxEx(bool &use_cuda_addr_wa) const {
+    const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
+    use_cuda_addr_wa = cuda_addr_wa_;
+    if (use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
+        NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
+        return NIXL_ERR_BACKEND;
+    }
+    return NIXL_SUCCESS;
 }
 #endif
 
@@ -500,8 +550,18 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
 
         // Start Progress thread for rail completion processing
         if (progress_thread_enabled_) {
+            // in case of PT=1 we need to allocate post ring buffer per rail
+            size_t post_queue_size = NIXL_LIBFABRC_DEFAULT_POST_QUEUE_SIZE;
+            LibfabricUtils::getCustomIntParam(
+                getCustomParams(), "post_queue_size", post_queue_size);
+
             for (size_t i = 0; i < rail_manager_.getNumRails(); ++i) {
                 rail_manager_.getRail(i).setProgressThreadEnabled(true);
+                if (!rail_manager_.getRail(i).initPostQueue(post_queue_size)) {
+                    NIXL_ERROR << "Failed to initialize post-queue for rail " << i;
+                    throw std::runtime_error("Failed to initialize the rail manager: unable to "
+                                             "initialize rail post queue");
+                }
             }
 
             NIXL_INFO << "Starting Progress thread for rails with delay: "
@@ -1211,31 +1271,19 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
     submitted_count = 0;
 
 #ifdef HAVE_CUDA
+    // NOTE: when progress thread is enabled and the call is deferred via ring-buffer, this should
+    // take place in the context of the progress thread
     const bool is_cuda_vram = local.getType() == VRAM_SEG && runtime_ == FI_HMEM_CUDA;
     bool use_cuda_addr_wa = false;
     int current_cuda_device = -1;
-    if (is_cuda_vram) {
-        const std::lock_guard<std::mutex> lock(cuda_ctx_mutex_);
-        use_cuda_addr_wa = cuda_addr_wa_;
-        if (use_cuda_addr_wa && cudaCtx_ && !cudaCtx_->cudaSetCtx()) {
-            NIXL_ERROR << "Failed to set CUDA context before posting descriptors";
-            return NIXL_ERR_BACKEND;
+    if (!progress_thread_enabled_ && is_cuda_vram) {
+        nixl_status_t status = vramApplyCtxEx(use_cuda_addr_wa);
+        if (status != NIXL_SUCCESS) {
+            return status;
         }
     }
-
-    auto prepare_cuda_descriptor_post = [&](int device_id, int desc_idx) -> nixl_status_t {
-        if (!is_cuda_vram || use_cuda_addr_wa || device_id == current_cuda_device) {
-            return NIXL_SUCCESS;
-        }
-        cudaError_t cuda_ret = cudaSetDevice(device_id);
-        if (cuda_ret != cudaSuccess) {
-            NIXL_ERROR << "Failed to set CUDA device " << device_id << " while posting descriptor "
-                       << desc_idx << ": " << cudaGetErrorString(cuda_ret);
-            return NIXL_ERR_BACKEND;
-        }
-        current_cuda_device = device_id;
-        return NIXL_SUCCESS;
-    };
+#else
+    const bool is_cuda_vram = false;
 #endif
 
     // A FI_MORE post rings no doorbell; a rail's queued batch is only submitted by a later
@@ -1270,9 +1318,18 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
         int device_id = local[desc_idx].devId;
 
 #ifdef HAVE_CUDA
-        if (nixl_status_t status = prepare_cuda_descriptor_post(device_id, desc_idx);
-            status != NIXL_SUCCESS) {
-            return status;
+        // NOTE: when progress thread is enabled and the call is deferred via ring-buffer, this
+        // should take place in the context of the progress thread
+        if (!progress_thread_enabled_ && is_cuda_vram && !use_cuda_addr_wa &&
+            device_id != current_cuda_device) {
+            cudaError_t cuda_ret = cudaSetDevice(device_id);
+            if (cuda_ret != cudaSuccess) {
+                NIXL_ERROR << "Failed to set CUDA device " << device_id
+                           << " while posting descriptor " << desc_idx << ": "
+                           << cudaGetErrorString(cuda_ret);
+                return NIXL_ERR_BACKEND;
+            }
+            current_cuda_device = device_id;
         }
 #endif
 
@@ -1300,7 +1357,9 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
             desc_submitted_count,
             desc_idx,
             xfer_base_offset,
-            apply_fi_more);
+            apply_fi_more,
+            local[desc_idx].devId,
+            is_cuda_vram);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -356,6 +356,11 @@ private:
     vramApplyCtx();
     void
     vramFiniCtx();
+
+    // same as vramApplyCtx, but with additional output parameter
+    nixl_status_t
+    vramApplyCtxEx(bool &use_cuda_addr_wa) const;
+    friend class nixlLibfaricCudaCtxEngineMediator;
 #endif
 
 public:

--- a/src/utils/libfabric/libfabric_common.cpp
+++ b/src/utils/libfabric/libfabric_common.cpp
@@ -298,4 +298,24 @@ getCustomIntParam(const nixl_b_params_t &custom_params, const std::string &key, 
     return NIXL_SUCCESS;
 }
 
+static std::unique_ptr<nixlLibfaricCudaCtxMediator> cuda_ctx_mediator;
+
+void
+setCudaCtxMediator(std::unique_ptr<nixlLibfaricCudaCtxMediator> &&mediator) {
+    cuda_ctx_mediator = std::move(mediator);
+}
+
+void
+clearCudaCtxMediator() {
+    cuda_ctx_mediator.reset(nullptr);
+}
+
+nixl_status_t
+cudaSetCtx(bool &use_cuda_addr_wa) {
+    if (cuda_ctx_mediator.get() == nullptr) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return cuda_ctx_mediator->cudaSetCtx(use_cuda_addr_wa);
+}
+
 } // namespace LibfabricUtils

--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -41,6 +41,7 @@
 #define NIXL_LIBFABRIC_CQ_SREAD_TIMEOUT_MS 10
 #define NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD (128 * 1024) // 128KB
 #define LF_EP_NAME_MAX_LEN 56
+#define NIXL_LIBFABRC_DEFAULT_POST_QUEUE_SIZE (32 * 1024) // 32K MPSC entries
 
 // Number of consecutive WRITE descriptors batched onto one rail with FI_MORE before flushing.
 #define NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE 16
@@ -338,6 +339,34 @@ getCustomStringParam(const nixl_b_params_t &custom_params,
  */
 extern nixl_status_t
 getCustomIntParam(const nixl_b_params_t &custom_params, const std::string &key, size_t &value);
+} // namespace LibfabricUtils
+
+// CUDA context workaround temporary API for exposing to progress thread
+namespace LibfabricUtils {
+
+/**
+ * @brief Mediator class for abstracting engine internals, while allowing consumers (e.g. progress
+ * thread) to have access to the API without having an engine pointer.
+ */
+class nixlLibfaricCudaCtxMediator {
+public:
+    virtual ~nixlLibfaricCudaCtxMediator() {}
+
+    virtual nixl_status_t
+    cudaSetCtx(bool &use_cuda_addr_wa) = 0;
+
+protected:
+    nixlLibfaricCudaCtxMediator() {}
+};
+
+extern void
+setCudaCtxMediator(std::unique_ptr<nixlLibfaricCudaCtxMediator> &&mediator);
+
+extern void
+clearCudaCtxMediator();
+
+extern nixl_status_t
+cudaSetCtx(bool &use_cuda_addr_wa);
 } // namespace LibfabricUtils
 
 #endif // NIXL_SRC_UTILS_LIBFABRIC_LIBFABRIC_COMMON_H

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -21,6 +21,10 @@
 #include "serdes/serdes.h"
 #include "libfabric_common.h"
 
+#ifdef HAVE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 #include <cstring>
 #include <stdexcept>
 #include <stack>
@@ -713,6 +717,11 @@ nixlLibfabricRail::setProgressThreadEnabled(bool enabled) {
     progress_thread_enabled_ = enabled;
 }
 
+bool
+nixlLibfabricRail::initPostQueue(size_t post_queue_size) {
+    return post_ring_.initialize(post_queue_size);
+}
+
 void
 nixlLibfabricRail::setXferIdCallback(std::function<void(uint64_t, uint16_t)> callback) {
     xferIdCallback = callback;
@@ -720,8 +729,8 @@ nixlLibfabricRail::setXferIdCallback(std::function<void(uint64_t, uint16_t)> cal
 
 // Per-rail completion processing - handles one rail's CQ with configurable blocking behavior
 nixl_status_t
-nixlLibfabricRail::progressCompletionQueue() const {
-    // Completion processing
+nixlLibfabricRail::progressCompletionQueue() {
+    // Completion processing FIRST — process arrivals before posting new items
     struct fi_cq_data_entry completions[NIXL_LIBFABRIC_CQ_BATCH_SIZE];
 
     int ret;
@@ -755,7 +764,7 @@ nixlLibfabricRail::progressCompletionQueue() const {
     // CQ lock released here - completion is now local data
 
     if (ret == -FI_EAGAIN) {
-        return NIXL_IN_PROG; // No completions available
+        // No completions - fall through to drainPostQueue
     }
 
     if (ret > 0) {
@@ -770,10 +779,34 @@ nixlLibfabricRail::progressCompletionQueue() const {
         }
 
         NIXL_DEBUG << "Processed " << ret << " completions on rail " << rail_id;
-        return NIXL_SUCCESS;
     }
 
-    return NIXL_ERR_BACKEND; // Unexpected case
+    // PT-owns-endpoint: drain pending posts AFTER processing completions
+    if (progress_thread_enabled_) {
+        nixl_status_t status = drainPostQueue();
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to drain post-qeueu";
+            return status;
+        }
+    }
+
+    return (ret > 0) ? NIXL_SUCCESS : NIXL_IN_PROG;
+}
+
+void
+nixlLibfabricRail::pollForCompletions() {
+    struct fi_cq_data_entry cq_buf[16];
+    int cq_ret = fi_cq_read(cq, cq_buf, 16);
+    if (cq_ret > 0) {
+        for (int c = 0; c < cq_ret; c++) {
+            processCompletionQueueEntry(&cq_buf[c]);
+        }
+    } else if (cq_ret < 0 && cq_ret != -FI_EAGAIN) {
+        struct fi_cq_err_entry err_entry = {};
+        fi_cq_readerr(cq, &err_entry, 0);
+        NIXL_ERROR << "CQ error in drain interleave on rail " << rail_id << ": "
+                   << fi_strerror(err_entry.err);
+    }
 }
 
 // Route completion to appropriate handler (rail-specific)
@@ -1037,9 +1070,7 @@ nixlLibfabricRail::postRecv(nixlLibfabricReq *req) const {
 }
 
 nixl_status_t
-nixlLibfabricRail::postSend(uint64_t immediate_data,
-                            fi_addr_t dest_addr,
-                            nixlLibfabricReq *req) const {
+nixlLibfabricRail::postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLibfabricReq *req) {
     if (req->buffer_size == 0 || req->buffer_size > NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE) {
         NIXL_ERROR << "Invalid message size=" << req->buffer_size
                    << " (max: " << NIXL_LIBFABRIC_SEND_RECV_BUFFER_SIZE << ")";
@@ -1118,6 +1149,141 @@ nixlLibfabricRail::postSend(uint64_t immediate_data,
     return NIXL_ERR_BACKEND;
 }
 
+/****************************************
+ * PT-owns-endpoint: post queue methods
+ ****************************************/
+
+void
+nixlLibfabricRail::enqueuePost(const nixlLibfabricPostRequest &req) {
+    post_ring_.push(req);
+}
+
+nixl_status_t
+nixlLibfabricRail::drainPostQueue() {
+    nixlLibfabricPostRequest pr;
+    int posted = 0;
+#if HAVE_CUDA
+    bool use_cuda_addr_wa = false;
+    int current_cuda_device = -1;
+#endif
+
+    // drain the queue up to configured limit,
+    // to ensure requests from other rails do not wait too much time
+    size_t post_req_count = 0;
+    while (post_req_count < POST_MAX_BATCH_SIZE && post_ring_.pop(pr)) {
+        ++post_req_count;
+        int ret = -FI_EAGAIN;
+
+#if HAVE_CUDA
+        if (pr.is_cuda_vram) {
+            // NOTE: for now we do not call engine to try to set context in work-around mode - this
+            // is postponsed to another PR, which requires substantial refactoring - instead we
+            // directly call cudaSetDevice() when needed
+            use_cuda_addr_wa = false;
+            nixl_status_t status = LibfabricUtils::cudaSetCtx(use_cuda_addr_wa);
+            if (status != NIXL_SUCCESS) {
+                // completion is notified also for failed requests
+                // (otherwise counters would never match)
+                if (pr.req && pr.req->completion_callback) {
+                    pr.req->completion_callback();
+                }
+
+                // defrred request cannot be executed, continue to the next
+                NIXL_ERROR << "Failed to set CUDA context, while posting deferred descriptor";
+                continue;
+            }
+
+            // other-wise set cuda device before call if needed
+            if (!use_cuda_addr_wa && pr.device_id != current_cuda_device) {
+                cudaError_t cuda_ret = cudaSetDevice(pr.device_id);
+                if (cuda_ret != cudaSuccess) {
+                    // completion is notified also for failed requests
+                    // (otherwise counters would never match)
+                    if (pr.req && pr.req->completion_callback) {
+                        pr.req->completion_callback();
+                    }
+
+                    // defrred request cannot be executed, continue to the next
+                    NIXL_ERROR << "Failed to set CUDA device " << pr.device_id
+                               << " while posting deferred descriptor: "
+                               << cudaGetErrorString(cuda_ret);
+                    continue;
+                }
+                current_cuda_device = pr.device_id;
+            }
+        }
+#endif
+
+        while (ret == -FI_EAGAIN) {
+            if (pr.type == nixlLibfabricPostRequest::WRITE) {
+                struct iovec iov{};
+                iov.iov_base = pr.local_addr;
+                iov.iov_len = pr.length;
+
+                struct fi_rma_iov rma_iov{};
+                rma_iov.addr = pr.remote_addr;
+                rma_iov.len = pr.length;
+                rma_iov.key = pr.remote_key;
+
+                void *desc = pr.local_desc;
+                struct fi_msg_rma msg = {};
+                msg.msg_iov = &iov;
+                msg.desc = &desc;
+                msg.iov_count = 1;
+                msg.addr = pr.dest_addr;
+                msg.rma_iov = &rma_iov;
+                msg.rma_iov_count = 1;
+                msg.context = &pr.req->ctx;
+                msg.data = pr.immediate_data;
+
+                ret = fi_writemsg(endpoint, &msg, pr.fi_flags | FI_REMOTE_CQ_DATA);
+            } else {
+                struct iovec iov{};
+                iov.iov_base = pr.local_addr;
+                iov.iov_len = pr.length;
+
+                struct fi_rma_iov rma_iov{};
+                rma_iov.addr = pr.remote_addr;
+                rma_iov.len = pr.length;
+                rma_iov.key = pr.remote_key;
+
+                void *desc = pr.local_desc;
+                struct fi_msg_rma msg = {};
+                msg.msg_iov = &iov;
+                msg.desc = &desc;
+                msg.iov_count = 1;
+                msg.addr = pr.dest_addr;
+                msg.rma_iov = &rma_iov;
+                msg.rma_iov_count = 1;
+                msg.context = &pr.req->ctx;
+
+                ret = fi_readmsg(endpoint, &msg, pr.fi_flags);
+            }
+
+            if (ret == -FI_EAGAIN) {
+                pollForCompletions();
+            }
+        }
+
+        if (ret != 0) {
+            NIXL_ERROR << "drainPostQueue: post failed ret=" << ret << " (" << fi_strerror(-ret)
+                       << ") on rail " << rail_id;
+            if (pr.req && pr.req->completion_callback) {
+                // completion is notified also for failed requests
+                // (otherwise counters would never match)
+                pr.req->completion_callback();
+            }
+            continue;
+        }
+        posted++;
+        if (posted % POST_POLL_INTERLEAVE_RATIO == 0) {
+            pollForCompletions();
+        }
+    }
+
+    return NIXL_SUCCESS;
+}
+
 nixl_status_t
 nixlLibfabricRail::postWrite(const void *local_buffer,
                              size_t length,
@@ -1127,7 +1293,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                              uint64_t remote_addr,
                              uint64_t remote_key,
                              nixlLibfabricReq *req,
-                             uint64_t fi_flags) const {
+                             uint64_t fi_flags) {
     // Validation
     if (!req) {
         NIXL_ERROR << "Invalid request for write on rail " << rail_id;
@@ -1179,6 +1345,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
         }
 
         if (ret == -FI_EAGAIN) {
+            // SQ full - do inline CQ progress to free slots, then retry
             // Resource temporarily unavailable - retry indefinitely for all providers
             attempt++;
 
@@ -1222,7 +1389,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
                             fi_addr_t dest_addr,
                             uint64_t remote_addr,
                             uint64_t remote_key,
-                            nixlLibfabricReq *req) const {
+                            nixlLibfabricReq *req) {
     // Validation
     if (!req) {
         NIXL_ERROR << "Invalid request for read on rail " << rail_id;
@@ -1261,6 +1428,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
         }
 
         if (ret == -FI_EAGAIN) {
+            // SQ full - do inline CQ progress to free slots, then retry
             // Resource temporarily unavailable - retry indefinitely for all providers
             attempt++;
 

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <functional>
 #include <mutex>
+#include <atomic>
+#include <thread>
 #include <ostream>
 #include <stack>
 
@@ -232,6 +234,162 @@ operator<<(std::ostream &os, const ConnectionState &state) {
     }
 }
 
+/**
+ * @brief Lock-free, and mostly wait-free, Multi-Producer Single-Consumer ring buffer.
+ * Multiple producer threads (postXfer) push concurrently.
+ * Single consumer (progress thread) pops and posts.
+ * Uses fetch-add on head for multi-producer safety and freedom to execute in parallel.
+ */
+template<typename T> class MpscRing {
+public:
+    MpscRing() : head_(0), tail_(0), capacity_(0), ring_(nullptr), committed_(nullptr) {}
+
+    MpscRing(const MpscRing &) = delete;
+    MpscRing(MpscRing &&) = delete;
+
+    MpscRing &
+    operator=(const MpscRing &) = delete;
+
+    ~MpscRing() {
+        destroy();
+    }
+
+    bool
+    initialize(size_t capacity) {
+        if (capacity == 0) {
+            NIXL_ERROR << "Invalid ring buffer zero size";
+            return false;
+        }
+        if (ring_ != nullptr) {
+            NIXL_WARN << "Ring buffer already initialized, request to initialize ignored";
+            return true;
+        }
+        if (committed_ != nullptr) {
+            // this should never happen
+            NIXL_ERROR << "Ring buffer in invalid state";
+            return false;
+        }
+        ring_ = new (std::nothrow) T[capacity];
+        if (ring_ == nullptr) {
+            NIXL_ERROR << "Failed to allocate ring buffer of size " << capacity;
+            return false;
+        }
+        committed_ = new (std::nothrow) std::atomic<bool>[capacity];
+        if (committed_ == nullptr) {
+            NIXL_ERROR << "Failed to allocated ring buffer committed array of size " << capacity;
+            delete[] ring_;
+            ring_ = nullptr;
+            return false;
+        }
+        for (size_t i = 0; i < capacity; ++i) {
+            committed_[i].store(false, std::memory_order_relaxed);
+        }
+        capacity_ = capacity;
+        return true;
+    }
+
+    void
+    destroy() {
+        if (ring_ != nullptr) {
+            delete[] ring_;
+            ring_ = nullptr;
+        }
+        if (committed_ != nullptr) {
+            delete[] committed_;
+            committed_ = nullptr;
+        }
+        capacity_ = 0;
+        head_ = 0;
+        tail_ = 0;
+    }
+
+    void
+    push(const T &item) {
+        // NOTE: although this is a blocking call, as long as there is enough room in the ring
+        // buffer, this is WAIT-FREE (as opposed to any other CAS-based solution)
+
+        // grab a unique slot among all concurrent writers
+        size_t absHead = head_.fetch_add(1, std::memory_order_relaxed);
+        size_t absTail = tail_.load(std::memory_order_acquire);
+
+        // wait until reader catches up
+        // NOTE: capacity should be matched with expected insert load and reader's capability to
+        // handle requests (should be large enough to handle the largest expected burst)
+        while (absHead - absTail >= capacity_) {
+            std::this_thread::yield();
+            absTail = tail_.load(std::memory_order_acquire);
+            // NOTE: we may add here some counters for reporting a full ring buffer
+        }
+
+        // head slot is now reserved for us
+        size_t head = absHead % capacity_;
+        ring_[head] = item;
+        // Signal that this slot is written (use a separate committed array)
+        committed_[head].store(true, std::memory_order_release);
+    }
+
+    bool
+    pop(T &item) {
+        size_t absTail = tail_.load(std::memory_order_relaxed);
+        size_t absHead = head_.load(std::memory_order_acquire);
+        if (absTail == absHead) {
+            return false;
+        }
+        size_t tail = absTail % capacity_;
+        // Wait for the slot to be committed (producer might still be writing)
+        // NOTE: we can actually peek entries ahead if head > tail + 1, but that would require
+        // skipping them later, so we need a third state for committed array, for now this
+        // optimization is not implemented, unless we see reader having difficulties
+        if (!committed_[tail].load(std::memory_order_acquire)) {
+            // item is not ready, so back-off
+            return false;
+        }
+        item = ring_[tail];
+        committed_[tail].store(false, std::memory_order_relaxed);
+        tail_.store((absTail + 1), std::memory_order_release);
+        return true;
+    }
+
+    bool
+    empty() const {
+        // NOTE: we don't care about order here, as long as both head and tail are loaded by the
+        // time we compare them
+        size_t absTail = tail_.load(std::memory_order_relaxed);
+        size_t absHead = head_.load(std::memory_order_relaxed);
+
+        // NOTE: if reader is busy reading last committed entry and has not advanced yet the tail
+        // pointer, we still consider this as not-empty
+        return (absTail == absHead);
+    }
+
+private:
+    alignas(64) std::atomic<size_t> head_;
+    alignas(64) std::atomic<size_t> tail_;
+    size_t capacity_;
+    T *ring_;
+    std::atomic<bool> *committed_;
+};
+
+/**
+ * @brief Queued post request for PT-owns-endpoint model
+ * Main thread enqueues; progress thread dequeues and posts.
+ */
+struct nixlLibfabricPostRequest {
+    enum post_type { WRITE, READ, SEND } type;
+
+    void *local_addr;
+    size_t length;
+    void *local_desc;
+    uint64_t immediate_data; // WRITE only
+    fi_addr_t dest_addr;
+    uint64_t remote_addr;
+    uint64_t remote_key;
+    nixlLibfabricReq *req;
+    uint64_t fi_flags;
+    int device_id; // CUDA device ordinal for cudaSetDevice in PT
+    bool is_cuda_vram;
+};
+
 /** Individual libfabric rail managing fabric, domain, endpoint, CQ, and AV */
 class nixlLibfabricRail {
 public:
@@ -303,7 +461,7 @@ public:
 
     /** Post send operation with immediate data */
     nixl_status_t
-    postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLibfabricReq *req) const;
+    postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLibfabricReq *req);
 
     /** Post RDMA write operation with immediate data */
     nixl_status_t
@@ -315,7 +473,7 @@ public:
               uint64_t remote_addr,
               uint64_t remote_key,
               nixlLibfabricReq *req,
-              uint64_t fi_flags = 0) const;
+              uint64_t fi_flags = 0);
 
     /** Post RDMA read operation */
     nixl_status_t
@@ -325,11 +483,19 @@ public:
              fi_addr_t dest_addr,
              uint64_t remote_addr,
              uint64_t remote_key,
-             nixlLibfabricReq *req) const;
+             nixlLibfabricReq *req);
 
     /** Process completion queue with batching support */
     nixl_status_t
-    progressCompletionQueue() const;
+    progressCompletionQueue();
+
+    /** Enqueue a post request for the progress thread to execute */
+    void
+    enqueuePost(const nixlLibfabricPostRequest &req);
+
+    /** Drain pending posts (called by progress thread) */
+    nixl_status_t
+    drainPostQueue();
 
     // Callback registration methods
     /** Set callback for notification message processing.
@@ -354,6 +520,23 @@ public:
      */
     void
     setProgressThreadEnabled(bool enabled);
+
+    /** Check if progress thread is enabled for this rail */
+    bool
+    isProgressThreadEnabled() const {
+        return progress_thread_enabled_;
+    }
+
+    /**
+     * @brief Initializes the post transfer queue (lokc-free ring buffer) for deferring requests
+     * when the progress thread is enabled.
+     *
+     * @param post_queue_size The size of the post transfer queue (lock-free ring buffer) size.
+     *
+     * @return True if initialization succeeded, otherwise false.
+     */
+    bool
+    initPostQueue(size_t post_queue_size);
 
     /** Set callback for XFER_ID tracking.
      *  Signature: (imm_data, sender_agent_idx_in_our_table). sender_agent_idx
@@ -393,6 +576,14 @@ private:
     // EP mutex to protect endpoint and CQ operations
     mutable std::mutex ep_mutex_;
 
+    // Lock-free MPSC ring: main thread pushes, PT pops and posts
+    using post_ring_t = MpscRing<nixlLibfabricPostRequest>;
+    post_ring_t post_ring_;
+
+    // the post/poll interleave ratio constants
+    static constexpr size_t POST_MAX_BATCH_SIZE = 256;
+    static constexpr size_t POST_POLL_INTERLEAVE_RATIO = 32;
+
     // Whether a progress thread is handling CQ draining
     bool progress_thread_enabled_ = false;
 
@@ -410,6 +601,8 @@ private:
     // Provider capability flags
     bool provider_supports_hmem_;
 
+    void
+    pollForCompletions();
 
     nixl_status_t
     processCompletionQueueEntry(struct fi_cq_data_entry *comp) const;

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -390,7 +390,9 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     size_t &submitted_count_out,
     int desc_idx,
     size_t base_offset,
-    bool apply_fi_more) {
+    bool apply_fi_more,
+    int device_id,
+    bool is_cuda_vram) {
     // Initialize output parameter
     submitted_count_out = 0;
 
@@ -443,9 +445,22 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         req->local_mr = local_mrs[rail_id];
         req->remote_key = remote_keys[remote_ep_id];
         req->rail_id = rail_id;
-        // Submit immediately
+        // Submit: either enqueue for PT, or post directly
         nixl_status_t status;
-        if (op_type == nixlLibfabricReq::WRITE) {
+        if (rails_[rail_id]->isProgressThreadEnabled()) {
+            // PT-owns-endpoint: enqueue for progress thread to post
+            deferTransferRequest(op_type,
+                                 agent_idx,
+                                 xfer_id,
+                                 fi_flags,
+                                 dest_addrs.at(rail_id)[remote_ep_id],
+                                 device_id,
+                                 is_cuda_vram,
+                                 rail_id,
+                                 req);
+            status = NIXL_SUCCESS;
+        } else if (op_type == nixlLibfabricReq::WRITE) {
+            // Direct post (PT OFF path)
             // Generate next SEQ_ID for this specific write operation
             uint8_t seq_id = LibfabricUtils::getNextSeqId();
             uint64_t imm_data =
@@ -495,7 +510,9 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
                 remote_selected_endpoints[i % remote_selected_endpoints.size()];
             NIXL_DEBUG << "rail " << rail_id << ", remote_ep_id=" << remote_ep_id;
             size_t current_chunk_size = chunk_size + (i == num_rails - 1 ? remainder : 0);
-            if (current_chunk_size == 0) break;
+            if (current_chunk_size == 0) {
+                break;
+            }
             // Allocate request
             nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);
             if (!req) {
@@ -527,7 +544,19 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             req->remote_key = remote_keys[remote_ep_id];
             req->rail_id = rail_id;
             nixl_status_t status;
-            if (op_type == nixlLibfabricReq::WRITE) {
+            if (rails_[rail_id]->isProgressThreadEnabled()) {
+                // PT-owns-endpoint: enqueue for progress thread to post
+                deferTransferRequest(op_type,
+                                     agent_idx,
+                                     xfer_id,
+                                     fi_flags,
+                                     dest_addrs.at(rail_id)[remote_ep_id],
+                                     device_id,
+                                     is_cuda_vram,
+                                     rail_id,
+                                     req);
+                status = NIXL_SUCCESS;
+            } else if (op_type == nixlLibfabricReq::WRITE) {
                 // Generate next SEQ_ID for this specific transfer operation
                 uint8_t seq_id = LibfabricUtils::getNextSeqId();
                 uint64_t imm_data =
@@ -569,6 +598,37 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     NIXL_DEBUG << "Successfully submitted requests for " << transfer_size << " bytes";
 
     return NIXL_SUCCESS;
+}
+
+void
+nixlLibfabricRailManager::deferTransferRequest(nixlLibfabricReq::OpType op_type,
+                                               uint16_t agent_idx,
+                                               uint16_t xfer_id,
+                                               uint64_t fi_flags,
+                                               fi_addr_t dest_addr,
+                                               int device_id,
+                                               bool is_cuda_vram,
+                                               size_t rail_id,
+                                               nixlLibfabricReq *req) {
+    uint8_t seq_id = (op_type == nixlLibfabricReq::WRITE) ? LibfabricUtils::getNextSeqId() : 0;
+    uint64_t imm_data = (op_type == nixlLibfabricReq::WRITE) ?
+        NIXL_MAKE_IMM_DATA(NIXL_LIBFABRIC_MSG_TRANSFER, agent_idx, xfer_id, seq_id) :
+        0;
+    nixlLibfabricPostRequest pr{};
+    pr.type = (op_type == nixlLibfabricReq::WRITE) ? nixlLibfabricPostRequest::WRITE :
+                                                     nixlLibfabricPostRequest::READ;
+    pr.local_addr = req->local_addr;
+    pr.length = req->chunk_size;
+    pr.local_desc = fi_mr_desc(req->local_mr);
+    pr.immediate_data = imm_data;
+    pr.dest_addr = dest_addr;
+    pr.remote_addr = req->remote_addr;
+    pr.remote_key = req->remote_key;
+    pr.req = req;
+    pr.fi_flags = fi_flags;
+    pr.device_id = device_id;
+    pr.is_cuda_vram = is_cuda_vram;
+    rails_[rail_id]->enqueuePost(pr);
 }
 
 bool

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -214,6 +214,8 @@ public:
      *        (posted with FI_MORE); false flushes the rail's batch. The caller passes false for
      *        a rail's last post and when a batch reaches NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE.
      *        Defaults to false so an unmarked descriptor flushes safely.
+     * @param device_id Device id when multi-GPU is enabled.
+     * @param is_cuda_device Specifies whether this is CUDA-VRAM transfer.
      * @return NIXL_SUCCESS on success, error code on failure
      */
     nixl_status_t
@@ -233,7 +235,20 @@ public:
                              size_t &submitted_count_out,
                              int desc_idx,
                              size_t base_offset,
-                             bool apply_fi_more = false);
+                             bool apply_fi_more = false,
+                             int device_id = -1,
+                             bool is_cuda_vram = false);
+
+    void
+    deferTransferRequest(nixlLibfabricReq::OpType op_type,
+                         uint16_t agent_idx,
+                         uint16_t xfer_id,
+                         uint64_t fi_flags,
+                         fi_addr_t dest_addr,
+                         int device_id,
+                         bool is_cuda_vram,
+                         size_t rail_id,
+                         nixlLibfabricReq *req);
 
     /** Reserve a base offset for a transfer to ensure stable rail assignment
      *  across all descriptors in the transfer. Call once per postXfer. */


### PR DESCRIPTION
libfabric: Move fi_writemsg/fi_readmsg posting into the Progress Thread (when progress thread is enabled) via a lock-free MPSC ring buffer, eliminating ep_mutex_ contention on the data path, resulting in performance improvement with larger batch sizes. Main thread enqueues to per-rail MpscRing; PT dequeues, posts, and polls completions in a single thread.

- MpscRing<T,2048>: CAS multi-producer, single-consumer ring
- drainPostQueue: PT posts with FI_MORE batching, interleaves CQ
- cudaSetDevice in PT for multi-GPU VRAM buffer validation
- Graceful error: completion callback on failure, continue draining

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Added a deferred, progress-thread-aware per-rail post queue that batches requests and interleaves completion draining with retry on temporary backpressure.
  - Introduced configurable post-queue sizing (default: 2048) to improve transfer throughput under progress-thread mode.

- **Reliability**
  - Strengthened CUDA context validation and selection for CUDA VRAM transfers, with more defensive handling of mismatches and query failures.
  - Improved handling of `-FI_EAGAIN` so progress continues via CQ drain/retry instead of stopping early.
  - Enabled per-transfer device targeting for multi-GPU CUDA operations.

- **Chores**
  - Added clearer error reporting when per-rail post queue initialization fails in progress-thread mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->