### PR TITLE
telemetry: add full-pipeline stress tests

### DIFF
--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -63,6 +63,26 @@ if build_doca_tests
     )
 
     test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false)
+
+    # Exporter volume/stress case, kept in its own source/binary so the sustained
+    # high-volume run stays isolated from the functional exporter tests.
+    doca_nixl_stress_test_exe = executable('doca_nixl_stress_test',
+        sources: [
+            'telemetry_doca_stress_test.cpp',
+            doca_exporter_dir / 'doca_exporter.cpp',
+        ],
+        include_directories: [
+            nixl_inc_dirs,
+            utils_inc_dirs,
+            include_directories(doca_exporter_dir),
+            include_directories('../../src/plugins/telemetry/common'),
+        ],
+        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep, absl_strings_dep],
+        cpp_args: ['-Wno-deprecated-declarations'],
+        install: true,
+    )
+
+    test('doca_nixl_stress_test', doca_nixl_stress_test_exe, is_parallel: false)
     message('Building standalone DOCA telemetry exporter tests')
 
     cmake = import('cmake')

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -82,7 +82,9 @@ if build_doca_tests
         install: true,
     )
 
-    test('doca_nixl_stress_test', doca_nixl_stress_test_exe, is_parallel: false)
+    # scrapeUntilValue polls up to 15s; give generous headroom over Meson's 30s
+    # default for the high-volume run plus setup/flush on loaded or sanitizer CI.
+    test('doca_nixl_stress_test', doca_nixl_stress_test_exe, is_parallel: false, timeout: 120)
     message('Building standalone DOCA telemetry exporter tests')
 
     cmake = import('cmake')

--- a/test/doca-telemetry/meson.build
+++ b/test/doca-telemetry/meson.build
@@ -49,25 +49,6 @@ if build_doca_tests
     doca_nixl_test_exe = executable('doca_nixl_test',
         sources: [
             'telemetry_doca_nixl_test.cpp',
-            doca_exporter_dir / 'doca_exporter.cpp',
-        ],
-        include_directories: [
-            nixl_inc_dirs,
-            utils_inc_dirs,
-            include_directories(doca_exporter_dir),
-            include_directories('../../src/plugins/telemetry/common'),
-        ],
-        dependencies: [gtest_dep, doca_telemetry_dep, doca_common_dep, nixl_infra, nixl_common_dep, absl_log_dep, absl_strings_dep],
-        cpp_args: ['-Wno-deprecated-declarations'],
-        install: true,
-    )
-
-    test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false)
-
-    # Exporter volume/stress case, kept in its own source/binary so the sustained
-    # high-volume run stays isolated from the functional exporter tests.
-    doca_nixl_stress_test_exe = executable('doca_nixl_stress_test',
-        sources: [
             'telemetry_doca_stress_test.cpp',
             doca_exporter_dir / 'doca_exporter.cpp',
         ],
@@ -82,9 +63,11 @@ if build_doca_tests
         install: true,
     )
 
-    # scrapeUntilValue polls up to 15s; give generous headroom over Meson's 30s
-    # default for the high-volume run plus setup/flush on loaded or sanitizer CI.
-    test('doca_nixl_stress_test', doca_nixl_stress_test_exe, is_parallel: false, timeout: 120)
+    # The suite normally runs in well under a second, but each case may spend its
+    # scrape settle budget (12-15s) waiting on a lagging DOCA endpoint. Bound the
+    # test by the sum of those budgets so a slow CI machine reports the failing
+    # assertion instead of a bare timeout.
+    test('doca_nixl_test', doca_nixl_test_exe, is_parallel: false, timeout: 180)
     message('Building standalone DOCA telemetry exporter tests')
 
     cmake = import('cmake')

--- a/test/doca-telemetry/telemetry_doca_stress_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_stress_test.cpp
@@ -1,0 +1,131 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// DOCA exporter volume within the standalone test architecture.
+//
+// test/doca-telemetry/doca_nixl_test intentionally does not link full NIXL core,
+// so this exercises the NIXL DOCA exporter's volume handling only -- not the core
+// staging queue, whose concurrency is validated through BUFFER and Prometheus in
+// the gtest stress suite. Kept in its own source/binary so the sustained
+// high-volume case stays isolated from the functional DOCA exporter tests.
+
+#include "scrape_util.h"
+
+#include "doca_exporter.h"
+#include "telemetry_event.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using nixl::doca_test::loopbackConnection;
+using nixl::doca_test::scrapeUntilValue;
+
+namespace {
+
+constexpr char docaPrometheusPortVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_PORT";
+constexpr char docaPrometheusLocalVar[] = "NIXL_TELEMETRY_DOCA_PROMETHEUS_LOCAL";
+
+} // namespace
+
+class docaNixlExporterStressTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        port_ = loopbackConnection::findFreePort();
+        ASSERT_NE(port_, 0) << "failed to allocate a free TCP port";
+
+        ASSERT_EQ(::setenv(docaPrometheusLocalVar, "y", 1), 0);
+        ASSERT_EQ(::setenv(docaPrometheusPortVar, std::to_string(port_).c_str(), 1), 0);
+    }
+
+    void
+    TearDown() override {
+        ::unsetenv(docaPrometheusLocalVar);
+        ::unsetenv(docaPrometheusPortVar);
+    }
+
+    uint16_t port_ = 0;
+};
+
+// Push a large deterministic sequence directly through nixlTelemetryDocaExporter.
+// Distinct increasing byte deltas make the cumulative counter sum and the
+// last-operation gauge sensitive to any dropped or duplicated sample, and a long
+// run of synthetic drop deltas exercises the drop counter's accumulation at
+// volume. One flush after production, then one settle-and-scrape on the stable
+// final totals.
+TEST_F(docaNixlExporterStressTest, HighVolumeSequenceCounterGaugeAndDropAccumulate) {
+    constexpr char agentName[] = "nixl_doca_volume_test";
+    const nixlTelemetryExporterInitParams params{agentName, 4096};
+    nixlTelemetryDocaExporter exporter(params);
+
+    const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
+    const std::string txCounter =
+        nixlEnumStrings::telemetryMetricDescriptor(nixl_telemetry_event_type_t::AGENT_TX_BYTES)
+            .counterName;
+    const std::string txLast = "agent_tx_last_bytes";
+    const std::string dropCounter = nixlEnumStrings::telemetryMetricDescriptor(
+                                        nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED)
+                                        .counterName;
+
+    constexpr uint64_t kByteEvents = 4000;
+    uint64_t counter_sum = 0;
+    for (uint64_t i = 1; i <= kByteEvents; ++i) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_TX_BYTES, i);
+        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
+        counter_sum += i;
+    }
+    const uint64_t last_byte_value = kByteEvents;
+
+    // A long run of per-flush drop deltas (as the core would emit them under
+    // sustained staging overflow), each a whole 4-event batch.
+    constexpr uint64_t kDropDeltas = 1000;
+    constexpr uint64_t kDropPerDelta = 4;
+    uint64_t drop_total = 0;
+    for (uint64_t i = 0; i < kDropDeltas; ++i) {
+        const nixlTelemetryEvent event(nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED,
+                                       kDropPerDelta);
+        ASSERT_EQ(exporter.exportEvent(event), NIXL_SUCCESS);
+        drop_total += kDropPerDelta;
+    }
+
+    ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
+
+    const auto metrics = scrapeUntilValue(
+        port_, txCounter, static_cast<double>(counter_sum), std::chrono::seconds(15), labels);
+    const std::optional<double> observed_counter = metrics.latestValue(txCounter, labels);
+    ASSERT_TRUE(observed_counter.has_value())
+        << txCounter << "{agent_name=" << agentName << "} not served after flush";
+    EXPECT_EQ(*observed_counter, static_cast<double>(counter_sum))
+        << "cumulative counter must equal the sum of all " << kByteEvents
+        << " distinct pushed deltas; a drop or duplicate would miss this total";
+
+    EXPECT_EQ(metrics.latestValue(txLast, labels), std::optional<double>(last_byte_value))
+        << "last-op gauge must reflect the final pushed value at volume";
+
+    EXPECT_EQ(metrics.latestValue(dropCounter, labels), std::optional<double>(drop_total))
+        << "drop counter must accumulate every emitted delta at volume (" << kDropDeltas << "*"
+        << kDropPerDelta << ")";
+}
+
+int
+main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/doca-telemetry/telemetry_doca_stress_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_stress_test.cpp
@@ -76,10 +76,10 @@ TEST_F(docaNixlExporterStressTest, HighVolumeSequenceCounterGaugeAndDropAccumula
     nixlTelemetryDocaExporter exporter(params);
 
     const nixl::doca_test::labelSet labels{{"agent_name", agentName}};
-    const std::string txCounter =
-        nixlEnumStrings::telemetryMetricDescriptor(nixl_telemetry_event_type_t::AGENT_TX_BYTES)
-            .counterName;
-    const std::string txLast = "agent_tx_last_bytes";
+    const auto txDescriptor =
+        nixlEnumStrings::telemetryMetricDescriptor(nixl_telemetry_event_type_t::AGENT_TX_BYTES);
+    const std::string txCounter = txDescriptor.counterName;
+    const std::string txLast = txDescriptor.gaugeName;
     const std::string dropCounter = nixlEnumStrings::telemetryMetricDescriptor(
                                         nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED)
                                         .counterName;

--- a/test/doca-telemetry/telemetry_doca_stress_test.cpp
+++ b/test/doca-telemetry/telemetry_doca_stress_test.cpp
@@ -20,8 +20,9 @@
 // test/doca-telemetry/doca_nixl_test intentionally does not link full NIXL core,
 // so this exercises the NIXL DOCA exporter's volume handling only -- not the core
 // staging queue, whose concurrency is validated through BUFFER and Prometheus in
-// the gtest stress suite. Kept in its own source/binary so the sustained
-// high-volume case stays isolated from the functional DOCA exporter tests.
+// the gtest stress suite. Kept in its own source (linked into doca_nixl_test) so
+// the sustained high-volume case stays readable next to, but separate from, the
+// functional DOCA exporter tests.
 
 #include "scrape_util.h"
 
@@ -107,8 +108,12 @@ TEST_F(docaNixlExporterStressTest, HighVolumeSequenceCounterGaugeAndDropAccumula
 
     ASSERT_EQ(exporter.flush(), NIXL_SUCCESS);
 
+    // Gate on the drop counter: it carries the last events pushed before the
+    // flush, so once it reads its final total the earlier byte events have
+    // certainly landed too. Gating on the byte counter instead would leave the
+    // drop assertion below reading a still-settling series.
     const auto metrics = scrapeUntilValue(
-        port_, txCounter, static_cast<double>(counter_sum), std::chrono::seconds(15), labels);
+        port_, dropCounter, static_cast<double>(drop_total), std::chrono::seconds(15), labels);
     const std::optional<double> observed_counter = metrics.latestValue(txCounter, labels);
     ASSERT_TRUE(observed_counter.has_value())
         << txCounter << "{agent_name=" << agentName << "} not served after flush";
@@ -122,10 +127,4 @@ TEST_F(docaNixlExporterStressTest, HighVolumeSequenceCounterGaugeAndDropAccumula
     EXPECT_EQ(metrics.latestValue(dropCounter, labels), std::optional<double>(drop_total))
         << "drop counter must accumulate every emitted delta at volume (" << kDropDeltas << "*"
         << kDropPerDelta << ")";
-}
-
-int
-main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
 }

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -90,6 +90,8 @@ gtest_sources = [
     'telemetry_test.cpp',
     'telemetry_prometheus_test.cpp',
     'telemetry_histogram_test.cpp',
+    'telemetry_prometheus_stress_test.cpp',
+    'telemetry_stress_test.cpp',
     'telemetry_benchmark.cpp',
     'nixl_duration_test.cpp',
     'configuration.cpp'

--- a/test/gtest/telemetry_prometheus_stress_test.cpp
+++ b/test/gtest/telemetry_prometheus_stress_test.cpp
@@ -1,0 +1,306 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Concurrent Prometheus stress coverage. Kept separate from the functional
+// Prometheus suite (telemetry_prometheus_test.cpp) but sharing its fixture via
+// prometheus_telemetry_fixture.h and scraping through the same OpenMetrics
+// parser/time-series helpers the DOCA and histogram tests use. The Prometheus
+// exporter is lossless and ring-free, so concurrent staging overflow and mixed
+// aggregation resolve to exact, hardware-independent conservation identities.
+
+#include "prometheus_telemetry_fixture.h"
+
+#include "common.h"
+#include "telemetry.h"
+#include "telemetry_event.h"
+
+#include "loopback_connection.h"
+#include "open_metrics_text_parser.h"
+#include "timeseries.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using nixl::doca_test::labelSet;
+using nixl::doca_test::loopbackConnection;
+using nixl::doca_test::timeSeries;
+
+namespace {
+
+// Sanitizer builds run the same concurrent aggregation with fewer producer
+// iterations so TSan/ASan stay within a CI-friendly runtime. Compile-time
+// detection in test code only.
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+constexpr bool kSanitizerBuild = true;
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer)
+constexpr bool kSanitizerBuild = true;
+#else
+constexpr bool kSanitizerBuild = false;
+#endif
+#else
+constexpr bool kSanitizerBuild = false;
+#endif
+
+timeSeries
+scrapeMetrics(uint16_t port) {
+    return timeSeries(
+        nixl::doca_test::open_metrics_text::parse(loopbackConnection::httpGet(port, "/metrics")));
+}
+
+struct OverflowScrape {
+    bool ok = false; // all produced events were accounted for before the timeout
+    double accepted = 0;
+    double dropped = 0;
+};
+
+// Drives `produce` against a fresh nixlTelemetry backed by the Prometheus
+// exporter with a small (256-slot) staging buffer, then polls /metrics until
+// every produced event is accounted for: accepted (`accepted_metric`, weighted by
+// `accepted_event_weight` events per sample) plus dropped
+// (`agent_telemetry_events_dropped_total`) equals `expected_total_events`. Polling
+// for that exact end state (not a fixed sleep) makes the result timing
+// independent. The instance stays alive through the scrape so the exporter keeps
+// serving the port.
+OverflowScrape
+scrapeCoreOverflow(uint16_t port,
+                   const std::string &agent_name,
+                   const std::string &accepted_metric,
+                   uint64_t accepted_event_weight,
+                   uint64_t expected_total_events,
+                   const std::function<void(nixlTelemetry &)> &produce) {
+    gtest::ScopedEnv telemetry_env;
+    telemetry_env.addVar(TELEMETRY_BUFFER_SIZE_VAR, "256");
+    telemetry_env.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
+
+    nixlTelemetry telemetry(agent_name, "prometheus");
+    produce(telemetry);
+
+    const labelSet labels{{"agent_name", agent_name}};
+    OverflowScrape result;
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kSanitizerBuild ? 20 : 5);
+    do {
+        const timeSeries metrics = scrapeMetrics(port);
+        const auto dropped = metrics.latestValue("agent_telemetry_events_dropped_total", labels);
+        const auto accepted = metrics.latestValue(accepted_metric, labels);
+        if (dropped && accepted) {
+            result.dropped = *dropped;
+            result.accepted = *accepted;
+            if (result.accepted * static_cast<double>(accepted_event_weight) + result.dropped ==
+                static_cast<double>(expected_total_events)) {
+                result.ok = true;
+                return result;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    } while (std::chrono::steady_clock::now() < deadline);
+    return result; // ok stays false: full accounting was not observed in time
+}
+
+} // namespace
+
+// Concurrent staging overflow conservation.
+//
+// Many producer threads flood a small (256-slot) staging queue with all-or-none
+// addXferStats batches. Driving the lossless, ring-free Prometheus exporter
+// makes the outcome exact and hardware independent: every 4-event batch is
+// either fully accepted (advancing agent_tx_requests_num_total by one per call,
+// weight 4 slots) or fully dropped (four staging drops). Thread scheduling may
+// change the accepted/dropped split but not the total, so
+// accepted*4 + dropped must equal the produced event slots, drops must be
+// nonzero, and drops must remain a multiple of four.
+TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
+    const std::string agent_name = "prometheus_concurrent_xfer_overflow_agent";
+    constexpr uint64_t kThreads = kSanitizerBuild ? 4 : 8;
+    constexpr uint64_t kCallsPerThread = kSanitizerBuild ? 5000 : 20000;
+    constexpr uint64_t kEventsPerCall = 4;
+    constexpr uint64_t kProducedEvents = kThreads * kCallsPerThread * kEventsPerCall;
+
+    const auto scrape =
+        scrapeCoreOverflow(port_,
+                           agent_name,
+                           "agent_tx_requests_num_total",
+                           kEventsPerCall,
+                           kProducedEvents,
+                           [](nixlTelemetry &telemetry) {
+                               std::vector<std::thread> producers;
+                               producers.reserve(kThreads);
+                               for (uint64_t t = 0; t < kThreads; ++t) {
+                                   producers.emplace_back([&telemetry] {
+                                       for (uint64_t i = 0; i < kCallsPerThread; ++i) {
+                                           telemetry.addXferStats(std::chrono::microseconds(10),
+                                                                  true,
+                                                                  2000,
+                                                                  std::chrono::microseconds(1));
+                                       }
+                                   });
+                               }
+                               for (auto &producer : producers) {
+                                   producer.join();
+                               }
+                           });
+
+    ASSERT_TRUE(scrape.ok) << "accepted*4 + dropped must reach produced events (" << kProducedEvents
+                           << ") under concurrent overflow -- no silent loss";
+    EXPECT_GT(scrape.dropped, 0.0)
+        << "flooding a 256-slot staging queue from many threads must drop batches";
+    EXPECT_EQ(std::fmod(scrape.dropped, static_cast<double>(kEventsPerCall)), 0.0)
+        << "addXferStats drops the whole 4-event batch, so drops are multiples of 4";
+}
+
+// Concurrent Prometheus mixed-workload aggregation.
+//
+// Multiple producers drive distinct metric families concurrently into one
+// Prometheus-backed instance whose staging queue is sized above the total, so
+// nothing is dropped. Deterministic per-thread values make every cumulative
+// counter's final total exact; the last-operation gauges must each hold one of
+// the submitted values; error counters must stay on the bounded status-labeled
+// series; and the staging-drop counter must remain zero (full conservation).
+TEST_F(prometheusTelemetryTest, ConcurrentMixedWorkloadAggregation) {
+    const std::string agent_name = "prometheus_concurrent_mixed_agent";
+    const uint64_t iters = kSanitizerBuild ? 500 : 4000;
+
+    gtest::ScopedEnv telemetry_env;
+    telemetry_env.addVar(TELEMETRY_BUFFER_SIZE_VAR, "65536"); // above the total: no staging drops
+    telemetry_env.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
+
+    nixlTelemetry telemetry(agent_name, "prometheus");
+
+    constexpr uint64_t kTxA = 1000;
+    constexpr uint64_t kTxB = 3000;
+    constexpr uint64_t kRxA = 500;
+    constexpr uint64_t kRxB = 1500;
+    constexpr uint64_t kMem = 4096;
+
+    std::vector<std::thread> producers;
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateTxBytes(kTxA);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateTxBytes(kTxB);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateRxBytes(kRxA);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateRxBytes(kRxB);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateTxRequestsNum(1);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateMemoryRegistered(kMem);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateErrorCount(NIXL_ERR_BACKEND);
+        }
+    });
+    producers.emplace_back([&] {
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateErrorCount(NIXL_ERR_INVALID_PARAM);
+        }
+    });
+    for (auto &producer : producers) {
+        producer.join();
+    }
+
+    const double tx_expected = static_cast<double>(iters) * (kTxA + kTxB);
+    const double rx_expected = static_cast<double>(iters) * (kRxA + kRxB);
+    const double tx_requests_expected = static_cast<double>(iters);
+    const double mem_expected = static_cast<double>(iters) * kMem;
+    const double err_expected = static_cast<double>(iters);
+
+    const labelSet labels{{"agent_name", agent_name}};
+
+    // Poll until every deterministic cumulative counter has reached its exact
+    // total; with no drops the periodic flush drains all events, so the end state
+    // is reached regardless of how flushes interleave (timing independent).
+    timeSeries metrics{nixl::doca_test::seriesMap{}};
+    bool converged = false;
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(kSanitizerBuild ? 30 : 10);
+    do {
+        metrics = scrapeMetrics(port_);
+        const auto tx = metrics.latestValue("agent_tx_bytes_total", labels);
+        const auto rx = metrics.latestValue("agent_rx_bytes_total", labels);
+        const auto tx_req = metrics.latestValue("agent_tx_requests_num_total", labels);
+        const auto mem = metrics.latestValue("agent_memory_registered_total", labels);
+        if (tx == tx_expected && rx == rx_expected && tx_req == tx_requests_expected &&
+            mem == mem_expected) {
+            converged = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    } while (std::chrono::steady_clock::now() < deadline);
+
+    ASSERT_TRUE(converged) << "concurrent cumulative counters must reach their exact totals; "
+                              "a lost event would leave a counter short of its deterministic sum";
+
+    // Last-operation gauges must each hold one of that direction's submitted
+    // values (the winner is scheduling dependent, the validity is not).
+    const auto tx_last = metrics.latestValue("agent_tx_last_bytes", labels);
+    ASSERT_TRUE(tx_last.has_value());
+    EXPECT_TRUE(*tx_last == static_cast<double>(kTxA) || *tx_last == static_cast<double>(kTxB))
+        << "tx last-op gauge must be a submitted tx value, got " << *tx_last;
+    const auto rx_last = metrics.latestValue("agent_rx_last_bytes", labels);
+    ASSERT_TRUE(rx_last.has_value());
+    EXPECT_TRUE(*rx_last == static_cast<double>(kRxA) || *rx_last == static_cast<double>(kRxB))
+        << "rx last-op gauge must be a submitted rx value, got " << *rx_last;
+    EXPECT_EQ(metrics.latestValue("agent_memory_registered_last_bytes", labels),
+              std::optional<double>(static_cast<double>(kMem)));
+
+    // Error counters stay on the bounded status-labeled series, correctly mapped.
+    EXPECT_EQ(metrics.latestValue("agent_errors_total",
+                                  {{"agent_name", agent_name}, {"status", "backend"}}),
+              std::optional<double>(err_expected));
+    EXPECT_EQ(metrics.latestValue("agent_errors_total",
+                                  {{"agent_name", agent_name}, {"status", "invalid_param"}}),
+              std::optional<double>(err_expected));
+    for (const auto &[id, series_samples] : metrics.series()) {
+        (void)series_samples;
+        EXPECT_NE(id.name.rfind("agent_err_", 0), 0u)
+            << "legacy per-type error counter must not be published: " << id.name;
+    }
+
+    // Full conservation: with the queue sized above the total, nothing is
+    // staging-dropped.
+    EXPECT_EQ(metrics.latestValue("agent_telemetry_events_dropped_total", labels),
+              std::optional<double>(0.0))
+        << "no event may be dropped when the queue exceeds the total";
+}

--- a/test/gtest/telemetry_prometheus_stress_test.cpp
+++ b/test/gtest/telemetry_prometheus_stress_test.cpp
@@ -32,6 +32,7 @@
 #include "open_metrics_text_parser.h"
 #include "timeseries.h"
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -63,6 +64,27 @@ constexpr bool kSanitizerBuild = false;
 #else
 constexpr bool kSanitizerBuild = false;
 #endif
+
+// A start latch so every producer thread is released together, after all threads
+// exist -- otherwise early threads can finish before later ones are created and
+// the workload runs largely serially, hiding concurrency defects.
+class StartGate {
+public:
+    void
+    wait() const {
+        while (!go_.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+    }
+
+    void
+    release() {
+        go_.store(true, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool> go_{false};
+};
 
 timeSeries
 scrapeMetrics(uint16_t port) {
@@ -146,10 +168,12 @@ TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
                            kEventsPerCall,
                            kProducedEvents,
                            [](nixlTelemetry &telemetry) {
+                               StartGate gate;
                                std::vector<std::thread> producers;
                                producers.reserve(kThreads);
                                for (uint64_t t = 0; t < kThreads; ++t) {
-                                   producers.emplace_back([&telemetry] {
+                                   producers.emplace_back([&telemetry, &gate] {
+                                       gate.wait();
                                        for (uint64_t i = 0; i < kCallsPerThread; ++i) {
                                            telemetry.addXferStats(std::chrono::microseconds(10),
                                                                   true,
@@ -158,6 +182,7 @@ TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
                                        }
                                    });
                                }
+                               gate.release();
                                for (auto &producer : producers) {
                                    producer.join();
                                }
@@ -195,47 +220,57 @@ TEST_F(prometheusTelemetryTest, ConcurrentMixedWorkloadAggregation) {
     constexpr uint64_t kRxB = 1500;
     constexpr uint64_t kMem = 4096;
 
+    StartGate gate;
     std::vector<std::thread> producers;
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxBytes(kTxA);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxBytes(kTxB);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxBytes(kRxA);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxBytes(kRxB);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxRequestsNum(1);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateMemoryRegistered(kMem);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(NIXL_ERR_BACKEND);
         }
     });
     producers.emplace_back([&] {
+        gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(NIXL_ERR_INVALID_PARAM);
         }
     });
+    gate.release();
     for (auto &producer : producers) {
         producer.join();
     }
@@ -255,14 +290,23 @@ TEST_F(prometheusTelemetryTest, ConcurrentMixedWorkloadAggregation) {
     bool converged = false;
     const auto deadline =
         std::chrono::steady_clock::now() + std::chrono::seconds(kSanitizerBuild ? 30 : 10);
+    const labelSet backend_labels{{"agent_name", agent_name}, {"status", "backend"}};
+    const labelSet invalid_param_labels{{"agent_name", agent_name}, {"status", "invalid_param"}};
     do {
         metrics = scrapeMetrics(port_);
         const auto tx = metrics.latestValue("agent_tx_bytes_total", labels);
         const auto rx = metrics.latestValue("agent_rx_bytes_total", labels);
         const auto tx_req = metrics.latestValue("agent_tx_requests_num_total", labels);
         const auto mem = metrics.latestValue("agent_memory_registered_total", labels);
+        // Error families are checked below; include them here too so convergence
+        // is not declared on a flush that has not yet published them (which would
+        // then fail the exact error assertions with stale totals).
+        const auto backend_err = metrics.latestValue("agent_errors_total", backend_labels);
+        const auto invalid_param_err =
+            metrics.latestValue("agent_errors_total", invalid_param_labels);
         if (tx == tx_expected && rx == rx_expected && tx_req == tx_requests_expected &&
-            mem == mem_expected) {
+            mem == mem_expected && backend_err == err_expected &&
+            invalid_param_err == err_expected) {
             converged = true;
             break;
         }
@@ -286,11 +330,9 @@ TEST_F(prometheusTelemetryTest, ConcurrentMixedWorkloadAggregation) {
               std::optional<double>(static_cast<double>(kMem)));
 
     // Error counters stay on the bounded status-labeled series, correctly mapped.
-    EXPECT_EQ(metrics.latestValue("agent_errors_total",
-                                  {{"agent_name", agent_name}, {"status", "backend"}}),
+    EXPECT_EQ(metrics.latestValue("agent_errors_total", backend_labels),
               std::optional<double>(err_expected));
-    EXPECT_EQ(metrics.latestValue("agent_errors_total",
-                                  {{"agent_name", agent_name}, {"status", "invalid_param"}}),
+    EXPECT_EQ(metrics.latestValue("agent_errors_total", invalid_param_labels),
               std::optional<double>(err_expected));
     for (const auto &[id, series_samples] : metrics.series()) {
         (void)series_samples;

--- a/test/gtest/telemetry_prometheus_stress_test.cpp
+++ b/test/gtest/telemetry_prometheus_stress_test.cpp
@@ -19,8 +19,11 @@
 // Prometheus suite (telemetry_prometheus_test.cpp) but sharing its fixture via
 // prometheus_telemetry_fixture.h and scraping through the same OpenMetrics
 // parser/time-series helpers the DOCA and histogram tests use. The Prometheus
-// exporter is lossless and ring-free, so concurrent staging overflow and mixed
-// aggregation resolve to exact, hardware-independent conservation identities.
+// exporter never drops on export and has no fixed-size ring behind it, so the
+// staging queue is the only place an event can be lost. Both tests can therefore
+// assert exact totals -- accepted plus dropped equals produced, and the
+// no-overflow case reaches exact counter sums -- instead of tolerances, whatever
+// order the threads happen to run in.
 
 #include "prometheus_telemetry_fixture.h"
 
@@ -32,11 +35,11 @@
 #include "open_metrics_text_parser.h"
 #include "timeseries.h"
 
-#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <functional>
+#include <latch>
 #include <optional>
 #include <string>
 #include <thread>
@@ -51,8 +54,7 @@ using nixl::doca_test::timeSeries;
 namespace {
 
 // Sanitizer builds run the same concurrent aggregation with fewer producer
-// iterations so TSan/ASan stay within a CI-friendly runtime. Compile-time
-// detection in test code only.
+// iterations so TSan/ASan stay within a CI-friendly runtime.
 #if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
 constexpr bool kSanitizerBuild = true;
 #elif defined(__has_feature)
@@ -64,27 +66,6 @@ constexpr bool kSanitizerBuild = false;
 #else
 constexpr bool kSanitizerBuild = false;
 #endif
-
-// A start latch so every producer thread is released together, after all threads
-// exist -- otherwise early threads can finish before later ones are created and
-// the workload runs largely serially, hiding concurrency defects.
-class StartGate {
-public:
-    void
-    wait() const {
-        while (!go_.load(std::memory_order_acquire)) {
-            std::this_thread::yield();
-        }
-    }
-
-    void
-    release() {
-        go_.store(true, std::memory_order_release);
-    }
-
-private:
-    std::atomic<bool> go_{false};
-};
 
 timeSeries
 scrapeMetrics(uint16_t port) {
@@ -115,7 +96,7 @@ scrapeCoreOverflow(uint16_t port,
                    const std::function<void(nixlTelemetry &)> &produce) {
     gtest::ScopedEnv telemetry_env;
     telemetry_env.addVar(TELEMETRY_BUFFER_SIZE_VAR, "256");
-    telemetry_env.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
+    telemetry_env.addVar(TELEMETRY_RUN_INTERVAL_VAR, "50");
 
     nixlTelemetry telemetry(agent_name, "prometheus");
     produce(telemetry);
@@ -152,8 +133,12 @@ scrapeCoreOverflow(uint16_t port,
 // either fully accepted (advancing agent_tx_requests_num_total by one per call,
 // weight 4 slots) or fully dropped (four staging drops). Thread scheduling may
 // change the accepted/dropped split but not the total, so
-// accepted*4 + dropped must equal the produced event slots, drops must be
-// nonzero, and drops must remain a multiple of four.
+// accepted*4 + dropped must equal the produced event slots and drops must remain
+// a multiple of four. Nonzero drops are bounded rather than merely likely: a
+// drain removes at most the 256 staged slots, so at the 50 ms flush interval
+// producing 640000 slots (80000 under sanitizers) without a single drop would
+// take over two minutes (15 s), against a workload that finishes in well under a
+// second even under TSan.
 TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
     const std::string agent_name = "prometheus_concurrent_xfer_overflow_agent";
     constexpr uint64_t kThreads = kSanitizerBuild ? 4 : 8;
@@ -168,12 +153,12 @@ TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
                            kEventsPerCall,
                            kProducedEvents,
                            [](nixlTelemetry &telemetry) {
-                               StartGate gate;
+                               std::latch start_gate(1);
                                std::vector<std::thread> producers;
                                producers.reserve(kThreads);
                                for (uint64_t t = 0; t < kThreads; ++t) {
-                                   producers.emplace_back([&telemetry, &gate] {
-                                       gate.wait();
+                                   producers.emplace_back([&telemetry, &start_gate] {
+                                       start_gate.wait();
                                        for (uint64_t i = 0; i < kCallsPerThread; ++i) {
                                            telemetry.addXferStats(std::chrono::microseconds(10),
                                                                   true,
@@ -182,7 +167,7 @@ TEST_F(prometheusTelemetryTest, ConcurrentAddXferStatsOverflowConservation) {
                                        }
                                    });
                                }
-                               gate.release();
+                               start_gate.count_down();
                                for (auto &producer : producers) {
                                    producer.join();
                                }
@@ -220,57 +205,57 @@ TEST_F(prometheusTelemetryTest, ConcurrentMixedWorkloadAggregation) {
     constexpr uint64_t kRxB = 1500;
     constexpr uint64_t kMem = 4096;
 
-    StartGate gate;
+    std::latch start_gate(1);
     std::vector<std::thread> producers;
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxBytes(kTxA);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxBytes(kTxB);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxBytes(kRxA);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxBytes(kRxB);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxRequestsNum(1);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateMemoryRegistered(kMem);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(NIXL_ERR_BACKEND);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(NIXL_ERR_INVALID_PARAM);
         }
     });
-    gate.release();
+    start_gate.count_down();
     for (auto &producer : producers) {
         producer.join();
     }

--- a/test/gtest/telemetry_stress_test.cpp
+++ b/test/gtest/telemetry_stress_test.cpp
@@ -1,0 +1,570 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "common.h"
+#include "common/cyclic_buffer.h"
+#include "nixl_types.h"
+#include "telemetry.h"
+#include "telemetry_event.h"
+
+// Full-pipeline telemetry stress coverage. These tests exercise the complete
+// observable telemetry path -- concurrent producers -> metric mapping and
+// activation -> nixlTelemetryStagingQueue -> periodic flush -> exporter ->
+// observable output -- rather than the queue mechanics the staging-queue unit
+// tests already cover directly. They must pass unchanged on both the mutex-backed
+// staging queue and a future low-lock implementation.
+
+namespace fs = std::filesystem;
+
+namespace {
+
+// Sanitizer builds run the same correctness checks with fewer repetitions: it
+// keeps TSan/ASan within a CI-friendly runtime and limits the repeated
+// thread-pool create/destroy that stresses the sanitizer thread registry, while
+// still surfacing intermittent timer/queue/exporter defects. Detection is
+// compile-time and test-only.
+#if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
+constexpr bool kSanitizerBuild = true;
+#elif defined(__has_feature)
+#if __has_feature(address_sanitizer) || __has_feature(thread_sanitizer)
+constexpr bool kSanitizerBuild = true;
+#else
+constexpr bool kSanitizerBuild = false;
+#endif
+#else
+constexpr bool kSanitizerBuild = false;
+#endif
+
+constexpr std::size_t
+eventIndex(nixl_telemetry_event_type_t type) noexcept {
+    return static_cast<std::size_t>(type);
+}
+
+using EventCounts = std::array<uint64_t, nixl_telemetry_event_type_count>;
+// Per event type, a histogram of received event values -> occurrence count. Used
+// to prove value parity: the multiset of values drained from the ring must equal
+// the multiset produced, so no value is corrupted, duplicated, or lost.
+using ValueHistograms =
+    std::array<std::unordered_map<uint64_t, uint64_t>, nixl_telemetry_event_type_count>;
+
+struct RingTally {
+    EventCounts counts{}; // occurrences per event type in the drained ring
+    ValueHistograms valueHistogram{}; // received value -> count, per non-drop event type
+    uint64_t nonDropEvents = 0; // total events excluding the synthetic drop event
+    uint64_t droppedTotal = 0; // summed value of synthetic drop events
+    uint64_t dropEventsSeen = 0; // number of synthetic drop events observed
+    bool allInRange = true; // every drained enum was a defined event type
+};
+
+// Smallest power of two strictly greater than n, so a BUFFER ring of that size
+// (usable capacity size-1) can hold every one of n exported events without the
+// downstream cyclic ring ever filling (the drop counter tracks only staging-queue
+// drops, so ring loss must be structurally impossible in the under-capacity tests).
+uint64_t
+ringSizeAbove(uint64_t n) {
+    uint64_t size = 1;
+    while (size <= n) {
+        size <<= 1;
+    }
+    return size;
+}
+
+// A start latch so every producer thread is released together, maximizing the
+// concurrency the staging queue actually sees (per the plan: coordinate with
+// atomics/barriers, do not rely on sleeps).
+class StartGate {
+public:
+    void
+    wait() {
+        while (!go_.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+    }
+
+    void
+    release() {
+        go_.store(true, std::memory_order_release);
+    }
+
+private:
+    std::atomic<bool> go_{false};
+};
+
+// Non-destructively poll the writer's published event count (the reader never
+// pops during polling, so read_pos stays 0 and size() == events pushed) until it
+// reaches expected or the deadline passes. Returns the last observed size.
+uint64_t
+waitForRingSize(sharedRingBuffer<nixlTelemetryEvent> &reader,
+                uint64_t expected,
+                std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    uint64_t observed = reader.size();
+    while (observed < expected && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        observed = reader.size();
+    }
+    return observed;
+}
+
+RingTally
+drainRing(sharedRingBuffer<nixlTelemetryEvent> &reader) {
+    RingTally tally;
+    nixlTelemetryEvent event;
+    while (reader.pop(event)) {
+        const auto idx = eventIndex(event.eventType_);
+        if (idx >= nixl_telemetry_event_type_count) {
+            tally.allInRange = false;
+            continue;
+        }
+        ++tally.counts[idx];
+        if (event.eventType_ == nixl_telemetry_event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED) {
+            tally.droppedTotal += event.value_;
+            ++tally.dropEventsSeen;
+        } else {
+            ++tally.valueHistogram[idx][event.value_];
+            ++tally.nonDropEvents;
+        }
+    }
+    return tally;
+}
+
+} // namespace
+
+class telemetryStressTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        testDir_ = fs::path("/tmp") /
+            ("telemetry_stress_" + std::to_string(::getpid()) + "_" +
+             ::testing::UnitTest::GetInstance()->current_test_info()->name());
+        fs::create_directories(testDir_);
+
+        env_.addVar("NIXL_TELEMETRY_ENABLE", "y");
+        env_.addVar("NIXL_TELEMETRY_DIR", testDir_.string());
+    }
+
+    void
+    TearDown() override {
+        env_.popVar();
+        env_.popVar();
+        std::error_code ec;
+        fs::remove_all(testDir_, ec);
+    }
+
+    std::string
+    ringPath(const std::string &file) const {
+        return (testDir_ / file).string();
+    }
+
+    fs::path testDir_;
+    gtest::ScopedEnv env_;
+};
+
+// Mixed concurrent full-pipeline value parity under capacity.
+//
+// Several producers drive every metric-producing path concurrently into one
+// BUFFER instance whose ring is sized above the complete event total, so nothing
+// can be staging-dropped or ring-dropped. Each producer emits a distinct,
+// disjoint value stream, so after the queue drains the multiset of values
+// received per event type must equal the multiset produced -- proving every
+// value sent was received exactly once, intact (no corruption, duplication, or
+// loss), on top of exact per-type counts and no synthetic drop event.
+TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
+    const uint64_t iters = kSanitizerBuild ? 128 : 512; // divisible by the error set size (4)
+    const std::string file = "mixed_value_parity";
+
+    constexpr std::array<nixl_status_t, 4> error_statuses{
+        NIXL_ERR_BACKEND, NIXL_ERR_INVALID_PARAM, NIXL_ERR_NOT_FOUND, NIXL_ERR_MISMATCH};
+
+    // Disjoint per-producer value bases (spaced far beyond iters) so every value
+    // is uniquely traceable and the expected multiset is unambiguous.
+    constexpr uint64_t kTxBytesBase = 1'000'000;
+    constexpr uint64_t kRxBytesBase = 2'000'000;
+    constexpr uint64_t kTxReqBase = 3'000'000;
+    constexpr uint64_t kRxReqBase = 4'000'000;
+    constexpr uint64_t kMemRegBase = 5'000'000;
+    constexpr uint64_t kMemDeregBase = 6'000'000;
+    constexpr uint64_t kWPostBase = 7'000'000;
+    constexpr uint64_t kWXferBase = 8'000'000;
+    constexpr uint64_t kWBytesBase = 9'000'000;
+    constexpr uint64_t kRPostBase = 10'000'000;
+    constexpr uint64_t kRXferBase = 11'000'000;
+    constexpr uint64_t kRBytesBase = 12'000'000;
+
+    using et = nixl_telemetry_event_type_t;
+
+    // Expected value multiset per event type, mirroring the producer workloads.
+    ValueHistograms expected_values{};
+    const auto add_range = [&](et type, uint64_t base) {
+        for (uint64_t i = 0; i < iters; ++i) {
+            ++expected_values[eventIndex(type)][base + i];
+        }
+    };
+    const auto add_const = [&](et type, uint64_t value, uint64_t n) {
+        expected_values[eventIndex(type)][value] += n;
+    };
+
+    add_range(et::AGENT_TX_BYTES, kTxBytesBase);
+    add_range(et::AGENT_RX_BYTES, kRxBytesBase);
+    add_range(et::AGENT_TX_REQUESTS_NUM, kTxReqBase);
+    add_range(et::AGENT_RX_REQUESTS_NUM, kRxReqBase);
+    add_range(et::AGENT_MEMORY_REGISTERED, kMemRegBase);
+    add_range(et::AGENT_MEMORY_DEREGISTERED, kMemDeregBase);
+    for (const auto status : error_statuses) {
+        add_const(nixlTelemetryEventTypeForStatus(status), 1, iters / error_statuses.size());
+    }
+    // addXferStats submits one all-or-none batch; requests carry the fixed value 1.
+    add_range(et::AGENT_XFER_POST_TIME, kWPostBase);
+    add_range(et::AGENT_XFER_TIME, kWXferBase);
+    add_range(et::AGENT_TX_BYTES, kWBytesBase);
+    add_const(et::AGENT_TX_REQUESTS_NUM, 1, iters);
+    add_range(et::AGENT_XFER_POST_TIME, kRPostBase);
+    add_range(et::AGENT_XFER_TIME, kRXferBase);
+    add_range(et::AGENT_RX_BYTES, kRBytesBase);
+    add_const(et::AGENT_RX_REQUESTS_NUM, 1, iters);
+
+    // Derive per-type counts and the grand total from the value multiset -- one
+    // source of truth for both the count and the value-parity assertions.
+    EventCounts expected{};
+    uint64_t expected_total = 0;
+    for (std::size_t t = 0; t < nixl_telemetry_event_type_count; ++t) {
+        for (const auto &[value, n] : expected_values[t]) {
+            (void)value;
+            expected[t] += n;
+        }
+        expected_total += expected[t];
+    }
+
+    const uint64_t ring_size = ringSizeAbove(expected_total);
+    env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, std::to_string(ring_size));
+    env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
+
+    StartGate gate;
+    nixlTelemetry telemetry(file, "BUFFER");
+
+    std::vector<std::thread> producers;
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateTxBytes(kTxBytesBase + i);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateRxBytes(kRxBytesBase + i);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateTxRequestsNum(static_cast<uint32_t>(kTxReqBase + i));
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateRxRequestsNum(static_cast<uint32_t>(kRxReqBase + i));
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateMemoryRegistered(kMemRegBase + i);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateMemoryDeregistered(kMemDeregBase + i);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateErrorCount(error_statuses[i % error_statuses.size()]);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.addXferStats(std::chrono::microseconds(kWXferBase + i),
+                                   true,
+                                   kWBytesBase + i,
+                                   std::chrono::microseconds(kWPostBase + i));
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.addXferStats(std::chrono::microseconds(kRXferBase + i),
+                                   false,
+                                   kRBytesBase + i,
+                                   std::chrono::microseconds(kRPostBase + i));
+        }
+    });
+
+    gate.release();
+    for (auto &producer : producers) {
+        producer.join();
+    }
+
+    auto reader = std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(
+        ringPath(file), false, TELEMETRY_VERSION);
+    const auto timeout = std::chrono::seconds(kSanitizerBuild ? 60 : 20);
+    const uint64_t observed = waitForRingSize(*reader, expected_total, timeout);
+    ASSERT_EQ(observed, expected_total)
+        << "all produced events must reach the BUFFER ring under capacity";
+
+    const RingTally tally = drainRing(*reader);
+    EXPECT_TRUE(tally.allInRange) << "every drained event must be a defined event type";
+    EXPECT_EQ(tally.dropEventsSeen, 0u) << "no staging drop may occur under capacity";
+    EXPECT_EQ(tally.droppedTotal, 0u);
+    EXPECT_EQ(tally.nonDropEvents, expected_total);
+    for (std::size_t i = 0; i < nixl_telemetry_event_type_count; ++i) {
+        EXPECT_EQ(tally.counts[i], expected[i])
+            << "event type " << i << " count mismatch under concurrent production";
+        EXPECT_TRUE(tally.valueHistogram[i] == expected_values[i])
+            << "event type " << i
+            << " value multiset mismatch: a value sent was corrupted, duplicated, or lost";
+    }
+}
+
+// Pipeline-level addXferStats() batch atomicity.
+//
+// Concurrent write and read addXferStats calls interleave with single-event
+// producers (kept to non-transfer event types so the transfer counts are
+// attributable only to the batch path). With the default allowlist every call
+// stages all four events all-or-none; sized above capacity there are no drops,
+// so each direction's four series must equal that direction's call count exactly
+// -- no batch may be torn.
+TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
+    const uint64_t iters = kSanitizerBuild ? 128 : 512;
+    const std::string file = "batch_atomicity";
+
+    const uint64_t write_calls = 2 * iters;
+    const uint64_t read_calls = 2 * iters;
+    const uint64_t mem_events = iters;
+    const uint64_t err_events = iters;
+
+    using et = nixl_telemetry_event_type_t;
+    EventCounts expected{};
+    expected[eventIndex(et::AGENT_XFER_POST_TIME)] = write_calls + read_calls;
+    expected[eventIndex(et::AGENT_XFER_TIME)] = write_calls + read_calls;
+    expected[eventIndex(et::AGENT_TX_BYTES)] = write_calls;
+    expected[eventIndex(et::AGENT_TX_REQUESTS_NUM)] = write_calls;
+    expected[eventIndex(et::AGENT_RX_BYTES)] = read_calls;
+    expected[eventIndex(et::AGENT_RX_REQUESTS_NUM)] = read_calls;
+    expected[eventIndex(et::AGENT_MEMORY_REGISTERED)] = mem_events;
+    expected[eventIndex(et::AGENT_ERR_BACKEND)] = err_events;
+
+    uint64_t expected_total = 0;
+    for (const auto c : expected) {
+        expected_total += c;
+    }
+
+    const uint64_t ring_size = ringSizeAbove(expected_total);
+    env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, std::to_string(ring_size));
+    env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
+
+    StartGate gate;
+    nixlTelemetry telemetry(file, "BUFFER");
+
+    std::vector<std::thread> producers;
+    for (int w = 0; w < 2; ++w) {
+        producers.emplace_back([&] {
+            gate.wait();
+            for (uint64_t i = 0; i < iters; ++i) {
+                telemetry.addXferStats(
+                    std::chrono::microseconds(100), true, 3000, std::chrono::microseconds(10));
+            }
+        });
+    }
+    for (int r = 0; r < 2; ++r) {
+        producers.emplace_back([&] {
+            gate.wait();
+            for (uint64_t i = 0; i < iters; ++i) {
+                telemetry.addXferStats(
+                    std::chrono::microseconds(70), false, 1500, std::chrono::microseconds(7));
+            }
+        });
+    }
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateMemoryRegistered(4096 + i);
+        }
+    });
+    producers.emplace_back([&] {
+        gate.wait();
+        for (uint64_t i = 0; i < iters; ++i) {
+            telemetry.updateErrorCount(NIXL_ERR_BACKEND);
+        }
+    });
+
+    gate.release();
+    for (auto &producer : producers) {
+        producer.join();
+    }
+
+    auto reader = std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(
+        ringPath(file), false, TELEMETRY_VERSION);
+    const auto timeout = std::chrono::seconds(kSanitizerBuild ? 60 : 20);
+    const uint64_t observed = waitForRingSize(*reader, expected_total, timeout);
+    ASSERT_EQ(observed, expected_total) << "all batched and single events must reach the ring";
+
+    const RingTally tally = drainRing(*reader);
+    EXPECT_TRUE(tally.allInRange);
+    EXPECT_EQ(tally.dropEventsSeen, 0u) << "no staging drop under configured capacity";
+    EXPECT_EQ(tally.droppedTotal, 0u);
+
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_XFER_POST_TIME)], write_calls + read_calls)
+        << "post-time count must equal successful addXferStats call count";
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_XFER_TIME)], write_calls + read_calls)
+        << "transfer-time count must equal successful addXferStats call count";
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_BYTES)], write_calls);
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_REQUESTS_NUM)], write_calls);
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_BYTES)], read_calls);
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_REQUESTS_NUM)], read_calls);
+    // Atomicity: with no drops the four members of each direction move in exact
+    // lockstep, so no accepted batch was published only partially.
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_BYTES)],
+              tally.counts[eventIndex(et::AGENT_TX_REQUESTS_NUM)]);
+    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_BYTES)],
+              tally.counts[eventIndex(et::AGENT_RX_REQUESTS_NUM)]);
+    EXPECT_EQ(tally.nonDropEvents, expected_total);
+}
+
+// Repeated queue/periodic-task lifecycle shake-out.
+//
+// Many short iterations each build a fresh telemetry instance with a unique
+// output identity, run producers, observe at least one periodic drain, then
+// destroy normally. No completeness assertion is made (there is no final-flush
+// contract); the value is letting sanitizers exercise timer/queue/exporter
+// construction and teardown repeatedly.
+TEST_F(telemetryStressTest, RepeatedLifecycleShakeOut) {
+    const int iterations = kSanitizerBuild ? 8 : 30;
+    const uint64_t iters = kSanitizerBuild ? 64 : 256;
+
+    env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, "1024");
+    env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "2");
+
+    for (int iteration = 0; iteration < iterations; ++iteration) {
+        const std::string file = "lifecycle_" + std::to_string(iteration);
+        StartGate gate;
+        {
+            nixlTelemetry telemetry(file, "BUFFER");
+
+            std::vector<std::thread> producers;
+            for (int t = 0; t < 3; ++t) {
+                producers.emplace_back([&, t] {
+                    gate.wait();
+                    for (uint64_t i = 0; i < iters; ++i) {
+                        if (t == 0) {
+                            telemetry.updateTxBytes(1024 + i);
+                        } else if (t == 1) {
+                            telemetry.updateRxBytes(2048 + i);
+                        } else {
+                            telemetry.addXferStats(std::chrono::microseconds(30),
+                                                   true,
+                                                   512,
+                                                   std::chrono::microseconds(3));
+                        }
+                    }
+                });
+            }
+
+            gate.release();
+            for (auto &producer : producers) {
+                producer.join();
+            }
+
+            // Observe at least one periodic drain by waiting until the ring has
+            // received some events (bounded), so destruction races a real,
+            // recently-active flush cycle rather than an idle one.
+            auto reader = std::make_unique<sharedRingBuffer<nixlTelemetryEvent>>(
+                ringPath(file), false, TELEMETRY_VERSION);
+            const auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(kSanitizerBuild ? 30 : 10);
+            while (reader->size() == 0 && std::chrono::steady_clock::now() < deadline) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            EXPECT_GT(reader->size(), 0u) << "at least one periodic drain must be observed";
+        }
+    }
+    SUCCEED() << "repeated construction/drain/destruction completed without hang or crash";
+}
+
+// Safe shutdown with an in-flight consumer.
+//
+// Producers are fully joined before destruction (no concurrent API calls during
+// the destructor -- that would violate object lifetime). With a very short flush
+// interval and a still-populated staging queue, the periodic consumer is likely
+// mid-flush when the destructor runs; teardown must stop and join the pool
+// cleanly and return within a bounded time, with no crash, deadlock, or
+// sanitizer report. No export-completeness is asserted after destruction.
+TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
+    const int iterations = kSanitizerBuild ? 4 : 12;
+    const uint64_t iters = kSanitizerBuild ? 256 : 2000;
+
+    env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, "1024");
+    env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "1");
+
+    const auto shutdown_budget = std::chrono::seconds(kSanitizerBuild ? 30 : 10);
+
+    for (int iteration = 0; iteration < iterations; ++iteration) {
+        const std::string file = "shutdown_" + std::to_string(iteration);
+        StartGate gate;
+
+        auto telemetry = std::make_unique<nixlTelemetry>(file, "BUFFER");
+
+        std::vector<std::thread> producers;
+        for (int t = 0; t < 4; ++t) {
+            producers.emplace_back([&] {
+                gate.wait();
+                for (uint64_t i = 0; i < iters; ++i) {
+                    telemetry->addXferStats(
+                        std::chrono::microseconds(20), true, 256, std::chrono::microseconds(2));
+                }
+            });
+        }
+
+        gate.release();
+        for (auto &producer : producers) {
+            producer.join();
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        telemetry.reset(); // destructor races an active periodic flush
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        EXPECT_LT(elapsed, shutdown_budget)
+            << "telemetry destruction must complete promptly, not deadlock on the flush timer";
+    }
+    SUCCEED() << "shutdown with a possibly in-flight periodic flush stayed bounded and crash-free";
+}

--- a/test/gtest/telemetry_stress_test.cpp
+++ b/test/gtest/telemetry_stress_test.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
+#include <future>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -66,16 +67,16 @@ eventIndex(nixl_telemetry_event_type_t type) noexcept {
     return static_cast<std::size_t>(type);
 }
 
-using EventCounts = std::array<uint64_t, nixl_telemetry_event_type_count>;
+using event_counts_t = std::array<uint64_t, nixl_telemetry_event_type_count>;
 // Per event type, a histogram of received event values -> occurrence count. Used
 // to prove value parity: the multiset of values drained from the ring must equal
 // the multiset produced, so no value is corrupted, duplicated, or lost.
-using ValueHistograms =
+using value_histograms_t =
     std::array<std::unordered_map<uint64_t, uint64_t>, nixl_telemetry_event_type_count>;
 
 struct RingTally {
-    EventCounts counts{}; // occurrences per event type in the drained ring
-    ValueHistograms valueHistogram{}; // received value -> count, per non-drop event type
+    event_counts_t counts{}; // occurrences per event type in the drained ring
+    value_histograms_t valueHistogram{}; // received value -> count, per non-drop event type
     uint64_t nonDropEvents = 0; // total events excluding the synthetic drop event
     uint64_t droppedTotal = 0; // summed value of synthetic drop events
     uint64_t dropEventsSeen = 0; // number of synthetic drop events observed
@@ -217,41 +218,41 @@ TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
     constexpr uint64_t kRXferBase = 11'000'000;
     constexpr uint64_t kRBytesBase = 12'000'000;
 
-    using et = nixl_telemetry_event_type_t;
+    using event_type_t = nixl_telemetry_event_type_t;
 
     // Expected value multiset per event type, mirroring the producer workloads.
-    ValueHistograms expected_values{};
-    const auto add_range = [&](et type, uint64_t base) {
+    value_histograms_t expected_values{};
+    const auto add_range = [&](event_type_t type, uint64_t base) {
         for (uint64_t i = 0; i < iters; ++i) {
             ++expected_values[eventIndex(type)][base + i];
         }
     };
-    const auto add_const = [&](et type, uint64_t value, uint64_t n) {
+    const auto add_const = [&](event_type_t type, uint64_t value, uint64_t n) {
         expected_values[eventIndex(type)][value] += n;
     };
 
-    add_range(et::AGENT_TX_BYTES, kTxBytesBase);
-    add_range(et::AGENT_RX_BYTES, kRxBytesBase);
-    add_range(et::AGENT_TX_REQUESTS_NUM, kTxReqBase);
-    add_range(et::AGENT_RX_REQUESTS_NUM, kRxReqBase);
-    add_range(et::AGENT_MEMORY_REGISTERED, kMemRegBase);
-    add_range(et::AGENT_MEMORY_DEREGISTERED, kMemDeregBase);
+    add_range(event_type_t::AGENT_TX_BYTES, kTxBytesBase);
+    add_range(event_type_t::AGENT_RX_BYTES, kRxBytesBase);
+    add_range(event_type_t::AGENT_TX_REQUESTS_NUM, kTxReqBase);
+    add_range(event_type_t::AGENT_RX_REQUESTS_NUM, kRxReqBase);
+    add_range(event_type_t::AGENT_MEMORY_REGISTERED, kMemRegBase);
+    add_range(event_type_t::AGENT_MEMORY_DEREGISTERED, kMemDeregBase);
     for (const auto status : error_statuses) {
         add_const(nixlTelemetryEventTypeForStatus(status), 1, iters / error_statuses.size());
     }
     // addXferStats submits one all-or-none batch; requests carry the fixed value 1.
-    add_range(et::AGENT_XFER_POST_TIME, kWPostBase);
-    add_range(et::AGENT_XFER_TIME, kWXferBase);
-    add_range(et::AGENT_TX_BYTES, kWBytesBase);
-    add_const(et::AGENT_TX_REQUESTS_NUM, 1, iters);
-    add_range(et::AGENT_XFER_POST_TIME, kRPostBase);
-    add_range(et::AGENT_XFER_TIME, kRXferBase);
-    add_range(et::AGENT_RX_BYTES, kRBytesBase);
-    add_const(et::AGENT_RX_REQUESTS_NUM, 1, iters);
+    add_range(event_type_t::AGENT_XFER_POST_TIME, kWPostBase);
+    add_range(event_type_t::AGENT_XFER_TIME, kWXferBase);
+    add_range(event_type_t::AGENT_TX_BYTES, kWBytesBase);
+    add_const(event_type_t::AGENT_TX_REQUESTS_NUM, 1, iters);
+    add_range(event_type_t::AGENT_XFER_POST_TIME, kRPostBase);
+    add_range(event_type_t::AGENT_XFER_TIME, kRXferBase);
+    add_range(event_type_t::AGENT_RX_BYTES, kRBytesBase);
+    add_const(event_type_t::AGENT_RX_REQUESTS_NUM, 1, iters);
 
     // Derive per-type counts and the grand total from the value multiset -- one
     // source of truth for both the count and the value-parity assertions.
-    EventCounts expected{};
+    event_counts_t expected{};
     uint64_t expected_total = 0;
     for (std::size_t t = 0; t < nixl_telemetry_event_type_count; ++t) {
         for (const auto &[value, n] : expected_values[t]) {
@@ -359,30 +360,41 @@ TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
 // Pipeline-level addXferStats() batch atomicity.
 //
 // Concurrent write and read addXferStats calls interleave with single-event
-// producers (kept to non-transfer event types so the transfer counts are
-// attributable only to the batch path). With the default allowlist every call
-// stages all four events all-or-none; sized above capacity there are no drops,
-// so each direction's four series must equal that direction's call count exactly
-// -- no batch may be torn.
+// producers. Each call carries a unique per-call id in its post-time, transfer-
+// time, and bytes values, so the drained ring can be scanned to prove every
+// call's four events are published as one indivisible, correctly ordered group
+// ([post, transfer, bytes, requests]) with a consistent id -- no other event
+// (another batch or a single-event producer) ever falls between them. Equal
+// aggregate counts alone would not prove this (an implementation appending the
+// four events independently would still hit the same totals under capacity);
+// contiguity + identity is what actually rejects a torn or interleaved batch.
 TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     const uint64_t iters = kSanitizerBuild ? 128 : 512;
     const std::string file = "batch_atomicity";
 
-    const uint64_t write_calls = 2 * iters;
-    const uint64_t read_calls = 2 * iters;
+    constexpr int kWriteThreads = 2;
+    constexpr int kReadThreads = 2;
+    const uint64_t write_calls = kWriteThreads * iters;
+    const uint64_t read_calls = kReadThreads * iters;
     const uint64_t mem_events = iters;
     const uint64_t err_events = iters;
 
-    using et = nixl_telemetry_event_type_t;
-    EventCounts expected{};
-    expected[eventIndex(et::AGENT_XFER_POST_TIME)] = write_calls + read_calls;
-    expected[eventIndex(et::AGENT_XFER_TIME)] = write_calls + read_calls;
-    expected[eventIndex(et::AGENT_TX_BYTES)] = write_calls;
-    expected[eventIndex(et::AGENT_TX_REQUESTS_NUM)] = write_calls;
-    expected[eventIndex(et::AGENT_RX_BYTES)] = read_calls;
-    expected[eventIndex(et::AGENT_RX_REQUESTS_NUM)] = read_calls;
-    expected[eventIndex(et::AGENT_MEMORY_REGISTERED)] = mem_events;
-    expected[eventIndex(et::AGENT_ERR_BACKEND)] = err_events;
+    using event_type_t = nixl_telemetry_event_type_t;
+
+    // Disjoint per-call id ranges so a batch's id also pins its direction, and
+    // never collides with the single-event memory values (4096 + i).
+    constexpr uint64_t kWriteIdBase = 1'000'000'000;
+    constexpr uint64_t kReadIdBase = 2'000'000'000;
+
+    event_counts_t expected{};
+    expected[eventIndex(event_type_t::AGENT_XFER_POST_TIME)] = write_calls + read_calls;
+    expected[eventIndex(event_type_t::AGENT_XFER_TIME)] = write_calls + read_calls;
+    expected[eventIndex(event_type_t::AGENT_TX_BYTES)] = write_calls;
+    expected[eventIndex(event_type_t::AGENT_TX_REQUESTS_NUM)] = write_calls;
+    expected[eventIndex(event_type_t::AGENT_RX_BYTES)] = read_calls;
+    expected[eventIndex(event_type_t::AGENT_RX_REQUESTS_NUM)] = read_calls;
+    expected[eventIndex(event_type_t::AGENT_MEMORY_REGISTERED)] = mem_events;
+    expected[eventIndex(event_type_t::AGENT_ERR_BACKEND)] = err_events;
 
     uint64_t expected_total = 0;
     for (const auto c : expected) {
@@ -397,21 +409,23 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     nixlTelemetry telemetry(file, "BUFFER");
 
     std::vector<std::thread> producers;
-    for (int w = 0; w < 2; ++w) {
-        producers.emplace_back([&] {
+    for (int w = 0; w < kWriteThreads; ++w) {
+        producers.emplace_back([&, w] {
             gate.wait();
             for (uint64_t i = 0; i < iters; ++i) {
+                const uint64_t id = kWriteIdBase + static_cast<uint64_t>(w) * iters + i;
                 telemetry.addXferStats(
-                    std::chrono::microseconds(100), true, 3000, std::chrono::microseconds(10));
+                    std::chrono::microseconds(id), true, id, std::chrono::microseconds(id));
             }
         });
     }
-    for (int r = 0; r < 2; ++r) {
-        producers.emplace_back([&] {
+    for (int r = 0; r < kReadThreads; ++r) {
+        producers.emplace_back([&, r] {
             gate.wait();
             for (uint64_t i = 0; i < iters; ++i) {
+                const uint64_t id = kReadIdBase + static_cast<uint64_t>(r) * iters + i;
                 telemetry.addXferStats(
-                    std::chrono::microseconds(70), false, 1500, std::chrono::microseconds(7));
+                    std::chrono::microseconds(id), false, id, std::chrono::microseconds(id));
             }
         });
     }
@@ -439,26 +453,71 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     const uint64_t observed = waitForRingSize(*reader, expected_total, timeout);
     ASSERT_EQ(observed, expected_total) << "all batched and single events must reach the ring";
 
-    const RingTally tally = drainRing(*reader);
-    EXPECT_TRUE(tally.allInRange);
-    EXPECT_EQ(tally.dropEventsSeen, 0u) << "no staging drop under configured capacity";
-    EXPECT_EQ(tally.droppedTotal, 0u);
+    // Drain in insertion order (the BUFFER ring preserves it) and walk it: single
+    // events stand alone; every transfer batch must be an intact ordered quad.
+    std::vector<nixlTelemetryEvent> events;
+    events.reserve(expected_total);
+    for (nixlTelemetryEvent e; reader->pop(e);) {
+        events.push_back(e);
+    }
+    ASSERT_EQ(events.size(), expected_total);
 
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_XFER_POST_TIME)], write_calls + read_calls)
-        << "post-time count must equal successful addXferStats call count";
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_XFER_TIME)], write_calls + read_calls)
-        << "transfer-time count must equal successful addXferStats call count";
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_BYTES)], write_calls);
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_REQUESTS_NUM)], write_calls);
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_BYTES)], read_calls);
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_REQUESTS_NUM)], read_calls);
-    // Atomicity: with no drops the four members of each direction move in exact
-    // lockstep, so no accepted batch was published only partially.
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_TX_BYTES)],
-              tally.counts[eventIndex(et::AGENT_TX_REQUESTS_NUM)]);
-    EXPECT_EQ(tally.counts[eventIndex(et::AGENT_RX_BYTES)],
-              tally.counts[eventIndex(et::AGENT_RX_REQUESTS_NUM)]);
-    EXPECT_EQ(tally.nonDropEvents, expected_total);
+    event_counts_t counts{};
+    uint64_t observed_batches = 0;
+    std::size_t i = 0;
+    while (i < events.size()) {
+        const auto type = events[i].eventType_;
+        ++counts[eventIndex(type)];
+        if (type == event_type_t::AGENT_MEMORY_REGISTERED ||
+            type == event_type_t::AGENT_ERR_BACKEND) {
+            ++i; // a single-event producer's record stands on its own
+            continue;
+        }
+
+        // Anything else must be the first member of an intact addXferStats quad.
+        ASSERT_EQ(type, event_type_t::AGENT_XFER_POST_TIME)
+            << "torn batch: a transfer event appeared outside an ordered batch at index " << i;
+        ASSERT_LE(i + 4, events.size()) << "torn batch: truncated quad at end of ring";
+
+        const nixlTelemetryEvent post = events[i];
+        const nixlTelemetryEvent xfer = events[i + 1];
+        const nixlTelemetryEvent bytes = events[i + 2];
+        const nixlTelemetryEvent reqs = events[i + 3];
+
+        EXPECT_EQ(xfer.eventType_, event_type_t::AGENT_XFER_TIME)
+            << "batch member 2 must be xfer time";
+        const bool is_tx = bytes.eventType_ == event_type_t::AGENT_TX_BYTES;
+        const bool is_rx = bytes.eventType_ == event_type_t::AGENT_RX_BYTES;
+        EXPECT_TRUE(is_tx || is_rx) << "batch member 3 must be a bytes event";
+        EXPECT_EQ(reqs.eventType_,
+                  is_tx ? event_type_t::AGENT_TX_REQUESTS_NUM : event_type_t::AGENT_RX_REQUESTS_NUM)
+            << "batch member 4 must be the matching requests event";
+
+        // Identity: the three id-carrying members share one call's id, that id is
+        // in the direction's range, and the request count is the fixed 1.
+        EXPECT_EQ(post.value_, xfer.value_);
+        EXPECT_EQ(post.value_, bytes.value_);
+        EXPECT_EQ(reqs.value_, 1u);
+        if (is_tx) {
+            EXPECT_GE(post.value_, kWriteIdBase);
+            EXPECT_LT(post.value_, kReadIdBase);
+        } else {
+            EXPECT_GE(post.value_, kReadIdBase);
+        }
+
+        ++counts[eventIndex(xfer.eventType_)];
+        ++counts[eventIndex(bytes.eventType_)];
+        ++counts[eventIndex(reqs.eventType_)];
+        ++observed_batches;
+        i += 4;
+    }
+
+    EXPECT_EQ(observed_batches, write_calls + read_calls) << "every accepted call must appear once";
+    for (std::size_t t = 0; t < nixl_telemetry_event_type_count; ++t) {
+        EXPECT_EQ(counts[t], expected[t]) << "event type " << t << " count mismatch";
+    }
+    EXPECT_EQ(counts[eventIndex(event_type_t::AGENT_TELEMETRY_EVENTS_DROPPED)], 0u)
+        << "no staging drop under configured capacity";
 }
 
 // Repeated queue/periodic-task lifecycle shake-out.
@@ -529,6 +588,14 @@ TEST_F(telemetryStressTest, RepeatedLifecycleShakeOut) {
 // mid-flush when the destructor runs; teardown must stop and join the pool
 // cleanly and return within a bounded time, with no crash, deadlock, or
 // sanitizer report. No export-completeness is asserted after destruction.
+//
+// The destructor runs on a separate thread guarded by an external timeout, so a
+// hang (e.g. a teardown deadlock on the flush timer) is reported as a hard
+// failure rather than blocking the whole test binary until the CI/meson timeout.
+// (Deterministically forcing overlap with an in-flight flush would need a
+// flush-entry hook in production code, which this test-only change avoids; the
+// short interval plus a large pending backlog makes overlap highly likely, and
+// sanitizer builds catch any teardown race.)
 TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
     const int iterations = kSanitizerBuild ? 4 : 12;
     const uint64_t iters = kSanitizerBuild ? 256 : 2000;
@@ -560,11 +627,24 @@ TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
             producer.join();
         }
 
-        const auto start = std::chrono::steady_clock::now();
-        telemetry.reset(); // destructor races an active periodic flush
-        const auto elapsed = std::chrono::steady_clock::now() - start;
-        EXPECT_LT(elapsed, shutdown_budget)
-            << "telemetry destruction must complete promptly, not deadlock on the flush timer";
+        // Destroy on a worker thread and bound it externally: reset() sets the
+        // unique_ptr null before invoking the destructor, so on a hang the local
+        // pointer is already empty and this scope's cleanup stays safe while the
+        // stuck deleter thread is abandoned.
+        std::packaged_task<void()> shutdown_task([&telemetry] { telemetry.reset(); });
+        std::future<void> shutdown_done = shutdown_task.get_future();
+        std::thread runner(std::move(shutdown_task));
+
+        if (shutdown_done.wait_for(shutdown_budget) == std::future_status::ready) {
+            runner.join();
+            shutdown_done.get(); // surface any exception thrown during teardown
+        } else {
+            runner.detach();
+            ADD_FAILURE() << "telemetry destruction did not complete within "
+                          << shutdown_budget.count()
+                          << "s -- likely a teardown deadlock on the flush timer";
+            return;
+        }
     }
     SUCCEED() << "shutdown with a possibly in-flight periodic flush stayed bounded and crash-free";
 }

--- a/test/gtest/telemetry_stress_test.cpp
+++ b/test/gtest/telemetry_stress_test.cpp
@@ -463,11 +463,21 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     ASSERT_EQ(events.size(), expected_total);
 
     event_counts_t counts{};
+    // Range-guarded tally so corrupted ring content fails cleanly instead of
+    // indexing counts[] out of bounds (mirrors drainRing()'s guard).
+    const auto bump = [&counts](nixl_telemetry_event_type_t t) {
+        const std::size_t idx = eventIndex(t);
+        if (idx >= nixl_telemetry_event_type_count) {
+            ADD_FAILURE() << "drained event enum out of range: " << idx;
+            return;
+        }
+        ++counts[idx];
+    };
     uint64_t observed_batches = 0;
     std::size_t i = 0;
     while (i < events.size()) {
         const auto type = events[i].eventType_;
-        ++counts[eventIndex(type)];
+        bump(type);
         if (type == event_type_t::AGENT_MEMORY_REGISTERED ||
             type == event_type_t::AGENT_ERR_BACKEND) {
             ++i; // a single-event producer's record stands on its own
@@ -505,9 +515,9 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
             EXPECT_GE(post.value_, kReadIdBase);
         }
 
-        ++counts[eventIndex(xfer.eventType_)];
-        ++counts[eventIndex(bytes.eventType_)];
-        ++counts[eventIndex(reqs.eventType_)];
+        bump(xfer.eventType_);
+        bump(bytes.eventType_);
+        bump(reqs.eventType_);
         ++observed_batches;
         i += 4;
     }
@@ -627,11 +637,13 @@ TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
             producer.join();
         }
 
-        // Destroy on a worker thread and bound it externally: reset() sets the
-        // unique_ptr null before invoking the destructor, so on a hang the local
-        // pointer is already empty and this scope's cleanup stays safe while the
-        // stuck deleter thread is abandoned.
-        std::packaged_task<void()> shutdown_task([&telemetry] { telemetry.reset(); });
+        // Destroy on a worker thread bounded by an external timeout. Ownership is
+        // moved into the task, so the object lives inside the worker's closure --
+        // not on this stack. On a hang we detach and return without touching the
+        // moved-from local, so the abandoned deleter thread references only its
+        // own closure (no dangling stack reference or cross-thread race).
+        std::packaged_task<void()> shutdown_task(
+            [tel = std::move(telemetry)]() mutable { tel.reset(); });
         std::future<void> shutdown_done = shutdown_task.get_future();
         std::thread runner(std::move(shutdown_task));
 

--- a/test/gtest/telemetry_stress_test.cpp
+++ b/test/gtest/telemetry_stress_test.cpp
@@ -18,11 +18,11 @@
 #include <gtest/gtest.h>
 
 #include <array>
-#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <future>
+#include <latch>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -48,8 +48,7 @@ namespace {
 // Sanitizer builds run the same correctness checks with fewer repetitions: it
 // keeps TSan/ASan within a CI-friendly runtime and limits the repeated
 // thread-pool create/destroy that stresses the sanitizer thread registry, while
-// still surfacing intermittent timer/queue/exporter defects. Detection is
-// compile-time and test-only.
+// still surfacing intermittent timer/queue/exporter defects.
 #if defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_THREAD__)
 constexpr bool kSanitizerBuild = true;
 #elif defined(__has_feature)
@@ -95,27 +94,6 @@ ringSizeAbove(uint64_t n) {
     }
     return size;
 }
-
-// A start latch so every producer thread is released together, maximizing the
-// concurrency the staging queue actually sees (per the plan: coordinate with
-// atomics/barriers, do not rely on sleeps).
-class StartGate {
-public:
-    void
-    wait() {
-        while (!go_.load(std::memory_order_acquire)) {
-            std::this_thread::yield();
-        }
-    }
-
-    void
-    release() {
-        go_.store(true, std::memory_order_release);
-    }
-
-private:
-    std::atomic<bool> go_{false};
-};
 
 // Non-destructively poll the writer's published event count (the reader never
 // pops during polling, so read_pos stays 0 and size() == events pushed) until it
@@ -266,54 +244,54 @@ TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
     env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, std::to_string(ring_size));
     env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
 
-    StartGate gate;
+    std::latch start_gate(1);
     nixlTelemetry telemetry(file, "BUFFER");
 
     std::vector<std::thread> producers;
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxBytes(kTxBytesBase + i);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxBytes(kRxBytesBase + i);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateTxRequestsNum(static_cast<uint32_t>(kTxReqBase + i));
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateRxRequestsNum(static_cast<uint32_t>(kRxReqBase + i));
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateMemoryRegistered(kMemRegBase + i);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateMemoryDeregistered(kMemDeregBase + i);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(error_statuses[i % error_statuses.size()]);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.addXferStats(std::chrono::microseconds(kWXferBase + i),
                                    true,
@@ -322,7 +300,7 @@ TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.addXferStats(std::chrono::microseconds(kRXferBase + i),
                                    false,
@@ -331,7 +309,7 @@ TEST_F(telemetryStressTest, MixedConcurrentValueParityUnderCapacity) {
         }
     });
 
-    gate.release();
+    start_gate.count_down();
     for (auto &producer : producers) {
         producer.join();
     }
@@ -405,13 +383,13 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     env_.addVar(TELEMETRY_BUFFER_SIZE_VAR, std::to_string(ring_size));
     env_.addVar(TELEMETRY_RUN_INTERVAL_VAR, "5");
 
-    StartGate gate;
+    std::latch start_gate(1);
     nixlTelemetry telemetry(file, "BUFFER");
 
     std::vector<std::thread> producers;
     for (int w = 0; w < kWriteThreads; ++w) {
         producers.emplace_back([&, w] {
-            gate.wait();
+            start_gate.wait();
             for (uint64_t i = 0; i < iters; ++i) {
                 const uint64_t id = kWriteIdBase + static_cast<uint64_t>(w) * iters + i;
                 telemetry.addXferStats(
@@ -421,7 +399,7 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
     }
     for (int r = 0; r < kReadThreads; ++r) {
         producers.emplace_back([&, r] {
-            gate.wait();
+            start_gate.wait();
             for (uint64_t i = 0; i < iters; ++i) {
                 const uint64_t id = kReadIdBase + static_cast<uint64_t>(r) * iters + i;
                 telemetry.addXferStats(
@@ -430,19 +408,19 @@ TEST_F(telemetryStressTest, PipelineBatchAtomicity) {
         });
     }
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateMemoryRegistered(4096 + i);
         }
     });
     producers.emplace_back([&] {
-        gate.wait();
+        start_gate.wait();
         for (uint64_t i = 0; i < iters; ++i) {
             telemetry.updateErrorCount(NIXL_ERR_BACKEND);
         }
     });
 
-    gate.release();
+    start_gate.count_down();
     for (auto &producer : producers) {
         producer.join();
     }
@@ -546,14 +524,14 @@ TEST_F(telemetryStressTest, RepeatedLifecycleShakeOut) {
 
     for (int iteration = 0; iteration < iterations; ++iteration) {
         const std::string file = "lifecycle_" + std::to_string(iteration);
-        StartGate gate;
+        std::latch start_gate(1);
         {
             nixlTelemetry telemetry(file, "BUFFER");
 
             std::vector<std::thread> producers;
             for (int t = 0; t < 3; ++t) {
                 producers.emplace_back([&, t] {
-                    gate.wait();
+                    start_gate.wait();
                     for (uint64_t i = 0; i < iters; ++i) {
                         if (t == 0) {
                             telemetry.updateTxBytes(1024 + i);
@@ -569,7 +547,7 @@ TEST_F(telemetryStressTest, RepeatedLifecycleShakeOut) {
                 });
             }
 
-            gate.release();
+            start_gate.count_down();
             for (auto &producer : producers) {
                 producer.join();
             }
@@ -617,14 +595,14 @@ TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
 
     for (int iteration = 0; iteration < iterations; ++iteration) {
         const std::string file = "shutdown_" + std::to_string(iteration);
-        StartGate gate;
+        std::latch start_gate(1);
 
         auto telemetry = std::make_unique<nixlTelemetry>(file, "BUFFER");
 
         std::vector<std::thread> producers;
         for (int t = 0; t < 4; ++t) {
             producers.emplace_back([&] {
-                gate.wait();
+                start_gate.wait();
                 for (uint64_t i = 0; i < iters; ++i) {
                     telemetry->addXferStats(
                         std::chrono::microseconds(20), true, 256, std::chrono::microseconds(2));
@@ -632,7 +610,7 @@ TEST_F(telemetryStressTest, SafeShutdownWithInFlightConsumer) {
             });
         }
 
-        gate.release();
+        start_gate.count_down();
         for (auto &producer : producers) {
             producer.join();
         }


### PR DESCRIPTION
## What?

Test-only, full-pipeline stress coverage for telemetry: concurrent producers through the staging queue → periodic flush → the BUFFER / Prometheus / DOCA exporters. No product, queue, exporter, schema, or public-API changes.

- `test/gtest/telemetry_stress_test.cpp` — value parity, `addXferStats` batch atomicity, lifecycle shake-out, safe shutdown (BUFFER, end-to-end).
- `test/gtest/telemetry_prometheus_stress_test.cpp` — concurrent staging-overflow conservation and mixed-workload aggregation.
- `test/doca-telemetry/telemetry_doca_stress_test.cpp` — high-volume DOCA exporter accumulation (standalone `doca_nixl_stress_test`).

## Why?

Closes [NIX-1205](https://linear.app/nvidia/issue/NIX-1205). Existing tests cover queue mechanics and single-threaded exporters, but not the concurrent observable pipeline. This pins down that contract — conservation, all-or-none batching, per-value fidelity, shutdown safety — so a regression anywhere in the path fails an assertion. It builds only on already-merged behavior (NIX-454 #1887, NIX-453 #1919), so it is independent of NIX-1542 and mergeable on its own, while serving as the validation gate for the NIX-1542/NIX-1544 queue changes.

## How?

Deterministic and timing-independent: conservation identities and value multisets rather than fixed accepted/dropped splits, bounded polling instead of sleeps, and sanitizer-scaled iteration counts.

<details>
<summary>Design & validation details</summary>

- Under-capacity BUFFER tests size the ring above the total so nothing is dropped; the overflow case drives the lossless, ring-free Prometheus exporter, so `accepted + dropped == produced` is exact and hardware-independent.
- `addXferStats` atomicity is proven by per-call identity + contiguity in the drained ring (a torn or interleaved batch fails), not just aggregate counts.
- Safe-shutdown destroys on a worker thread bounded by an external timeout, so a teardown deadlock fails as an assertion instead of hanging; producers are released together via a start latch to maximize real concurrency.
- Validation: normal C++17, TSan, UBSan, and DOCA-enabled builds pass; focused telemetry suites run warning-clean. ASan can't run in some environments due to a prebuilt mixed-Abseil ABI incompatibility (documented in the plan).

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Added high-volume telemetry stress coverage, including concurrent Prometheus metrics scraping and validation of counters, last-operation gauges, and dropped-event accounting.
- Added concurrency tests for overflow handling, metric aggregation, and error/status labeling.
- Added end-to-end checks for batching integrity, repeated telemetry lifecycles, and safe shutdown during active flushing.
- Added a dedicated DOCA telemetry stress test with an extended timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->