### PR TITLE
ci: rename BUILD_TARGET local var to stop Jenkins param leak

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -283,9 +283,11 @@ BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 
 if [ -n "$WHEEL_BASE_IMAGE" ]; then
     BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"
-    BUILD_TARGET="--target wheel"
+    # Not named BUILD_TARGET: Jenkins exports a BUILD_TARGET job parameter
+    # (nixl/nixlbench) that would leak into the docker command line.
+    DOCKER_BUILD_TARGET="--target wheel"
 fi
 
 show_build_options
 
-docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${BUILD_TARGET:-} $BUILD_CONTEXT
+docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${DOCKER_BUILD_TARGET:-} $BUILD_CONTEXT


### PR DESCRIPTION
## What?
Rename the local `BUILD_TARGET` in `contrib/build-container.sh` to `DOCKER_BUILD_TARGET`.

## Why?
The container job exports a `BUILD_TARGET` param (nixl/nixlbench), which leaked into the `docker build` line via `${BUILD_TARGET:-}` as a stray positional arg. Every nixl-target run has failed since #1870 with `accepts at most 1 arg(s), received 2`.

## How?
Rename the local var so it no longer collides with the param. The `--wheel-base-image` path still passes `--target wheel`.

### Note
This highlights the need for the per-PR container check https://github.com/ai-dynamo/nixl/pull/1863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container builds when a wheel base image is configured.
  * Prevented build parameters from being unintentionally passed to Docker, resulting in more reliable build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->