### PR TITLE
fix(core): preserve requests during async release in agent::releaseXferReq()

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1316,6 +1316,10 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
             req_hndl->status = req_hndl->engine->releaseReqH(
                                          req_hndl->backendHandle);
 
+            if (req_hndl->status == NIXL_IN_PROG) {
+                return NIXL_ERR_REPOST_ACTIVE; // Might need renaming
+            }
+
             if (req_hndl->status < 0) {
                 NIXL_ERROR_FUNC << "backend '" << req_hndl->engine->getType()
                                 << "' could not release transfer request and returned error status "

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -433,6 +433,49 @@ namespace agent {
         EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
     }
 
+    TEST_F(dualAgentBridgeFixture, ReleaseXferReqKeepsAsyncReleasePollable) {
+        DualAgentSetup s(DRAM_SEG);
+        setupDualAgent(s);
+
+        nixlBackendReqH backend_req;
+        EXPECT_CALL(local_agent_helper_->getGMockEngine(), prepXfer)
+            .WillOnce([&backend_req](const nixl_xfer_op_t &,
+                                     const nixl_meta_dlist_t &,
+                                     const nixl_meta_dlist_t &,
+                                     const std::string &,
+                                     nixlBackendReqH *&handle,
+                                     const nixl_opt_b_args_t *) {
+                handle = &backend_req;
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(local_agent_helper_->getGMockEngine(), postXfer)
+            .WillOnce(testing::Return(NIXL_IN_PROG));
+        EXPECT_CALL(local_agent_helper_->getGMockEngine(), checkXfer)
+            .WillOnce(testing::Return(NIXL_IN_PROG))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+        EXPECT_CALL(local_agent_helper_->getGMockEngine(), releaseReqH)
+            .WillOnce(testing::Return(NIXL_IN_PROG))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+
+        nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG), remote_xfer_dlist(DRAM_SEG);
+        local_xfer_dlist.addDesc(s.local_blob.getDesc());
+        remote_xfer_dlist.addDesc(s.remote_blob.getDesc());
+
+        nixlXferReqH *xfer_req;
+        ASSERT_EQ(local_agent_->createXferReq(NIXL_WRITE,
+                                              local_xfer_dlist,
+                                              remote_xfer_dlist,
+                                              s.remote_agent_name,
+                                              xfer_req,
+                                              &s.local_extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(local_agent_->postXferReq(xfer_req), NIXL_IN_PROG);
+
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_ERR_REPOST_ACTIVE);
+        EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
+    }
+
     TEST_F(dualAgentBridgeFixture, PrepMemViewRemoteDRAM) {
         DualAgentSetup s(DRAM_SEG);
         setupDualAgent(s, /*register_local=*/false);


### PR DESCRIPTION
## What?

Fix `nixlAgent::releaseXferReq()` so a backend returning `NIXL_IN_PROG` from `releaseReqH()` does not lose its request. The agent now keeps the outer request and backend handle alive, leaves the status pollable, and returns `NIXL_ERR_REPOST_ACTIVE`. A mock regression covers release in progress, polling to completion, and final successful release.

## Why?

Fixes [#1958](https://github.com/ai-dynamo/nixl/issues/1958).

For an active transfer, the current code can follow this path:

1. `releaseXferReq()` calls `checkXfer()`, which returns `NIXL_IN_PROG`.
2. It calls the backend's `releaseReqH()`, which also returns `NIXL_IN_PROG` because cleanup is not finished.
3. The agent checks only `status < 0`, so it treats `NIXL_IN_PROG` as successful release.
4. It clears `backendHandle`, deletes the outer request, and returns `NIXL_SUCCESS`.
5. The caller can no longer poll cleanup, while the backend may still own active work and resources.

I reviewed all 14 concrete backend implementations to determine impact:

| Release behavior | Backends |
|---|---|
| Never returns `NIXL_IN_PROG` | Azure Blob, CUDA GDS, GDS MT, GUSLI, HF3FS, Infinia, Libfabric, Mooncake, OBJ S3, OBJ Dell, POSIX, UCCL, UCX |
| May return `NIXL_IN_PROG` | GPUNetIO / DOCA |

See below for the changed GPUNetIO behavior

### Why return `NIXL_ERR_REPOST_ACTIVE`?

The request itself remains in `NIXL_IN_PROG`; `NIXL_ERR_REPOST_ACTIVE` is only the result of an unsuccessful release attempt. Returning the negative status preserves the request across the existing language wrappers:

- **C++:** receives `NIXL_ERR_REPOST_ACTIVE` directly and retains the request handle for polling or a later release attempt.
- **Python:** the low-level binding raises on `NIXL_ERR_REPOST_ACTIVE`, so the high-level `release()` method does not set its `_released` flag. If the agent returned `NIXL_IN_PROG`, the binding would treat it as non-error and the wrapper would incorrectly mark the still-live handle released.
- **C/Rust:** the C shim maps every non-successful release to `NIXL_CAPI_ERROR_BACKEND` and clears its internal request pointer only on `NIXL_SUCCESS`. It therefore retains the request, although the exact NIXL error is not exposed. Rust's `Drop` path currently ignores this release error; that pre-existing wrapper limitation is outside this PR.

Using the existing error therefore fixes the core lifetime problem without changing the binding contract.

### GPUNetIO behavior before and after this PR

**Before:** when GPUNetIO returned `NIXL_IN_PROG` from `releaseReqH()`, the agent treated it as success, cleared the backend handle, deleted the outer request, and returned `NIXL_SUCCESS`. The caller lost the request while work could still be active and could no longer poll it.

**After:** the agent returns `NIXL_ERR_REPOST_ACTIVE` and keeps both handles with status `NIXL_IN_PROG`. The caller can continue polling `getXferStatus()` or retry release until the transfer reaches a terminal state. The request status remains `NIXL_IN_PROG`; only the return value of the unsuccessful release attempt is mapped to `NIXL_ERR_REPOST_ACTIVE`.

This PR fixes the agent-side lifetime handling only. GPUNetIO's current `releaseReqH()` also polls an unrelated completion slot and never deletes its backend request; that backend leak remains a separate follow-up.

## How?

Immediately after `releaseReqH()`, special-case `NIXL_IN_PROG` and return `NIXL_ERR_REPOST_ACTIVE` before clearing or deleting either handle.

No backend implementation or public API is changed. The focused regression and all 64 core unit tests pass.
