### PR TITLE
NIXLBENCH: Fix race condition with ASIO runtime on shutdown.

### DIFF
--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    ret = worker_ptr->synchronize(); // Make sure environment is not used anymore
+    ret = worker_ptr->synchronize(true); // Make sure environment is not used anymore
     if (0 != ret) {
         return EXIT_FAILURE;
     }

--- a/benchmark/nixlbench/src/runtime/asio_runtime.h
+++ b/benchmark/nixlbench/src/runtime/asio_runtime.h
@@ -137,9 +137,9 @@ public:
     }
 
     int
-    barrier(const std::string &barrier_id) override {
+    barrier(const std::string &barrier_id, const bool finishing) override {
         const std::string barrier_name = barrier_id + "/" + std::to_string(++barrier_);
-        postSend(asio_msg_type_t::BARRIER, barrier_name.data(), barrier_name.size());
+        postSend(asio_msg_type_t::BARRIER, barrier_name.data(), barrier_name.size(), finishing);
         recvWait(asio_msg_type_t::BARRIER,
                  [&](const std::string &data) { return data == barrier_name; });
         return 0;
@@ -214,7 +214,10 @@ private:
     }
 
     void
-    postSend(const asio_msg_type_t type, const void *data, const std::size_t size) {
+    postSend(const asio_msg_type_t type,
+             const void *data,
+             const std::size_t size,
+             const bool finishing = false) {
         if (size > sizeMask_) {
             throw std::runtime_error("Runtime message size " + std::to_string(size) +
                                      " exceeds 16MB-1 limit");
@@ -230,6 +233,7 @@ private:
             if (exception_) {
                 std::rethrow_exception(exception_);
             }
+            finishing_ = finishing;
         }
         asio::post(context_, [this, buffer]() {
             const bool was_empty = outgoing_.empty();
@@ -282,13 +286,18 @@ private:
                              if (ec.value()) {
                                  throw std::runtime_error("ASIO Read data failed: " + ec.message());
                              }
+                             bool finishing = false;
+
                              // Lock scope
                              {
                                  const std::unique_lock lock(mutex_);
                                  incoming_.emplace_back(temp_);
                                  cond_.notify_one();
+                                 finishing = finishing_;
                              }
-                             recvHead();
+                             if (!finishing) {
+                                 recvHead();
+                             }
                          });
     }
 
@@ -332,6 +341,7 @@ private:
     std::list<xferBenchAsioIncoming> incoming_;
     std::exception_ptr exception_;
 
+    bool finishing_ = false;
     std::uint32_t head_;
     xferBenchAsioIncoming temp_;
     std::list<std::string> outgoing_;

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -468,7 +468,8 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
     }
 }
 
-int xferBenchEtcdRT::barrier(const std::string& barrier_id, const bool finishing) {
+int
+xferBenchEtcdRT::barrier(const std::string &barrier_id, const bool finishing) {
     int count = 0;
     std::string barrier_suffix = "barrier/" + barrier_id + "/" + std::to_string(barrier_gen);
     std::string barrier_key = namespace_prefix + barrier_suffix + "/";

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.cpp
@@ -468,7 +468,7 @@ int xferBenchEtcdRT::reduceSumDouble(double *local_value, double *global_value, 
     }
 }
 
-int xferBenchEtcdRT::barrier(const std::string& barrier_id) {
+int xferBenchEtcdRT::barrier(const std::string& barrier_id, const bool finishing) {
     int count = 0;
     std::string barrier_suffix = "barrier/" + barrier_id + "/" + std::to_string(barrier_gen);
     std::string barrier_key = namespace_prefix + barrier_suffix + "/";

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -99,7 +99,8 @@ public:
     int reduceSumDouble(double *local_value, double *global_value, int dest_rank) override;
 
     // Barrier synchronization
-    int barrier(const std::string& barrier_id, bool finishing = false) override;
+    int
+    barrier(const std::string &barrier_id, bool finishing = false) override;
 
     // Check if all peer rank keys are still present in etcd
     bool

--- a/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
+++ b/benchmark/nixlbench/src/runtime/etcd/etcd_rt.h
@@ -99,7 +99,7 @@ public:
     int reduceSumDouble(double *local_value, double *global_value, int dest_rank) override;
 
     // Barrier synchronization
-    int barrier(const std::string& barrier_id) override;
+    int barrier(const std::string& barrier_id, bool finishing = false) override;
 
     // Check if all peer rank keys are still present in etcd
     bool

--- a/benchmark/nixlbench/src/runtime/runtime.cpp
+++ b/benchmark/nixlbench/src/runtime/runtime.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,6 +50,7 @@ int xferBenchRT::reduceSumDouble(double *local_buffer, double *global_buffer, in
     return 0;
 }
 
-int xferBenchRT::barrier(const std::string& barrier_id, bool finishing) {
+int
+xferBenchRT::barrier(const std::string &barrier_id, bool finishing) {
     return 0;
 }

--- a/benchmark/nixlbench/src/runtime/runtime.cpp
+++ b/benchmark/nixlbench/src/runtime/runtime.cpp
@@ -50,6 +50,6 @@ int xferBenchRT::reduceSumDouble(double *local_buffer, double *global_buffer, in
     return 0;
 }
 
-int xferBenchRT::barrier(const std::string& barrier_id) {
+int xferBenchRT::barrier(const std::string& barrier_id, bool finishing) {
     return 0;
 }

--- a/benchmark/nixlbench/src/runtime/runtime.h
+++ b/benchmark/nixlbench/src/runtime/runtime.h
@@ -40,7 +40,8 @@ class xferBenchRT {
         virtual int reduceSumDouble(double *local_value, double *global_value, int dest_rank) = 0;
 
         // Add a barrier function to synchronize all processes
-        virtual int barrier(const std::string& barrier_id, const bool finishing = false) = 0;
+        virtual int
+        barrier(const std::string &barrier_id, const bool finishing = false) = 0;
 
         // Check if all peer processes are still alive; returns true by default
         [[nodiscard]] virtual bool

--- a/benchmark/nixlbench/src/runtime/runtime.h
+++ b/benchmark/nixlbench/src/runtime/runtime.h
@@ -40,7 +40,7 @@ class xferBenchRT {
         virtual int reduceSumDouble(double *local_value, double *global_value, int dest_rank) = 0;
 
         // Add a barrier function to synchronize all processes
-        virtual int barrier(const std::string& barrier_id) = 0;
+        virtual int barrier(const std::string& barrier_id, const bool finishing = false) = 0;
 
         // Check if all peer processes are still alive; returns true by default
         [[nodiscard]] virtual bool

--- a/benchmark/nixlbench/src/worker/worker.cpp
+++ b/benchmark/nixlbench/src/worker/worker.cpp
@@ -64,7 +64,7 @@ public:
     }
 
     virtual int
-    barrier(const std::string &barrier_id) override {
+    barrier(const std::string &barrier_id, const bool finishing) override {
         return 0;
     }
 };
@@ -122,8 +122,8 @@ createRT(std::atomic<int> *terminate) {
 } // namespace
 
 int
-xferBenchWorker::synchronize() {
-    if (rt->barrier("sync") != 0) {
+xferBenchWorker::synchronize(const bool finishing) {
+    if (rt->barrier("sync", finishing) != 0) {
         std::cerr << "Failed to synchronize" << std::endl;
         // Best-effort cleanup of non-leased etcd keys (e.g. the "size" key)
         // so they don't poison subsequent runs in the same benchmark_group.

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -40,7 +40,7 @@ class xferBenchWorker {
         bool isMasterRank();
         bool isInitiator();
         bool isTarget();
-        int synchronize();
+        int synchronize(bool finishing = false);
         bool signaled() const { return terminate != 0; }
         static void signalHandler(int signal);
 

--- a/benchmark/nixlbench/src/worker/worker.h
+++ b/benchmark/nixlbench/src/worker/worker.h
@@ -40,7 +40,8 @@ class xferBenchWorker {
         bool isMasterRank();
         bool isInitiator();
         bool isTarget();
-        int synchronize(bool finishing = false);
+        int
+        synchronize(bool finishing = false);
         bool signaled() const { return terminate != 0; }
         static void signalHandler(int signal);
 


### PR DESCRIPTION
## What?
Depending on timing, the ASIO runtime can throw an exception after the final barrier succeeded.

This PR suppresses further read operations after the final barrier has finished receiving data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “finishing” mode to benchmark barrier/synchronization signaling, allowing workers to communicate when shutdown is in its final phase.
  * Updated synchronization APIs to accept an optional completion flag and forward it through the active runtime.
* **Bug Fixes**
  * Improved shutdown coordination to ensure no further receive/head reads are scheduled once the finishing barrier is processed.
  * Ensured the final cleanup synchronization step uses the finishing signal for cleaner runtime termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->