### PR TITLE
CI: Increase cleanup job timeout to 180 minutes

### DIFF
--- a/.ci/jenkins/lib/cleanup-matrix.yaml
+++ b/.ci/jenkins/lib/cleanup-matrix.yaml
@@ -2,7 +2,7 @@
 job: nixl-ci-cleanup-artifacts
 
 failFast: true
-timeout_minutes: 60
+timeout_minutes: 180
 
 kubernetes:
   cloud: il-ipp-blossom-prod


### PR DESCRIPTION
## What?
Increase cleanup job timeout to 180 minutes

## Why?
Job runs daily and currently takes ~55 min. Raised the
limit to handle growth in artifacts so the job does not
time out before finishing cleanup.

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the cleanup job timeout to improve reliability when removing build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->