### PR TITLE
CI: bind test_sync_mode_agent listener on an ephemeral port

### DIFF
--- a/test/python/test_nixl_api.py
+++ b/test/python/test_nixl_api.py
@@ -113,7 +113,11 @@ def test_sync_mode_agent(monkeypatch, sync_mode, enable_listen):
         return real_ctor(agent_name, agent_config)
 
     monkeypatch.setattr(bindings, "nixlAgent", spy_ctor)
-    config = nixl_agent_config(sync_mode=sync_mode, enable_listen_thread=enable_listen)
+    # listen_port=0 lets the OS pick an ephemeral port, so concurrent agents (parametrized
+    # cases here, or parallel CI jobs sharing a node) don't collide on the fixed default port.
+    config = nixl_agent_config(
+        sync_mode=sync_mode, enable_listen_thread=enable_listen, listen_port=0
+    )
     nixl_agent(str(uuid.uuid4()), nixl_conf=config)
     if sync_mode is not None:
         assert captured["syncMode"] == sync_mode.value


### PR DESCRIPTION
## What?

Bind `test_sync_mode_agent[enable_listen=True]`'s listener on an ephemeral port (`listen_port=0`) instead of the fixed default `8888`.

## Why?

- The four `enable_listen=True` cases all bind `8888`, so they (and parallel CI jobs sharing a node) collide: `Failed to bind metadata listener socket`.
- Sample: [nixl-ci-gpu #2829](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/job/nixl-ci-gpu/2829/) - 4 failed, 20 passed.

## How?

- `listen_port=0` lets the OS pick a free port (already supported). The test only asserts `syncMode`, so the port is irrelevant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent test runs by allowing the operating system to select an available network port, reducing potential port collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->