### PR TITLE
libfabric: flush FI_MORE per rail, not per group

### DIFF
--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -1106,6 +1106,40 @@ nixlLibfabricEngine::estimateXferCost(const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
+int
+nixlLibfabricEngine::batchingRail(const nixl_meta_dlist_t &local,
+                                  int desc_idx,
+                                  size_t xfer_base_offset) const {
+    auto *md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
+    if (!md || md->selected_rails_.empty()) {
+        return -1;
+    }
+    // Striped descriptors are split across their rails and posted without FI_MORE, so they
+    // are not part of the single-rail batching tracked here.
+    if (rail_manager_.usesStriping(local[desc_idx].len, md->selected_rails_.size())) {
+        return -1;
+    }
+    return (int)md->selected_rails_[nixlLibfabricRailManager::railSelectionIndex(
+        xfer_base_offset, desc_idx, /*batch_write=*/true, md->selected_rails_.size())];
+}
+
+bool
+nixlLibfabricEngine::useFiMore(int desc_idx,
+                               int rail_id,
+                               const std::vector<int> &last_desc_idx_per_rail,
+                               std::vector<int> &posts_since_flush) const {
+    if (rail_id < 0) {
+        return false;
+    }
+    if (desc_idx == last_desc_idx_per_rail[rail_id] ||
+        posts_since_flush[rail_id] == NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE - 1) {
+        posts_since_flush[rail_id] = 0;
+        return false;
+    }
+    ++posts_since_flush[rail_id];
+    return true;
+}
+
 nixl_status_t
 nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
                                          const nixl_meta_dlist_t &local,
@@ -1114,8 +1148,8 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
                                          nixlLibfabricBackendH *backend_handle,
                                          int start_idx,
                                          int end_idx,
-                                         int desc_count,
                                          size_t xfer_base_offset,
+                                         bool allow_fi_more,
                                          size_t &submitted_count) const {
     submitted_count = 0;
 
@@ -1147,7 +1181,30 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
     };
 #endif
 
+    // A FI_MORE post rings no doorbell; a rail's queued batch is only submitted by a later
+    // non-FI_MORE post on the same rail. Rails are resolved per-buffer, so descriptors of one
+    // round-robin group can land on different rails: every rail this chunk touches must have its
+    // last post flushed, or its batch would never be submitted.
+    // allow_fi_more is false on the thread-pool path: chunks on other threads can interleave
+    // posts on the same rail, so a per-chunk walk cannot know a rail's true last post there.
+    const bool batch_writes = allow_fi_more && op_type == nixlLibfabricReq::WRITE;
+
+    std::vector<int> last_desc_idx_per_rail(rail_manager_.getNumRails(), -1);
+    std::vector<int> posts_since_flush(rail_manager_.getNumRails(), 0);
+    if (batch_writes) {
+        for (int i = start_idx; i < end_idx; ++i) {
+            const int rail_id = batchingRail(local, i, xfer_base_offset);
+            if (rail_id >= 0) {
+                last_desc_idx_per_rail[rail_id] = i;
+            }
+        }
+    }
+
     for (int desc_idx = start_idx; desc_idx < end_idx; ++desc_idx) {
+        const int rail_id = batch_writes ? batchingRail(local, desc_idx, xfer_base_offset) : -1;
+        const bool apply_fi_more =
+            useFiMore(desc_idx, rail_id, last_desc_idx_per_rail, posts_since_flush);
+
         auto *local_md = static_cast<nixlLibfabricPrivateMetadata *>(local[desc_idx].metadataP);
         auto *remote_md = static_cast<nixlLibfabricPublicMetadata *>(remote[desc_idx].metadataP);
 
@@ -1182,8 +1239,8 @@ nixlLibfabricEngine::postXferDescriptors(nixlLibfabricReq::OpType op_type,
             [backend_handle]() { backend_handle->increment_completed_requests(); },
             desc_submitted_count,
             desc_idx,
-            desc_count,
-            xfer_base_offset);
+            xfer_base_offset,
+            apply_fi_more);
 
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "prepareAndSubmitTransfer failed for descriptor " << desc_idx
@@ -1294,8 +1351,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                                                    backend_handle,
                                                    0,
                                                    desc_count,
-                                                   desc_count,
                                                    xfer_base_offset,
+                                                   /*allow_fi_more=*/true,
                                                    total_submitted);
         if (status != NIXL_SUCCESS) {
             return status;
@@ -1327,8 +1384,8 @@ nixlLibfabricEngine::postXfer(const nixl_xfer_op_t &operation,
                                                      backend_handle,
                                                      start_idx,
                                                      end_idx,
-                                                     desc_count,
                                                      xfer_base_offset,
+                                                     /*allow_fi_more=*/false,
                                                      chunk_submitted);
                     }
                     catch (const std::exception &e) {

--- a/src/plugins/libfabric/libfabric_backend.h
+++ b/src/plugins/libfabric/libfabric_backend.h
@@ -308,9 +308,23 @@ private:
                         nixlLibfabricBackendH *backend_handle,
                         int start_idx,
                         int end_idx,
-                        int desc_count,
                         size_t xfer_base_offset,
+                        bool allow_fi_more,
                         size_t &submitted_count) const;
+
+    /** Rail a WRITE descriptor posts on, or -1 if it does not participate in FI_MORE batching
+     *  (no metadata, no selected rails, or striped across multiple rails). */
+    int
+    batchingRail(const nixl_meta_dlist_t &local, int desc_idx, size_t xfer_base_offset) const;
+
+    /** Whether descriptor desc_idx should carry FI_MORE: false (flush) for a rail's last post
+     *  in [start,end) and when the rail's batch reaches NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE.
+     *  Updates posts_since_flush. */
+    bool
+    useFiMore(int desc_idx,
+              int rail_id,
+              const std::vector<int> &last_desc_idx_per_rail,
+              std::vector<int> &posts_since_flush) const;
 
 #ifdef HAVE_CUDA
     // CUDA context management methods

--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -42,6 +42,9 @@
 #define NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD (128 * 1024) // 128KB
 #define LF_EP_NAME_MAX_LEN 56
 
+// Number of consecutive WRITE descriptors batched onto one rail with FI_MORE before flushing.
+#define NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE 16
+
 // Request pool configuration constants
 #define NIXL_LIBFABRIC_CONTROL_REQUESTS_PER_RAIL 4096 // SEND/RECV operations (for notifications)
 #define NIXL_LIBFABRIC_DATA_REQUESTS_PER_RAIL 1024 // WRITE/READ operations

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -367,11 +367,6 @@ nixlLibfabricRailManager::createRails(const std::vector<std::string> &efa_device
     return NIXL_SUCCESS;
 }
 
-bool
-nixlLibfabricRailManager::shouldUseStriping(size_t transfer_size) const {
-    return transfer_size >= striping_threshold_;
-}
-
 size_t
 nixlLibfabricRailManager::reserveBaseOffset() {
     return round_robin_counter.fetch_add(1);
@@ -394,8 +389,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     std::function<void()> completion_callback,
     size_t &submitted_count_out,
     int desc_idx,
-    int desc_count,
-    size_t base_offset) {
+    size_t base_offset,
+    bool apply_fi_more) {
     // Initialize output parameter
     submitted_count_out = 0;
 
@@ -405,22 +400,22 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
     }
 
     // Determine striping strategy
-    bool use_striping = shouldUseStriping(transfer_size) && selected_rails.size() > 1;
+    bool use_striping = usesStriping(transfer_size, selected_rails.size());
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
-        // WRITE: group 16 consecutive descs to same rail for FI_MORE batching.
-        // READ: per-descriptor round-robin (FI_MORE has no benefit for reads).
-        constexpr int FI_MORE_BATCH_SIZE = 16;
+        // WRITE: group NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE consecutive descriptors on one rail
+        // for FI_MORE batching. READ: per-descriptor round-robin (FI_MORE has no benefit).
+        // apply_fi_more is precomputed by the caller, which leaves it false for the last post
+        // on each rail so that every rail's FI_MORE batch is flushed.
         const bool batch_write = (op_type == nixlLibfabricReq::WRITE);
-        const size_t rr_idx =
-            batch_write ? (base_offset + desc_idx / FI_MORE_BATCH_SIZE) : (base_offset + desc_idx);
-        const size_t rail_id = selected_rails[rr_idx % selected_rails.size()];
-        const size_t remote_ep_id =
-            remote_selected_endpoints[rr_idx % remote_selected_endpoints.size()];
-        const int pos_in_group = desc_idx % FI_MORE_BATCH_SIZE;
-        const bool is_last_in_group =
-            (pos_in_group == FI_MORE_BATCH_SIZE - 1) || (desc_idx == desc_count - 1);
-        const uint64_t fi_flags = (batch_write && !is_last_in_group) ? FI_MORE : 0;
+        const size_t rail_sel_idx =
+            railSelectionIndex(base_offset, desc_idx, batch_write, selected_rails.size());
+        const size_t rail_id = selected_rails[rail_sel_idx];
+        // The remote endpoint round-robins over its own count, which can differ from the
+        // local rail count.
+        const size_t remote_ep_id = remote_selected_endpoints[railSelectionIndex(
+            base_offset, desc_idx, batch_write, remote_selected_endpoints.size())];
+        const uint64_t fi_flags = (batch_write && apply_fi_more) ? FI_MORE : 0;
         NIXL_DEBUG << "rail " << rail_id << ", remote_ep_id " << remote_ep_id;
         // Allocate request
         nixlLibfabricReq *req = rails_[rail_id]->allocateDataRequest(op_type, xfer_id);

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -132,6 +132,17 @@ public:
         return rails_.size();
     }
 
+    /** Round-robin index of a descriptor into a selection array of `count` entries.
+     * batch_write groups NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE consecutive descriptors per entry.
+     * The FI_MORE flush precompute and the rail selection must agree, so both call this. */
+    static size_t
+    railSelectionIndex(size_t base_offset, int desc_idx, bool batch_write, size_t count) {
+        const size_t rr_idx = batch_write ?
+            (base_offset + static_cast<size_t>(desc_idx) / NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE) :
+            (base_offset + static_cast<size_t>(desc_idx));
+        return rr_idx % count;
+    }
+
     // Memory registration management
     /** Register memory with topology-aware rail selection based on memory type and location
      * @param buffer Memory buffer to register
@@ -198,8 +209,11 @@ public:
      * @param completion_callback Callback for completion notification
      * @param submitted_count_out Number of requests successfully submitted
      * @param desc_idx Index of current descriptor within the transfer
-     * @param desc_count Total number of descriptors in the transfer
      * @param base_offset Pre-reserved round-robin offset from reserveBaseOffset()
+     * @param apply_fi_more Precomputed by the caller: true keeps a non-striped WRITE batched
+     *        (posted with FI_MORE); false flushes the rail's batch. The caller passes false for
+     *        a rail's last post and when a batch reaches NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE.
+     *        Defaults to false so an unmarked descriptor flushes safely.
      * @return NIXL_SUCCESS on success, error code on failure
      */
     nixl_status_t
@@ -218,19 +232,23 @@ public:
                              std::function<void()> completion_callback,
                              size_t &submitted_count_out,
                              int desc_idx,
-                             int desc_count,
-                             size_t base_offset);
+                             size_t base_offset,
+                             bool apply_fi_more = false);
 
     /** Reserve a base offset for a transfer to ensure stable rail assignment
      *  across all descriptors in the transfer. Call once per postXfer. */
     size_t
     reserveBaseOffset();
-    /** Determine if striping should be used for given transfer size
+
+    /** True when a transfer of this size across this many rails is striped (split across the
+     *  rails) rather than posted on a single rail.
      * @param transfer_size Size of the transfer in bytes
-     * @return true if striping should be used, false for round-robin
+     * @param rail_count Number of rails selected for the transfer
      */
     bool
-    shouldUseStriping(size_t transfer_size) const;
+    usesStriping(size_t transfer_size, size_t rail_count) const {
+        return transfer_size >= striping_threshold_ && rail_count > 1;
+    }
 
     // Control Message APIs
     /** Control message types for rail communication */


### PR DESCRIPTION
## What?
The positional flush then rings only one rail's doorbell; the other rail's batch is never submitted and the transfer hangs. nixlbench doesn't hit this: one buffer per device = one rail list.

## Why?
FI_MORE WRITE batching (#1626) flushes the doorbell positionally (last of each 16-group / last of the transfer), which is only correct when every descriptor in a group is on the same rail.  But each descriptor's rail comes from its own buffer's selected_rails, so a transfer spanning buffers with different rail lists (e.g. dynamo's many DRAM registrations) alternates physical rails within a group. 

## How?
postXfer precomputes the flush decision per physical rail (walking descriptors backwards, the first rail seen is its last post), and prepareAndSubmitTransfer takes a bool apply_fi_more instead of deciding positionally. Batching is opt-in, so unmarked descriptors (READ, striped, rail-less) flush.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved Libfabric WRITE batching by precomputing per-descriptor `FI_MORE` decisions, with tighter rail-aligned round-robin selection for better endpoint targeting.
* **Behavior Changes**
  * WRITE posts now respect controlled “flush” boundaries more consistently; behavior differs between single-path posting and chunked/thread-pool posting to avoid incorrect “last post” assumptions.
  * READ behavior remains unchanged.
* **Configuration**
  * Added `NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE` (default: 16) to limit consecutive WRITE descriptors eligible for `FI_MORE` batching before flushing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->