### PR TITLE
ci: include pipeline name in Slurm job names

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -204,6 +204,20 @@ their own nightly/manual trigger. They split into two groups:
 - **What it does:** Runs smoke/perf/accuracy tests for one published LLM inference container image on the `mizu` SLURM partition (2-GPU node); framework (vllm/sglang) is auto-detected from the image URL.
 - **Automatic on every PR:** No — standalone/manual only.
 
+## Slurm job naming
+
+Jobs submitted via the `slurmCI` module are named `${JOB_BASE_NAME}-<variant>-${BUILD_NUMBER}`, where `JOB_BASE_NAME` is the Jenkins job name and `variant` disambiguates parallel allocations within a build:
+
+| Pipeline | Slurm job name pattern |
+|---|---|
+| `nixl-ci-gpu` | `nixl-ci-gpu-<ucx_version>-<build>` |
+| `nixl-ci-dl-gpu` | `nixl-ci-dl-gpu-<ucx_version>-<build>` |
+| `nixl-ci-dl-gpu-ep` | `nixl-ci-dl-gpu-ep-<ucx_version>-<build>` |
+| `nixl-ci-build-wheel` | `nixl-ci-build-wheel-<fw>-<build>` (`fw`: `vllm` or `sglang`) |
+| `nixl-ci-test-llm-container` | `nixl-ci-test-llm-container-<build>` |
+
+Use `squeue --name <pattern>` or `squeue -u <user>` to identify which pipeline owns a running job.
+
 ## How to trigger CI manually
 
 - **Full Jenkins pipeline for a PR:** comment `/build` on the PR (requires authorization — see `Authorization` step in `blossom-ci.yml`).

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -335,7 +335,7 @@ steps:
       nodes: "${SLURM_NODES}"
       jobTimeout: "${SLURM_JOB_TIMEOUT}"
       immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-vs-${fw}-${BUILD_NUMBER}"
+      jobName: "${JOB_BASE_NAME}-${fw}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${fw}_${BUILD_NUMBER}.txt"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       extraArgs: [

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -134,7 +134,7 @@ steps:
       nodes: "${SLURM_NODES}"
       jobTimeout: "${SLURM_JOB_TIMEOUT}"
       immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-ci-ep-${ucx_version}-${BUILD_NUMBER}"
+      jobName: "${JOB_BASE_NAME}-${ucx_version}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_ep_${ucx_version}_${BUILD_NUMBER}.txt"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       extraArgs: [

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -125,7 +125,7 @@ steps:
       nodes: "${SLURM_NODES}"
       jobTimeout: "${SLURM_JOB_TIMEOUT}"
       immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      jobName: "${JOB_BASE_NAME}-${ucx_version}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       extraArgs: [

--- a/.ci/jenkins/lib/test-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/test-llm-container-matrix.yaml
@@ -146,7 +146,7 @@ steps:
       nodes: "${SLURM_NODES}"
       jobTimeout: "${SLURM_JOB_TIMEOUT}"
       immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-llm-${BUILD_NUMBER}"
+      jobName: "${JOB_BASE_NAME}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       extraArgs: [

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -126,7 +126,7 @@ steps:
       nodes: "${SLURM_NODES}"
       jobTimeout: "${SLURM_JOB_TIMEOUT}"
       immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
-      jobName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
+      jobName: "${JOB_BASE_NAME}-${ucx_version}-${BUILD_NUMBER}"
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       extraArgs: [


### PR DESCRIPTION
## What?
Replace hardcoded nixl-ci-* prefixes with ${JOB_BASE_NAME} so each Slurm allocation's --job-name reflects the Jenkins pipeline that submitted it. ucx_version / fw axis variables are kept where multiple allocations run concurrently within the same build.

Before → After:
  test-matrix.yaml:          nixl-ci-${ucx_version}-${BUILD_NUMBER}
  test-dl-matrix.yaml:       nixl-ci-${ucx_version}-${BUILD_NUMBER}  (was same as above)
  test-dl-ep-matrix.yaml:    nixl-ci-ep-${ucx_version}-${BUILD_NUMBER}
  build-wheel-matrix.yaml:   nixl-vs-${fw}-${BUILD_NUMBER}
  test-llm-container-matrix: nixl-llm-${BUILD_NUMBER}

All become:
  ${JOB_BASE_NAME}-<variant>-${BUILD_NUMBER}

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on Slurm job naming patterns for CI pipelines.
  - Included `squeue` examples for locating running jobs by name or user.

- **Bug Fixes**
  - Updated CI jobs to use consistent, descriptive names based on the pipeline, variant, and build number.
  - Improved job identification for build, test, GPU, and container workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->