### PR TITLE
build/ci: backport wheel-build CI and UCX spcx + Infinia plugin bundling to release/1.4.0

### DIFF
--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -eE
+set -o pipefail
 
-# Files to check for changes
+# CI source files whose last-touching commit determines CI_IMAGE_TAG.
+# When any of these files change in a commit, the derived tag changes
+# and the matrix jobs rebuild their base Docker images automatically.
 CI_FILES=(
     ".ci/dockerfiles/Dockerfile.base"
     ".ci/dockerfiles/Dockerfile.gpu-test"
@@ -10,136 +13,32 @@ CI_FILES=(
     "contrib/Dockerfile.manylinux"
 )
 
-# YAML files containing CI_IMAGE_TAG
-BUILD_MATRIX_YAML=".ci/jenkins/lib/build-matrix.yaml"
-TEST_MATRIX_YAML=".ci/jenkins/lib/test-matrix.yaml"
-TEST_DL_MATRIX_YAML=".ci/jenkins/lib/test-dl-matrix.yaml"
-TEST_DL_EP_MATRIX_YAML=".ci/jenkins/lib/test-dl-ep-matrix.yaml"
-SANITIZER_MATRIX_YAML=".ci/jenkins/lib/test-sanitizer-matrix.yaml"
-WHEEL_BUILD_MATRIX_YAML=".ci/jenkins/lib/build-wheel-matrix.yaml"
+# Matrix YAML files that contain the CI_MANAGED placeholder.
+# These are patched in the Jenkins workspace before the matrix library
+# reads them — no commit or push is made.
+YAML_FILES=(
+    ".ci/jenkins/lib/build-matrix.yaml"
+    ".ci/jenkins/lib/test-matrix.yaml"
+    ".ci/jenkins/lib/test-dl-matrix.yaml"
+    ".ci/jenkins/lib/test-dl-ep-matrix.yaml"
+    ".ci/jenkins/lib/test-sanitizer-matrix.yaml"
+    ".ci/jenkins/lib/build-wheel-matrix.yaml"
+)
 
-# Function to extract CI_IMAGE_TAG from a YAML file
-get_ci_image_tag() {
-    local file=$1
-    local ref=$2  # git ref (HEAD, HEAD~1, etc.)
+# Derive the tag from the most recent commit that touched any CI file.
+NEW_TAG=$(git log -1 --format=%h -- "${CI_FILES[@]}")
 
-    if [ -z "$ref" ]; then
-        # Current working tree
-        grep -E '^\s*CI_IMAGE_TAG:' "$file" | sed 's/.*CI_IMAGE_TAG:\s*"\(.*\)".*/\1/' | tr -d ' '
-    else
-        # Previous commit
-        git show "${ref}:${file}" 2>/dev/null | grep -E '^\s*CI_IMAGE_TAG:' | sed 's/.*CI_IMAGE_TAG:\s*"\(.*\)".*/\1/' | tr -d ' '
-    fi
-}
-
-# Check if we're in a git repository
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
-    echo "Not a git repository. Skipping CI_IMAGE_TAG check."
-    echo "Ok"
-    exit 0
+# Fallback: if no commit has ever touched those files (should not happen
+# in practice), use a sha256sum of their content truncated to 12 chars.
+if [ -z "$NEW_TAG" ]; then
+    echo "Warning: git log returned empty for CI files. Falling back to content hash."
+    NEW_TAG=$(cat "${CI_FILES[@]}" | sha256sum | cut -c1-12)
 fi
 
-# Check if any CI files were changed in the last commit or working tree
-files_changed=false
-for file in "${CI_FILES[@]}"; do
-    # Check if file was changed in HEAD commit or has uncommitted changes
-    if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^${file}$" || \
-       git diff --name-only 2>/dev/null | grep -q "^${file}$" || \
-       git diff --cached --name-only 2>/dev/null | grep -q "^${file}$"; then
-        echo "Detected changes in: $file"
-        files_changed=true
-    fi
+echo "CI_IMAGE_TAG derived as: ${NEW_TAG}"
+
+for yaml in "${YAML_FILES[@]}"; do
+    grep -q 'CI_IMAGE_TAG: "CI_MANAGED"' "$yaml" || { echo "ERROR: CI_MANAGED placeholder missing in $yaml" >&2; exit 1; }
+    sed -i "s/CI_IMAGE_TAG: \"CI_MANAGED\"/CI_IMAGE_TAG: \"${NEW_TAG}\"/" "$yaml"
+    echo "Patched: $yaml"
 done
-
-if [ "$files_changed" = false ]; then
-    echo "No changes detected in CI files. Skipping CI_IMAGE_TAG check."
-    echo "Ok"
-    exit 0
-fi
-
-# Files were changed, now check if CI_IMAGE_TAG was increased
-echo "CI files were modified. Checking if CI_IMAGE_TAG was increased..."
-
-# Get current and previous CI_IMAGE_TAG values
-current_build_image_tag=$(get_ci_image_tag "$BUILD_MATRIX_YAML" "")
-current_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "")
-current_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "")
-current_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "")
-current_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "")
-current_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "")
-
-previous_build_image_tag=$(get_ci_image_tag "$BUILD_MATRIX_YAML" "HEAD~1")
-previous_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "HEAD~1")
-previous_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "HEAD~1")
-previous_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "HEAD~1")
-previous_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "HEAD~1")
-previous_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "HEAD~1")
-
-echo "Build Matrix CI_IMAGE_TAG:     $previous_build_image_tag -> $current_build_image_tag"
-echo "Test Matrix CI_IMAGE_TAG:      $previous_test_image_tag -> $current_test_image_tag"
-echo "Test DL Matrix CI_IMAGE_TAG:   $previous_test_dl_image_tag -> $current_test_dl_image_tag"
-echo "Test DL EP Matrix CI_IMAGE_TAG: $previous_test_dl_ep_image_tag -> $current_test_dl_ep_image_tag"
-echo "Sanitizer Matrix CI_IMAGE_TAG: $previous_sanitizer_image_tag -> $current_sanitizer_image_tag"
-echo "Wheel Build Matrix CI_IMAGE_TAG: $previous_wheel_build_image_tag -> $current_wheel_build_image_tag"
-
-# Check if CI_IMAGE_TAG was changed in all files
-build_tag_changed=false
-test_tag_changed=false
-test_dl_tag_changed=false
-test_dl_ep_tag_changed=false
-sanitizer_tag_changed=false
-wheel_build_tag_changed=false
-
-if [ "$current_build_image_tag" != "$previous_build_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in build-matrix.yaml was updated"
-    build_tag_changed=true
-fi
-
-if [ "$current_test_image_tag" != "$previous_test_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in test-matrix.yaml was updated"
-    test_tag_changed=true
-fi
-
-if [ "$current_test_dl_image_tag" != "$previous_test_dl_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in test-dl-matrix.yaml was updated"
-    test_dl_tag_changed=true
-fi
-
-if [ "$current_test_dl_ep_image_tag" != "$previous_test_dl_ep_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in test-dl-ep-matrix.yaml was updated"
-    test_dl_ep_tag_changed=true
-fi
-
-if [ "$current_sanitizer_image_tag" != "$previous_sanitizer_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in test-sanitizer-matrix.yaml was updated"
-    sanitizer_tag_changed=true
-fi
-
-if [ "$current_wheel_build_image_tag" != "$previous_wheel_build_image_tag" ]; then
-    echo "✓ CI_IMAGE_TAG in build-wheel-matrix.yaml was updated"
-    wheel_build_tag_changed=true
-fi
-
-if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$test_dl_tag_changed" = false ] || [ "$test_dl_ep_tag_changed" = false ] || [ "$sanitizer_tag_changed" = false ] || [ "$wheel_build_tag_changed" = false ]; then
-    echo ""
-    echo "❌ ERROR: You have changed CI files but forgot to increase CI_IMAGE_TAG!"
-    echo ""
-    echo "Changed files:"
-    for file in "${CI_FILES[@]}"; do
-        if git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q "^${file}$" || \
-           git diff --name-only 2>/dev/null | grep -q "^${file}$" || \
-           git diff --cached --name-only 2>/dev/null | grep -q "^${file}$"; then
-            echo "  - $file"
-        fi
-    done
-    echo ""
-    echo "Please update CI_IMAGE_TAG in:"
-    echo "  - $BUILD_MATRIX_YAML (line 46)"
-    echo "  - $TEST_MATRIX_YAML (line 53)"
-    echo "  - $TEST_DL_MATRIX_YAML (line 52)"
-    echo "  - $TEST_DL_EP_MATRIX_YAML"
-    echo "  - $SANITIZER_MATRIX_YAML"
-    echo "  - $WHEEL_BUILD_MATRIX_YAML"
-    echo ""
-    exit 1
-fi

--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -7,6 +7,7 @@ CI_FILES=(
     ".ci/dockerfiles/Dockerfile.build_helper"
     ".gitlab/build.sh"
     ".ci/scripts/common.sh"
+    "contrib/Dockerfile.manylinux"
 )
 
 # YAML files containing CI_IMAGE_TAG
@@ -15,6 +16,7 @@ TEST_MATRIX_YAML=".ci/jenkins/lib/test-matrix.yaml"
 TEST_DL_MATRIX_YAML=".ci/jenkins/lib/test-dl-matrix.yaml"
 TEST_DL_EP_MATRIX_YAML=".ci/jenkins/lib/test-dl-ep-matrix.yaml"
 SANITIZER_MATRIX_YAML=".ci/jenkins/lib/test-sanitizer-matrix.yaml"
+WHEEL_BUILD_MATRIX_YAML=".ci/jenkins/lib/build-wheel-matrix.yaml"
 
 # Function to extract CI_IMAGE_TAG from a YAML file
 get_ci_image_tag() {
@@ -64,18 +66,21 @@ current_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "")
 current_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "")
 current_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "")
 current_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "")
+current_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "")
 
 previous_build_image_tag=$(get_ci_image_tag "$BUILD_MATRIX_YAML" "HEAD~1")
 previous_test_image_tag=$(get_ci_image_tag "$TEST_MATRIX_YAML" "HEAD~1")
 previous_test_dl_image_tag=$(get_ci_image_tag "$TEST_DL_MATRIX_YAML" "HEAD~1")
 previous_test_dl_ep_image_tag=$(get_ci_image_tag "$TEST_DL_EP_MATRIX_YAML" "HEAD~1")
 previous_sanitizer_image_tag=$(get_ci_image_tag "$SANITIZER_MATRIX_YAML" "HEAD~1")
+previous_wheel_build_image_tag=$(get_ci_image_tag "$WHEEL_BUILD_MATRIX_YAML" "HEAD~1")
 
 echo "Build Matrix CI_IMAGE_TAG:     $previous_build_image_tag -> $current_build_image_tag"
 echo "Test Matrix CI_IMAGE_TAG:      $previous_test_image_tag -> $current_test_image_tag"
 echo "Test DL Matrix CI_IMAGE_TAG:   $previous_test_dl_image_tag -> $current_test_dl_image_tag"
 echo "Test DL EP Matrix CI_IMAGE_TAG: $previous_test_dl_ep_image_tag -> $current_test_dl_ep_image_tag"
 echo "Sanitizer Matrix CI_IMAGE_TAG: $previous_sanitizer_image_tag -> $current_sanitizer_image_tag"
+echo "Wheel Build Matrix CI_IMAGE_TAG: $previous_wheel_build_image_tag -> $current_wheel_build_image_tag"
 
 # Check if CI_IMAGE_TAG was changed in all files
 build_tag_changed=false
@@ -83,6 +88,7 @@ test_tag_changed=false
 test_dl_tag_changed=false
 test_dl_ep_tag_changed=false
 sanitizer_tag_changed=false
+wheel_build_tag_changed=false
 
 if [ "$current_build_image_tag" != "$previous_build_image_tag" ]; then
     echo "✓ CI_IMAGE_TAG in build-matrix.yaml was updated"
@@ -109,7 +115,12 @@ if [ "$current_sanitizer_image_tag" != "$previous_sanitizer_image_tag" ]; then
     sanitizer_tag_changed=true
 fi
 
-if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$test_dl_tag_changed" = false ] || [ "$test_dl_ep_tag_changed" = false ] || [ "$sanitizer_tag_changed" = false ]; then
+if [ "$current_wheel_build_image_tag" != "$previous_wheel_build_image_tag" ]; then
+    echo "✓ CI_IMAGE_TAG in build-wheel-matrix.yaml was updated"
+    wheel_build_tag_changed=true
+fi
+
+if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$test_dl_tag_changed" = false ] || [ "$test_dl_ep_tag_changed" = false ] || [ "$sanitizer_tag_changed" = false ] || [ "$wheel_build_tag_changed" = false ]; then
     echo ""
     echo "❌ ERROR: You have changed CI files but forgot to increase CI_IMAGE_TAG!"
     echo ""
@@ -128,6 +139,7 @@ if [ "$build_tag_changed" = false ] || [ "$test_tag_changed" = false ] || [ "$te
     echo "  - $TEST_DL_MATRIX_YAML (line 52)"
     echo "  - $TEST_DL_EP_MATRIX_YAML"
     echo "  - $SANITIZER_MATRIX_YAML"
+    echo "  - $WHEEL_BUILD_MATRIX_YAML"
     echo ""
     exit 1
 fi

--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -19,8 +19,20 @@ The CI pipeline consists of four main components:
 ┌─────────────────┐    ┌──────────────────┐    ┌──────────────────┐    ┌─────────────────┐
 │   Jenkins       │    │  build-          │    │   Dockerfile     │    │   build-        │
 │   Matrix Job    │───▶│  container.sh    │───▶│   .manylinux     │───▶│   wheel.sh      │
-│  (podman runner)│    │  (docker build)  │    │  (full build)    │    │  (wheel pkg)    │
+│  (podman runner)│    │  --wheel-base-   │    │   wheel stage    │    │  (wheel pkg)    │
+│                 │    │  image <url>     │    │   only (~16 steps│    │                 │
 └─────────────────┘    └──────────────────┘    └──────────────────┘    └─────────────────┘
+                                                        ▲
+                                               pulls pre-built image
+                                               from Artifactory
+                                          ┌──────────────────┐
+                                          │  wheel_base stage│
+                                          │  (UCX, gRPC,     │
+                                          │  Rust, DOCA, …)  │
+                                          │  built & pushed  │
+                                          │  by CI-demo when │
+                                          │  Dockerfile changes│
+                                          └──────────────────┘
 ```
 
 ## 1. Jenkins Matrix Configuration
@@ -48,27 +60,35 @@ The job builds wheels for multiple combinations:
 ```yaml
 runs_on_dockers:
   - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+  - { file: 'contrib/Dockerfile.manylinux', name: "nixl-wheel-base-manylinux_2_28",
+      tag: "${CI_IMAGE_TAG}", build_args: '... --target wheel_base' }
 ```
 
-The CI runner uses podman-in-container. `build-container.sh` is called inside this container and executes `docker build` (symlinked to podman) to build the wheel image using `contrib/Dockerfile.manylinux`.
+The CI runner uses podman-in-container. `build-container.sh` is called inside this container and executes `docker build` (symlinked to podman). The `nixl-wheel-base-manylinux_2_28` entry is never used as a runner — CI-demo builds and pushes it to Artifactory whenever `CI_IMAGE_TAG` changes, so that each PR build can pull the pre-built `wheel_base` layer instead of compiling all dependencies from scratch.
 
 ## 2. Docker Build Environment (`contrib/Dockerfile.manylinux`)
 
 ### Multi-Stage Build Architecture
 
-The Dockerfile uses a multi-stage build approach with two main stages:
+The Dockerfile has two stages:
+
+- **`wheel_base`** — builds all slow dependencies (hwloc, OpenSSL, Abseil, gRPC, etcd, curl, AWS SDK, libxml2, Azure SDK, Rust, DOCA, gdrcopy, libfabric, Python/uv, UCX). Built and pushed to Artifactory by CI-demo when `CI_IMAGE_TAG` changes. This stage is never rebuilt per-PR.
+- **`wheel`** — `FROM $wheel_base AS wheel` — builds NIXL itself and runs `build-wheel.sh`. The `wheel_base` ARG is overridden to the Artifactory URL so this stage pulls the pre-built image as its base; only ~16 steps run per PR.
 
 ```dockerfile
-# Stage 1: Base stage with all dependencies and build environment
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} as wheel-base
+ARG wheel_base=wheel_base   # overridden to Artifactory URL in CI
 
-# ... (dependency installation and build setup)
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS wheel_base
+# ... installs UCX, gRPC, Rust, DOCA, gdrcopy, etc.
 
-# Stage 2: Default stage that builds and generates wheels
-FROM wheel-base
-# ... (NIXL build and wheel generation)
+FROM $wheel_base AS wheel
+ARG ARCH="x86_64"
+ARG BUILD_TYPE="release"
+ARG BUILD_NIXL_EP="true"
+ARG UCX_SONAME_SUFFIX=""
+# ... builds NIXL and generates wheels
 ```
 
 **Base Image**: `artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda:13.0-devel-manylinux--25.09`
@@ -76,38 +96,35 @@ FROM wheel-base
 ### Stage Usage Patterns
 
 #### CI Pipeline Usage (via build-container.sh)
-In the CI pipeline, `build-container.sh` is called with Artifactory base image and the target arch/Python version:
+In the PR CI pipeline, `build-container.sh` is called with `--wheel-base-image` pointing to the pre-built `wheel_base` image in Artifactory:
 
 ```bash
 ./contrib/build-container.sh \
   --base-image 'artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda' \
   --base-image-tag '13.0-devel-manylinux--25.09' \
-  --wheel-base "manylinux_${manylinux}" \
+  --wheel-base "manylinux_2_28" \
   --python-versions "${python_version}" \
   --arch ${arch} \
-  --dockerfile contrib/Dockerfile.manylinux
+  --torch-versions "2.13" \
+  --dockerfile contrib/Dockerfile.manylinux \
+  --wheel-base-image "${registry_host}${registry_path}/${arch}/${WHEEL_BASE_IMAGE_NAME}:${CI_IMAGE_TAG}"
 ```
 
-The script invokes `docker build` (symlinked to podman) with `BUILD_ARGS` assembled from those parameters, running a full Dockerfile.manylinux build that produces wheels inside the container.
+`--wheel-base-image` causes the script to pass `--build-arg wheel_base=<url> --target wheel`, so only the `wheel` stage runs and the pre-built deps are pulled from Artifactory rather than recompiled.
 
-#### User Usage (Default Stage)
-Users can build the complete image without specifying a target:
+`--torch-versions "2.13"` limits PR builds to the latest torch version. The nightly job omits this flag, building the full matrix.
+
+#### User Usage (Full Build)
+Users can build the complete image locally without specifying a target:
 
 ```bash
-docker build -f contrib/Dockerfile.manylinux .
+./contrib/build-container.sh --dockerfile contrib/Dockerfile.manylinux
 ```
 
-This will:
-- Use the `wheel-base` stage as foundation
-- Build NIXL from source
-- Generate wheels for all configured Python versions
-- Install the wheel for testing
+This builds both stages from scratch without the `--wheel-base-image` override.
 
-**User Benefits:**
-- Self-contained build environment
-- Pre-built wheels ready for distribution
-- Complete testing environment
-- No need to run separate build steps
+#### Nightly Build
+The nightly job (`nixl-ci-build-wheel-nightly`) omits `--torch-versions` and `--wheel-base-image`, so it builds all torch versions and runs the full two-stage build.
 
 ### Key Dependencies Installed
 
@@ -250,13 +267,14 @@ Sets up the podman container runtime and authenticates with Artifactory:
 
 ### Step 2: Build Wheel
 
-Builds the full NIXL container image (including wheel generation) via `build-container.sh`:
+Builds only the `wheel` stage of `Dockerfile.manylinux` by pulling the pre-built `wheel_base` from Artifactory:
 
-- Calls `contrib/build-container.sh` with the Artifactory base image, target arch, manylinux platform, and Python version
-- The script invokes `docker build` (podman) with `contrib/Dockerfile.manylinux`, which:
-  - Installs all system dependencies (UCX, gRPC, CUDA tools, Rust toolchain, etc.)
+- Calls `contrib/build-container.sh` with `--wheel-base-image <artifactory-url>` and `--torch-versions "2.13"`
+- The script invokes `docker build --target wheel --build-arg wheel_base=<url>` (podman), which:
+  - Pulls the pre-built `nixl-wheel-base-manylinux_2_28:${CI_IMAGE_TAG}` image (all deps already compiled)
   - Builds NIXL from source with meson/ninja
   - Runs `build-wheel.sh` to produce the Python wheel with auditwheel repair
+- Only ~16 Docker steps run per PR build (instead of the full ~53-step build)
 - Wheels are written to the `dist/` directory inside the container image
 
 
@@ -412,6 +430,7 @@ uv pip install --force-reinstall dist/nixl-*.whl
 
 ### Updating Dependencies
 - Modify `contrib/Dockerfile.manylinux` for system package updates
+- **Bump `CI_IMAGE_TAG`** in all six matrix YAMLs (including `.ci/jenkins/lib/build-wheel-matrix.yaml`) — `Dockerfile.manylinux` is in the `CI_FILES` list, so the `cidemo-init.sh` check will fail the PR otherwise
 - Update Python versions in matrix configuration
 - Test new dependencies in isolated environment
 
@@ -424,7 +443,7 @@ uv pip install --force-reinstall dist/nixl-*.whl
 ### Performance Optimization
 - Adjust `NPROC` build argument for parallel compilation
 - Monitor resource usage and adjust Kubernetes limits
-- Consider caching strategies for faster builds
+- Dependencies are cached in the `wheel_base` image; rebuilding it only requires bumping `CI_IMAGE_TAG`
 
 ## 10. Build Configuration Tools
 

--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -126,6 +126,16 @@ This builds both stages from scratch without the `--wheel-base-image` override.
 #### Nightly Build
 The nightly job (`nixl-ci-build-wheel-nightly`) omits `--torch-versions` and `--wheel-base-image`, so it builds all torch versions and runs the full two-stage build.
 
+#### Optional: UCX spcx external plugin
+`build-container.sh --build-ucx-spcx-plugin` opt-in flag fetches the internal `ucx-spcx-plugin` source on the host into the build context, compiles it against the just-built UCX inside the Dockerfile, and installs it into the UCX plugins dir where `wheel_add_ucx_plugins.py` bundles it like any other UCX module. It requires `--dockerfile contrib/Dockerfile.manylinux` and two environment variables — neither is hardcoded so the repo location and token stay out of the source and image layers:
+
+| Env var | Purpose | Jenkins credential | Credential type |
+|---|---|---|---|
+| `NIXL_SPCX_PLUGIN_REPO_URL` | Git URL of the plugin repo | `ucx-plugin-gitlab-url` | Secret text |
+| `NIXL_GITLAB_TOKEN` | GitLab token (`read_repository` scope) used via a git credential helper so it never appears in URLs, argv, or git error output | `svc-nixl-gitlab-token` | Username/Password (token in password field) |
+
+The plugin ref defaults to `main` and is selectable with `--ucx-spcx-plugin-ref`. This flag is not enabled in the PR CI pipeline; it is consumed by the QA/release invocations of `build-container.sh`, which bind both credentials into the environment.
+
 ### Key Dependencies Installed
 
 #### System Packages

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -165,6 +165,11 @@ their own nightly/manual trigger. They split into two groups:
 - **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
 - **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all six) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
 
+### `nixl-ci-build-wheel` (dispatcher-triggered)
+- **Config:** `.ci/jenkins/lib/build-wheel-matrix.yaml`
+- **What it does:** Builds NIXL Python wheels for each Python version × architecture combination. Uses a two-stage `contrib/Dockerfile.manylinux` build: the `wheel_base` stage (all slow deps: UCX, gRPC, Rust, etc.) is pre-built and cached in Artifactory under `CI_IMAGE_TAG`; PR builds pull this pre-built image and run only the `wheel` stage (~16 steps). PR builds also pass `--torch-versions` (set via the `TORCH_VERSIONS` env in the matrix file) to limit the torch extension builds to the latest version.
+- **`CI_IMAGE_TAG`:** Same convention as the other five matrix files. `contrib/Dockerfile.manylinux` is part of the `CI_FILES` list in `cidemo-init.sh`, so changing it (or any other CI file) without bumping `CI_IMAGE_TAG` in all six matrix YAMLs will fail the pre-commit check.
+
 ### `nixl-ci-build-container` (standalone)
 - **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the DLFW PyTorch daily image, ~3–4 AM), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).
 - **What it does:** Builds and pushes x86_64/aarch64 NIXL/NIXLBench container images to Artifactory.

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -168,7 +168,7 @@ their own nightly/manual trigger. They split into two groups:
 ### `nixl-ci-build-wheel` (dispatcher-triggered)
 - **Config:** `.ci/jenkins/lib/build-wheel-matrix.yaml`
 - **What it does:** Builds NIXL Python wheels for each Python version × architecture combination. Uses a two-stage `contrib/Dockerfile.manylinux` build: the `wheel_base` stage (all slow deps: UCX, gRPC, Rust, etc.) is pre-built and cached in Artifactory under `CI_IMAGE_TAG`; PR builds pull this pre-built image and run only the `wheel` stage (~16 steps). PR builds also pass `--torch-versions` (set via the `TORCH_VERSIONS` env in the matrix file) to limit the torch extension builds to the latest version.
-- **`CI_IMAGE_TAG`:** Same convention as the other five matrix files. `contrib/Dockerfile.manylinux` is part of the `CI_FILES` list in `cidemo-init.sh`, so changing it (or any other CI file) without bumping `CI_IMAGE_TAG` in all six matrix YAMLs will fail the pre-commit check.
+- **`CI_IMAGE_TAG`:** Same convention as the other five matrix files. `contrib/Dockerfile.manylinux` is part of the `CI_FILES` list in `cidemo-init.sh`, so changing it (or any other CI file) automatically derives a new `CI_IMAGE_TAG` and rebuilds the cached `wheel_base` image (see [CI_IMAGE_TAG management](#ci_image_tag-management)).
 
 ### `nixl-ci-build-container` (standalone)
 - **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the DLFW PyTorch daily image, ~3–4 AM), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).
@@ -195,6 +195,35 @@ their own nightly/manual trigger. They split into two groups:
 - **Full Jenkins pipeline for a PR:** comment `/build` on the PR (requires authorization — see `Authorization` step in `blossom-ci.yml`).
 - **Re-run a single Jenkins job with different parameters:** use `workflow_dispatch` on `blossom-ci.yml`, or trigger the Jenkins job directly if you have Jenkins access.
 - **Container/wheel builds outside the nightly schedule:** run `nixl-ci-build-container` or `nixl-ci-build-wheel-nightly` manually from the Jenkins UI with custom parameters.
+
+## CI_IMAGE_TAG management
+
+`CI_IMAGE_TAG` is the Docker image tag used by all matrix jobs to identify the
+base images they build and pull. It appears as `CI_IMAGE_TAG: "CI_MANAGED"` in
+the six matrix YAML files — this placeholder is intentional and must not be
+replaced with a static value.
+
+At the start of every Jenkins run, `cidemo-init.sh` derives the real tag
+automatically:
+
+```bash
+NEW_TAG=$(git log -1 --format=%h -- "${CI_FILES[@]}")
+```
+
+This returns the short git commit hash of the most recent commit that touched
+any of the CI source files (`Dockerfile.base`, `Dockerfile.gpu-test`,
+`Dockerfile.build_helper`, `build.sh`, `common.sh`, `Dockerfile.manylinux`). It
+then patches all six YAML files in the Jenkins workspace with `sed` before the
+matrix library reads them. No commit or push is made — the patch exists only in
+the workspace.
+
+**Caching behaviour:** the derived tag is stable as long as the CI source files
+are unchanged. Two PRs that both leave the CI files untouched get the same tag
+and share the cached Artifactory images. A PR that changes a Dockerfile gets a
+new tag and triggers a rebuild automatically.
+
+**You never need to manually update `CI_IMAGE_TAG`.** The `CI_MANAGED`
+placeholder signals this clearly.
 
 ## Related docs
 

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -20,18 +20,18 @@ runs on-demand (`workflow_dispatch`, a PR comment, or a cron schedule).
 | [Claude Code Review](#claude-code-review-claude-reviewyml) | GitHub Actions | `pull_request` (opened/synchronize/reopened) | Yes |
 | [External Contributor](#external-contributor-external_contributoryaml) | GitHub Actions | `pull_request_target` (opened, fork only) | Yes (fork PRs only) |
 | [Blossom-CI](#blossom-ci-blossom-ciyml) | GitHub Actions | `/build` PR comment, or `workflow_dispatch` | No — manual |
-| `nixl-ci-dispatcher` → `non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`, `test-sanitizers` | Jenkins (dispatcher-triggered) | Fan-out from Blossom-CI `Job-trigger` | No — only after `/build`, but these 6 are the *only* Jenkins jobs in the PR CI path |
+| `nixl-ci-dispatcher` → `non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`, `test-sanitizers`, `build-container-pr` | Jenkins (dispatcher-triggered) | Fan-out from Blossom-CI `Job-trigger` | No — only after `/build`, but these 7 are the *only* Jenkins jobs in the PR CI path |
 | `nixl-ci-build-container` | Jenkins (standalone) | Nightly cron + manual | No — never runs as part of PR CI |
 | `nixl-ci-build-wheel-nightly` | Jenkins (standalone) | Nightly cron + manual | No — never runs as part of PR CI |
 | `nixl-ci-build-llm-container` | Jenkins (standalone) | Manual only | No — never runs as part of PR CI |
 | `nixl-ci-test-llm-container` | Jenkins (standalone) | Manual, or chained from `build-llm-container` via `RUN_TEST` | No — never runs as part of PR CI |
 
-> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 10 Jenkins jobs, but only the
-> 6 that `nixl-ci-dispatcher` fans out to are ever part of the PR CI flow. The
-> other 4 (`build-container`, `build-wheel-nightly`, `build-llm-container`,
-> `test-llm-container`) are entirely standalone — they run only on a nightly
-> cron or when someone triggers them manually from the Jenkins UI, and are
-> never invoked by the dispatcher or by a PR event.
+> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 12 Jenkins jobs: the
+> dispatcher, the 7 jobs it fans out to (the PR CI flow), and 4 standalone jobs
+> (`build-container`, `build-wheel-nightly`, `build-llm-container`,
+> `test-llm-container`). The standalone ones run only on a nightly cron or when
+> someone triggers them manually from the Jenkins UI, and are never invoked by
+> the dispatcher or by a PR event.
 
 ## GitHub Actions workflows
 
@@ -98,7 +98,7 @@ sequenceDiagram
     participant Scan as Vulnerability-scan (Black Duck)
     participant Trigger as Job-trigger
     participant Jenkins as nixl-ci-dispatcher
-    participant Children as Child jobs<br/>(non-gpu, gpu, dl-gpu,<br/>dl-gpu-ep, build-wheel,<br/>test-sanitizers)
+    participant Children as Child jobs<br/>(non-gpu, gpu, dl-gpu,<br/>dl-gpu-ep, build-wheel,<br/>test-sanitizers, build-container-pr)
 
     User->>GH: comment "/build"
     GH->>Blossom: issue_comment event
@@ -128,15 +128,15 @@ Step by step, matching the jobs in `blossom-ci.yml`:
    Duck-based vulnerability scan via the `NVIDIA/blossom-action`.
 5. **Job-trigger** calls `blossom-ci` with `OPERATION: START-CI-JOB`, which
    triggers the Jenkins `nixl-ci-dispatcher` job.
-6. `nixl-ci-dispatcher` fans out in parallel to its six child jobs
+6. `nixl-ci-dispatcher` fans out in parallel to its seven child jobs
    (`non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`,
-   `test-sanitizers` — see [Jenkins jobs](#jenkins-jobs) below).
+   `test-sanitizers`, `build-container-pr` — see [Jenkins jobs](#jenkins-jobs) below).
 7. Each child job reports its own status back as an individual GitHub PR
    check, so the PR shows per-job pass/fail rather than one aggregate check.
 
 ## Jenkins jobs
 
-All 10 Jenkins jobs are defined in `.ci/jenkins/pipeline/proj-jjb.yaml`
+All 12 Jenkins jobs are defined in `.ci/jenkins/pipeline/proj-jjb.yaml`
 (Jenkins Job Builder config). The dispatcher runs its own pipeline,
 `.ci/jenkins/pipeline/Jenkinsfile.dispatcher`, checked out from the PR merge
 ref (`refs/pull/<n>/merge`) on webhook runs, or from any branch/commit passed
@@ -146,7 +146,7 @@ events — they only start via the Jenkins webhook fired by Blossom-CI, or via
 their own nightly/manual trigger. They split into two groups:
 
 - **Dispatcher-triggered (part of the PR CI path):** `nixl-ci-dispatcher` and
-  the 6 jobs it fans out to. This is the *only* way any Jenkins job runs
+  the 7 jobs it fans out to. This is the *only* way any Jenkins job runs
   against a PR, and only after a `/build` comment.
 - **Standalone (never run against a PR):** `nixl-ci-build-container`,
   `nixl-ci-build-wheel-nightly`, `nixl-ci-build-llm-container`,
@@ -155,15 +155,21 @@ their own nightly/manual trigger. They split into two groups:
 
 ### `nixl-ci-dispatcher` (dispatcher-triggered)
 - **Trigger:** GitHub webhook payload forwarded by Blossom-CI's `Job-trigger` step (`OPERATION: START-CI-JOB`). Not a raw GitHub Actions event.
-- **What it does:** Fans out in parallel to six downstream Jenkins jobs, waiting on all of them:
+- **What it does:** Fans out in parallel to seven downstream Jenkins jobs, waiting on all of them:
   - `nixl-ci-non-gpu` — `.ci/jenkins/lib/build-matrix.yaml`
   - `nixl-ci-gpu` — `.ci/jenkins/lib/test-matrix.yaml`
   - `nixl-ci-dl-gpu` — `.ci/jenkins/lib/test-dl-matrix.yaml` (dlcluster.nvidia.com)
   - `nixl-ci-dl-gpu-ep` — `.ci/jenkins/lib/test-dl-ep-matrix.yaml` (nixl_ep elastic tests on dlcluster.nvidia.com)
   - `nixl-ci-build-wheel` — `.ci/jenkins/lib/build-wheel-matrix.yaml`
   - `nixl-ci-test-sanitizers` — `.ci/jenkins/lib/test-sanitizer-matrix.yaml` (ASan/UBSan + TSan)
+  - `nixl-ci-build-container-pr` — `.ci/jenkins/lib/build-container-pr-matrix.yaml`
 - **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
-- **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all six) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
+- **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all seven) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
+
+### `nixl-ci-build-container-pr` (dispatcher-triggered)
+- **Trigger:** Fan-out from `nixl-ci-dispatcher` (same as the other PR CI jobs).
+- **What it does:** Build-only verification (no push) of the `nixl` (EP + debug) and `nixlbench` container images — one matrix cell per target/arch (x86_64 and aarch64), all in parallel. It runs the same `contrib/build-container.sh` / `benchmark/nixlbench/contrib/build.sh` the standalone `nixl-ci-build-container` job runs, so container/packaging breakage (e.g. a missing `--torch-versions`, or an EP nvlink register-count failure) is caught on the PR instead of only by the nightly job. Like the other leaf jobs it runs whenever the dispatcher fans out; drop it for a specific run via the dispatcher's `LEAF_JOBS` parameter.
+- **Automatic on every PR:** No — only after a `/build` comment (like the other dispatcher jobs).
 
 ### `nixl-ci-build-wheel` (dispatcher-triggered)
 - **Config:** `.ci/jenkins/lib/build-wheel-matrix.yaml`

--- a/.ci/jenkins/lib/build-container-pr-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-pr-matrix.yaml
@@ -1,0 +1,98 @@
+# NIXL PR container-build gate: build-only (no push) verification of the nixl (EP+debug)
+# and nixlbench images, so container/packaging breakage is caught on the PR, not just by
+# the nightly nixl-ci-build-container job. One matrix cell per target/arch so all images
+# build in parallel with independent status.
+
+---
+job: nixl-ci-build-container-pr
+
+failFast: false
+timeout_minutes: 180
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: "{memory: 24Gi, cpu: 12000m}"
+  requests: "{memory: 24Gi, cpu: 12000m}"
+
+runs_on_dockers:
+  - { name: "podman", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+
+matrix:
+  axes:
+    arch:
+      - x86_64
+      - aarch64
+    target:
+      - nixl
+      - nixlbench
+
+env:
+  NPROC: 24
+  UCX_VERSION: "v1.22.x"
+  BASE_IMAGE: "nvcr.io/nvidia/pytorch"
+  BASE_IMAGE_TAG: "26.06-py3"
+  LOCAL_TAG_BASE: "nixl-ci-pr:build-"
+
+taskName: "container-build/${target}/${arch}"
+
+# Read-only creds to pull the base images. Nothing is pushed.
+credentials:
+  - credentialsId: 'svc-nixl-new-artifactory-token'
+    usernameVariable: 'ARTIFACTORY_USERNAME'
+    passwordVariable: 'ARTIFACTORY_PASSWORD'
+  - credentialsId: 'nixl-gitlab-registry-token'
+    type: 'string'
+    variable: 'GITLAB_REGISTRY_TOKEN'
+
+steps:
+  - name: Setup docker
+    containerSelector: "{name: 'podman'}"
+    credentialsId:
+      - 'svc-nixl-new-artifactory-token'
+      - 'nixl-gitlab-registry-token'
+    run: |
+      set -e
+      # Prepare podman and log in so the base images can be pulled.
+      rm -f /etc/containers/storage.conf /usr/share/containers/storage.conf
+      podman system reset -f || true
+      ln -sfT "$(type -p podman)" /usr/bin/docker
+      echo "$ARTIFACTORY_PASSWORD" | docker login artifactory.nvidia.com -u "$ARTIFACTORY_USERNAME" --password-stdin
+      if [ -n "${GITLAB_REGISTRY_TOKEN:-}" ]; then
+        echo "$GITLAB_REGISTRY_TOKEN" | docker login gitlab-master.nvidia.com:5005 -u nixl-ci --password-stdin
+      fi
+
+  - name: Prepare environment
+    containerSelector: "{name: 'podman'}"
+    run: |
+      set -e
+      # nixlbench builds against a UCX source tree; nixl consumes UCX_VERSION directly.
+      if [ "$target" = "nixlbench" ]; then
+        rm -rf ucx-src
+        git clone https://github.com/openucx/ucx.git ucx-src
+        git -C ucx-src checkout "$UCX_VERSION"
+      fi
+
+  - name: Build image
+    containerSelector: "{name: 'podman'}"
+    run: |
+      set -e
+      case "$target" in
+        nixl)
+          # nixl container, debug build. build-container.sh enables EP by default.
+          # debug + EP exercises the EP device link and the torch-version wheel
+          # packaging - the parts most sensitive to build/packaging changes.
+          export UCX_REF="$UCX_VERSION"
+          contrib/build-container.sh \
+            --base-image "$BASE_IMAGE" --base-image-tag "$BASE_IMAGE_TAG" \
+            --tag "${LOCAL_TAG_BASE}${target}-${arch}" --arch "$arch" \
+            --build-type debug --no-cache
+          ;;
+        nixlbench)
+          benchmark/nixlbench/contrib/build.sh \
+            --base-image "$BASE_IMAGE" --base-image-tag "$BASE_IMAGE_TAG" \
+            --tag "${LOCAL_TAG_BASE}${target}-${arch}" --arch "$arch" \
+            --no-cache --nixl "$WORKSPACE" --ucx "$WORKSPACE/ucx-src"
+          ;;
+      esac
+      echo "Container build verification passed ($target) on ${arch}. No images pushed."

--- a/.ci/jenkins/lib/build-matrix.yaml
+++ b/.ci/jenkins/lib/build-matrix.yaml
@@ -45,7 +45,9 @@ env:
   TEST_TIMEOUT: 30
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260707-1"
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
+  CI_IMAGE_TAG: "CI_MANAGED"
 
 runs_on_dockers:
   - {

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -80,6 +80,16 @@ kubernetes:
 # build-container.sh runs podman/docker inside this container to build the wheel image
 runs_on_dockers:
   - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
+  # wheel_base: built and pushed by CI-demo when Dockerfile.manylinux changes.
+  # No step selects this container, so it is never used as a runner — only as a cached deps image.
+  # name/tag cannot use matrix axes (${manylinux}, ${arch}) — those resolve only inside steps.
+  # manylinux is hardcoded to 2_28 (the only matrix value); arch is handled by ci-demo per node.
+  - {
+      file: 'contrib/Dockerfile.manylinux',
+      name: "${WHEEL_BASE_IMAGE_NAME}",
+      tag: "${CI_IMAGE_TAG}",
+      build_args: '--build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_IMAGE_TAG=${BASE_TAG} --build-arg ARCH=${arch} --build-arg NPROC=${NPROC} --build-arg GRPC_NPROC=${GRPC_NPROC} --target wheel_base'
+    }
 
 # =============================================================================
 # Build Matrix Configuration
@@ -88,8 +98,6 @@ runs_on_dockers:
 # Each combination runs in parallel
 matrix:
   axes:
-    manylinux:
-      - "2_28"
     # Python versions supported by NIXL
     # Each version gets its own wheel with appropriate ABI tags
     python_version:
@@ -106,10 +114,14 @@ matrix:
 # =============================================================================
 # Global environment variables for the build process
 env:
-  NPROC: 16
+  NPROC: 32
   GRPC_NPROC: 10
   BASE_IMAGE: "${registry_host}/sw-nbu-swx-nixl-docker-local/base/cuda"
   BASE_TAG: '13.0-devel-manylinux--25.09'
+  CI_IMAGE_TAG: "20260709-1"
+  WHL_BASE: "manylinux_2_28"
+  TORCH_VERSIONS: "2.13"
+  WHEEL_BASE_IMAGE_NAME: "nixl-wheel-base-manylinux_2_28"
 
 steps:
   # =============================================================================
@@ -120,6 +132,7 @@ steps:
   - name: Prepare
     credentialsId: 'svc-nixl-new-artifactory-token'
     parallel: false
+    containerSelector: "{name: 'manylinux'}"
     run: |
       # Setup podman and dependencies
       rm -f /etc/containers/storage.conf /usr/share/containers/storage.conf
@@ -135,6 +148,7 @@ steps:
   # This step uses the build-wheel.sh script to package everything into wheels
   - name: Build Wheel
     parallel: false
+    containerSelector: "{name: 'manylinux'}"
     run: |
       set -x
       export NPROC=$NPROC
@@ -142,13 +156,15 @@ steps:
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
-        --wheel-base "manylinux_${manylinux}" \
+        --wheel-base "${WHL_BASE}" \
         --python-versions "${python_version}" \
         --arch ${arch} \
-        --dockerfile contrib/Dockerfile.manylinux
+        --torch-versions "${TORCH_VERSIONS}" \
+        --dockerfile contrib/Dockerfile.manylinux \
+        --wheel-base-image "${registry_host}${registry_path}/${arch}/${WHEEL_BASE_IMAGE_NAME}:${CI_IMAGE_TAG}"
 
 # =============================================================================
 # Task Naming Convention
 # =============================================================================
 # Unique identifier for each matrix combination
-taskName: '${name}_${manylinux}/${arch}/python_${python_version}'
+taskName: '${name}/${arch}/python_${python_version}'

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -118,7 +118,9 @@ env:
   GRPC_NPROC: 10
   BASE_IMAGE: "${registry_host}/sw-nbu-swx-nixl-docker-local/base/cuda"
   BASE_TAG: '13.0-devel-manylinux--25.09'
-  CI_IMAGE_TAG: "20260709-1"
+  # CI image tag for wheel_base + build_helper + the sanity base images
+  # (auto-derived by cidemo-init.sh — the "CI_MANAGED" placeholder must not be hand-edited)
+  CI_IMAGE_TAG: "CI_MANAGED"
   WHL_BASE: "manylinux_2_28"
   TORCH_VERSIONS: "2.13"
   WHEEL_BASE_IMAGE_NAME: "nixl-wheel-base-manylinux_2_28"

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -60,7 +60,9 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
+  CI_IMAGE_TAG: "CI_MANAGED"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -54,7 +54,9 @@ env:
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   TEST_TIMEOUT: 50
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
+  CI_IMAGE_TAG: "CI_MANAGED"
 
 empty_volumes:
   - {mountPath: /var/lib/containers/storage, memory: false}

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -52,7 +52,9 @@ env:
   SCCTL_CREDENTIALS_ID: 'svc-nixl-scctl'
   JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
   STORAGE_DRIVER: overlay
-  CI_IMAGE_TAG: "20260707-1"
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
+  CI_IMAGE_TAG: "CI_MANAGED"
   ENROOT_MOUNT_PATH: "/enroot_images"  # NFS mount on mizu nodes; on failure the container is exported here as <containerName>.sqsh
   ENROOT_DATA_PATH: "/enroot-data/enroot-data-148069/user-148069"  # svc-nixl user on mizu nodes
 

--- a/.ci/jenkins/lib/test-sanitizer-matrix.yaml
+++ b/.ci/jenkins/lib/test-sanitizer-matrix.yaml
@@ -15,8 +15,8 @@
 #    prebuilt, non-instrumented abseil, TSan misses the lock and every
 #    nixlLock-protected access shows up as a false race.
 #
-# Note: changes to .ci/dockerfiles/Dockerfile.base, .gitlab/build.sh or
-# .ci/scripts/common.sh require bumping CI_IMAGE_TAG here too (see cidemo-init.sh).
+# Note: CI_IMAGE_TAG is auto-derived by cidemo-init.sh from the CI source files
+# and patched in at CI time — the "CI_MANAGED" placeholder must not be hand-edited.
 
 ---
 job: nixl-ci-test-sanitizers
@@ -42,7 +42,7 @@ env:
   TEST_TIMEOUT: 40
   UCX_TLS: "^shm"
   STORAGE_DRIVER: 'overlay'
-  CI_IMAGE_TAG: "20260707-1"
+  CI_IMAGE_TAG: "CI_MANAGED"
 
 runs_on_dockers:
   # TSan-instrumented dependency image for the tsan build (DEPS_SANITIZE=thread

--- a/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
@@ -87,12 +87,13 @@ currentBuild.description = githubHelper.getBuildDescription()
 
 // Leaf jobs to dispatch, keyed by parallel-branch name
 def leafJobs = [
-    'non-gpu':    'nixl-ci-non-gpu',
-    'gpu':        'nixl-ci-gpu',
-    'dl-gpu':     'nixl-ci-dl-gpu',
-    'dl-gpu-ep':  'nixl-ci-dl-gpu-ep',
-    'wheel':      'nixl-ci-build-wheel',
-    'sanitizers': 'nixl-ci-test-sanitizers',
+    'non-gpu':         'nixl-ci-non-gpu',
+    'gpu':             'nixl-ci-gpu',
+    'dl-gpu':          'nixl-ci-dl-gpu',
+    'dl-gpu-ep':       'nixl-ci-dl-gpu-ep',
+    'wheel':           'nixl-ci-build-wheel',
+    'sanitizers':      'nixl-ci-test-sanitizers',
+    'build-container': 'nixl-ci-build-container-pr',
 ]
 
 try {

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -59,7 +59,7 @@
             description: "Ref to check out the dispatcher pipeline from. Set to refs/pull/<n>/merge by the webhook; manual runs may pass a branch name, commit SHA, or any ref"
         - string:
             name: "LEAF_JOBS"
-            default: "non-gpu,gpu,dl-gpu,dl-gpu-ep,wheel,sanitizers"
+            default: "non-gpu,gpu,dl-gpu,dl-gpu-ep,wheel,sanitizers,build-container"
             description: "Comma-separated list of leaf jobs to dispatch. Edit the default here (via job config) to temporarily disable a leaf job for all runs without a code change; JJB redeploy restores the full list"
     # SCM configuration - checks out whatever ref sha1 holds: the PR merge ref
     # (set by the webhook) so a PR into a release branch runs that branch's
@@ -137,6 +137,65 @@
                 browser: githubweb
                 browser-url: "{jjb_git}"
                 # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
+
+# Template for the PR container-build gate.
+# Build-only verification (no push) of the nixl (EP+debug) and nixlbench container
+# images on every PR, so container/packaging breakage is caught before merge instead
+# of only by the nightly nixl-ci-build-container job (see build-container-pr-matrix.yaml).
+- job-template:
+    name: "{jjb_proj}-build-container-pr"      # Will be expanded to 'nixl-ci-build-container-pr'
+    project-type: pipeline
+    disabled: false
+    properties:
+        - github:
+            url: "{jjb_gh_url}"
+        - build-discarder:
+            days-to-keep: 14
+            num-to-keep: 1000
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}-build-container-pr
+    description: Do NOT edit this job through the Web GUI !
+    concurrent: true
+    sandbox: true
+    parameters:
+        - string:
+            name: "sha1"
+            default: "{jjb_branch}"    # Default to 'main' branch
+            description: "Commit to be checked, usually set by PR"
+        - string:
+            name: "githubData"
+            default: ""
+            description: "Variables from post"
+        - string:
+            name: "conf_file"
+            default: ".ci/jenkins/lib/build-container-pr-matrix.yaml"  # PR container-build matrix
+            description: "Job config file"
+        - bool:
+            name: "build_dockers"
+            default: false
+            description: "Force rebuild docker containers"
+        - string:
+            name: "DEBUG"
+            default: 0
+            description: "Enable debug prints and traces, valid values are 0-9"
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
                 submodule:
                     disable: false
                     recursive: true
@@ -896,6 +955,7 @@
     jobs:
         - "{jjb_proj}-dispatcher"  # Create dispatcher job
         - "{jjb_proj}-non-gpu"       # Create non-gpu job
+        - "{jjb_proj}-build-container-pr"  # Create PR container-build gate job
         - "{jjb_proj}-test-sanitizers"  # Create sanitizer test job
         - "{jjb_proj}-build-container"  # Create container builder job
         - "{jjb_proj}-build-llm-container"  # Create LLM (vllm/sglang) container builder job

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ subprojects/*
 # Local Python environments
 .venv/
 .venv*/
+
+# Infinia DDN libs staged into the build context by build-container.sh --build-infinia
+/infinia-libs/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ subprojects/*
 
 # Infinia DDN libs staged into the build context by build-container.sh --build-infinia
 /infinia-libs/
+
+# ucx-spcx-plugin source fetched into the build context by build-container.sh
+ucx-spcx-plugin-src/

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -16,7 +16,11 @@
 
 ARG BASE_IMAGE
 ARG BASE_IMAGE_TAG
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
+# When overridden to an Artifactory URL, the wheel stage pulls the pre-built deps
+# image instead of building them locally. Default keeps the single-stage local build.
+ARG wheel_base=wheel_base
+
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS wheel_base
 
 ARG DEFAULT_PYTHON_VERSION="3.14"
 ARG ARCH="x86_64"
@@ -347,6 +351,13 @@ RUN cd /usr/local/src && \
      make -j &&                      \
      make -j install-strip &&        \
      ldconfig
+
+FROM $wheel_base AS wheel
+
+ARG ARCH="x86_64"
+ARG BUILD_TYPE="release"
+ARG BUILD_NIXL_EP="true"
+ARG UCX_SONAME_SUFFIX=""
 
 COPY . /workspace/nixl
 WORKDIR /workspace/nixl

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -362,6 +362,27 @@ ARG UCX_SONAME_SUFFIX=""
 COPY . /workspace/nixl
 WORKDIR /workspace/nixl
 
+# Opt-in: place the pre-staged DDN Infinia libs (from infinia-libs/ in the build
+# context, populated by build-container.sh --build-infinia) into /opt/ddn/red so
+# meson auto-detects red_client and builds libplugin_INFINIA.so into the wheel.
+# libred_client/libred_async are excluded from the final wheel by auditwheel
+# (build-wheel.sh AUDITWHEEL_EXCLUDES) — only libplugin_INFINIA.so is bundled;
+# the DDN libs are loaded at runtime from the customer's installation.
+# No external registry pull here: libs arrive via COPY . /workspace/nixl above.
+# libuuid-devel provides uuid/uuid.h, included by the DDN red_client headers;
+# it is the only extra build-time system dep the plugin needs (the DDN libs'
+# own runtime deps are provided by the customer's install and excluded by auditwheel).
+ARG BUILD_INFINIA=false
+RUN if [ "$BUILD_INFINIA" = "true" ]; then \
+        if [ -z "$(ls -A /workspace/nixl/infinia-libs 2>/dev/null)" ]; then \
+            echo "ERROR: BUILD_INFINIA=true but /workspace/nixl/infinia-libs is empty (staging failed?)" >&2; \
+            exit 1; \
+        fi; \
+        dnf install -y libuuid-devel && \
+        mkdir -p /opt/ddn/red && \
+        cp -a /workspace/nixl/infinia-libs/. /opt/ddn/red/; \
+    fi
+
 RUN rm -rf build && \
     mkdir build && \
     if [ "$BUILD_NIXL_EP" = "true" ]; then \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -358,6 +358,7 @@ ARG ARCH="x86_64"
 ARG BUILD_TYPE="release"
 ARG BUILD_NIXL_EP="true"
 ARG UCX_SONAME_SUFFIX=""
+ARG NPROC=1
 
 COPY . /workspace/nixl
 WORKDIR /workspace/nixl
@@ -381,6 +382,36 @@ RUN if [ "$BUILD_INFINIA" = "true" ]; then \
         dnf install -y libuuid-devel && \
         mkdir -p /opt/ddn/red && \
         cp -a /workspace/nixl/infinia-libs/. /opt/ddn/red/; \
+    fi
+
+# Opt-in: build the internal ucx-spcx-plugin against the just-built UCX and
+# install it into the UCX plugins dir, where the wheel bundling
+# (wheel_add_ucx_plugins.py) picks it up like any other UCX module. The
+# plugin source is cloned into the build context (ucx-spcx-plugin-src/) by
+# build-container.sh --build-ucx-spcx-plugin.
+# FlexIO SDK + dpacc (build-time dependencies of the plugin's DPA transport) come from
+# the doca-host repo installed above; libflexio is compile-against only —
+# it is not bundled into the wheel, at runtime it comes from the target
+# machine's DOCA/FlexIO installation (like libmlx5 from rdma-core).
+ARG BUILD_UCX_SPCX_PLUGIN=false
+RUN if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then \
+        rpm -ivh --nodeps /usr/share/doca-host-3.3.0/repo/Packages/flexio-sdk-*rpm && \
+        rpm -ivh --nodeps /usr/share/doca-host-3.3.0/repo/Packages/dpacc-[0-9]*rpm && \
+        ldconfig && \
+        cd ucx-spcx-plugin-src && \
+        export ACLOCAL_PATH="/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}" && \
+        ./autogen.sh /usr/local/src/ucx && \
+        ./configure --prefix=/usr --libdir=/usr/lib64 \
+            --enable-shared --disable-static \
+            --with-ucx-src=/usr/local/src/ucx \
+            --with-ucx-build=/usr/local/src/ucx \
+            --with-cuda=/usr/local/cuda \
+            --with-flexio=/opt/mellanox/flexio \
+            --with-dpacc=/opt/mellanox/doca/tools/dpacc \
+            LDFLAGS="-L/usr/lib64/ucx -L/usr/lib64" && \
+        make -j"${NPROC}" && \
+        make install && \
+        cd /workspace/nixl && rm -rf ucx-spcx-plugin-src; \
     fi
 
 RUN rm -rf build && \

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -119,6 +119,14 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --torch-versions)
+            if [ "$2" ]; then
+                WHL_TORCH_VERSIONS=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --ucx-repo)
             if [ "$2" ]; then
                 UCX_REPO=$2
@@ -152,6 +160,14 @@ get_options() {
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+        --wheel-base-image)
+            if [ "$2" ]; then
+                WHEEL_BASE_IMAGE=$2
                 shift
             else
                 missing_requirement $1
@@ -230,6 +246,8 @@ show_help() {
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
+    echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
+    echo "  [--wheel-base-image pre-built wheel base image URL; skips wheel_base stage and builds only the wheel stage]"
     exit 0
 }
 
@@ -251,6 +269,7 @@ fi
 
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
+BUILD_ARGS+="${WHL_TORCH_VERSIONS:+ --build-arg WHL_TORCH_VERSIONS=$WHL_TORCH_VERSIONS}"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"
 BUILD_ARGS+=" --build-arg UCX_REPO=$UCX_REPO"
@@ -262,6 +281,11 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 
+if [ -n "$WHEEL_BASE_IMAGE" ]; then
+    BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"
+    BUILD_TARGET="--target wheel"
+fi
+
 show_build_options
 
-docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE $BUILD_CONTEXT
+docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${BUILD_TARGET:-} $BUILD_CONTEXT

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -44,6 +44,8 @@ OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
+BUILD_INFINIA="false"
+INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
 
 get_options() {
     while :; do
@@ -173,6 +175,17 @@ get_options() {
                 missing_requirement $1
             fi
             ;;
+        --build-infinia)
+            BUILD_INFINIA="true"
+            ;;
+        --infinia-image)
+            if [ "$2" ]; then
+                INFINIA_LIBS_IMAGE=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --)
             shift
             break
@@ -226,6 +239,11 @@ show_build_options() {
     else
         echo "NIXL EP: Disabled"
     fi
+    if [ "$BUILD_INFINIA" = "true" ]; then
+        echo "Infinia DDN plugin: Enabled (image: ${INFINIA_LIBS_IMAGE})"
+    else
+        echo "Infinia DDN plugin: Disabled"
+    fi
     echo "Build Type: ${BUILD_TYPE}"
 }
 
@@ -248,6 +266,8 @@ show_help() {
     echo "  [--dockerfile path to a dockerfile to use]"
     echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
     echo "  [--wheel-base-image pre-built wheel base image URL; skips wheel_base stage and builds only the wheel stage]"
+    echo "  [--build-infinia build and bundle the Infinia DDN plugin (requires --dockerfile contrib/Dockerfile.manylinux; harbor.mellanox.com must be reachable)]"
+    echo "  [--infinia-image full image reference for infinia-libs (default: ${INFINIA_LIBS_IMAGE})]"
     exit 0
 }
 
@@ -280,10 +300,40 @@ BUILD_ARGS+=" --build-arg NPROC=$NPROC"
 BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
+BUILD_ARGS+=" --build-arg BUILD_INFINIA=$BUILD_INFINIA"
 
 if [ -n "$WHEEL_BASE_IMAGE" ]; then
     BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"
     BUILD_TARGET="--target wheel"
+fi
+
+# Infinia DDN libs: pre-pulled from harbor on the host and placed flat into
+# infinia-libs/ in the build context. The Dockerfile's BUILD_INFINIA RUN block
+# copies them to /opt/ddn/red/ — no harbor reference in the Dockerfile. The whole
+# block is guarded so external docker build runs are unaffected when
+# BUILD_INFINIA=false (default): no filesystem writes and no EXIT trap installed.
+if [ "$BUILD_INFINIA" = "true" ]; then
+    case "$DOCKER_FILE" in
+        *Dockerfile.manylinux) ;;
+        *) error "ERROR:" "--build-infinia requires --dockerfile contrib/Dockerfile.manylinux" ;;
+    esac
+    INFINIA_LIBS_DIR="$BUILD_CONTEXT/infinia-libs"
+    rm -rf "$INFINIA_LIBS_DIR"
+    mkdir -p "$INFINIA_LIBS_DIR"
+    trap 'rm -rf "$INFINIA_LIBS_DIR"' EXIT
+    (
+        set -e
+        echo "Pulling Infinia libs image: ${INFINIA_LIBS_IMAGE}"
+        docker pull "$INFINIA_LIBS_IMAGE"
+        cid=$(docker create "$INFINIA_LIBS_IMAGE")
+        trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+        docker cp "$cid:/infinia/$ARCH/." "$INFINIA_LIBS_DIR/"
+        echo "Infinia libs staged from ${INFINIA_LIBS_IMAGE} (arch: ${ARCH})"
+    ) || error "ERROR:" "failed to stage Infinia libs from ${INFINIA_LIBS_IMAGE}"
+    # Fail fast on an empty extraction (wrong $ARCH, misconfigured image): otherwise
+    # the wheel would silently build without libplugin_INFINIA.so.
+    [ -n "$(ls -A "$INFINIA_LIBS_DIR")" ] || \
+        error "ERROR:" "no Infinia libs found for arch $ARCH in ${INFINIA_LIBS_IMAGE}"
 fi
 
 show_build_options

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -46,6 +46,8 @@ GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
 BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
+BUILD_UCX_SPCX_PLUGIN="false"
+UCX_SPCX_PLUGIN_REF="main"
 
 get_options() {
     while :; do
@@ -159,6 +161,17 @@ get_options() {
         --build-nixl-ep)
             BUILD_NIXL_EP=true
             ;;
+        --build-ucx-spcx-plugin)
+            BUILD_UCX_SPCX_PLUGIN="true"
+            ;;
+        --ucx-spcx-plugin-ref)
+            if [ "$2" ]; then
+                UCX_SPCX_PLUGIN_REF=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
         --arch)
             if [ "$2" ]; then
                 ARCH=$2
@@ -244,6 +257,11 @@ show_build_options() {
     else
         echo "Infinia DDN plugin: Disabled"
     fi
+    if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then
+        echo "UCX spcx plugin: Enabled (ref: ${UCX_SPCX_PLUGIN_REF})"
+    else
+        echo "UCX spcx plugin: Disabled"
+    fi
     echo "Build Type: ${BUILD_TYPE}"
 }
 
@@ -262,6 +280,8 @@ show_help() {
     echo "  [--ucx-soname-suffix suffix to pass to UCX --with-soname-suffix]"
     echo "  [--private-ucx shortcut for --ucx-soname-suffix ${PRIVATE_UCX_SONAME_SUFFIX}; requires a UCX ref with --with-soname-suffix and --enable-module-deepbind]"
     echo "  [--build-nixl-ep build NIXL with NIXL EP support (requires UCX >= 1.21)]"
+    echo "  [--build-ucx-spcx-plugin build and bundle the UCX spcx external plugin (requires NIXL_GITLAB_TOKEN and NIXL_SPCX_PLUGIN_REPO_URL in the environment) (requires --dockerfile contrib/Dockerfile.manylinux)]"
+    echo "  [--ucx-spcx-plugin-ref git ref of ucx-spcx-plugin to build (default: ${UCX_SPCX_PLUGIN_REF})]"
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
@@ -301,6 +321,43 @@ BUILD_ARGS+=" --build-arg GRPC_NPROC=$GRPC_NPROC"
 BUILD_ARGS+=" --build-arg OS=$OS"
 BUILD_ARGS+=" --build-arg BUILD_TYPE=$BUILD_TYPE"
 BUILD_ARGS+=" --build-arg BUILD_INFINIA=$BUILD_INFINIA"
+BUILD_ARGS+=" --build-arg BUILD_UCX_SPCX_PLUGIN=$BUILD_UCX_SPCX_PLUGIN"
+
+# The plugin source is fetched on the host and placed inside the build
+# context (ucx-spcx-plugin-src/), where the Dockerfile's plugin RUN builds
+# it from the copied context. This keeps credentials and BuildKit-specific
+# syntax out of the Dockerfile entirely, so the default build works with
+# any docker builder. The token stays out of URLs and argv (git credential
+# helper reading the environment) so git errors cannot leak it.
+SPCX_SRC_DIR="$BUILD_CONTEXT/ucx-spcx-plugin-src"
+rm -rf "$SPCX_SRC_DIR"
+if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then
+    case "$DOCKER_FILE" in
+        *Dockerfile.manylinux) ;;
+        *) error "ERROR:" "--build-ucx-spcx-plugin requires --dockerfile contrib/Dockerfile.manylinux (the default Dockerfile does not consume it)" ;;
+    esac
+    if [ -z "${NIXL_GITLAB_TOKEN:-}" ]; then
+        error "ERROR:" "--build-ucx-spcx-plugin requires the NIXL_GITLAB_TOKEN environment variable"
+    fi
+    if [ -z "${NIXL_SPCX_PLUGIN_REPO_URL:-}" ]; then
+        error "ERROR:" "--build-ucx-spcx-plugin requires the NIXL_SPCX_PLUGIN_REPO_URL environment variable"
+    fi
+    trap 'rm -rf "$SPCX_SRC_DIR"' EXIT
+    mkdir -p "$SPCX_SRC_DIR"
+    (
+        set -e
+        cd "$SPCX_SRC_DIR"
+        git init -q
+        git remote add origin "$NIXL_SPCX_PLUGIN_REPO_URL"
+        # shellcheck disable=SC2016
+        GIT_TERMINAL_PROMPT=0 git -c credential.helper= \
+            -c credential.helper='!f() { echo "username=oauth2"; echo "password=${NIXL_GITLAB_TOKEN}"; }; f' \
+            fetch -q --depth 1 origin "$UCX_SPCX_PLUGIN_REF"
+        git checkout -q FETCH_HEAD
+        echo "ucx-spcx-plugin ref ${UCX_SPCX_PLUGIN_REF} -> commit $(git rev-parse HEAD)"
+        rm -rf .git
+    ) || error "ERROR:" "failed to fetch ucx-spcx-plugin at ref ${UCX_SPCX_PLUGIN_REF}"
+fi
 
 if [ -n "$WHEEL_BASE_IMAGE" ]; then
     BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -361,7 +361,9 @@ fi
 
 if [ -n "$WHEEL_BASE_IMAGE" ]; then
     BUILD_ARGS+=" --build-arg wheel_base=$WHEEL_BASE_IMAGE"
-    BUILD_TARGET="--target wheel"
+    # Not named BUILD_TARGET: Jenkins exports a BUILD_TARGET job parameter
+    # (nixl/nixlbench) that would leak into the docker command line.
+    DOCKER_BUILD_TARGET="--target wheel"
 fi
 
 # Infinia DDN libs: pre-pulled from harbor on the host and placed flat into
@@ -395,4 +397,4 @@ fi
 
 show_build_options
 
-docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${BUILD_TARGET:-} $BUILD_CONTEXT
+docker build --platform linux/$ARCH -f $DOCKER_FILE $BUILD_ARGS $TAG $NO_CACHE ${DOCKER_BUILD_TARGET:-} $BUILD_CONTEXT


### PR DESCRIPTION
## What

Backports the wheel-build and CI infrastructure from `main` to `release/1.4.0` — six commits, cherry-picked in main's chronological order:

1. **#1870** — split `Dockerfile.manylinux` into `wheel_base`/`wheel` stages so CI caches the expensive deps image; adds `--wheel-base-image` to `build-container.sh`
2. **#1933** — auto-derive `CI_IMAGE_TAG` in `cidemo-init.sh` (matrix YAMLs carry a `CI_MANAGED` placeholder patched at CI time; no manual tag bumps)
3. **#1941** — `--build-infinia`: bundle the Infinia DDN plugin (`libplugin_INFINIA.so`) into the wheel (opt-in)
4. **#1918** — `--build-ucx-spcx-plugin`: build and bundle the UCX spcx external plugin (`libuct_ib_mlx5_ext.so`) into the wheel (opt-in)
5. **#1956** — rename `BUILD_TARGET` → `DOCKER_BUILD_TARGET` in `build-container.sh` (Jenkins exports a `BUILD_TARGET` job param that leaked into the docker command line)
6. **#1863** — add the per-PR container-build pipeline (`nixl-ci-build-container-pr`) and dispatcher fan-out

After this PR, `Jenkinsfile.dispatcher`, `cidemo-init.sh`, `build-container.sh`, `Dockerfile.manylinux`, and `build-container-pr-matrix.yaml` are byte-identical to `main`.

Conflict resolutions (all mechanical):
- Matrix YAMLs: release-branch hardcoded `CI_IMAGE_TAG` values replaced by the `CI_MANAGED` placeholder (#1933)
- `ci-overview.md`: kept release-accurate wording where main's text references features not backported (vLLM/SGLang sanity #1777, cleanup job #1785)

Intentionally **not** backported (not needed for release CI): vLLM/SGLang sanity testing (#1777), Artifactory cleanup job (#1785, #1964), CI timeout right-sizing (#1932), LLM base image pins (#1893), port pool cap (#1685).

## Why

Needed for the 1.4.0 release: internal wheels must bundle the UCX spcx and Infinia plugins, and the release-branch CI needs the same wheel-build pipeline as `main` to build them.

Both plugin features are opt-in (off by default); default builds are byte-identical to the current release branch.