### PR TITLE
nixlbench: fix pipelined transfer for non-divisible batch sizes

### DIFF
--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1559,7 +1559,12 @@ execTransferLoop(nixlAgent *agent,
         depth = std::min(depth, static_cast<int>(local_iov.size()));
     }
     depth = std::max(depth, 1);
-    if (depth < xferBenchConfig::pipeline_depth) {
+    // Report the cap once, from the master thread only: this runs inside an
+    // omp parallel region, so an unguarded print is emitted per thread and the
+    // N copies interleave into garbled output. Skip single-iteration passes
+    // (setup/warmup), where capping to 1 is trivially expected and not useful.
+    if (depth < xferBenchConfig::pipeline_depth && num_iter > 1 &&
+        omp_get_thread_num() == 0) {
         std::cout << "Warning: capping pipeline_depth from " << xferBenchConfig::pipeline_depth
                   << " to " << depth << " (num_iter=" << num_iter
                   << ", descriptors=" << local_iov.size() << ")" << std::endl;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1547,26 +1547,35 @@ execTransferLoop(nixlAgent *agent,
                  const std::vector<xferBenchIOV> &local_iov,
                  const std::vector<xferBenchIOV> &remote_iov,
                  const std::atomic<int> *terminate_ptr = nullptr) {
-    const int depth = std::min(xferBenchConfig::pipeline_depth, num_iter);
+    // Cap the in-flight window to what this run can actually support: never
+    // more requests in flight than there are iterations, and never more slots
+    // than there are descriptors to fill them (empty slots have nothing to
+    // transfer). The descriptor count need not be a multiple of the depth --
+    // any remainder is spread one entry per slot across the leading slots, so
+    // the pipeline works for every (batch_size, pipeline_depth, num_iter)
+    // combination instead of failing on the non-divisible ones.
+    int depth = std::min(xferBenchConfig::pipeline_depth, num_iter);
+    if (!local_iov.empty()) {
+        depth = std::min(depth, static_cast<int>(local_iov.size()));
+    }
+    depth = std::max(depth, 1);
     if (depth < xferBenchConfig::pipeline_depth) {
-        std::cout << "Warning: pipeline_depth (" << xferBenchConfig::pipeline_depth
-                  << ") exceeds num_iter (" << num_iter << "), capping to " << depth << std::endl;
+        std::cout << "Warning: capping pipeline_depth from " << xferBenchConfig::pipeline_depth
+                  << " to " << depth << " (num_iter=" << num_iter
+                  << ", descriptors=" << local_iov.size() << ")" << std::endl;
     }
     const bool recreate = xferBenchConfig::recreate_xfer;
 
-    if (local_iov.size() % depth != 0) {
-        std::cerr << "Error: descriptor count (" << local_iov.size()
-                  << ") is not evenly divisible by pipeline depth (" << depth << ")" << std::endl;
-        return -1;
-    }
-    const size_t entries_per_slot = local_iov.size() / depth;
+    const size_t base_entries = local_iov.size() / depth;
+    const size_t extra_entries = local_iov.size() % depth;
 
     std::vector<slotState> slots(depth);
+    size_t off = 0;
     for (int s = 0; s < depth; s++) {
-        auto lb = local_iov.begin() + s * entries_per_slot;
-        auto rb = remote_iov.begin() + s * entries_per_slot;
-        slots[s].local_iov.assign(lb, lb + entries_per_slot);
-        slots[s].remote_iov.assign(rb, rb + entries_per_slot);
+        const size_t cnt = base_entries + (static_cast<size_t>(s) < extra_entries ? 1 : 0);
+        slots[s].local_iov.assign(local_iov.begin() + off, local_iov.begin() + off + cnt);
+        slots[s].remote_iov.assign(remote_iov.begin() + off, remote_iov.begin() + off + cnt);
+        off += cnt;
     }
 
     int issued = 0;


### PR DESCRIPTION
## Problem

`nixlbench` aborts mid-run with

```
Error: descriptor count (128) is not evenly divisible by pipeline depth (13)
```

for entirely default-ish parameters. It reproduces with a plain multi-threaded run, e.g.:

```
nixlbench --backend <backend> --num_threads 8 \
          --start_batch_size 8 --max_batch_size 128 \
          --num_iter 256 --pipeline_depth 16
```

The failure happens during **warmup**, before any timing, so no results are ever produced.

## Root cause

`execTransferLoop()` uses `depth = min(pipeline_depth, num_iter)` for two coupled purposes: the number of in-flight requests *and* the number of equal-sized slots it splits the descriptor list into. It then requires the descriptor count to be an exact multiple of `depth`, and errors out otherwise.

That divisibility rarely holds under normal use:

- `warmup_iter` is rounded up to a multiple of `num_threads` (100 → 104 for 8 threads), so the per-thread warmup count is `104 / 8 = 13`. That caps `depth` to 13, and the descriptor count (`num_target_dev × max_batch_size`, here 128) is not a multiple of 13.
- Separately, a `pipeline_depth` larger than the descriptor count produces empty slots.

## Fix

Two commits:

1. **Fix the pipelined transfer for non-divisible batch sizes.**
   - Cap `depth` by the descriptor count in addition to `num_iter`, so a slot is never empty.
   - Distribute any remainder one entry per slot across the leading slots instead of requiring even division.

   The pipeline now runs for every `(batch_size, pipeline_depth, num_iter)` combination. Depth `1` still collapses to the original single-request baseline. No public API or CLI change.

2. **Quiet the `pipeline_depth` cap warning.** The warning is emitted from inside an `omp parallel` region, so every thread printed its own copy and the N lines interleaved into garbled output; it also fired for the single-iteration setup/warmup passes where capping to 1 is trivially expected. It now reports once, from the master thread only, and only for multi-iteration runs.
