### PR TITLE
UCX: Bound in-flight transfer work on AMD GPUs

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -156,8 +156,7 @@ public:
                 /* If last request is incomplete, return NIXL_IN_PROG early
                  * without checking other requests. */
                 nixlUcxReq req = requests_.back();
-                const nixl_status_t ret =
-                    nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
+                const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
                 if (ret == NIXL_IN_PROG) {
                     return NIXL_IN_PROG;
                 } else if (ret != NIXL_SUCCESS) {
@@ -169,8 +168,8 @@ public:
                 size_t incomplete_reqs = 0;
                 nixl_status_t out_ret = NIXL_SUCCESS;
                 for (nixlUcxReq req : requests_) {
-                    const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(
-                        ucp_request_check_status(req));
+                    const nixl_status_t ret =
+                        nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
                     if (ret == NIXL_SUCCESS) [[likely]] {
                         worker_->reqRelease(req);
                     } else if (ret == NIXL_IN_PROG) {
@@ -196,7 +195,7 @@ public:
             }
 
             auto continuation = std::move(continueXfer_);
-            continueXfer_     = nullptr;
+            continueXfer_ = nullptr;
             const nixl_status_t ret = continuation();
             if (ret != NIXL_SUCCESS) {
                 return ret;
@@ -806,9 +805,8 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
         num_workers = num_dedicated_workers + 1;
     }
     numSharedWorkers_ = num_workers - num_dedicated_workers;
-    maxInflightRequests_ = std::max(
-        1u,
-        nixl::getBackendParamDefaulted(custom_params, "max_inflight_requests", 64u));
+    maxInflightRequests_ =
+        std::max(1u, nixl::getBackendParamDefaulted(custom_params, "max_inflight_requests", 64u));
 
     const size_t num_device_channels =
         nixl::getBackendParamDefaulted(custom_params, "ucx_num_device_channels", 4u);

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -24,6 +24,7 @@
 #include <optional>
 #include <limits>
 #include <future>
+#include <functional>
 #include <set>
 #include <string.h>
 #include <unistd.h>
@@ -51,6 +52,7 @@ private:
     std::vector<nixlUcxReq> requests_;
     nixlUcxWorker *worker_;
     size_t workerId_;
+    std::function<nixl_status_t()> continueXfer_;
 
     [[nodiscard]] nixl_status_t
     checkConnection(const nixl_status_t status = NIXL_SUCCESS) const {
@@ -95,6 +97,11 @@ public:
         NIXL_ASSERT(connections_.empty());
     }
 
+    void
+    setContinuation(std::function<nixl_status_t()> continuation) {
+        continueXfer_ = std::move(continuation);
+    }
+
     [[nodiscard]] nixl_status_t
     append(nixl_status_t status, nixlUcxReq req, const ucx_connection_ptr_t &conn) {
         switch (status) {
@@ -125,6 +132,7 @@ public:
 
     virtual void
     release() {
+        continueXfer_ = nullptr;
         // TODO: Error log: uncompleted requests found! Cancelling ...
         for (nixlUcxReq req : requests_) {
             const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
@@ -141,48 +149,59 @@ public:
 
     [[nodiscard]] virtual nixl_status_t
     status() {
-        if (requests_.empty()) {
-            /* No pending transmissions */
-            connections_.clear();
-            return NIXL_SUCCESS;
-        }
+        while (true) {
+            if (!requests_.empty()) {
+                worker_->progressLoop();
 
-        worker_->progressLoop();
-
-        /* If last request is incomplete, return NIXL_IN_PROG early without
-         * checking other requests */
-        nixlUcxReq req = requests_.back();
-        const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
-        if (ret == NIXL_IN_PROG) {
-            return NIXL_IN_PROG;
-        } else if (ret != NIXL_SUCCESS) {
-            return checkConnection(ret);
-        }
-
-        /* Last request completed successfully, all the others must be in the
-         * same state. TODO: remove extra checks? */
-        size_t incomplete_reqs = 0;
-        nixl_status_t out_ret = NIXL_SUCCESS;
-        for (nixlUcxReq req : requests_) {
-            const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
-            if (ret == NIXL_SUCCESS) [[likely]] {
-                worker_->reqRelease(req);
-            } else if (ret == NIXL_IN_PROG) {
-                if (out_ret == NIXL_SUCCESS) {
-                    out_ret = NIXL_IN_PROG;
+                /* If last request is incomplete, return NIXL_IN_PROG early
+                 * without checking other requests. */
+                nixlUcxReq req = requests_.back();
+                const nixl_status_t ret =
+                    nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
+                if (ret == NIXL_IN_PROG) {
+                    return NIXL_IN_PROG;
+                } else if (ret != NIXL_SUCCESS) {
+                    return checkConnection(ret);
                 }
-                requests_[incomplete_reqs++] = req;
-            } else {
-                // Any other ret value is ERR and will be returned
-                out_ret = checkConnection(ret);
+
+                /* Last request completed successfully, all the others must be
+                 * in the same state. TODO: remove extra checks? */
+                size_t incomplete_reqs = 0;
+                nixl_status_t out_ret = NIXL_SUCCESS;
+                for (nixlUcxReq req : requests_) {
+                    const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(
+                        ucp_request_check_status(req));
+                    if (ret == NIXL_SUCCESS) [[likely]] {
+                        worker_->reqRelease(req);
+                    } else if (ret == NIXL_IN_PROG) {
+                        if (out_ret == NIXL_SUCCESS) {
+                            out_ret = NIXL_IN_PROG;
+                        }
+                        requests_[incomplete_reqs++] = req;
+                    } else {
+                        // Any other ret value is ERR and will be returned
+                        out_ret = checkConnection(ret);
+                    }
+                }
+
+                requests_.resize(incomplete_reqs);
+                if (!requests_.empty() || (out_ret != NIXL_SUCCESS)) {
+                    return out_ret;
+                }
+            }
+
+            connections_.clear();
+            if (!continueXfer_) {
+                return NIXL_SUCCESS;
+            }
+
+            auto continuation = std::move(continueXfer_);
+            continueXfer_     = nullptr;
+            const nixl_status_t ret = continuation();
+            if (ret != NIXL_SUCCESS) {
+                return ret;
             }
         }
-
-        requests_.resize(incomplete_reqs);
-        if (requests_.empty()) {
-            connections_.clear();
-        }
-        return out_ret;
     }
 
     [[nodiscard]] nixlUcxWorker *
@@ -787,6 +806,9 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
         num_workers = num_dedicated_workers + 1;
     }
     numSharedWorkers_ = num_workers - num_dedicated_workers;
+    maxInflightRequests_ = std::max(
+        1u,
+        nixl::getBackendParamDefaulted(custom_params, "max_inflight_requests", 64u));
 
     const size_t num_device_channels =
         nixl::getBackendParamDefaulted(custom_params, "ucx_num_device_channels", 4u);
@@ -1184,6 +1206,29 @@ nixlUcxEngine::sendXferRange(const nixl_xfer_op_t &operation,
                              nixlBackendReqH *handle,
                              size_t start_idx,
                              size_t end_idx) const {
+    const size_t window_end = std::min(start_idx + maxInflightRequests_, end_idx);
+    const nixl_status_t ret =
+        sendXferRangeWindow(operation, local, remote, handle, start_idx, window_end);
+    if ((ret != NIXL_SUCCESS) || (window_end == end_idx)) {
+        return ret;
+    }
+
+    auto int_handle = static_cast<nixlUcxBackendReqH *>(handle);
+    int_handle->setContinuation(
+        [this, operation, &local, &remote, remote_agent, handle, window_end, end_idx]() {
+            return sendXferRange(
+                operation, local, remote, remote_agent, handle, window_end, end_idx);
+        });
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlUcxEngine::sendXferRangeWindow(const nixl_xfer_op_t &operation,
+                                   const nixl_meta_dlist_t &local,
+                                   const nixl_meta_dlist_t &remote,
+                                   nixlBackendReqH *handle,
+                                   size_t start_idx,
+                                   size_t end_idx) const {
     const auto int_handle = static_cast<nixlUcxBackendReqH *>(handle);
     const size_t worker_id = int_handle->getWorkerId();
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -287,6 +287,14 @@ private:
                        size_t start_idx,
                        size_t end_idx);
 
+    nixl_status_t
+    sendXferRangeWindow(const nixl_xfer_op_t &operation,
+                        const nixl_meta_dlist_t &local,
+                        const nixl_meta_dlist_t &remote,
+                        nixlBackendReqH *handle,
+                        size_t start_idx,
+                        size_t end_idx) const;
+
     /**
      * Get the worker ID from the optional arguments.
      * Returns std::nullopt if the 'worker_id' option extraction fails.
@@ -298,6 +306,7 @@ private:
     std::unique_ptr<nixlUcxContext> uc;
     std::vector<std::unique_ptr<nixlUcxWorker>> workers_;
     size_t numSharedWorkers_;
+    size_t maxInflightRequests_;
     std::string workerAddr;
     mutable std::atomic<size_t> sharedWorkerIndex_;
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -33,9 +33,8 @@
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {
-    nixl_b_params_t params = {{"ucx_devices", ""},
-                              {"num_workers", "1"},
-                              {"max_inflight_requests", "64"}};
+    nixl_b_params_t params = {
+        {"ucx_devices", ""}, {"num_workers", "1"}, {"max_inflight_requests", "64"}};
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -33,7 +33,9 @@
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options() {
-    nixl_b_params_t params = {{"ucx_devices", ""}, {"num_workers", "1"}};
+    nixl_b_params_t params = {{"ucx_devices", ""},
+                              {"num_workers", "1"},
+                              {"max_inflight_requests", "64"}};
 
     params.emplace(nixl_ucx_err_handling_param_name,
                    ucx_err_mode_to_string(UCP_ERR_HANDLING_MODE_PEER));
@@ -447,6 +449,14 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
     }
 
     const auto &hw_info = nixl::hwInfo::instance();
+    if (hw_info.numAmdGpus != 0) {
+        /* Keep enough rendezvous fragments active to overlap staging and
+         * transfer without allowing one request to consume the ROCm copy
+         * transport's signal pool. UCX_RNDV_PIPELINE_MAX_INFLIGHT, when set,
+         * still takes precedence through config::modify(). */
+        config.modify("RNDV_PIPELINE_MAX_INFLIGHT", "4");
+    }
+
     if (hw_info.numEfaDevices != 0) {
         config.modify("ADDRESS_VERSION", "v2");
         if (ucpVersion_ >= UCP_VERSION(1, 19)) {

--- a/src/utils/common/hw_info.cpp
+++ b/src/utils/common/hw_info.cpp
@@ -41,6 +41,7 @@ namespace {
     constexpr unsigned long kPciClassIb = 0x0207;
     constexpr unsigned long kPciClassGpuDisplay = 0x0300;
     constexpr unsigned long kPciClassGpu3d = 0x0302;
+    constexpr unsigned long kPciClassProcessingAccelerator = 0x1200;
 
     constexpr unsigned long kPciDeviceEfa[] = {0xefa0, 0xefa1, 0xefa2, 0xefa3};
 
@@ -125,7 +126,8 @@ hwInfo::hwInfo() {
                        << std::dec;
         }
         if ((*vendor_id == kPciVendorAmd) &&
-            ((*class_id == kPciClassGpuDisplay) || (*class_id == kPciClassGpu3d))) {
+            ((*class_id == kPciClassGpuDisplay) || (*class_id == kPciClassGpu3d) ||
+             (*class_id == kPciClassProcessingAccelerator))) {
             numAmdGpus++;
             NIXL_DEBUG << "Found AMD GPU #" << numAmdGpus << ": " << device_name << " vendor=0x"
                        << std::hex << *vendor_id << " class=0x" << *class_id << std::dec;

--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -117,6 +117,7 @@ createEngine(std::string name, bool p_thread) {
     init.localAgent   = name;
     init.customParams = &custom_params;
     init.type         = "UCX";
+    custom_params["max_inflight_requests"] = "8";
 
     auto ucx = nixlUcxEngine::create(init).release();
     nixl_exit_on_failure(!ucx->getInitErr(), "Failed to initialize worker1");


### PR DESCRIPTION
- Post large UCX transfer lists in bounded descriptor windows.
- Use a conservative UCX rendezvous pipeline depth on AMD GPUs.
- Recognize AMD processing-accelerator PCI devices when applying the ROCm policy.

NIXL can submit large descriptor lists while UCX may split each transfer into multiple rendezvous fragments. On ROCm, staging fragments consume HSA signals from a fixed pool, so excessive posting can exhaust the pool even when UCX correctly reclaims completed signals. Apply backpressure at the source by posting large transfer lists in bounded descriptor windows. On AMD GPUs, request a conservative UCX rendezvous pipeline depth while still allowing an explicit UCX environment setting to override it. Also recognize AMD processing-accelerator PCI devices so this policy is applied on MI systems. This complements the UCX change that introduces the bounded rendezvous pipeline setting and signal reclamation under pool pressure.