### PR TITLE
ci: remove LEAF_JOBS parameter from dispatcher job

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -165,11 +165,10 @@ their own nightly/manual trigger. They split into two groups:
   - `nixl-ci-test-sanitizers` — `.ci/jenkins/lib/test-sanitizer-matrix.yaml` (ASan/UBSan + TSan)
   - `nixl-ci-build-container-pr` — `.ci/jenkins/lib/build-container-pr-matrix.yaml`
 - **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
-- **Skipping leaf jobs:** The `LEAF_JOBS` parameter (default: all seven) restricts the fan-out. Editing its default in the job config temporarily disables a leaf job for all runs without a code change; the next JJB redeploy restores the full list.
 
 ### `nixl-ci-build-container-pr` (dispatcher-triggered)
 - **Trigger:** Fan-out from `nixl-ci-dispatcher` (same as the other PR CI jobs).
-- **What it does:** Build-only verification (no push) of the `nixl` (EP + debug) and `nixlbench` container images — one matrix cell per target/arch (x86_64 and aarch64), all in parallel. It runs the same `contrib/build-container.sh` / `benchmark/nixlbench/contrib/build.sh` the standalone `nixl-ci-build-container` job runs, so container/packaging breakage (e.g. a missing `--torch-versions`, or an EP nvlink register-count failure) is caught on the PR instead of only by the nightly job. Like the other leaf jobs it runs whenever the dispatcher fans out; drop it for a specific run via the dispatcher's `LEAF_JOBS` parameter.
+- **What it does:** Build-only verification (no push) of the `nixl` (EP + debug) and `nixlbench` container images — one matrix cell per target/arch (x86_64 and aarch64), all in parallel. It runs the same `contrib/build-container.sh` / `benchmark/nixlbench/contrib/build.sh` the standalone `nixl-ci-build-container` job runs, so container/packaging breakage (e.g. a missing `--torch-versions`, or an EP nvlink register-count failure) is caught on the PR instead of only by the nightly job. Like the other leaf jobs it runs whenever the dispatcher fans out.
 - **Automatic on every PR:** No — only after a `/build` comment (like the other dispatcher jobs).
 
 ### `nixl-ci-build-wheel` (dispatcher-triggered)

--- a/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
@@ -97,22 +97,6 @@ def leafJobs = [
 ]
 
 try {
-    // Restrict the fan-out to the LEAF_JOBS parameter (comma-separated branch
-    // names). Webhook runs use the default (all jobs); a leaf job can be disabled
-    // temporarily by editing the parameter default in the job config, without a PR.
-    def requested = params.LEAF_JOBS?.trim() ? params.LEAF_JOBS.split(',').collect { it.trim() }.findAll { it } : []
-    def unknown = requested.findAll { !leafJobs.containsKey(it) }
-    if (unknown) {
-        error "Unknown LEAF_JOBS entries: ${unknown.join(', ')} (valid: ${leafJobs.keySet().join(', ')})"
-    }
-    if (requested) {
-        def skipped = leafJobs.keySet() - (requested as Set)
-        if (skipped) {
-            echo "LEAF_JOBS: skipping ${skipped.join(', ')}"
-        }
-        leafJobs = leafJobs.subMap(requested)
-    }
-
     // Compute the merged SHA once so all leaf jobs test the same commit
     def mergedSHA = githubHelper.getMergedSHA()
 

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -57,10 +57,6 @@
             name: "sha1"
             default: "{jjb_branch}"    # Default to 'main' branch for manual runs
             description: "Ref to check out the dispatcher pipeline from. Set to refs/pull/<n>/merge by the webhook; manual runs may pass a branch name, commit SHA, or any ref"
-        - string:
-            name: "LEAF_JOBS"
-            default: "non-gpu,gpu,dl-gpu,dl-gpu-ep,wheel,sanitizers,build-container"
-            description: "Comma-separated list of leaf jobs to dispatch. Edit the default here (via job config) to temporarily disable a leaf job for all runs without a code change; JJB redeploy restores the full list"
     # SCM configuration - checks out whatever ref sha1 holds: the PR merge ref
     # (set by the webhook) so a PR into a release branch runs that branch's
     # dispatcher, or a branch/commit for manual runs.


### PR DESCRIPTION
## Summary

- Removes the `LEAF_JOBS` string parameter from the dispatcher Jenkins job (`proj-jjb.yaml`)
- Removes the corresponding filtering logic in `Jenkinsfile.dispatcher` — the dispatcher now always fans out to all defined leaf jobs
- Updates `ci-overview.md` to drop documentation of the removed parameter

## Why

The `LEAF_JOBS` parameter listed leaf job names in its default value. When a new leaf job was added on `main`, older release branches would fail at dispatcher runtime because the new name wasn't in their copy of the parameter default — triggering the unknown-entry validation error. Since the parameter isn't actively used, removing it is simpler than maintaining the list across branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI documentation to reflect that dispatcher runs execute all available build jobs.

* **Bug Fixes**
  * Removed the option to selectively skip individual build jobs during dispatcher runs.
  * Simplified dispatcher configuration by removing the unused job-selection parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->