### PR TITLE
CI: enable GPU tests for nixlbench on DL cluster

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -198,9 +198,6 @@ steps:
       dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-dl-gpu-test-${ucx_version}:${BUILD_NUMBER}"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       containerName: "nixl-ci-${ucx_version}-${BUILD_NUMBER}"
-      slurmEnv: [
-        'HAS_GPU=false'
-      ]
 
 pipeline_stop:
   containerSelector: "{name: 'build_helper_dl'}"

--- a/test/gtest/device_api/single_write_test.cu
+++ b/test/gtest/device_api/single_write_test.cu
@@ -199,6 +199,9 @@ protected:
             EXPECT_NE(backend_handle, nullptr);
             backend_handles.push_back(backend_handle);
         }
+        if (lig_->getIgnoredCount() > 0) {
+            GTEST_SKIP() << "UCX accelerated IB support not found; GPUDirect RDMA unavailable";
+        }
     }
 
     void


### PR DESCRIPTION
For some reason we switched GPU flag off for nixlbench tests on DL cluster.

This commit switch it back on to enable GPU tests for nixlbench.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GPU test configuration so Nixlbench is no longer explicitly forced to run with GPU support disabled.
* **Tests**
  * Improved the single-write test setup to detect missing UCX accelerated IB support and automatically skip the test when GPUDirect RDMA isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->