### PR TITLE
[DO NOT MERGE] CI: test held Slurm allocations (liveness-coupled salloc)

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -119,6 +119,7 @@ steps:
     module: slurmCI
     run: allocation
     args:
+      ref: 'slurm-hold-allocation'
       partition: "${SLURM_PARTITION}"
       headNode: "${SLURM_HEAD_NODE}"
       headUser: "${SLURM_HEAD_USER}"
@@ -140,6 +141,7 @@ steps:
     module: slurmCI
     run: run
     args:
+      ref: 'slurm-hold-allocation'
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       testScript: ".gitlab/test_python.sh ${NIXL_INSTALL_DIR}"
       headNode: "${SLURM_HEAD_NODE}"
@@ -156,6 +158,7 @@ steps:
     module: slurmCI
     run: run
     args:
+      ref: 'slurm-hold-allocation'
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       testScript: ".gitlab/test_rust.sh ${NIXL_INSTALL_DIR}"
       headNode: "${SLURM_HEAD_NODE}"
@@ -172,6 +175,7 @@ steps:
     module: slurmCI
     run: run
     args:
+      ref: 'slurm-hold-allocation'
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       testScript: ".gitlab/test_cpp.sh ${NIXL_INSTALL_DIR}"
       headNode: "${SLURM_HEAD_NODE}"
@@ -191,6 +195,7 @@ steps:
     module: slurmCI
     run: run
     args:
+      ref: 'slurm-hold-allocation'
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${ucx_version}_${BUILD_NUMBER}.txt"
       testScript: ".gitlab/test_nixlbench.sh ${NIXL_INSTALL_DIR}"
       headNode: "${SLURM_HEAD_NODE}"
@@ -209,6 +214,7 @@ pipeline_stop:
   module: slurmCI
   run: stopAllForBuild
   args:
+    ref: 'slurm-hold-allocation'
     credentialsId: "${SSH_CREDENTIALS_ID}"
     headNode: "${SLURM_HEAD_NODE}"
     headUser: "${SLURM_HEAD_USER}"

--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -15,7 +15,7 @@
 // It is used to update the commit status and upload logs
 @Library('blossom-github-lib@master')
 @Library('ci-demo')  // External library for matrix build functionality
-@Library('swx-jenkins-lib') // External library for matrix build functionality
+@Library('swx-jenkins-lib@slurm-hold-allocation') // TESTING: pin lib branch under test (annotation wins over slurmCI ref: - first definition rule)
 
 // Initialize the build matrix
 // The matrix class handles the parallel execution of different build configurations


### PR DESCRIPTION
## What

CI-only experiment: loads `swx-jenkins-lib@slurm-hold-allocation` in every slurmCI step of the **dl-gpu** job via the existing `ref:` override. That branch changes `slurm.allocation()` (SSH mode) to hold the allocation open with a background `ssh -tt ... salloc ... sleep infinity` holder instead of `salloc --no-shell`, so Slurm revokes the allocation as soon as the build's agent dies — however it dies.

## Why

When a new commit is pushed to a PR, the dispatcher hard-kills (`doKill`) the stale builds, `pipeline_stop` never runs, and Slurm allocations hang until their `--time` limit. This tests coupling the allocation's lifetime to the build agent instead.

## Test plan

1. Run the dl pipeline for this PR; wait for `Slurm allocation job ID: <N>` in the console.
2. Kill the build (or push a second commit so the dispatcher does it).
3. Verify job `<N>` disappears from `squeue` on dlcluster within seconds (`dl-gpu-ep` intentionally stays on the default lib as the control group).
4. Let a run finish untouched: all test steps pass against the held allocation and `pipeline_stop` cleans up normally.

**Not for merge** — test scaffolding only; `ci-overview.md` deliberately not synced.
