### PR TITLE
CI: fix SGLang router port collision in sanity test

### DIFF
--- a/.gitlab/test_vllm_sglang_sanity.sh
+++ b/.gitlab/test_vllm_sglang_sanity.sh
@@ -153,6 +153,12 @@ elif [ "$FRAMEWORK" = "sglang" ]; then
   wait_for "http://localhost:${PREFILL_PORT}/health" "$SERVER_TIMEOUT"
   wait_for "http://localhost:${DECODE_PORT}/health" "$SERVER_TIMEOUT"
 
+  # Re-pick PROXY_PORT now that the SGLang servers are fully up. SGLang binds internal
+  # ports derived from its base port (gRPC, ZMQ, etc.) that aren't visible to
+  # get_next_tcp_port() until the servers are running; re-allocating here ensures the
+  # router gets a port that doesn't collide with any of those.
+  PROXY_PORT="$(get_next_tcp_port)"
+
   # sglang-router fronts the prefill/decode pair (replaces the removed in-core mini_lb).
   # Installed into the sglang weights-base image (contrib/Dockerfile.sglang-base).
   setsid python3 -m sglang_router.launch_router --pd-disaggregation \
@@ -160,7 +166,7 @@ elif [ "$FRAMEWORK" = "sglang" ]; then
     --decode "http://localhost:${DECODE_PORT}" \
     --host 0.0.0.0 --port "$PROXY_PORT" &
   pids+=($!)
-  wait_for "http://localhost:${PROXY_PORT}/health" "$PROXY_TIMEOUT" || true
+  wait_for "http://localhost:${PROXY_PORT}/health" "$PROXY_TIMEOUT"
   ENDPOINT="http://localhost:${PROXY_PORT}/v1/completions"
 
 else


### PR DESCRIPTION
get_next_tcp_port() checks ss -tuln at call time but does not bind the port, so PROXY_PORT allocated at startup (before the servers run) is vulnerable to a race: SGLang binds internal gRPC/ZMQ ports derived from its base port after startup, and one of those can land on PROXY_PORT before sglang_router tries to bind it. The router then exits immediately with "Address already in use", and the masked `|| true` on the health wait lets the script limp on until the 120s request timeout fires.

Fix: re-allocate PROXY_PORT after both SGLang servers pass their health checks, so get_next_tcp_port() sees all internally-bound ports in ss -tuln and skips past them. Also remove the `|| true` so a router startup failure surfaces immediately instead of 120s later.

Reported by the CI triage agent on PR #1987.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SGLang router startup by preventing port conflicts.
  * Added stricter router health checks so startup failures are detected reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->