### PR TITLE
EXAMPLES/DEVICE/EP/CSRC: Reverted force close of UCP endpoints.

### DIFF
--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1407,8 +1407,7 @@ void Buffer::_nixl_agent_init() {
 
     const char* num_channels_env = std::getenv("NIXL_EP_NUM_CHANNELS");
     init_params["ucx_num_device_channels"] = num_channels_env ? num_channels_env : "4";
-    init_params["ucx_error_handling_mode"] = "peer";
-    init_params["ucx_ep_close_force"] = "yes";
+    init_params["ucx_error_handling_mode"] = "none";
     init_params["num_workers"] = std::to_string(1);
 
     nixlBackendH* ucx_backend = nullptr;


### PR DESCRIPTION
## What?
Reverted the adding of option `ucx_ep_close_force` to forcibly close UCP endpoints.

## Why?
This option forcibly closes UCX transport layer endpoints when the UCX protocol layer endpoint is closed.
This change has revealed a couple of issues at the UCX transport layer that have the following symptoms:
- `UCX  ERROR   mlx5dv_devx_obj_modify(opcode=0x503) failed, syndrome 0x5d668c: Remote I/O error`
- `UCX  WARN    cuStreamDestroy_v2(*stream) failed: an illegal memory access was encountered`