### PR TITLE
CI: install redis server to container

### DIFF
--- a/.ci/scripts/common.sh
+++ b/.ci/scripts/common.sh
@@ -131,6 +131,33 @@ wait_for_etcd() {
     echo "Etcd is ready"
 }
 
+wait_for_redis_server() {
+    local port=$1
+    local timeout=30
+    echo "Waiting for Redis to be ready on port ${port} (timeout: ${timeout}s)..."
+    while ! redis-cli -p "${port}" ping 2>/dev/null | grep -q 'PONG'; do
+        timeout=$((timeout - 1))
+        if [ $timeout -eq 0 ]; then
+            echo "Redis failed to start"
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "Redis is ready"
+}
+
+start_redis_server() {
+    echo "==== Running Redis server ===="
+    redis_port=$(get_next_tcp_port)
+    export REDIS_HOST="127.0.0.1"
+    export REDIS_PORT="${redis_port}"
+
+    redis-server --port "${redis_port}" --daemonize no --loglevel warning &
+    REDIS_PID=$!
+
+    wait_for_redis_server "${redis_port}"
+}
+
 start_etcd_server() {
     local namespace_prefix=$1
     if [ -z "${namespace_prefix}" ]; then

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -134,6 +134,9 @@ else
                                  protobuf-compiler-grpc \
                                  pybind11-dev \
                                  etcd-server \
+                                 redis-server \
+                                 libhiredis-dev \
+                                 libevent-dev \
                                  net-tools \
                                  iproute2 \
                                  pciutils \

--- a/.gitlab/test_cpp.sh
+++ b/.gitlab/test_cpp.sh
@@ -75,6 +75,8 @@ fi
 
 start_etcd_server "/nixl/cpp_ci"
 
+start_redis_server
+
 echo "==== Running C++ tests ===="
 cd ${INSTALL_DIR}
 ./bin/desc_example
@@ -125,6 +127,8 @@ echo "./bin/ucx_worker_test disabled"
 echo "${TEXT_CLEAR}"
 
 kill -9 $ETCD_PID 2>/dev/null || true
+
+kill -9 $REDIS_PID 2>/dev/null || true
 
 sleep 5
 

--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -60,6 +60,16 @@ for op_type in READ WRITE; do
     run_nixlbench_one_worker --backend POSIX --op_type $op_type --check_consistency
 done
 
+
+# REDIS storage backend: single-process, no peer, no runtime coordinator needed
+start_redis_server
+
+for op_type in READ WRITE; do
+    run_nixlbench_one_worker --backend REDIS --op_type $op_type --check_consistency
+done
+
+kill -9 $REDIS_PID 2>/dev/null || true
+
 if $HAS_GPU ; then
     seg_types="VRAM DRAM"
 else

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -55,6 +55,9 @@ RUN apt-get update -y && \
     libcpprest-dev \
     etcd-server \
     etcd-client \
+    redis-server \
+    libhiredis-dev \
+    libevent-dev \
     autotools-dev \
     automake \
     libtool \


### PR DESCRIPTION
install redis server into the CI workflow container, in order to make it ready for testing CI workflow for redis plugin [PR 1791](https://github.com/ai-dynamo/nixl/pull/1791).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running Redis-backed Nixlbench read and write tests.
  - Added automatic local Redis server startup, readiness checks, and cleanup for test workflows.

- **Chores**
  - Added Redis and related development libraries to build environments.
  - Expanded continuous integration coverage to validate Redis integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->