### PR TITLE
CI: Skip UCCL nixlbench tests

### DIFF
--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -119,14 +119,16 @@ for op_type in READ WRITE; do
     done
 done
 
-if $HAS_GPU ; then
-    for op_type in READ WRITE; do
-        for initiator in $seg_types; do
-            for target in $seg_types; do
-                run_nixlbench_two_workers_etcd --backend UCCL --op_type $op_type --initiator_seg_type $initiator --target_seg_type $target --check_consistency
-            done
-        done
-    done
-fi
+# TODO: remove this once https://github.com/ai-dynamo/nixl/issues/1999 is fixed
+# Skip UCCL nixlbench transfer tests to reduce CI flakiness
+# if $HAS_GPU ; then
+#     for op_type in READ WRITE; do
+#         for initiator in $seg_types; do
+#             for target in $seg_types; do
+#                 run_nixlbench_two_workers_etcd --backend UCCL --op_type $op_type --initiator_seg_type $initiator --target_seg_type $target --check_consistency
+#             done
+#         done
+#     done
+# fi
 
 kill -9 $ETCD_PID 2>/dev/null || true


### PR DESCRIPTION
## What?
Skip UCCL nixlbench test due to frequent hangs, see https://github.com/ai-dynamo/nixl/issues/1999


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled flaky GPU-based UCCL transfer tests in CI pending an upstream fix.
  * Other UCX tests and supporting test infrastructure remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->