### PR TITLE
PLUGINS/UCX: Removed unused endpoint state.

### DIFF
--- a/src/plugins/ucx/ucx_enums.h
+++ b/src/plugins/ucx/ucx_enums.h
@@ -52,7 +52,6 @@ enum class ep_state_t {
     UNINITIALIZED,
     CONNECTED,
     FAILED,
-    DISCONNECTED,
 };
 
 [[nodiscard]] constexpr std::string_view
@@ -64,8 +63,6 @@ toStringView(const ep_state_t t) noexcept {
         return "CONNECTED";
     case ep_state_t::FAILED:
         return "FAILED";
-    case ep_state_t::DISCONNECTED:
-        return "DISCONNECTED";
     }
     return nixl::ucx::invalid_string;
 }
@@ -121,7 +118,6 @@ toNixlStatus(const ep_state_t t) noexcept {
     case ep_state_t::FAILED:
         return NIXL_ERR_REMOTE_DISCONNECT;
     case ep_state_t::UNINITIALIZED:
-    case ep_state_t::DISCONNECTED:
         return NIXL_ERR_BACKEND;
     }
     return NIXL_ERR_BACKEND;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -98,8 +98,6 @@ nixlUcxEp::err_cb(ucp_ep_h ucp_ep, ucs_status_t status) {
     case nixl::ucx::ep_state_t::UNINITIALIZED:
     case nixl::ucx::ep_state_t::FAILED:
         // The error was already handled, nothing to do
-    case nixl::ucx::ep_state_t::DISCONNECTED:
-        // The EP has been disconnected, nothing to do
         return;
     case nixl::ucx::ep_state_t::CONNECTED:
         setState(nixl::ucx::ep_state_t::FAILED);
@@ -126,8 +124,7 @@ nixlUcxEp::closeImpl() {
 
     switch (current_state) {
     case nixl::ucx::ep_state_t::UNINITIALIZED:
-    case nixl::ucx::ep_state_t::DISCONNECTED:
-        // The EP has not been connected, or already disconnected.
+        // The EP has not been connected.
         // Nothing to do.
         NIXL_ASSERT(eph == nullptr);
         return NIXL_SUCCESS;


### PR DESCRIPTION
## What?
Removed unused `nixl::ucx::ep_state_t::DISCONNECTED`.

## Why?
The state is not set in any place.