### PR TITLE
ci: run dl-ep job steps only when EP-relevant files change

### DIFF
--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -42,3 +42,46 @@ for yaml in "${YAML_FILES[@]}"; do
     sed -i "s/CI_IMAGE_TAG: \"CI_MANAGED\"/CI_IMAGE_TAG: \"${NEW_TAG}\"/" "$yaml"
     echo "Patched: $yaml"
 done
+
+# EP path filter: flip EP_ENABLED to "false" in test-dl-ep-matrix.yaml when the
+# PR changes no EP-relevant file. On a PR trigger HEAD is the refs/pull/<n>/merge
+# commit, so HEAD^1..HEAD is the PR's diff against whatever branch it targets.
+#
+# EP sources/tests plus the CI files feeding this job's images: CI_FILES above
+# minus the wheel-only manylinux Dockerfile.
+EP_PATHS=(
+    "examples/device/ep/"
+    ".gitlab/test_ep.sh"
+    ".gitlab/build.sh"
+    ".ci/scripts/common.sh"
+    ".ci/jenkins/lib/test-dl-ep-matrix.yaml"
+    ".ci/dockerfiles/Dockerfile.base"
+    ".ci/dockerfiles/Dockerfile.gpu-test"
+    ".ci/dockerfiles/Dockerfile.build_helper"
+)
+
+if [ -z "${githubData:-}" ]; then
+    # Manual run: a hand-picked ref could itself be a merge commit.
+    echo "EP filter: no githubData (manual run) - EP steps enabled"
+elif ! git rev-parse --verify -q HEAD^2 >/dev/null; then
+    echo "EP filter: HEAD is not a merge commit - EP steps enabled"
+else
+    CHANGED_FILES=$(git diff --name-only HEAD^1 HEAD)
+    echo "EP filter: changed files (HEAD^1..HEAD):"
+    echo "$CHANGED_FILES" | sed 's/^/    /'
+    EP_TOUCHED="false"
+    for ep_path in "${EP_PATHS[@]}"; do
+        # Here-string, so no pipeline runs under `set -o pipefail`.
+        if grep -q "^${ep_path}" <<< "$CHANGED_FILES"; then
+            EP_TOUCHED="true"
+            break
+        fi
+    done
+    if [ "$EP_TOUCHED" = "false" ]; then
+        sed -i 's/EP_ENABLED: "true"/EP_ENABLED: "false"/' \
+            ".ci/jenkins/lib/test-dl-ep-matrix.yaml"
+        echo "No EP-relevant files changed - EP steps disabled"
+    else
+        echo "EP-relevant files changed - EP steps enabled"
+    fi
+fi

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -160,7 +160,7 @@ their own nightly/manual trigger. They split into two groups:
   - `nixl-ci-non-gpu` — `.ci/jenkins/lib/build-matrix.yaml`
   - `nixl-ci-gpu` — `.ci/jenkins/lib/test-matrix.yaml`
   - `nixl-ci-dl-gpu` — `.ci/jenkins/lib/test-dl-matrix.yaml` (dlcluster.nvidia.com)
-  - `nixl-ci-dl-gpu-ep` — `.ci/jenkins/lib/test-dl-ep-matrix.yaml` (nixl_ep elastic tests on dlcluster.nvidia.com)
+  - `nixl-ci-dl-gpu-ep` — `.ci/jenkins/lib/test-dl-ep-matrix.yaml` (nixl_ep elastic tests on dlcluster.nvidia.com; steps skipped via `enable:` when no EP-relevant files changed — see [nixl-ci-dl-gpu-ep](#nixl-ci-dl-gpu-ep-dispatcher-triggered))
   - `nixl-ci-build-wheel` — `.ci/jenkins/lib/build-wheel-matrix.yaml`
   - `nixl-ci-test-sanitizers` — `.ci/jenkins/lib/test-sanitizer-matrix.yaml` (ASan/UBSan + TSan)
   - `nixl-ci-build-container-pr` — `.ci/jenkins/lib/build-container-pr-matrix.yaml`
@@ -169,6 +169,13 @@ their own nightly/manual trigger. They split into two groups:
 ### `nixl-ci-build-container-pr` (dispatcher-triggered)
 - **Trigger:** Fan-out from `nixl-ci-dispatcher` (same as the other PR CI jobs).
 - **What it does:** Build-only verification (no push) of the `nixl` (EP + debug) and `nixlbench` container images — one matrix cell per target/arch (x86_64 and aarch64), all in parallel. It runs the same `contrib/build-container.sh` / `benchmark/nixlbench/contrib/build.sh` the standalone `nixl-ci-build-container` job runs, so container/packaging breakage (e.g. a missing `--torch-versions`, or an EP nvlink register-count failure) is caught on the PR instead of only by the nightly job. Like the other leaf jobs it runs whenever the dispatcher fans out.
+- **Automatic on every PR:** No — only after a `/build` comment (like the other dispatcher jobs).
+
+### `nixl-ci-dl-gpu-ep` (dispatcher-triggered)
+- **Config:** `.ci/jenkins/lib/test-dl-ep-matrix.yaml`
+- **What it does:** Builds the EP Docker image (`BUILD_NIXL_EP=true`), allocates a Slurm node on `gb200nvl72_cx8`, and runs the `nixl_ep` elastic tests (NVLink + RDMA, 4 GPUs) via `.gitlab/test_ep.sh`.
+- **Path filter:** All three steps carry `enable: "${EP_ENABLED}"`. `EP_ENABLED` defaults to `"true"` in the `env:` section of `test-dl-ep-matrix.yaml`; `cidemo-init.sh` flips it to `"false"` (via `sed`, the same in-workspace patching used for `CI_IMAGE_TAG`) when the PR touches none of: `examples/device/ep/`, `.gitlab/test_ep.sh`, `.gitlab/build.sh`, `.ci/scripts/common.sh`, `.ci/jenkins/lib/test-dl-ep-matrix.yaml`, `.ci/dockerfiles/Dockerfile.base`, `.ci/dockerfiles/Dockerfile.gpu-test`, `.ci/dockerfiles/Dockerfile.build_helper`. That is the EP sources and tests plus every [CI file](#ci_image_tag-management) feeding the two images this job builds (`contrib/Dockerfile.manylinux` is excluded as wheel-only). A step that always runs, `EP path filter status`, reports which way the filter went so a skipped run is obvious in the Jenkins UI.
+- **How the diff is taken:** On a PR trigger the checked-out commit is the `refs/pull/<n>/merge` merge commit, so `cidemo-init.sh` diffs `HEAD^1..HEAD` — base branch tip vs merged result. The first parent is the base tip whatever the PR targets, so PRs into release branches work with no base branch to guess (unlike ci-demo's own `getChangedFilesList`, which falls back to `origin/main`/`origin/master`). Runs without `githubData` (manual/standalone) are excluded explicitly rather than by commit shape, since a manually built ref could itself be a merge commit and would otherwise engage the filter by accident. Every path logs its reason, so a filter that doesn't fire is visible in the job output rather than silent.
 - **Automatic on every PR:** No — only after a `/build` comment (like the other dispatcher jobs).
 
 ### `nixl-ci-build-wheel` (dispatcher-triggered)

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -46,6 +46,8 @@ credentials:
   - {credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
 
 env:
+  # Set to "false" by cidemo-init.sh when no EP-relevant files changed.
+  EP_ENABLED: "true"
   ARTIFACTORY_PATH: /sw-nbu-swx-nixl-docker-local/ci
   NIXL_INSTALL_DIR: /opt/nixl
   NIXL_BUILD_DIR: nixl_build
@@ -101,7 +103,20 @@ matrix:
 taskName: "${name}/${arch}/ucx-${ucx_version}/${axis_index}"
 
 steps:
+  # Always runs: makes a filtered-out run visible instead of just missing steps.
+  - name: EP path filter status
+    containerSelector: "{name: 'build_helper_dl_ep'}"
+    parallel: false
+    run: |
+      if [ "${EP_ENABLED}" != "true" ]; then
+          echo "=========================================================="
+          echo " nixl_ep elastic tests SKIPPED - no EP-relevant changes."
+          echo " Triggering paths are listed in .ci/cidemo-init.sh."
+          echo "=========================================================="
+      fi
+
   - name: Compiling NIXL EP Docker Image for DL
+    enable: "${EP_ENABLED}"
     containerSelector: "{name: 'build_helper_dl_ep'}"
     credentialsId: "svc-nixl-new-artifactory-token"
     parallel: false
@@ -122,6 +137,7 @@ steps:
       podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE}
 
   - name: Allocate DL EP Environment
+    enable: "${EP_ENABLED}"
     containerSelector: "{name: 'build_helper_dl_ep'}"
     parallel: false
     shell: action
@@ -142,6 +158,7 @@ steps:
       ]
 
   - name: Run DL EP elastic tests
+    enable: "${EP_ENABLED}"
     containerSelector: "{name: 'build_helper_dl_ep'}"
     timeout: "${TEST_TIMEOUT}"
     parallel: false


### PR DESCRIPTION
The `nixl-ci-dl-gpu-ep` job builds a dedicated EP image and holds a `gb200nvl72_cx8` Slurm reservation on every PR, including changes that cannot affect the EP elastic tests. This gates its steps on a path filter so unrelated PRs skip that work while the job still reports SUCCESS — so it can remain a required check.

- Add `EP_ENABLED` (`"true"` by default) to the `env:` block of `test-dl-ep-matrix.yaml` and put `enable: "${EP_ENABLED}"` on the three real steps
- Extend `cidemo-init.sh` to diff the PR and flip `EP_ENABLED` to `"false"` when it touches none of `EP_PATHS`. On a PR trigger `HEAD` is the `refs/pull/<n>/merge` commit, so `HEAD^1..HEAD` is the diff against whatever branch the PR targets — no base branch to guess, so PRs into release branches work too
- `EP_PATHS` covers the EP sources and tests plus the CI files feeding this job's two images (`nixl-ci-dl-gpu-ep-base`, `build_helper_dl_ep`): `CI_FILES` minus the wheel-only `contrib/Dockerfile.manylinux`
- Skip filtering entirely when `githubData` is unset, so a manual run on a hand-picked ref that happens to be a merge commit is unaffected
- Add an always-on `EP path filter status` step that prints why the EP tests were skipped. ci-demo's `enable:` has no negation operator (`replaceVars` does a literal `${KEY}` substitution, then `toBoolean()`), so the step branches on `$EP_ENABLED` in shell, which ci-demo exports from the matrix `env:` block
- Leave `pipeline_stop` ungated so Slurm cleanup always runs

`EP_ENABLED` is patched in the Jenkins workspace by `sed`, the same mechanism already used for `CI_IMAGE_TAG` — `cidemo-init.sh` runs as a child shell so it cannot export into the Jenkins env, but it does run before ci-demo parses the matrix YAML.

### Verified on this PR

- **Skip path:** with a temporary commit removing `test-dl-ep-matrix.yaml` from `EP_PATHS` (so this PR matched nothing), `/build` skipped the image build, Slurm allocation and elastic tests, and the job reported SUCCESS. That commit is not part of this branch.
- **Run path:** with the production `EP_PATHS`, this PR matches (it edits the matrix file), so the full job runs.