### PR TITLE
EP/TESTS: Skip Kineto reporting when CUDA profiling is unavailable

### DIFF
--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -32,6 +32,7 @@ import nixl_ep
 import rank_server
 import store_group
 import torch
+import torch.distributed as dist
 from nixl_ep.buffer import DEFAULT_TIMEOUT_MS
 from plan import Plan
 
@@ -39,7 +40,6 @@ from plan import Plan
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import (  # noqa: E402
-    KinetoUnavailableError,
     bench,
     bench_kineto,
     calc_diff,
@@ -99,6 +99,8 @@ def test_main(
     num_ranks: int,
     max_num_ranks: int,
     buffer: nixl_ep.Buffer,
+    tcp_store: dist.TCPStore,
+    phase: int,
     use_logfmt: bool = False,
     seed: int = 0,
     kineto: bool = False,
@@ -435,28 +437,32 @@ def test_main(
     if not kineto:
         return
 
+    def kineto_unavailable_on_any_rank(unavailable: bool, step: str) -> bool:
+        key = f"kineto_unavailable:{phase}:{step}"
+        tcp_store.add(key, int(unavailable))
+        buffer.barrier()
+        return int(tcp_store.get(key)) > 0
+
     kineto_supported, reason = kineto_device_supported(torch.cuda.current_device())
-    if not kineto_supported:
+    if kineto_unavailable_on_any_rank(
+        not kineto_supported,
+        "device_support",
+    ):
+        if kineto_supported:
+            reason = "CUPTI is unavailable on another rank"
         print(f"[rank {rank}] Skipping Kineto profiling: {reason}", flush=True)
         return
 
     for return_recv_hook in (False, True):
         buffer.barrier()
-        try:
-            dispatch_t, combine_t = bench_kineto(
-                partial(test_func, return_recv_hook=return_recv_hook),
-                kernel_names=("dispatch", "combine"),
-                barrier_comm_profiling=True,
-                suppress_kineto_output=False,
-                num_kernels_per_period=2 if return_recv_hook else 1,
-                barrier_fn=test_barrier,
-            )
-        except KinetoUnavailableError as exc:
-            print(
-                f"[rank {rank}] Skipping Kineto profiling: {exc}",
-                flush=True,
-            )
-            return
+        dispatch_t, combine_t = bench_kineto(
+            partial(test_func, return_recv_hook=return_recv_hook),
+            kernel_names=("dispatch", "combine"),
+            barrier_comm_profiling=True,
+            suppress_kineto_output=False,
+            num_kernels_per_period=2 if return_recv_hook else 1,
+            barrier_fn=test_barrier,
+        )
         if not return_recv_hook:
             print(
                 f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "
@@ -588,6 +594,8 @@ def worker(torch_rank: int, args: argparse.Namespace):
             current_num_ranks,
             max_num_ranks,
             buffer,
+            tcp_store,
+            plan.get_phase(),
             kineto=args.kineto,
             fault_tolerance_test=kill_rank,
         )

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -39,6 +39,7 @@ from plan import Plan
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import (  # noqa: E402
+    KinetoUnavailableError,
     bench,
     bench_kineto,
     calc_diff,
@@ -435,14 +436,18 @@ def test_main(
 
     for return_recv_hook in (False, True):
         buffer.barrier()
-        dispatch_t, combine_t = bench_kineto(
-            partial(test_func, return_recv_hook=return_recv_hook),
-            kernel_names=("dispatch", "combine"),
-            barrier_comm_profiling=True,
-            suppress_kineto_output=False,
-            num_kernels_per_period=2 if return_recv_hook else 1,
-            barrier_fn=test_barrier,
-        )
+        try:
+            dispatch_t, combine_t = bench_kineto(
+                partial(test_func, return_recv_hook=return_recv_hook),
+                kernel_names=("dispatch", "combine"),
+                barrier_comm_profiling=True,
+                suppress_kineto_output=False,
+                num_kernels_per_period=2 if return_recv_hook else 1,
+                barrier_fn=test_barrier,
+            )
+        except KinetoUnavailableError as exc:
+            print(f"[rank {rank}] Skipping Kineto profiling: {exc}", flush=True)
+            return
         if not return_recv_hook:
             print(
                 f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -44,6 +44,7 @@ from utils import (  # noqa: E402
     bench_kineto,
     calc_diff,
     hash_tensor,
+    kineto_device_supported,
     per_token_cast_back,
 )
 
@@ -434,6 +435,11 @@ def test_main(
     if not kineto:
         return
 
+    kineto_supported, reason = kineto_device_supported(torch.cuda.current_device())
+    if not kineto_supported:
+        print(f"[rank {rank}] Skipping Kineto profiling: {reason}", flush=True)
+        return
+
     for return_recv_hook in (False, True):
         buffer.barrier()
         try:
@@ -446,7 +452,10 @@ def test_main(
                 barrier_fn=test_barrier,
             )
         except KinetoUnavailableError as exc:
-            print(f"[rank {rank}] Skipping Kineto profiling: {exc}", flush=True)
+            print(
+                f"[rank {rank}] Skipping Kineto profiling: {exc}",
+                flush=True,
+            )
             return
         if not return_recv_hook:
             print(

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -31,6 +31,10 @@ import torch
 import torch.distributed as dist
 
 
+class KinetoUnavailableError(RuntimeError):
+    """Raised when the profiler records no CUDA timing activities."""
+
+
 def init_dist(local_rank: int, num_local_ranks: int):
     # NOTES: you may rewrite this function with your own cluster settings
     ip = os.getenv("MASTER_ADDR", "127.0.0.1")
@@ -221,17 +225,23 @@ def bench_kineto(
     # Parse the profiling table
     assert isinstance(kernel_names, str) or isinstance(kernel_names, tuple)
     is_tuple = isinstance(kernel_names, tuple)
-    prof_lines = (
-        prof.key_averages()
-        .table(sort_by="cuda_time_total", max_name_column_width=100)
-        .split("\n")
+    prof_table = prof.key_averages().table(
+        sort_by="cuda_time_total", max_name_column_width=100
     )
+
+    if "CUDA" not in prof_table:
+        raise KinetoUnavailableError(
+            "Kineto recorded no CUDA timing activities; "
+            "per-kernel profiling is unavailable"
+        )
+
+    prof_lines = prof_table.split("\n")
     kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
     assert all([isinstance(name, str) for name in kernel_names])
     for name in kernel_names:
         assert (
             sum([name in line for line in prof_lines]) == 1
-        ), f"Errors of the kernel {name} in the profiling table"
+        ), f"Errors of the kernel {name} in the profiling table:\n{prof_table}"
 
     # Save chrome traces
     if trace_path is not None:

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ctypes
 import inspect
 import json
 import os
@@ -32,7 +33,63 @@ import torch.distributed as dist
 
 
 class KinetoUnavailableError(RuntimeError):
-    """Raised when the profiler records no CUDA timing activities."""
+    """Raised when Kineto cannot collect CUDA timing activities."""
+
+
+def kineto_device_supported(device_ordinal: int):
+    """Return whether CUPTI supports the selected CUDA device."""
+    if not torch.cuda.is_available():
+        return False, "CUDA is unavailable"
+
+    properties = torch.cuda.get_device_properties(device_ordinal)
+    device_description = (
+        f"{properties.name}, compute capability "
+        f"{properties.major}.{properties.minor}"
+    )
+
+    try:
+        cuda = ctypes.CDLL("libcuda.so.1")
+        cuda_major = torch.version.cuda.split(".", maxsplit=1)[0]
+        cupti = ctypes.CDLL(f"libcupti.so.{cuda_major}")
+    except (AttributeError, OSError) as exc:
+        return False, f"unable to load CUDA/CUPTI: {exc}"
+
+    cuda.cuInit.argtypes = [ctypes.c_uint]
+    cuda.cuInit.restype = ctypes.c_int
+    cuda.cuDeviceGet.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.c_int,
+    ]
+    cuda.cuDeviceGet.restype = ctypes.c_int
+    cupti.cuptiDeviceSupported.argtypes = [
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    cupti.cuptiDeviceSupported.restype = ctypes.c_int
+
+    result = cuda.cuInit(0)
+    if result != 0:
+        return False, f"cuInit failed with CUresult {result}"
+
+    cuda_device = ctypes.c_int()
+    result = cuda.cuDeviceGet(ctypes.byref(cuda_device), device_ordinal)
+    if result != 0:
+        return False, f"cuDeviceGet failed with CUresult {result}"
+
+    supported = ctypes.c_int()
+    result = cupti.cuptiDeviceSupported(
+        cuda_device.value,
+        ctypes.byref(supported),
+    )
+    if result != 0:
+        return False, (
+            f"cuptiDeviceSupported failed with CUptiResult {result} "
+            f"for {device_description}"
+        )
+    if supported.value == 0:
+        return False, f"loaded CUPTI does not support {device_description}"
+
+    return True, device_description
 
 
 def init_dist(local_rank: int, num_local_ranks: int):
@@ -228,13 +285,11 @@ def bench_kineto(
     prof_table = prof.key_averages().table(
         sort_by="cuda_time_total", max_name_column_width=100
     )
-
     if "CUDA" not in prof_table:
         raise KinetoUnavailableError(
             "Kineto recorded no CUDA timing activities; "
             "per-kernel profiling is unavailable"
         )
-
     prof_lines = prof_table.split("\n")
     kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
     assert all([isinstance(name, str) for name in kernel_names])

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -48,7 +48,7 @@ def kineto_device_supported(device_ordinal: int):
         supported = cupti.device_supported(device_ordinal)
     except ImportError as exc:
         return False, f"unable to import cupti-python: {exc}"
-    except (OSError, RuntimeError) as exc:
+    except (cupti.cuptiError, OSError, RuntimeError) as exc:
         return False, f"unable to query CUPTI support for {device_description}: {exc}"
 
     if supported == 0:

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
 import inspect
 import json
 import os
@@ -30,10 +29,6 @@ from typing import Callable, Optional, Union
 import numpy as np
 import torch
 import torch.distributed as dist
-
-
-class KinetoUnavailableError(RuntimeError):
-    """Raised when Kineto cannot collect CUDA timing activities."""
 
 
 def kineto_device_supported(device_ordinal: int):
@@ -48,45 +43,15 @@ def kineto_device_supported(device_ordinal: int):
     )
 
     try:
-        cuda = ctypes.CDLL("libcuda.so.1")
-        cuda_major = torch.version.cuda.split(".", maxsplit=1)[0]
-        cupti = ctypes.CDLL(f"libcupti.so.{cuda_major}")
-    except (AttributeError, OSError) as exc:
-        return False, f"unable to load CUDA/CUPTI: {exc}"
+        from cupti import cupti
 
-    cuda.cuInit.argtypes = [ctypes.c_uint]
-    cuda.cuInit.restype = ctypes.c_int
-    cuda.cuDeviceGet.argtypes = [
-        ctypes.POINTER(ctypes.c_int),
-        ctypes.c_int,
-    ]
-    cuda.cuDeviceGet.restype = ctypes.c_int
-    cupti.cuptiDeviceSupported.argtypes = [
-        ctypes.c_int,
-        ctypes.POINTER(ctypes.c_int),
-    ]
-    cupti.cuptiDeviceSupported.restype = ctypes.c_int
+        supported = cupti.device_supported(device_ordinal)
+    except ImportError as exc:
+        return False, f"unable to import cupti-python: {exc}"
+    except (OSError, RuntimeError) as exc:
+        return False, f"unable to query CUPTI support for {device_description}: {exc}"
 
-    result = cuda.cuInit(0)
-    if result != 0:
-        return False, f"cuInit failed with CUresult {result}"
-
-    cuda_device = ctypes.c_int()
-    result = cuda.cuDeviceGet(ctypes.byref(cuda_device), device_ordinal)
-    if result != 0:
-        return False, f"cuDeviceGet failed with CUresult {result}"
-
-    supported = ctypes.c_int()
-    result = cupti.cuptiDeviceSupported(
-        cuda_device.value,
-        ctypes.byref(supported),
-    )
-    if result != 0:
-        return False, (
-            f"cuptiDeviceSupported failed with CUptiResult {result} "
-            f"for {device_description}"
-        )
-    if supported.value == 0:
+    if supported == 0:
         return False, f"loaded CUPTI does not support {device_description}"
 
     return True, device_description
@@ -282,21 +247,17 @@ def bench_kineto(
     # Parse the profiling table
     assert isinstance(kernel_names, str) or isinstance(kernel_names, tuple)
     is_tuple = isinstance(kernel_names, tuple)
-    prof_table = prof.key_averages().table(
-        sort_by="cuda_time_total", max_name_column_width=100
+    prof_lines = (
+        prof.key_averages()
+        .table(sort_by="cuda_time_total", max_name_column_width=100)
+        .split("\n")
     )
-    if "CUDA" not in prof_table:
-        raise KinetoUnavailableError(
-            "Kineto recorded no CUDA timing activities; "
-            "per-kernel profiling is unavailable"
-        )
-    prof_lines = prof_table.split("\n")
     kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
     assert all([isinstance(name, str) for name in kernel_names])
     for name in kernel_names:
         assert (
             sum([name in line for line in prof_lines]) == 1
-        ), f"Errors of the kernel {name} in the profiling table:\n{prof_table}"
+        ), f"Errors of the kernel {name} in the profiling table"
 
     # Save chrome traces
     if trace_path is not None:


### PR DESCRIPTION
## What?
Skip optional Kineto reporting when CUDA profiling data is unavailable.

## Why?
CUPTI 12 is incompatible with gb300 and fails to initialize, leaving Kineto without CUDA timing. NIXL previously reported this as a misleading kernel-dispatch assertion.

## How?
Detect missing CUDA profiling data, print a clear skip message, and preserve kernel validation when profiling is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved profiling test reliability by detecting when Kineto/CUDA timing activities are unavailable and skipping Kineto-based benchmarking instead of failing.
  - Synchronized device-support checks across distributed test processes so unsupported environments are handled consistently.
  - Enhanced diagnostics for kernel-name mismatches by including the full profiling table in error output.
  - Simplified elastic profiling execution to gracefully handle unsupported or unavailable Kineto scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->