### PR TITLE
PLUGIN/UCX: Improve UCX context&worker logging

### DIFF
--- a/src/plugins/ucx/mem_list.cpp
+++ b/src/plugins/ucx/mem_list.cpp
@@ -147,10 +147,10 @@ createElements(const T &dlist, size_t worker_id = 0) {
 }
 
 void *
-createMemList(const nixl_remote_meta_dlist_t &dlist, size_t worker_id, nixlUcxWorker &worker) {
+createMemList(const nixl_remote_meta_dlist_t &dlist, nixlUcxWorker &worker) {
     using namespace std::chrono_literals;
 
-    const device_mem_vector_t elements = createElements(dlist, worker_id);
+    const device_mem_vector_t elements = createElements(dlist, worker.getId());
     const memListParams params{elements};
 
     ucp_device_remote_mem_list_h handle{nullptr};
@@ -206,7 +206,7 @@ const std::string error_message{"UCX GPU device API is not supported"};
 
 namespace nixl::ucx {
 void *
-createMemList(const nixl_remote_meta_dlist_t &, size_t, nixlUcxWorker &) {
+createMemList(const nixl_remote_meta_dlist_t &, nixlUcxWorker &) {
     throw std::runtime_error(error_message);
 }
 

--- a/src/plugins/ucx/mem_list.h
+++ b/src/plugins/ucx/mem_list.h
@@ -24,7 +24,7 @@ class nixlUcxWorker;
 
 namespace nixl::ucx {
 [[nodiscard]] void *
-createMemList(const nixl_remote_meta_dlist_t &, size_t, nixlUcxWorker &);
+createMemList(const nixl_remote_meta_dlist_t &, nixlUcxWorker &);
 
 [[nodiscard]] void *
 createMemList(const nixl_meta_dlist_t &, const nixlUcxWorker &);

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -875,7 +875,7 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
     nixlSerDes::_stringToBytes(addr.data(), remote_conn_info, size);
     std::shared_ptr<nixlUcxConnection> conn = std::make_shared<nixlUcxConnection>();
     for (const auto &uw : workers_) {
-        std::unique_ptr<nixlUcxEp> ep = uw->connect(addr.data(), size);
+        std::unique_ptr<nixlUcxEp> ep = uw->connect(addr.data());
         if (!ep) {
             return NIXL_ERR_BACKEND;
         }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -49,14 +49,13 @@ class nixlUcxBackendReqH : public nixlBackendReqH {
 private:
     std::set<ucx_connection_ptr_t> connections_;
     std::vector<nixlUcxReq> requests_;
-    nixlUcxWorker *worker_;
-    size_t workerId_;
+    nixlUcxWorker *worker_ = nullptr;
 
     [[nodiscard]] nixl_status_t
     checkConnection(const nixl_status_t status = NIXL_SUCCESS) const {
         NIXL_ASSERT(!connections_.empty());
         for (const auto &conn : connections_) {
-            const nixl_status_t conn_status = conn->getEp(workerId_)->checkTxState();
+            const nixl_status_t conn_status = conn->getEp(getWorkerId())->checkTxState();
             if (conn_status != NIXL_SUCCESS) {
                 return conn_status;
             }
@@ -66,10 +65,9 @@ private:
 
 protected:
     void
-    setWorker(nixlUcxWorker *worker, size_t worker_id) {
+    setWorker(nixlUcxWorker *worker) {
         NIXL_ASSERT(worker_ == nullptr || worker == nullptr);
         worker_ = worker;
-        workerId_ = worker_id;
     }
 
 public:
@@ -85,9 +83,9 @@ public:
 
     std::optional<Notif> notif;
 
-    nixlUcxBackendReqH(nixlUcxWorker *worker, size_t worker_id)
-        : worker_(worker),
-          workerId_(worker_id) {}
+    explicit nixlUcxBackendReqH(nixlUcxWorker *worker) {
+        setWorker(worker);
+    }
 
     void
     reserve(size_t size) {
@@ -192,7 +190,7 @@ public:
 
     [[nodiscard]] size_t
     getWorkerId() const noexcept {
-        return workerId_;
+        return worker_->getId();
     }
 };
 
@@ -232,20 +230,14 @@ public:
     }
 
     virtual void
-    addWorker(nixlUcxWorker *worker, size_t worker_id) {
+    addWorker(nixlUcxWorker *worker) {
         NIXL_ASSERT(workers_.size() < workers_.capacity());
         workers_.push_back(worker);
-        workerIds_.push_back(worker_id);
     }
 
     const std::vector<nixlUcxWorker *> &
     getWorkers() const {
         return workers_;
-    }
-
-    size_t
-    getWorkerId(size_t idx = 0) const {
-        return workerIds_[idx];
     }
 
     void
@@ -263,8 +255,11 @@ public:
 
     friend std::ostream &
     operator<<(std::ostream &os, const nixlUcxThread &thread) {
+        const auto id_formatter = [](std::string *out, const nixlUcxWorker *worker) {
+            out->append(std::to_string(worker->getId()));
+        };
         return os << "thread " << &thread << "{engine: " << thread.engine_ << ", worker_ids: ["
-                  << absl::StrJoin(thread.workerIds_, ",") << "]}";
+                  << absl::StrJoin(thread.workers_, ",", id_formatter) << "]}";
     }
 
 protected:
@@ -274,7 +269,6 @@ protected:
 private:
     const nixlUcxEngine *engine_;
     std::vector<nixlUcxWorker *> workers_;
-    std::vector<size_t> workerIds_;
     std::unique_ptr<std::thread> thread_;
     std::unique_ptr<std::promise<void>> threadActive_;
 };
@@ -313,9 +307,9 @@ public:
     }
 
     void
-    addWorker(nixlUcxWorker *worker, size_t worker_id) override {
+    addWorker(nixlUcxWorker *worker) override {
         pollFds_[getWorkers().size()] = {worker->getEfd(), POLLIN, 0};
-        nixlUcxThread::addWorker(worker, worker_id);
+        nixlUcxThread::addWorker(worker);
     }
 
 protected:
@@ -376,7 +370,7 @@ nixlUcxThreadEngine::nixlUcxThreadEngine(const nixlBackendInitParams &init_param
     const size_t shared_count = getSharedWorkers().size();
     thread_ = std::make_unique<nixlUcxSharedThread>(this, shared_count, init_params.pthrDelay);
     for (size_t i = 0; i < shared_count; i++) {
-        thread_->addWorker(getSharedWorkers()[i].get(), i);
+        thread_->addWorker(getSharedWorkers()[i].get());
     }
     thread_->start();
 }
@@ -422,15 +416,14 @@ struct nixlUcxBackendSharedState;
  */
 class nixlUcxChunkBackendReqH : public nixlUcxBackendReqH {
 public:
-    nixlUcxChunkBackendReqH() : nixlUcxBackendReqH(nullptr, UINT64_MAX) {}
+    nixlUcxChunkBackendReqH() : nixlUcxBackendReqH(nullptr) {}
 
     void
     startXfer(const std::shared_ptr<nixlUcxBackendSharedState> &shared_state,
-              nixlUcxWorker *worker,
-              size_t worker_id) {
+              nixlUcxWorker *worker) {
         NIXL_ASSERT(sharedState_.get() == nullptr);
         sharedState_ = shared_state;
-        setWorker(worker, worker_id);
+        setWorker(worker);
     }
 
     void
@@ -441,8 +434,10 @@ public:
 
     friend std::ostream &
     operator<<(std::ostream &os, const nixlUcxChunkBackendReqH &chunk) {
-        return os << "chunk " << &chunk << "{worker_id: " << chunk.getWorkerId()
-                  << ", state: " << chunk.sharedState_.get() << "}";
+        std::string id = chunk.getWorker() ? std::to_string(chunk.getWorkerId()) : "none";
+        os << "chunk " << &chunk << "{worker_id: " << id << ", state: " << chunk.sharedState_.get()
+           << "}";
+        return os;
     }
 
 private:
@@ -477,7 +472,7 @@ nixlUcxChunkBackendReqH::complete(const nixl_status_t status) {
     }
     sharedState_->pendingReqs.fetch_sub(1);
     NIXL_TRACE << *this << " completed with status: " << status << ", " << *sharedState_;
-    setWorker(nullptr, UINT64_MAX);
+    setWorker(nullptr);
     sharedState_.reset();
 }
 
@@ -499,11 +494,8 @@ nixlUcxChunkBackendReqH::status() {
  */
 class nixlUcxCompositeBackendReqH : public nixlUcxBackendReqH {
 public:
-    nixlUcxCompositeBackendReqH(nixlUcxWorker *worker,
-                                size_t worker_id,
-                                size_t chunk_size,
-                                size_t num_chunks)
-        : nixlUcxBackendReqH(worker, worker_id),
+    nixlUcxCompositeBackendReqH(nixlUcxWorker *worker, size_t chunk_size, size_t num_chunks)
+        : nixlUcxBackendReqH(worker),
           sharedState_(std::make_shared<nixlUcxBackendSharedState>()),
           chunkSize_(chunk_size) {
         sharedState_->chunks.resize(num_chunks);
@@ -527,9 +519,9 @@ public:
     }
 
     [[nodiscard]] nixlUcxChunkBackendReqH *
-    startChunk(size_t idx, nixlUcxWorker *worker, size_t worker_id) {
+    startChunk(size_t idx, nixlUcxWorker *worker) {
         nixlUcxChunkBackendReqH *chunk = &sharedState_->chunks[idx];
-        chunk->startXfer(sharedState_, worker, worker_id);
+        chunk->startXfer(sharedState_, worker);
         return chunk;
     }
 
@@ -658,9 +650,8 @@ nixlUcxThreadPoolEngine::nixlUcxThreadPoolEngine(const nixlBackendInitParams &in
     io_.reset(new asio::io_context());
     dedicatedThreads_.reserve(dedicated_workers.size());
     for (size_t i = 0; i < dedicated_workers.size(); ++i) {
-        const size_t worker_id = getSharedWorkersSize() + i;
         dedicatedThreads_.emplace_back(std::make_unique<nixlUcxDedicatedThread>(this, *io_));
-        dedicatedThreads_.back()->addWorker(dedicated_workers[i].get(), worker_id);
+        dedicatedThreads_.back()->addWorker(dedicated_workers[i].get());
         dedicatedThreads_.back()->start();
     }
 }
@@ -689,9 +680,8 @@ nixlUcxThreadPoolEngine::prepXfer(const nixl_xfer_op_t &operation,
     size_t chunk_size = std::max(batch_size / dedicatedThreads_.size(), splitBatchSize_);
     size_t num_chunks = (batch_size + chunk_size - 1) / chunk_size;
 
-    size_t worker_id = getSharedWorkerId();
     const auto comp_handle = new nixlUcxCompositeBackendReqH(
-        getSharedWorker(worker_id).get(), worker_id, chunk_size, num_chunks);
+        getSharedWorker(getSharedWorkerId()).get(), chunk_size, num_chunks);
     NIXL_TRACE << "created " << *comp_handle;
     handle = comp_handle;
     return NIXL_SUCCESS;
@@ -727,7 +717,7 @@ nixlUcxThreadPoolEngine::sendXferRange(const nixl_xfer_op_t &operation,
             NIXL_ASSERT(thread != nullptr);
 
             nixlUcxChunkBackendReqH *chunk_handle =
-                comp_handle->startChunk(i, thread->getWorkers()[0], thread->getWorkerId());
+                comp_handle->startChunk(i, thread->getWorkers()[0]);
             NIXL_TRACE << "dedicated " << *thread << " starting " << *chunk_handle;
 
             size_t start_idx = i * chunk_size;
@@ -815,7 +805,7 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
     workers_.reserve(num_workers);
     for (size_t i = 0; i < num_workers; i++) {
         workers_.emplace_back(
-            std::make_unique<nixlUcxWorker>(*uc, err_handling_mode, ep_close_flags));
+            std::make_unique<nixlUcxWorker>(*uc, err_handling_mode, ep_close_flags, i));
     }
 
     auto &worker = workers_.front();
@@ -1070,7 +1060,7 @@ nixl_status_t nixlUcxEngine::prepXfer (const nixl_xfer_op_t &operation,
 
     const size_t worker_id = getSharedWorkerId(opt_args);
     /* TODO: try to get from a pool first */
-    handle = new nixlUcxBackendReqH(getSharedWorker(worker_id).get(), worker_id);
+    handle = new nixlUcxBackendReqH(getSharedWorker(worker_id).get());
 
     return NIXL_SUCCESS;
 }
@@ -1443,7 +1433,7 @@ nixlUcxEngine::prepMemView(const nixl_remote_meta_dlist_t &dlist,
                            const nixl_opt_b_args_t *opt_args) const {
     const size_t worker_id = getSharedWorkerId(opt_args);
     try {
-        mvh = nixl::ucx::createMemList(dlist, worker_id, *getSharedWorker(worker_id));
+        mvh = nixl::ucx::createMemList(dlist, *getSharedWorker(worker_id));
         return NIXL_SUCCESS;
     }
     catch (const std::exception &e) {

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -798,7 +798,8 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
                                           num_workers,
                                           init_params.syncMode,
                                           num_device_channels,
-                                          engine_config);
+                                          engine_config,
+                                          localAgent);
 
     uc->warnAboutHardwareSupportMismatch();
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -28,7 +28,6 @@
 
 #include "common/hw_info.h"
 #include "common/nixl_log.h"
-#include "common/operators.h"
 #include "config.h"
 #include "serdes/serdes.h"
 
@@ -519,9 +518,10 @@ toUcsThreadModeChecked(const nixl::ucx::mt_mode_t t) {
 }
 
 struct nixlUcpWorkerParams : ucp_worker_params_t {
-    explicit nixlUcpWorkerParams(const nixl::ucx::mt_mode_t t) {
-        field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    nixlUcpWorkerParams(const nixl::ucx::mt_mode_t t, const std::string &worker_name) {
+        field_mask = UCP_WORKER_PARAM_FIELD_THREAD_MODE | UCP_WORKER_PARAM_FIELD_NAME;
         thread_mode = toUcsThreadModeChecked(t);
+        name = worker_name.c_str();
     }
 };
 
@@ -530,26 +530,34 @@ static_assert(sizeof(nixlUcpWorkerParams) == sizeof(ucp_worker_params_t));
 } // namespace
 
 ucp_worker *
-nixlUcxWorker::createUcpWorker(const nixlUcxContext &ctx) {
+nixlUcxWorker::createUcpWorker(const nixlUcxContext &ctx) const {
     ucp_worker *worker = nullptr;
-    const nixlUcpWorkerParams params(ctx.mtType_);
+    const nixlUcpWorkerParams params(ctx.mtType_, name_);
     const ucs_status_t status = ucp_worker_create(ctx.ctx, &params, &worker);
     if (status != UCS_OK) {
-        throw std::runtime_error(std::string("Failed to create UCX worker: ") +
+        throw std::runtime_error(std::string("Failed to create UCX worker ") + name_ + ": " +
                                  ucs_status_string(status));
     }
 
     return worker;
 }
 
+std::ostream &
+operator<<(std::ostream &os, const nixlUcxWorker &worker) {
+    return os << "nixlUcxWorker " << worker.getName();
+}
+
 nixlUcxWorker::nixlUcxWorker(const nixlUcxContext &ctx,
                              ucp_err_handling_mode_t err_handling_mode,
                              uint32_t ep_close_flags,
                              size_t id)
-    : worker(createUcpWorker(ctx), &ucp_worker_destroy),
+    : name_(ctx.getName() + ":" + std::to_string(id)),
+      worker(createUcpWorker(ctx), &ucp_worker_destroy),
       err_handling_mode_(err_handling_mode),
       epCloseFlags_(ep_close_flags),
-      id_(id) {}
+      id_(id) {
+    NIXL_DEBUG << *this << ": created ucp worker " << worker.get();
+}
 
 std::string
 nixlUcxWorker::epAddr() {
@@ -558,8 +566,8 @@ nixlUcxWorker::epAddr() {
     wattr.field_mask = UCP_WORKER_ATTR_FIELD_ADDRESS;
     const ucs_status_t status = ucp_worker_query(worker.get(), &wattr);
     if (UCS_OK != status) {
-        throw std::runtime_error(std::string("Unable to query UCX worker address: ") +
-                                 ucs_status_string(status));
+        throw std::runtime_error(std::string("Unable to query address of UCX worker ") + name_ +
+                                 ": " + ucs_status_string(status));
     }
 
     const std::string result = nixlSerDes::_bytesToString(wattr.address, wattr.address_length);
@@ -570,10 +578,13 @@ nixlUcxWorker::epAddr() {
 std::unique_ptr<nixlUcxEp>
 nixlUcxWorker::connect(void *addr) {
     try {
-        return std::make_unique<nixlUcxEp>(worker.get(), addr, err_handling_mode_, epCloseFlags_);
+        auto ep =
+            std::make_unique<nixlUcxEp>(worker.get(), addr, err_handling_mode_, epCloseFlags_);
+        NIXL_DEBUG << *this << ": created ep " << ep->getEp();
+        return ep;
     }
     catch (const std::exception &e) {
-        NIXL_ERROR << "UCX endpoint create failed: " << e.what();
+        NIXL_ERROR << *this << ": UCX endpoint create failed: " << e.what();
         return {};
     }
 }
@@ -621,8 +632,8 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         }
     }
 
-    NIXL_DEBUG << *this << ": registered " << nixl_mem_type << " " << mem.size << " bytes at "
-               << mem.base << ", memh " << mem.memh;
+    NIXL_DEBUG << *this << ": registered " << mem.size << " bytes at " << mem.base << ", memh "
+               << mem.memh;
     return 0;
 }
 
@@ -699,6 +710,8 @@ nixlUcxWorker::regAmCallback(nixl::ucx::am_cb_op_t msg_id, ucp_am_recv_callback_
         // TODO: error handling
         return -1;
     }
+
+    NIXL_DEBUG << *this << ": registered AM callback for " << msg_id;
     return 0;
 }
 
@@ -733,6 +746,7 @@ nixlUcxWorker::reqRelease(nixlUcxReq req) {
 
 void
 nixlUcxWorker::reqCancel(nixlUcxReq req) {
+    NIXL_DEBUG << *this << ": cancelling request " << req;
     ucp_request_cancel(worker.get(), req);
 }
 
@@ -746,8 +760,8 @@ nixlUcxWorker::getEfd() const {
     int fd;
     const auto status = ucp_worker_get_efd(worker.get(), &fd);
     if (status != UCS_OK) {
-        const auto err_str =
-            std::string("Couldn't obtain fd for a worker: ") + ucs_status_string(status);
+        const auto err_str = std::string("Couldn't obtain fd for UCX worker ") + name_ + ": " +
+            ucs_status_string(status);
         NIXL_ERROR << err_str;
         throw std::runtime_error(err_str);
     }

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -409,13 +409,20 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
                                unsigned long num_workers,
                                nixl_thread_sync_t sync_mode,
                                size_t num_device_channels,
-                               const std::string &engine_config)
+                               const std::string &engine_config,
+                               const std::string &name)
     : mtType_(makeMtType(prog_thread, sync_mode)),
-      ucpVersion_(makeUcpVersion()) {
+      ucpVersion_(makeUcpVersion()),
+      name_(name) {
 
     ucp_params_t ucp_params;
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
     ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64 | UCP_FEATURE_AM;
+
+    if (!name_.empty()) {
+        ucp_params.field_mask |= UCP_PARAM_FIELD_NAME;
+        ucp_params.name = name_.c_str();
+    }
 #ifdef HAVE_UCX_GPU_DEVICE_API
     ucp_params.features |= UCP_FEATURE_DEVICE;
 #endif
@@ -480,13 +487,18 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
 
     const auto status = ucp_init(&ucp_params, config.getUcpConfig(), &ctx);
     if (status != UCS_OK) {
-        throw std::runtime_error("Failed to create UCX context: " +
+        throw std::runtime_error(std::string("Failed to create UCX context ") + name_ + ": " +
                                  std::string(ucs_status_string(status)));
     }
 }
 
 nixlUcxContext::~nixlUcxContext() {
     ucp_cleanup(ctx);
+}
+
+std::ostream &
+operator<<(std::ostream &os, const nixlUcxContext &ctx) {
+    return os << "nixlUcxContext " << ctx.getName();
 }
 
 namespace {
@@ -584,7 +596,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
 
     ucs_status_t status = ucp_mem_map(ctx, &mem_params, &mem.memh);
     if (status != UCS_OK) {
-        NIXL_ERROR << "Failed to ucp_mem_map: " << ucs_status_string(status);
+        NIXL_ERROR << *this << ": failed to ucp_mem_map: " << ucs_status_string(status);
         return -1;
     }
 
@@ -593,13 +605,14 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         attr.field_mask = UCP_MEM_ATTR_FIELD_MEM_TYPE;
         status = ucp_mem_query(mem.memh, &attr);
         if (status != UCS_OK) {
-            NIXL_ERROR << "Failed to ucp_mem_query: " << ucs_status_string(status);
+            NIXL_ERROR << *this << ": failed to ucp_mem_query: " << ucs_status_string(status);
             ucp_mem_unmap(ctx, mem.memh);
             return -1;
         }
 
         if (attr.mem_type == UCS_MEMORY_TYPE_HOST) {
-            NIXL_ERROR << "VRAM memory is detected as host by UCX. "
+            NIXL_ERROR << *this
+                       << ": VRAM memory is detected as host by UCX. "
                           "UCX is likely not configured with CUDA/ROCm support. "
                           "VRAM registration cannot proceed.";
             ucp_mem_unmap(ctx, mem.memh);
@@ -617,7 +630,7 @@ nixlUcxContext::packRkey(nixlUcxMem &mem) {
 
     const ucs_status_t status = ucp_rkey_pack(ctx, mem.memh, &rkey_buf, &size);
     if (status != UCS_OK) {
-        NIXL_ERROR << "Failed to ucp_rkey_pack: " << ucs_status_string(status);
+        NIXL_ERROR << *this << ": failed to ucp_rkey_pack: " << ucs_status_string(status);
         return {};
     }
     const std::string result = nixlSerDes::_bytesToString(rkey_buf, size);
@@ -637,7 +650,7 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
     };
     const auto status = ucp_context_query(ctx, &attr);
     if (status != UCS_OK) {
-        NIXL_WARN << "Failed to query UCX context: " << ucs_status_string(status) << ", "
+        NIXL_WARN << *this << ": failed to query UCX context: " << ucs_status_string(status) << ", "
                   << "hardware support mismatch check will be skipped";
         return;
     }
@@ -645,14 +658,14 @@ nixlUcxContext::warnAboutHardwareSupportMismatch() const {
     const auto &hw_info = nixl::hwInfo::instance();
 
     if (hw_info.numNvidiaGpus > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_CUDA)) {
-        NIXL_WARN << hw_info.numNvidiaGpus
+        NIXL_WARN << *this << ": " << hw_info.numNvidiaGpus
                   << " NVIDIA GPU(s) were detected, but UCX CUDA support was not found! "
                   << "GPU memory is not supported.";
     }
 
     if (ucpVersion_ >= ucp_version_mem_type_rdma) {
         if (hw_info.numIbDevices > 0 && !UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_RDMA)) {
-            NIXL_WARN << hw_info.numIbDevices
+            NIXL_WARN << *this << ": " << hw_info.numIbDevices
                       << " IB device(s) were detected, but accelerated IB support was not found! "
                          "Performance may be degraded.";
         }

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -567,7 +567,7 @@ nixlUcxWorker::epAddr() {
 }
 
 std::unique_ptr<nixlUcxEp>
-nixlUcxWorker::connect(void *addr, std::size_t size) {
+nixlUcxWorker::connect(void *addr) {
     try {
         return std::make_unique<nixlUcxEp>(worker.get(), addr, err_handling_mode_, epCloseFlags_);
     }

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -531,10 +531,12 @@ nixlUcxWorker::createUcpWorker(const nixlUcxContext &ctx) {
 
 nixlUcxWorker::nixlUcxWorker(const nixlUcxContext &ctx,
                              ucp_err_handling_mode_t err_handling_mode,
-                             uint32_t ep_close_flags)
+                             uint32_t ep_close_flags,
+                             size_t id)
     : worker(createUcpWorker(ctx), &ucp_worker_destroy),
       err_handling_mode_(err_handling_mode),
-      epCloseFlags_(ep_close_flags) {}
+      epCloseFlags_(ep_close_flags),
+      id_(id) {}
 
 std::string
 nixlUcxWorker::epAddr() {

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -28,6 +28,7 @@
 
 #include "common/hw_info.h"
 #include "common/nixl_log.h"
+#include "common/operators.h"
 #include "config.h"
 #include "serdes/serdes.h"
 
@@ -620,6 +621,8 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
         }
     }
 
+    NIXL_DEBUG << *this << ": registered " << nixl_mem_type << " " << mem.size << " bytes at "
+               << mem.base << ", memh " << mem.memh;
     return 0;
 }
 
@@ -635,11 +638,14 @@ nixlUcxContext::packRkey(nixlUcxMem &mem) {
     }
     const std::string result = nixlSerDes::_bytesToString(rkey_buf, size);
     ucp_rkey_buffer_release(rkey_buf);
+    NIXL_DEBUG << *this << ": packed rkey of " << size << " bytes for memh " << mem.memh;
     return result;
 }
 
 void
 nixlUcxContext::memDereg(nixlUcxMem &mem) {
+    NIXL_DEBUG << *this << ": deregistering " << mem.size << " bytes at " << mem.base << ", memh "
+               << mem.memh;
     ucp_mem_unmap(ctx, mem.memh);
 }
 

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -217,7 +217,7 @@ public:
     [[nodiscard]] std::string
     epAddr();
     [[nodiscard]] std::unique_ptr<nixlUcxEp>
-    connect(void *addr, size_t size);
+    connect(void *addr);
 
     /* Active message handling */
     int

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -193,7 +193,8 @@ public:
     explicit nixlUcxWorker(
         const nixlUcxContext &,
         ucp_err_handling_mode_t ucp_err_handling_mode = UCP_ERR_HANDLING_MODE_NONE,
-        uint32_t ep_close_flags = 0);
+        uint32_t ep_close_flags = 0,
+        size_t id = 0);
 
     nixlUcxWorker(nixlUcxWorker &&) = delete;
     nixlUcxWorker(const nixlUcxWorker &) = delete;
@@ -242,6 +243,11 @@ public:
         return worker.get();
     }
 
+    [[nodiscard]] size_t
+    getId() const noexcept {
+        return id_;
+    }
+
 private:
     [[nodiscard]] static ucp_worker *
     createUcpWorker(const nixlUcxContext &);
@@ -249,6 +255,7 @@ private:
     const std::unique_ptr<ucp_worker, void (*)(ucp_worker *)> worker;
     const ucp_err_handling_mode_t err_handling_mode_;
     const uint32_t epCloseFlags_;
+    const size_t id_;
 };
 
 [[nodiscard]] nixl_b_params_t

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -258,15 +258,24 @@ public:
         return id_;
     }
 
-private:
-    [[nodiscard]] static ucp_worker *
-    createUcpWorker(const nixlUcxContext &);
+    [[nodiscard]] const std::string &
+    getName() const noexcept {
+        return name_;
+    }
 
+private:
+    [[nodiscard]] ucp_worker *
+    createUcpWorker(const nixlUcxContext &) const;
+
+    const std::string name_;
     const std::unique_ptr<ucp_worker, void (*)(ucp_worker *)> worker;
     const ucp_err_handling_mode_t err_handling_mode_;
     const uint32_t epCloseFlags_;
     const size_t id_;
 };
+
+std::ostream &
+operator<<(std::ostream &os, const nixlUcxWorker &worker);
 
 [[nodiscard]] nixl_b_params_t
 get_ucx_backend_common_options();

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -153,6 +153,7 @@ private:
     ucp_context_h ctx;
     const nixl::ucx::mt_mode_t mtType_;
     const unsigned ucpVersion_;
+    const std::string name_;
 
 public:
     nixlUcxContext(const std::vector<std::string> &devs,
@@ -160,7 +161,8 @@ public:
                    unsigned long num_workers,
                    nixl_thread_sync_t sync_mode,
                    size_t num_device_channels,
-                   const std::string &engine_conf = "");
+                   const std::string &engine_conf = "",
+                   const std::string &name = "");
     ~nixlUcxContext();
 
     nixlUcxContext(nixlUcxContext &&) = delete;
@@ -170,6 +172,11 @@ public:
     operator=(nixlUcxContext &&) = delete;
     void
     operator=(const nixlUcxContext &) = delete;
+
+    [[nodiscard]] const std::string &
+    getName() const noexcept {
+        return name_;
+    }
 
     /* Memory management */
     int
@@ -184,6 +191,9 @@ public:
 
     friend class nixlUcxWorker;
 };
+
+std::ostream &
+operator<<(std::ostream &os, const nixlUcxContext &ctx);
 
 [[nodiscard]] bool
 nixlUcxMtLevelIsSupported(const nixl::ucx::mt_mode_t) noexcept;

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -465,7 +465,7 @@ TEST_P(TestErrorHandling, ErrorCallbackMarksEndpointFailedWithoutClosingIt) {
     nixlUcxWorker consumer(consumer_context, UCP_ERR_HANDLING_MODE_PEER);
     nixlUcxWorker producer(producer_context, UCP_ERR_HANDLING_MODE_PEER);
     std::string producer_address = producer.epAddr();
-    auto endpoint = consumer.connect(producer_address.data(), producer_address.size());
+    auto endpoint = consumer.connect(producer_address.data());
     ASSERT_NE(endpoint, nullptr);
 
     const ucp_ep_h native_endpoint = endpoint->getEp();

--- a/test/unit/plugins/ucx/ucx_worker_test.cpp
+++ b/test/unit/plugins/ucx/ucx_worker_test.cpp
@@ -93,7 +93,7 @@ main() {
     for (i = 0; i < 2; i++) {
         const std::string addr = w[i].epAddr();
         assert(!addr.empty());
-        auto result = w[!i].connect((void *)addr.data(), addr.size());
+        auto result = w[!i].connect((void *)addr.data());
         assert(result);
         ep[!i] = std::move(result);
         assert(0 == c[i].memReg(buffer[i], buf_size, mem[i], nixl_mem_type));


### PR DESCRIPTION
## What?
Improve traceability of NIXL UCX context and worker

## Why?
When investigating NIXL and UCX logs it's impossible to understand **which** context and worker produces the log output.

## How?
- Moves ID to nixlUcxWorker class, instead of passing as a pair
- Added name to nixlUcxContext based on agent name, updated existing logging
- Added more debug context logs
- Added name to nixlUcxWorker to better distinguish between them
- Updated all the worker logs, added debug logs
- Removed dead code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - UCX workers now have clearer names and identifiers, making connection and transfer activity easier to trace.
  - Enhanced error messages and diagnostic logging provide more context when worker initialization, memory operations, or endpoint connections fail.
  - Simplified worker and connection handling improves consistency across transfers and memory operations.
- **Compatibility**
  - Updated UCX connection interfaces maintain existing behavior while reducing redundant configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->