### PR TITLE
EP/TESTS: Skip Kineto reporting when CUDA profiling is unavailable - 1.4.0

### DIFF
--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -39,6 +39,7 @@ from plan import Plan
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import (  # noqa: E402
+    KinetoUnavailableError,
     bench,
     bench_kineto,
     calc_diff,
@@ -435,14 +436,18 @@ def test_main(
 
     for return_recv_hook in (False, True):
         buffer.barrier()
-        dispatch_t, combine_t = bench_kineto(
-            partial(test_func, return_recv_hook=return_recv_hook),
-            kernel_names=("dispatch", "combine"),
-            barrier_comm_profiling=True,
-            suppress_kineto_output=False,
-            num_kernels_per_period=2 if return_recv_hook else 1,
-            barrier_fn=test_barrier,
-        )
+        try:
+            dispatch_t, combine_t = bench_kineto(
+                partial(test_func, return_recv_hook=return_recv_hook),
+                kernel_names=("dispatch", "combine"),
+                barrier_comm_profiling=True,
+                suppress_kineto_output=False,
+                num_kernels_per_period=2 if return_recv_hook else 1,
+                barrier_fn=test_barrier,
+            )
+        except KinetoUnavailableError as exc:
+            print(f"[rank {rank}] Skipping Kineto profiling: {exc}", flush=True)
+            return
         if not return_recv_hook:
             print(
                 f"[rank {rank}] Dispatch bandwidth: {num_dispatch_comm_bytes / 1e9 / dispatch_t:.2f} GB/s, avg_t={dispatch_t * 1e6:.2f} us | "

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -31,6 +31,10 @@ import torch
 import torch.distributed as dist
 
 
+class KinetoUnavailableError(RuntimeError):
+    """Raised when the profiler records no CUDA timing activities."""
+
+
 def init_dist(local_rank: int, num_local_ranks: int):
     # NOTES: you may rewrite this function with your own cluster settings
     ip = os.getenv("MASTER_ADDR", "127.0.0.1")
@@ -221,17 +225,23 @@ def bench_kineto(
     # Parse the profiling table
     assert isinstance(kernel_names, str) or isinstance(kernel_names, tuple)
     is_tuple = isinstance(kernel_names, tuple)
-    prof_lines = (
-        prof.key_averages()
-        .table(sort_by="cuda_time_total", max_name_column_width=100)
-        .split("\n")
+    prof_table = prof.key_averages().table(
+        sort_by="cuda_time_total", max_name_column_width=100
     )
+
+    if "CUDA" not in prof_table:
+        raise KinetoUnavailableError(
+            "Kineto recorded no CUDA timing activities; "
+            "per-kernel profiling is unavailable"
+        )
+
+    prof_lines = prof_table.split("\n")
     kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
     assert all([isinstance(name, str) for name in kernel_names])
     for name in kernel_names:
         assert (
             sum([name in line for line in prof_lines]) == 1
-        ), f"Errors of the kernel {name} in the profiling table"
+        ), f"Errors of the kernel {name} in the profiling table:\n{prof_table}"
 
     # Save chrome traces
     if trace_path is not None:


### PR DESCRIPTION
## What?
Skip optional Kineto reporting when CUDA profiling data is unavailable.

## Why?
CUPTI 12 is incompatible with gb300 and fails to initialize, leaving Kineto without CUDA timing. NIXL previously reported this as a misleading kernel-dispatch assertion.

## How?
Detect missing CUDA profiling data, print a clear skip message, and preserve kernel validation when profiling is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added build verification for container images across supported architectures and targets.
  * Improved wheel builds with cached base images for faster CI execution.
  * Added optional support for Infinia libraries and the UCX SPcX plugin during builds.

* **Bug Fixes**
  * Improved profiling diagnostics when CUDA timing data is unavailable.

* **Documentation**
  * Updated CI documentation to describe the expanded validation workflow and image caching.

* **Chores**
  * Updated the project version to 1.4.0 and refreshed attribution metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->