### PR TITLE
ci: request a whole node for the vLLM/SGLang sanity allocation

### DIFF
--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -220,9 +220,6 @@ env:
   SLURM_HEAD_NODE: dlcluster.nvidia.com
   SLURM_HEAD_USER: svc-nixl
   SLURM_ACCOUNT: oberon-gb-ci
-  SLURM_GRES: gpu:2
-  SLURM_MEM: 128G
-  SLURM_MINCPUS: 24
   SLURM_JOB_TIMEOUT: '01:30:00'
   SLURM_IMMEDIATE_TIMEOUT: "3600"
   SSH_CREDENTIALS_ID: 'svc-nixl-ssh_key'
@@ -353,10 +350,7 @@ steps:
       jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${fw}_${BUILD_NUMBER}.txt"
       credentialsId: "${SSH_CREDENTIALS_ID}"
       extraArgs: [
-        "--account=${SLURM_ACCOUNT}",
-        "--gres=${SLURM_GRES}",
-        "--mincpus=${SLURM_MINCPUS}",
-        "--mem=${SLURM_MEM}"
+        "--account=${SLURM_ACCOUNT}"
       ]
 
   # The two run steps are identical modulo ${fw} as well, but are kept as separate,

--- a/.gitlab/test_vllm_sglang_sanity.sh
+++ b/.gitlab/test_vllm_sglang_sanity.sh
@@ -18,8 +18,9 @@ FRAMEWORK="${1:?usage: test_vllm_sglang_sanity.sh <vllm|sglang>}"
 # resolve the model by its HuggingFace repo id from the cache prefetched below.
 MODEL="${NIXL_SANITY_MODEL_ID:?NIXL_SANITY_MODEL_ID not set (set by the base image)}"
 
-# Multiple sanity jobs can share a SLURM node (8 GPUs, 2 per job) and the srun/enroot
-# containers use HOST networking, so fixed ports would collide across concurrent jobs.
+# This run needs several listeners at once (prefill, decode, proxy, and the frameworks'
+# own side channels) and the srun/enroot containers use HOST networking, so fixed ports
+# would collide with each other and with anything else already bound on the node.
 # Reuse the CI helper (from the workspace copied into the image) to hand out free TCP
 # ports that roll over. common.sh references unset env vars (CI_CONCURRENT_ID/
 # EXECUTOR_NUMBER) at source time, so disable nounset while sourcing, then restore it.
@@ -41,9 +42,9 @@ PROXY_PORT="${PROXY_PORT:-$(get_next_tcp_port)}"
 PROMPT="${PROMPT:-San Francisco is a}"
 SERVER_TIMEOUT="${SERVER_TIMEOUT:-300}"
 # Fraction of GPU memory each server may claim. The frameworks default to ~0.9, which
-# demands nearly the whole GPU to be free at startup; on the shared GB200 CI nodes other
-# processes may already hold GPU memory, and the sanity model needs only a small slice
-# anyway (0.3 of a 186 GiB GB200 is ~56 GiB, ample for 8B weights + KV cache).
+# demands nearly the whole GPU to be free at startup; the sanity model needs only a small
+# slice (0.3 of a 186 GiB GB200 is ~56 GiB, ample for 8B weights + KV cache), so the lower
+# value leaves room for anything the driver or a previous step has not yet released.
 GPU_MEM_FRACTION="${GPU_MEM_FRACTION:-0.3}"
 PROXY_TIMEOUT="${PROXY_TIMEOUT:-120}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-120}"
@@ -77,8 +78,8 @@ wait_for() {  # wait_for <url> <timeout_s>
 }
 
 # Servers are started with setsid so each gets its own process group; cleanup signals the
-# whole group so forked engine/worker subprocesses can't survive and keep holding GPUs on
-# the shared SLURM node.
+# whole group so forked engine/worker subprocesses can't survive this job and keep holding
+# GPUs against whatever the SLURM node runs next.
 pids=()
 cleanup() {
   for p in "${pids[@]:-}"; do
@@ -111,8 +112,7 @@ if [ "$FRAMEWORK" = "vllm" ]; then
   python3 -c "from importlib.metadata import version; print('vllm', version('vllm'))"
 
   # Prefill and decode are co-located on one node, so each needs its own NIXL
-  # side-channel handshake port (default 5600 for both -> "Address already in use"),
-  # and they must be host-unique so concurrent jobs on the same node don't collide.
+  # side-channel handshake port (default 5600 for both -> "Address already in use").
   PREFILL_SIDE_PORT="$(get_next_tcp_port)"
   DECODE_SIDE_PORT="$(get_next_tcp_port)"
   setsid env CUDA_VISIBLE_DEVICES=0 VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_SIDE_PORT" \
@@ -142,8 +142,8 @@ elif [ "$FRAMEWORK" = "sglang" ]; then
   python3 -c "from importlib.metadata import version; print('sglang', version('sglang'))"
 
   # The prefill binds a bootstrap server on --disaggregation-bootstrap-port (default
-  # 8998); make it host-unique so concurrent jobs on the same node don't collide. Both
-  # sides are configured with the same port (decode connects to the prefill's bootstrap).
+  # 8998); take a free port rather than trusting the default to be unbound. Both sides
+  # are configured with the same port (decode connects to the prefill's bootstrap).
   BOOTSTRAP_PORT="$(get_next_tcp_port)"
   setsid env CUDA_VISIBLE_DEVICES=0 python3 -m sglang.launch_server --model-path "$MODEL" \
     --mem-fraction-static "$GPU_MEM_FRACTION" \


### PR DESCRIPTION
The sanity allocation asked for `--gres=gpu:2 --mincpus=24 --mem=128G`, copied from the mizu-based matrices. On dlcluster an allocation gets the whole node, so asking for a slice of a 4-GPU node is what let SLURM place a second job on it.

The sanity servers are pinned to `CUDA_VISIBLE_DEVICES=0` and `1` while the enroot container is not device-constrained — `nvidia-smi -L` inside it lists all four cards — so both jobs drove the same two physical GPUs. The prefill server came up on a card another job had already filled (15.29 GB free of 186 GB, while its sibling card had 183.44 GB) and died at init with `RuntimeError: Not enough memory` (SGLang) or a free-memory `ValueError` (vLLM), after which the health check burned its full 300s on a process that was already gone. Seen on `nixl-ci-build-wheel` 1212, 1214 and 1215.

- Drop `--gres`, `--mincpus` and `--mem` from the sanity allocation and pass only `--account`, matching the other two dlcluster jobs (`test-dl-matrix`, `test-dl-ep-matrix`).
- Remove the now-unused `SLURM_GRES` / `SLURM_MEM` / `SLURM_MINCPUS` variables.
- Update the sanity script comments that justified port handling, GPU memory fraction and process cleanup by several jobs sharing a node — that no longer happens, and the port comment also had the node at 8 GPUs rather than 4. Comments only, no behaviour change.

The allocation then covers the node and nothing else lands on it, so the fixed device indices in `.gitlab/test_vllm_sglang_sanity.sh` are correct as they stand.

Separately worth raising with the cluster admins: `ConstrainDevices=yes` in `cgroup.conf` would stop a container seeing GPUs outside its allocation at all, which is the general fix for this class of bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build environment resource allocation settings by adjusting SLURM-related parameters used during wheel builds.
  * Updated internal test script comments to clarify dynamic port selection and related process/handshake behavior when running multiple server components concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->