### PR TITLE
ci: build wheel_base on the ubi8 base (public manylinux + NG… (#1991)

### DIFF
--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -88,7 +88,7 @@ runs_on_dockers:
       file: 'contrib/Dockerfile.manylinux',
       name: "${WHEEL_BASE_IMAGE_NAME}",
       tag: "${CI_IMAGE_TAG}",
-      build_args: '--build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_IMAGE_TAG=${BASE_TAG} --build-arg ARCH=${arch} --build-arg NPROC=${NPROC} --build-arg GRPC_NPROC=${GRPC_NPROC} --target wheel_base'
+      build_args: '--build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_IMAGE_TAG=${BASE_TAG} --build-arg ARCH=${arch} --build-arg NPROC=${NPROC} --build-arg GRPC_NPROC=${GRPC_NPROC} --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg MANYLINUX_VERSION=${MANYLINUX_VERSION} --target wheel_base'
     }
 
 # =============================================================================
@@ -116,10 +116,19 @@ matrix:
 env:
   NPROC: 32
   GRPC_NPROC: 10
-  BASE_IMAGE: "${registry_host}/sw-nbu-swx-nixl-docker-local/base/cuda"
-  BASE_TAG: '13.0-devel-manylinux--25.09'
-  # CI image tag for wheel_base + build_helper + the sanity base images
-  # (auto-derived by cidemo-init.sh — the "CI_MANAGED" placeholder must not be hand-edited)
+  # Option B base: wheel_base builds on the public PyPA manylinux_2_28 image and
+  # copies CUDA from an el8/ubi8 NGC CUDA *devel* image (BASE_IMAGE:BASE_TAG).
+  # REACHABILITY: the blossom runner must be able to pull nvcr.io (and quay.io for
+  # the manylinux base). If it cannot, repoint BASE_IMAGE at the Artifactory ubi8
+  # mirror that svc-nixl-new-artifactory-token can pull, keeping the same ubi8 tag.
+  BASE_IMAGE: "nvcr.io/nvidia/cuda"
+  BASE_TAG: '13.0.1-devel-ubi8'
+  # CUDA MAJOR.MINOR — drives the torch cuXXX index + cu12/cu13 meta-wheel split.
+  CUDA_VERSION: "13.0"
+  # Pin the PyPA manylinux release so the toolchain is reproducible.
+  MANYLINUX_VERSION: "2026.06.06-1"
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
   CI_IMAGE_TAG: "CI_MANAGED"
   WHL_BASE: "manylinux_2_28"
   TORCH_VERSIONS: "2.13"
@@ -158,6 +167,7 @@ steps:
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
+        --cuda-version "${CUDA_VERSION}" \
         --wheel-base "${WHL_BASE}" \
         --python-versions "${python_version}" \
         --arch ${arch} \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -14,16 +14,59 @@
 # limitations under the License.
 
 
-ARG BASE_IMAGE
+# === Manylinux wheel build (public PyPA base + NGC CUDA) — "Option B" =========
+# Build the wheel_base deps stage on the PUBLIC PyPA manylinux_2_28 image and
+# bring CUDA in from a public NGC CUDA *devel* image (el8/ubi8), instead of a
+# combined internal manylinux+CUDA base. el8/ubi8 matches the AlmaLinux-8
+# manylinux base. ARCH / MANYLINUX_VERSION / BASE_IMAGE must be declared before
+# the FROM lines that interpolate them.
+ARG ARCH="x86_64"
+# Pin the PyPA manylinux release so the toolchain (gcc, CMake, CPython) is
+# reproducible; the implicit :latest would drift between builds.
+ARG MANYLINUX_VERSION="2026.06.06-1"
+# CUDA toolkit provider: a public NGC CUDA *devel* image, el8/ubi8 to match the
+# AlmaLinux-8 manylinux base (e.g. nvcr.io/nvidia/cuda:13.0.1-devel-ubi8).
+ARG BASE_IMAGE="nvcr.io/nvidia/cuda"
 ARG BASE_IMAGE_TAG
 # When overridden to an Artifactory URL, the wheel stage pulls the pre-built deps
-# image instead of building them locally. Default keeps the single-stage local build.
+# image instead of building wheel_base locally (CI caching). Default builds wheel_base here.
 ARG wheel_base=wheel_base
 
-FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS wheel_base
+# CUDA donor stage — the toolkit is copied onto the manylinux base below.
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS cuda
 
-ARG DEFAULT_PYTHON_VERSION="3.14"
+# Manylinux build base — official PyPA image (public on quay.io; ECR pull-through
+# available). AlmaLinux 8 / glibc 2.28 => manylinux_2_28 wheels.
+FROM quay.io/pypa/manylinux_2_28_${ARCH}:${MANYLINUX_VERSION} AS wheel_base
+
+# Re-declare args needed inside this stage (pre-FROM args are only visible to FROM lines).
 ARG ARCH="x86_64"
+ARG DEFAULT_PYTHON_VERSION="3.14"
+
+# CUDA version (e.g. 12.9 / 13.0) — passed explicitly (was an ENV from the old
+# combined base). Drives the torch cuXXX index and the cu12/cu13 wheel split.
+# Default matches build-container.sh's CUDA_VERSION fallback so a direct
+# `docker build` (bypassing build-container.sh / the CI yaml) still works.
+ARG CUDA_VERSION="13.0"
+ENV CUDA_VERSION=${CUDA_VERSION}
+
+# Bring the CUDA toolkit onto the manylinux base (dynamo wheel_builder pattern).
+COPY --from=cuda /usr/local/cuda /usr/local/cuda
+ENV CUDA_HOME=/usr/local/cuda \
+    PATH=/usr/local/cuda/bin:${PATH} \
+    LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}
+
+# CUDA needs gcc <= 14. The PyPA manylinux base + system "Development Tools" can
+# pull in a gcc that CUDA rejects, so pin gcc-toolset-14 on PATH ahead of the
+# system gcc (gcc-toolset-14 is added to the dnf install list below).
+ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
+    LD_LIBRARY_PATH=/opt/rh/gcc-toolset-14/root/usr/lib64:${LD_LIBRARY_PATH:-}
+
+# PyPA manylinux_2_28 ships CMake 4.x, which removed support for
+# cmake_minimum_required(VERSION < 3.5). Some bundled deps (e.g. gRPC's c-ares)
+# still declare ancient minimums. This tells CMake 4.x to accept them.
+ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+# === end Option B header ======================================================
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG HWLOC_VERSION="2.12.2"
 ARG BUILD_TYPE="release"
@@ -33,7 +76,7 @@ ARG GRPC_TAG="v1.73.0"
 ARG NPROC
 
 RUN yum groupinstall -y 'Development Tools' &&  \
-    dnf install -y almalinux-release-synergy && \
+    dnf install -y almalinux-release-synergy epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf install -y \
     boost \
@@ -46,6 +89,7 @@ RUN yum groupinstall -y 'Development Tools' &&  \
     gflags \
     glibc-headers \
     gcc-c++ \
+    gcc-toolset-14 \
     libaio \
     libaio-devel \
     libtool-ltdl \
@@ -353,6 +397,13 @@ RUN cd /usr/local/src && \
      ldconfig
 
 FROM $wheel_base AS wheel
+
+# Re-declare CUDA_VERSION here so an explicit --cuda-version reaches this stage.
+# With the --wheel-base-image caching path, wheel_base is a pre-built external
+# image; without this ARG the wheel stage would silently use the CUDA_VERSION
+# baked into that cache instead of the value passed to this build (line 509).
+ARG CUDA_VERSION="13.0"
+ENV CUDA_VERSION=${CUDA_VERSION}
 
 ARG ARCH="x86_64"
 ARG BUILD_TYPE="release"

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -44,6 +44,10 @@ OS="ubuntu24"
 NPROC=${NPROC:-$(nproc)}
 GRPC_NPROC=${GRPC_NPROC:-$(nproc)}
 BUILD_TYPE="release"
+# CUDA MAJOR.MINOR for the manylinux (Option B) wheel build — drives the torch
+# cuXXX index and the cu12/cu13 meta-wheel split. Default 13.0 matches the default
+# ubi8 BASE_IMAGE_TAG; override with --cuda-version (e.g. 12.9).
+CUDA_VERSION=${CUDA_VERSION:-13.0}
 BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
 BUILD_UCX_SPCX_PLUGIN="false"
@@ -126,6 +130,14 @@ get_options() {
         --torch-versions)
             if [ "$2" ]; then
                 WHL_TORCH_VERSIONS=$2
+                shift
+            else
+                missing_requirement $1
+            fi
+            ;;
+        --cuda-version)
+            if [ "$2" ]; then
+                CUDA_VERSION=$2
                 shift
             else
                 missing_requirement $1
@@ -285,6 +297,7 @@ show_help() {
     echo "  [--arch [x86_64|aarch64] to select target architecture]"
     echo "  [--dockerfile path to a dockerfile to use]"
     echo "  [--torch-versions torch versions to build for, comma separated (default: uses Dockerfile ARG default)]"
+    echo "  [--cuda-version CUDA MAJOR.MINOR for the manylinux wheel build, e.g. 12.9 (default: ${CUDA_VERSION})]"
     echo "  [--wheel-base-image pre-built wheel base image URL; skips wheel_base stage and builds only the wheel stage]"
     echo "  [--build-infinia build and bundle the Infinia DDN plugin (requires --dockerfile contrib/Dockerfile.manylinux; harbor.mellanox.com must be reachable)]"
     echo "  [--infinia-image full image reference for infinia-libs (default: ${INFINIA_LIBS_IMAGE})]"
@@ -310,6 +323,7 @@ fi
 BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
 BUILD_ARGS+="${WHL_TORCH_VERSIONS:+ --build-arg WHL_TORCH_VERSIONS=$WHL_TORCH_VERSIONS}"
+BUILD_ARGS+=" --build-arg CUDA_VERSION=$CUDA_VERSION"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"
 BUILD_ARGS+=" --build-arg UCX_REPO=$UCX_REPO"


### PR DESCRIPTION
…C CUDA)

Incorporates the "ubi8" base image discussed on #1968: the wheel_base deps stage now builds on the public PyPA manylinux_2_28 image and COPYs CUDA from an el8/ubi8 NGC CUDA devel image
(nvcr.io/nvidia/cuda:*-devel-ubi8), instead of a combined internal manylinux+CUDA base.

- Dockerfile.manylinux: add the Option-B header (cuda donor stage + quay manylinux wheel_base + COPY --from=cuda + gcc-toolset-14 + CMake 4.x policy). Keeps #1968's two-stage wheel_base/wheel caching split and the opt-in --build-infinia / --build-ucx-spcx-plugin blocks untouched. INFINIA stays opt-in (host-pull COPY) — not the bundled-default FROM stage.
- build-container.sh: restore --cuda-version (MAJOR.MINOR) so local/release full builds drive the torch cuXXX index + cu12/cu13 meta-wheel split.
- build-wheel-matrix.yaml: point BASE_IMAGE/BASE_TAG at the ubi8 CUDA image, add CUDA_VERSION + MANYLINUX_VERSION, pass --cuda-version, and forward CUDA_VERSION/MANYLINUX_VERSION to the wheel_base cache build.
- Bump CI_IMAGE_TAG in all six matrix YAMLs (cidemo-init.sh requires it when a CI file such as Dockerfile.manylinux changes).

Note: only the ci-demo wheel_base cache build pulls nvcr.io/quay.io; per-PR wheel builds pull the cached wheel_base from Artifactory. If the blossom runner cannot reach nvcr.io/quay.io, repoint BASE_IMAGE at an Artifactory ubi8 mirror (same ubi8 tag).

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
* Updated wheel builds to use pinned CUDA and manylinux versions for more consistent, repeatable packaging.
* Added a selectable CUDA version option for containerized wheel builds (defaulting to CUDA 13.0).
* Improved build compatibility by aligning the toolchain/CMake behavior with newer environments.
* Refreshed the wheel build base image approach while preserving CUDA support for the build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
