### PR TITLE
build: pin ucx-spcx-plugin default ref to v0.1.0 for 1.4.0 release

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -51,7 +51,7 @@ CUDA_VERSION=${CUDA_VERSION:-13.0}
 BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
 BUILD_UCX_SPCX_PLUGIN="false"
-UCX_SPCX_PLUGIN_REF="main"
+UCX_SPCX_PLUGIN_REF="v0.1.0"
 
 get_options() {
     while :; do


### PR DESCRIPTION
## Summary

- Changes the default `UCX_SPCX_PLUGIN_REF` in `contrib/build-container.sh` from `main` to `v0.1.0`, pinning the ucx-spcx-plugin to its stable release tag for the 1.4.0 wheel build.