### PR TITLE
build: keep CC free of -std=gnu23 for the ucx-spcx-plugin build

### DIFF
--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -444,6 +444,12 @@ RUN if [ "$BUILD_INFINIA" = "true" ]; then \
 # the doca-host repo installed above; libflexio is compile-against only —
 # it is not bundled into the wheel, at runtime it comes from the target
 # machine's DOCA/FlexIO installation (like libmlx5 from rdma-core).
+# ac_cv_prog_cc_c23=no: gcc-toolset-14 supports C23, so AC_PROG_CC resolves
+# CC to "gcc -std=gnu23". The plugin's src/gdp/Makefile.am passes the compiler
+# through unsplit as -hostcc=$(CC), so dpacc receives a bare -std=gnu23 argument
+# and rejects it ("Unknown option"). Presetting the cache var makes autoconf fall
+# back to C11 (already covered by gcc 14's default gnu17), leaving CC as plain
+# gcc. Drop this once the plugin splits the compiler from its flags.
 ARG BUILD_UCX_SPCX_PLUGIN=false
 RUN if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then \
         rpm -ivh --nodeps /usr/share/doca-host-3.3.0/repo/Packages/flexio-sdk-*rpm && \
@@ -451,6 +457,7 @@ RUN if [ "$BUILD_UCX_SPCX_PLUGIN" = "true" ]; then \
         ldconfig && \
         cd ucx-spcx-plugin-src && \
         export ACLOCAL_PATH="/usr/share/aclocal${ACLOCAL_PATH:+:$ACLOCAL_PATH}" && \
+        export ac_cv_prog_cc_c23=no && \
         ./autogen.sh /usr/local/src/ucx && \
         ./configure --prefix=/usr --libdir=/usr/lib64 \
             --enable-shared --disable-static \


### PR DESCRIPTION
## Summary

The release wheel build fails in the `--build-ucx-spcx-plugin` step with `dpacc error : Unknown option '-std=gnu23'` (exit 255), breaking every python/arch cell.

Since #2009 pinned `gcc-toolset-14` ahead of the system gcc on `PATH`, the plugin's `AC_PROG_CC` detects C23 support and resolves `CC` to `gcc -std=gnu23`. The plugin's `src/gdp/Makefile.am` forwards the compiler unsplit as `-hostcc=$(CC)`, so dpacc receives a bare `-std=gnu23` argument and rejects it.

- Preset `ac_cv_prog_cc_c23=no` before the plugin's `configure`, so autoconf falls back to C11 — already covered by gcc 14's default gnu17 — and `CC` stays plain `gcc`.

This is a workaround on the nixl side. The underlying bug is in the plugin, which should split the compiler from its flags (`-hostcc=$(firstword $(CC))`, remainder into `--hostcc-options`); the comment notes the revert condition.