### PR TITLE
CONTRIB: pin spcx-plugin to v0.2.x branch instead of master (v1.5.0 release)

### DIFF
--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -51,7 +51,7 @@ CUDA_VERSION=${CUDA_VERSION:-13.0}
 BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
 BUILD_UCX_SPCX_PLUGIN="false"
-UCX_SPCX_PLUGIN_REF="main"
+UCX_SPCX_PLUGIN_REF="v0.2.x"
 
 get_options() {
     while :; do


### PR DESCRIPTION
## What?
Change EXT plugin ref to v0.2.x release branch

## Why?
Currently, it's pinned to master which aligned with UCX master while NIXL release uses v1.22.x, 
v0.2.x branch of the plugin is aligned with UCX v1.22.x plugin API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default UCX SPCX plugin version used during container builds to the v0.2.x release line.
  * Build help and options now reflect the updated default when no version is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->