### PR TITLE
[nixlbench] add worker part for device api

### DIFF
--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -110,17 +110,12 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
     const bool any_put_failed = __syncthreads_or(put_status != NIXL_SUCCESS);
     if (threadIdx.x == 0) {
         if (any_put_failed) {
-            if (nixlbenchSignalError(params) != NIXL_SUCCESS) {
-                printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
-            }
+            (void)nixlbenchSignalError(params);
             return;
         }
 
         if (nixlbenchSignalCompletion(params) != NIXL_SUCCESS) {
-            printf("[nixlbenchPutKernel] completion nixlAtomicAdd failed\n");
-            if (nixlbenchSignalError(params) != NIXL_SUCCESS) {
-                printf("[nixlbenchPutKernel] error nixlAtomicAdd failed\n");
-            }
+            (void)nixlbenchSignalError(params);
         }
     }
 }

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -21,6 +21,7 @@
 namespace {
 
 constexpr unsigned kWarpSize = 32; // Assumed equal to device warpSize (CUDA guarantee);
+constexpr unsigned kMaxGroups = 32; // 32 threads or max 1024 / 32 warps per block
 
 template<nixl_gpu_level_t Level>
 __device__ nixl_status_t
@@ -33,24 +34,12 @@ nixlbenchPollXferStatus(nixl_status_t status, nixlGpuXferStatusH &xfer_status) {
 
 template<nixl_gpu_level_t Level>
 __device__ nixl_status_t
-nixlbenchPutLevel(const nixlbenchDeviceXferParams &params,
-                  size_t region_idx,
-                  nixlGpuXferStatusH &xfer_status) {
+nixlbenchPostPut(const nixlbenchDeviceXferParams &params,
+                 size_t region_idx,
+                 nixlGpuXferStatusH &xfer_status) {
     const nixlMemViewElem src{params.localMvh, region_idx, 0};
     const nixlMemViewElem dst{params.remoteMvh, region_idx, 0};
-    nixl_status_t status = nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
-    status = nixlbenchPollXferStatus<Level>(status, xfer_status);
-
-    if (status != NIXL_SUCCESS) {
-        printf("[nixlbenchPutLevel] transfer did not complete: region=%zu "
-               "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
-               region_idx,
-               threadIdx.x,
-               blockIdx.x,
-               blockDim.x,
-               static_cast<int>(status));
-    }
-    return status;
+    return nixlPut<Level>(src, dst, params.regionSize, 0, 0, &xfer_status);
 }
 
 __device__ nixl_status_t
@@ -89,6 +78,8 @@ nixlbenchSignalError(nixlbenchDeviceXferParams params) {
 template<nixl_gpu_level_t Level>
 __global__ void
 nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
+    __shared__ nixlGpuXferStatusH xfer_statuses[kMaxGroups];
+
     unsigned group_id, num_groups;
     if constexpr (Level == nixl_gpu_level_t::THREAD) {
         group_id = threadIdx.x;
@@ -98,13 +89,27 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
         num_groups = (blockDim.x + warpSize - 1) / warpSize;
     }
 
-    nixlGpuXferStatusH xfer_status;
+    nixlGpuXferStatusH &xfer_status = xfer_statuses[group_id];
     nixl_status_t put_status = NIXL_SUCCESS;
     for (size_t region_idx = group_id; region_idx < params.numRegions; region_idx += num_groups) {
-        put_status = nixlbenchPutLevel<Level>(params, region_idx, xfer_status);
-        if (put_status != NIXL_SUCCESS) {
+        put_status = nixlbenchPostPut<Level>(params, region_idx, xfer_status);
+        if (put_status != NIXL_IN_PROG) {
             break;
         }
+    }
+
+    if (put_status == NIXL_IN_PROG) {
+        put_status = nixlbenchPollXferStatus<Level>(put_status, xfer_status);
+    }
+
+    if (put_status != NIXL_SUCCESS &&
+        (Level == nixl_gpu_level_t::THREAD || threadIdx.x % warpSize == 0)) {
+        printf("[nixlbenchPutKernel] transfer did not complete: "
+               "threadIdx.x=%u blockIdx.x=%u blockDim.x=%u final_status=%d\n",
+               threadIdx.x,
+               blockIdx.x,
+               blockDim.x,
+               static_cast<int>(put_status));
     }
 
     const bool any_put_failed = __syncthreads_or(put_status != NIXL_SUCCESS);

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -79,7 +79,6 @@ template<nixl_gpu_level_t Level>
 __global__ void
 nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
     __shared__ nixlGpuXferStatusH xfer_statuses[kMaxGroups];
-
     unsigned group_id, num_groups;
     if constexpr (Level == nixl_gpu_level_t::THREAD) {
         group_id = threadIdx.x;
@@ -97,11 +96,9 @@ nixlbenchPutKernel(nixlbenchDeviceXferParams params) {
             break;
         }
     }
-
     if (put_status == NIXL_IN_PROG) {
         put_status = nixlbenchPollXferStatus<Level>(put_status, xfer_status);
     }
-
     if (put_status != NIXL_SUCCESS &&
         (Level == nixl_gpu_level_t::THREAD || threadIdx.x % warpSize == 0)) {
         printf("[nixlbenchPutKernel] transfer did not complete: "

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -53,7 +53,6 @@ nixlbenchPutLevel(const nixlbenchDeviceXferParams &params,
     return status;
 }
 
-template<nixl_gpu_level_t Level>
 __device__ nixl_status_t
 nixlbenchSignalCounter(const nixlbenchDeviceXferParams &params,
                        size_t counter_offset,
@@ -61,8 +60,9 @@ nixlbenchSignalCounter(const nixlbenchDeviceXferParams &params,
                        const char *counter_name) {
     const nixlMemViewElem counter{params.remoteMvh, params.numRegions, counter_offset};
     nixlGpuXferStatusH xfer_status;
-    nixl_status_t status = nixlAtomicAdd<Level>(value, counter, 0, 0, &xfer_status);
-    status = nixlbenchPollXferStatus<Level>(status, xfer_status);
+    nixl_status_t status =
+        nixlAtomicAdd<nixl_gpu_level_t::THREAD>(value, counter, 0, 0, &xfer_status);
+    status = nixlbenchPollXferStatus<nixl_gpu_level_t::THREAD>(status, xfer_status);
 
     if (status != NIXL_SUCCESS) {
         printf("[nixlbenchSignalCounter] nixlAtomicAdd(%s) did not complete: final_status=%d\n",
@@ -74,18 +74,16 @@ nixlbenchSignalCounter(const nixlbenchDeviceXferParams &params,
 
 __device__ nixl_status_t
 nixlbenchSignalCompletion(nixlbenchDeviceXferParams params) {
-    return nixlbenchSignalCounter<nixl_gpu_level_t::THREAD>(
-        params, params.completionCounterOffsetBytes, 1ull, "completion");
+    return nixlbenchSignalCounter(params, params.completionCounterOffsetBytes, 1ull, "completion");
 }
 
 __device__ nixl_status_t
 nixlbenchSignalError(nixlbenchDeviceXferParams params) {
-    return nixlbenchSignalCounter<nixl_gpu_level_t::THREAD>(
-        params, params.errorCounterOffsetBytes, 1ull, "error");
+    return nixlbenchSignalCounter(params, params.errorCounterOffsetBytes, 1ull, "error");
 }
 
 /**
- * Performs device-initiated NIXL PUT transfers and optionally reports completion or errors
+ * Performs device-initiated NIXL PUT transfers and reports completion or errors
  * through remote counters.
  */
 template<nixl_gpu_level_t Level>

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cu
@@ -137,12 +137,6 @@ nixlbenchLaunchDevicePut(const nixlbenchDeviceXferParams &params, unsigned block
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    if (!params.signalRemoteCompletion) {
-        std::cerr << "nixlbench: nixlbenchLaunchDevicePut: remote completion signaling is "
-                     "required\n";
-        return NIXL_ERR_INVALID_PARAM;
-    }
-
     if (block_threads == 0 || block_threads > 1024u) {
         std::cerr << "nixlbench: nixlbenchLaunchDevicePut: invalid block_threads=" << block_threads
                   << " (must be 1..1024)\n";

--- a/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
+++ b/benchmark/nixlbench/src/kernels/nixlbench_device_launch.cuh
@@ -16,22 +16,19 @@
  * order as xferBenchNixlWorker::prepareGPULocalView / prepareGPURemoteView (outer vector = thread
  * lists, inner vector = IOVs for that thread).
  *
- * @a numRegions is the **data** region count (put loop uses indices @c 0 .. @a numRegions-1). When
- * @a signalRemoteCompletion is true, the host must have appended a counter buffer as the last
- * remote descriptor so the view has @a numRegions + 1 regions. The counter buffer stores:
+ * @a numRegions is the **data** region count (put loop uses indices @c 0 .. @a numRegions-1).
+ * The host must append a counter buffer as the last remote descriptor, so the view has
+ * @a numRegions + 1 regions. The counter buffer stores:
  * - done counter at byte offset @a completionCounterOffsetBytes
  * - error counter at byte offset @a errorCounterOffsetBytes
  *
  * Kernel uses @c nixlAtomicAdd on @c { remoteMvh, numRegions, offset }.
- * When @a signalRemoteCompletion is false, @a remoteMvh has exactly @a numRegions regions and
- * no counter atomic is issued.
  */
 struct nixlbenchDeviceXferParams {
     nixlMemViewH localMvh; ///< Local memory view from prepMemView
     nixlMemViewH remoteMvh; ///< Remote memory view from prepMemView
     size_t numRegions; ///< Data region count (puts); completion index when signaling
     size_t regionSize; ///< Bytes per region for this transfer pattern
-    bool signalRemoteCompletion; ///< If true, counter region exists at index @a numRegions
     size_t completionCounterOffsetBytes; ///< Done counter offset in the counter region
     size_t errorCounterOffsetBytes; ///< Error counter offset in the counter region
 };

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -140,7 +140,6 @@ static int processBatchSizes(xferBenchWorker &worker,
                 worker.exchangeIOV(local_trans_lists, block_size));
 
             auto result = worker.transfer(block_size, local_trans_lists, remote_trans_lists);
-
             if (std::holds_alternative<int>(result)) {
                 return 1;
             }

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -124,8 +124,20 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return EXIT_FAILURE;
             }
 
+            if (xferBenchConfig::use_device_api) {
+                if (auto nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->prepareGPULocalView(local_trans_lists);
+                }
+            }
+
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
+
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->releaseGPULocalView();
+                }
+            }
 
             if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
                 return EXIT_FAILURE;
@@ -139,7 +151,22 @@ static int processBatchSizes(xferBenchWorker &worker,
             std::vector<std::vector<xferBenchIOV>> remote_trans_lists(
                 worker.exchangeIOV(local_trans_lists, block_size));
 
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->prepareGPULocalView(local_trans_lists);
+                    nixl_worker->prepareGPURemoteView(remote_trans_lists);
+                }
+            }
+
             auto result = worker.transfer(block_size, local_trans_lists, remote_trans_lists);
+
+            if (xferBenchConfig::use_device_api) {
+                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
+                    nixl_worker->releaseGPURemoteView();
+                    nixl_worker->releaseGPULocalView();
+                }
+            }
+
             if (std::holds_alternative<int>(result)) {
                 return 1;
             }

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -124,20 +124,8 @@ static int processBatchSizes(xferBenchWorker &worker,
                 return EXIT_FAILURE;
             }
 
-            if (xferBenchConfig::use_device_api) {
-                if (auto nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
-                    nixl_worker->prepareGPULocalView(local_trans_lists);
-                }
-            }
-
             worker.exchangeIOV(local_trans_lists, block_size);
             worker.poll(block_size);
-
-            if (xferBenchConfig::use_device_api) {
-                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
-                    nixl_worker->releaseGPULocalView();
-                }
-            }
 
             if (!xferBenchUtils::validateTransfer(false, local_trans_lists, local_trans_lists)) {
                 return EXIT_FAILURE;
@@ -151,21 +139,7 @@ static int processBatchSizes(xferBenchWorker &worker,
             std::vector<std::vector<xferBenchIOV>> remote_trans_lists(
                 worker.exchangeIOV(local_trans_lists, block_size));
 
-            if (xferBenchConfig::use_device_api) {
-                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
-                    nixl_worker->prepareGPULocalView(local_trans_lists);
-                    nixl_worker->prepareGPURemoteView(remote_trans_lists);
-                }
-            }
-
             auto result = worker.transfer(block_size, local_trans_lists, remote_trans_lists);
-
-            if (xferBenchConfig::use_device_api) {
-                if (auto *nixl_worker = dynamic_cast<xferBenchNixlWorker *>(&worker)) {
-                    nixl_worker->releaseGPURemoteView();
-                    nixl_worker->releaseGPULocalView();
-                }
-            }
 
             if (std::holds_alternative<int>(result)) {
                 return 1;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -915,7 +915,8 @@ xferBenchConfig::printConfig() {
     printOption("Num threads (--num_threads=N)", std::to_string(num_threads));
     printOption("Use Device API (--use_device_api=[0,1])", std::to_string(use_device_api));
     if (use_device_api) {
-        printOption("Device API Kernel block threads (--num_threads=N)", std::to_string(block_threads));
+        printOption("Device API Kernel block threads (--num_threads=N)",
+                    std::to_string(block_threads) + " (default)");
     }
     printSeparator('-');
     std::cout << std::endl;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -574,13 +574,13 @@ xferBenchConfig::loadParams(void) {
     }
     if (use_device_api) {
         if (num_threads < 1 || num_threads > 1024) {
-            std::cerr << "Invalid value for --num-threads: " << num_threads
+            std::cerr << "Invalid value for --num_threads: " << num_threads
                       << ". Device API requires a GPU kernel block thread count in [1, 1024]"
                       << std::endl;
             return -1;
         }
         if (num_threads > 32 && num_threads % 32 != 0) {
-            std::cerr << "Invalid value for --num-threads: " << num_threads
+            std::cerr << "Invalid value for --num_threads: " << num_threads
                       << ". Device API requires block_threads > 32 must be a multiple of 32"
                       << std::endl;
             return -1;
@@ -916,7 +916,7 @@ xferBenchConfig::printConfig() {
     printOption("Use Device API (--use_device_api=[0,1])", std::to_string(use_device_api));
     if (use_device_api) {
         printOption("Device API Kernel block threads (--num_threads=N)",
-                    std::to_string(block_threads) + " (default)");
+                    std::to_string(block_threads));
     }
     printSeparator('-');
     std::cout << std::endl;

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -360,6 +360,9 @@ isDeviceAPISupported() {
     if (xferBenchConfig::scheme != XFERBENCH_SCHEME_PAIRWISE) {
         return reject("scheme must be pairwise");
     }
+    if (xferBenchConfig::pipeline_depth != 1) {
+        return reject("pipeline_depth must be 1");
+    }
     return true;
 #else
     return reject("UCX GPU Device API support is not enabled in this build. "
@@ -559,6 +562,11 @@ xferBenchConfig::loadParams(void) {
     large_blk_iter_ftr = NB_ARG(large_blk_iter_ftr);
     warmup_iter = NB_ARG(warmup_iter);
     num_threads = NB_ARG(num_threads);
+    pipeline_depth = NB_ARG(pipeline_depth);
+    if (pipeline_depth < 1) {
+        std::cerr << "pipeline_depth must be >= 1" << std::endl;
+        return -1;
+    }
     bool intended_use_device_api = NB_ARG(use_device_api);
     use_device_api = intended_use_device_api && isDeviceAPISupported();
     if (intended_use_device_api && !use_device_api) {
@@ -595,11 +603,6 @@ xferBenchConfig::loadParams(void) {
     recreate_xfer = NB_ARG(recreate_xfer);
     reregister_mem = NB_ARG(reregister_mem);
     prepared_xfer = NB_ARG(prepared_xfer);
-    pipeline_depth = NB_ARG(pipeline_depth);
-    if (pipeline_depth < 1) {
-        std::cerr << "pipeline_depth must be >= 1" << std::endl;
-        return -1;
-    }
     use_hugepages = NB_ARG(use_hugepages);
     if (use_hugepages && (total_buffer_size % HUGEPAGE_SIZE) != 0) {
         size_t hugepage_aligned_size = ROUND_UP(total_buffer_size, HUGEPAGE_SIZE);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -241,6 +241,13 @@ NB_ARG_BOOL(gusli_try_use_uring,
             false,
             "Try to use io_uring engine in GUSLI backend (default: false)");
 
+// UCX GPU Device API options
+NB_ARG_BOOL(use_device_api,
+            false,
+            "Use UCX GPU Device API for GPU-kernel-initiated PUT transfers. "
+            "When enabled, --num_threads is repurposed as the CUDA kernel "
+            "block size (num_threads <= 32 -> THREAD level; > 32 -> WARP level, must be a "
+            "multiple of 32), and the internal CPU thread count is forced to 1.");
 
 #undef NB_ARG_INT32
 #undef NB_ARG_UINT32
@@ -321,6 +328,44 @@ std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
 bool xferBenchConfig::gusli_try_use_uring = false;
+bool xferBenchConfig::use_device_api = false;
+int xferBenchConfig::block_threads = 1;
+
+static bool
+isDeviceAPISupported() {
+    auto reject = [](const char *reason) {
+        std::cerr << "Invalid configuration for NIXL Device API: " << reason << std::endl;
+        return false;
+    };
+#ifdef HAVE_UCX_GPU_DEVICE_API
+    if (xferBenchConfig::worker_type != XFERBENCH_WORKER_NIXL) {
+        return reject("worker_type must be nixl");
+    }
+    if (xferBenchConfig::backend != XFERBENCH_BACKEND_UCX) {
+        return reject("backend must be UCX");
+    }
+    if (xferBenchConfig::op_type != XFERBENCH_OP_WRITE) {
+        return reject("op_type must be WRITE");
+    }
+    if (xferBenchConfig::initiator_seg_type != XFERBENCH_SEG_TYPE_VRAM ||
+        xferBenchConfig::target_seg_type != XFERBENCH_SEG_TYPE_VRAM) {
+        return reject("initiator_seg_type and target_seg_type must be VRAM");
+    }
+    if (!xferBenchConfig::enable_pt) {
+        return reject("--enable_pt must be set");
+    }
+    if (xferBenchConfig::mode != XFERBENCH_MODE_SG) {
+        return reject("mode must be SG");
+    }
+    if (xferBenchConfig::scheme != XFERBENCH_SCHEME_PAIRWISE) {
+        return reject("scheme must be pairwise");
+    }
+    return true;
+#else
+    return reject("UCX GPU Device API support is not enabled in this build. "
+                  "Set -Ducx_path=<path> with UCX GPU device headers available");
+#endif
+}
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -514,6 +559,29 @@ xferBenchConfig::loadParams(void) {
     large_blk_iter_ftr = NB_ARG(large_blk_iter_ftr);
     warmup_iter = NB_ARG(warmup_iter);
     num_threads = NB_ARG(num_threads);
+    bool intended_use_device_api = NB_ARG(use_device_api);
+    use_device_api = intended_use_device_api && isDeviceAPISupported();
+    if (intended_use_device_api && !use_device_api) {
+        return -1;
+    }
+    if (use_device_api) {
+        if (num_threads < 1 || num_threads > 1024) {
+            std::cerr << "Invalid value for --num-threads: " << num_threads
+                      << ". Device API requires a GPU kernel block thread count in [1, 1024]"
+                      << std::endl;
+            return -1;
+        }
+        if (num_threads > 32 && num_threads % 32 != 0) {
+            std::cerr << "Invalid value for --num-threads: " << num_threads
+                      << ". Device API requires block_threads > 32 must be a multiple of 32"
+                      << std::endl;
+            return -1;
+        }
+        block_threads = num_threads;
+        num_threads = 1;
+        std::cout << "Device API mode: kernel block_threads=" << block_threads
+                  << ", num_threads forced to 1" << std::endl;
+    }
     etcd_endpoints = NB_ARG(etcd_endpoints);
     asio_address = NB_ARG(asio_address);
     asio_port = NB_ARG(asio_port);
@@ -842,6 +910,10 @@ xferBenchConfig::printConfig() {
     printOption("Large block iter factor (--large_blk_iter_ftr=N)",
                 std::to_string(large_blk_iter_ftr));
     printOption("Num threads (--num_threads=N)", std::to_string(num_threads));
+    printOption("Use Device API (--use_device_api=[0,1])", std::to_string(use_device_api));
+    if (use_device_api) {
+        printOption("Device API Kernel block threads (--num_threads=N)", std::to_string(block_threads));
+    }
     printSeparator('-');
     std::cout << std::endl;
 }

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -332,7 +332,7 @@ bool xferBenchConfig::use_device_api = false;
 int xferBenchConfig::block_threads = 1;
 
 static bool
-isDeviceAPISupported() {
+validateDeviceAPIConfig() {
     auto reject = [](const char *reason) {
         std::cerr << "Invalid configuration for NIXL Device API: " << reason << std::endl;
         return false;
@@ -567,9 +567,8 @@ xferBenchConfig::loadParams(void) {
         std::cerr << "pipeline_depth must be >= 1" << std::endl;
         return -1;
     }
-    bool intended_use_device_api = NB_ARG(use_device_api);
-    use_device_api = intended_use_device_api && isDeviceAPISupported();
-    if (intended_use_device_api && !use_device_api) {
+    use_device_api = NB_ARG(use_device_api);
+    if (use_device_api && !validateDeviceAPIConfig()) {
         return -1;
     }
     if (use_device_api) {

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -227,6 +227,8 @@ public:
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
     static bool gusli_try_use_uring;
+    static bool use_device_api;
+    static int block_threads; ///< derived from num_threads when use_device_api=true
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -228,7 +228,7 @@ public:
     static std::string gusli_device_security;
     static bool gusli_try_use_uring;
     static bool use_device_api;
-    static int block_threads; ///< derived from num_threads when use_device_api=true
+    static int block_threads;
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1458,8 +1458,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             std::string cc_str;
             cc_str.resize(static_cast<size_t>(desc_str_sz), '\0');
             if (rt->recvChar(cc_str.data(), cc_str.size(), srcrank) != 0) {
-                std::cerr << "NIXL: failed to receive completion counter descriptor"
-                          << std::endl;
+                std::cerr << "NIXL: failed to receive completion counter descriptor" << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             cc_ser.importStr(cc_str);
@@ -1929,8 +1928,7 @@ execDeviceTransfer(nixlMemViewH local_mvh,
             stats.total_duration.add(total_timer.lap());
             return -1;
         }
-        nixl_status_t st =
-            nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads));
+        nixl_status_t st = nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads));
         if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
             std::cerr << "nixlbenchLaunchDevicePut failed: " << nixlEnumStrings::statusStr(st)
                       << std::endl;
@@ -1971,8 +1969,7 @@ xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_
     if (expected_value == 0) {
         return true;
     }
-    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId),
-                     "Failed to set completion counter device");
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
 
     while (!signaled()) {
         xferBenchDeviceCounters counters{};
@@ -2015,8 +2012,7 @@ resetDeviceCounters(const xferBenchIOV &counter_iov) {
     CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
     CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
                      "Failed to reset completion counters in VRAM");
-    CHECK_CUDA_ERROR(cudaStreamSynchronize(0),
-                     "Failed to synchronize completion counter reset");
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(0), "Failed to synchronize completion counter reset");
 
 #else
     (void)counter_iov;
@@ -2123,8 +2119,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
                            xfer_op,
                            num_iter,
                            xferBenchConfig::num_threads,
-                        stats,
-                       &terminate);
+                           stats,
+                           &terminate);
     }
     if (ret < 0) {
         return std::variant<xferBenchStats, int>(ret);
@@ -2241,8 +2237,7 @@ xferBenchNixlWorker::prepareGPURemoteView(
     const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
     if (remote_agent_name.empty()) {
         std::cerr << "NIXL Device API: remote_agent_name is empty; "
-                  << "exchangeMetadata must be called before prepareGPURemoteView"
-                  << std::endl;
+                  << "exchangeMetadata must be called before prepareGPURemoteView" << std::endl;
         std::exit(EXIT_FAILURE);
     }
 
@@ -2255,11 +2250,10 @@ xferBenchNixlWorker::prepareGPURemoteView(
         }
     }
 
-    const nixlRemoteDesc remoteDesc{
-        completion_counter_iov.value().addr,
-        completion_counter_iov.value().len,
-        static_cast<uint64_t>(completion_counter_iov.value().devId),
-        remote_agent_name};
+    const nixlRemoteDesc remoteDesc{completion_counter_iov.value().addr,
+                                    completion_counter_iov.value().len,
+                                    static_cast<uint64_t>(completion_counter_iov.value().devId),
+                                    remote_agent_name};
     remote_list.addDesc(remoteDesc);
     CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
                      "prepMemView on remote view failed");

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -704,7 +704,6 @@ allocVramValueZero(int devid, size_t nbytes) {
     if (neuronCoreCount() > 0) {
         return getVramDescNeuron(devid, nbytes, 0);
     }
-
     CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
     if (xferBenchConfig::enable_vmm) {
         return getVramDescCudaVmm(devid, nbytes, 0);
@@ -723,12 +722,10 @@ xferBenchNixlWorker::initCompletionCounterVram() {
     if (!xferBenchConfig::use_device_api || !isTarget() || seg_type != VRAM_SEG) {
         return std::nullopt;
     }
-
     int counter_dev = 0;
     if (IS_PAIRWISE_AND_SG()) {
         counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev;
     }
-
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
 
@@ -1431,7 +1428,6 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             cc_dlist.addDesc(cc_basic);
             cc_dlist.serialize(&cc_ser);
             std::string cc_export = cc_ser.exportStr();
-
             int destrank;
             if (IS_PAIRWISE_AND_SG()) {
                 destrank = rt->getRank() - xferBenchConfig::num_target_dev;
@@ -1909,7 +1905,6 @@ execDeviceTransfer(nixlMemViewH local_mvh,
                    const std::atomic<int> *terminate_ptr = nullptr) {
 #ifdef HAVE_UCX_GPU_DEVICE_API
     stats.clear();
-
     nixlbenchDeviceXferParams params;
     params.localMvh = local_mvh;
     params.remoteMvh = remote_mvh;
@@ -1917,12 +1912,10 @@ execDeviceTransfer(nixlMemViewH local_mvh,
     params.regionSize = region_size;
     params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
     params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
-
     xferBenchTimer total_timer;
     xferBenchStats iter_stats;
     iter_stats.reserve(num_iter);
     xferBenchTimer timer;
-
     for (int i = 0; i < num_iter; ++i) {
         if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
             stats.total_duration.add(total_timer.lap());
@@ -1937,7 +1930,6 @@ execDeviceTransfer(nixlMemViewH local_mvh,
         }
         iter_stats.transfer_duration.add(timer.lap());
     }
-
     stats.add(iter_stats);
     stats.total_duration.add(total_timer.lap());
     return 0;
@@ -1965,12 +1957,10 @@ xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_
         uint64_t done;
         uint64_t error;
     };
-
     if (expected_value == 0) {
         return true;
     }
     CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
-
     while (!signaled()) {
         xferBenchDeviceCounters counters{};
         CHECK_CUDA_ERROR(cudaMemcpy(&counters,
@@ -2013,7 +2003,6 @@ resetDeviceCounters(const xferBenchIOV &counter_iov) {
     CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
                      "Failed to reset completion counters in VRAM");
     CHECK_CUDA_ERROR(cudaStreamSynchronize(0), "Failed to synchronize completion counter reset");
-
 #else
     (void)counter_iov;
     std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
@@ -2058,7 +2047,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
         }
         num_regions = remote_regions;
     }
-
     auto gpu_view_guard = make_scope_guard([this] {
         if (xferBenchConfig::use_device_api) {
             releaseGPURemoteView();
@@ -2239,7 +2227,6 @@ xferBenchNixlWorker::prepareGPURemoteView(
                   << "exchangeMetadata must be called before prepareGPURemoteView" << std::endl;
         std::exit(EXIT_FAILURE);
     }
-
     nixl_remote_dlist_t remote_list(VRAM_SEG);
     for (const auto &remote_iov_list : remote_iov_lists) {
         for (const auto &iov : remote_iov_list) {
@@ -2248,7 +2235,6 @@ xferBenchNixlWorker::prepareGPURemoteView(
             remote_list.addDesc(remoteDesc);
         }
     }
-
     const nixlRemoteDesc remoteDesc{completion_counter_iov.value().addr,
                                     completion_counter_iov.value().len,
                                     static_cast<uint64_t>(completion_counter_iov.value().devId),

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -115,8 +115,6 @@ getRandomSeed() {
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
     : xferBenchWorker(),
-      local_mvh(nullptr),
-      remote_mvh(nullptr),
       default_rng_(getRandomSeed()) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
@@ -363,8 +361,6 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
-        releaseGPURemoteView();
-        releaseGPULocalView();
         delete agent;
         agent = nullptr;
     }
@@ -719,13 +715,7 @@ allocVramValueZero(int devid, size_t nbytes) {
 
 std::optional<xferBenchIOV>
 xferBenchNixlWorker::initCompletionCounterVram() {
-    if (!xferBenchConfig::use_device_api || !isTarget() || seg_type != VRAM_SEG) {
-        return std::nullopt;
-    }
-    int counter_dev = 0;
-    if (IS_PAIRWISE_AND_SG()) {
-        counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev;
-    }
+    int counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev; // pairwise SG only
     return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
 
@@ -1464,13 +1454,12 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                 std::cerr << "NIXL: expected 1 completion counter descriptor, got "
                           << cc_iovs.size() << std::endl;
                 std::exit(EXIT_FAILURE);
-            } else {
-                completion_counter_iov = cc_iovs[0];
-                if (completion_counter_iov->len < kDeviceCounterBytes) {
-                    std::cerr << "NIXL: completion counter descriptor too small: "
-                              << completion_counter_iov->len << " bytes" << std::endl;
-                    std::exit(EXIT_FAILURE);
-                }
+            }
+            completion_counter_iov = cc_iovs[0];
+            if (completion_counter_iov->len < kDeviceCounterBytes) {
+                std::cerr << "NIXL: completion counter descriptor too small: "
+                          << completion_counter_iov->len << " bytes" << std::endl;
+                std::exit(EXIT_FAILURE);
             }
         }
     }
@@ -1913,8 +1902,7 @@ execDeviceTransfer(nixlMemViewH local_mvh,
     params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
     params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
     xferBenchTimer total_timer;
-    xferBenchStats iter_stats;
-    iter_stats.reserve(num_iter);
+    stats.transfer_duration.reserve(num_iter);
     xferBenchTimer timer;
     for (int i = 0; i < num_iter; ++i) {
         if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
@@ -1928,9 +1916,8 @@ execDeviceTransfer(nixlMemViewH local_mvh,
             stats.total_duration.add(total_timer.lap());
             return -1;
         }
-        iter_stats.transfer_duration.add(timer.lap());
+        stats.transfer_duration.add(timer.lap());
     }
-    stats.add(iter_stats);
     stats.total_duration.add(total_timer.lap());
     return 0;
 #else
@@ -2031,6 +2018,13 @@ xferBenchNixlWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
+    nixlMemViewH local_mvh = nullptr;
+    nixlMemViewH remote_mvh = nullptr;
+    auto gpu_view_guard = make_scope_guard([this, &local_mvh, &remote_mvh] {
+        releaseMemView(remote_mvh);
+        releaseMemView(local_mvh);
+    });
+
     size_t num_regions = 0;
     if (xferBenchConfig::use_device_api) {
         if (local_iovs.size() != 1 || remote_iovs.size() != 1) {
@@ -2047,16 +2041,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
             return std::variant<xferBenchStats, int>(-1);
         }
         num_regions = remote_regions;
-    }
-    auto gpu_view_guard = make_scope_guard([this] {
-        if (xferBenchConfig::use_device_api) {
-            releaseGPURemoteView();
-            releaseGPULocalView();
-        }
-    });
-    if (xferBenchConfig::use_device_api) {
-        prepareGPULocalView(local_iovs);
-        prepareGPURemoteView(remote_iovs);
+        local_mvh = prepareGPULocalView(local_iovs);
+        remote_mvh = prepareGPURemoteView(remote_iovs);
     }
 
     if (skip > 0) {
@@ -2087,8 +2073,6 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     // Synchronize to ensure all processes have completed the warmup (iter and polling)
     synchronize();
-
-    stats.clear();
 
     if (xferBenchConfig::use_device_api) {
         ret = execDeviceTransfer(local_mvh,
@@ -2207,7 +2191,7 @@ xferBenchNixlWorker::synchronizeStart() {
     return -1;
 }
 
-void
+nixlMemViewH
 xferBenchNixlWorker::prepareGPULocalView(
     const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) {
     nixl_xfer_dlist_t local_list(VRAM_SEG);
@@ -2217,10 +2201,12 @@ xferBenchNixlWorker::prepareGPULocalView(
             local_list.addDesc(localDesc);
         }
     }
+    nixlMemViewH local_mvh = nullptr;
     CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh), "prepMemView on local view failed");
+    return local_mvh;
 }
 
-void
+nixlMemViewH
 xferBenchNixlWorker::prepareGPURemoteView(
     const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
     if (remote_agent_name.empty()) {
@@ -2241,8 +2227,10 @@ xferBenchNixlWorker::prepareGPURemoteView(
                                     static_cast<uint64_t>(completion_counter_iov.value().devId),
                                     remote_agent_name};
     remote_list.addDesc(remoteDesc);
+    nixlMemViewH remote_mvh = nullptr;
     CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
                      "prepMemView on remote view failed");
+    return remote_mvh;
 }
 
 void
@@ -2251,14 +2239,4 @@ xferBenchNixlWorker::releaseMemView(nixlMemViewH &mvh) {
         agent->releaseMemView(mvh);
         mvh = nullptr;
     }
-}
-
-void
-xferBenchNixlWorker::releaseGPULocalView() {
-    releaseMemView(local_mvh);
-}
-
-void
-xferBenchNixlWorker::releaseGPURemoteView() {
-    releaseMemView(remote_mvh);
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -2110,8 +2110,7 @@ xferBenchNixlWorker::transfer(size_t block_size,
                                  block_size,
                                  stats,
                                  &terminate);
-    }
-    else {
+    } else {
         ret = execTransfer(agent,
                            backend_engine,
                            local_iovs,

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1957,6 +1957,7 @@ xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_
         uint64_t done;
         uint64_t error;
     };
+
     if (expected_value == 0) {
         return true;
     }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <filesystem>
 #include <iomanip>
+#include "kernels/nixlbench_device_launch.cuh"
 #include <memory>
 #include <numeric>
 #include <sstream>
@@ -34,6 +35,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <thread>
 #include <utils/serdes/serdes.h>
 #include <omp.h>
 
@@ -70,6 +72,10 @@ resolveVramSegment() {
         }                                                                                   \
         _seg_type;                                                                          \
     })
+
+constexpr size_t kDeviceCounterDoneOffsetBytes = 0;
+constexpr size_t kDeviceCounterErrorOffsetBytes = sizeof(uint64_t);
+constexpr size_t kDeviceCounterBytes = 2 * sizeof(uint64_t);
 
 // Reuse parser from utils
 
@@ -108,6 +114,8 @@ getRandomSeed() {
 
 xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices)
     : xferBenchWorker(),
+      local_mvh(nullptr),
+      remote_mvh(nullptr),
       default_rng_(getRandomSeed()) {
     seg_type = GET_SEG_TYPE(isInitiator());
 
@@ -354,6 +362,8 @@ xferBenchNixlWorker::~xferBenchNixlWorker() {
     rt = nullptr;
 
     if (agent) {
+        releaseGPURemoteView();
+        releaseGPULocalView();
         delete agent;
         agent = nullptr;
     }
@@ -684,6 +694,41 @@ getVramDesc(int devid, size_t buffer_size, bool isInit) {
     std::cerr << "VRAM not supported without CUDA, ROCm or Neuron" << std::endl;
     return std::nullopt;
 #endif
+}
+
+/** Allocate @a nbytes of VRAM on @a devid with all bytes set to zero. */
+static std::optional<xferBenchIOV>
+allocVramValueZero(int devid, size_t nbytes) {
+#ifdef HAVE_UCX_GPU_DEVICE_API
+    if (neuronCoreCount() > 0) {
+        return getVramDescNeuron(devid, nbytes, 0);
+    }
+
+    CHECK_CUDA_ERROR(cudaSetDevice(devid), "Failed to set device");
+    if (xferBenchConfig::enable_vmm) {
+        return getVramDescCudaVmm(devid, nbytes, 0);
+    }
+    return getVramDescCuda(devid, nbytes, 0);
+#else
+    (void)devid;
+    (void)nbytes;
+    std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
+    return std::nullopt;
+#endif
+}
+
+std::optional<xferBenchIOV>
+xferBenchNixlWorker::initCompletionCounterVram() {
+    if (!xferBenchConfig::use_device_api || !isTarget() || seg_type != VRAM_SEG) {
+        return std::nullopt;
+    }
+
+    int counter_dev = 0;
+    if (IS_PAIRWISE_AND_SG()) {
+        counter_dev = rt->getRank() - xferBenchConfig::num_initiator_dev;
+    }
+
+    return allocVramValueZero(counter_dev, kDeviceCounterBytes);
 }
 
 std::optional<xferBenchIOV>
@@ -1162,6 +1207,20 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         iov_lists.push_back(std::move(iov_list));
     }
 
+    if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+        completion_counter_iov = initCompletionCounterVram();
+        if (isTarget() && !completion_counter_iov.has_value()) {
+            std::cerr << "NIXL: failed to allocate completion counter for Device API" << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+        if (completion_counter_iov.has_value()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc = iovListToNixlRegDlist(cc_list, VRAM_SEG);
+            CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
+                             "registerMem failed for completion counter");
+        }
+    }
+
     return iov_lists;
 }
 
@@ -1173,6 +1232,20 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
     remote_regs_.clear();
     // xferFileState RAII closes backing fds after deregistrations complete.
     remote_fds.clear();
+
+    if (completion_counter_iov.has_value()) {
+        if (isTarget()) {
+            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+            nixl_reg_dlist_t cc_desc = iovListToNixlRegDlist(cc_list, VRAM_SEG);
+            nixl_opt_args_t opt_args;
+            opt_args.backends.push_back(backend_engine);
+            CHECK_NIXL_ERROR(agent->deregisterMem(cc_desc, &opt_args),
+                             "deregisterMem failed for completion counter");
+            cleanupBasicDescVram(completion_counter_iov.value());
+        }
+        completion_counter_iov.reset();
+    }
+
     local_regs_.clear();
     iov_lists.clear();
 }
@@ -1206,7 +1279,6 @@ xferBenchNixlWorker::exchangeMetadata() {
         rt->sendInt(&meta_sz, destrank);
         rt->sendChar((char *)buffer, meta_sz, destrank);
     } else if (isInitiator()) {
-        std::string remote_agent;
         int srcrank;
 
         if (IS_PAIRWISE_AND_SG()) {
@@ -1230,7 +1302,7 @@ xferBenchNixlWorker::exchangeMetadata() {
             return ret;
         }
 
-        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent);
+        nixl_status_t status = agent->loadRemoteMD(remote_metadata, remote_agent_name);
         if (status != NIXL_SUCCESS) {
             std::cerr << "NIXL: loadRemoteMD failed: " << nixlEnumStrings::statusStr(status)
                       << std::endl;
@@ -1347,6 +1419,68 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             }
         }
     }
+
+    if (xferBenchConfig::use_device_api) {
+        if (isTarget() && completion_counter_iov.has_value()) {
+            nixlSerDes cc_ser;
+            nixl_xfer_dlist_t cc_dlist(seg_type);
+            nixlBasicDesc cc_basic;
+            const xferBenchIOV &cc = completion_counter_iov.value();
+            cc_basic.addr = cc.addr;
+            cc_basic.len = cc.len;
+            cc_basic.devId = cc.devId;
+            cc_dlist.addDesc(cc_basic);
+            cc_dlist.serialize(&cc_ser);
+            std::string cc_export = cc_ser.exportStr();
+
+            int destrank;
+            if (IS_PAIRWISE_AND_SG()) {
+                destrank = rt->getRank() - xferBenchConfig::num_target_dev;
+            } else {
+                destrank = 0;
+            }
+            desc_str_sz = static_cast<int>(cc_export.size());
+            rt->sendInt(&desc_str_sz, destrank);
+            rt->sendChar(cc_export.data(), cc_export.size(), destrank);
+        } else if (isInitiator()) {
+            nixlSerDes cc_ser;
+            int srcrank;
+            if (IS_PAIRWISE_AND_SG()) {
+                srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
+            } else {
+                srcrank = 1;
+            }
+            completion_counter_iov.reset();
+            if (rt->recvInt(&desc_str_sz, srcrank) != 0) {
+                std::cerr << "NIXL: failed to receive completion counter descriptor size"
+                          << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            std::string cc_str;
+            cc_str.resize(static_cast<size_t>(desc_str_sz), '\0');
+            if (rt->recvChar(cc_str.data(), cc_str.size(), srcrank) != 0) {
+                std::cerr << "NIXL: failed to receive completion counter descriptor"
+                          << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
+            cc_ser.importStr(cc_str);
+            nixl_xfer_dlist_t remote_cc(&cc_ser);
+            std::vector<xferBenchIOV> cc_iovs = nixlXferDlistToIOVList(remote_cc);
+            if (cc_iovs.size() != 1) {
+                std::cerr << "NIXL: expected 1 completion counter descriptor, got "
+                          << cc_iovs.size() << std::endl;
+                std::exit(EXIT_FAILURE);
+            } else {
+                completion_counter_iov = cc_iovs[0];
+                if (completion_counter_iov->len < kDeviceCounterBytes) {
+                    std::cerr << "NIXL: completion counter descriptor too small: "
+                              << completion_counter_iov->len << " bytes" << std::endl;
+                    std::exit(EXIT_FAILURE);
+                }
+            }
+        }
+    }
+
     // Ensure all processes have completed the exchange with a barrier/sync
     synchronize();
     return res;
@@ -1766,6 +1900,147 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
+// Descriptor count after the same flattening as prepareGPULocalView.
+static size_t
+countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
+    size_t n = 0;
+    for (const auto &lst : local_iovs) {
+        n += lst.size();
+    }
+    return n;
+}
+
+// Device PUT: MVHs from prepMemView; runs num_iter launches with CUDA block size num_threads.
+// signal_remote_completion: host appended counter as last remote region.
+static int
+execDeviceTransfer(nixlMemViewH local_mvh,
+                   nixlMemViewH remote_mvh,
+                   bool signal_remote_completion,
+                   const int num_iter,
+                   const int num_threads,
+                   size_t num_regions,
+                   size_t region_size,
+                   xferBenchStats &stats,
+                   const std::atomic<int> *terminate_ptr = nullptr) {
+#ifdef HAVE_UCX_GPU_DEVICE_API
+    stats.clear();
+
+    if (num_threads < 1 || num_threads > 1024) {
+        std::cerr << "execDeviceTransfer: num_threads must be >= 1 and <= 1024" << std::endl;
+        return -1;
+    }
+
+    nixlbenchDeviceXferParams params;
+    params.localMvh = local_mvh;
+    params.remoteMvh = remote_mvh;
+    params.numRegions = num_regions;
+    params.regionSize = region_size;
+    params.signalRemoteCompletion = signal_remote_completion;
+    params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
+    params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
+
+    xferBenchTimer total_timer;
+    xferBenchStats iter_stats;
+    iter_stats.reserve(num_iter);
+    xferBenchTimer timer;
+
+    for (int i = 0; i < num_iter; ++i) {
+        if (__builtin_expect(terminate_ptr && terminate_ptr->load(), 0)) {
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
+        nixl_status_t st =
+            nixlbenchLaunchDevicePut(params, static_cast<unsigned>(num_threads));
+        if (__builtin_expect(st != NIXL_SUCCESS, 0)) {
+            std::cerr << "nixlbenchLaunchDevicePut failed: " << nixlEnumStrings::statusStr(st)
+                      << std::endl;
+            stats.total_duration.add(total_timer.lap());
+            return -1;
+        }
+        iter_stats.transfer_duration.add(timer.lap());
+    }
+
+    stats.add(iter_stats);
+    stats.total_duration.add(total_timer.lap());
+    return 0;
+#else
+    (void)local_mvh;
+    (void)remote_mvh;
+    (void)signal_remote_completion;
+    (void)num_iter;
+    (void)num_threads;
+    (void)num_regions;
+    (void)region_size;
+    (void)stats;
+    (void)terminate_ptr;
+    std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
+    return -1;
+#endif
+}
+
+bool
+xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                                                    uint64_t expected_value,
+                                                    const char *phase,
+                                                    const std::function<void()> &checkLiveness) {
+#ifdef HAVE_UCX_GPU_DEVICE_API
+    struct xferBenchDeviceCounters {
+        uint64_t done;
+        uint64_t error;
+    };
+
+    if (expected_value == 0) {
+        return true;
+    }
+    while (!signaled()) {
+        CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId),
+                         "Failed to set completion counter device");
+        xferBenchDeviceCounters counters{};
+        CHECK_CUDA_ERROR(cudaMemcpy(&counters,
+                                    reinterpret_cast<const void *>(counter_iov.addr),
+                                    sizeof(counters),
+                                    cudaMemcpyDeviceToHost),
+                         "Failed to read completion counters from VRAM");
+        if (counters.error > 0) {
+            std::cerr << "NIXL Device API: " << phase << " failed: remote error counter is "
+                      << counters.error << std::endl;
+            terminate.store(1);
+            return false;
+        }
+        if (counters.done >= expected_value) {
+            return true;
+        }
+        checkLiveness();
+        if (signaled()) {
+            std::cerr << "NIXL Device API: " << phase
+                      << " wait interrupted by signal/liveness failure" << std::endl;
+            return false;
+        }
+        std::this_thread::yield();
+    }
+    return false;
+#else
+    (void)counter_iov;
+    (void)expected_value;
+    (void)phase;
+    (void)checkLiveness;
+    std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
+    return false;
+#endif
+}
+
+static void
+resetDeviceCounters(const xferBenchIOV &counter_iov) {
+#ifdef HAVE_UCX_GPU_DEVICE_API
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
+    CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
+                     "Failed to reset completion counters in VRAM");
+#else
+    (void)counter_iov;
+    std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
+#endif
+}
+
 std::variant<xferBenchStats, int>
 xferBenchNixlWorker::transfer(size_t block_size,
                               const std::vector<std::vector<xferBenchIOV>> &local_iovs,
@@ -1787,16 +2062,43 @@ xferBenchNixlWorker::transfer(size_t block_size,
         num_iter /= xferBenchConfig::large_blk_iter_ftr;
     }
 
+    size_t num_regions = 0;
+    if (xferBenchConfig::use_device_api) {
+        const size_t local_regions = countFlattenedRegions(local_iovs);
+        const size_t remote_regions = countFlattenedRegions(remote_iovs);
+        assert(local_regions == remote_regions);
+        if (__builtin_expect(local_regions != remote_regions, 0)) {
+            std::cerr << "NIXL Device API requires equal flattened local/remote region counts: "
+                      << "local=" << local_regions << ", remote=" << remote_regions << std::endl;
+            return std::variant<xferBenchStats, int>(-1);
+        }
+        num_regions = remote_regions;
+    }
+
     if (skip > 0) {
-        ret = execTransfer(agent,
-                           backend_engine,
-                           local_iovs,
-                           remote_iovs,
-                           xfer_op,
-                           skip,
-                           xferBenchConfig::num_threads,
-                           stats,
-                           &terminate);
+        if (xferBenchConfig::use_device_api) {
+            const bool signal_remote_completion =
+                completion_counter_iov.has_value() && remote_mvh != nullptr;
+            ret = execDeviceTransfer(local_mvh,
+                                     remote_mvh,
+                                     signal_remote_completion,
+                                     skip,
+                                     xferBenchConfig::block_threads,
+                                     num_regions,
+                                     block_size,
+                                     stats,
+                                     &terminate);
+        } else {
+            ret = execTransfer(agent,
+                               backend_engine,
+                               local_iovs,
+                               remote_iovs,
+                               xfer_op,
+                               skip,
+                               xferBenchConfig::num_threads,
+                               stats,
+                               &terminate);
+        }
         if (ret < 0) {
             return std::variant<xferBenchStats, int>(ret);
         }
@@ -1807,15 +2109,30 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     stats.clear();
 
-    ret = execTransfer(agent,
-                       backend_engine,
-                       local_iovs,
-                       remote_iovs,
-                       xfer_op,
-                       num_iter,
-                       xferBenchConfig::num_threads,
-                       stats,
+    if (xferBenchConfig::use_device_api) {
+        const bool signal_remote_completion =
+            completion_counter_iov.has_value() && remote_mvh != nullptr;
+        ret = execDeviceTransfer(local_mvh,
+                                 remote_mvh,
+                                 signal_remote_completion,
+                                 num_iter,
+                                 xferBenchConfig::block_threads,
+                                 num_regions,
+                                 block_size,
+                                 stats,
+                                 &terminate);
+    }
+    else {
+        ret = execTransfer(agent,
+                           backend_engine,
+                           local_iovs,
+                           remote_iovs,
+                           xfer_op,
+                           num_iter,
+                           xferBenchConfig::num_threads,
+                        stats,
                        &terminate);
+    }
     if (ret < 0) {
         return std::variant<xferBenchStats, int>(ret);
     }
@@ -1856,6 +2173,24 @@ xferBenchNixlWorker::poll(size_t block_size) {
         }
     };
 
+    const bool use_device_completion_counter =
+        xferBenchConfig::use_device_api && completion_counter_iov.has_value();
+    if (use_device_completion_counter) {
+        const xferBenchIOV &counter_iov = completion_counter_iov.value();
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(skip), "warmup", checkLiveness)) {
+            return;
+        }
+        synchronize();
+        if (!waitForDeviceCompletionCounter(
+                counter_iov, static_cast<uint64_t>(total_iter), "transfer", checkLiveness)) {
+            return;
+        }
+        synchronize();
+        resetDeviceCounters(counter_iov);
+        return;
+    }
+
     /* Ensure warmup is done*/
     do {
         status = agent->getNotifs(notifs);
@@ -1893,4 +2228,65 @@ xferBenchNixlWorker::synchronizeStart() {
         return 0;
     }
     return -1;
+}
+
+void
+xferBenchNixlWorker::prepareGPULocalView(
+    const std::vector<std::vector<xferBenchIOV>> &local_iov_lists) {
+    nixl_xfer_dlist_t local_list(VRAM_SEG);
+    for (const auto &local_iov_list : local_iov_lists) {
+        for (const auto &iov : local_iov_list) {
+            const nixlBasicDesc localDesc{iov.addr, iov.len, static_cast<uint64_t>(iov.devId)};
+            local_list.addDesc(localDesc);
+        }
+    }
+    CHECK_NIXL_ERROR(agent->prepMemView(local_list, local_mvh), "prepMemView on local view failed");
+}
+
+void
+xferBenchNixlWorker::prepareGPURemoteView(
+    const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) {
+    if (remote_agent_name.empty()) {
+        std::cerr << "NIXL Device API: remote_agent_name is empty; "
+                  << "exchangeMetadata must be called before prepareGPURemoteView"
+                  << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    // prepare remote memory view
+    nixl_remote_dlist_t remote_list(VRAM_SEG);
+    for (const auto &remote_iov_list : remote_iov_lists) {
+        for (const auto &iov : remote_iov_list) {
+            const nixlRemoteDesc remoteDesc{
+                iov.addr, iov.len, static_cast<uint64_t>(iov.devId), remote_agent_name};
+            remote_list.addDesc(remoteDesc);
+        }
+    }
+    if (completion_counter_iov.has_value()) {
+        const nixlRemoteDesc remoteDesc{
+            completion_counter_iov.value().addr,
+            completion_counter_iov.value().len,
+            static_cast<uint64_t>(completion_counter_iov.value().devId),
+            remote_agent_name};
+        remote_list.addDesc(remoteDesc);
+    }
+    CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
+                     "prepMemView on remote view failed");
+}
+
+void
+xferBenchNixlWorker::releaseMemView(nixlMemViewH &mvh) {
+    if (mvh != nullptr) {
+        agent->releaseMemView(mvh);
+        mvh = nullptr;
+    }
+}
+
+void
+xferBenchNixlWorker::releaseGPULocalView() {
+    releaseMemView(local_mvh);
+}
+
+void
+xferBenchNixlWorker::releaseGPURemoteView() {
+    releaseMemView(remote_mvh);
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <sstream>
 #include "utils/neuron.h"
+#include "utils/scope_guard.h"
 #include "utils/utils.h"
 #include <unistd.h>
 #include <utility>
@@ -1207,18 +1208,16 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         iov_lists.push_back(std::move(iov_list));
     }
 
-    if (xferBenchConfig::use_device_api && seg_type == VRAM_SEG) {
+    if (xferBenchConfig::use_device_api && isTarget()) {
         completion_counter_iov = initCompletionCounterVram();
-        if (isTarget() && !completion_counter_iov.has_value()) {
+        if (!completion_counter_iov.has_value()) {
             std::cerr << "NIXL: failed to allocate completion counter for Device API" << std::endl;
             std::exit(EXIT_FAILURE);
         }
-        if (completion_counter_iov.has_value()) {
-            std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
-            nixl_reg_dlist_t cc_desc = iovListToNixlRegDlist(cc_list, VRAM_SEG);
-            CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
-                             "registerMem failed for completion counter");
-        }
+        std::vector<xferBenchIOV> cc_list{completion_counter_iov.value()};
+        nixl_reg_dlist_t cc_desc = iovListToNixlRegDlist(cc_list, VRAM_SEG);
+        CHECK_NIXL_ERROR(agent->registerMem(cc_desc, &opt_args),
+                         "registerMem failed for completion counter");
     }
 
     return iov_lists;
@@ -1900,22 +1899,9 @@ execTransfer(nixlAgent *agent,
     return ret;
 }
 
-// Descriptor count after the same flattening as prepareGPULocalView.
-static size_t
-countFlattenedRegions(const std::vector<std::vector<xferBenchIOV>> &local_iovs) {
-    size_t n = 0;
-    for (const auto &lst : local_iovs) {
-        n += lst.size();
-    }
-    return n;
-}
-
-// Device PUT: MVHs from prepMemView; runs num_iter launches with CUDA block size num_threads.
-// signal_remote_completion: host appended counter as last remote region.
 static int
 execDeviceTransfer(nixlMemViewH local_mvh,
                    nixlMemViewH remote_mvh,
-                   bool signal_remote_completion,
                    const int num_iter,
                    const int num_threads,
                    size_t num_regions,
@@ -1925,17 +1911,11 @@ execDeviceTransfer(nixlMemViewH local_mvh,
 #ifdef HAVE_UCX_GPU_DEVICE_API
     stats.clear();
 
-    if (num_threads < 1 || num_threads > 1024) {
-        std::cerr << "execDeviceTransfer: num_threads must be >= 1 and <= 1024" << std::endl;
-        return -1;
-    }
-
     nixlbenchDeviceXferParams params;
     params.localMvh = local_mvh;
     params.remoteMvh = remote_mvh;
     params.numRegions = num_regions;
     params.regionSize = region_size;
-    params.signalRemoteCompletion = signal_remote_completion;
     params.completionCounterOffsetBytes = kDeviceCounterDoneOffsetBytes;
     params.errorCounterOffsetBytes = kDeviceCounterErrorOffsetBytes;
 
@@ -1966,7 +1946,6 @@ execDeviceTransfer(nixlMemViewH local_mvh,
 #else
     (void)local_mvh;
     (void)remote_mvh;
-    (void)signal_remote_completion;
     (void)num_iter;
     (void)num_threads;
     (void)num_regions;
@@ -1992,9 +1971,10 @@ xferBenchNixlWorker::waitForDeviceCompletionCounter(const xferBenchIOV &counter_
     if (expected_value == 0) {
         return true;
     }
+    CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId),
+                     "Failed to set completion counter device");
+
     while (!signaled()) {
-        CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId),
-                         "Failed to set completion counter device");
         xferBenchDeviceCounters counters{};
         CHECK_CUDA_ERROR(cudaMemcpy(&counters,
                                     reinterpret_cast<const void *>(counter_iov.addr),
@@ -2035,6 +2015,9 @@ resetDeviceCounters(const xferBenchIOV &counter_iov) {
     CHECK_CUDA_ERROR(cudaSetDevice(counter_iov.devId), "Failed to set completion counter device");
     CHECK_CUDA_ERROR(cudaMemset(reinterpret_cast<void *>(counter_iov.addr), 0, kDeviceCounterBytes),
                      "Failed to reset completion counters in VRAM");
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(0),
+                     "Failed to synchronize completion counter reset");
+
 #else
     (void)counter_iov;
     std::cerr << "NIXL Device API support is not enabled in this build" << std::endl;
@@ -2064,24 +2047,37 @@ xferBenchNixlWorker::transfer(size_t block_size,
 
     size_t num_regions = 0;
     if (xferBenchConfig::use_device_api) {
-        const size_t local_regions = countFlattenedRegions(local_iovs);
-        const size_t remote_regions = countFlattenedRegions(remote_iovs);
-        assert(local_regions == remote_regions);
+        if (local_iovs.size() != 1 || remote_iovs.size() != 1) {
+            std::cerr << "NIXL Device API requires exactly one local and one remote IOV list: "
+                      << "local=" << local_iovs.size() << ", remote=" << remote_iovs.size()
+                      << std::endl;
+            return std::variant<xferBenchStats, int>(-1);
+        }
+        const size_t local_regions = local_iovs.front().size();
+        const size_t remote_regions = remote_iovs.front().size();
         if (__builtin_expect(local_regions != remote_regions, 0)) {
-            std::cerr << "NIXL Device API requires equal flattened local/remote region counts: "
+            std::cerr << "NIXL Device API requires equal local/remote region counts: "
                       << "local=" << local_regions << ", remote=" << remote_regions << std::endl;
             return std::variant<xferBenchStats, int>(-1);
         }
         num_regions = remote_regions;
     }
 
+    auto gpu_view_guard = make_scope_guard([this] {
+        if (xferBenchConfig::use_device_api) {
+            releaseGPURemoteView();
+            releaseGPULocalView();
+        }
+    });
+    if (xferBenchConfig::use_device_api) {
+        prepareGPULocalView(local_iovs);
+        prepareGPURemoteView(remote_iovs);
+    }
+
     if (skip > 0) {
         if (xferBenchConfig::use_device_api) {
-            const bool signal_remote_completion =
-                completion_counter_iov.has_value() && remote_mvh != nullptr;
             ret = execDeviceTransfer(local_mvh,
                                      remote_mvh,
-                                     signal_remote_completion,
                                      skip,
                                      xferBenchConfig::block_threads,
                                      num_regions,
@@ -2110,11 +2106,8 @@ xferBenchNixlWorker::transfer(size_t block_size,
     stats.clear();
 
     if (xferBenchConfig::use_device_api) {
-        const bool signal_remote_completion =
-            completion_counter_iov.has_value() && remote_mvh != nullptr;
         ret = execDeviceTransfer(local_mvh,
                                  remote_mvh,
-                                 signal_remote_completion,
                                  num_iter,
                                  xferBenchConfig::block_threads,
                                  num_regions,
@@ -2252,7 +2245,7 @@ xferBenchNixlWorker::prepareGPURemoteView(
                   << std::endl;
         std::exit(EXIT_FAILURE);
     }
-    // prepare remote memory view
+
     nixl_remote_dlist_t remote_list(VRAM_SEG);
     for (const auto &remote_iov_list : remote_iov_lists) {
         for (const auto &iov : remote_iov_list) {
@@ -2261,14 +2254,13 @@ xferBenchNixlWorker::prepareGPURemoteView(
             remote_list.addDesc(remoteDesc);
         }
     }
-    if (completion_counter_iov.has_value()) {
-        const nixlRemoteDesc remoteDesc{
-            completion_counter_iov.value().addr,
-            completion_counter_iov.value().len,
-            static_cast<uint64_t>(completion_counter_iov.value().devId),
-            remote_agent_name};
-        remote_list.addDesc(remoteDesc);
-    }
+
+    const nixlRemoteDesc remoteDesc{
+        completion_counter_iov.value().addr,
+        completion_counter_iov.value().len,
+        static_cast<uint64_t>(completion_counter_iov.value().devId),
+        remote_agent_name};
+    remote_list.addDesc(remoteDesc);
     CHECK_NIXL_ERROR(agent->prepMemView(remote_list, remote_mvh),
                      "prepMemView on remote view failed");
 }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -46,8 +46,6 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::vector<NixlMemRegion> remote_regs_;
         std::vector<NixlMemRegion> local_regs_;
         std::vector<GusliDeviceConfig> gusli_devices;
-        nixlMemViewH local_mvh;
-        nixlMemViewH remote_mvh;
         std::string remote_agent_name;
         std::optional<xferBenchIOV> completion_counter_iov;
 
@@ -75,15 +73,6 @@ class xferBenchNixlWorker: public xferBenchWorker {
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
-        void
-        prepareGPULocalView(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
-        void
-        prepareGPURemoteView(const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
-        void
-        releaseGPULocalView();
-        void
-        releaseGPURemoteView();
-
     private:
         std::optional<xferBenchIOV>
         initBasicDescDram(size_t buffer_size, int mem_dev_id);
@@ -101,6 +90,10 @@ class xferBenchNixlWorker: public xferBenchWorker {
         getFileOffset(size_t current_offset, size_t max_offset_in_blocks, size_t block_size);
         void
         releaseMemView(nixlMemViewH &mvh);
+        nixlMemViewH
+        prepareGPULocalView(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
+        nixlMemViewH
+        prepareGPURemoteView(const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
         std::optional<xferBenchIOV>
         initCompletionCounterVram();
         bool

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -27,7 +27,9 @@
 #include <optional>
 #include <memory>
 #include <unistd.h>
+#include <functional>
 #include <nixl.h>
+#include <nixl_types.h>
 #include "utils/utils.h"
 #include "worker/worker.h"
 #include <random>
@@ -44,6 +46,13 @@ class xferBenchNixlWorker: public xferBenchWorker {
         std::vector<NixlMemRegion> remote_regs_;
         std::vector<NixlMemRegion> local_regs_;
         std::vector<GusliDeviceConfig> gusli_devices;
+        nixlMemViewH local_mvh;
+        nixlMemViewH remote_mvh;
+        std::string remote_agent_name;
+        /// Device API: target holds local registered counter buffer (done + error uint64_t
+        /// counters); initiator holds peer descriptor after exchangeIOV (no local alloc on
+        /// initiator).
+        std::optional<xferBenchIOV> completion_counter_iov;
 
     public:
         explicit xferBenchNixlWorker(const std::vector<std::string> &devices);
@@ -69,6 +78,15 @@ class xferBenchNixlWorker: public xferBenchWorker {
                  const std::vector<std::vector<xferBenchIOV>> &local_iov_lists,
                  const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists) override;
 
+        void
+        prepareGPULocalView(const std::vector<std::vector<xferBenchIOV>> &local_iov_lists);
+        void
+        prepareGPURemoteView(const std::vector<std::vector<xferBenchIOV>> &remote_iov_lists);
+        void
+        releaseGPULocalView();
+        void
+        releaseGPURemoteView();
+
     private:
         std::optional<xferBenchIOV>
         initBasicDescDram(size_t buffer_size, int mem_dev_id);
@@ -84,6 +102,15 @@ class xferBenchNixlWorker: public xferBenchWorker {
         ensureFileHasConsistencyData(const GusliDeviceConfig &device, size_t size);
         uint64_t
         getFileOffset(size_t current_offset, size_t max_offset_in_blocks, size_t block_size);
+        void
+        releaseMemView(nixlMemViewH &mvh);
+        std::optional<xferBenchIOV>
+        initCompletionCounterVram();
+        bool
+        waitForDeviceCompletionCounter(const xferBenchIOV &counter_iov,
+                                       uint64_t expected_value,
+                                       const char *phase,
+                                       const std::function<void()> &checkLiveness);
 
         std::mt19937_64 default_rng_;
 };

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -49,9 +49,6 @@ class xferBenchNixlWorker: public xferBenchWorker {
         nixlMemViewH local_mvh;
         nixlMemViewH remote_mvh;
         std::string remote_agent_name;
-        /// Device API: target holds local registered counter buffer (done + error uint64_t
-        /// counters); initiator holds peer descriptor after exchangeIOV (no local alloc on
-        /// initiator).
         std::optional<xferBenchIOV> completion_counter_iov;
 
     public:


### PR DESCRIPTION
## What?
Integrate Device API into nixlbench so transfers can be initiated from a CUDA kernel instead of the host path.
Adds --use_device_api to enable GPU-kernel-initiated PUT transfers. When enabled, --num_threads is repurposed as the CUDA kernel block size, and the internal CPU thread count is forced to 1.
This builds on the kernel launch support landed in #1761.

## Why?
nixlbench could not exercise Device API end-to-end now. Wire the existing device kernels into the worker so we can benchmark and validate GPU-initiated WRITE transfers under a supported configuration.

## How?
- Add --use_device_api and validate required options at config parse time (UCX, VRAM↔VRAM, --enable_pt, pairwise, SG, WRITE, pipeline_depth=1, and a build with HAVE_UCX_GPU_DEVICE_API).

- In the NIXL worker, prepare local/remote nixlMemViews, allocate/exchange a VRAM completion counter, and launch nixlbenchLaunchDevicePut for the transfer path.

- On the target, wait on the device completion/error counters instead of host-side request completion.

- Keep the existing host transfer path unchanged when --use_device_api is not set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional NIXL Device API mode for GPU-based transfer benchmarking.
  * Added GPU-resident completion tracking and automatic monitoring for warmup and timed transfers.
  * Added GPU memory preparation and cleanup for local and remote transfer views.
  * Added validation and status reporting for device API settings, including CUDA block size and supported transfer configurations.

* **Bug Fixes**
  * Device transfers no longer require remote completion signaling to be explicitly enabled.
  * Completion and error signaling now consistently use the remote counter region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->