### PR TITLE
build: discover cuobjclient across CUDA Toolkit versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -147,8 +147,40 @@ has_posix_aio = cpp.has_function('aio_cancel', prefix: '#include <aio.h>', depen
 # Check whether the POSIX plugin is enabled
 has_posix_plugin = has_linux_aio or has_io_uring or has_posix_aio
 
-# Check for CUObject Client library
-cuobj_dep = dependency('cuobjclient-13.1', required: false)
+# Check for CUObject Client library.
+# The library ships with the CUDA Toolkit and its pkg-config file is named after
+# the toolkit release it belongs to (cuobjclient-13.1.pc, cuobjclient-13.3.pc, ...),
+# so a single module name cannot be used. Probe the pkg-config modules that are
+# installed and pick the newest one that satisfies the minimum supported version.
+cuobj_min_version = '13.1'
+cuobj_dep = dependency('cuobjclient', required: false)
+
+if not cuobj_dep.found()
+    pkgconfig_prog = find_program('pkg-config', 'pkgconf', required: false)
+    cuobj_module = ''
+    cuobj_version = ''
+    if pkgconfig_prog.found()
+        pkgconfig_modules = run_command(pkgconfig_prog, '--list-all', check: false)
+        if pkgconfig_modules.returncode() == 0
+            foreach line : pkgconfig_modules.stdout().strip().split('\n')
+                module = line.strip().split(' ')[0]
+                if module.startswith('cuobjclient-')
+                    version = module.split('cuobjclient-')[1]
+                    if version.version_compare('>=' + cuobj_min_version)
+                        if cuobj_version == '' or version.version_compare('>' + cuobj_version)
+                            cuobj_module = module
+                            cuobj_version = version
+                        endif
+                    endif
+                endif
+            endforeach
+        endif
+    endif
+    if cuobj_module != ''
+        cuobj_dep = dependency(cuobj_module, required: false)
+    endif
+endif
+
 if cuobj_dep.found()
     add_project_arguments('-DHAVE_CUOBJ_CLIENT', language: ['cpp'])
 endif

--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -42,11 +42,13 @@ git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git --branch 1
 
 ### Optional Dependencies
 
-**S3 Accelerated Engines** (`cuobjclient-13.1`): Required for GPU-direct and accelerated object storage operations. When available, enables:
+**S3 Accelerated Engines** (`cuobjclient`, CUDA Toolkit 13.1 or later): Required for GPU-direct and accelerated object storage operations. When available, enables:
 - `S3AccelObjEngineImpl` - Base accelerated S3 engine
 - Vendor-specific accelerated implementations under `s3_accel/`
 
-If `cuobjclient-13.1` is not found during build, the S3 Accelerated engines will be automatically disabled, and the plugin will fall back to standard S3 and S3 CRT engines.
+The CUObject Client library ships with the CUDA Toolkit and its pkg-config module is named after the toolkit release (for example `cuobjclient-13.1` or `cuobjclient-13.3`). The build picks the newest installed module that is at least version 13.1, so later CUDA Toolkit releases are used automatically.
+
+If no suitable `cuobjclient` module is found during build, the S3 Accelerated engines will be automatically disabled, and the plugin will fall back to standard S3 and S3 CRT engines.
 
 ## Configuration
 
@@ -333,7 +335,7 @@ Each engine implementation defines its own supported memory segment types via `g
 
 > **⚠️ Important: Conditional Compilation for S3 Accelerated Engines**
 >
-> The S3 Accelerated path (`s3_accel`) and any vendor implementations under it require the `cuobjclient-13.1` library. When adding new extensions to `s3_accel`:
+> The S3 Accelerated path (`s3_accel`) and any vendor implementations under it require the `cuobjclient` library (CUDA Toolkit 13.1 or later). When adding new extensions to `s3_accel`:
 >
 >
 > Vendor engines self-register via `objAccelEngineRegistrar`

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -41,7 +41,7 @@ compile_defs = []
 compile_flags = []
 
 if cuobj_dep.found()
-    message('Found CUObjClient Library. Enabling S3 Accelerated engines')
+    message('Found CUObjClient Library ' + cuobj_dep.version() + '. Enabling S3 Accelerated engines')
     obj_sources += [
         's3_accel/client.cpp',
         's3_accel/client.h',
@@ -54,7 +54,7 @@ if cuobj_dep.found()
     ]
     plugin_deps += [ cuobj_dep ]
 else
-    message('Could not find CUObjClient Library. Skipping S3 Accelerated engines')
+    message('Could not find CUObjClient Library >= ' + cuobj_min_version + '. Skipping S3 Accelerated engines')
 endif
 
 if 'OBJ' in static_plugins


### PR DESCRIPTION
The OBJ plugin's accelerated S3 engines looked for the pkg-config module 'cuobjclient-13.1' only. That module name encodes the CUDA Toolkit release the library ships with, so newer toolkits (e.g. 13.3, carrying cuObject client v1.2.0) install 'cuobjclient-13.3.pc' and were never picked up, leaving the accelerated engines silently disabled.

Enumerate the installed cuobjclient pkg-config modules and select the newest one that is at least 13.1, treating 13.1 as a minimum rather than an exact requirement.

Fixes ai-dynamo/nixl#1763

## Summary by CodeRabbit

* **Build Improvements**
  * Automatically detects the newest compatible CUObjClient library version (CUDA Toolkit 13.1 or later) instead of requiring one fixed version.
  * S3 accelerated engines now build when a suitable installed version is available and are skipped otherwise.
* **Documentation**
  * Updated dependency and configuration guidance for S3 accelerated engines.
  * Build messages now report the detected or required CUObjClient version.