### PR TITLE
ucx: name endpoints after remote agents

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -868,6 +868,13 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
     size_t size = remote_conn_info.size();
     std::vector<char> addr(size);
 
+    if (remote_agent.size() >= UCP_ENTITY_NAME_MAX) {
+        NIXL_ERROR << "Remote agent name is " << remote_agent.size()
+                   << " bytes, but UCX endpoint names are limited to " << UCP_ENTITY_NAME_MAX - 1
+                   << " bytes";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
     if(remoteConnMap.count(remote_agent)) {
         return NIXL_ERR_INVALID_PARAM;
     }

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -875,7 +875,7 @@ nixl_status_t nixlUcxEngine::loadRemoteConnInfo (const std::string &remote_agent
     nixlSerDes::_stringToBytes(addr.data(), remote_conn_info, size);
     std::shared_ptr<nixlUcxConnection> conn = std::make_shared<nixlUcxConnection>();
     for (const auto &uw : workers_) {
-        std::unique_ptr<nixlUcxEp> ep = uw->connect(addr.data());
+        std::unique_ptr<nixlUcxEp> ep = uw->connect(addr.data(), remote_agent);
         if (!ep) {
             return NIXL_ERR_BACKEND;
         }

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -162,6 +162,7 @@ nixlUcxEp::closeImpl() {
 
 nixlUcxEp::nixlUcxEp(ucp_worker_h worker,
                      void *addr,
+                     const std::string &ep_name,
                      ucp_err_handling_mode_t err_handling_mode,
                      uint32_t close_flags)
     : closeFlags_{close_flags} {
@@ -174,6 +175,10 @@ nixlUcxEp::nixlUcxEp(ucp_worker_h worker,
     ep_params.err_handler.cb = err_cb_wrapper;
     ep_params.err_handler.arg = static_cast<void *>(this);
     ep_params.address = reinterpret_cast<ucp_address_t *>(addr);
+    if (!ep_name.empty()) {
+        ep_params.field_mask |= UCP_EP_PARAM_FIELD_NAME;
+        ep_params.name = ep_name.c_str();
+    }
 
     status = nixl::ucx::ucsToNixlStatus(ucp_ep_create(worker, &ep_params, &eph));
     if (status == NIXL_SUCCESS)
@@ -577,10 +582,10 @@ nixlUcxWorker::epAddr() {
 }
 
 std::unique_ptr<nixlUcxEp>
-nixlUcxWorker::connect(void *addr) {
+nixlUcxWorker::connect(void *addr, const std::string &ep_name) {
     try {
-        auto ep =
-            std::make_unique<nixlUcxEp>(worker.get(), addr, err_handling_mode_, epCloseFlags_);
+        auto ep = std::make_unique<nixlUcxEp>(
+            worker.get(), addr, ep_name, err_handling_mode_, epCloseFlags_);
         NIXL_DEBUG << *this << ": created ep " << ep->getEp();
         return ep;
     }

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -71,6 +71,7 @@ public:
 
     nixlUcxEp(ucp_worker_h worker,
               void *addr,
+              const std::string &ep_name,
               ucp_err_handling_mode_t err_handling_mode,
               uint32_t close_flags);
     ~nixlUcxEp();
@@ -217,7 +218,7 @@ public:
     [[nodiscard]] std::string
     epAddr();
     [[nodiscard]] std::unique_ptr<nixlUcxEp>
-    connect(void *addr);
+    connect(void *addr, const std::string &ep_name = {});
 
     /* Active message handling */
     int

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -25,6 +25,10 @@ extern "C" {
 #include <ucp/api/ucp.h>
 }
 
+#if UCP_API_VERSION < UCP_VERSION(1, 11)
+#error "NIXL UCX endpoint naming requires UCX 1.11 or newer"
+#endif
+
 #include <nixl_types.h>
 
 #include "rkey.h"
@@ -69,6 +73,12 @@ public:
         return nixl::ucx::toNixlStatus(state_);
     }
 
+    /**
+     * Create a UCX endpoint.
+     *
+     * @param ep_name Optional endpoint identity exposed to UCX tracing tools.
+     *                An empty name preserves UCX's default endpoint naming.
+     */
     nixlUcxEp(ucp_worker_h worker,
               void *addr,
               const std::string &ep_name,
@@ -217,6 +227,12 @@ public:
     /* Connection */
     [[nodiscard]] std::string
     epAddr();
+    /**
+     * Connect to a remote worker.
+     *
+     * @param ep_name Optional endpoint identity exposed to UCX tracing tools.
+     *                An empty name preserves UCX's default endpoint naming.
+     */
     [[nodiscard]] std::unique_ptr<nixlUcxEp>
     connect(void *addr, const std::string &ep_name = {});
 

--- a/test/unit/plugins/ucx/ucx_worker_test.cpp
+++ b/test/unit/plugins/ucx/ucx_worker_test.cpp
@@ -96,11 +96,19 @@ main() {
         const std::string endpoint_name = "Agent" + std::to_string(i);
         assert(!addr.empty());
         auto result = w[!i].connect((void *)addr.data(), endpoint_name);
-        assert(result);
+        if (!result) {
+            cerr << "Failed to connect UCX endpoint " << endpoint_name << endl;
+            return EXIT_FAILURE;
+        }
 
-        ucp_ep_attr_t attr;
+        ucp_ep_attr_t attr{};
         attr.field_mask = UCP_EP_ATTR_FIELD_NAME;
-        assert(ucp_ep_query(result->getEp(), &attr) == UCS_OK);
+        const ucs_status_t query_status = ucp_ep_query(result->getEp(), &attr);
+        if (query_status != UCS_OK) {
+            cerr << "Failed to query UCX endpoint " << endpoint_name << ": "
+                 << ucs_status_string(query_status) << endl;
+            return EXIT_FAILURE;
+        }
 
         char default_name[UCP_ENTITY_NAME_MAX];
         std::snprintf(
@@ -110,7 +118,11 @@ main() {
                     "documented pointer fallback"
                  << endl;
         } else {
-            assert(endpoint_name == attr.name);
+            if (endpoint_name != attr.name) {
+                cerr << "UCX endpoint name mismatch: expected " << endpoint_name << ", got "
+                     << attr.name << endl;
+                return EXIT_FAILURE;
+            }
         }
 
         ep[!i] = std::move(result);

--- a/test/unit/plugins/ucx/ucx_worker_test.cpp
+++ b/test/unit/plugins/ucx/ucx_worker_test.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <string>
 #include <cassert>
+#include <cstdio>
 #include <cstring>
 #include <iostream>
 
@@ -92,9 +93,26 @@ main() {
     /* Test control path */
     for (i = 0; i < 2; i++) {
         const std::string addr = w[i].epAddr();
+        const std::string endpoint_name = "Agent" + std::to_string(i);
         assert(!addr.empty());
-        auto result = w[!i].connect((void *)addr.data());
+        auto result = w[!i].connect((void *)addr.data(), endpoint_name);
         assert(result);
+
+        ucp_ep_attr_t attr;
+        attr.field_mask = UCP_EP_ATTR_FIELD_NAME;
+        assert(ucp_ep_query(result->getEp(), &attr) == UCS_OK);
+
+        char default_name[UCP_ENTITY_NAME_MAX];
+        std::snprintf(
+            default_name, sizeof(default_name), "%p", static_cast<void *>(result->getEp()));
+        if (std::strcmp(attr.name, default_name) == 0) {
+            cout << "NOTE: UCX debug data is disabled; endpoint name query returned the "
+                    "documented pointer fallback"
+                 << endl;
+        } else {
+            assert(endpoint_name == attr.name);
+        }
+
         ep[!i] = std::move(result);
         assert(0 == c[i].memReg(buffer[i], buf_size, mem[i], nixl_mem_type));
         std::string rkey_tmp = c[i].packRkey(mem[i]);


### PR DESCRIPTION
## What?

Propagate the remote NIXL agent name into each UCX endpoint created for that agent:

- pass `remote_agent` through `nixlUcxWorker::connect()`
- set `UCP_EP_PARAM_FIELD_NAME` and `ucp_ep_params_t::name` during endpoint creation
- verify the endpoint name through `ucp_ep_query()` in the UCX worker test

## Why?

Fixes #1974. Giving endpoints a NIXL-supplied peer name lets UCX tracing and analysis tools attribute transport activity to the remote agent without adding work to the transfer data path.

## How?

The name is supplied only while `ucp_ep_create()` runs; UCX copies it into the endpoint's debug data. Existing low-level callers may omit the optional name, while the backend connection path always supplies `remote_agent`.

UCX documents that endpoint names are retained and returned only in builds with `ENABLE_DEBUG_DATA`. Without it, `ucp_ep_query(UCP_EP_ATTR_FIELD_NAME)` returns the endpoint pointer string. The test recognizes that documented fallback so release-mode system UCX builds do not fail spuriously; debug-data builds assert the exact agent name.

Validation:

- `git clang-format origin/main -- <changed files>`
- `pre-commit run --files <changed files>`
- `git diff --check`
- verified the fields against the UCX 1.19 public API (NIXL's minimum accepted UCX version)

The UCX test binary could not be built locally because this macOS checkout has no UCX/Meson toolchain; project CI provides the Linux UCX compile and runtime coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * UCX connections now support assigning and propagating endpoint names.
  * Endpoint names are preserved when connecting to remote agents, with compatibility maintained when no name is provided.

* **Bug Fixes**
  * Remote agent names exceeding UCX limits are now rejected with a clear error instead of creating an invalid connection.

* **Tests**
  * Added validation that connected endpoints expose the expected names, including fallback behavior when debug data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->