### PR TITLE
PLUGIN/POSIX: Document batched submission and the polling requirement

### DIFF
--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -210,7 +210,7 @@ Note that inside a transfer, a backend might provide methods for network resilie
 
 ### Get transfer status:
 
-The agent will call the backend specific transfer handle that is stored within the agent transfer handle, and check the status of the transfer. This is achieved through a call to **checkXfer** in the SB API. Internal to the backend, they can call their internal progress method, if that’s necessary to get the latest status of the transfers. Because a backend may also complete submission inside this call, a user must keep calling **getXferStatus** until the request reaches DONE rather than checking once and waiting on something else; a request that stops being polled may stop making progress.
+The agent will call the backend specific transfer handle that is stored within the agent transfer handle, and check the status of the transfer. This is achieved through a call to **checkXfer** in the SB API. Internal to the backend, they can call their internal progress method, if that’s necessary to get the latest status of the transfers. Because a backend may also complete submission inside this call, a user must keep calling **getXferStatus** while the request reports NIXL_IN_PROG, stopping when it completes or returns an error, rather than checking once and waiting on something else; a request that stops being polled may stop making progress.
 
 ### Invalidate transfer request:
 

--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -94,7 +94,7 @@ getPublicData and loadRemoteMD are required if backend supportsRemote, and loadL
 * prepXfer(): Given a descriptor list on each side, read or write operation, and remote agent name (can be loopback to itself if supported), any preparation for a transfer can be performed here, generating a pointer nixlBackendReqH that is a base class to be inherited by the backend for storing state of transfer request.
 * estimateXferCost: Given the same info as prepXfer, as well as the transfer request output from prepXfer, the backend can estimate the time of transfer, with noise margin and method of estimation. This is optional.
 * postXfer(): Posts a transfer request, meaning the backend should start the transfer. This call is asynchronous, meaning it should not wait to finish the transfer. If the transfer is really small, it’s fine to return DONE right after this call.
-* checkXfer(): Checks the status of a transfer request.
+* checkXfer(): Checks the status of a transfer request. A backend may also make forward progress here, not just report it: if postXfer only submits part of a request (for instance because the backend batches submissions to a kernel queue), the remainder is expected to be submitted by subsequent checkXfer calls. The POSIX plugin works this way, so requests larger than its submission batch need repeated status checks to be fully issued; see [`src/plugins/posix/README.md`](../src/plugins/posix/README.md#transfer-submission-and-completion).
 * releaseReqH(): Releases a transfer request handle, which should be an extension of the nixlBackendReqH. Note that the NIXL agent may release that handle at a number of error cases, expecting this function to handle proper cancellation of requests in addition to freeing resources.
 
 Within each transfer request, a descriptor list is passed, if there is room for parallelization across different contiguous memory locations, such as across different GPUs (one transfer can expand multiple GPUs). Optionally the user might ask for a notification, which should be sent after all the descriptors within a transfer request are sent. If a backend does not set supportsNotifications, no such notification will be asked.
@@ -210,7 +210,7 @@ Note that inside a transfer, a backend might provide methods for network resilie
 
 ### Get transfer status:
 
-The agent will call the backend specific transfer handle that is stored within the agent transfer handle, and check the status of the transfer. This is achieved through a call to **checkXfer** in the SB API. Internal to the backend, they can call their internal progress method, if that’s necessary to get the latest status of the transfers.
+The agent will call the backend specific transfer handle that is stored within the agent transfer handle, and check the status of the transfer. This is achieved through a call to **checkXfer** in the SB API. Internal to the backend, they can call their internal progress method, if that’s necessary to get the latest status of the transfers. Because a backend may also complete submission inside this call, a user must keep calling **getXferStatus** until the request reaches DONE rather than checking once and waiting on something else; a request that stops being polled may stop making progress.
 
 ### Invalidate transfer request:
 

--- a/src/plugins/posix/README.md
+++ b/src/plugins/posix/README.md
@@ -26,6 +26,36 @@ Optionally POSIX plugin can also use liburing.
 `"<modes>:<path>"` string in `metaInfo` (path-mode, backend owns the
 open/close); see [`src/utils/file/README.md`](../../utils/file/README.md#path-mode-file-registration).
 
+## Transfer submission and completion
+
+Submission is batched: `postXfer` enqueues every descriptor of the request but
+issues at most `MAX_IO_SUBMIT_BATCH_SIZE` (64) I/Os to the kernel. The remaining
+I/Os are issued by later calls to `checkXfer`, which polls the I/O queue and
+submits the next batch before reaping completions. This is the same in all three
+queue implementations (Linux AIO, io_uring, POSIX AIO).
+
+Two consequences for callers:
+
+* **A request with more than 64 descriptors is not fully submitted until it has
+  been polled.** `getXferStatus` must be called repeatedly until it returns
+  `NIXL_SUCCESS`; a caller that posts and then stops polling (for example one
+  waiting on an external event instead) leaves the remaining I/Os unissued and
+  the transfer never completes. Polling is required for progress, not only to
+  observe it.
+* **Time to completion has a floor of `ceil(descriptors / 64)` polls**,
+  independent of device speed. With a sleep between polls, that floor is
+  `ceil(descriptors / 64) x poll_interval`: a 256-descriptor request polled every
+  5 ms cannot finish in less than about 20 ms even on an idle NVMe device. Poll
+  without sleeping, or size the interval against the descriptor count, when
+  latency matters.
+
+The I/O queue is shared by all requests on a POSIX backend instance, so polling
+any one transfer handle also advances the in-flight I/Os of the others.
+
+`MAX_IO_SUBMIT_BATCH_SIZE` is a compile-time constant. The surrounding queue
+sizes are tunable through the backend parameters `ios_pool_size` (default 65536)
+and `kernel_queue_size` (default 256).
+
 ## Dependencies
 To enable Linux AIO support, you need to install the libaio package:
 

--- a/src/plugins/posix/README.md
+++ b/src/plugins/posix/README.md
@@ -37,17 +37,20 @@ queue implementations (Linux AIO, io_uring, POSIX AIO).
 Two consequences for callers:
 
 * **A request with more than 64 descriptors is not fully submitted until it has
-  been polled.** `getXferStatus` must be called repeatedly until it returns
-  `NIXL_SUCCESS`; a caller that posts and then stops polling (for example one
-  waiting on an external event instead) leaves the remaining I/Os unissued and
-  the transfer never completes. Polling is required for progress, not only to
-  observe it.
-* **Time to completion has a floor of `ceil(descriptors / 64)` polls**,
-  independent of device speed. With a sleep between polls, that floor is
-  `ceil(descriptors / 64) x poll_interval`: a 256-descriptor request polled every
-  5 ms cannot finish in less than about 20 ms even on an idle NVMe device. Poll
-  without sleeping, or size the interval against the descriptor count, when
-  latency matters.
+  been polled.** `getXferStatus` must be called repeatedly while the request
+  reports `NIXL_IN_PROG`, stopping only when it reaches completion or returns an
+  error; a caller that posts and then stops polling (for example one waiting on
+  an external event instead) leaves the remaining I/Os unissued and the transfer
+  never completes. Polling is required for progress, not only to observe it.
+* **Completion is bounded by the number of polls, not only by device speed.**
+  `postXfer` issues the first batch, so a request of N descriptors needs
+  `ceil(N / 64) - 1` further polls to finish submitting, plus at least one more
+  to observe completion. Any sleep the caller inserts between polls is therefore
+  multiplied by that count. Measured on a local NVMe device (256 KiB pages,
+  writes, 5 ms between status checks, median of 9 runs): a 64-descriptor request
+  completed in about 13 ms after 2 polls, and a 256-descriptor request in about
+  37 ms after 5 polls. Poll without sleeping, or scale the interval with the
+  descriptor count, when latency matters.
 
 The I/O queue is shared by all requests on a POSIX backend instance, so polling
 any one transfer handle also advances the in-flight I/Os of the others.


### PR DESCRIPTION
## What?

Documents an undocumented behavior of the POSIX plugin: submission is batched, and `checkXfer` is where the rest of a request gets submitted.

- `src/plugins/posix/README.md`: new "Transfer submission and completion" section covering the 64-I/O submission batch, the resulting requirement to keep polling for a large request to be fully issued, the `ceil(descriptors / 64)` poll floor on completion time, the fact that the I/O queue is shared across requests on an instance, and which queue sizes are tunable (`ios_pool_size`, `kernel_queue_size`).
- `docs/BackendGuide.md`: note that a backend may complete submission inside `checkXfer`, so the status call can be a progress point rather than a pure read, with a pointer to the POSIX section.

Docs only, no code changes.

## Why?

`postXfer` enqueues the whole descriptor list but issues at most `MAX_IO_SUBMIT_BATCH_SIZE` (64) I/Os; `poll()` calls `post()` before reaping completions, so the remainder is issued by subsequent `checkXfer` calls. This is consistent across all three queue implementations (`linux_aio_io_queue.cpp`, `io_uring_io_queue.cpp`, `posix_aio_io_queue.cpp`), but the documentation describes `checkXfer` only as "checks the status of a transfer request", and `BackendGuide` mentions internal progress only as an optional aside.

That gap is easy to fall into from the caller side. A request larger than the batch is not fully submitted until it has been polled, so any design that posts and then waits on something other than repeated `getXferStatus` calls stalls with I/Os still queued. It also gives completion a floor in poll count rather than device time, which is not obvious when reading the API.

Measured on a GCP c3-standard-8-lssd (local NVMe, ext4, nixl 1.3.2, default AIO queue), 256 KiB pages, WRITE, 5 ms between status checks, median of 9 runs: polls to completion are exactly `ceil(K / 64) + 1` and wall time steps by one poll interval at K = 65, 129 and 193.

| descriptors | polls to DONE | median wall |
|---|---|---|
| 64 | 2 | 12.9 ms |
| 65 | 3 | 18.0 ms |
| 128 | 3 | 20.8 ms |
| 129 | 4 | 25.9 ms |
| 256 | 5 | 36.8 ms |

Data, script and a plot: https://github.com/aaltinsoy/nixl-posix-bench

Found while looking into asynchronous completion handling for SGLang's NIXL-backed HiCache storage tier (sgl-project/sglang#32841), where this behavior determines whether a completion sweep is optional or required.

## How?

n/a, documentation only. Happy to reword if maintainers would rather state the batch size as an implementation detail that may change, or move the caller-facing part somewhere other than the plugin README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that transfer status checks may advance batched submissions and should be repeated until completion or error.
  * Added POSIX transfer guidance covering batching, polling, completion timing, shared queues, and configurable queue settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->