### PR TITLE
PLUGINS/UCX: Build notification right after post for overlapping

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1400,7 +1400,7 @@ nixlUcxEngine::sendNotif(std::unique_ptr<std::string> &&msg, const nixlUcxEp &ep
                      buffer->size(),
                      UCP_AM_SEND_FLAG_EAGER,
                      req,
-                     deleter);
+                     std::move(deleter));
 }
 
 nixl_status_t

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1385,7 +1385,7 @@ nixlUcxEngine::buildNotif(const std::string &msg) const {
 nixl_status_t
 nixlUcxEngine::sendNotif(std::unique_ptr<std::string> &&msg, const nixlUcxEp &ep, nixlUcxReq *req) {
     std::string *buffer = msg.release();
-    auto deleter = [buffer, req](void *completed_request, void *ptr) {
+    auto cleanup = [buffer, req](void *completed_request, void *ptr) {
         delete buffer;
         if ((req == nullptr) && (completed_request != nullptr)) {
             /* Caller is not interested in the request, free it */
@@ -1400,7 +1400,7 @@ nixlUcxEngine::sendNotif(std::unique_ptr<std::string> &&msg, const nixlUcxEp &ep
                      buffer->size(),
                      UCP_AM_SEND_FLAG_EAGER,
                      req,
-                     std::move(deleter));
+                     std::move(cleanup));
 }
 
 nixl_status_t

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1383,7 +1383,7 @@ nixlUcxEngine::buildNotif(const std::string &msg) const {
 }
 
 nixl_status_t
-nixlUcxEngine::sendNotif(std::unique_ptr<std::string> msg, const nixlUcxEp &ep, nixlUcxReq *req) {
+nixlUcxEngine::sendNotif(std::unique_ptr<std::string> &&msg, const nixlUcxEp &ep, nixlUcxReq *req) {
     std::string *buffer = msg.release();
     auto deleter = [buffer, req](void *completed_request, void *ptr) {
         delete buffer;

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -74,11 +74,11 @@ public:
     // Notification to be sent after completion of all requests
     struct Notif {
         const std::string agent;
-        const nixl_blob_t payload;
+        std::unique_ptr<std::string> msg;
 
-        Notif(const std::string &remote_agent, const nixl_blob_t &msg)
+        Notif(const std::string &remote_agent, std::unique_ptr<std::string> msg)
             : agent(remote_agent),
-              payload(msg) {}
+              msg(std::move(msg)) {}
     };
 
     std::optional<Notif> notif;
@@ -1265,7 +1265,7 @@ nixlUcxEngine::postXfer(const nixl_xfer_op_t &operation,
 
             ret = int_handle->status();
         } else if (ret == NIXL_IN_PROG) {
-            int_handle->notif.emplace(remote_agent, opt_args->notifMsg);
+            int_handle->notif.emplace(remote_agent, buildNotif(opt_args->notifMsg));
         }
     }
 
@@ -1281,7 +1281,7 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
         return handle_status;
     }
 
-    const nixlUcxBackendReqH::Notif notif(std::move(int_handle->notif).value());
+    nixlUcxBackendReqH::Notif notif(std::move(int_handle->notif).value());
     int_handle->notif.reset();
 
     if (handle_status != NIXL_SUCCESS) [[unlikely]] {
@@ -1295,7 +1295,7 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
 
     nixlUcxReq req;
     const auto &ep = conn->getEp(int_handle->getWorkerId());
-    const nixl_status_t status = notifSendPriv(notif.agent, notif.payload, ep, &req);
+    const nixl_status_t status = sendNotif(std::move(notif.msg), ep, &req);
 
     if (int_handle->append(status, req, conn) != NIXL_SUCCESS) {
         return status;
@@ -1335,19 +1335,21 @@ nixlUcxEngine::progressLoop() {
  * Notifications
 *****************************************/
 
-//agent will provide cached msg
-nixl_status_t
-nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
-                             const std::string &msg,
-                             const std::unique_ptr<nixlUcxEp> &ep,
-                             nixlUcxReq *req) const {
+std::unique_ptr<std::string>
+nixlUcxEngine::buildNotif(const std::string &msg) const {
     nixlSerDes ser_des;
 
     ser_des.addStr("name", localAgent);
     ser_des.addStr("msg", msg);
     // TODO: replace with mpool for performance
+    return std::make_unique<std::string>(ser_des.exportStr());
+}
 
-    std::string *buffer = new std::string(ser_des.exportStr());
+nixl_status_t
+nixlUcxEngine::sendNotif(std::unique_ptr<std::string> msg,
+                         const std::unique_ptr<nixlUcxEp> &ep,
+                         nixlUcxReq *req) {
+    std::string *buffer = msg.release();
     auto deleter = [buffer, req](void *completed_request, void *ptr) {
         delete buffer;
         if ((req == nullptr) && (completed_request != nullptr)) {
@@ -1359,11 +1361,19 @@ nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
     return ep->sendAm(nixl::ucx::am_cb_op_t::NOTIF_STR,
                       nullptr,
                       0,
-                      (void *)buffer->data(),
+                      buffer->data(),
                       buffer->size(),
                       UCP_AM_SEND_FLAG_EAGER,
                       req,
                       deleter);
+}
+
+nixl_status_t
+nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
+                             const std::string &msg,
+                             const std::unique_ptr<nixlUcxEp> &ep,
+                             nixlUcxReq *req) const {
+    return sendNotif(buildNotif(msg), ep, req);
 }
 
 ucx_connection_ptr_t

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1255,10 +1255,8 @@ nixlUcxEngine::postXfer(const nixl_xfer_op_t &operation,
         if (ret == NIXL_SUCCESS) {
             nixlUcxReq req;
             const auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[0].metadataP);
-            ret = notifSendPriv(remote_agent,
-                                opt_args->notifMsg,
-                                rmd->conn->getEp(int_handle->getWorkerId()),
-                                &req);
+            const nixlUcxEp &ep = *rmd->conn->getEp(int_handle->getWorkerId());
+            ret = notifSendPriv(remote_agent, opt_args->notifMsg, ep, &req);
             if (int_handle->append(ret, req, rmd->conn) != NIXL_SUCCESS) {
                 return ret;
             }
@@ -1294,7 +1292,7 @@ nixl_status_t nixlUcxEngine::checkXfer (nixlBackendReqH* handle) const
     }
 
     nixlUcxReq req;
-    const auto &ep = conn->getEp(int_handle->getWorkerId());
+    const nixlUcxEp &ep = *conn->getEp(int_handle->getWorkerId());
     const nixl_status_t status = sendNotif(std::move(notif.msg), ep, &req);
 
     if (int_handle->append(status, req, conn) != NIXL_SUCCESS) {
@@ -1346,9 +1344,7 @@ nixlUcxEngine::buildNotif(const std::string &msg) const {
 }
 
 nixl_status_t
-nixlUcxEngine::sendNotif(std::unique_ptr<std::string> msg,
-                         const std::unique_ptr<nixlUcxEp> &ep,
-                         nixlUcxReq *req) {
+nixlUcxEngine::sendNotif(std::unique_ptr<std::string> msg, const nixlUcxEp &ep, nixlUcxReq *req) {
     std::string *buffer = msg.release();
     auto deleter = [buffer, req](void *completed_request, void *ptr) {
         delete buffer;
@@ -1358,20 +1354,20 @@ nixlUcxEngine::sendNotif(std::unique_ptr<std::string> msg,
         }
     };
 
-    return ep->sendAm(nixl::ucx::am_cb_op_t::NOTIF_STR,
-                      nullptr,
-                      0,
-                      buffer->data(),
-                      buffer->size(),
-                      UCP_AM_SEND_FLAG_EAGER,
-                      req,
-                      deleter);
+    return ep.sendAm(nixl::ucx::am_cb_op_t::NOTIF_STR,
+                     nullptr,
+                     0,
+                     buffer->data(),
+                     buffer->size(),
+                     UCP_AM_SEND_FLAG_EAGER,
+                     req,
+                     deleter);
 }
 
 nixl_status_t
 nixlUcxEngine::notifSendPriv(const std::string &remote_agent,
                              const std::string &msg,
-                             const std::unique_ptr<nixlUcxEp> &ep,
+                             const nixlUcxEp &ep,
                              nixlUcxReq *req) const {
     return sendNotif(buildNotif(msg), ep, req);
 }
@@ -1431,7 +1427,8 @@ nixlUcxEngine::genNotif(const std::string &remote_agent, const std::string &msg)
         return NIXL_ERR_NOT_FOUND;
     }
 
-    const nixl_status_t ret = notifSendPriv(remote_agent, msg, conn->getEp(getSharedWorkerId()));
+    const nixlUcxEp &ep = *conn->getEp(getSharedWorkerId());
+    const nixl_status_t ret = notifSendPriv(remote_agent, msg, ep);
     if (ret == NIXL_IN_PROG) {
         return NIXL_SUCCESS;
     }

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -267,14 +267,12 @@ private:
     buildNotif(const std::string &msg) const;
 
     [[nodiscard]] static nixl_status_t
-    sendNotif(std::unique_ptr<std::string> msg,
-              const std::unique_ptr<nixlUcxEp> &ep,
-              nixlUcxReq *req);
+    sendNotif(std::unique_ptr<std::string> msg, const nixlUcxEp &ep, nixlUcxReq *req);
 
     nixl_status_t
     notifSendPriv(const std::string &remote_agent,
                   const std::string &msg,
-                  const std::unique_ptr<nixlUcxEp> &ep,
+                  const nixlUcxEp &ep,
                   nixlUcxReq *req = nullptr) const;
 
     ucx_connection_ptr_t

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -263,6 +263,14 @@ private:
               size_t length,
               const ucp_am_recv_param_t *param);
 
+    [[nodiscard]] std::unique_ptr<std::string>
+    buildNotif(const std::string &msg) const;
+
+    [[nodiscard]] static nixl_status_t
+    sendNotif(std::unique_ptr<std::string> msg,
+              const std::unique_ptr<nixlUcxEp> &ep,
+              nixlUcxReq *req);
+
     nixl_status_t
     notifSendPriv(const std::string &remote_agent,
                   const std::string &msg,

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -267,7 +267,7 @@ private:
     buildNotif(const std::string &msg) const;
 
     [[nodiscard]] static nixl_status_t
-    sendNotif(std::unique_ptr<std::string> msg, const nixlUcxEp &ep, nixlUcxReq *req);
+    sendNotif(std::unique_ptr<std::string> &&msg, const nixlUcxEp &ep, nixlUcxReq *req);
 
     nixl_status_t
     notifSendPriv(const std::string &remote_agent,

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -203,7 +203,7 @@ nixlUcxEp::disconnect_nb() {
  * Active message handling
  * =========================================== */
 
-using nixl_ucx_am_cb_ctx_t = std::pair<void *, nixlUcxEp::am_deleter_t>;
+using nixl_ucx_am_cb_ctx_t = std::pair<void *, nixlUcxEp::am_cleanup_t>;
 using nixl_ucx_am_cb_ctx_ptr_t = std::unique_ptr<nixl_ucx_am_cb_ctx_t>;
 
 void
@@ -225,14 +225,14 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
                   size_t len,
                   uint32_t flags,
                   nixlUcxReq *req,
-                  am_deleter_t &&deleter) const {
+                  am_cleanup_t &&cleanup) const {
     const nixl_status_t status = checkTxState();
     if (status != NIXL_SUCCESS) {
         // The endpoint is already in a failed state (e.g. the peer disconnected),
-        // so no request will be issued. Invoke the deleter -- as the inline
+        // so no request will be issued. Invoke the cleanup -- as the inline
         // completion path below does -- so the caller's buffer is not leaked.
-        if (deleter) {
-            deleter(nullptr, buffer);
+        if (cleanup) {
+            cleanup(nullptr, buffer);
         }
         return status;
     }
@@ -243,8 +243,8 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
     param.memory_type = UCS_MEMORY_TYPE_HOST;
 
     nixl_ucx_am_cb_ctx_ptr_t ctx;
-    if (deleter) {
-        ctx = std::make_unique<nixl_ucx_am_cb_ctx_t>(buffer, std::move(deleter));
+    if (cleanup) {
+        ctx = std::make_unique<nixl_ucx_am_cb_ctx_t>(buffer, std::move(cleanup));
         param.op_attr_mask |= UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
         param.cb.send = sendAmCallback;
         param.user_data = ctx.get();

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -225,7 +225,7 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
                   size_t len,
                   uint32_t flags,
                   nixlUcxReq *req,
-                  const am_deleter_t &deleter) const {
+                  am_deleter_t &&deleter) const {
     const nixl_status_t status = checkTxState();
     if (status != NIXL_SUCCESS) {
         // The endpoint is already in a failed state (e.g. the peer disconnected),
@@ -243,7 +243,7 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
 
     nixl_ucx_am_cb_ctx_ptr_t ctx;
     if (deleter) {
-        ctx = std::make_unique<nixl_ucx_am_cb_ctx_t>(buffer, deleter);
+        ctx = std::make_unique<nixl_ucx_am_cb_ctx_t>(buffer, std::move(deleter));
         param.op_attr_mask |= UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
         param.cb.send = sendAmCallback;
         param.user_data = ctx.get();
@@ -257,8 +257,8 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
             *req = static_cast<nixlUcxReq>(request);
         }
         return NIXL_IN_PROG;
-    } else if (deleter) {
-        deleter(nullptr, buffer);
+    } else if (ctx) {
+        ctx->second(nullptr, ctx->first);
     }
 
     return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -225,7 +225,7 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
                   size_t len,
                   uint32_t flags,
                   nixlUcxReq *req,
-                  const am_deleter_t &deleter) {
+                  const am_deleter_t &deleter) const {
     const nixl_status_t status = checkTxState();
     if (status != NIXL_SUCCESS) {
         // The endpoint is already in a failed state (e.g. the peer disconnected),

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -89,7 +89,7 @@ public:
            size_t len,
            uint32_t flags,
            nixlUcxReq *req = nullptr,
-           const am_deleter_t &deleter = nullptr) const;
+           am_deleter_t &&deleter = nullptr) const;
 
     /* Data access */
     [[nodiscard]] nixl_status_t

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -89,7 +89,7 @@ public:
            size_t len,
            uint32_t flags,
            nixlUcxReq *req = nullptr,
-           const am_deleter_t &deleter = nullptr);
+           const am_deleter_t &deleter = nullptr) const;
 
     /* Data access */
     [[nodiscard]] nixl_status_t

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -78,7 +78,7 @@ public:
     nixlUcxEp &
     operator=(const nixlUcxEp &) = delete;
 
-    using am_deleter_t = std::function<void(void *request, void *buffer)>;
+    using am_cleanup_t = std::function<void(void *request, void *buffer)>;
 
     /* Active message handling */
     nixl_status_t
@@ -89,7 +89,7 @@ public:
            size_t len,
            uint32_t flags,
            nixlUcxReq *req = nullptr,
-           am_deleter_t &&deleter = nullptr) const;
+           am_cleanup_t &&cleanup = nullptr) const;
 
     /* Data access */
     [[nodiscard]] nixl_status_t

--- a/src/utils/serdes/serdes.cpp
+++ b/src/utils/serdes/serdes.cpp
@@ -37,6 +37,7 @@ nixl_status_t nixlSerDes::addStr(const std::string &tag, const std::string &str)
 
     const size_t len = str.size();
 
+    workingStr.reserve(workingStr.size() + tag.size() + sizeof(len) + len + 1);
     workingStr.append(tag);
     workingStr.append(_bytesToString(&len, sizeof(size_t)));
     workingStr.append(str);


### PR DESCRIPTION
## What?
Micro-optimization that decreases Tx latency by building notification message right after posting, while requests are in-flight, and therefore benefit from overlapping.

## Why?
Before we were building notification (around 6 string allocations) after payload completion, therefore consuming CPU cycles before we can send the notification.

## How?
Serialize the notification once at post time and keep it in the handle as unique_ptr.

#### Testing performance on 4KB x 1 nixlbench WRITE
I see stable **3.5% BW** and latency improvement on low dimensions.
```
Block Size (B)      Batch Size     B/W (GB/Sec)   Avg Lat. (us)  Avg Prep (us)  P99 Prep (us)  Avg Post (us)  P99 Post (us)  Avg Tx (us)    P99 Tx (us)
----------------------------------------------------------------------------------------------------------------------------------------------------------------
4096                1              0.935155       4.4            10.0           10.0           1.1            2.0            3.2            4.0
4096                1              0.968380       4.2            13.0           13.0           1.2            2.0            2.9            4.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of UCX notification delivery by keeping message data available until transmission completes.
  * Enhanced asynchronous notification handling for safer endpoint usage and more dependable cleanup.
  * Improved consistency when sending notifications through communication endpoints.

* **Performance**
  * Reduced temporary memory reallocations when constructing serialized messages.
  * Streamlined notification preparation and transmission for more efficient processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->