### PR TITLE
PLUGIN/SPDK: Add an SPDK plugin for both BLK and OBJ

### DIFF
--- a/benchmark/kvbench/commands/args.py
+++ b/benchmark/kvbench/commands/args.py
@@ -45,13 +45,13 @@ def cli_args(func):
         "--source",
         default="file",
         type=str,
-        help="Source of the nixl descriptors [file, memory, gpu] (default: file)",
+        help="Source of the nixl descriptors [file, memory, gpu, bdev] (default: file)",
     )(func)
     func = click.option(
         "--destination",
         default="memory",
         type=str,
-        help="Destination of the nixl descriptors [file, memory, gpu] (default: memory)",
+        help="Destination of the nixl descriptors [file, memory, gpu, bdev] (default: memory)",
     )(func)
     return func
 
@@ -72,7 +72,7 @@ def nixl_bench_args(func):
     func = click.option(
         "--backend",
         type=str,
-        help="Communication backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ] (default: UCX)",
+        help="Communication backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ, SPDK] (default: UCX)",
     )(func)
     func = click.option(
         "--worker_type",
@@ -278,6 +278,26 @@ def nixl_bench_args(func):
         "--obj_ca_bundle",
         type=str,
         help="Path to CA bundle for S3 backend (only used with OBJ backend)",
+    )(func)
+    func = click.option(
+        "--spdk_json_config_file",
+        type=str,
+        help="SPDK JSON config file for bdev setup (only used with SPDK backend)",
+    )(func)
+    func = click.option(
+        "--spdk_bdev_name",
+        type=str,
+        help="SPDK bdev name used for BLK descriptors (only used with SPDK backend)",
+    )(func)
+    func = click.option(
+        "--spdk_bdev_offset",
+        type=int,
+        help="Starting byte offset for SPDK bdev operations (default: 0)",
+    )(func)
+    func = click.option(
+        "--spdk_msg_mempool_size",
+        type=int,
+        help="SPDK thread message mempool size; 0 uses SPDK default",
     )(func)
     return func
 

--- a/benchmark/kvbench/commands/nixlbench.py
+++ b/benchmark/kvbench/commands/nixlbench.py
@@ -74,6 +74,10 @@ class NIXLBench:
         obj_use_virtual_addressing=False,
         obj_endpoint_override="",
         obj_req_checksum="supported",
+        spdk_json_config_file="",
+        spdk_bdev_name="",
+        spdk_bdev_offset=0,
+        spdk_msg_mempool_size=0,
         # Additional nixlbench arguments
         large_blk_iter_ftr=16,
         recreate_xfer=False,
@@ -128,6 +132,10 @@ class NIXLBench:
             obj_use_virtual_addressing (bool, optional): Use virtual addressing for OBJ/S3. Defaults to False.
             obj_endpoint_override (str, optional): Endpoint override for OBJ/S3. Defaults to "".
             obj_req_checksum (str, optional): Required checksum for OBJ/S3. Defaults to "supported".
+            spdk_json_config_file (str, optional): SPDK JSON config file. Defaults to "".
+            spdk_bdev_name (str, optional): SPDK bdev name. Defaults to "".
+            spdk_bdev_offset (int, optional): Starting byte offset for SPDK bdev operations. Defaults to 0.
+            spdk_msg_mempool_size (int, optional): SPDK thread message mempool size. Defaults to 0.
             large_blk_iter_ftr (int, optional): Factor to reduce iterations for large blocks. Defaults to 16.
         """
         self.model = model
@@ -176,6 +184,10 @@ class NIXLBench:
         self.obj_use_virtual_addressing = obj_use_virtual_addressing
         self.obj_endpoint_override = obj_endpoint_override
         self.obj_req_checksum = obj_req_checksum
+        self.spdk_json_config_file = spdk_json_config_file
+        self.spdk_bdev_name = spdk_bdev_name
+        self.spdk_bdev_offset = spdk_bdev_offset
+        self.spdk_msg_mempool_size = spdk_msg_mempool_size
         self.large_blk_iter_ftr = large_blk_iter_ftr
         self.recreate_xfer = recreate_xfer
         self._override_defaults()
@@ -205,6 +217,20 @@ class NIXLBench:
             self.initiator_seg_type = "DRAM"
         else:
             raise ValueError(f"Invalid source for POSIX/HF3FS: {source}")
+
+    def _configure_spdk(self, source: str, destination: str):
+        """Configure SPDK bdev operations."""
+        bdev_names = {"bdev", "blk", "block"}
+        if source in bdev_names and destination == "memory":
+            self.op_type = "READ"
+            self.initiator_seg_type = "DRAM"
+        elif source == "memory" and destination in bdev_names:
+            self.op_type = "WRITE"
+            self.initiator_seg_type = "DRAM"
+        else:
+            raise ValueError(
+                "Invalid source/destination for SPDK: expected memory->bdev or bdev->memory"
+            )
 
     def _configure_ucx(self, backend: str, source: str, destination: str):
         """Configure UCX, GPUNETIO, and Mooncake plugins (same logic for all)"""
@@ -261,6 +287,8 @@ class NIXLBench:
             self._configure_gds(source, destination)
         elif backend_lower in ["posix", "hf3fs"]:
             self._configure_posix(source, destination)
+        elif backend_lower == "spdk":
+            self._configure_spdk(source, destination)
         elif backend_lower in ["ucx", "gpunetio", "mooncake"]:
             self._configure_ucx(backend_lower, source, destination)
         elif backend_lower == "obj":
@@ -354,6 +382,10 @@ class NIXLBench:
             "obj_use_virtual_addressing": self.obj_use_virtual_addressing,
             "obj_endpoint_override": self.obj_endpoint_override,
             "obj_req_checksum": self.obj_req_checksum,
+            "spdk_json_config_file": self.spdk_json_config_file,
+            "spdk_bdev_name": self.spdk_bdev_name,
+            "spdk_bdev_offset": self.spdk_bdev_offset,
+            "spdk_msg_mempool_size": self.spdk_msg_mempool_size,
             # Additional nixlbench parameters
             "large_blk_iter_ftr": self.large_blk_iter_ftr,
             "recreate_xfer": self.recreate_xfer,
@@ -415,6 +447,10 @@ class NIXLBench:
             "obj_use_virtual_addressing": False,
             "obj_endpoint_override": "",
             "obj_req_checksum": "supported",
+            "spdk_json_config_file": "",
+            "spdk_bdev_name": "",
+            "spdk_bdev_offset": 0,
+            "spdk_msg_mempool_size": 0,
             # Additional nixlbench defaults
             "large_blk_iter_ftr": 16,
             "recreate_xfer": False,

--- a/benchmark/nixlbench/contrib/spdk_malloc_bdev.json
+++ b/benchmark/nixlbench/contrib/spdk_malloc_bdev.json
@@ -1,0 +1,17 @@
+{
+  "subsystems": [
+    {
+      "subsystem": "bdev",
+      "config": [
+        {
+          "method": "bdev_malloc_create",
+          "params": {
+            "name": "Malloc0",
+            "num_blocks": 131072,
+            "block_size": 512
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -58,7 +58,7 @@ NB_ARG_STRING(worker_type, XFERBENCH_WORKER_NIXL, "Type of worker [nixl, nvshmem
 NB_ARG_STRING(backend,
               XFERBENCH_BACKEND_UCX,
               "Name of NIXL backend [UCX, GDS, GDS_MT, POSIX, GPUNETIO, Mooncake, HF3FS, OBJ, "
-              "GUSLI, AZURE_BLOB] (only used with nixl worker)");
+              "GUSLI, SPDK, AZURE_BLOB] (only used with nixl worker)");
 NB_ARG_STRING(initiator_seg_type,
               XFERBENCH_SEG_TYPE_DRAM,
               "Type of memory segment for initiator [DRAM, VRAM]. Note: Storage backends always "
@@ -241,6 +241,12 @@ NB_ARG_BOOL(gusli_try_use_uring,
             false,
             "Try to use io_uring engine in GUSLI backend (default: false)");
 
+// SPDK options - only used when backend is SPDK
+NB_ARG_STRING(spdk_json_config_file, "", "SPDK JSON config file for bdev setup");
+NB_ARG_STRING(spdk_bdev_name, "", "SPDK bdev name used for BLK descriptors");
+NB_ARG_UINT64(spdk_bdev_offset, 0, "Starting byte offset for SPDK bdev operations");
+NB_ARG_UINT64(spdk_msg_mempool_size, 0, "SPDK thread message mempool size; 0 uses SPDK default");
+
 
 #undef NB_ARG_INT32
 #undef NB_ARG_UINT32
@@ -321,6 +327,10 @@ std::string xferBenchConfig::gusli_config_file = "";
 std::string xferBenchConfig::gusli_device_byte_offsets = "";
 std::string xferBenchConfig::gusli_device_security = "";
 bool xferBenchConfig::gusli_try_use_uring = false;
+std::string xferBenchConfig::spdk_json_config_file = "";
+std::string xferBenchConfig::spdk_bdev_name = "";
+size_t xferBenchConfig::spdk_bdev_offset = 0;
+size_t xferBenchConfig::spdk_msg_mempool_size = 0;
 
 int
 xferBenchConfig::parseConfig(int argc, char *argv[]) {
@@ -446,6 +456,13 @@ xferBenchConfig::loadParams(void) {
             gusli_device_byte_offsets = NB_ARG(gusli_device_byte_offsets);
             gusli_device_security = NB_ARG(gusli_device_security);
             gusli_try_use_uring = NB_ARG(gusli_try_use_uring);
+        }
+
+        if (backend == XFERBENCH_BACKEND_SPDK) {
+            spdk_json_config_file = NB_ARG(spdk_json_config_file);
+            spdk_bdev_name = NB_ARG(spdk_bdev_name);
+            spdk_bdev_offset = NB_ARG(spdk_bdev_offset);
+            spdk_msg_mempool_size = NB_ARG(spdk_msg_mempool_size);
         }
 
         // Load OBJ-specific configurations if backend is OBJ
@@ -622,6 +639,21 @@ xferBenchConfig::loadParams(void) {
         return -1;
     }
 
+    if (backend == XFERBENCH_BACKEND_SPDK) {
+        if (spdk_json_config_file.empty()) {
+            std::cerr << "Error: SPDK backend requires --spdk_json_config_file" << std::endl;
+            return -1;
+        }
+        if (spdk_bdev_name.empty()) {
+            std::cerr << "Error: SPDK backend requires --spdk_bdev_name" << std::endl;
+            return -1;
+        }
+        if (check_consistency) {
+            std::cerr << "Error: Consistency check is not supported for SPDK backend" << std::endl;
+            return -1;
+        }
+    }
+
     if (worker_type == XFERBENCH_WORKER_NVSHMEM) {
         if (!((XFERBENCH_SEG_TYPE_VRAM == initiator_seg_type) &&
               (XFERBENCH_SEG_TYPE_VRAM == target_seg_type) && (1 == num_threads) &&
@@ -729,7 +761,7 @@ xferBenchConfig::printConfig() {
     }
     printOption("Worker type (--worker_type=[nixl,nvshmem])", worker_type);
     if (worker_type == XFERBENCH_WORKER_NIXL) {
-        printOption("Backend (--backend=[UCX,GDS,GDS_MT,POSIX,Mooncake,HF3FS,OBJ,AZURE_BLOB])",
+        printOption("Backend (--backend=[UCX,GDS,GDS_MT,POSIX,Mooncake,HF3FS,OBJ,SPDK,AZURE_BLOB])",
                     backend);
         printOption("Enable pt (--enable_pt=[0,1])", std::to_string(enable_pt));
         printOption("Progress threads (--progress_threads=N)", std::to_string(progress_threads));
@@ -816,6 +848,16 @@ xferBenchConfig::printConfig() {
             }
         }
 
+        if (backend == XFERBENCH_BACKEND_SPDK) {
+            printOption("SPDK JSON config file (--spdk_json_config_file=path)",
+                        spdk_json_config_file);
+            printOption("SPDK bdev name (--spdk_bdev_name=name)", spdk_bdev_name);
+            printOption("SPDK bdev offset (--spdk_bdev_offset=N)",
+                        std::to_string(spdk_bdev_offset));
+            printOption("SPDK message mempool size (--spdk_msg_mempool_size=N)",
+                        std::to_string(spdk_msg_mempool_size));
+        }
+
         // Print DOCA GPUNetIO options if backend is DOCA GPUNetIO
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             printOption("GPU CUDA Device id list (--device_list=dev1,dev2,...)",
@@ -881,6 +923,7 @@ xferBenchConfig::isStorageBackend() {
             XFERBENCH_BACKEND_POSIX == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_OBJ == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
+            XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_AZURE_BLOB == xferBenchConfig::backend ||
             XFERBENCH_BACKEND_INFINIA == xferBenchConfig::backend);
 }

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -95,6 +95,7 @@
 #define XFERBENCH_BACKEND_HF3FS "HF3FS"
 #define XFERBENCH_BACKEND_OBJ "OBJ"
 #define XFERBENCH_BACKEND_GUSLI "GUSLI"
+#define XFERBENCH_BACKEND_SPDK "SPDK"
 #define XFERBENCH_BACKEND_UCCL "UCCL"
 #define XFERBENCH_BACKEND_AZURE_BLOB "AZURE_BLOB"
 #define XFERBENCH_BACKEND_INFINIA "INFINIA"
@@ -227,6 +228,10 @@ public:
     static std::string gusli_device_byte_offsets;
     static std::string gusli_device_security;
     static bool gusli_try_use_uring;
+    static std::string spdk_json_config_file;
+    static std::string spdk_bdev_name;
+    static size_t spdk_bdev_offset;
+    static size_t spdk_msg_mempool_size;
 
     static int
     parseConfig(int argc, char *argv[]);

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -316,6 +316,18 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
                       << "]: " << dev.device_path << " (" << dev.security_flags << ")"
                       << ", offset = " << dev.dev_offset << std::endl;
         }
+    } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_SPDK)) {
+        backend_params["json_config_file"] = xferBenchConfig::spdk_json_config_file;
+        if (xferBenchConfig::spdk_msg_mempool_size > 0) {
+            backend_params["msg_mempool_size"] =
+                std::to_string(xferBenchConfig::spdk_msg_mempool_size);
+        }
+        std::cout << "SPDK backend initialized:" << std::endl;
+        std::cout << "  JSON config file: " << xferBenchConfig::spdk_json_config_file << std::endl;
+        std::cout << "  bdev name: " << xferBenchConfig::spdk_bdev_name << std::endl;
+        std::cout << "  bdev offset: " << xferBenchConfig::spdk_bdev_offset << std::endl;
+        std::cout << "  message mempool size: " << xferBenchConfig::spdk_msg_mempool_size
+                  << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_UCCL)) {
         std::cout << "UCCL backend" << std::endl;
         backend_params["in_python"] = "0";
@@ -895,6 +907,12 @@ xferBenchNixlWorker::initBasicDescBlk(size_t buffer_size, int mem_dev_id, size_t
     return std::optional<xferBenchIOV>(std::in_place, dev_offset, buffer_size, mem_dev_id);
 }
 
+static std::optional<xferBenchIOV>
+initBasicDescSpdk(size_t buffer_size, int mem_dev_id, size_t dev_offset) {
+    return std::optional<xferBenchIOV>(
+        std::in_place, dev_offset, buffer_size, mem_dev_id, xferBenchConfig::spdk_bdev_name);
+}
+
 bool
 xferBenchNixlWorker::ensureFileHasConsistencyData(const GusliDeviceConfig &device, size_t size) {
     int flags = O_RDWR | O_CREAT | O_LARGEFILE;
@@ -1047,6 +1065,20 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
                 // Use device IDs from parsed configuration (num_devices == gusli_devices.size())
                 basic_desc = initBasicDescBlk(
                     buffer_size, gusli_devices[i].device_id, gusli_devices[i].dev_offset);
+                if (basic_desc) {
+                    iov_list.push_back(basic_desc.value());
+                }
+            }
+            nixl_reg_dlist_t desc_list = iovListToNixlRegDlist(iov_list, BLK_SEG);
+            CHECK_NIXL_ERROR(agent->registerMem(desc_list, &opt_args), "registerMem failed");
+            remote_regs_.emplace_back(*agent, backend_engine, BLK_SEG, std::move(iov_list));
+        }
+    } else if (XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend) {
+        for (int list_idx = 0; list_idx < num_threads; list_idx++) {
+            std::vector<xferBenchIOV> iov_list;
+            for (i = 0; i < num_devices; i++) {
+                auto basic_desc =
+                    initBasicDescSpdk(buffer_size, i, xferBenchConfig::spdk_bdev_offset);
                 if (basic_desc) {
                     iov_list.push_back(basic_desc.value());
                 }
@@ -1269,6 +1301,13 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                     iov_remote.len = block_size;
                     iov_remote.devId = iov.devId;
                     remote_iov_list.push_back(iov_remote);
+                } else if (XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend) {
+                    xferBenchIOV iov_remote(iov);
+                    iov_remote.addr = xferBenchConfig::spdk_bdev_offset + file_offset;
+                    iov_remote.len = block_size;
+                    iov_remote.devId = iov.devId;
+                    iov_remote.metaInfo = xferBenchConfig::spdk_bdev_name;
+                    remote_iov_list.push_back(iov_remote);
                 } else {
                     xferBenchIOV iov_remote(iov);
                     iov_remote.addr = file_offset;
@@ -1291,7 +1330,8 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             }
 
             res.push_back(remote_iov_list);
-            if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+            if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
+                XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend) {
                 const size_t max_offset_in_blocks = local_iovs.size() - 1;
                 file_offset = getFileOffset(file_offset, max_offset_in_blocks, block_size);
             }
@@ -1361,7 +1401,8 @@ prepareTransferDescriptors(nixl_xfer_dlist_t &local_desc,
     // Set remote descriptor type based on backend
     if (xferBenchConfig::isObjStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(OBJ_SEG);
-    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
+               XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend) {
         remote_desc = nixl_xfer_dlist_t(BLK_SEG);
     } else if (xferBenchConfig::isStorageBackend()) {
         remote_desc = nixl_xfer_dlist_t(FILE_SEG);
@@ -1375,7 +1416,8 @@ static nixl_mem_t
 getRemoteSegType() {
     if (xferBenchConfig::isObjStorageBackend()) {
         return OBJ_SEG;
-    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend) {
+    } else if (XFERBENCH_BACKEND_GUSLI == xferBenchConfig::backend ||
+               XFERBENCH_BACKEND_SPDK == xferBenchConfig::backend) {
         return BLK_SEG;
     } else if (xferBenchConfig::isStorageBackend()) {
         return FILE_SEG;

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('nixl', 'CPP', version: '1.4.0',
+project('nixl', 'CPP', 'C', version: '1.4.0',
     default_options: ['buildtype=release',
                 'werror=true',
                 'cpp_std=c++20',
@@ -29,7 +29,7 @@ if enable_plugins_opt != '' and disable_plugins_opt != ''
     error('Cannot specify both enable_plugins and disable_plugins options')
 endif
 
-all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA']
+all_plugins = ['UCX', 'LIBFABRIC', 'POSIX', 'OBJ', 'GDS', 'GDS_MT', 'MOONCAKE', 'HF3FS', 'GUSLI', 'SPDK', 'GPUNETIO', 'UCCL', 'AZURE_BLOB', 'INFINIA', 'TELEMETRY_DOCA']
 
 enabled_plugins = {}
 
@@ -392,6 +392,22 @@ if libfabric_path != ''
 else
   libfabric_dep = dependency('libfabric', required: false)
 endif
+
+# The pkg-config components the SPDK plugin links; src/plugins/spdk/meson.build
+# resolves this same list to build its link line. Detection and linking must
+# agree: a component missing here but required there turns a clean "plugin
+# skipped" into a hard configure failure. Note spdk_env_dpdk is deliberately
+# absent — the plugin supplies its own implementation of SPDK's env interface.
+spdk_pc_components = ['spdk_event_bdev', 'spdk_event_accel', 'spdk_init',
+                      'spdk_bdev_malloc']
+# spdk_syslibs is queried separately rather than as part of the closure above:
+# it names the system and ISA-L libraries the SPDK archives depend on, which
+# must land outside the --whole-archive group. It is still required, so it
+# belongs in this gate.
+spdk_dep_found = dependency('spdk_syslibs', required: false).found()
+foreach spdk_pc_component : spdk_pc_components
+    spdk_dep_found = spdk_dep_found and dependency(spdk_pc_component, required: false).found()
+endforeach
 
 # UCX GPU device API detection
 nvcc_prog = find_program('nvcc', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,8 @@
 
 option('ucx_path', type: 'string', value: '', description: 'Path to UCX install')
 option('libfabric_path', type: 'string', value: '', description: 'Path to LIBFABRIC install')
+option('spdk_include_path', type: 'string', value: '', description: 'Path to SPDK headers when pkg-config cflags are incomplete')
+option('spdk_library_path', type: 'string', value: '', description: 'Path to SPDK libraries when pkg-config libdirs are incomplete')
 option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD Headers')
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD Libraries')
 option('disable_gds_backend', type : 'boolean', value : false, description : 'disable gds backend')

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -42,6 +42,10 @@ if 'OBJ' in static_plugins
     nixl_lib_deps += [ obj_backend_interface ]
 endif
 
+if 'SPDK' in static_plugins
+    nixl_lib_deps += [ spdk_backend_interface ]
+endif
+
 disable_gds_backend = get_option('disable_gds_backend')
 if not disable_gds_backend and 'GDS' in static_plugins
     nixl_lib_deps += [ gds_backend_interface, cuda_dep ]

--- a/src/core/nixl_plugin_manager.cpp
+++ b/src/core/nixl_plugin_manager.cpp
@@ -859,6 +859,10 @@ void nixlPluginManager::registerBuiltinPlugins() {
     NIXL_REGISTER_STATIC_PLUGIN(Backend, INFINIA)
 #endif
 
+#ifdef STATIC_PLUGIN_SPDK
+    NIXL_REGISTER_STATIC_PLUGIN(Backend, SPDK)
+#endif
+
     NIXL_REGISTER_STATIC_PLUGIN(Telemetry, BUFFER)
     NIXL_REGISTER_STATIC_PLUGIN(Telemetry, NOP)
 }

--- a/src/plugins/meson.build
+++ b/src/plugins/meson.build
@@ -128,6 +128,14 @@ if enabled_plugins.get('GUSLI')
     endif
 endif
 
+if enabled_plugins.get('SPDK')
+    if not spdk_dep_found and is_explicit_enable
+        error('SPDK plugin requested but SPDK pkg-config dependencies were not found')
+    elif spdk_dep_found
+        subdir('spdk')
+    endif
+endif
+
 if enabled_plugins.get('GPUNETIO')
     if (not cuda_dep.found() or not doca_gpunetio_dep.found()) and is_explicit_enable
         if not cuda_dep.found()

--- a/src/plugins/spdk/README.md
+++ b/src/plugins/spdk/README.md
@@ -1,0 +1,219 @@
+# NIXL SPDK Plugin
+
+This plugin moves data between host DRAM and storage using
+[SPDK](https://spdk.io) bdevs. It stands up a private, user-space SPDK runtime
+(env, thread, accel, and bdev subsystems), opens the bdevs described by a
+configuration, and services NIXL transfers as SPDK bdev I/O — the whole data
+path runs in user space and bypasses the kernel block stack.
+
+## No DPDK
+
+The plugin links SPDK's static libraries but supplies its **own implementation of
+SPDK's env interface** instead of `spdk_env_dpdk`, so DPDK is never linked or
+initialized. Three consequences shape everything below:
+
+- **No hugepages and no EAL setup.** Data buffers are ordinary page-aligned host
+  memory; hugepages are used opportunistically if available but never required,
+  and the process needs no special privileges.
+- **No local PCI devices.** PCI probing is stubbed out, so a locally attached
+  NVMe drive cannot be used. Transport-attached storage (NVMe-oF over TCP/RDMA)
+  and in-memory or file-backed bdevs work normally.
+- **No dynamically loaded bdev modules.** Only the modules statically linked into
+  the plugin are available: `malloc`, `aio`, `null`, `nvme`, `passthru`, `delay`,
+  `error`, `gpt`, `lvol`, `raid`, `split`, `ftl`, and `virtio`. To add another,
+  extend `spdk_pc_components` in `src/plugins/spdk/meson.build`.
+
+Build against SPDK **v26.05** or newer.
+
+## Memory types and the transfer model
+
+- **`DRAM_SEG`** is the local staging buffer (host memory).
+- **`BLK_SEG`** is a block device (the "remote" side, even though the transfer
+  is local/loopback).
+
+Transfers are always DRAM ↔ bdev, expressed as a loopback transfer whose remote
+agent name is the agent's *own* name:
+
+- `NIXL_WRITE`: DRAM → bdev
+- `NIXL_READ`:  bdev → DRAM
+
+The plugin reports `supportsLocal() == true`, `supportsRemote() == false`, and
+`supportsNotif() == false`.
+
+## Registration contract
+
+Both sides are registered with `registerMem` before use.
+
+| Field      | `DRAM_SEG` (buffer)    | `BLK_SEG` (bdev)                  |
+|------------|------------------------|-----------------------------------|
+| `devId`    | Caller-chosen handle   | Same handle scheme                |
+| `metaInfo` | (unused)               | **bdev name** (e.g. `Nvme0n1`)    |
+| `addr`     | Buffer virtual address | Byte offset into the bdev         |
+| `len`      | Buffer length          | Accessible length in bytes        |
+
+- **DRAM must be page-aligned (4 KiB) in address and length.** The plugin
+  registers host memory directly for zero-copy DMA and does **not** fall back to
+  bounce buffers, so registration hard-fails for memory it cannot map.
+  `posix_memalign(&buf, 4096, len)` with a 4 KiB-multiple length is sufficient.
+- **BLK transfers must be block-aligned**: offset and length must be multiples of
+  the bdev block size (and of its write-unit size) and stay within capacity.
+- **The bdev is selected by name** via `metaInfo`. An NVMe controller attached as
+  `Nvme0` exposes its namespace as `Nvme0n1`.
+
+## Configuration
+
+The backend is created with `createBackend("SPDK", params, …)`. All parameters
+are string key/value pairs; call `getPluginParams("SPDK", …)` to discover them
+and their defaults at runtime.
+
+The bdev configuration is supplied one of three ways, in precedence order:
+
+1. `json_config` — inline SPDK subsystem JSON
+2. `json_config_file` — path to a file containing the same JSON
+3. Convenience parameters (`bdev_type` + `bdev_name` + a type-specific source)
+
+Exactly one source must be provided or `createBackend` fails.
+
+### Convenience parameters
+
+For the common single-bdev case you can skip SPDK JSON entirely:
+
+| `bdev_type` | Required                                | Optional                       | Resulting bdev name |
+|-------------|-----------------------------------------|--------------------------------|---------------------|
+| `malloc`    | `bdev_name`, `bdev_num_blocks`          | `bdev_block_size` (def. `512`) | `bdev_name`         |
+| `aio`       | `bdev_name`, `bdev_filename`            | `bdev_block_size`              | `bdev_name`         |
+| `nvme`      | `bdev_name`, `bdev_traddr`              | —                              | `<bdev_name>n1`     |
+
+```cpp
+// In-memory malloc device for testing — no JSON, no file:
+nixl_b_params_t params;
+params["bdev_type"]       = "malloc";
+params["bdev_name"]       = "Malloc0";
+params["bdev_num_blocks"] = "131072";   // 64 MiB at 512 B blocks
+params["bdev_block_size"] = "512";
+agent.createBackend("SPDK", params, spdk);
+// ... register BLK_SEG with metaInfo = "Malloc0" ...
+```
+
+### General case: SPDK JSON
+
+Any bdev module and options SPDK supports, e.g. an NVMe-oF target over TCP:
+
+```cpp
+params["json_config"] =
+    R"({"subsystems":[{"subsystem":"bdev","config":[
+        {"method":"bdev_nvme_attach_controller",
+         "params":{"name":"Nvme0","trtype":"TCP","adrfam":"IPv4",
+                   "traddr":"192.168.1.10","trsvcid":"4420",
+                   "subnqn":"nqn.2016-06.io.spdk:cnode1"}}
+    ]}]})";
+// ... register BLK_SEG with metaInfo = "Nvme0n1" ...
+```
+
+`bdev_traddr` with `trtype: PCIe` will not attach — see [No DPDK](#no-dpdk).
+
+### Runtime parameters
+
+| Parameter          | Default       | Meaning |
+|--------------------|---------------|---------|
+| `spdk_name`        | `nixl_spdk`   | Names the SPDK thread in logs and traces. |
+| `core_mask`        | `""`          | Core mask or `[list]` for the SPDK thread's affinity. |
+| `msg_mempool_size` | `0` (default) | SPDK thread message-pool size. The default (256K entries) is generous; lower it for a small footprint. |
+
+`core_mask` and `msg_mempool_size` configure the process-wide SPDK runtime, so
+only the backend that starts it applies them — see
+[Multiple backends](#multiple-backends).
+
+## Multiple backends
+
+SPDK's env, thread, accel and bdev subsystems are singletons within this copy of
+SPDK, so the plugin shares one runtime across the process: the first backend
+brings it up, the last one to go away tears it down, in any order. Each backend
+still gets its own SPDK thread, its own I/O channels and its own bdev
+configuration. Because the bdev registry is shared, **each backend must name its
+bdevs uniquely** — a second backend that configures a bdev the first already
+created will fail to start.
+
+Bdevs created by a backend live until the *last* backend in the process is
+released, not until that backend is released. Sequential create/destroy/create
+cycles are therefore fine; overlapping ones must use distinct names.
+
+The plugin links SPDK privately, so it is unaffected by — and does not interfere
+with — a host application that initializes its own copy of SPDK.
+
+## Limitations
+
+- **No local PCI / NVMe devices, no external bdev modules** — see
+  [No DPDK](#no-dpdk).
+- **No bounce-buffer path.** DRAM registration requires 4 KiB-aligned address and
+  length; anything else is rejected rather than silently copied.
+- **Local transfers only.** No remote-agent support and no notifications.
+- **Config load needs a writable `/var/tmp`.** `spdk_subsystem_load_config`
+  briefly opens an RPC socket there.
+
+## Building
+
+```bash
+meson setup build -Denable_plugins=SPDK \
+    -Dspdk_include_path=/path/to/spdk/install/include \
+    -Dspdk_library_path=/path/to/spdk/install/lib
+ninja -C build
+```
+
+If SPDK is discoverable via `pkg-config` — a system install, or any prefix on
+`PKG_CONFIG_PATH` — both `*_path` options may be omitted; the headers and the
+library directory are taken from `--cflags-only-I` and `--libs-only-L`. Set them
+only when the `.pc` files do not report those paths.
+
+The plugin resolves the SPDK library closure at **configure** time, so re-run
+`meson setup --reconfigure` after rebuilding or moving SPDK.
+
+Both plugin models are supported: the default builds a dynamically loaded
+`libplugin_SPDK.so`, and `-Dstatic_plugins=SPDK` bakes the plugin into `libnixl`
+instead.
+
+## Tests
+
+Two unit tests live under `test/unit/plugins/spdk/`:
+
+- `nixl_spdk_test` — plugin metadata and advertised-parameter checks (no SPDK
+  runtime required).
+- `nixl_spdk_runtime_test` — a round trip over a `malloc` bdev: write/read/verify,
+  handle repost, release-while-in-flight, and a second backend sharing the
+  runtime with the first (including releasing the first one while the second
+  keeps running).
+
+```bash
+# Tests are only built when buildtype != release, and the runtime test finds the
+# plugin through the pluginlist that a debug build generates.
+meson setup build --reconfigure -Dbuildtype=debug -Dbuild_tests=true
+meson test -C build spdk_plugin_test spdk_plugin_runtime_test
+```
+
+The runtime test prints `SKIP` and exits cleanly if the SPDK runtime cannot start.
+Set `NIXL_SPDK_TEST_PROG_THREAD=0` to run it in caller-driven mode instead of
+with a progress thread.
+
+## Using SPDK with NIXLBench
+
+NIXLBench drives the backend with `--backend=SPDK`. Storage
+transfers are single-process (local DRAM initiator, bdev target); `--op_type`
+sets direction.
+
+```bash
+./nixlbench --backend=SPDK \
+            --spdk_json_config_file=contrib/spdk_malloc_bdev.json \
+            --spdk_bdev_name=Malloc0 \
+            --op_type=WRITE \
+            --start_block_size=4096 --max_block_size=65536 \
+            --total_buffer_size=$((1024*1024))
+```
+
+- `--spdk_json_config_file` (required): bdev subsystem JSON config file.
+- `--spdk_bdev_name` (required): bdev name used for the `BLK_SEG` descriptors.
+- `--spdk_bdev_offset`: starting byte offset into the bdev (default `0`).
+- `--spdk_msg_mempool_size`: SPDK message-pool size (`0` = default).
+
+A sample malloc config is provided at
+`benchmark/nixlbench/contrib/spdk_malloc_bdev.json`. Data buffers use ordinary
+page-aligned host memory; `--use_hugepages` is optional, not required.

--- a/src/plugins/spdk/README.md
+++ b/src/plugins/spdk/README.md
@@ -30,12 +30,13 @@ Build against SPDK **v26.05** or newer.
 - **`DRAM_SEG`** is the local staging buffer (host memory).
 - **`BLK_SEG`** is a block device (the "remote" side, even though the transfer
   is local/loopback).
+- **`OBJ_SEG`** is a key-value object on an NVMe Key-Value device.
 
-Transfers are always DRAM ↔ bdev, expressed as a loopback transfer whose remote
+Transfers are always DRAM ↔ device, expressed as a loopback transfer whose remote
 agent name is the agent's *own* name:
 
-- `NIXL_WRITE`: DRAM → bdev
-- `NIXL_READ`:  bdev → DRAM
+- `NIXL_WRITE`: DRAM → device (bdev write, or KV **Store** for `OBJ_SEG`)
+- `NIXL_READ`:  device → DRAM (bdev read, or KV **Retrieve** for `OBJ_SEG`)
 
 The plugin reports `supportsLocal() == true`, `supportsRemote() == false`, and
 `supportsNotif() == false`.
@@ -44,12 +45,12 @@ The plugin reports `supportsLocal() == true`, `supportsRemote() == false`, and
 
 Both sides are registered with `registerMem` before use.
 
-| Field      | `DRAM_SEG` (buffer)    | `BLK_SEG` (bdev)                  |
-|------------|------------------------|-----------------------------------|
-| `devId`    | Caller-chosen handle   | Same handle scheme                |
-| `metaInfo` | (unused)               | **bdev name** (e.g. `Nvme0n1`)    |
-| `addr`     | Buffer virtual address | Byte offset into the bdev         |
-| `len`      | Buffer length          | Accessible length in bytes        |
+| Field      | `DRAM_SEG` (buffer)    | `BLK_SEG` (bdev)                  | `OBJ_SEG` (KV object)           |
+|------------|------------------------|-----------------------------------|---------------------------------|
+| `devId`    | (unused)               | (unused)                          | (unused)                        |
+| `metaInfo` | (unused)               | **bdev name** (e.g. `Nvme0n1`)    | **object key** (1–16 bytes)     |
+| `addr`     | Buffer virtual address | Byte offset into the bdev         | Must be `0` (whole-value)       |
+| `len`      | Buffer length          | Accessible length in bytes        | Value length                    |
 
 - **DRAM must be page-aligned (4 KiB) in address and length.** The plugin
   registers host memory directly for zero-copy DMA and does **not** fall back to
@@ -59,6 +60,70 @@ Both sides are registered with `registerMem` before use.
   the bdev block size (and of its write-unit size) and stay within capacity.
 - **The bdev is selected by name** via `metaInfo`. An NVMe controller attached as
   `Nvme0` exposes its namespace as `Nvme0n1`.
+
+## OBJ_SEG: NVMe Key-Value
+
+`OBJ_SEG` maps a NIXL object onto a key on an NVMe Key-Value namespace. Requests
+become raw NVMe KV commands (Store for `NIXL_WRITE`, Retrieve for `NIXL_READ`)
+carried over **bdev NVMe passthru** — the plugin builds the `spdk_nvme_cmd`
+itself, as SPDK has no KV bdev abstraction.
+
+The KV device is the backend's `bdev_name` bdev. On the first `OBJ_SEG`
+registration the plugin opens it and requires that it both supports NVMe passthru
+(`SPDK_BDEV_IO_TYPE_NVME_IO`) and identifies as the KV command set
+(`spdk_bdev_get_nvme_csi() == SPDK_NVME_CSI_KV`); anything else fails with
+`NIXL_ERR_NOT_SUPPORTED`.
+
+Keys are per-object, as in NIXL's other OBJ backends: the key comes from
+`metaInfo` at registration and is recovered at transfer time. `metaInfo` is
+required — there is no fallback, because deriving a key from another field would
+silently collide when two descriptors shared it.
+
+```cpp
+// Store a value under the key "user:42", then read it back.
+nixl_b_params_t params;
+params["json_config"] =
+    R"({"subsystems":[{"subsystem":"bdev","config":[
+        {"method":"bdev_nvme_attach_controller",
+         "params":{"name":"Kv0","trtype":"TCP","adrfam":"IPv4",
+                   "traddr":"192.168.1.10","trsvcid":"4420",
+                   "subnqn":"nqn.2016-06.io.spdk:kv0"}}
+    ]}]})";
+// bdev_name selects the KV bdev itself, so it is the namespace (Kv0n1), not
+// the controller (Kv0) that the JSON above attaches.
+params["bdev_name"] = "Kv0n1";
+agent.createBackend("SPDK", params, spdk);
+
+nixl_opt_args_t args;
+args.backends.push_back(spdk);
+
+void *buf = nullptr;
+posix_memalign(&buf, 4096, 4096);
+
+nixl_reg_dlist_t dram(DRAM_SEG);
+dram.addDesc(nixlBlobDesc(reinterpret_cast<uintptr_t>(buf), 4096, 1));
+agent.registerMem(dram, &args);
+
+nixl_reg_dlist_t obj(OBJ_SEG);              // one registration per key
+obj.addDesc(nixlBlobDesc(0, 4096, 1, "user:42"));
+agent.registerMem(obj, &args);
+
+nixl_xfer_dlist_t src(DRAM_SEG), dst(OBJ_SEG);
+src.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(buf), 4096, 1));
+dst.addDesc(nixlBasicDesc(0, 4096, 1));     // addr must be 0
+nixlXferReqH *req = nullptr;
+agent.createXferReq(NIXL_WRITE, src, dst, agentName, req, &args);   // KV Store
+```
+
+**Whole-value only.** NVMe KV transfers the entire value, so the OBJ descriptor's
+offset must be `0` and its length must equal the local length. On Retrieve the
+caller sizes the buffer; the device's actual value length (returned in the
+completion) is not yet surfaced.
+
+> **Testing.** This is the *initiator* side; exercising it needs a target that
+> exposes an NVMe KV namespace. The in-memory `malloc` bdev is not KV, so the
+> bundled test only verifies that `OBJ_SEG` registration is correctly rejected on
+> a non-KV device.
 
 ## Configuration
 
@@ -82,7 +147,11 @@ For the common single-bdev case you can skip SPDK JSON entirely:
 |-------------|-----------------------------------------|--------------------------------|---------------------|
 | `malloc`    | `bdev_name`, `bdev_num_blocks`          | `bdev_block_size` (def. `512`) | `bdev_name`         |
 | `aio`       | `bdev_name`, `bdev_filename`            | `bdev_block_size`              | `bdev_name`         |
-| `nvme`      | `bdev_name`, `bdev_traddr`              | —                              | `<bdev_name>n1`     |
+| `nvme`      | `bdev_name`, `bdev_trtype`, `bdev_traddr`, `bdev_subnqn` | `bdev_trsvcid`, `bdev_adrfam` | `<bdev_name>n1`     |
+
+`bdev_trtype` must name a network transport (`RDMA` or `TCP`). `PCIe` is
+rejected at configuration time: this plugin does not probe PCI devices — see
+[No DPDK](#no-dpdk).
 
 ```cpp
 // In-memory malloc device for testing — no JSON, no file:
@@ -110,7 +179,7 @@ params["json_config"] =
 // ... register BLK_SEG with metaInfo = "Nvme0n1" ...
 ```
 
-`bdev_traddr` with `trtype: PCIe` will not attach — see [No DPDK](#no-dpdk).
+A `trtype: PCIe` controller will not attach — see [No DPDK](#no-dpdk).
 
 ### Runtime parameters
 
@@ -150,6 +219,8 @@ with — a host application that initializes its own copy of SPDK.
 - **Local transfers only.** No remote-agent support and no notifications.
 - **Config load needs a writable `/var/tmp`.** `spdk_subsystem_load_config`
   briefly opens an RPC socket there.
+- **`OBJ_SEG` is whole-value KV**: one KV device per backend, one registration
+  per key, keys 1–16 bytes, no partial-object access.
 
 ## Building
 
@@ -179,9 +250,9 @@ Two unit tests live under `test/unit/plugins/spdk/`:
 - `nixl_spdk_test` — plugin metadata and advertised-parameter checks (no SPDK
   runtime required).
 - `nixl_spdk_runtime_test` — a round trip over a `malloc` bdev: write/read/verify,
-  handle repost, release-while-in-flight, and a second backend sharing the
-  runtime with the first (including releasing the first one while the second
-  keeps running).
+  handle repost, release-while-in-flight, `OBJ_SEG` capability rejection, and a
+  second backend sharing the runtime with the first (including releasing the
+  first one while the second keeps running).
 
 ```bash
 # Tests are only built when buildtype != release, and the runtime test finds the
@@ -196,7 +267,7 @@ with a progress thread.
 
 ## Using SPDK with NIXLBench
 
-NIXLBench drives the backend with `--backend=SPDK`. Storage
+NIXLBench drives the backend with `--backend=SPDK` over `BLK_SEG`. Storage
 transfers are single-process (local DRAM initiator, bdev target); `--op_type`
 sets direction.
 

--- a/src/plugins/spdk/meson.build
+++ b/src/plugins/spdk/meson.build
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+spdk_sources = [
+    'spdk_backend.cpp',
+    'spdk_backend.h',
+    'spdk_progress_engine.cpp',
+    'spdk_progress_engine.h',
+    'spdk_plugin.cpp',
+]
+
+# This plugin supplies its own implementation of SPDK's env interface (memory,
+# threads, memory-registration map, and stubbed PCI) instead of linking
+# spdk_env_dpdk. That removes the DPDK runtime entirely: no EAL bring-up, no
+# hugepage requirement, and no PCI probing (local PCI devices are unsupported).
+# These are plain C sources, built as a standalone library so the C++ plugin's
+# warning flags and dependency compile args (which are C++-only) do not reach
+# them; _GNU_SOURCE is needed for the CPU affinity / pthread_*_np helpers.
+spdk_env_sources = [
+    'spdk_env/env.c',
+    'spdk_env/init.c',
+    'spdk_env/threads.c',
+    'spdk_env/memory.c',
+    'spdk_env/mem_map.c',
+    'spdk_env/pci.c',
+]
+
+# NOTE: the SPDK libraries are linked via spdk_link_args below (wrapped in
+# --whole-archive), not as meson dependencies. SPDK registers bdev modules,
+# accel modules, subsystems and RPC methods through link-time constructors that
+# carry no referenced symbol, so a normal dependency link drops them and the
+# runtime silently lacks mempool ops / accel modules / bdev create RPCs.
+spdk_plugin_deps = [
+    nixl_infra,
+    nixl_common_dep,
+    absl_log_dep,
+]
+
+spdk_include_path = get_option('spdk_include_path')
+spdk_library_path = get_option('spdk_library_path')
+
+# Every pkg-config query below goes through this: when an explicit library path
+# was given, its prefix owns the .pc files, otherwise the default search path
+# applies. Defined here because the include-directory lookup already needs it.
+spdk_pc_env = {}
+if spdk_library_path != ''
+    spdk_pc_env = {'PKG_CONFIG_PATH': spdk_library_path + '/pkgconfig'}
+endif
+
+spdk_inc_dirs = [nixl_inc_dirs, utils_inc_dirs]
+if spdk_include_path != ''
+    spdk_inc_dirs += include_directories(spdk_include_path, is_system: true)
+else
+    # Fall back to pkg-config so a discoverable SPDK needs no *_path options at
+    # all. Without this the headers were only ever found when they sat in a
+    # default system include directory: any other prefix configured cleanly and
+    # then failed the compile on spdk/stdinc.h.
+    spdk_pc_cflags = run_command('pkg-config', '--cflags-only-I', spdk_pc_components,
+        env: spdk_pc_env, check: true)
+    spdk_pc_incs = []
+    foreach _inc : spdk_pc_cflags.stdout().split()
+        if _inc.startswith('-I') and not spdk_pc_incs.contains(_inc.substring(2))
+            spdk_pc_incs += _inc.substring(2)
+            spdk_inc_dirs += include_directories(_inc.substring(2), is_system: true)
+        endif
+    endforeach
+endif
+
+# Build the DPDK-free env implementation as its own C-only static library.
+spdk_env_lib = static_library('nixl_spdk_env',
+    spdk_env_sources,
+    include_directories: spdk_inc_dirs,
+    c_args: ['-D_GNU_SOURCE'],
+    pic: true,
+    install: false)
+
+spdk_link_args = []
+if spdk_library_path != ''
+    spdk_link_args += ['-L' + spdk_library_path]
+endif
+
+# Resolve the SPDK library closure via pkg-config. spdk_pc_components is defined
+# in the top-level meson.build, which gates this subdir on the same list being
+# present. spdk_bdev_malloc pulls the malloc bdev module (a minimal default so
+# the runtime can create a bdev from JSON); spdk_event_{bdev,accel} pull the
+# bdev/accel subsystem and module registrations; spdk_init provides
+# spdk_subsystem_load_config.
+spdk_pc = run_command('pkg-config', '--libs', spdk_pc_components,
+    env: spdk_pc_env, check: true)
+
+# The directory holding the SPDK archives. Without spdk_library_path it comes
+# from pkg-config, because the -lspdk_* tokens below have to be rewritten to
+# full .a paths in every configuration, not just the explicit-path one (see the
+# reordering note below).
+spdk_resolved_libdir = spdk_library_path
+if spdk_resolved_libdir == ''
+    spdk_pc_libdirs = run_command('pkg-config', '--libs-only-L', spdk_pc_components,
+        env: spdk_pc_env, check: true)
+    foreach _dir : spdk_pc_libdirs.stdout().split()
+        if _dir.startswith('-L') and spdk_resolved_libdir == ''
+            spdk_resolved_libdir = _dir.substring(2)
+        endif
+    endforeach
+endif
+
+# Drop spdk_env_dpdk and the DPDK runtime from the closure: the spdk_env/
+# sources above provide the spdk/env.h implementation instead. Filtering out
+# env_dpdk avoids duplicate env symbols, and filtering the rte_* libraries and
+# the DPDK library path keeps the EAL (and its PCI bus/mempool drivers) from
+# being linked back in.
+# Resolve the SPDK libs to full .a paths rather than -l flags. Meson reorders
+# bare -l library flags out of a raw -Wl,--whole-archive group (which would break
+# it and drop the constructor-only registrations - e.g. the software accel module
+# - leaving g_modules_opc unpopulated and crashing spdk_accel_initialize). Full
+# archive paths are kept in place. This matters especially for the baked-in
+# (static_plugins) build, where the closure rides on the dependency and meson is
+# free to reorder it. Non-spdk (system) entries are left untouched.
+spdk_libs = []
+foreach _lib : spdk_pc.stdout().split()
+    if _lib == '-lspdk_env_dpdk' or _lib.startswith('-lrte_') or _lib.contains('/dpdk/')
+        continue
+    elif _lib.startswith('-lspdk_') and spdk_resolved_libdir != ''
+        spdk_libs += spdk_resolved_libdir / ('lib' + _lib.substring(2) + '.a')
+    else
+        spdk_libs += _lib
+    endif
+endforeach
+
+# Whole-archive the SPDK static libs so their constructor-based self-registration
+# (bdev modules, accel modules, subsystems, RPC methods) is retained.
+spdk_link_args += ['-Wl,--whole-archive'] + spdk_libs + ['-Wl,--no-whole-archive']
+
+# The system and ISA-L libraries the SPDK archives depend on. Taken from
+# pkg-config rather than hardcoded: which ones SPDK needs depends on how it was
+# configured, so a fixed list breaks against a build with, say, fuse disabled.
+# These belong after --no-whole-archive; they carry no constructor registrations
+# and whole-archiving them would drag in every object they contain.
+spdk_syslibs_pc = run_command('pkg-config', '--libs', 'spdk_syslibs',
+    env: spdk_pc_env, check: true)
+spdk_link_args += spdk_syslibs_pc.stdout().split()
+
+compile_defs = []
+compile_flags = []
+
+if 'SPDK' in static_plugins
+    # A static_library has no link step, so link_args on it are dropped. The SPDK
+    # library closure (spdk_link_args, whole-archived) must instead ride on the
+    # dependency so it reaches whatever links this plugin in (libnixl and the unit
+    # tests) when the plugin is baked in.
+    spdk_backend_lib = static_library('SPDK',
+        spdk_sources,
+        dependencies: spdk_plugin_deps,
+        link_whole: spdk_env_lib,
+        include_directories: spdk_inc_dirs,
+        install: false,
+        cpp_args: compile_defs + compile_flags,
+        name_prefix: 'libplugin_')
+    spdk_backend_interface = declare_dependency(
+        link_whole: spdk_backend_lib,
+        link_args: spdk_link_args)
+else
+    spdk_backend_lib = shared_library('SPDK',
+        spdk_sources,
+        dependencies: spdk_plugin_deps,
+        link_args: spdk_link_args,
+        link_whole: spdk_env_lib,
+        include_directories: spdk_inc_dirs,
+        install: true,
+        cpp_args: compile_defs + ['-fPIC'],
+        name_prefix: 'libplugin_',
+        install_dir: plugin_install_dir,
+        install_rpath: '$ORIGIN/..')
+    spdk_backend_interface = declare_dependency(link_with: spdk_backend_lib)
+    if get_option('buildtype') == 'debug'
+        run_command('sh', '-c',
+            'echo "SPDK=' + spdk_backend_lib.full_path() + '" >> ' + plugin_build_dir + '/pluginlist',
+            check: true)
+    endif
+endif

--- a/src/plugins/spdk/spdk_backend.cpp
+++ b/src/plugins/spdk/spdk_backend.cpp
@@ -1,0 +1,267 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spdk_backend.h"
+#include "spdk_progress_engine.h"
+
+#include <memory>
+
+#include "common/nixl_log.h"
+
+namespace {
+
+[[nodiscard]] nixl_status_t
+validateLists(nixl_xfer_op_t operation,
+              const nixl_meta_dlist_t &local,
+              const nixl_meta_dlist_t &remote) {
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        NIXL_ERROR << "SPDK: unsupported operation " << operation;
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+    if (local.getType() != DRAM_SEG) {
+        NIXL_ERROR << "SPDK: local descriptor list must be DRAM_SEG";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (remote.getType() != BLK_SEG) {
+        NIXL_ERROR << "SPDK: remote descriptor list must be BLK_SEG";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (local.descCount() == 0 || local.descCount() != remote.descCount()) {
+        NIXL_ERROR << "SPDK: descriptor count mismatch local=" << local.descCount()
+                   << " remote=" << remote.descCount();
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return NIXL_SUCCESS;
+}
+
+// The dynamic_cast is the NIXL boundary check that the metadata is ours; the
+// kind tag drives the downcast from there.
+[[nodiscard]] nixl_status_t
+resolveDescriptorPair(const nixlMetaDesc &local,
+                      const nixlMetaDesc &remote,
+                      nixlSpdkIoContext &io) {
+    auto *local_md = dynamic_cast<nixlSpdkMD *>(local.metadataP);
+    if (!local_md || local_md->kind() != nixlSpdkMD::Kind::Dram) {
+        NIXL_ERROR << "SPDK: local (DRAM) descriptor metadata is missing or invalid";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto *dram = static_cast<nixlSpdkDramMD *>(local_md);
+    if (local.addr < dram->addr || (local.addr + local.len) > (dram->addr + dram->len)) {
+        NIXL_ERROR << "SPDK: local descriptor is outside registered DRAM range";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto *remote_md = dynamic_cast<nixlSpdkMD *>(remote.metadataP);
+    if (!remote_md || remote_md->kind() != nixlSpdkMD::Kind::Bdev) {
+        NIXL_ERROR << "SPDK: BLK descriptor metadata is missing or invalid";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto *bdev = static_cast<nixlSpdkBdevMD *>(remote_md);
+    if (!bdev->desc || !bdev->channel || !bdev->bdev) {
+        NIXL_ERROR << "SPDK: BLK descriptor metadata is missing or invalid";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (local.len != remote.len) {
+        NIXL_ERROR << "SPDK: local and BLK descriptor lengths must match";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if ((remote.addr % bdev->blockSize) != 0 || (remote.len % bdev->blockSize) != 0) {
+        NIXL_ERROR << "SPDK: BLK descriptor offset and length must be block aligned";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if ((remote.addr + remote.len) > (bdev->numBlocks * bdev->blockSize)) {
+        NIXL_ERROR << "SPDK: BLK descriptor exceeds bdev capacity";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if ((remote.len / bdev->blockSize) % bdev->writeUnitSize != 0) {
+        NIXL_ERROR << "SPDK: BLK descriptor length is not write-unit aligned";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    io.dram = dram;
+    io.bdev = bdev;
+    io.offset = remote.addr;
+    return NIXL_SUCCESS;
+}
+
+} // namespace
+
+nixlSpdkBackendReqH::nixlSpdkBackendReqH(nixl_xfer_op_t operation,
+                                         std::vector<nixlSpdkIoContext> ios)
+    : operation_(operation),
+      ios_(std::move(ios)) {
+    // Each entry carries its own address as the SPDK completion cb_arg, so this
+    // has to happen after the vector reaches its final storage.
+    for (auto &io : ios_) {
+        io.reqH = this;
+        io.waitEntry.bdev = io.bdev->bdev;
+        io.waitEntry.cb_arg = &io;
+    }
+}
+
+nixl_status_t
+nixlSpdkBackendReqH::status() const noexcept {
+    if ((lifeState_.load(std::memory_order_acquire) & kDone) == 0) {
+        return NIXL_IN_PROG;
+    }
+    return overallStatus_.load(std::memory_order_acquire);
+}
+
+void
+nixlSpdkBackendReqH::reset() noexcept {
+    outstanding_.store(static_cast<uint32_t>(ios_.size()) + 1, std::memory_order_relaxed);
+    overallStatus_.store(NIXL_IN_PROG, std::memory_order_relaxed);
+    cancelled_.store(false, std::memory_order_relaxed);
+    for (auto &io : ios_) {
+        io.ioWaitQueued = false;
+    }
+    lifeState_.store(0, std::memory_order_release);
+}
+
+nixlSpdkEngine::nixlSpdkEngine(const nixlBackendInitParams *init_params)
+    : nixlBackendEngine(init_params),
+      progress_(std::make_unique<nixlSpdkProgressEngine>(init_params)) {
+    initErr = progress_->hasInitError();
+}
+
+nixlSpdkEngine::~nixlSpdkEngine() = default;
+
+nixl_status_t
+nixlSpdkEngine::registerMem(const nixlBlobDesc &mem,
+                            const nixl_mem_t &mem_type,
+                            nixlBackendMD *&out) {
+    out = nullptr;
+    if (!progress_ || progress_->hasInitError()) {
+        return NIXL_ERR_BACKEND;
+    }
+
+    if (mem_type == DRAM_SEG) {
+        auto md = std::make_unique<nixlSpdkDramMD>(mem.addr, mem.len);
+        const nixl_status_t status = progress_->registerDram(*md);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        out = md.release();
+        return NIXL_SUCCESS;
+    }
+
+    if (mem_type == BLK_SEG) {
+        if (mem.metaInfo.empty()) {
+            NIXL_ERROR << "SPDK: BLK_SEG metaInfo must contain an SPDK bdev name";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto md = std::make_unique<nixlSpdkBdevMD>(mem.devId, mem.metaInfo);
+        const nixl_status_t status = progress_->openBdev(*md);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        out = md.release();
+        return NIXL_SUCCESS;
+    }
+
+    return NIXL_ERR_NOT_SUPPORTED;
+}
+
+nixl_status_t
+nixlSpdkEngine::deregisterMem(nixlBackendMD *meta) {
+    // Exhaustive switch: a new Kind fails to compile rather than silently
+    // falling through to an error.
+    auto *md = dynamic_cast<nixlSpdkMD *>(meta);
+    if (!md) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    const std::unique_ptr<nixlSpdkMD> owned(md);
+
+    switch (md->kind()) {
+    case nixlSpdkMD::Kind::Dram:
+        return progress_->deregisterDram(static_cast<nixlSpdkDramMD &>(*md));
+    case nixlSpdkMD::Kind::Bdev:
+        progress_->closeBdev(static_cast<nixlSpdkBdevMD &>(*md));
+        return NIXL_SUCCESS;
+    }
+    return NIXL_ERR_INVALID_PARAM;
+}
+
+nixl_status_t
+nixlSpdkEngine::prepXfer(const nixl_xfer_op_t &operation,
+                         const nixl_meta_dlist_t &local,
+                         const nixl_meta_dlist_t &remote,
+                         const std::string &,
+                         nixlBackendReqH *&handle,
+                         const nixl_opt_b_args_t *) const {
+    handle = nullptr;
+    const nixl_status_t status = validateLists(operation, local, remote);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    std::vector<nixlSpdkIoContext> ios;
+    ios.reserve(local.descCount());
+    for (int i = 0; i < local.descCount(); ++i) {
+        nixlSpdkIoContext io;
+        const nixl_status_t resolved = resolveDescriptorPair(local[i], remote[i], io);
+        if (resolved != NIXL_SUCCESS) {
+            return resolved;
+        }
+        io.buf = reinterpret_cast<void *>(local[i].addr);
+        io.nbytes = local[i].len;
+        ios.push_back(io);
+    }
+
+    handle = std::make_unique<nixlSpdkBackendReqH>(operation, std::move(ios)).release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlSpdkEngine::postXfer(const nixl_xfer_op_t &operation,
+                         const nixl_meta_dlist_t &local,
+                         const nixl_meta_dlist_t &remote,
+                         const std::string &remote_agent,
+                         nixlBackendReqH *&handle,
+                         const nixl_opt_b_args_t *opt_args) const {
+    if (!handle) {
+        nixl_status_t status = prepXfer(operation, local, remote, remote_agent, handle, opt_args);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+    }
+
+    auto *req_h = dynamic_cast<nixlSpdkBackendReqH *>(handle);
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return progress_->postXfer(req_h);
+}
+
+nixl_status_t
+nixlSpdkEngine::checkXfer(nixlBackendReqH *handle) const {
+    auto *req_h = dynamic_cast<nixlSpdkBackendReqH *>(handle);
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return progress_->checkXfer(req_h);
+}
+
+nixl_status_t
+nixlSpdkEngine::releaseReqH(nixlBackendReqH *handle) const {
+    auto *req_h = dynamic_cast<nixlSpdkBackendReqH *>(handle);
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    progress_->cancelRequest(req_h);
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlSpdkEngine::queryMem(const nixl_reg_dlist_t &descs,
+                         std::vector<nixl_query_resp_t> &resp) const {
+    resp.clear();
+    for (const auto &desc : descs) {
+        nixl_b_params_t item;
+        item["size"] = std::to_string(desc.len);
+        resp.emplace_back(std::move(item));
+    }
+    return NIXL_SUCCESS;
+}

--- a/src/plugins/spdk/spdk_backend.cpp
+++ b/src/plugins/spdk/spdk_backend.cpp
@@ -24,8 +24,8 @@ validateLists(nixl_xfer_op_t operation,
         NIXL_ERROR << "SPDK: local descriptor list must be DRAM_SEG";
         return NIXL_ERR_INVALID_PARAM;
     }
-    if (remote.getType() != BLK_SEG) {
-        NIXL_ERROR << "SPDK: remote descriptor list must be BLK_SEG";
+    if (remote.getType() != BLK_SEG && remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << "SPDK: remote descriptor list must be BLK_SEG or OBJ_SEG";
         return NIXL_ERR_INVALID_PARAM;
     }
     if (local.descCount() == 0 || local.descCount() != remote.descCount()) {
@@ -41,7 +41,9 @@ validateLists(nixl_xfer_op_t operation,
 [[nodiscard]] nixl_status_t
 resolveDescriptorPair(const nixlMetaDesc &local,
                       const nixlMetaDesc &remote,
-                      nixlSpdkIoContext &io) {
+                      nixl_mem_t remote_type,
+                      nixlSpdkDramMD *&dram_out,
+                      nixlSpdkIoTarget &target_out) {
     auto *local_md = dynamic_cast<nixlSpdkMD *>(local.metadataP);
     if (!local_md || local_md->kind() != nixlSpdkMD::Kind::Dram) {
         NIXL_ERROR << "SPDK: local (DRAM) descriptor metadata is missing or invalid";
@@ -54,36 +56,76 @@ resolveDescriptorPair(const nixlMetaDesc &local,
     }
 
     auto *remote_md = dynamic_cast<nixlSpdkMD *>(remote.metadataP);
-    if (!remote_md || remote_md->kind() != nixlSpdkMD::Kind::Bdev) {
-        NIXL_ERROR << "SPDK: BLK descriptor metadata is missing or invalid";
-        return NIXL_ERR_INVALID_PARAM;
-    }
-    auto *bdev = static_cast<nixlSpdkBdevMD *>(remote_md);
-    if (!bdev->desc || !bdev->channel || !bdev->bdev) {
-        NIXL_ERROR << "SPDK: BLK descriptor metadata is missing or invalid";
+    if (!remote_md) {
+        NIXL_ERROR << "SPDK: remote descriptor metadata is missing or invalid";
         return NIXL_ERR_INVALID_PARAM;
     }
     if (local.len != remote.len) {
-        NIXL_ERROR << "SPDK: local and BLK descriptor lengths must match";
-        return NIXL_ERR_INVALID_PARAM;
-    }
-    if ((remote.addr % bdev->blockSize) != 0 || (remote.len % bdev->blockSize) != 0) {
-        NIXL_ERROR << "SPDK: BLK descriptor offset and length must be block aligned";
-        return NIXL_ERR_INVALID_PARAM;
-    }
-    if ((remote.addr + remote.len) > (bdev->numBlocks * bdev->blockSize)) {
-        NIXL_ERROR << "SPDK: BLK descriptor exceeds bdev capacity";
-        return NIXL_ERR_INVALID_PARAM;
-    }
-    if ((remote.len / bdev->blockSize) % bdev->writeUnitSize != 0) {
-        NIXL_ERROR << "SPDK: BLK descriptor length is not write-unit aligned";
+        NIXL_ERROR << "SPDK: local and remote descriptor lengths must match";
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    io.dram = dram;
-    io.bdev = bdev;
-    io.offset = remote.addr;
-    return NIXL_SUCCESS;
+    // validateLists() checks the list type and this checks the metadata kind;
+    // neither implies the other. Dispatching on the kind alone would let a
+    // BLK_SEG list holding OBJ metadata issue an NVMe KV command.
+    const nixlSpdkMD::Kind expected =
+        (remote_type == BLK_SEG) ? nixlSpdkMD::Kind::Bdev : nixlSpdkMD::Kind::Obj;
+    if (remote_md->kind() != expected) {
+        NIXL_ERROR << "SPDK: remote descriptor metadata does not match the list type";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    switch (remote_md->kind()) {
+    case nixlSpdkMD::Kind::Bdev: {
+        auto *bdev = static_cast<nixlSpdkBdevMD *>(remote_md);
+        if (!bdev->desc || !bdev->channel || !bdev->bdev) {
+            NIXL_ERROR << "SPDK: BLK descriptor metadata is missing or invalid";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if ((remote.addr % bdev->blockSize) != 0 || (remote.len % bdev->blockSize) != 0) {
+            NIXL_ERROR << "SPDK: BLK descriptor offset and length must be block aligned";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if ((remote.addr + remote.len) > (bdev->numBlocks * bdev->blockSize)) {
+            NIXL_ERROR << "SPDK: BLK descriptor exceeds bdev capacity";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if ((remote.len / bdev->blockSize) % bdev->writeUnitSize != 0) {
+            NIXL_ERROR << "SPDK: BLK descriptor length is not write-unit aligned";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        dram_out = dram;
+        target_out = nixlSpdkBlkTarget{bdev, remote.addr};
+        return NIXL_SUCCESS;
+    }
+    case nixlSpdkMD::Kind::Obj: {
+        // NVMe KV has no intra-object offset, so the remote addr must be 0.
+        auto *obj = static_cast<nixlSpdkObjMD *>(remote_md);
+        // Defensive only: nixlSpdkObjMD::create() rejects an empty key and the
+        // constructor is private, so this cannot fire today. Kept so a future
+        // construction path cannot quietly emit a zero-length KV key.
+        if (obj->key().empty()) {
+            NIXL_ERROR << "SPDK: OBJ descriptor has an empty key";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if (remote.addr != 0) {
+            NIXL_ERROR << "SPDK: OBJ descriptor offset must be 0 (KV whole-value)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if (remote.len == 0) {
+            NIXL_ERROR << "SPDK: OBJ descriptor value length must be non-zero";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        dram_out = dram;
+        target_out = nixlSpdkObjTarget{obj};
+        return NIXL_SUCCESS;
+    }
+    case nixlSpdkMD::Kind::Dram:
+        break;
+    }
+
+    NIXL_ERROR << "SPDK: remote descriptor list must be BLK_SEG or OBJ_SEG";
+    return NIXL_ERR_INVALID_PARAM;
 }
 
 } // namespace
@@ -96,7 +138,6 @@ nixlSpdkBackendReqH::nixlSpdkBackendReqH(nixl_xfer_op_t operation,
     // has to happen after the vector reaches its final storage.
     for (auto &io : ios_) {
         io.reqH = this;
-        io.waitEntry.bdev = io.bdev->bdev;
         io.waitEntry.cb_arg = &io;
     }
 }
@@ -152,8 +193,31 @@ nixlSpdkEngine::registerMem(const nixlBlobDesc &mem,
             NIXL_ERROR << "SPDK: BLK_SEG metaInfo must contain an SPDK bdev name";
             return NIXL_ERR_INVALID_PARAM;
         }
-        auto md = std::make_unique<nixlSpdkBdevMD>(mem.devId, mem.metaInfo);
+        auto md = std::make_unique<nixlSpdkBdevMD>(mem.metaInfo);
         const nixl_status_t status = progress_->openBdev(*md);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        out = md.release();
+        return NIXL_SUCCESS;
+    }
+
+    if (mem_type == OBJ_SEG) {
+        // The key must be given explicitly, as BLK_SEG requires its bdev name.
+        // Deriving one from devId would silently collide: two descriptors that
+        // share a devId and omit metaInfo would map to the same object, and the
+        // second write would overwrite the first.
+        if (mem.metaInfo.empty()) {
+            NIXL_ERROR << "SPDK: OBJ_SEG requires the object key in the descriptor metaInfo";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto md = nixlSpdkObjMD::create(mem.metaInfo);
+        if (!md) {
+            NIXL_ERROR << "SPDK: OBJ_SEG key must be 1.." << kNixlSpdkMaxKeyLen
+                       << " bytes (NVMe KV limit), got " << mem.metaInfo.size();
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const nixl_status_t status = progress_->ensureKvBdev();
         if (status != NIXL_SUCCESS) {
             return status;
         }
@@ -180,6 +244,10 @@ nixlSpdkEngine::deregisterMem(nixlBackendMD *meta) {
     case nixlSpdkMD::Kind::Bdev:
         progress_->closeBdev(static_cast<nixlSpdkBdevMD &>(*md));
         return NIXL_SUCCESS;
+    case nixlSpdkMD::Kind::Obj:
+        // The shared KV device is owned by the progress engine and torn down at
+        // finalization; per-object metadata carries only the key.
+        return NIXL_SUCCESS;
     }
     return NIXL_ERR_INVALID_PARAM;
 }
@@ -200,14 +268,19 @@ nixlSpdkEngine::prepXfer(const nixl_xfer_op_t &operation,
     std::vector<nixlSpdkIoContext> ios;
     ios.reserve(local.descCount());
     for (int i = 0; i < local.descCount(); ++i) {
-        nixlSpdkIoContext io;
-        const nixl_status_t resolved = resolveDescriptorPair(local[i], remote[i], io);
+        nixlSpdkDramMD *dram = nullptr;
+        nixlSpdkIoTarget target;
+        const nixl_status_t resolved =
+            resolveDescriptorPair(local[i], remote[i], remote.getType(), dram, target);
         if (resolved != NIXL_SUCCESS) {
             return resolved;
         }
-        io.buf = reinterpret_cast<void *>(local[i].addr);
-        io.nbytes = local[i].len;
-        ios.push_back(io);
+        ios.push_back(nixlSpdkIoContext{
+            .dram = dram,
+            .target = target,
+            .buf = reinterpret_cast<void *>(local[i].addr),
+            .nbytes = local[i].len,
+        });
     }
 
     handle = std::make_unique<nixlSpdkBackendReqH>(operation, std::move(ios)).release();
@@ -251,17 +324,5 @@ nixlSpdkEngine::releaseReqH(nixlBackendReqH *handle) const {
         return NIXL_ERR_INVALID_PARAM;
     }
     progress_->cancelRequest(req_h);
-    return NIXL_SUCCESS;
-}
-
-nixl_status_t
-nixlSpdkEngine::queryMem(const nixl_reg_dlist_t &descs,
-                         std::vector<nixl_query_resp_t> &resp) const {
-    resp.clear();
-    for (const auto &desc : descs) {
-        nixl_b_params_t item;
-        item["size"] = std::to_string(desc.len);
-        resp.emplace_back(std::move(item));
-    }
     return NIXL_SUCCESS;
 }

--- a/src/plugins/spdk/spdk_backend.h
+++ b/src/plugins/spdk/spdk_backend.h
@@ -6,11 +6,16 @@
 #ifndef NIXL_SRC_PLUGINS_SPDK_SPDK_BACKEND_H
 #define NIXL_SRC_PLUGINS_SPDK_SPDK_BACKEND_H
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <string>
+#include <string_view>
+#include <variant>
 #include <vector>
 
 #include "backend/backend_engine.h"
@@ -31,6 +36,7 @@ public:
     enum class Kind : uint8_t {
         Dram,
         Bdev,
+        Obj,
     };
 
     explicit nixlSpdkMD(Kind kind) noexcept : nixlBackendMD(true), kind_(kind) {}
@@ -59,12 +65,10 @@ struct nixlSpdkDramMD : nixlSpdkMD {
 };
 
 struct nixlSpdkBdevMD : nixlSpdkMD {
-    nixlSpdkBdevMD(uint64_t dev_id, std::string bdev_name)
+    explicit nixlSpdkBdevMD(std::string bdev_name)
         : nixlSpdkMD(Kind::Bdev),
-          devId(dev_id),
           bdevName(std::move(bdev_name)) {}
 
-    uint64_t devId;
     std::string bdevName;
     spdk_bdev_desc *desc = nullptr;
     spdk_bdev *bdev = nullptr;
@@ -74,15 +78,62 @@ struct nixlSpdkBdevMD : nixlSpdkMD {
     uint64_t numBlocks = 0;
 };
 
+// NVMe KV keys are 1..16 bytes.
+inline constexpr std::size_t kNixlSpdkMaxKeyLen = 16;
+
+// One object (key) on the KV device. Keys are per-object, as in NIXL's other
+// OBJ backends: captured from the descriptor metaInfo at registration and
+// recovered via metadataP at transfer. The KV device itself is the backend's
+// bdev (see 'bdev_name'), owned by the progress engine.
+class nixlSpdkObjMD : public nixlSpdkMD {
+public:
+    // Returns nullptr for an out-of-range key rather than truncating it.
+    [[nodiscard]] static std::unique_ptr<nixlSpdkObjMD>
+    create(std::string_view object_key) {
+        if (object_key.empty() || object_key.size() > kNixlSpdkMaxKeyLen) {
+            return nullptr;
+        }
+        return std::unique_ptr<nixlSpdkObjMD>(new nixlSpdkObjMD(object_key));
+    }
+
+    [[nodiscard]] std::span<const std::byte>
+    key() const noexcept {
+        return std::span(key_).first(keyLen_);
+    }
+
+private:
+    explicit nixlSpdkObjMD(std::string_view object_key) noexcept
+        : nixlSpdkMD(Kind::Obj),
+          keyLen_(static_cast<uint8_t>(object_key.size())) {
+        std::ranges::copy(std::as_bytes(std::span(object_key)), key_.begin());
+    }
+
+    std::array<std::byte, kNixlSpdkMaxKeyLen> key_{};
+    uint8_t keyLen_;
+};
+
+// A transfer targets either a block range on a bdev or a key on the KV device.
+// The offset lives in the BLK alternative because NVMe KV has no intra-object
+// offset.
+struct nixlSpdkBlkTarget {
+    nixlSpdkBdevMD *md;
+    uint64_t offset;
+};
+
+struct nixlSpdkObjTarget {
+    nixlSpdkObjMD *md;
+};
+
+using nixlSpdkIoTarget = std::variant<nixlSpdkBlkTarget, nixlSpdkObjTarget>;
+
 // One bdev I/O within a request.
 struct nixlSpdkIoContext {
     nixlSpdkBackendReqH *reqH = nullptr;
     nixlSpdkProgressEngine *engine = nullptr;
     nixlSpdkDramMD *dram = nullptr;
-    nixlSpdkBdevMD *bdev = nullptr;
-    void *buf = nullptr;
-    uint64_t offset = 0;
-    uint64_t nbytes = 0;
+    nixlSpdkIoTarget target;
+    void *buf = nullptr; // value buffer (from the local DRAM descriptor)
+    uint64_t nbytes = 0; // value size
     bool ioWaitQueued = false;
     spdk_bdev_io_wait_entry waitEntry = {};
 };
@@ -153,7 +204,7 @@ public:
 
     [[nodiscard]] nixl_mem_list_t
     getSupportedMems() const override {
-        return {DRAM_SEG, BLK_SEG};
+        return {DRAM_SEG, BLK_SEG, OBJ_SEG};
     }
 
     [[nodiscard]] nixl_status_t
@@ -203,11 +254,13 @@ public:
     [[nodiscard]] nixl_status_t
     releaseReqH(nixlBackendReqH *handle) const override;
 
-    [[nodiscard]] nixl_status_t
-    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+    // queryMem is deliberately not overridden. The registration descriptor list
+    // carries no resolved metadata, so there is no bdev or KV handle to consult;
+    // the base class reports NIXL_ERR_NOT_SUPPORTED, which is more useful to a
+    // caller than echoing back the length it just passed in.
 
 private:
     std::unique_ptr<nixlSpdkProgressEngine> progress_;
 };
 
-#endif
+#endif // NIXL_SRC_PLUGINS_SPDK_SPDK_BACKEND_H

--- a/src/plugins/spdk/spdk_backend.h
+++ b/src/plugins/spdk/spdk_backend.h
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_PLUGINS_SPDK_SPDK_BACKEND_H
+#define NIXL_SRC_PLUGINS_SPDK_SPDK_BACKEND_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "backend/backend_engine.h"
+
+#include <spdk/bdev.h>
+
+class nixlSpdkProgressEngine;
+class nixlSpdkBackendReqH;
+
+// Common base for this backend's metadata. The kind tag discriminates the
+// subtypes without RTTI: one checked dynamic_cast at the NIXL boundary proves a
+// pointer is ours, and everything after that switches on kind().
+//
+// Copying is deleted because nixlSpdkBdevMD owns SPDK handles that a duplicate
+// would close twice; these are also polymorphic, so a copy would slice.
+class nixlSpdkMD : public nixlBackendMD {
+public:
+    enum class Kind : uint8_t {
+        Dram,
+        Bdev,
+    };
+
+    explicit nixlSpdkMD(Kind kind) noexcept : nixlBackendMD(true), kind_(kind) {}
+
+    nixlSpdkMD(const nixlSpdkMD &) = delete;
+    nixlSpdkMD &
+    operator=(const nixlSpdkMD &) = delete;
+
+    [[nodiscard]] Kind
+    kind() const noexcept {
+        return kind_;
+    }
+
+private:
+    Kind kind_;
+};
+
+struct nixlSpdkDramMD : nixlSpdkMD {
+    nixlSpdkDramMD(uintptr_t addr, std::size_t len) noexcept
+        : nixlSpdkMD(Kind::Dram),
+          addr(addr),
+          len(len) {}
+
+    uintptr_t addr;
+    std::size_t len;
+};
+
+struct nixlSpdkBdevMD : nixlSpdkMD {
+    nixlSpdkBdevMD(uint64_t dev_id, std::string bdev_name)
+        : nixlSpdkMD(Kind::Bdev),
+          devId(dev_id),
+          bdevName(std::move(bdev_name)) {}
+
+    uint64_t devId;
+    std::string bdevName;
+    spdk_bdev_desc *desc = nullptr;
+    spdk_bdev *bdev = nullptr;
+    spdk_io_channel *channel = nullptr;
+    uint32_t blockSize = 0;
+    uint32_t writeUnitSize = 0;
+    uint64_t numBlocks = 0;
+};
+
+// One bdev I/O within a request.
+struct nixlSpdkIoContext {
+    nixlSpdkBackendReqH *reqH = nullptr;
+    nixlSpdkProgressEngine *engine = nullptr;
+    nixlSpdkDramMD *dram = nullptr;
+    nixlSpdkBdevMD *bdev = nullptr;
+    void *buf = nullptr;
+    uint64_t offset = 0;
+    uint64_t nbytes = 0;
+    bool ioWaitQueued = false;
+    spdk_bdev_io_wait_entry waitEntry = {};
+};
+
+class nixlSpdkBackendReqH : public nixlBackendReqH {
+public:
+    nixlSpdkBackendReqH(nixl_xfer_op_t operation, std::vector<nixlSpdkIoContext> ios);
+    ~nixlSpdkBackendReqH() override = default;
+
+    // Each IoContext holds its own address as the SPDK completion cb_arg, so a
+    // copy would leave the duplicate's callbacks pointing into the original's
+    // vector.
+    nixlSpdkBackendReqH(const nixlSpdkBackendReqH &) = delete;
+    nixlSpdkBackendReqH &
+    operator=(const nixlSpdkBackendReqH &) = delete;
+
+    [[nodiscard]] nixl_status_t
+    status() const noexcept;
+
+private:
+    // The engine drives this handle's whole lifetime: submission, completion
+    // accounting, and the delete protocol below.
+    friend class nixlSpdkProgressEngine;
+
+    // The handle can be freed from either the completion path (all I/Os done)
+    // or the release path (cancelRequest). Both record their arrival in
+    // lifeState_ via a single atomic fetch_or; the thread that observes the
+    // other's bit already set is the second arriver and is the sole deleter.
+    // This makes the two paths race-free without a post-store read of *this.
+    // Typed to match the atomic below: fetch_or() requires an integral type.
+    static constexpr uint32_t kSubmitted = 1u << 0; // entered the SPDK execution context
+    static constexpr uint32_t kDone = 1u << 1; // all I/Os retired (success or error)
+    static constexpr uint32_t kReleased = 1u << 2; // NIXL released/cancelled the request
+
+    // Clear per-post state so a handle can be reposted. outstanding_ is primed
+    // with one extra "submission guard" reference (released by submitRequest)
+    // so a synchronous completion cannot retire the request mid-submit.
+    void
+    reset() noexcept;
+
+    nixl_xfer_op_t operation_;
+    std::vector<nixlSpdkIoContext> ios_;
+    std::atomic<uint32_t> outstanding_{0};
+    std::atomic<uint32_t> lifeState_{0};
+    std::atomic<bool> cancelled_{false};
+    std::atomic<nixl_status_t> overallStatus_{NIXL_IN_PROG};
+};
+
+class nixlSpdkEngine : public nixlBackendEngine {
+public:
+    explicit nixlSpdkEngine(const nixlBackendInitParams *init_params);
+    ~nixlSpdkEngine() override;
+
+    [[nodiscard]] bool
+    supportsRemote() const noexcept override {
+        return false;
+    }
+
+    [[nodiscard]] bool
+    supportsLocal() const noexcept override {
+        return true;
+    }
+
+    [[nodiscard]] bool
+    supportsNotif() const noexcept override {
+        return false;
+    }
+
+    [[nodiscard]] nixl_mem_list_t
+    getSupportedMems() const override {
+        return {DRAM_SEG, BLK_SEG};
+    }
+
+    [[nodiscard]] nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+    [[nodiscard]] nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    [[nodiscard]] nixl_status_t
+    connect(const std::string &) override {
+        return NIXL_SUCCESS;
+    }
+
+    [[nodiscard]] nixl_status_t
+    disconnect(const std::string &) override {
+        return NIXL_SUCCESS;
+    }
+
+    [[nodiscard]] nixl_status_t
+    loadLocalMD(nixlBackendMD *in, nixlBackendMD *&out) override {
+        out = in;
+        return NIXL_SUCCESS;
+    }
+
+    [[nodiscard]] nixl_status_t
+    unloadMD(nixlBackendMD *) override {
+        return NIXL_SUCCESS;
+    }
+
+    [[nodiscard]] nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    [[nodiscard]] nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    [[nodiscard]] nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+    [[nodiscard]] nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+    [[nodiscard]] nixl_status_t
+    queryMem(const nixl_reg_dlist_t &descs, std::vector<nixl_query_resp_t> &resp) const override;
+
+private:
+    std::unique_ptr<nixlSpdkProgressEngine> progress_;
+};
+
+#endif

--- a/src/plugins/spdk/spdk_env/.clang-format
+++ b/src/plugins/spdk/spdk_env/.clang-format
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# These sources implement SPDK's env interface and are derived from SPDK, so
+# they follow SPDK's coding style rather than NIXL's. Leave them alone so diffs
+# against upstream SPDK stay readable.
+DisableFormat: true
+SortIncludes: Never

--- a/src/plugins/spdk/spdk_env/env.c
+++ b/src/plugins/spdk/spdk_env/env.c
@@ -1,0 +1,935 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "env_internal.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+#include "spdk/memory.h"
+#include "spdk/queue.h"
+#include "spdk/util.h"
+
+#ifndef MAP_HUGE_2MB
+#define MAP_HUGE_2MB (21 << 26)
+#endif
+
+#define CACHE_LINE_SIZE 64
+
+struct hugepage_chunk;
+
+struct alloc_header {
+	void *raw;
+	struct hugepage_chunk *chunk;
+	size_t size;
+	size_t align;
+	uint32_t flags;
+};
+
+/* align must be a power of two: the mask below is meaningless otherwise.
+ * spdk_malloc()/spdk_realloc() enforce this on the caller-supplied value.
+ */
+static inline size_t align_up(size_t val, size_t align)
+{
+	return (val + align - 1) & ~(align - 1);
+}
+
+static inline bool is_power_of_two(size_t val)
+{
+	return val != 0 && (val & (val - 1)) == 0;
+}
+
+static void *_alloc(size_t size, size_t align, int numa_id, uint32_t flags)
+{
+	struct alloc_header *hdr;
+	void *raw, *ret;
+
+	if (align < CACHE_LINE_SIZE) {
+		align = CACHE_LINE_SIZE;
+	}
+
+	raw = env_aligned_alloc(align, size + align);
+	if (raw == NULL) {
+		return NULL;
+	}
+
+	ret = (char *)raw + align;
+	hdr = (struct alloc_header *)((char *)ret - sizeof(struct alloc_header));
+	hdr->raw = raw;
+	hdr->chunk = NULL;
+	hdr->size = size;
+	hdr->align = align;
+	hdr->flags = flags;
+
+	return ret;
+}
+
+static struct alloc_header *_get_header(void *buf)
+{
+	return (struct alloc_header *)((char *)buf - sizeof(struct alloc_header));
+}
+
+/* ---------- DMA hugepage allocator ---------- */
+
+struct hugepage_chunk {
+	void *base;
+	size_t size;
+	size_t offset;
+	int alloc_count;
+	TAILQ_ENTRY(hugepage_chunk) link;
+};
+
+static pthread_mutex_t g_dma_mutex = PTHREAD_MUTEX_INITIALIZER;
+static TAILQ_HEAD(, hugepage_chunk) g_dma_chunks = TAILQ_HEAD_INITIALIZER(g_dma_chunks);
+static struct hugepage_chunk *g_dma_current;
+
+/*
+ * Offset into chunk such that chunk->base + offset is aligned to align and
+ * leaves room for the header below it. The alignment is computed on the
+ * absolute address, not on the offset: the hugepage mmap in
+ * _dma_map_hugepages() falls back to an anonymous mapping that is only
+ * page-aligned, so aligning the offset alone would return a buffer that does
+ * not satisfy an align larger than 4 KiB.
+ */
+static size_t chunk_aligned_start(const struct hugepage_chunk *chunk, size_t align)
+{
+	uintptr_t base = (uintptr_t)chunk->base;
+	uintptr_t want = base + chunk->offset + sizeof(struct alloc_header);
+
+	return (size_t)(align_up(want, align) - base);
+}
+
+static struct hugepage_chunk *_dma_map_hugepages(size_t size)
+{
+	struct hugepage_chunk *chunk;
+	void *addr;
+
+	size = align_up(size, VALUE_2MB);
+
+	addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | MAP_HUGE_2MB, -1, 0);
+	if (addr == MAP_FAILED) {
+		addr = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (addr == MAP_FAILED) {
+			return NULL;
+		}
+	}
+
+	if (spdk_mem_register(addr, size) != 0) {
+		munmap(addr, size);
+		return NULL;
+	}
+
+	chunk = calloc(1, sizeof(*chunk));
+	if (!chunk) {
+		spdk_mem_unregister(addr, size);
+		munmap(addr, size);
+		return NULL;
+	}
+
+	chunk->base = addr;
+	chunk->size = size;
+	TAILQ_INSERT_TAIL(&g_dma_chunks, chunk, link);
+
+	return chunk;
+}
+
+static void *_dma_alloc(size_t size, size_t align, uint32_t flags)
+{
+	struct hugepage_chunk *chunk;
+	struct alloc_header *hdr;
+	void *ret;
+	size_t aligned_start, end;
+
+	if (align < CACHE_LINE_SIZE) {
+		align = CACHE_LINE_SIZE;
+	}
+
+	pthread_mutex_lock(&g_dma_mutex);
+
+	chunk = g_dma_current;
+	if (chunk) {
+		aligned_start = chunk_aligned_start(chunk, align);
+		end = aligned_start + size;
+		if (end <= chunk->size) {
+			goto allocate;
+		}
+	}
+
+	{
+		size_t need = sizeof(struct alloc_header) + align + size;
+		size_t chunk_size = (need > VALUE_2MB) ? align_up(need, VALUE_2MB) : VALUE_2MB;
+
+		chunk = _dma_map_hugepages(chunk_size);
+		if (!chunk) {
+			pthread_mutex_unlock(&g_dma_mutex);
+			return NULL;
+		}
+		g_dma_current = chunk;
+
+		aligned_start = chunk_aligned_start(chunk, align);
+		end = aligned_start + size;
+	}
+
+allocate:
+	ret = (char *)chunk->base + aligned_start;
+	hdr = (struct alloc_header *)((char *)ret - sizeof(struct alloc_header));
+	hdr->raw = NULL;
+	hdr->chunk = chunk;
+	hdr->size = size;
+	hdr->align = align;
+	hdr->flags = flags;
+
+	chunk->offset = end;
+	chunk->alloc_count++;
+
+	pthread_mutex_unlock(&g_dma_mutex);
+	return ret;
+}
+
+/*
+ * Chunks are bump-allocated and never reused internally: a chunk is released
+ * only once every allocation inside it has been freed. A single long-lived
+ * buffer therefore pins its whole chunk (at least 2 MiB). This suits the
+ * plugin, which allocates its DMA buffers per registration rather than per
+ * transfer; a workload that churned mixed-lifetime buffers would need a
+ * per-chunk free list.
+ */
+static void _dma_free(struct alloc_header *hdr)
+{
+	struct hugepage_chunk *chunk = hdr->chunk;
+
+	pthread_mutex_lock(&g_dma_mutex);
+
+	chunk->alloc_count--;
+	if (chunk->alloc_count == 0) {
+		if (g_dma_current == chunk) {
+			g_dma_current = NULL;
+		}
+		TAILQ_REMOVE(&g_dma_chunks, chunk, link);
+		pthread_mutex_unlock(&g_dma_mutex);
+
+		spdk_mem_unregister(chunk->base, chunk->size);
+		munmap(chunk->base, chunk->size);
+		free(chunk);
+		return;
+	}
+
+	pthread_mutex_unlock(&g_dma_mutex);
+}
+
+static void *_realloc(void *buf, size_t size, size_t align)
+{
+	struct alloc_header *old_hdr;
+	void *new_buf;
+
+	old_hdr = _get_header(buf);
+
+	if (align == 0) {
+		align = old_hdr->align;
+	}
+
+	if (old_hdr->chunk) {
+		new_buf = _dma_alloc(size, align, old_hdr->flags);
+	} else {
+		new_buf = _alloc(size, align, SPDK_ENV_NUMA_ID_ANY, old_hdr->flags);
+	}
+	if (!new_buf) {
+		return NULL;
+	}
+
+	memcpy(new_buf, buf, old_hdr->size < size ? old_hdr->size : size);
+
+	if (old_hdr->chunk) {
+		_dma_free(old_hdr);
+	} else {
+		free(old_hdr->raw);
+	}
+
+	return new_buf;
+}
+
+static void *_dma_realloc(void *buf, size_t size, size_t align)
+{
+	struct alloc_header *old_hdr;
+	void *new_buf;
+
+	old_hdr = _get_header(buf);
+
+	if (align == 0) {
+		align = old_hdr->align;
+	}
+
+	new_buf = _dma_alloc(size, align, old_hdr->flags);
+	if (!new_buf) {
+		return NULL;
+	}
+
+	memcpy(new_buf, buf, old_hdr->size < size ? old_hdr->size : size);
+
+	if (old_hdr->chunk) {
+		_dma_free(old_hdr);
+	} else {
+		free(old_hdr->raw);
+	}
+
+	return new_buf;
+}
+
+static void _free(void *buf)
+{
+	struct alloc_header *hdr = _get_header(buf);
+
+	if (hdr->chunk) {
+		_dma_free(hdr);
+	} else {
+		free(hdr->raw);
+	}
+}
+
+void *spdk_malloc(size_t size, size_t align, uint64_t *unused, int numa_id, uint32_t flags)
+{
+	if (unused || flags == 0) {
+		return NULL;
+	}
+
+	/* align == 0 means "no preference"; the allocators raise it to
+	 * CACHE_LINE_SIZE. Anything else must be a power of two, or align_up()
+	 * inside them computes a bogus offset.
+	 */
+	if (align != 0 && !is_power_of_two(align)) {
+		ENV_ERRLOG("Alignment %zu is not a power of two", align);
+		return NULL;
+	}
+
+	if (flags & SPDK_MALLOC_DMA) {
+		return _dma_alloc(size, align, flags);
+	}
+
+	return _alloc(size, align, numa_id, flags);
+}
+
+void *spdk_zmalloc(size_t size, size_t align, uint64_t *unused, int numa_id, uint32_t flags)
+{
+	void *buf;
+
+	buf = spdk_malloc(size, align, unused, numa_id, flags);
+	if (buf) {
+		memset(buf, 0, size);
+	}
+
+	return buf;
+}
+
+void *spdk_realloc(void *buf, size_t size, size_t align)
+{
+	/* align == 0 here means "keep the original alignment". */
+	if (align != 0 && !is_power_of_two(align)) {
+		ENV_ERRLOG("Alignment %zu is not a power of two", align);
+		return NULL;
+	}
+
+	if (!buf) {
+		return spdk_malloc(size, align, NULL, SPDK_ENV_NUMA_ID_ANY, SPDK_MALLOC_SHARE);
+	}
+
+	return _realloc(buf, size, align);
+}
+
+void spdk_free(void *buf)
+{
+	if (!buf) {
+		return;
+	}
+
+	_free(buf);
+}
+
+void *spdk_dma_malloc(size_t size, size_t align, uint64_t *unused)
+{
+	return spdk_malloc(size, align, unused, SPDK_ENV_NUMA_ID_ANY, SPDK_MALLOC_DMA);
+}
+
+void *spdk_dma_malloc_socket(size_t size, size_t align, uint64_t *unused, int numa_id)
+{
+	return spdk_malloc(size, align, unused, numa_id, SPDK_MALLOC_DMA);
+}
+
+void *spdk_dma_zmalloc(size_t size, size_t align, uint64_t *unused)
+{
+	return spdk_zmalloc(size, align, unused, SPDK_ENV_NUMA_ID_ANY, SPDK_MALLOC_DMA);
+}
+
+void *spdk_dma_zmalloc_socket(size_t size, size_t align, uint64_t *unused, int numa_id)
+{
+	return spdk_zmalloc(size, align, unused, numa_id, SPDK_MALLOC_DMA);
+}
+
+void *spdk_dma_realloc(void *buf, size_t size, size_t align, uint64_t *unused)
+{
+	if (unused) {
+		return NULL;
+	}
+
+	if (!buf) {
+		return spdk_malloc(size, align, NULL, SPDK_ENV_NUMA_ID_ANY, SPDK_MALLOC_DMA);
+	}
+
+	return _dma_realloc(buf, size, align);
+}
+
+void spdk_dma_free(void *buf)
+{
+	spdk_free(buf);
+}
+
+/* ---------- memzone ---------- */
+
+struct spdk_memzone_entry {
+	char name[256];
+	void *addr;
+	size_t len;
+	TAILQ_ENTRY(spdk_memzone_entry) link;
+};
+
+static TAILQ_HEAD(, spdk_memzone_entry) g_memzones = TAILQ_HEAD_INITIALIZER(g_memzones);
+static pthread_mutex_t g_memzone_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void *spdk_memzone_reserve(const char *name, size_t len, int numa_id, unsigned flags)
+{
+	return spdk_memzone_reserve_aligned(name, len, numa_id, flags, 0);
+}
+
+void *spdk_memzone_reserve_aligned(const char *name, size_t len, int numa_id, unsigned flags, unsigned align)
+{
+	struct spdk_memzone_entry *entry;
+	void *addr;
+
+	pthread_mutex_lock(&g_memzone_lock);
+
+	TAILQ_FOREACH(entry, &g_memzones, link)
+	{
+		if (strcmp(entry->name, name) == 0) {
+			pthread_mutex_unlock(&g_memzone_lock);
+			return NULL;
+		}
+	}
+
+	addr = spdk_zmalloc(len, align, NULL, numa_id, SPDK_MALLOC_DMA | SPDK_MALLOC_SHARE);
+	if (!addr) {
+		pthread_mutex_unlock(&g_memzone_lock);
+		return NULL;
+	}
+
+	entry = calloc(1, sizeof(*entry));
+	if (!entry) {
+		spdk_free(addr);
+		pthread_mutex_unlock(&g_memzone_lock);
+		return NULL;
+	}
+
+	snprintf(entry->name, sizeof(entry->name), "%s", name);
+	entry->addr = addr;
+	entry->len = len;
+	TAILQ_INSERT_TAIL(&g_memzones, entry, link);
+
+	pthread_mutex_unlock(&g_memzone_lock);
+	return addr;
+}
+
+void *spdk_memzone_lookup(const char *name)
+{
+	struct spdk_memzone_entry *entry;
+
+	pthread_mutex_lock(&g_memzone_lock);
+	TAILQ_FOREACH(entry, &g_memzones, link)
+	{
+		if (strcmp(entry->name, name) == 0) {
+			pthread_mutex_unlock(&g_memzone_lock);
+			return entry->addr;
+		}
+	}
+	pthread_mutex_unlock(&g_memzone_lock);
+	return NULL;
+}
+
+int spdk_memzone_free(const char *name)
+{
+	struct spdk_memzone_entry *entry;
+
+	pthread_mutex_lock(&g_memzone_lock);
+	TAILQ_FOREACH(entry, &g_memzones, link)
+	{
+		if (strcmp(entry->name, name) == 0) {
+			TAILQ_REMOVE(&g_memzones, entry, link);
+			spdk_free(entry->addr);
+			free(entry);
+			pthread_mutex_unlock(&g_memzone_lock);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&g_memzone_lock);
+	return -1;
+}
+
+void spdk_memzone_dump(FILE *f)
+{
+	struct spdk_memzone_entry *entry;
+
+	pthread_mutex_lock(&g_memzone_lock);
+	TAILQ_FOREACH(entry, &g_memzones, link)
+	{
+		fprintf(f, "  zone \"%s\": addr=%p len=%zu\n", entry->name, entry->addr, entry->len);
+	}
+	pthread_mutex_unlock(&g_memzone_lock);
+}
+
+/* ---------- mempool ---------- */
+
+struct spdk_mempool {
+	char name[256];
+	size_t ele_size;
+	size_t count;
+	void *base;
+	size_t base_len;
+
+	void **free_stack;
+	size_t free_count;
+	pthread_mutex_t lock;
+
+	TAILQ_ENTRY(spdk_mempool) link;
+};
+
+static TAILQ_HEAD(, spdk_mempool) g_mempools = TAILQ_HEAD_INITIALIZER(g_mempools);
+static pthread_mutex_t g_mempool_lock = PTHREAD_MUTEX_INITIALIZER;
+
+struct spdk_mempool *spdk_mempool_create(const char *name, size_t count, size_t ele_size, size_t cache_size, int numa_id)
+{
+	return spdk_mempool_create_ctor(name, count, ele_size, cache_size, numa_id, NULL, NULL);
+}
+
+struct spdk_mempool *spdk_mempool_create_ctor(const char *name,
+					      size_t count,
+					      size_t ele_size,
+					      size_t cache_size,
+					      int numa_id,
+					      spdk_mempool_obj_cb_t *obj_init,
+					      void *obj_init_arg)
+{
+	struct spdk_mempool *mp;
+	size_t aligned_ele_size;
+	size_t i;
+
+	mp = calloc(1, sizeof(*mp));
+	if (!mp) {
+		return NULL;
+	}
+
+	aligned_ele_size = align_up(ele_size, CACHE_LINE_SIZE);
+
+	/* A wrapped base_len would under-allocate while the loop below still
+	 * initialises count elements, writing past the end of the buffer.
+	 */
+	if (count != 0 && aligned_ele_size > SIZE_MAX / count) {
+		ENV_ERRLOG("Mempool %s size overflow: %zu elements of %zu bytes",
+			   name, count, aligned_ele_size);
+		free(mp);
+		return NULL;
+	}
+
+	snprintf(mp->name, sizeof(mp->name), "%s", name);
+	mp->ele_size = ele_size;
+	mp->count = count;
+	pthread_mutex_init(&mp->lock, NULL);
+
+	mp->base_len = aligned_ele_size * count;
+
+	if (count > 0) {
+		mp->base =
+			spdk_zmalloc(mp->base_len, CACHE_LINE_SIZE, NULL, numa_id, SPDK_MALLOC_DMA | SPDK_MALLOC_SHARE);
+		if (!mp->base) {
+			pthread_mutex_destroy(&mp->lock);
+			free(mp);
+			return NULL;
+		}
+
+		mp->free_stack = calloc(count, sizeof(void *));
+		if (!mp->free_stack) {
+			spdk_free(mp->base);
+			pthread_mutex_destroy(&mp->lock);
+			free(mp);
+			return NULL;
+		}
+
+		for (i = 0; i < count; i++) {
+			void *obj = (char *)mp->base + i * aligned_ele_size;
+
+			if (obj_init) {
+				obj_init(mp, obj_init_arg, obj, (unsigned)i);
+			}
+			mp->free_stack[i] = obj;
+		}
+		mp->free_count = count;
+	}
+
+	pthread_mutex_lock(&g_mempool_lock);
+	TAILQ_INSERT_TAIL(&g_mempools, mp, link);
+	pthread_mutex_unlock(&g_mempool_lock);
+
+	return mp;
+}
+
+char *spdk_mempool_get_name(struct spdk_mempool *mp)
+{
+	return mp->name;
+}
+
+void spdk_mempool_free(struct spdk_mempool *mp)
+{
+	if (!mp) {
+		return;
+	}
+
+	pthread_mutex_lock(&g_mempool_lock);
+	TAILQ_REMOVE(&g_mempools, mp, link);
+	pthread_mutex_unlock(&g_mempool_lock);
+
+	spdk_free(mp->base);
+	free(mp->free_stack);
+	pthread_mutex_destroy(&mp->lock);
+	free(mp);
+}
+
+void *spdk_mempool_get(struct spdk_mempool *mp)
+{
+	void *ele = NULL;
+
+	pthread_mutex_lock(&mp->lock);
+	if (mp->free_count > 0) {
+		ele = mp->free_stack[--mp->free_count];
+	}
+	pthread_mutex_unlock(&mp->lock);
+
+	return ele;
+}
+
+int spdk_mempool_get_bulk(struct spdk_mempool *mp, void **ele_arr, size_t count)
+{
+	size_t i;
+
+	pthread_mutex_lock(&mp->lock);
+	if (mp->free_count < count) {
+		pthread_mutex_unlock(&mp->lock);
+		return -ENOMEM;
+	}
+	for (i = 0; i < count; i++) {
+		ele_arr[i] = mp->free_stack[--mp->free_count];
+	}
+	pthread_mutex_unlock(&mp->lock);
+
+	return 0;
+}
+
+void spdk_mempool_put(struct spdk_mempool *mp, void *ele)
+{
+	pthread_mutex_lock(&mp->lock);
+	assert(mp->free_count < mp->count);
+	mp->free_stack[mp->free_count++] = ele;
+	pthread_mutex_unlock(&mp->lock);
+}
+
+void spdk_mempool_put_bulk(struct spdk_mempool *mp, void **ele_arr, size_t count)
+{
+	size_t i;
+
+	pthread_mutex_lock(&mp->lock);
+	for (i = 0; i < count; i++) {
+		assert(mp->free_count < mp->count);
+		mp->free_stack[mp->free_count++] = ele_arr[i];
+	}
+	pthread_mutex_unlock(&mp->lock);
+}
+
+size_t spdk_mempool_count(const struct spdk_mempool *pool)
+{
+	return pool->free_count;
+}
+
+uint32_t spdk_mempool_obj_iter(struct spdk_mempool *mp, spdk_mempool_obj_cb_t obj_cb, void *obj_cb_arg)
+{
+	size_t aligned_ele_size = align_up(mp->ele_size, CACHE_LINE_SIZE);
+	uint32_t i;
+
+	for (i = 0; i < mp->count; i++) {
+		void *obj = (char *)mp->base + i * aligned_ele_size;
+		obj_cb(mp, obj_cb_arg, obj, i);
+	}
+
+	return (uint32_t)mp->count;
+}
+
+uint32_t spdk_mempool_mem_iter(struct spdk_mempool *mp, spdk_mempool_mem_cb_t mem_cb, void *mem_cb_arg)
+{
+	if (mp->base && mp->base_len > 0) {
+		mem_cb(mp, mem_cb_arg, mp->base, SPDK_VTOPHYS_ERROR, mp->base_len, 0);
+		return 1;
+	}
+
+	return 0;
+}
+
+struct spdk_mempool *spdk_mempool_lookup(const char *name)
+{
+	struct spdk_mempool *mp;
+
+	pthread_mutex_lock(&g_mempool_lock);
+	TAILQ_FOREACH(mp, &g_mempools, link)
+	{
+		if (strcmp(mp->name, name) == 0) {
+			pthread_mutex_unlock(&g_mempool_lock);
+			return mp;
+		}
+	}
+	pthread_mutex_unlock(&g_mempool_lock);
+	return NULL;
+}
+
+bool spdk_process_is_primary(void)
+{
+	return true;
+}
+
+uint64_t spdk_get_ticks(void)
+{
+	struct timespec ts;
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+uint64_t spdk_get_ticks_hz(void)
+{
+	return 1000000000ULL;
+}
+
+void spdk_delay_us(unsigned int us)
+{
+	struct timespec ts;
+
+	ts.tv_sec = us / 1000000;
+	ts.tv_nsec = (us % 1000000) * 1000;
+	nanosleep(&ts, NULL);
+}
+
+void spdk_pause(void)
+{
+#if defined(__x86_64__)
+	__asm volatile("pause");
+#elif defined(__aarch64__)
+	__asm volatile("yield");
+#endif
+}
+
+/* ---------- ring ----------
+ *
+ * Lock-free MPMC ring using DPDK's two-pointer scheme (see rte_ring_c11_pvt.h).
+ * Each side has a (publication, reservation) pair:
+ *
+ *   tail       - producer publication: consumers read up to here.
+ *   rsvd_tail  - producer reservation: next free slot for producers to claim.
+ *   head       - consumer publication: producers see slots reusable up to here.
+ *   rsvd_head  - consumer reservation: next slot for consumers to claim.
+ *
+ * Layout: producer-written fields (tail, rsvd_tail) and consumer-written fields
+ * (head, rsvd_head) live on separate cache lines to eliminate producer/consumer false
+ * sharing, matching DPDK's rte_ring_headtail layout.
+ */
+struct spdk_ring {
+	uint32_t size;
+	uint32_t mask;
+	enum spdk_ring_type type;
+	volatile uint32_t rsvd_tail __attribute__((aligned(CACHE_LINE_SIZE)));
+	volatile uint32_t tail;
+	volatile uint32_t rsvd_head __attribute__((aligned(CACHE_LINE_SIZE)));
+	volatile uint32_t head;
+	void *ring[];
+};
+
+struct spdk_ring *spdk_ring_create(enum spdk_ring_type type, size_t count, int numa_id)
+{
+	struct spdk_ring *ring;
+	size_t alloc_size;
+	size_t power;
+
+	if (count == 0) {
+		return NULL;
+	}
+
+	/*
+	 * Round up to next power of 2. Bail out if the rounded value would
+	 * not fit in ring->size/mask (uint32_t) or if the resulting alloc_size
+	 * would overflow size_t.
+	 */
+	power = 1;
+	while (power < count) {
+		if (power > ((size_t)UINT32_MAX >> 1)) {
+			return NULL;
+		}
+		power <<= 1;
+	}
+
+	if (power > (SIZE_MAX - sizeof(struct spdk_ring)) / sizeof(void *)) {
+		return NULL;
+	}
+	alloc_size = sizeof(struct spdk_ring) + power * sizeof(void *);
+	ring = spdk_zmalloc(alloc_size, CACHE_LINE_SIZE, NULL, numa_id, SPDK_MALLOC_DMA | SPDK_MALLOC_SHARE);
+	if (!ring) {
+		return NULL;
+	}
+
+	ring->size = (uint32_t)power;
+	ring->mask = (uint32_t)(power - 1);
+	ring->type = type;
+	ring->rsvd_head = 0;
+	ring->head = 0;
+	ring->rsvd_tail = 0;
+	ring->tail = 0;
+
+	return ring;
+}
+
+void spdk_ring_free(struct spdk_ring *ring)
+{
+	spdk_free(ring);
+}
+
+size_t spdk_ring_count(struct spdk_ring *ring)
+{
+	uint32_t head = __atomic_load_n(&ring->head, __ATOMIC_ACQUIRE);
+	uint32_t tail = __atomic_load_n(&ring->tail, __ATOMIC_ACQUIRE);
+
+	return tail - head;
+}
+
+size_t spdk_ring_enqueue(struct spdk_ring *ring, void **objs, size_t count, size_t *free_space)
+{
+	uint32_t head, tail, free_entries, i;
+
+	if (ring->type == SPDK_RING_TYPE_SP_SC) {
+		head = __atomic_load_n(&ring->head, __ATOMIC_ACQUIRE);
+		tail = ring->tail;
+
+		free_entries = ring->size - (tail - head);
+		if (count > free_entries) {
+			count = free_entries;
+		}
+
+		for (i = 0; i < count; i++) {
+			ring->ring[(tail + i) & ring->mask] = objs[i];
+		}
+
+		__atomic_store_n(&ring->tail, tail + (uint32_t)count, __ATOMIC_RELEASE);
+	} else {
+		/* MP enqueue: DPDK two-pointer scheme (see file header comment). */
+		uint32_t tail_old, tail_new;
+
+		do {
+			tail_old = __atomic_load_n(&ring->rsvd_tail, __ATOMIC_ACQUIRE);
+			head = __atomic_load_n(&ring->head, __ATOMIC_ACQUIRE);
+
+			free_entries = ring->size - (tail_old - head);
+			if (count > free_entries) {
+				count = free_entries;
+			}
+			if (count == 0) {
+				if (free_space) {
+					*free_space = 0;
+				}
+				return 0;
+			}
+
+			tail_new = tail_old + (uint32_t)count;
+		} while (!__atomic_compare_exchange_n(&ring->rsvd_tail,
+						      &tail_old,
+						      tail_new,
+						      false,
+						      __ATOMIC_ACQ_REL,
+						      __ATOMIC_ACQUIRE));
+
+		for (i = 0; i < count; i++) {
+			ring->ring[(tail_old + i) & ring->mask] = objs[i];
+		}
+
+		/* Wait for prior producers to publish, then publish ourselves. */
+		while (__atomic_load_n(&ring->tail, __ATOMIC_RELAXED) != tail_old) {
+			spdk_pause();
+		}
+		__atomic_store_n(&ring->tail, tail_new, __ATOMIC_RELEASE);
+	}
+
+	if (free_space) {
+		*free_space = ring->size - (ring->tail - __atomic_load_n(&ring->head, __ATOMIC_ACQUIRE));
+	}
+
+	return count;
+}
+
+size_t spdk_ring_dequeue(struct spdk_ring *ring, void **objs, size_t count)
+{
+	uint32_t head, tail, avail, i;
+
+	if (ring->type == SPDK_RING_TYPE_SP_SC || ring->type == SPDK_RING_TYPE_MP_SC) {
+		tail = __atomic_load_n(&ring->tail, __ATOMIC_ACQUIRE);
+		head = ring->head;
+
+		avail = tail - head;
+		if (count > avail) {
+			count = avail;
+		}
+
+		for (i = 0; i < count; i++) {
+			objs[i] = ring->ring[(head + i) & ring->mask];
+		}
+
+		__atomic_store_n(&ring->head, head + (uint32_t)count, __ATOMIC_RELEASE);
+	} else {
+		/* MC dequeue: DPDK two-pointer scheme (see file header comment). */
+		uint32_t head_old, head_new;
+
+		do {
+			head_old = __atomic_load_n(&ring->rsvd_head, __ATOMIC_ACQUIRE);
+			tail = __atomic_load_n(&ring->tail, __ATOMIC_ACQUIRE);
+
+			avail = tail - head_old;
+			if (count > avail) {
+				count = avail;
+			}
+			if (count == 0) {
+				return 0;
+			}
+
+			head_new = head_old + (uint32_t)count;
+		} while (!__atomic_compare_exchange_n(&ring->rsvd_head,
+						      &head_old,
+						      head_new,
+						      false,
+						      __ATOMIC_ACQ_REL,
+						      __ATOMIC_ACQUIRE));
+
+		for (i = 0; i < count; i++) {
+			objs[i] = ring->ring[(head_old + i) & ring->mask];
+		}
+
+		/* Wait for prior consumers to publish, then publish ourselves. */
+		while (__atomic_load_n(&ring->head, __ATOMIC_RELAXED) != head_old) {
+			spdk_pause();
+		}
+		__atomic_store_n(&ring->head, head_new, __ATOMIC_RELEASE);
+	}
+
+	return count;
+}
+
+int spdk_get_tid(void)
+{
+	return (int)syscall(SYS_gettid);
+}

--- a/src/plugins/spdk/spdk_env/env_internal.h
+++ b/src/plugins/spdk/spdk_env/env_internal.h
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_INTERNAL_H
+#define NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_INTERNAL_H
+
+#include "spdk/stdinc.h"
+#include "spdk/env.h"
+
+/* x86-64 and ARM userspace virtual addresses use only the low 48 bits [0..47],
+ * which is enough to cover 256 TB. env_mem_map.h builds its index macros on
+ * these, so they live here and are defined once.
+ */
+#define SHIFT_256TB 48
+#define MASK_256TB ((1ULL << SHIFT_256TB) - 1)
+
+#define SHIFT_1GB 30
+#define VALUE_1GB (1ULL << SHIFT_1GB)
+#define MASK_1GB ((1ULL << SHIFT_1GB) - 1)
+
+int threads_init(const struct spdk_env_opts *opts);
+void threads_fini(void);
+
+int pci_env_init(void);
+void pci_env_reinit(void);
+void pci_env_fini(void);
+int mem_map_init(void);
+void mem_map_fini(void);
+
+void mem_enforce_numa(void);
+
+#endif /* NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_INTERNAL_H */

--- a/src/plugins/spdk/spdk_env/env_mem_map.h
+++ b/src/plugins/spdk/spdk_env/env_mem_map.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This file incorporates material from the SPDK project, licensed under the
+ * BSD-3-Clause License. The modifications made by NVIDIA are licensed under the
+ * Apache License, Version 2.0.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0
+ */
+#ifndef NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_MEM_MAP_H
+#define NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_MEM_MAP_H
+
+#include "spdk/stdinc.h"
+#include "spdk/env.h"
+#include "spdk/queue.h"
+#include "spdk/memory.h"
+
+/* SHIFT_256TB, MASK_256TB, SHIFT_1GB, VALUE_1GB and MASK_1GB. */
+#include "env_internal.h"
+
+#define VFN_2MB(vaddr) ((vaddr) >> SHIFT_2MB)
+#define VFN_4KB(vaddr) ((vaddr) >> SHIFT_4KB)
+
+#define FN_2MB_TO_4KB(fn) ((fn) << (SHIFT_2MB - SHIFT_4KB))
+#define FN_4KB_TO_2MB(fn) ((fn) >> (SHIFT_2MB - SHIFT_4KB))
+
+#define MAP_256TB_IDX(vfn_2mb) ((vfn_2mb) >> (SHIFT_1GB - SHIFT_2MB))
+#define MAP_1GB_IDX(vfn_2mb) ((vfn_2mb) & ((1ULL << (SHIFT_1GB - SHIFT_2MB)) - 1))
+#define MAP_2MB_IDX(vfn_4kb) ((vfn_4kb) & ((1ULL << (SHIFT_2MB - SHIFT_4KB)) - 1))
+
+#define MAP_256TB_SIZE (1ULL << (SHIFT_256TB - SHIFT_1GB))
+#define MAP_1GB_SIZE (1ULL << (SHIFT_1GB - SHIFT_2MB))
+#define MAP_2MB_SIZE (1ULL << (SHIFT_2MB - SHIFT_4KB))
+
+#define ADDR_FROM_IDX(idx_256tb, idx_1gb, idx_2mb) \
+	(((idx_256tb) << SHIFT_1GB) | ((idx_1gb) << SHIFT_2MB) | ((idx_2mb) << SHIFT_4KB))
+
+#define REG_MAP_REGISTERED (1ULL << 62)
+#define REG_MAP_NOTIFY_START (1ULL << 63)
+
+#define VTOPHYS_4KB (1ULL << 63)
+#define VTOPHYS_ADDR(paddr) ((paddr) & ~VTOPHYS_4KB)
+
+struct map_2mb4kb {
+	uint64_t translation_4kb[MAP_2MB_SIZE];
+};
+
+struct map_1gb2mb {
+	uint64_t translation_2mb[MAP_1GB_SIZE];
+};
+
+struct map_1gb4kb {
+	struct map_2mb4kb *map[MAP_1GB_SIZE];
+};
+
+struct map_256tb {
+	struct {
+		struct map_1gb2mb *map_1gb2mb;
+		struct map_1gb4kb *map_1gb4kb;
+	} map[MAP_256TB_SIZE];
+};
+
+struct spdk_mem_map {
+	struct map_256tb map_256tb;
+	pthread_mutex_t mutex;
+	uint64_t default_translation;
+	struct spdk_mem_map_ops ops;
+	void *cb_ctx;
+	TAILQ_ENTRY(spdk_mem_map) tailq;
+};
+
+TAILQ_HEAD(spdk_mem_map_head, spdk_mem_map);
+
+extern struct spdk_mem_map *g_mem_reg_map;
+extern struct spdk_mem_map_head g_spdk_mem_maps;
+extern pthread_mutex_t g_spdk_mem_map_mutex;
+
+#endif /* NIXL_SRC_PLUGINS_SPDK_SPDK_ENV_ENV_MEM_MAP_H */

--- a/src/plugins/spdk/spdk_env/init.c
+++ b/src/plugins/spdk/spdk_env/init.c
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "env_internal.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+#include "spdk/version.h"
+
+
+
+static bool g_initialized;
+
+static void env_copy_opts(struct spdk_env_opts *dst, const struct spdk_env_opts *src, size_t user_opts_size)
+{
+	spdk_env_opts_init(dst);
+	memcpy(dst, src, offsetof(struct spdk_env_opts, opts_size));
+
+#define SET_FIELD(field) \
+	if (offsetof(struct spdk_env_opts, field) + sizeof(dst->field) <= user_opts_size) { \
+		dst->field = src->field; \
+	}
+
+	SET_FIELD(enforce_numa);
+
+#undef SET_FIELD
+}
+
+void spdk_env_opts_init(struct spdk_env_opts *opts)
+{
+	if (!opts) {
+		return;
+	}
+
+	memset(opts, 0, sizeof(*opts));
+	opts->name = "spdk";
+	opts->core_mask = "0x1";
+	opts->shm_id = -1;
+	opts->mem_size = -1;
+	opts->main_core = -1;
+	opts->mem_channel = -1;
+	opts->base_virtaddr = 0x200000000000;
+	opts->opts_size = sizeof(*opts);
+}
+
+int spdk_env_init(const struct spdk_env_opts *opts_user)
+{
+	struct spdk_env_opts opts_local = {};
+	struct spdk_env_opts *opts = &opts_local;
+	size_t min_opts_size, user_opts_size;
+	int rc;
+
+	if (g_initialized) {
+		if (opts_user != NULL) {
+			ENV_ERRLOG("Invalid arguments to reinitialize SPDK env");
+			return -EINVAL;
+		}
+
+		SPDK_PRINTF("Starting %s reinitialization...\n", SPDK_VERSION_STRING);
+		pci_env_reinit();
+		return 0;
+	}
+
+	if (opts_user == NULL) {
+		ENV_ERRLOG("NULL arguments to initialize SPDK env");
+		return -EINVAL;
+	}
+
+	min_opts_size = offsetof(struct spdk_env_opts, opts_size) + sizeof(opts->opts_size);
+	user_opts_size = opts_user->opts_size;
+	/* env_copy_opts() memcpy()s offsetof(opts_size) bytes out of the caller's
+	 * structure, so a smaller one cannot be honoured by clamping: the copy
+	 * would read past its end. Reject it instead.
+	 */
+	if (user_opts_size < min_opts_size) {
+		ENV_ERRLOG("Invalid opts->opts_size %d too small", (int)opts_user->opts_size);
+		return -EINVAL;
+	}
+
+	env_copy_opts(opts, opts_user, user_opts_size);
+
+	if (opts->enforce_numa) {
+		mem_enforce_numa();
+	}
+
+	SPDK_PRINTF("Starting %s initialization...\n", SPDK_VERSION_STRING);
+
+	rc = threads_init(opts);
+	if (rc < 0) {
+		ENV_ERRLOG("threads_init() failed");
+		return rc;
+	}
+
+	rc = pci_env_init();
+	if (rc < 0) {
+		ENV_ERRLOG("pci_env_init() failed");
+		goto err_threads;
+	}
+
+	rc = mem_map_init();
+	if (rc < 0) {
+		ENV_ERRLOG("Failed to allocate mem_map");
+		goto err_pci;
+	}
+
+	g_initialized = true;
+	return 0;
+
+	/* Unwind in reverse order. g_initialized stays false, so a later retry
+	 * must not find half-configured global state.
+	 */
+err_pci:
+	pci_env_fini();
+err_threads:
+	threads_fini();
+	return rc;
+}
+
+void spdk_env_fini(void)
+{
+	/* Workers first: threads_fini() joins them, so they cannot touch the
+	 * memory map or the PCI state after those are released.
+	 */
+	threads_fini();
+	mem_map_fini();
+	pci_env_fini();
+
+	g_initialized = false;
+}

--- a/src/plugins/spdk/spdk_env/mem_map.c
+++ b/src/plugins/spdk/spdk_env/mem_map.c
@@ -1,0 +1,815 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This file incorporates material from the SPDK project, licensed under the
+ * BSD-3-Clause License. The modifications made by NVIDIA are licensed under the
+ * Apache License, Version 2.0.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause AND Apache-2.0
+ */
+#include "spdk/stdinc.h"
+#include "spdk/assert.h"
+#include "spdk/likely.h"
+#include "spdk/util.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+
+#include "env_mem_map.h"
+
+
+
+#if DEBUG
+#define DEBUG_PRINT(...) ENV_ERRLOG(__VA_ARGS__)
+#else
+#define DEBUG_PRINT(...)
+#endif
+
+#define ADDR_INVALID ((uint64_t)-1)
+#define _4KB_OFFSET(ptr) (((uintptr_t)(ptr)) & MASK_4KB)
+
+struct spdk_mem_map *g_mem_reg_map;
+struct spdk_mem_map_head g_spdk_mem_maps = TAILQ_HEAD_INITIALIZER(g_spdk_mem_maps);
+pthread_mutex_t g_spdk_mem_map_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static inline uint64_t mem_map_translate(const struct spdk_mem_map *map, uint64_t vaddr, int *page_size)
+{
+	const struct map_1gb2mb *map_1gb2mb;
+	const struct map_1gb4kb *map_1gb4kb;
+	const struct map_2mb4kb *map_2mb4kb;
+	uint64_t translation, vfn_4kb, vfn_2mb, idx_2mb, idx_1gb, idx_256tb;
+
+	vfn_2mb = VFN_2MB(vaddr);
+	idx_256tb = MAP_256TB_IDX(vfn_2mb);
+	idx_1gb = MAP_1GB_IDX(vfn_2mb);
+
+	map_1gb2mb = map->map_256tb.map[idx_256tb].map_1gb2mb;
+	if (spdk_likely(map_1gb2mb != NULL)) {
+		translation = map_1gb2mb->translation_2mb[idx_1gb];
+		if (spdk_likely(translation != map->default_translation)) {
+			*page_size = VALUE_2MB;
+			return translation;
+		}
+	}
+
+	map_1gb4kb = map->map_256tb.map[idx_256tb].map_1gb4kb;
+	if (spdk_likely(map_1gb4kb != NULL)) {
+		map_2mb4kb = map_1gb4kb->map[idx_1gb];
+		if (spdk_likely(map_2mb4kb != NULL)) {
+			vfn_4kb = VFN_4KB(vaddr);
+			idx_2mb = MAP_2MB_IDX(vfn_4kb);
+			*page_size = VALUE_4KB;
+
+			return map_2mb4kb->translation_4kb[idx_2mb];
+		}
+	}
+
+	*page_size = VALUE_2MB;
+	return map->default_translation;
+}
+
+static bool mem_map_is_4kb_mapping(struct spdk_mem_map *map, uint64_t vaddr)
+{
+	int page_size;
+
+	mem_map_translate(map, vaddr, &page_size);
+	return page_size == VALUE_4KB;
+}
+
+static int mem_map_walk_region(struct spdk_mem_map *map,
+			       uint64_t vaddr,
+			       size_t size,
+			       int (*callback)(struct spdk_mem_map *map, uint64_t addr, size_t sz, void *ctx),
+			       void *ctx)
+{
+	uint64_t vfn_4kb, vfn_2mb;
+	uint64_t vfn_4kb_end, vfn_2mb_end;
+	int rc;
+
+	vfn_4kb = VFN_4KB(vaddr);
+	vfn_4kb_end = spdk_min(FN_2MB_TO_4KB(VFN_2MB(vaddr + MASK_2MB)), VFN_4KB(vaddr + size));
+	while (vfn_4kb < vfn_4kb_end) {
+		rc = callback(map, vaddr, VALUE_4KB, ctx);
+		if (rc != 0) {
+			return rc;
+		}
+		vaddr += VALUE_4KB;
+		size -= VALUE_4KB;
+		vfn_4kb++;
+	}
+
+	vfn_2mb = VFN_2MB(vaddr);
+	vfn_2mb_end = VFN_2MB(vaddr + size);
+	while (vfn_2mb < vfn_2mb_end) {
+		rc = callback(map, vaddr, VALUE_2MB, ctx);
+		if (rc != 0) {
+			return rc;
+		}
+		vaddr += VALUE_2MB;
+		size -= VALUE_2MB;
+		vfn_2mb++;
+	}
+
+	vfn_4kb = VFN_4KB(vaddr);
+	vfn_4kb_end = VFN_4KB(vaddr + size);
+	while (vfn_4kb < vfn_4kb_end) {
+		rc = callback(map, vaddr, VALUE_4KB, ctx);
+		if (rc != 0) {
+			return rc;
+		}
+		vaddr += VALUE_4KB;
+		size -= VALUE_4KB;
+		vfn_4kb++;
+	}
+
+	return 0;
+}
+
+static uint64_t mem_reg_map_next_region(uint64_t addr)
+{
+	uint64_t idx_256tb, idx_1gb, idx_2mb;
+	uint64_t reg, vfn_2mb, vfn_4kb;
+	int page_size;
+
+	vfn_2mb = VFN_2MB(addr);
+	vfn_4kb = VFN_4KB(addr);
+	idx_256tb = MAP_256TB_IDX(vfn_2mb);
+	idx_1gb = MAP_1GB_IDX(vfn_2mb);
+	idx_2mb = MAP_2MB_IDX(vfn_4kb);
+	for (; idx_256tb < MAP_256TB_SIZE; idx_256tb++) {
+		if (!g_mem_reg_map->map_256tb.map[idx_256tb].map_1gb2mb &&
+		    !g_mem_reg_map->map_256tb.map[idx_256tb].map_1gb4kb) {
+			goto next_256tb;
+		}
+
+		for (; idx_1gb < MAP_1GB_SIZE; idx_1gb++) {
+			addr = ADDR_FROM_IDX(idx_256tb, idx_1gb, idx_2mb);
+			reg = mem_map_translate(g_mem_reg_map, addr, &page_size);
+
+			if (reg & REG_MAP_NOTIFY_START) {
+				assert(reg & REG_MAP_REGISTERED);
+				return addr;
+			}
+
+			if (page_size == VALUE_4KB) {
+				for (; idx_2mb < MAP_2MB_SIZE; idx_2mb++) {
+					addr = ADDR_FROM_IDX(idx_256tb, idx_1gb, idx_2mb);
+					reg = mem_map_translate(g_mem_reg_map, addr, &page_size);
+
+					if (reg & REG_MAP_NOTIFY_START) {
+						assert(reg & REG_MAP_REGISTERED);
+						return addr;
+					}
+				}
+			}
+
+			idx_2mb = 0;
+		}
+next_256tb:
+		idx_1gb = 0;
+	}
+
+	return ADDR_INVALID;
+}
+
+static int mem_map_notify_walk(struct spdk_mem_map *map, enum spdk_mem_map_notify_action action)
+{
+	uint64_t addr, fail_addr, size;
+	int rc;
+
+	if (!g_mem_reg_map) {
+		return -EINVAL;
+	}
+
+	pthread_mutex_lock(&g_mem_reg_map->mutex);
+	for (addr = mem_reg_map_next_region(0); addr != ADDR_INVALID; addr = mem_reg_map_next_region(addr)) {
+		size = UINT64_MAX;
+		spdk_mem_map_translate(g_mem_reg_map, addr, &size);
+		rc = map->ops.notify_cb(map->cb_ctx, map, action, (void *)addr, size);
+		if (rc != 0 && action == SPDK_MEM_MAP_NOTIFY_REGISTER) {
+			goto err_unregister;
+		}
+		addr += size;
+	}
+
+	pthread_mutex_unlock(&g_mem_reg_map->mutex);
+	return 0;
+
+err_unregister:
+	fail_addr = addr;
+	for (addr = mem_reg_map_next_region(0); addr != ADDR_INVALID && addr != fail_addr;
+	     addr = mem_reg_map_next_region(addr)) {
+		size = UINT64_MAX;
+		spdk_mem_map_translate(g_mem_reg_map, addr, &size);
+		map->ops.notify_cb(map->cb_ctx, map, SPDK_MEM_MAP_NOTIFY_UNREGISTER, (void *)addr, size);
+		addr += size;
+	}
+
+	pthread_mutex_unlock(&g_mem_reg_map->mutex);
+	return rc;
+}
+
+static void mem_map_free(struct spdk_mem_map *map)
+{
+	struct map_1gb4kb *map_1gb4kb;
+	size_t i, j;
+
+	for (i = 0; i < SPDK_COUNTOF(map->map_256tb.map); i++) {
+		free(map->map_256tb.map[i].map_1gb2mb);
+		map_1gb4kb = map->map_256tb.map[i].map_1gb4kb;
+		if (map_1gb4kb == NULL) {
+			continue;
+		}
+		for (j = 0; j < SPDK_COUNTOF(map_1gb4kb->map); j++) {
+			free(map_1gb4kb->map[j]);
+		}
+		free(map_1gb4kb);
+	}
+	pthread_mutex_destroy(&map->mutex);
+	free(map);
+}
+
+struct spdk_mem_map *spdk_mem_map_alloc(uint64_t default_translation, const struct spdk_mem_map_ops *ops, void *cb_ctx)
+{
+	struct spdk_mem_map *map;
+	int rc;
+
+	map = calloc(1, sizeof(*map));
+	if (map == NULL) {
+		return NULL;
+	}
+
+	if (pthread_mutex_init(&map->mutex, NULL)) {
+		free(map);
+		return NULL;
+	}
+
+	map->default_translation = default_translation;
+	map->cb_ctx = cb_ctx;
+	if (ops) {
+		map->ops = *ops;
+	}
+
+	if (ops && ops->notify_cb) {
+		pthread_mutex_lock(&g_spdk_mem_map_mutex);
+		rc = mem_map_notify_walk(map, SPDK_MEM_MAP_NOTIFY_REGISTER);
+		if (rc != 0) {
+			pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+			DEBUG_PRINT("Initial mem_map notify failed");
+			mem_map_free(map);
+			return NULL;
+		}
+		TAILQ_INSERT_TAIL(&g_spdk_mem_maps, map, tailq);
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+	}
+
+	return map;
+}
+
+void spdk_mem_map_free(struct spdk_mem_map **pmap)
+{
+	struct spdk_mem_map *map;
+
+	if (!pmap) {
+		return;
+	}
+
+	map = *pmap;
+
+	if (!map) {
+		return;
+	}
+
+	if (map->ops.notify_cb) {
+		pthread_mutex_lock(&g_spdk_mem_map_mutex);
+		mem_map_notify_walk(map, SPDK_MEM_MAP_NOTIFY_UNREGISTER);
+		TAILQ_REMOVE(&g_spdk_mem_maps, map, tailq);
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+	}
+
+	mem_map_free(map);
+	*pmap = NULL;
+}
+
+static int mem_check_region_unregistered(struct spdk_mem_map *map, uint64_t vaddr, size_t len, void *ctx)
+{
+	uint64_t reg, curlen;
+
+	while (len > 0) {
+		curlen = len;
+		reg = spdk_mem_map_translate(map, vaddr, &curlen);
+		if (reg & REG_MAP_REGISTERED) {
+			return -EBUSY;
+		}
+
+		vaddr += curlen;
+		len -= curlen;
+	}
+
+	return 0;
+}
+
+static int mem_check_region_registered(struct spdk_mem_map *map, uint64_t vaddr, size_t len, void *ctx)
+{
+	uint64_t reg, curlen;
+
+	while (len > 0) {
+		curlen = len;
+		reg = spdk_mem_map_translate(map, vaddr, &curlen);
+		if (!(reg & REG_MAP_REGISTERED)) {
+			return -EINVAL;
+		}
+
+		vaddr += curlen;
+		len -= curlen;
+	}
+
+	return 0;
+}
+
+static int mem_register_page(struct spdk_mem_map *map, uint64_t vaddr, size_t len, void *ctx)
+{
+	int *page = ctx;
+
+	return spdk_mem_map_set_translation(map,
+					    vaddr,
+					    len,
+					    (*page)++ == 0 ? REG_MAP_REGISTERED | REG_MAP_NOTIFY_START :
+							     REG_MAP_REGISTERED);
+}
+
+static int mem_clear_page(struct spdk_mem_map *map, uint64_t vaddr, size_t len, void *ctx)
+{
+	(void)ctx;
+
+	return spdk_mem_map_set_translation(map, vaddr, len, 0);
+}
+
+int spdk_mem_register(void *vaddr, size_t len)
+{
+	struct spdk_mem_map *map;
+	int rc, page = 0;
+
+	if (g_mem_reg_map == NULL) {
+		DEBUG_PRINT("%s before spdk_env_init() or after spdk_env_fini()", __func__);
+		return -EINVAL;
+	}
+
+	if ((uintptr_t)vaddr & ~MASK_256TB) {
+		DEBUG_PRINT("invalid usermode virtual address %p", vaddr);
+		return -EINVAL;
+	}
+
+	if (((uintptr_t)vaddr & MASK_4KB) || (len & MASK_4KB)) {
+		DEBUG_PRINT("invalid %s parameters, vaddr=%p len=%ju", __func__, vaddr, len);
+		return -EINVAL;
+	}
+
+	if (len == 0) {
+		return 0;
+	}
+
+	pthread_mutex_lock(&g_spdk_mem_map_mutex);
+	rc = mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_check_region_unregistered, NULL);
+	if (rc != 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return rc;
+	}
+
+	rc = mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_register_page, &page);
+	if (rc != 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return rc;
+	}
+
+	TAILQ_FOREACH(map, &g_spdk_mem_maps, tailq)
+	{
+		rc = map->ops.notify_cb(map->cb_ctx, map, SPDK_MEM_MAP_NOTIFY_REGISTER, vaddr, len);
+		if (rc != 0) {
+			struct spdk_mem_map *unwind;
+
+			DEBUG_PRINT("failed to register vaddr %p to map %p, rc = %d", vaddr, map, rc);
+
+			/* Undo the maps already notified and drop the registration
+			 * itself. Callers release the mapping on failure (see
+			 * _dma_map_hugepages() in env.c), so leaving either behind
+			 * would keep a translation for memory that no longer exists.
+			 */
+			TAILQ_FOREACH(unwind, &g_spdk_mem_maps, tailq)
+			{
+				if (unwind == map) {
+					break;
+				}
+				unwind->ops.notify_cb(unwind->cb_ctx,
+						      unwind,
+						      SPDK_MEM_MAP_NOTIFY_UNREGISTER,
+						      vaddr,
+						      len);
+			}
+			mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_clear_page, NULL);
+
+			pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+			return rc;
+		}
+	}
+
+	pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+	return 0;
+}
+
+static int mem_unregister_page(struct spdk_mem_map *map, uint64_t vaddr, size_t len, void *ctx)
+{
+	struct iovec *region = ctx;
+	uint64_t off, reg;
+	int rc;
+
+	if (len > VALUE_4KB && mem_map_is_4kb_mapping(map, vaddr)) {
+		assert(len == VALUE_2MB);
+		for (off = 0; off < len; off += VALUE_4KB) {
+			rc = mem_unregister_page(map, vaddr + off, VALUE_4KB, ctx);
+			if (rc != 0) {
+				return rc;
+			}
+		}
+		return spdk_mem_map_set_translation(map, vaddr, len, 0);
+	}
+
+	reg = spdk_mem_map_translate(map, vaddr, NULL);
+	spdk_mem_map_set_translation(map, vaddr, len, 0);
+	if (region->iov_len > 0 && (reg & REG_MAP_NOTIFY_START)) {
+		struct spdk_mem_map *notify;
+
+		/* A separate variable: the loop must not clobber the caller's map. */
+		TAILQ_FOREACH_REVERSE(notify, &g_spdk_mem_maps, spdk_mem_map_head, tailq)
+		{
+			rc = notify->ops.notify_cb(notify->cb_ctx,
+						   notify,
+						   SPDK_MEM_MAP_NOTIFY_UNREGISTER,
+						   region->iov_base,
+						   region->iov_len);
+			if (rc != 0) {
+				DEBUG_PRINT("failed to unregister vaddr %p from map %p, rc = %d",
+					    region->iov_base,
+					    notify,
+					    rc);
+			}
+		}
+
+		region->iov_base = (void *)vaddr;
+		region->iov_len = len;
+	} else {
+		region->iov_len += len;
+	}
+
+	return 0;
+}
+
+int spdk_mem_unregister(void *vaddr, size_t len)
+{
+	struct spdk_mem_map *map;
+	struct iovec region;
+	int rc;
+	uint64_t reg, newreg;
+
+	if (g_mem_reg_map == NULL) {
+		DEBUG_PRINT("%s before spdk_env_init() or after spdk_env_fini()", __func__);
+		return -EINVAL;
+	}
+
+	if ((uintptr_t)vaddr & ~MASK_256TB) {
+		DEBUG_PRINT("invalid usermode virtual address %p", vaddr);
+		return -EINVAL;
+	}
+
+	if (((uintptr_t)vaddr & MASK_4KB) || (len & MASK_4KB)) {
+		DEBUG_PRINT("invalid %s parameters, vaddr=%p len=%ju", __func__, vaddr, len);
+		return -EINVAL;
+	}
+
+	pthread_mutex_lock(&g_spdk_mem_map_mutex);
+
+	reg = spdk_mem_map_translate(g_mem_reg_map, (uint64_t)vaddr, NULL);
+	if ((reg & REG_MAP_REGISTERED) && (reg & REG_MAP_NOTIFY_START) == 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return -ERANGE;
+	}
+
+	rc = mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_check_region_registered, NULL);
+	if (rc != 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return rc;
+	}
+
+	newreg = spdk_mem_map_translate(g_mem_reg_map, (uint64_t)vaddr + len, NULL);
+	if ((newreg & REG_MAP_NOTIFY_START) == 0 && (newreg & REG_MAP_REGISTERED)) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return -ERANGE;
+	}
+
+	region.iov_base = vaddr;
+	region.iov_len = 0;
+	rc = mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_unregister_page, &region);
+	if (rc != 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return rc;
+	}
+
+	if (region.iov_len > 0) {
+		TAILQ_FOREACH_REVERSE(map, &g_spdk_mem_maps, spdk_mem_map_head, tailq)
+		{
+			rc = map->ops.notify_cb(map->cb_ctx,
+						map,
+						SPDK_MEM_MAP_NOTIFY_UNREGISTER,
+						region.iov_base,
+						region.iov_len);
+			if (rc != 0) {
+				DEBUG_PRINT("failed to unregister vaddr %p from map %p, rc = %d",
+					    region.iov_base,
+					    map,
+					    rc);
+				pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+				return rc;
+			}
+		}
+	}
+
+	pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+	return 0;
+}
+
+int spdk_mem_reserve(void *vaddr, size_t len)
+{
+	struct spdk_mem_map *map;
+	int rc;
+
+	if (g_mem_reg_map == NULL) {
+		DEBUG_PRINT("%s before spdk_env_init() or after spdk_env_fini()", __func__);
+		return -EINVAL;
+	}
+
+	if ((uintptr_t)vaddr & ~MASK_256TB) {
+		DEBUG_PRINT("invalid usermode virtual address %p", vaddr);
+		return -EINVAL;
+	}
+
+	if (((uintptr_t)vaddr & MASK_4KB) || (len & MASK_4KB)) {
+		DEBUG_PRINT("invalid %s parameters, vaddr=%p len=%ju", __func__, vaddr, len);
+		return -EINVAL;
+	}
+
+	if (len == 0) {
+		return 0;
+	}
+
+	pthread_mutex_lock(&g_spdk_mem_map_mutex);
+
+	rc = mem_map_walk_region(g_mem_reg_map, (uint64_t)vaddr, len, mem_check_region_unregistered, NULL);
+	if (rc != 0) {
+		pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+		return rc;
+	}
+
+	spdk_mem_map_set_translation(g_mem_reg_map, (uint64_t)vaddr, len, g_mem_reg_map->default_translation);
+
+	TAILQ_FOREACH(map, &g_spdk_mem_maps, tailq)
+	{
+		spdk_mem_map_set_translation(map, (uint64_t)vaddr, len, map->default_translation);
+	}
+
+	pthread_mutex_unlock(&g_spdk_mem_map_mutex);
+	return 0;
+}
+
+static struct map_1gb2mb *mem_map_get_map_1gb2mb(struct spdk_mem_map *map, uint64_t vfn_2mb, bool alloc)
+{
+	struct map_1gb2mb *map_1gb2mb;
+	uint64_t idx_256tb = MAP_256TB_IDX(vfn_2mb);
+	size_t i;
+
+	if (spdk_unlikely(idx_256tb >= SPDK_COUNTOF(map->map_256tb.map))) {
+		return NULL;
+	}
+
+	map_1gb2mb = map->map_256tb.map[idx_256tb].map_1gb2mb;
+	if (!map_1gb2mb && alloc) {
+		pthread_mutex_lock(&map->mutex);
+
+		/* Recheck to make sure nobody else got the mutex first. */
+		map_1gb2mb = map->map_256tb.map[idx_256tb].map_1gb2mb;
+		if (!map_1gb2mb) {
+			map_1gb2mb = malloc(sizeof(struct map_1gb2mb));
+			if (map_1gb2mb) {
+				for (i = 0; i < SPDK_COUNTOF(map_1gb2mb->translation_2mb); i++) {
+					map_1gb2mb->translation_2mb[i] = map->default_translation;
+				}
+				map->map_256tb.map[idx_256tb].map_1gb2mb = map_1gb2mb;
+			}
+		}
+
+		pthread_mutex_unlock(&map->mutex);
+
+		if (!map_1gb2mb) {
+			DEBUG_PRINT("allocation failed");
+			return NULL;
+		}
+	}
+
+	return map_1gb2mb;
+}
+
+static struct map_1gb4kb *mem_map_get_map_1gb4kb(struct spdk_mem_map *map, uint64_t vfn_4kb, bool alloc)
+{
+	struct map_1gb4kb *map_1gb4kb;
+	uint64_t vfn_2mb, idx_256tb;
+
+	vfn_2mb = FN_4KB_TO_2MB(vfn_4kb);
+	idx_256tb = MAP_256TB_IDX(vfn_2mb);
+	if (idx_256tb >= SPDK_COUNTOF(map->map_256tb.map)) {
+		return NULL;
+	}
+
+	map_1gb4kb = map->map_256tb.map[idx_256tb].map_1gb4kb;
+	if (map_1gb4kb == NULL && alloc) {
+		pthread_mutex_lock(&map->mutex);
+		/* Recheck to make sure nobody else got the mutex first. */
+		map_1gb4kb = map->map_256tb.map[idx_256tb].map_1gb4kb;
+		if (map_1gb4kb == NULL) {
+			map_1gb4kb = calloc(1, sizeof(*map_1gb4kb));
+			/* Store only on success, so a failed allocation does not
+			 * write NULL back over the slot.
+			 */
+			if (map_1gb4kb) {
+				map->map_256tb.map[idx_256tb].map_1gb4kb = map_1gb4kb;
+			}
+		}
+		pthread_mutex_unlock(&map->mutex);
+
+		if (!map_1gb4kb) {
+			DEBUG_PRINT("allocation failed");
+			return NULL;
+		}
+	}
+
+	return map_1gb4kb;
+}
+
+static struct map_2mb4kb *mem_map_get_map_2mb4kb(struct spdk_mem_map *map, uint64_t vfn_4kb, bool alloc)
+{
+	struct map_2mb4kb *map_2mb4kb;
+	struct map_1gb4kb *map_1gb4kb;
+	uint64_t vfn_2mb, idx_1gb, translation;
+	int page_size;
+	size_t i;
+
+	map_1gb4kb = mem_map_get_map_1gb4kb(map, vfn_4kb, alloc);
+	if (map_1gb4kb == NULL) {
+		return NULL;
+	}
+
+	vfn_2mb = FN_4KB_TO_2MB(vfn_4kb);
+	idx_1gb = MAP_1GB_IDX(vfn_2mb);
+	map_2mb4kb = map_1gb4kb->map[idx_1gb];
+	if (map_2mb4kb == NULL && alloc) {
+		pthread_mutex_lock(&map->mutex);
+		/* Recheck to make sure nobody else got the mutex first. */
+		map_2mb4kb = map_1gb4kb->map[idx_1gb];
+		if (map_2mb4kb == NULL) {
+			map_2mb4kb = malloc(sizeof(*map_2mb4kb));
+			if (map_2mb4kb != NULL) {
+				translation = mem_map_translate(map, vfn_4kb << SHIFT_4KB, &page_size);
+				for (i = 0; i < SPDK_COUNTOF(map_2mb4kb->translation_4kb); i++) {
+					map_2mb4kb->translation_4kb[i] = translation;
+				}
+				map_1gb4kb->map[idx_1gb] = map_2mb4kb;
+			}
+		}
+		pthread_mutex_unlock(&map->mutex);
+	}
+
+	return map_2mb4kb;
+}
+
+static int mem_map_set_4kb_translation(struct spdk_mem_map *map, uint64_t vaddr, uint64_t translation)
+{
+	struct map_2mb4kb *map_2mb4kb;
+	struct map_1gb2mb *map_1gb2mb;
+	uint64_t vfn_4kb, vfn_2mb;
+	uint64_t idx_2mb, idx_1gb;
+
+	vfn_4kb = VFN_4KB(vaddr);
+	map_2mb4kb = mem_map_get_map_2mb4kb(map, vfn_4kb, true);
+	if (!map_2mb4kb) {
+		DEBUG_PRINT("could not get %p map", (void *)vaddr);
+		return -ENOMEM;
+	}
+
+	idx_2mb = MAP_2MB_IDX(vfn_4kb);
+	map_2mb4kb->translation_4kb[idx_2mb] = translation;
+
+	vfn_2mb = FN_4KB_TO_2MB(vfn_4kb);
+	map_1gb2mb = mem_map_get_map_1gb2mb(map, vfn_2mb, false);
+	if (map_1gb2mb != NULL) {
+		idx_1gb = MAP_1GB_IDX(vfn_2mb);
+		map_1gb2mb->translation_2mb[idx_1gb] = map->default_translation;
+	}
+
+	return 0;
+}
+
+static int mem_map_set_2mb_translation(struct spdk_mem_map *map, uint64_t vaddr, uint64_t translation)
+{
+	struct map_2mb4kb *map_2mb4kb;
+	struct map_1gb2mb *map_1gb2mb;
+	uint64_t i, vfn_2mb, idx_1gb;
+
+	vfn_2mb = VFN_2MB(vaddr);
+	map_1gb2mb = mem_map_get_map_1gb2mb(map, vfn_2mb, true);
+	if (!map_1gb2mb) {
+		DEBUG_PRINT("could not get %p map", (void *)vaddr);
+		return -ENOMEM;
+	}
+
+	idx_1gb = MAP_1GB_IDX(vfn_2mb);
+	map_1gb2mb->translation_2mb[idx_1gb] = translation;
+
+	map_2mb4kb = mem_map_get_map_2mb4kb(map, FN_2MB_TO_4KB(vfn_2mb), false);
+	if (map_2mb4kb != NULL) {
+		for (i = 0; i < SPDK_COUNTOF(map_2mb4kb->translation_4kb); i++) {
+			map_2mb4kb->translation_4kb[i] = translation;
+		}
+	}
+
+	return 0;
+}
+
+static int mem_map_set_page_translation(struct spdk_mem_map *map, uint64_t vaddr, size_t page_size, void *translation)
+{
+	switch (page_size) {
+	case VALUE_4KB:
+		return mem_map_set_4kb_translation(map, vaddr, (uint64_t)translation);
+	case VALUE_2MB:
+		return mem_map_set_2mb_translation(map, vaddr, (uint64_t)translation);
+	default:
+		assert(0 && "should never happen");
+		return -EINVAL;
+	}
+}
+
+int spdk_mem_map_set_translation(struct spdk_mem_map *map, uint64_t vaddr, uint64_t size, uint64_t translation)
+{
+	if ((uintptr_t)vaddr & ~MASK_256TB) {
+		DEBUG_PRINT("invalid usermode virtual address %" PRIu64, vaddr);
+		return -EINVAL;
+	}
+
+	if (((uintptr_t)vaddr & MASK_4KB) || (size & MASK_4KB)) {
+		DEBUG_PRINT("invalid %s parameters, vaddr=%" PRIu64 " len=%" PRIu64, __func__, vaddr, size);
+		return -EINVAL;
+	}
+
+	return mem_map_walk_region(map, vaddr, size, mem_map_set_page_translation, (void *)translation);
+}
+
+int spdk_mem_map_clear_translation(struct spdk_mem_map *map, uint64_t vaddr, uint64_t size)
+{
+	return spdk_mem_map_set_translation(map, vaddr, size, map->default_translation);
+}
+
+inline uint64_t spdk_mem_map_translate(const struct spdk_mem_map *map, uint64_t vaddr, uint64_t *size)
+{
+	uint64_t cur_size;
+	uint64_t prev_translation;
+	uint64_t orig_translation;
+	uint64_t curr_translation;
+	int page_size;
+
+	if (spdk_unlikely(vaddr & ~MASK_256TB)) {
+		DEBUG_PRINT("invalid usermode virtual address %p", (void *)vaddr);
+		return map->default_translation;
+	}
+
+	curr_translation = mem_map_translate(map, vaddr, &page_size);
+	cur_size = page_size - (page_size == VALUE_4KB ? _4KB_OFFSET(vaddr) : _2MB_OFFSET(vaddr));
+	if (size == NULL || map->ops.are_contiguous == NULL || curr_translation == map->default_translation) {
+		if (size != NULL) {
+			*size = spdk_min(*size, cur_size);
+		}
+		return curr_translation;
+	}
+
+	prev_translation = orig_translation = curr_translation;
+	vaddr += cur_size;
+	while (cur_size < *size) {
+		curr_translation = mem_map_translate(map, vaddr, &page_size);
+		if (!map->ops.are_contiguous(prev_translation, curr_translation)) {
+			break;
+		}
+
+		cur_size += page_size;
+		vaddr += page_size;
+		prev_translation = curr_translation;
+	}
+
+	*size = spdk_min(*size, cur_size);
+	return orig_translation;
+}

--- a/src/plugins/spdk/spdk_env/memory.c
+++ b/src/plugins/spdk/spdk_env/memory.c
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "spdk/stdinc.h"
+#include "spdk/env.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+#include "spdk/memory.h"
+
+#include "env_internal.h"
+#include "env_mem_map.h"
+
+
+
+#ifdef __linux__
+#include <numaif.h>
+#endif
+
+/* This environment has no IOMMU and does no PCI probing, so nothing can perform
+ * physical-address DMA. Every translation fails; callers that need a physical
+ * address (local PCIe devices) are unsupported by design.
+ */
+uint64_t spdk_vtophys(const void *buf, uint64_t *size)
+{
+	(void)buf;
+
+	if (size) {
+		*size = UINT64_MAX;
+	}
+	return SPDK_VTOPHYS_ERROR;
+}
+
+bool spdk_iommu_is_enabled(void)
+{
+	return false;
+}
+
+int32_t spdk_mem_get_numa_id(const void *buf, uint64_t *size)
+{
+	if (size) {
+		*size = UINT64_MAX;
+	}
+	return SPDK_ENV_NUMA_ID_ANY;
+}
+
+int spdk_mem_get_fd_and_offset(void *vaddr, uint64_t *offset)
+{
+	(void)vaddr;
+	(void)offset;
+
+	return -ENOTSUP;
+}
+
+void mem_enforce_numa(void)
+{
+}
+
+static int mem_reg_map_check_contiguous(uint64_t addr1, uint64_t addr2)
+{
+	assert(addr1 & REG_MAP_REGISTERED);
+	if (!(addr2 & REG_MAP_REGISTERED)) {
+		return 0;
+	}
+
+	/* addr2 is the start of a new registration */
+	return !(addr2 & REG_MAP_NOTIFY_START);
+}
+
+int mem_map_init(void)
+{
+	const struct spdk_mem_map_ops reg_map_ops = {
+		.notify_cb = NULL,
+		.are_contiguous = mem_reg_map_check_contiguous,
+	};
+
+	g_mem_reg_map = spdk_mem_map_alloc(0, &reg_map_ops, NULL);
+	if (g_mem_reg_map == NULL) {
+		ENV_ERRLOG("Failed to allocate g_mem_reg_map");
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+void mem_map_fini(void)
+{
+	spdk_mem_map_free(&g_mem_reg_map);
+}

--- a/src/plugins/spdk/spdk_env/pci.c
+++ b/src/plugins/spdk/spdk_env/pci.c
@@ -1,0 +1,430 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "env_internal.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+#include "spdk/string.h"
+
+
+
+struct spdk_pci_driver {
+	const char *name;
+	struct spdk_pci_id *id_table;
+	uint32_t flags;
+	TAILQ_ENTRY(spdk_pci_driver) tailq;
+};
+
+static TAILQ_HEAD(, spdk_pci_driver) g_pci_drivers = TAILQ_HEAD_INITIALIZER(g_pci_drivers);
+static TAILQ_HEAD(, spdk_pci_device) g_pci_devices = TAILQ_HEAD_INITIALIZER(g_pci_devices);
+static TAILQ_HEAD(, spdk_pci_device_provider) g_pci_device_providers = TAILQ_HEAD_INITIALIZER(g_pci_device_providers);
+
+int pci_env_init(void)
+{
+	return 0;
+}
+
+void pci_env_reinit(void)
+{
+}
+
+void pci_env_fini(void)
+{
+}
+
+void spdk_pci_driver_register(const char *name, struct spdk_pci_id *id_table, uint32_t flags)
+{
+	struct spdk_pci_driver *driver;
+
+	driver = calloc(1, sizeof(*driver));
+	if (!driver) {
+		/* Without this the driver simply goes missing and the caller sees
+		 * an unrelated "no such driver" failure later.
+		 */
+		ENV_ERRLOG("Failed to allocate PCI driver %s", name);
+		return;
+	}
+
+	driver->name = name;
+	driver->id_table = id_table;
+	driver->flags = flags;
+	TAILQ_INSERT_TAIL(&g_pci_drivers, driver, tailq);
+}
+
+struct spdk_pci_driver *spdk_pci_get_driver(const char *name)
+{
+	struct spdk_pci_driver *driver;
+
+	TAILQ_FOREACH(driver, &g_pci_drivers, tailq)
+	{
+		if (strcmp(driver->name, name) == 0) {
+			return driver;
+		}
+	}
+
+	return NULL;
+}
+
+struct spdk_pci_driver *spdk_pci_nvme_get_driver(void)
+{
+	return spdk_pci_get_driver("nvme");
+}
+
+int spdk_pci_enumerate(struct spdk_pci_driver *driver, spdk_pci_enum_cb enum_cb, void *enum_ctx)
+{
+	return -ENOTSUP;
+}
+
+void spdk_pci_for_each_device(void *ctx, void (*fn)(void *ctx, struct spdk_pci_device *dev))
+{
+	struct spdk_pci_device *dev;
+
+	TAILQ_FOREACH(dev, &g_pci_devices, internal.tailq)
+	{
+		fn(ctx, dev);
+	}
+}
+
+int spdk_pci_device_map_bar(struct spdk_pci_device *dev,
+			    uint32_t bar,
+			    void **mapped_addr,
+			    uint64_t *phys_addr,
+			    uint64_t *size)
+{
+	if (dev->map_bar) {
+		return dev->map_bar(dev, bar, mapped_addr, phys_addr, size);
+	}
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_unmap_bar(struct spdk_pci_device *dev, uint32_t bar, void *mapped_addr)
+{
+	if (dev->unmap_bar) {
+		return dev->unmap_bar(dev, bar, mapped_addr);
+	}
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_enable_interrupt(struct spdk_pci_device *dev)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_disable_interrupt(struct spdk_pci_device *dev)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_get_interrupt_efd(struct spdk_pci_device *dev)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_enable_interrupts(struct spdk_pci_device *dev, uint32_t efd_count)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_disable_interrupts(struct spdk_pci_device *dev)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_get_interrupt_efd_by_index(struct spdk_pci_device *dev, uint32_t index)
+{
+	return -ENOTSUP;
+}
+
+uint32_t spdk_pci_device_get_domain(struct spdk_pci_device *dev)
+{
+	return dev->addr.domain;
+}
+
+uint8_t spdk_pci_device_get_bus(struct spdk_pci_device *dev)
+{
+	return dev->addr.bus;
+}
+
+uint8_t spdk_pci_device_get_dev(struct spdk_pci_device *dev)
+{
+	return dev->addr.dev;
+}
+
+uint8_t spdk_pci_device_get_func(struct spdk_pci_device *dev)
+{
+	return dev->addr.func;
+}
+
+struct spdk_pci_addr spdk_pci_device_get_addr(struct spdk_pci_device *dev)
+{
+	return dev->addr;
+}
+
+uint16_t spdk_pci_device_get_vendor_id(struct spdk_pci_device *dev)
+{
+	return dev->id.vendor_id;
+}
+
+uint16_t spdk_pci_device_get_device_id(struct spdk_pci_device *dev)
+{
+	return dev->id.device_id;
+}
+
+uint16_t spdk_pci_device_get_subvendor_id(struct spdk_pci_device *dev)
+{
+	return dev->id.subvendor_id;
+}
+
+uint16_t spdk_pci_device_get_subdevice_id(struct spdk_pci_device *dev)
+{
+	return dev->id.subdevice_id;
+}
+
+struct spdk_pci_id spdk_pci_device_get_id(struct spdk_pci_device *dev)
+{
+	return dev->id;
+}
+
+int spdk_pci_device_get_numa_id(struct spdk_pci_device *dev)
+{
+	return dev->numa_id;
+}
+
+int spdk_pci_device_get_serial_number(struct spdk_pci_device *dev, char *sn, size_t len)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_claim(struct spdk_pci_device *dev)
+{
+	return -ENOTSUP;
+}
+
+void spdk_pci_device_unclaim(struct spdk_pci_device *dev)
+{
+}
+
+void spdk_pci_device_detach(struct spdk_pci_device *device)
+{
+}
+
+int spdk_pci_device_attach(struct spdk_pci_driver *driver,
+			   spdk_pci_enum_cb enum_cb,
+			   void *enum_ctx,
+			   struct spdk_pci_addr *pci_address)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_allow(struct spdk_pci_addr *pci_addr)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_cfg_read(struct spdk_pci_device *dev, void *buf, uint32_t len, uint32_t offset)
+{
+	if (dev->cfg_read) {
+		return dev->cfg_read(dev, buf, len, offset);
+	}
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_cfg_write(struct spdk_pci_device *dev, void *buf, uint32_t len, uint32_t offset)
+{
+	if (dev->cfg_write) {
+		return dev->cfg_write(dev, buf, len, offset);
+	}
+	return -ENOTSUP;
+}
+
+int spdk_pci_device_cfg_read8(struct spdk_pci_device *dev, uint8_t *value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_read(dev, value, 1, offset);
+}
+
+int spdk_pci_device_cfg_write8(struct spdk_pci_device *dev, uint8_t value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_write(dev, &value, 1, offset);
+}
+
+int spdk_pci_device_cfg_read16(struct spdk_pci_device *dev, uint16_t *value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_read(dev, value, 2, offset);
+}
+
+int spdk_pci_device_cfg_write16(struct spdk_pci_device *dev, uint16_t value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_write(dev, &value, 2, offset);
+}
+
+int spdk_pci_device_cfg_read32(struct spdk_pci_device *dev, uint32_t *value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_read(dev, value, 4, offset);
+}
+
+int spdk_pci_device_cfg_write32(struct spdk_pci_device *dev, uint32_t value, uint32_t offset)
+{
+	return spdk_pci_device_cfg_write(dev, &value, 4, offset);
+}
+
+bool spdk_pci_device_is_removed(struct spdk_pci_device *dev)
+{
+	return dev->internal.pending_removal;
+}
+
+int spdk_pci_addr_compare(const struct spdk_pci_addr *a1, const struct spdk_pci_addr *a2)
+{
+	if (a1->domain > a2->domain) {
+		return 1;
+	} else if (a1->domain < a2->domain) {
+		return -1;
+	} else if (a1->bus > a2->bus) {
+		return 1;
+	} else if (a1->bus < a2->bus) {
+		return -1;
+	} else if (a1->dev > a2->dev) {
+		return 1;
+	} else if (a1->dev < a2->dev) {
+		return -1;
+	} else if (a1->func > a2->func) {
+		return 1;
+	} else if (a1->func < a2->func) {
+		return -1;
+	}
+	return 0;
+}
+
+int spdk_pci_addr_parse(struct spdk_pci_addr *addr, const char *bdf)
+{
+	unsigned domain, bus, dev, func;
+	size_t len;
+	int n = -1;
+
+	if (addr == NULL || bdf == NULL) {
+		return -EINVAL;
+	}
+
+	len = strlen(bdf);
+
+	/* %n records how much each pattern consumed. sscanf() ignores whatever
+	 * follows, so without this "0000:00:04.0garbage" would parse cleanly and
+	 * select a device the caller never named.
+	 */
+	if (strchr(bdf, ':') != NULL) {
+		if (sscanf(bdf, "%x:%x:%x.%x%n", &domain, &bus, &dev, &func, &n) == 4 &&
+		    n >= 0 && (size_t)n == len) {
+			goto ok;
+		}
+		n = -1;
+		if (sscanf(bdf, "%x:%x.%x%n", &bus, &dev, &func, &n) == 3 &&
+		    n >= 0 && (size_t)n == len) {
+			domain = 0;
+			goto ok;
+		}
+		return -EINVAL;
+	}
+
+	if (sscanf(bdf, "%x.%x.%x.%x%n", &domain, &bus, &dev, &func, &n) == 4 &&
+	    n >= 0 && (size_t)n == len) {
+		goto ok;
+	}
+
+	return -EINVAL;
+
+ok:
+	/* The fields are narrower than unsigned, so an out-of-range value would
+	 * otherwise be silently truncated into a valid-looking address.
+	 */
+	if (bus > 0xFF || dev > 0x1F || func > 0x7) {
+		return -EINVAL;
+	}
+
+	addr->domain = domain;
+	addr->bus = (uint8_t)bus;
+	addr->dev = (uint8_t)dev;
+	addr->func = (uint8_t)func;
+	return 0;
+}
+
+int spdk_pci_addr_fmt(char *bdf, size_t sz, const struct spdk_pci_addr *addr)
+{
+	int rc;
+
+	rc = snprintf(bdf, sz, "%04x:%02x:%02x.%x", addr->domain, addr->bus, addr->dev, addr->func);
+	if (rc < 0 || (size_t)rc >= sz) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/* Hooked devices go on g_pci_devices, the same list spdk_pci_for_each_device()
+ * walks, so a hooked device is visible to enumeration. A separate list would
+ * not work anyway: both would thread through the same internal.tailq link.
+ */
+int spdk_pci_hook_device(struct spdk_pci_driver *drv, struct spdk_pci_device *dev)
+{
+	dev->internal.driver = drv;
+	dev->internal.attached = false;
+	TAILQ_INSERT_TAIL(&g_pci_devices, dev, internal.tailq);
+	return 0;
+}
+
+void spdk_pci_unhook_device(struct spdk_pci_device *dev)
+{
+	TAILQ_REMOVE(&g_pci_devices, dev, internal.tailq);
+}
+
+const char *spdk_pci_device_get_type(const struct spdk_pci_device *dev)
+{
+	return dev->type;
+}
+
+void spdk_pci_register_device_provider(struct spdk_pci_device_provider *provider)
+{
+	TAILQ_INSERT_TAIL(&g_pci_device_providers, provider, tailq);
+}
+
+struct spdk_pci_driver *spdk_pci_vmd_get_driver(void)
+{
+	return spdk_pci_get_driver("vmd");
+}
+
+struct spdk_pci_driver *spdk_pci_idxd_get_driver(void)
+{
+	return spdk_pci_get_driver("idxd");
+}
+
+struct spdk_pci_driver *spdk_pci_ioat_get_driver(void)
+{
+	return spdk_pci_get_driver("ioat");
+}
+
+struct spdk_pci_driver *spdk_pci_ae4dma_get_driver(void)
+{
+	return spdk_pci_get_driver("ae4dma");
+}
+
+struct spdk_pci_driver *spdk_pci_virtio_get_driver(void)
+{
+	return spdk_pci_get_driver("virtio");
+}
+
+int spdk_pci_event_listen(void)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_get_event(int fd, struct spdk_pci_event *event)
+{
+	return -ENOTSUP;
+}
+
+int spdk_pci_register_error_handler(spdk_pci_error_handler sighandler, void *ctx)
+{
+	return -ENOTSUP;
+}
+
+void spdk_pci_unregister_error_handler(spdk_pci_error_handler sighandler)
+{
+}

--- a/src/plugins/spdk/spdk_env/spdk_env_compat.h
+++ b/src/plugins/spdk/spdk_env/spdk_env_compat.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Small helpers used across this DPDK-free implementation of SPDK's env
+ * interface: an aligned allocation wrapper and an error-logging macro that
+ * routes into SPDK's own logging.
+ */
+
+#ifndef NIXL_SPDK_ENV_COMPAT_H
+#define NIXL_SPDK_ENV_COMPAT_H
+
+#include <stdlib.h>
+
+#include "spdk/log.h"
+
+#define ENV_ERRLOG(fmt, ...) SPDK_ERRLOG(fmt "\n", ##__VA_ARGS__)
+
+static inline void *env_aligned_alloc(size_t alignment, size_t size)
+{
+	void *ptr = NULL;
+
+	if (posix_memalign(&ptr, alignment, size) != 0) {
+		return NULL;
+	}
+	return ptr;
+}
+
+#endif /* NIXL_SPDK_ENV_COMPAT_H */

--- a/src/plugins/spdk/spdk_env/threads.c
+++ b/src/plugins/spdk/spdk_env/threads.c
@@ -1,0 +1,577 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "env_internal.h"
+#include "spdk/log.h"
+#include "spdk_env_compat.h"
+#include "spdk/cpuset.h"
+#include "spdk/string.h"
+
+#include <dirent.h>
+
+#define MAX_CORES 128
+
+#define THREAD_SIBLINGS_FILE "/sys/devices/system/cpu/cpu%d/topology/thread_siblings"
+
+/*
+ * Comma-separated 32-bit hex mask: 9 chars per 32 CPUs. 1024 bytes accommodates
+ * over 3500 CPUs, far above any realistic system this code runs on.
+ */
+#define SMT_CPUSET_LINE_SIZE 1024
+
+static uint32_t g_cores[MAX_CORES];
+static uint32_t g_core_count;
+static uint32_t g_main_core;
+
+static __thread uint32_t t_core_id = SPDK_ENV_LCORE_ID_ANY;
+
+struct worker_thread {
+	pthread_t thread;
+	thread_start_fn fn;
+	void *arg;
+	uint32_t core;
+	bool running;
+};
+
+static struct worker_thread g_workers[MAX_CORES];
+
+static int32_t g_numa_ids[MAX_CORES];
+static uint32_t g_numa_count;
+
+static int numa_id_cmp(const void *a, const void *b)
+{
+	int32_t x = *(const int32_t *)a;
+	int32_t y = *(const int32_t *)b;
+
+	return (x > y) - (x < y);
+}
+
+static void build_numa_list(void)
+{
+	uint32_t i, j;
+	bool found;
+
+	g_numa_count = 0;
+
+	for (i = 0; i < g_core_count; i++) {
+		int32_t nid = spdk_env_get_numa_id(g_cores[i]);
+
+		found = false;
+		for (j = 0; j < g_numa_count; j++) {
+			if (g_numa_ids[j] == nid) {
+				found = true;
+				break;
+			}
+		}
+		if (!found && g_numa_count < MAX_CORES) {
+			g_numa_ids[g_numa_count] = nid;
+			g_numa_count++;
+		}
+	}
+
+	/* Ids are collected in core order, which is not id order. Sort so
+	 * spdk_env_get_last_numa_id() returns the largest id and
+	 * spdk_env_get_next_numa_id() walks them monotonically, matching the
+	 * ordering threads_init() establishes for g_cores.
+	 */
+	qsort(g_numa_ids, g_numa_count, sizeof(g_numa_ids[0]), numa_id_cmp);
+}
+
+static int parse_core_mask(const char *mask)
+{
+	const char *p = mask;
+	size_t len, i;
+
+	if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+		p += 2;
+	}
+
+	len = strlen(p);
+	if (len == 0) {
+		return -EINVAL;
+	}
+
+	g_core_count = 0;
+	/*
+	 * Parse an arbitrary-width hex mask (not just 64 bits) so cores >= 64 are
+	 * reachable. The rightmost hex digit holds cores 0-3; cores are emitted in
+	 * ascending order and bounded by MAX_CORES.
+	 */
+	for (i = 0; i < len; i++) {
+		char c = p[len - 1 - i];
+		int nibble;
+
+		if (c >= '0' && c <= '9') {
+			nibble = c - '0';
+		} else if (c >= 'a' && c <= 'f') {
+			nibble = c - 'a' + 10;
+		} else if (c >= 'A' && c <= 'F') {
+			nibble = c - 'A' + 10;
+		} else {
+			return -EINVAL;
+		}
+
+		for (int b = 0; b < 4; b++) {
+			if (nibble & (1 << b)) {
+				uint32_t core = (uint32_t)(i * 4 + b);
+
+				if (core >= MAX_CORES) {
+					ENV_ERRLOG("Core %u in mask exceeds the %d-core limit",
+						   core, MAX_CORES);
+					return -EINVAL;
+				}
+				if (g_core_count < MAX_CORES) {
+					g_cores[g_core_count++] = core;
+				}
+			}
+		}
+	}
+
+	if (g_core_count == 0) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int parse_core_list(const char *list)
+{
+	const char *p = list;
+	char *end;
+	unsigned long val;
+
+	if (*p == '[') {
+		p++;
+	}
+
+	g_core_count = 0;
+
+	while (*p != '\0' && *p != ']') {
+		while (*p == ' ' || *p == ',') {
+			p++;
+		}
+		if (*p == '\0' || *p == ']') {
+			break;
+		}
+
+		val = strtoul(p, &end, 10);
+		if (end == p) {
+			return -EINVAL;
+		}
+		p = end;
+
+		if (*p == '-') {
+			unsigned long hi;
+
+			p++;
+			hi = strtoul(p, &end, 10);
+			if (end == p || hi < val) {
+				return -EINVAL;
+			}
+			p = end;
+
+			if (hi >= MAX_CORES) {
+				ENV_ERRLOG("Core %lu in list exceeds the %d-core limit",
+					   hi, MAX_CORES);
+				return -EINVAL;
+			}
+
+			while (val <= hi && g_core_count < MAX_CORES) {
+				g_cores[g_core_count++] = (uint32_t)val;
+				val++;
+			}
+		} else {
+			/* Bound the id itself, not just the count: it later reaches
+			 * CPU_SET(), which writes outside cpu_set_t for an index at
+			 * or above CPU_SETSIZE.
+			 */
+			if (val >= MAX_CORES) {
+				ENV_ERRLOG("Core %lu in list exceeds the %d-core limit",
+					   val, MAX_CORES);
+				return -EINVAL;
+			}
+			if (g_core_count < MAX_CORES) {
+				g_cores[g_core_count++] = (uint32_t)val;
+			}
+		}
+	}
+
+	if (g_core_count == 0) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static int core_id_cmp(const void *a, const void *b)
+{
+	uint32_t x = *(const uint32_t *)a;
+	uint32_t y = *(const uint32_t *)b;
+
+	return (x > y) - (x < y);
+}
+
+int threads_init(const struct spdk_env_opts *opts)
+{
+	int rc;
+
+	if (opts->lcore_map) {
+		rc = parse_core_list(opts->lcore_map);
+	} else if (opts->core_mask) {
+		if (opts->core_mask[0] == '[') {
+			rc = parse_core_list(opts->core_mask);
+		} else {
+			rc = parse_core_mask(opts->core_mask);
+		}
+	} else {
+		return -EINVAL;
+	}
+
+	if (rc != 0) {
+		ENV_ERRLOG("Failed to parse core mask/list");
+		return rc;
+	}
+
+	/*
+	 * spdk_env_get_first_core()/get_next_core() (and thus SPDK_ENV_FOREACH_CORE
+	 * and the cpuset helpers) require g_cores to be ascending and de-duplicated;
+	 * parse_core_list() preserves the user's input order and may contain
+	 * duplicates.
+	 */
+	if (g_core_count > 1) {
+		uint32_t r, w;
+
+		qsort(g_cores, g_core_count, sizeof(g_cores[0]), core_id_cmp);
+		w = 1;
+		for (r = 1; r < g_core_count; r++) {
+			if (g_cores[r] != g_cores[w - 1]) {
+				g_cores[w++] = g_cores[r];
+			}
+		}
+		g_core_count = w;
+	}
+
+	if (opts->main_core >= 0) {
+		uint32_t i;
+
+		/* The main core must be one the workers actually run on, or
+		 * spdk_env_get_main_core() reports a core outside the core set.
+		 */
+		for (i = 0; i < g_core_count; i++) {
+			if (g_cores[i] == (uint32_t)opts->main_core) {
+				break;
+			}
+		}
+		if (i == g_core_count) {
+			ENV_ERRLOG("main_core %d is not in the core mask/list",
+				   opts->main_core);
+			return -EINVAL;
+		}
+		g_main_core = (uint32_t)opts->main_core;
+	} else {
+		g_main_core = g_cores[0];
+	}
+
+	t_core_id = g_main_core;
+
+	memset(g_workers, 0, sizeof(g_workers));
+	build_numa_list();
+
+	return 0;
+}
+
+void threads_fini(void)
+{
+	/* Join first: spdk_env_thread_wait_all() walks g_workers up to
+	 * g_core_count, so clearing the count first would strand any running
+	 * worker and let it outlive the environment it runs against.
+	 */
+	spdk_env_thread_wait_all();
+
+	g_core_count = 0;
+	t_core_id = SPDK_ENV_LCORE_ID_ANY;
+}
+
+uint32_t spdk_env_get_core_count(void)
+{
+	return g_core_count;
+}
+
+uint32_t spdk_env_get_current_core(void)
+{
+	return t_core_id;
+}
+
+uint32_t spdk_env_get_main_core(void)
+{
+	return g_main_core;
+}
+
+uint32_t spdk_env_get_first_core(void)
+{
+	if (g_core_count == 0) {
+		return UINT32_MAX;
+	}
+
+	return g_cores[0];
+}
+
+uint32_t spdk_env_get_last_core(void)
+{
+	uint32_t i;
+	uint32_t last_core = UINT32_MAX;
+
+	SPDK_ENV_FOREACH_CORE(i)
+	{
+		last_core = i;
+	}
+
+	assert(last_core != UINT32_MAX);
+
+	return last_core;
+}
+
+uint32_t spdk_env_get_next_core(uint32_t prev_core)
+{
+	uint32_t i;
+
+	for (i = 0; i < g_core_count; i++) {
+		if (g_cores[i] > prev_core) {
+			return g_cores[i];
+		}
+	}
+
+	return UINT32_MAX;
+}
+
+int32_t spdk_env_get_numa_id(uint32_t core)
+{
+	char path[PATH_MAX];
+	DIR *dir;
+	struct dirent *ent;
+	int32_t nid = SPDK_ENV_NUMA_ID_ANY;
+
+	/*
+	 * The NUMA node is exposed as a cpuN/nodeM symlink; use that rather than
+	 * topology/physical_package_id, which is the socket/package id and differs
+	 * from the NUMA node under sub-NUMA clustering (Intel SNC, AMD NPS > 1).
+	 */
+	snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%u", core);
+	dir = opendir(path);
+	if (dir == NULL) {
+		return SPDK_ENV_NUMA_ID_ANY;
+	}
+
+	while ((ent = readdir(dir)) != NULL) {
+		if (strncmp(ent->d_name, "node", 4) == 0 &&
+		    ent->d_name[4] >= '0' && ent->d_name[4] <= '9') {
+			nid = (int32_t)strtol(ent->d_name + 4, NULL, 10);
+			break;
+		}
+	}
+
+	closedir(dir);
+	return nid;
+}
+
+int32_t spdk_env_get_first_numa_id(void)
+{
+	if (g_numa_count == 0) {
+		return INT32_MAX;
+	}
+
+	return g_numa_ids[0];
+}
+
+int32_t spdk_env_get_last_numa_id(void)
+{
+	if (g_numa_count == 0) {
+		return INT32_MAX;
+	}
+
+	return g_numa_ids[g_numa_count - 1];
+}
+
+int32_t spdk_env_get_next_numa_id(int32_t prev_numa_id)
+{
+	uint32_t i;
+
+	for (i = 0; i < g_numa_count; i++) {
+		if (g_numa_ids[i] == prev_numa_id && (i + 1) < g_numa_count) {
+			return g_numa_ids[i + 1];
+		}
+	}
+
+	return INT32_MAX;
+}
+
+void spdk_env_get_cpuset(struct spdk_cpuset *cpuset)
+{
+	uint32_t i;
+
+	spdk_cpuset_zero(cpuset);
+	SPDK_ENV_FOREACH_CORE(i)
+	{
+		spdk_cpuset_set_cpu(cpuset, i, true);
+	}
+}
+
+/* Pure sysfs parsing of a core's SMT siblings. */
+static bool env_core_get_smt_cpuset(struct spdk_cpuset *cpuset, uint32_t core)
+{
+	struct spdk_cpuset smt_siblings;
+	char path[PATH_MAX];
+	char line[SMT_CPUSET_LINE_SIZE];
+	FILE *f;
+	size_t len;
+	bool valid = false;
+
+	snprintf(path, sizeof(path), THREAD_SIBLINGS_FILE, core);
+	f = fopen(path, "r");
+	if (f == NULL) {
+		ENV_ERRLOG("Could not fopen('%s'): %s", path, spdk_strerror(errno));
+		return false;
+	}
+	if (fgets(line, sizeof(line), f) == NULL) {
+		ENV_ERRLOG("Could not fgets() for '%s': %s", path, spdk_strerror(errno));
+		goto ret;
+	}
+
+	len = strlen(line);
+	if (len > 0 && line[len - 1] == '\n') {
+		line[len - 1] = '\0';
+	}
+	if (spdk_cpuset_parse(&smt_siblings, line)) {
+		ENV_ERRLOG("Could not parse '%s' from '%s'", line, path);
+		goto ret;
+	}
+
+	valid = true;
+	spdk_cpuset_or(cpuset, &smt_siblings);
+ret:
+	fclose(f);
+	return valid;
+}
+
+bool spdk_env_core_get_smt_cpuset(struct spdk_cpuset *cpuset, uint32_t core)
+{
+	uint32_t i;
+
+	spdk_cpuset_zero(cpuset);
+
+	if (core != UINT32_MAX) {
+		return env_core_get_smt_cpuset(cpuset, core);
+	}
+
+	SPDK_ENV_FOREACH_CORE(i)
+	{
+		if (!env_core_get_smt_cpuset(cpuset, i)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static void *worker_thread_entry(void *ctx)
+{
+	struct worker_thread *w = ctx;
+
+	t_core_id = w->core;
+	w->fn(w->arg);
+
+	return NULL;
+}
+
+int spdk_env_thread_launch_pinned(uint32_t core, thread_start_fn fn, void *arg)
+{
+	struct worker_thread *w = NULL;
+	cpu_set_t cpuset;
+	pthread_attr_t attr;
+	uint32_t i;
+	int rc;
+
+	for (i = 0; i < g_core_count; i++) {
+		if (g_cores[i] == core) {
+			w = &g_workers[i];
+			break;
+		}
+	}
+
+	if (w == NULL || w->running) {
+		return -EINVAL;
+	}
+
+	w->fn = fn;
+	w->arg = arg;
+	w->core = core;
+
+	CPU_ZERO(&cpuset);
+	CPU_SET(core, &cpuset);
+
+	pthread_attr_init(&attr);
+	pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset);
+
+	rc = pthread_create(&w->thread, &attr, worker_thread_entry, w);
+	pthread_attr_destroy(&attr);
+
+	if (rc != 0) {
+		return -rc;
+	}
+
+	w->running = true;
+	return 0;
+}
+
+void spdk_env_thread_wait_all(void)
+{
+	uint32_t i;
+
+	for (i = 0; i < g_core_count; i++) {
+		if (g_workers[i].running) {
+			pthread_join(g_workers[i].thread, NULL);
+			g_workers[i].running = false;
+		}
+	}
+}
+
+void spdk_unaffinitize_thread(void)
+{
+	cpu_set_t mask;
+	long num_cpus;
+	int i;
+
+	num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	/* cpu_set_t holds CPU_SETSIZE bits; a larger machine would make CPU_SET()
+	 * write past the end of mask.
+	 */
+	if (num_cpus > CPU_SETSIZE) {
+		num_cpus = CPU_SETSIZE;
+	}
+	CPU_ZERO(&mask);
+	for (i = 0; i < num_cpus; i++) {
+		CPU_SET(i, &mask);
+	}
+	sched_setaffinity(0, sizeof(mask), &mask);
+}
+
+void *spdk_call_unaffinitized(void *cb(void *arg), void *arg)
+{
+	cpu_set_t orig;
+	void *result;
+
+	if (cb == NULL) {
+		return NULL;
+	}
+
+	if (pthread_getaffinity_np(pthread_self(), sizeof(orig), &orig)) {
+		return cb(arg);
+	}
+
+	spdk_unaffinitize_thread();
+	result = cb(arg);
+
+	pthread_setaffinity_np(pthread_self(), sizeof(orig), &orig);
+	return result;
+}

--- a/src/plugins/spdk/spdk_plugin.cpp
+++ b/src/plugins/spdk/spdk_plugin.cpp
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "backend/backend_plugin.h"
+#include "spdk_backend.h"
+
+using spdk_plugin_t = nixlBackendPluginCreator<nixlSpdkEngine>;
+
+// Advertised so getPluginParams() exposes the configurable knobs and their
+// defaults. Exactly one of json_config / json_config_file must be set.
+[[nodiscard]] static nixl_b_params_t
+get_spdk_backend_options() {
+    nixl_b_params_t params;
+    // Bdev configuration. Provide JSON directly, or via the convenience params
+    // below for the common single-bdev case (explicit JSON takes precedence).
+    params["json_config"] = ""; // inline SPDK bdev subsystem JSON (preferred)
+    params["json_config_file"] = ""; // path to the same JSON (alternative)
+    // Convenience single-bdev config (used when no JSON is given):
+    params["bdev_type"] = ""; // malloc | aio | nvme
+    params["bdev_name"] = ""; // bdev name (NVMe exposes namespaces as <name>n1)
+    params["bdev_num_blocks"] = ""; // malloc: number of blocks
+    params["bdev_block_size"] = ""; // malloc/aio: block size in bytes (default 512)
+    params["bdev_filename"] = ""; // aio: backing file or device path
+    params["bdev_traddr"] = ""; // nvme: PCIe transport address
+    params["spdk_name"] = "nixl_spdk"; // names the SPDK thread in logs
+    params["core_mask"] = ""; // SPDK core mask (empty = SPDK default)
+    params["msg_mempool_size"] = "0"; // SPDK thread message-pool size (0 = default)
+    return params;
+}
+
+#ifdef STATIC_PLUGIN_SPDK
+nixlBackendPlugin *
+createStaticSPDKPlugin() {
+    return spdk_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, "SPDK", "0.1.0", get_spdk_backend_options(), {DRAM_SEG, BLK_SEG});
+}
+#else
+extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
+nixl_plugin_init() {
+    return spdk_plugin_t::create(
+        NIXL_PLUGIN_API_VERSION, "SPDK", "0.1.0", get_spdk_backend_options(), {DRAM_SEG, BLK_SEG});
+}
+
+extern "C" NIXL_PLUGIN_EXPORT void
+nixl_plugin_fini() {}
+#endif

--- a/src/plugins/spdk/spdk_plugin.cpp
+++ b/src/plugins/spdk/spdk_plugin.cpp
@@ -8,10 +8,12 @@
 
 using spdk_plugin_t = nixlBackendPluginCreator<nixlSpdkEngine>;
 
+namespace {
+
 // Advertised so getPluginParams() exposes the configurable knobs and their
 // defaults. Exactly one of json_config / json_config_file must be set.
-[[nodiscard]] static nixl_b_params_t
-get_spdk_backend_options() {
+[[nodiscard]] nixl_b_params_t
+getSpdkBackendOptions() {
     nixl_b_params_t params;
     // Bdev configuration. Provide JSON directly, or via the convenience params
     // below for the common single-bdev case (explicit JSON takes precedence).
@@ -23,24 +25,38 @@ get_spdk_backend_options() {
     params["bdev_num_blocks"] = ""; // malloc: number of blocks
     params["bdev_block_size"] = ""; // malloc/aio: block size in bytes (default 512)
     params["bdev_filename"] = ""; // aio: backing file or device path
-    params["bdev_traddr"] = ""; // nvme: PCIe transport address
+    // nvme: NVMe-oF only. Local PCIe is unsupported, as this plugin does not
+    // probe PCI devices.
+    params["bdev_trtype"] = ""; // nvme: RDMA | TCP
+    params["bdev_traddr"] = ""; // nvme: transport address
+    params["bdev_trsvcid"] = ""; // nvme: transport service id (port)
+    params["bdev_adrfam"] = ""; // nvme: IPv4 | IPv6
+    params["bdev_subnqn"] = ""; // nvme: target subsystem NQN
     params["spdk_name"] = "nixl_spdk"; // names the SPDK thread in logs
     params["core_mask"] = ""; // SPDK core mask (empty = SPDK default)
     params["msg_mempool_size"] = "0"; // SPDK thread message-pool size (0 = default)
     return params;
 }
 
+} // namespace
+
 #ifdef STATIC_PLUGIN_SPDK
 nixlBackendPlugin *
 createStaticSPDKPlugin() {
-    return spdk_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "SPDK", "0.1.0", get_spdk_backend_options(), {DRAM_SEG, BLK_SEG});
+    return spdk_plugin_t::create(NIXL_PLUGIN_API_VERSION,
+                                 "SPDK",
+                                 "0.1.0",
+                                 getSpdkBackendOptions(),
+                                 {DRAM_SEG, BLK_SEG, OBJ_SEG});
 }
 #else
 extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
 nixl_plugin_init() {
-    return spdk_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "SPDK", "0.1.0", get_spdk_backend_options(), {DRAM_SEG, BLK_SEG});
+    return spdk_plugin_t::create(NIXL_PLUGIN_API_VERSION,
+                                 "SPDK",
+                                 "0.1.0",
+                                 getSpdkBackendOptions(),
+                                 {DRAM_SEG, BLK_SEG, OBJ_SEG});
 }
 
 extern "C" NIXL_PLUGIN_EXPORT void

--- a/src/plugins/spdk/spdk_progress_engine.cpp
+++ b/src/plugins/spdk/spdk_progress_engine.cpp
@@ -10,6 +10,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <format>
 #include <fstream>
 #include <iterator>
@@ -18,6 +19,7 @@
 #include <ranges>
 #include <string_view>
 #include <utility>
+#include <variant>
 
 #include "backend/backend_aux.h"
 #include "common/backend.h"
@@ -27,6 +29,7 @@ extern "C" {
 #include <spdk/accel.h>
 #include <spdk/env.h>
 #include <spdk/init.h>
+#include <spdk/nvme_spec.h>
 #include <spdk/rpc.h>
 #include <spdk/thread.h>
 }
@@ -49,7 +52,10 @@ struct SharedRuntime {
     // Serializes execution on appThread. Backends acquire it opportunistically
     // (try_lock) from their poll loops, so no backend can block another.
     std::mutex appMutex;
-    spdk_thread *appThread = nullptr;
+    // Atomic because pollAppThread() reads it outside g_runtime.mutex: a second
+    // backend bringing the runtime up publishes it concurrently with an existing
+    // backend's poll loop.
+    std::atomic<spdk_thread *> appThread{nullptr};
     std::size_t refs = 0;
     bool envInitialized = false;
     bool threadLibInitialized = false;
@@ -183,12 +189,46 @@ buildBdevConfigJson(const nixl_b_params_t *params) {
             body += std::format(R"(, "block_size": {})", block_size);
         }
     } else if (type == "nvme") {
-        // Attaching an NVMe controller named <name> exposes namespaces as
-        // <name>n1, <name>n2, ...; that is the name to use in BLK descriptors.
+        // Transport-attached NVMe only. This plugin supplies its own env
+        // implementation, which does no PCI enumeration and cannot translate a
+        // virtual address to a physical one, so a local PCIe controller can
+        // never be driven from here. Reject it up front instead of letting the
+        // attach fail obscurely much later.
+        //
+        // Attaching a controller named <name> exposes namespaces as <name>n1,
+        // <name>n2, ...; that is the name to use in BLK descriptors.
+        const std::string trtype = opt("bdev_trtype");
+        if (trtype.empty()) {
+            NIXL_ERROR << "SPDK: bdev_type 'nvme' requires 'bdev_trtype' (RDMA or TCP)";
+            return "";
+        }
+        if (std::ranges::equal(trtype, std::string_view("pcie"), [](char a, char b) {
+                return std::tolower(static_cast<unsigned char>(a)) == b;
+            })) {
+            NIXL_ERROR << "SPDK: bdev_trtype 'PCIe' is not supported: this plugin does not "
+                          "probe local PCI devices. Use an RDMA or TCP NVMe-oF target.";
+            return "";
+        }
+        const std::string traddr = opt("bdev_traddr");
+        const std::string subnqn = opt("bdev_subnqn");
+        if (traddr.empty() || subnqn.empty()) {
+            NIXL_ERROR << "SPDK: bdev_type 'nvme' requires 'bdev_traddr' and 'bdev_subnqn'";
+            return "";
+        }
         method = "bdev_nvme_attach_controller";
-        body = std::format(R"("name": "{}", "trtype": "PCIe", "traddr": "{}")",
+        body = std::format(R"("name": "{}", "trtype": "{}", "traddr": "{}", "subnqn": "{}")",
                            jsonEscape(name),
-                           jsonEscape(opt("bdev_traddr")));
+                           jsonEscape(trtype),
+                           jsonEscape(traddr),
+                           jsonEscape(subnqn));
+        const std::string adrfam = opt("bdev_adrfam");
+        if (!adrfam.empty()) {
+            body += std::format(R"(, "adrfam": "{}")", jsonEscape(adrfam));
+        }
+        const std::string trsvcid = opt("bdev_trsvcid");
+        if (!trsvcid.empty()) {
+            body += std::format(R"(, "trsvcid": "{}")", jsonEscape(trsvcid));
+        }
     } else {
         NIXL_ERROR << "SPDK: unknown bdev_type '" << type << "' (expected malloc, aio, or nvme)";
         return "";
@@ -199,11 +239,22 @@ buildBdevConfigJson(const nixl_b_params_t *params) {
         body);
 }
 
+template<typename... Ts> struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+
 constexpr bool kOpenForWrite = true;
 // spdk_thread_poll() takes a message budget and a timestamp; 0 means "no limit"
 // and "read the current time" respectively.
 constexpr uint32_t kPollAllMessages = 0;
 constexpr uint64_t kPollUseCurrentTime = 0;
+
+// The SPDK handles an I/O is issued against, resolved from the transfer target.
+struct Device {
+    spdk_bdev *bdev;
+    spdk_bdev_desc *desc;
+    spdk_io_channel *channel;
+};
 
 // Makes the calling thread impersonate an SPDK thread for a scope. Restoring
 // from a destructor matters: the work run under it allocates, so an exception
@@ -233,7 +284,7 @@ thread_local bool t_onAppThread = false;
 
 class AppThreadScope {
 public:
-    AppThreadScope() : lock_(g_runtime.appMutex), scope_(g_runtime.appThread) {
+    AppThreadScope() : lock_(g_runtime.appMutex), scope_(g_runtime.appThread.load()) {
         t_onAppThread = true;
     }
 
@@ -301,6 +352,11 @@ nixlSpdkProgressEngine::parseParams(const nixlBackendInitParams *init_params) {
         if (auto value = nixl::getBackendParamOptional<size_t>(params, "msg_mempool_size")) {
             msgMempoolSize_ = *value;
         }
+        // OBJ_SEG (NVMe-KV) uses the backend's bdev, named by 'bdev_name' (the
+        // same parameter that names the convenience-config bdev).
+        if (auto value = nixl::getBackendParamOptional<std::string>(params, "bdev_name")) {
+            objBdevName_ = *value;
+        }
     }
     // Fall back to the convenience parameters only when no explicit JSON was
     // supplied; explicit json_config / json_config_file always take precedence.
@@ -344,10 +400,12 @@ nixlSpdkProgressEngine::runThread() {
         if (!producerQueue_.empty()) {
             continue;
         }
-        if (inFlight_ > 0) {
+        if (inFlight_ > 0 || ioWaiting_ > 0) {
             // I/O is outstanding: the device may post a completion at any moment,
-            // so keep polling. threadDelayUs_ optionally throttles the poll to
-            // trade completion latency for CPU; 0 means busy-poll.
+            // so keep polling. Entries parked on an io_wait queue count too --
+            // only continued polling of the channel drives their retry callback.
+            // threadDelayUs_ optionally throttles the poll to trade completion
+            // latency for CPU; 0 means busy-poll.
             if (threadDelayUs_ > 0) {
                 queueCv_.wait_for(lock, std::chrono::microseconds(threadDelayUs_));
             }
@@ -359,6 +417,13 @@ nixlSpdkProgressEngine::runThread() {
     }
 
     drainQueue();
+
+    // Drain before tearing anything down. cancelRequest() returns while its I/O
+    // may still be on the device, and the completion callback dereferences
+    // io->engine and io->reqH; finiRuntime() would close the bdev and run
+    // spdk_bdev_finish() underneath it, and the handle would never be retired.
+    pollUntil([this]() { return inFlight_ == 0 && ioWaiting_ == 0; });
+
     execute([this]() { finiRuntime(); });
 }
 
@@ -516,6 +581,22 @@ nixlSpdkProgressEngine::finiRuntimeLocked() {
     // reference; everything else here is this backend's own state.
     const bool last = ownsRuntimeRef_ && g_runtime.refs == 1;
 
+    if (spdkThread_) {
+        // Release this backend's KV device before any bdev teardown.
+        execute([this]() {
+            if (kvChannel_) {
+                spdk_put_io_channel(kvChannel_);
+                kvChannel_ = nullptr;
+            }
+            if (kvDesc_) {
+                spdk_bdev_close(kvDesc_);
+                kvDesc_ = nullptr;
+                kvBdev_ = nullptr;
+            }
+        });
+        kvOpened_ = false;
+    }
+
     if (last) {
         executeOnAppThread([this]() {
             if (g_runtime.bdevInitialized) {
@@ -588,16 +669,18 @@ nixlSpdkProgressEngine::pollOnce() {
 // thread never stalls behind one that is holding it.
 void
 nixlSpdkProgressEngine::pollAppThread() {
-    if (!g_runtime.appThread) {
+    // Loaded once: another backend may publish or clear it while this runs.
+    spdk_thread *const app_thread = g_runtime.appThread.load(std::memory_order_acquire);
+    if (!app_thread) {
         return;
     }
     if (t_onAppThread) {
-        spdk_thread_poll(g_runtime.appThread, kPollAllMessages, kPollUseCurrentTime);
+        spdk_thread_poll(app_thread, kPollAllMessages, kPollUseCurrentTime);
         return;
     }
     std::unique_lock<std::mutex> lock(g_runtime.appMutex, std::try_to_lock);
     if (lock.owns_lock()) {
-        spdk_thread_poll(g_runtime.appThread, kPollAllMessages, kPollUseCurrentTime);
+        spdk_thread_poll(app_thread, kPollAllMessages, kPollUseCurrentTime);
     }
 }
 
@@ -606,8 +689,23 @@ nixlSpdkProgressEngine::pollAppThread() {
 template<std::predicate F>
 void
 nixlSpdkProgressEngine::pollUntil(F &&done) {
+    // Deliberately no deadline: every caller is a bring-up, teardown or drain
+    // step with no way to recover from a half-finished operation, so abandoning
+    // the wait would leave the runtime in a worse state than continuing to poll.
+    // Warn periodically instead, so a bdev module that never completes shows up
+    // in the log rather than as a silent spin. None of these paths are on the
+    // per-transfer hot path, so the clock read costs nothing that matters.
+    constexpr auto kStallWarnInterval = std::chrono::seconds(30);
+    auto next_warn = std::chrono::steady_clock::now() + kStallWarnInterval;
+
     while (!done()) {
         pollOnce();
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= next_warn) {
+            NIXL_WARN << "SPDK: still waiting for an SPDK operation to complete after "
+                      << kStallWarnInterval.count() << "s; the bdev configuration may be stuck";
+            next_warn = now + kStallWarnInterval;
+        }
     }
 }
 
@@ -647,8 +745,6 @@ nixlSpdkProgressEngine::executeSync(F &&fn) {
     // Hand the work to the progress thread and block until it retires. The
     // latch is released from a destructor so an exception escaping fn() cannot
     // strand this thread waiting forever.
-    // The captured locals outlive these lambdas only because this thread blocks
-    // on the latch until the work has retired.
     std::latch done{1};
 
     struct Signal {
@@ -659,6 +755,8 @@ nixlSpdkProgressEngine::executeSync(F &&fn) {
         }
     };
 
+    // The captured locals outlive these lambdas only because this thread blocks
+    // on the latch until the work has retired.
     if constexpr (std::is_void_v<Result>) {
         enqueueAsync([&fn, &done]() {
             const Signal signal{done};
@@ -745,40 +843,98 @@ nixlSpdkProgressEngine::openBdev(nixlSpdkBdevMD &md) {
         md.channel = spdk_bdev_get_io_channel(md.desc);
         if (!md.channel) {
             NIXL_ERROR << "SPDK: failed to get I/O channel for bdev " << md.bdevName;
-            spdk_bdev_close(md.desc);
-            md.desc = nullptr;
-            md.bdev = nullptr;
+            releaseBdevHandles(md.desc, md.bdev, md.channel);
             return NIXL_ERR_BACKEND;
         }
         if (!spdk_bdev_io_type_supported(md.bdev, SPDK_BDEV_IO_TYPE_READ) ||
             !spdk_bdev_io_type_supported(md.bdev, SPDK_BDEV_IO_TYPE_WRITE)) {
             NIXL_ERROR << "SPDK: bdev " << md.bdevName << " does not support read/write";
-            spdk_put_io_channel(md.channel);
-            spdk_bdev_close(md.desc);
-            md.channel = nullptr;
-            md.desc = nullptr;
-            md.bdev = nullptr;
+            releaseBdevHandles(md.desc, md.bdev, md.channel);
             return NIXL_ERR_NOT_SUPPORTED;
         }
         md.blockSize = spdk_bdev_get_block_size(md.bdev);
         md.writeUnitSize = spdk_bdev_get_write_unit_size(md.bdev);
         md.numBlocks = spdk_bdev_get_num_blocks(md.bdev);
+        // Both are divisors in the descriptor validation on the transfer path;
+        // a module reporting zero would raise SIGFPE on the first transfer.
+        if (md.blockSize == 0 || md.writeUnitSize == 0) {
+            NIXL_ERROR << "SPDK: bdev " << md.bdevName << " reports an invalid geometry: "
+                       << "block size " << md.blockSize << ", write unit size " << md.writeUnitSize;
+            releaseBdevHandles(md.desc, md.bdev, md.channel);
+            return NIXL_ERR_BACKEND;
+        }
         return NIXL_SUCCESS;
     });
 }
 
 void
+nixlSpdkProgressEngine::releaseBdevHandles(spdk_bdev_desc *&desc,
+                                           spdk_bdev *&bdev,
+                                           spdk_io_channel *&channel) {
+    if (channel) {
+        spdk_put_io_channel(channel);
+        channel = nullptr;
+    }
+    if (desc) {
+        spdk_bdev_close(desc);
+        desc = nullptr;
+    }
+    bdev = nullptr;
+}
+
+void
 nixlSpdkProgressEngine::closeBdev(nixlSpdkBdevMD &md) {
-    executeSync([&]() {
-        if (md.channel) {
-            spdk_put_io_channel(md.channel);
-            md.channel = nullptr;
+    executeSync([&]() { releaseBdevHandles(md.desc, md.bdev, md.channel); });
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::ensureKvBdev() {
+    return executeSync([&]() {
+        if (kvOpened_) {
+            return NIXL_SUCCESS;
         }
-        if (md.desc) {
-            spdk_bdev_close(md.desc);
-            md.desc = nullptr;
-            md.bdev = nullptr;
+        if (objBdevName_.empty()) {
+            NIXL_ERROR << "SPDK: OBJ_SEG requires the 'bdev_name' parameter naming a "
+                          "KV-capable bdev";
+            return NIXL_ERR_INVALID_PARAM;
         }
+        const int rc =
+            spdk_bdev_open_ext(objBdevName_.c_str(), kOpenForWrite, kvBdevEventCb, this, &kvDesc_);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: failed to open KV bdev " << objBdevName_ << ": " << rc;
+            return NIXL_ERR_NOT_FOUND;
+        }
+        kvBdev_ = spdk_bdev_desc_get_bdev(kvDesc_);
+
+        // OBJ_SEG only works on devices that accept NVMe passthru (to carry the
+        // KV command) and identify as the NVMe KV command set.
+        nixl_status_t supported = NIXL_SUCCESS;
+        if (!spdk_bdev_io_type_supported(kvBdev_, SPDK_BDEV_IO_TYPE_NVME_IO)) {
+            NIXL_ERROR << "SPDK: KV bdev " << objBdevName_
+                       << " does not support NVMe passthru (SPDK_BDEV_IO_TYPE_NVME_IO)";
+            supported = NIXL_ERR_NOT_SUPPORTED;
+        } else if (spdk_bdev_get_nvme_csi(kvBdev_) != SPDK_NVME_CSI_KV) {
+            NIXL_ERROR << "SPDK: KV bdev " << objBdevName_
+                       << " does not identify as the NVMe KV command set";
+            supported = NIXL_ERR_NOT_SUPPORTED;
+        }
+        if (supported != NIXL_SUCCESS) {
+            spdk_bdev_close(kvDesc_);
+            kvDesc_ = nullptr;
+            kvBdev_ = nullptr;
+            return supported;
+        }
+
+        kvChannel_ = spdk_bdev_get_io_channel(kvDesc_);
+        if (!kvChannel_) {
+            NIXL_ERROR << "SPDK: failed to get I/O channel for KV bdev " << objBdevName_;
+            spdk_bdev_close(kvDesc_);
+            kvDesc_ = nullptr;
+            kvBdev_ = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        kvOpened_ = true;
+        return NIXL_SUCCESS;
     });
 }
 
@@ -869,24 +1025,89 @@ nixlSpdkProgressEngine::submitOne(nixlSpdkIoContext *io) {
         return;
     }
 
+    // BLK_SEG issues read/write against the registered bdev's own handles;
+    // OBJ_SEG carries an NVMe KV command over passthru on the shared KV device.
+    // std::visit keeps the two exhaustive: a new target alternative will not
+    // compile until it is handled here.
+    const Device device = std::visit(
+        overloaded{
+            [](const nixlSpdkBlkTarget &blk) {
+                return Device{blk.md->bdev, blk.md->desc, blk.md->channel};
+            },
+            [this](const nixlSpdkObjTarget &) { return Device{kvBdev_, kvDesc_, kvChannel_}; },
+        },
+        io->target);
+
+    // The BLK handles come from the registration and the OBJ handles from this
+    // engine, so neither is guaranteed here: OBJ metadata registered against a
+    // different engine instance reaches this point with the KV device unopened,
+    // and passthru would receive a null descriptor and channel.
+    if (!device.bdev || !device.desc || !device.channel) {
+        NIXL_ERROR << "SPDK: transfer target has no open device";
+        completeOne(req_h, NIXL_ERR_BACKEND);
+        return;
+    }
+
     io->ioWaitQueued = false;
-    io->waitEntry.bdev = io->bdev->bdev;
+    io->waitEntry.bdev = device.bdev;
     io->waitEntry.cb_fn = ioWaitRetry;
     io->waitEntry.cb_arg = io;
 
-    int rc;
-    if (req_h->operation_ == NIXL_READ) {
-        rc = spdk_bdev_read(
-            io->bdev->desc, io->bdev->channel, io->buf, io->offset, io->nbytes, bdevComplete, io);
-    } else {
-        rc = spdk_bdev_write(
-            io->bdev->desc, io->bdev->channel, io->buf, io->offset, io->nbytes, bdevComplete, io);
-    }
+    const int rc = std::visit(
+        overloaded{
+            [&](const nixlSpdkBlkTarget &blk) {
+                return (req_h->operation_ == NIXL_READ) ? spdk_bdev_read(device.desc,
+                                                                         device.channel,
+                                                                         io->buf,
+                                                                         blk.offset,
+                                                                         io->nbytes,
+                                                                         bdevComplete,
+                                                                         io) :
+                                                          spdk_bdev_write(device.desc,
+                                                                          device.channel,
+                                                                          io->buf,
+                                                                          blk.offset,
+                                                                          io->nbytes,
+                                                                          bdevComplete,
+                                                                          io);
+            },
+            [&](const nixlSpdkObjTarget &obj) {
+                // Build a raw NVMe KV command (Store for WRITE, Retrieve for
+                // READ) and forward it via bdev NVMe passthru. The key packs into
+                // cdw2-3 (first 8 bytes) and cdw14-15 (next 8); cdw10.vsize is the
+                // value size and cdw11.kl the key length.
+                const std::span<const std::byte> key = obj.md->key();
+                spdk_nvme_cmd cmd = {};
+                cmd.opc = (req_h->operation_ == NIXL_WRITE) ? SPDK_NVME_OPC_KV_STORE :
+                                                              SPDK_NVME_OPC_KV_RETRIEVE;
+                cmd.cdw10_bits.kv.vsize = static_cast<uint32_t>(io->nbytes);
+                cmd.cdw11_bits.kv.kl = static_cast<uint32_t>(key.size());
+                cmd.cdw11_bits.kv.ro = 0;
+
+                // Assemble the key as four dwords and assign them individually.
+                // Each cdw member is 4 bytes wide, so copying 8 bytes through
+                // cdw2 (or cdw14) would write through one member into the next.
+                std::array<uint32_t, 4> kw{};
+                std::memcpy(
+                    kw.data(), key.data(), std::min(key.size(), kw.size() * sizeof(uint32_t)));
+                cmd.cdw2 = kw[0];
+                cmd.cdw3 = kw[1];
+                cmd.cdw14 = kw[2];
+                cmd.cdw15 = kw[3];
+                return spdk_bdev_nvme_io_passthru(
+                    device.desc, device.channel, &cmd, io->buf, io->nbytes, bdevComplete, io);
+            },
+        },
+        io->target);
 
     if (rc == -ENOMEM) {
-        int wait_rc = spdk_bdev_queue_io_wait(io->bdev->bdev, io->bdev->channel, &io->waitEntry);
+        int wait_rc = spdk_bdev_queue_io_wait(device.bdev, device.channel, &io->waitEntry);
         if (wait_rc == 0) {
             io->ioWaitQueued = true;
+            // Counted as outstanding work: the retry only runs while the poll
+            // loop keeps driving the channel, and without this the loop would
+            // see no in-flight I/O, block on the queue, and never resume.
+            ++ioWaiting_;
             return;
         }
         NIXL_ERROR << "SPDK: spdk_bdev_queue_io_wait failed: " << wait_rc;
@@ -952,6 +1173,7 @@ void
 nixlSpdkProgressEngine::ioWaitRetry(void *cb_arg) {
     auto *io = static_cast<nixlSpdkIoContext *>(cb_arg);
     io->ioWaitQueued = false;
+    --io->engine->ioWaiting_;
     io->engine->submitOne(io);
 }
 
@@ -961,4 +1183,13 @@ nixlSpdkProgressEngine::bdevEventCb(enum spdk_bdev_event_type type,
                                     void *event_ctx) {
     auto *md = static_cast<nixlSpdkBdevMD *>(event_ctx);
     NIXL_WARN << "SPDK: bdev event " << static_cast<int>(type) << " for " << md->bdevName;
+}
+
+void
+nixlSpdkProgressEngine::kvBdevEventCb(enum spdk_bdev_event_type type,
+                                      struct spdk_bdev *,
+                                      void *event_ctx) {
+    auto *engine = static_cast<nixlSpdkProgressEngine *>(event_ctx);
+    NIXL_WARN << "SPDK: bdev event " << static_cast<int>(type) << " for KV bdev "
+              << engine->objBdevName_;
 }

--- a/src/plugins/spdk/spdk_progress_engine.cpp
+++ b/src/plugins/spdk/spdk_progress_engine.cpp
@@ -1,0 +1,964 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "spdk_progress_engine.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <format>
+#include <fstream>
+#include <iterator>
+#include <latch>
+#include <optional>
+#include <ranges>
+#include <string_view>
+#include <utility>
+
+#include "backend/backend_aux.h"
+#include "common/backend.h"
+#include "common/nixl_log.h"
+
+extern "C" {
+#include <spdk/accel.h>
+#include <spdk/env.h>
+#include <spdk/init.h>
+#include <spdk/rpc.h>
+#include <spdk/thread.h>
+}
+
+namespace {
+
+// SPDK's env, thread, accel and bdev subsystems are singletons within this copy
+// of SPDK, so every backend in the process shares one runtime: the first to
+// start brings it up and the last to go away tears it down. Each backend still
+// owns its own SPDK thread, its own I/O channels and its own bdev configuration.
+//
+// SPDK also designates the first thread created as the "app thread" and posts
+// control-plane work to it (the JSON config loader, bdev unregistration). It
+// cannot be reassigned and is only freed by spdk_thread_lib_fini(), so the
+// runtime owns it rather than any one backend: otherwise a second backend's
+// config load would deadlock waiting on the first backend to poll, and the
+// first backend's destruction would strand it for everyone else.
+struct SharedRuntime {
+    std::mutex mutex;
+    // Serializes execution on appThread. Backends acquire it opportunistically
+    // (try_lock) from their poll loops, so no backend can block another.
+    std::mutex appMutex;
+    spdk_thread *appThread = nullptr;
+    std::size_t refs = 0;
+    bool envInitialized = false;
+    bool threadLibInitialized = false;
+    bool iobufInitialized = false;
+    bool accelInitialized = false;
+    bool bdevInitialized = false;
+};
+
+SharedRuntime g_runtime;
+
+struct AsyncResult {
+    bool done = false;
+    int rc = 0;
+};
+
+void
+asyncDone(int rc, void *ctx) {
+    auto *result = static_cast<AsyncResult *>(ctx);
+    result->rc = rc;
+    result->done = true;
+}
+
+void
+bdevInitDone(void *ctx, int rc) {
+    auto *result = static_cast<AsyncResult *>(ctx);
+    result->rc = rc;
+    result->done = true;
+}
+
+void
+bdevFiniDone(void *ctx) {
+    auto *result = static_cast<AsyncResult *>(ctx);
+    result->done = true;
+}
+
+void
+finishDone(void *ctx) {
+    auto *result = static_cast<AsyncResult *>(ctx);
+    result->done = true;
+}
+
+// Bdev names, file paths and transport addresses come from the caller, so a
+// stray quote or backslash would otherwise produce malformed JSON, or let a
+// value inject additional keys into the generated config.
+std::string
+jsonEscape(std::string_view value) {
+    std::string out;
+    out.reserve(value.size());
+    for (const char c : value) {
+        switch (c) {
+        case '"':
+            out += "\\\"";
+            break;
+        case '\\':
+            out += "\\\\";
+            break;
+        case '\n':
+            out += "\\n";
+            break;
+        case '\r':
+            out += "\\r";
+            break;
+        case '\t':
+            out += "\\t";
+            break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20) {
+                out += std::format("\\u{:04x}", static_cast<unsigned>(c));
+            } else {
+                out += c;
+            }
+            break;
+        }
+    }
+    return out;
+}
+
+// Build a single-bdev subsystem config from the convenience parameters
+// (bdev_type + bdev_name + a type-specific source), so callers do not have to
+// hand-write SPDK bdev RPC JSON for the common case. Returns "" when the
+// convenience params are absent or the type is unknown.
+std::string
+buildBdevConfigJson(const nixl_b_params_t *params) {
+    if (!params) {
+        return "";
+    }
+    auto opt = [&](const char *key) -> std::string {
+        auto v = nixl::getBackendParamOptional<std::string>(params, key);
+        return v ? *v : std::string();
+    };
+    const std::string type = opt("bdev_type");
+    const std::string name = opt("bdev_name");
+    if (type.empty() || name.empty()) {
+        return "";
+    }
+
+    // Numeric fields are emitted unquoted, so reject anything that is not a
+    // plain decimal number rather than splicing it into the JSON verbatim.
+    auto number = [&](const char *key, std::string_view fallback) -> std::string {
+        const std::string value = opt(key);
+        if (value.empty()) {
+            return std::string(fallback);
+        }
+        if (!std::ranges::all_of(value, [](unsigned char c) { return std::isdigit(c) != 0; })) {
+            NIXL_ERROR << "SPDK: parameter '" << key << "' must be a decimal number, got '" << value
+                       << "'";
+            return {};
+        }
+        return value;
+    };
+
+    std::string method, body;
+    if (type == "malloc") {
+        const std::string num_blocks = number("bdev_num_blocks", "");
+        const std::string block_size = number("bdev_block_size", "512");
+        if (num_blocks.empty() || block_size.empty()) {
+            return "";
+        }
+        method = "bdev_malloc_create";
+        body = std::format(R"("name": "{}", "num_blocks": {}, "block_size": {})",
+                           jsonEscape(name),
+                           num_blocks,
+                           block_size);
+    } else if (type == "aio") {
+        method = "bdev_aio_create";
+        body = std::format(R"("name": "{}", "filename": "{}")",
+                           jsonEscape(name),
+                           jsonEscape(opt("bdev_filename")));
+        const std::string block_size = number("bdev_block_size", "");
+        if (!block_size.empty()) {
+            body += std::format(R"(, "block_size": {})", block_size);
+        }
+    } else if (type == "nvme") {
+        // Attaching an NVMe controller named <name> exposes namespaces as
+        // <name>n1, <name>n2, ...; that is the name to use in BLK descriptors.
+        method = "bdev_nvme_attach_controller";
+        body = std::format(R"("name": "{}", "trtype": "PCIe", "traddr": "{}")",
+                           jsonEscape(name),
+                           jsonEscape(opt("bdev_traddr")));
+    } else {
+        NIXL_ERROR << "SPDK: unknown bdev_type '" << type << "' (expected malloc, aio, or nvme)";
+        return "";
+    }
+    return std::format(
+        R"({{"subsystems": [{{"subsystem": "bdev", "config": [{{"method": "{}", "params": {{{}}}}}]}}]}})",
+        method,
+        body);
+}
+
+constexpr bool kOpenForWrite = true;
+// spdk_thread_poll() takes a message budget and a timestamp; 0 means "no limit"
+// and "read the current time" respectively.
+constexpr uint32_t kPollAllMessages = 0;
+constexpr uint64_t kPollUseCurrentTime = 0;
+
+// Makes the calling thread impersonate an SPDK thread for a scope. Restoring
+// from a destructor matters: the work run under it allocates, so an exception
+// must not leave the caller permanently impersonating the SPDK thread.
+class SpdkThreadScope {
+public:
+    explicit SpdkThreadScope(spdk_thread *thread) : prev_(spdk_get_thread()) {
+        spdk_set_thread(thread);
+    }
+
+    ~SpdkThreadScope() {
+        spdk_set_thread(prev_);
+    }
+
+    SpdkThreadScope(const SpdkThreadScope &) = delete;
+    SpdkThreadScope &
+    operator=(const SpdkThreadScope &) = delete;
+
+private:
+    spdk_thread *prev_;
+};
+
+// Set while this thread runs inside executeOnAppThread(), i.e. already holds
+// g_runtime.appMutex. std::mutex::try_lock() on a mutex the caller already owns
+// is undefined, so the poll path checks this instead of re-locking.
+thread_local bool t_onAppThread = false;
+
+class AppThreadScope {
+public:
+    AppThreadScope() : lock_(g_runtime.appMutex), scope_(g_runtime.appThread) {
+        t_onAppThread = true;
+    }
+
+    ~AppThreadScope() {
+        t_onAppThread = false;
+    }
+
+    AppThreadScope(const AppThreadScope &) = delete;
+    AppThreadScope &
+    operator=(const AppThreadScope &) = delete;
+
+private:
+    std::scoped_lock<std::mutex> lock_;
+    SpdkThreadScope scope_;
+};
+
+} // namespace
+
+nixlSpdkProgressEngine::nixlSpdkProgressEngine(const nixlBackendInitParams *init_params) {
+    parseParams(init_params);
+
+    if (execMode_ == ExecMode::ProgressThread) {
+        progressThread_ = std::thread(&nixlSpdkProgressEngine::runThread, this);
+        std::unique_lock<std::mutex> lock(queueMutex_);
+        queueCv_.wait(lock, [this]() { return runtimeInitialized_ || initErr_; });
+    } else {
+        const nixl_status_t status = initRuntime();
+        if (status != NIXL_SUCCESS) {
+            initErr_ = true;
+        }
+    }
+}
+
+nixlSpdkProgressEngine::~nixlSpdkProgressEngine() {
+    if (execMode_ == ExecMode::ProgressThread) {
+        {
+            const std::scoped_lock lock(queueMutex_);
+            stopThread_ = true;
+        }
+        queueCv_.notify_one();
+        if (progressThread_.joinable()) {
+            progressThread_.join();
+        }
+    } else {
+        executeLocked([this]() { finiRuntime(); });
+    }
+}
+
+void
+nixlSpdkProgressEngine::parseParams(const nixlBackendInitParams *init_params) {
+    const nixl_b_params_t *params = init_params ? init_params->customParams : nullptr;
+    if (params) {
+        if (auto value = nixl::getBackendParamOptional<std::string>(params, "json_config")) {
+            jsonConfig_ = *value;
+        }
+        if (auto value = nixl::getBackendParamOptional<std::string>(params, "json_config_file")) {
+            jsonConfigFile_ = *value;
+        }
+        if (auto value = nixl::getBackendParamOptional<std::string>(params, "spdk_name")) {
+            name_ = *value;
+        }
+        if (auto value = nixl::getBackendParamOptional<std::string>(params, "core_mask")) {
+            coreMask_ = *value;
+        }
+        if (auto value = nixl::getBackendParamOptional<size_t>(params, "msg_mempool_size")) {
+            msgMempoolSize_ = *value;
+        }
+    }
+    // Fall back to the convenience parameters only when no explicit JSON was
+    // supplied; explicit json_config / json_config_file always take precedence.
+    if (jsonConfig_.empty() && jsonConfigFile_.empty()) {
+        jsonConfig_ = buildBdevConfigJson(params);
+    }
+    threadDelayUs_ = init_params ? init_params->pthrDelay : 0;
+
+    if (init_params && init_params->enableProgTh) {
+        execMode_ = ExecMode::ProgressThread;
+    } else if (init_params && init_params->syncMode == nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE) {
+        execMode_ = ExecMode::CallerSerialized;
+    } else {
+        execMode_ = ExecMode::BackendLocked;
+    }
+}
+
+void
+nixlSpdkProgressEngine::runThread() {
+    const nixl_status_t status = initRuntime();
+    {
+        const std::scoped_lock lock(queueMutex_);
+        initErr_ = status != NIXL_SUCCESS;
+        runtimeInitialized_ = status == NIXL_SUCCESS;
+    }
+    queueCv_.notify_all();
+    if (status != NIXL_SUCCESS) {
+        // initRuntime() already unwound itself; the destructor only joins this
+        // thread.
+        return;
+    }
+
+    while (true) {
+        drainQueue();
+        pollOnce();
+
+        std::unique_lock<std::mutex> lock(queueMutex_);
+        if (stopThread_) {
+            break;
+        }
+        if (!producerQueue_.empty()) {
+            continue;
+        }
+        if (inFlight_ > 0) {
+            // I/O is outstanding: the device may post a completion at any moment,
+            // so keep polling. threadDelayUs_ optionally throttles the poll to
+            // trade completion latency for CPU; 0 means busy-poll.
+            if (threadDelayUs_ > 0) {
+                queueCv_.wait_for(lock, std::chrono::microseconds(threadDelayUs_));
+            }
+        } else {
+            // Nothing queued and nothing in flight, so no completion can arrive.
+            // Block until new work is enqueued instead of spinning a core.
+            queueCv_.wait(lock, [this]() { return !producerQueue_.empty() || stopThread_; });
+        }
+    }
+
+    drainQueue();
+    execute([this]() { finiRuntime(); });
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::initRuntime() {
+    if (jsonConfig_.empty() && jsonConfigFile_.empty()) {
+        NIXL_ERROR << "SPDK: a bdev configuration is required via the 'json_config' "
+                      "(inline JSON) or 'json_config_file' (path) backend parameter";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    // Held across the whole of init so a second backend starting concurrently
+    // cannot observe a half-built runtime. finiRuntimeLocked() is used on the
+    // failure paths below because this thread already owns the lock.
+    std::unique_lock<std::mutex> runtime_lock(g_runtime.mutex);
+
+    // Taken before anything is brought up so that a failure part-way through
+    // leaves this backend as the last reference and finiRuntimeLocked() unwinds
+    // whatever did come up.
+    ++g_runtime.refs;
+    ownsRuntimeRef_ = true;
+
+    if (!g_runtime.envInitialized) {
+        spdk_env_opts env_opts;
+        env_opts.opts_size = sizeof(env_opts);
+        spdk_env_opts_init(&env_opts);
+        env_opts.name = name_.c_str();
+        if (!coreMask_.empty()) {
+            env_opts.core_mask = coreMask_.c_str();
+        }
+        const int rc = spdk_env_init(&env_opts);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: spdk_env_init failed: " << rc;
+            finiRuntimeLocked();
+            return NIXL_ERR_BACKEND;
+        }
+        g_runtime.envInitialized = true;
+    }
+
+    if (!g_runtime.threadLibInitialized) {
+        const int rc = msgMempoolSize_ > 0 ?
+            spdk_thread_lib_init_ext(nullptr, nullptr, 0, msgMempoolSize_) :
+            spdk_thread_lib_init(nullptr, 0);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: spdk_thread_lib_init failed: " << rc;
+            finiRuntimeLocked();
+            return NIXL_ERR_BACKEND;
+        }
+        g_runtime.threadLibInitialized = true;
+    }
+
+    // Created before any backend thread so that SPDK picks it, not a backend's
+    // thread, as the app thread.
+    if (!g_runtime.appThread) {
+        g_runtime.appThread = spdk_thread_create("nixl_spdk_ctrl", nullptr);
+        if (!g_runtime.appThread) {
+            NIXL_ERROR << "SPDK: spdk_thread_create failed for the control thread";
+            finiRuntimeLocked();
+            return NIXL_ERR_BACKEND;
+        }
+    }
+
+    spdkThread_ = spdk_thread_create(name_.c_str(), nullptr);
+    if (!spdkThread_) {
+        NIXL_ERROR << "SPDK: spdk_thread_create failed";
+        finiRuntimeLocked();
+        return NIXL_ERR_BACKEND;
+    }
+
+    // The subsystems below and the config loader both assume they run on the app
+    // thread; g_runtime.mutex is held, so nobody else is driving it.
+    executeOnAppThread([this]() {
+        if (!g_runtime.iobufInitialized) {
+            int iobuf_rc = spdk_iobuf_initialize();
+            if (iobuf_rc != 0) {
+                NIXL_ERROR << "SPDK: spdk_iobuf_initialize failed: " << iobuf_rc;
+                initErr_ = true;
+                return;
+            }
+            g_runtime.iobufInitialized = true;
+        }
+
+        // The bdev layer (and most bdev modules, e.g. malloc) rely on the accel
+        // framework for data-path operations, so it must come up before bdev.
+        if (!g_runtime.accelInitialized) {
+            int accel_rc = spdk_accel_initialize();
+            if (accel_rc != 0) {
+                NIXL_ERROR << "SPDK: spdk_accel_initialize failed: " << accel_rc;
+                initErr_ = true;
+                return;
+            }
+            g_runtime.accelInitialized = true;
+        }
+
+        if (!g_runtime.bdevInitialized) {
+            AsyncResult bdev_init;
+            spdk_bdev_initialize(bdevInitDone, &bdev_init);
+            pollUntil([&bdev_init]() { return bdev_init.done; });
+            if (bdev_init.rc != 0) {
+                NIXL_ERROR << "SPDK: spdk_bdev_initialize failed: " << bdev_init.rc;
+                initErr_ = true;
+                return;
+            }
+            g_runtime.bdevInitialized = true;
+        }
+
+        // Each backend applies its own configuration into the shared bdev
+        // registry, so a second backend must name bdevs the first did not.
+        std::string json;
+        if (!jsonConfig_.empty()) {
+            json = jsonConfig_;
+        } else {
+            std::ifstream json_file(jsonConfigFile_, std::ios::binary);
+            if (!json_file) {
+                NIXL_ERROR << "SPDK: failed to open JSON config file " << jsonConfigFile_;
+                initErr_ = true;
+                return;
+            }
+            json.assign((std::istreambuf_iterator<char>(json_file)),
+                        std::istreambuf_iterator<char>());
+        }
+        // load_config (initialize_subsystems=false) applies the JSON in a single
+        // pass at the current RPC state, running a method only when that state is
+        // a subset of the method's registration mask. bdev_*_create are
+        // RUNTIME-only, so the state must be exactly RUNTIME (not STARTUP|RUNTIME,
+        // which would exclude them).
+        spdk_rpc_set_state(SPDK_RPC_RUNTIME);
+        AsyncResult config_load;
+        spdk_subsystem_load_config(
+            json.data(), static_cast<ssize_t>(json.size()), asyncDone, &config_load, true);
+        pollUntil([&config_load]() { return config_load.done; });
+        if (config_load.rc != 0) {
+            NIXL_ERROR << "SPDK: failed to load JSON config: " << config_load.rc;
+            initErr_ = true;
+        }
+    });
+
+    if (initErr_) {
+        finiRuntimeLocked();
+        return NIXL_ERR_BACKEND;
+    }
+    runtimeInitialized_ = true;
+    return NIXL_SUCCESS;
+}
+
+void
+nixlSpdkProgressEngine::finiRuntime() {
+    const std::scoped_lock lock(g_runtime.mutex);
+    finiRuntimeLocked();
+}
+
+void
+nixlSpdkProgressEngine::finiRuntimeLocked() {
+    // The shared subsystems come down only with the last backend holding a
+    // reference; everything else here is this backend's own state.
+    const bool last = ownsRuntimeRef_ && g_runtime.refs == 1;
+
+    if (last) {
+        executeOnAppThread([this]() {
+            if (g_runtime.bdevInitialized) {
+                AsyncResult finish;
+                spdk_bdev_finish(bdevFiniDone, &finish);
+                pollUntil([&finish]() { return finish.done; });
+                g_runtime.bdevInitialized = false;
+            }
+            if (g_runtime.accelInitialized) {
+                AsyncResult finish;
+                spdk_accel_finish(finishDone, &finish);
+                pollUntil([&finish]() { return finish.done; });
+                g_runtime.accelInitialized = false;
+            }
+            if (g_runtime.iobufInitialized) {
+                AsyncResult finish;
+                spdk_iobuf_finish(finishDone, &finish);
+                pollUntil([&finish]() { return finish.done; });
+                g_runtime.iobufInitialized = false;
+            }
+        });
+    }
+
+    if (spdkThread_) {
+        execute([this]() {
+            spdk_thread_exit(spdkThread_);
+            pollUntil([this]() { return spdk_thread_is_exited(spdkThread_); });
+        });
+        spdk_thread_destroy(spdkThread_);
+        spdkThread_ = nullptr;
+    }
+
+    // spdk_thread_lib_fini() requires every SPDK thread to be gone, so the app
+    // thread goes away only once this backend has destroyed its own.
+    if (last) {
+        if (g_runtime.appThread) {
+            executeOnAppThread([this]() {
+                spdk_thread_exit(g_runtime.appThread);
+                pollUntil([]() { return spdk_thread_is_exited(g_runtime.appThread); });
+            });
+            spdk_thread_destroy(g_runtime.appThread);
+            g_runtime.appThread = nullptr;
+        }
+        if (g_runtime.threadLibInitialized) {
+            spdk_thread_lib_fini();
+            g_runtime.threadLibInitialized = false;
+        }
+        if (g_runtime.envInitialized) {
+            spdk_env_fini();
+            g_runtime.envInitialized = false;
+        }
+    }
+
+    if (ownsRuntimeRef_) {
+        --g_runtime.refs;
+        ownsRuntimeRef_ = false;
+    }
+}
+
+void
+nixlSpdkProgressEngine::pollOnce() {
+    if (spdkThread_) {
+        spdk_thread_poll(spdkThread_, kPollAllMessages, kPollUseCurrentTime);
+    }
+    pollAppThread();
+}
+
+// The app thread has no dedicated poller: whichever backend is running drives
+// it. try_lock rather than lock so that a backend with nothing to do for the app
+// thread never stalls behind one that is holding it.
+void
+nixlSpdkProgressEngine::pollAppThread() {
+    if (!g_runtime.appThread) {
+        return;
+    }
+    if (t_onAppThread) {
+        spdk_thread_poll(g_runtime.appThread, kPollAllMessages, kPollUseCurrentTime);
+        return;
+    }
+    std::unique_lock<std::mutex> lock(g_runtime.appMutex, std::try_to_lock);
+    if (lock.owns_lock()) {
+        spdk_thread_poll(g_runtime.appThread, kPollAllMessages, kPollUseCurrentTime);
+    }
+}
+
+// Defined here rather than in the header: these are private and every call site
+// is in this file, so a stray call from another TU fails to link.
+template<std::predicate F>
+void
+nixlSpdkProgressEngine::pollUntil(F &&done) {
+    while (!done()) {
+        pollOnce();
+    }
+}
+
+template<std::invocable F>
+std::invoke_result_t<F>
+nixlSpdkProgressEngine::execute(F &&fn) {
+    const SpdkThreadScope scope(spdkThread_);
+    return fn();
+}
+
+template<std::invocable F>
+std::invoke_result_t<F>
+nixlSpdkProgressEngine::executeOnAppThread(F &&fn) {
+    const AppThreadScope scope;
+    return fn();
+}
+
+template<std::invocable F>
+std::invoke_result_t<F>
+nixlSpdkProgressEngine::executeLocked(F &&fn) {
+    if (execMode_ == ExecMode::BackendLocked) {
+        const std::scoped_lock lock(execMutex_);
+        return execute(std::forward<F>(fn));
+    }
+    return execute(std::forward<F>(fn));
+}
+
+template<std::invocable F>
+std::invoke_result_t<F>
+nixlSpdkProgressEngine::executeSync(F &&fn) {
+    using Result = std::invoke_result_t<F>;
+
+    if (execMode_ != ExecMode::ProgressThread) {
+        return executeLocked(std::forward<F>(fn));
+    }
+
+    // Hand the work to the progress thread and block until it retires. The
+    // latch is released from a destructor so an exception escaping fn() cannot
+    // strand this thread waiting forever.
+    // The captured locals outlive these lambdas only because this thread blocks
+    // on the latch until the work has retired.
+    std::latch done{1};
+
+    struct Signal {
+        std::latch &latch;
+
+        ~Signal() {
+            latch.count_down();
+        }
+    };
+
+    if constexpr (std::is_void_v<Result>) {
+        enqueueAsync([&fn, &done]() {
+            const Signal signal{done};
+            fn();
+        });
+        done.wait();
+    } else {
+        std::optional<Result> result;
+        enqueueAsync([&fn, &done, &result]() {
+            const Signal signal{done};
+            result.emplace(fn());
+        });
+        done.wait();
+        return std::move(*result);
+    }
+}
+
+void
+nixlSpdkProgressEngine::enqueueAsync(std::function<void()> fn) {
+    {
+        const std::scoped_lock lock(queueMutex_);
+        producerQueue_.push_back(std::move(fn));
+    }
+    queueCv_.notify_one();
+}
+
+void
+nixlSpdkProgressEngine::drainQueue() {
+    {
+        const std::scoped_lock lock(queueMutex_);
+        consumerQueue_.swap(producerQueue_);
+    }
+    if (consumerQueue_.empty()) {
+        return;
+    }
+    execute([this]() {
+        for (auto &fn : consumerQueue_) {
+            fn();
+        }
+    });
+    consumerQueue_.clear();
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::registerDram(nixlSpdkDramMD &md) {
+    return executeSync([&]() {
+        // We map the DRAM directly for zero-copy DMA and intentionally do not
+        // fall back to bounce buffers, so reject memory that cannot be
+        // registered. spdk_mem_register requires page-aligned (4 KiB) address
+        // and length on current SPDK.
+        const int rc = spdk_mem_register(reinterpret_cast<void *>(md.addr), md.len);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: spdk_mem_register failed (" << rc
+                       << "); DRAM registered with the SPDK backend must be page-aligned "
+                          "(4 KiB) in address and length";
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    });
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::deregisterDram(nixlSpdkDramMD &md) {
+    return executeSync([&]() {
+        const int rc = spdk_mem_unregister(reinterpret_cast<void *>(md.addr), md.len);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: spdk_mem_unregister failed: " << rc;
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    });
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::openBdev(nixlSpdkBdevMD &md) {
+    return executeSync([&]() {
+        const int rc =
+            spdk_bdev_open_ext(md.bdevName.c_str(), kOpenForWrite, bdevEventCb, &md, &md.desc);
+        if (rc != 0) {
+            NIXL_ERROR << "SPDK: failed to open bdev " << md.bdevName << ": " << rc;
+            return NIXL_ERR_NOT_FOUND;
+        }
+        md.bdev = spdk_bdev_desc_get_bdev(md.desc);
+        md.channel = spdk_bdev_get_io_channel(md.desc);
+        if (!md.channel) {
+            NIXL_ERROR << "SPDK: failed to get I/O channel for bdev " << md.bdevName;
+            spdk_bdev_close(md.desc);
+            md.desc = nullptr;
+            md.bdev = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        if (!spdk_bdev_io_type_supported(md.bdev, SPDK_BDEV_IO_TYPE_READ) ||
+            !spdk_bdev_io_type_supported(md.bdev, SPDK_BDEV_IO_TYPE_WRITE)) {
+            NIXL_ERROR << "SPDK: bdev " << md.bdevName << " does not support read/write";
+            spdk_put_io_channel(md.channel);
+            spdk_bdev_close(md.desc);
+            md.channel = nullptr;
+            md.desc = nullptr;
+            md.bdev = nullptr;
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+        md.blockSize = spdk_bdev_get_block_size(md.bdev);
+        md.writeUnitSize = spdk_bdev_get_write_unit_size(md.bdev);
+        md.numBlocks = spdk_bdev_get_num_blocks(md.bdev);
+        return NIXL_SUCCESS;
+    });
+}
+
+void
+nixlSpdkProgressEngine::closeBdev(nixlSpdkBdevMD &md) {
+    executeSync([&]() {
+        if (md.channel) {
+            spdk_put_io_channel(md.channel);
+            md.channel = nullptr;
+        }
+        if (md.desc) {
+            spdk_bdev_close(md.desc);
+            md.desc = nullptr;
+            md.bdev = nullptr;
+        }
+    });
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::postXfer(nixlSpdkBackendReqH *req_h) {
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    // Reset completion state so a previously completed handle can be reposted,
+    // then mark it submitted before handing it to the execution context. Both
+    // happen on the caller thread, ahead of any progress-thread activity, so
+    // cancelRequest() (also caller thread) sees a stable kSubmitted bit.
+    req_h->reset();
+    req_h->lifeState_.fetch_or(nixlSpdkBackendReqH::kSubmitted, std::memory_order_acq_rel);
+    if (execMode_ == ExecMode::ProgressThread) {
+        enqueueAsync([this, req_h]() { submitRequest(req_h); });
+    } else {
+        executeLocked([this, req_h]() {
+            submitRequest(req_h);
+            pollOnce();
+        });
+    }
+    return NIXL_IN_PROG;
+}
+
+nixl_status_t
+nixlSpdkProgressEngine::checkXfer(nixlSpdkBackendReqH *req_h) {
+    if (!req_h) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (execMode_ != ExecMode::ProgressThread &&
+        (req_h->lifeState_.load(std::memory_order_acquire) & nixlSpdkBackendReqH::kDone) == 0) {
+        executeLocked([this]() { pollOnce(); });
+    }
+    return req_h->status();
+}
+
+void
+nixlSpdkProgressEngine::cancelRequest(nixlSpdkBackendReqH *req_h) {
+    if (!req_h) {
+        return;
+    }
+    // SPDK cannot un-submit an I/O that has already reached the device, so we do
+    // not attempt a hard abort. Instead the handle is kept alive until its
+    // outstanding I/O actually completes (retireRequest frees it then); the
+    // caller must keep the registered DRAM buffer valid until completion.
+    req_h->cancelled_.store(true, std::memory_order_release);
+    const uint32_t prev =
+        req_h->lifeState_.fetch_or(nixlSpdkBackendReqH::kReleased, std::memory_order_acq_rel);
+    if (prev & nixlSpdkBackendReqH::kDone) {
+        // Completion path already retired it; we are the last owner.
+        delete req_h;
+        return;
+    }
+    if (!(prev & nixlSpdkBackendReqH::kSubmitted)) {
+        // Prepared but never posted: no completion will ever arrive for it.
+        delete req_h;
+    }
+    // Otherwise I/O is in flight; retireRequest() frees it on completion.
+}
+
+void
+nixlSpdkProgressEngine::submitRequest(nixlSpdkBackendReqH *req_h) {
+    if (req_h->lifeState_.load(std::memory_order_acquire) & nixlSpdkBackendReqH::kReleased) {
+        // Released before we reached the execution context; nothing is in
+        // flight, so retire (and free) it here instead of submitting.
+        retireRequest(req_h);
+        return;
+    }
+    // outstanding_ carries a submission guard (see reset()), so a synchronous
+    // completion from submitOne() cannot drop the count to zero while we are
+    // still iterating req_h->ios_. We release the guard once submission is done.
+    const size_t count = req_h->ios_.size();
+    for (size_t i = 0; i < count; ++i) {
+        submitOne(&req_h->ios_[i]);
+    }
+    if (req_h->outstanding_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        retireRequest(req_h);
+    }
+}
+
+void
+nixlSpdkProgressEngine::submitOne(nixlSpdkIoContext *io) {
+    auto *req_h = io->reqH;
+    io->engine = this;
+    if (req_h->cancelled_.load(std::memory_order_acquire)) {
+        completeOne(req_h, NIXL_ERR_NOT_ALLOWED);
+        return;
+    }
+
+    io->ioWaitQueued = false;
+    io->waitEntry.bdev = io->bdev->bdev;
+    io->waitEntry.cb_fn = ioWaitRetry;
+    io->waitEntry.cb_arg = io;
+
+    int rc;
+    if (req_h->operation_ == NIXL_READ) {
+        rc = spdk_bdev_read(
+            io->bdev->desc, io->bdev->channel, io->buf, io->offset, io->nbytes, bdevComplete, io);
+    } else {
+        rc = spdk_bdev_write(
+            io->bdev->desc, io->bdev->channel, io->buf, io->offset, io->nbytes, bdevComplete, io);
+    }
+
+    if (rc == -ENOMEM) {
+        int wait_rc = spdk_bdev_queue_io_wait(io->bdev->bdev, io->bdev->channel, &io->waitEntry);
+        if (wait_rc == 0) {
+            io->ioWaitQueued = true;
+            return;
+        }
+        NIXL_ERROR << "SPDK: spdk_bdev_queue_io_wait failed: " << wait_rc;
+        completeOne(req_h, NIXL_ERR_BACKEND);
+        return;
+    }
+    if (rc != 0) {
+        NIXL_ERROR << "SPDK: bdev I/O submit failed: " << rc;
+        completeOne(req_h, rc == -EINVAL ? NIXL_ERR_INVALID_PARAM : NIXL_ERR_BACKEND);
+        return;
+    }
+    // The I/O is now in flight on the device; bdevComplete will decrement this
+    // when it retires. The progress thread polls hard while inFlight_ > 0 rather
+    // than sleeping (a poll that returns no work does not mean the device is
+    // idle - it may just not have posted the completion yet). Only the progress
+    // thread touches inFlight_ (submit and completion both run on it), so it
+    // needs no atomicity.
+    ++inFlight_;
+}
+
+void
+nixlSpdkProgressEngine::completeOne(nixlSpdkBackendReqH *req_h, nixl_status_t status) {
+    if (status != NIXL_SUCCESS) {
+        nixl_status_t expected = NIXL_IN_PROG;
+        req_h->overallStatus_.compare_exchange_strong(expected, status, std::memory_order_acq_rel);
+    }
+
+    // fetch_sub returns the value before the decrement; reaching 1 means this
+    // call took the count to zero, i.e. the last I/O retired the request.
+    if (req_h->outstanding_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        retireRequest(req_h);
+    }
+}
+
+void
+nixlSpdkProgressEngine::retireRequest(nixlSpdkBackendReqH *req_h) {
+    nixl_status_t expected = NIXL_IN_PROG;
+    req_h->overallStatus_.compare_exchange_strong(
+        expected, NIXL_SUCCESS, std::memory_order_acq_rel);
+
+    // Mark completion and elect the single deleter: whichever of this path and
+    // cancelRequest() sees the other's bit already set frees the handle.
+    const uint32_t prev =
+        req_h->lifeState_.fetch_or(nixlSpdkBackendReqH::kDone, std::memory_order_acq_rel);
+    if (prev & nixlSpdkBackendReqH::kReleased) {
+        delete req_h;
+    }
+}
+
+void
+nixlSpdkProgressEngine::bdevComplete(spdk_bdev_io *bdev_io, bool success, void *cb_arg) {
+    auto *io = static_cast<nixlSpdkIoContext *>(cb_arg);
+    // Capture the engine before completeOne(), which may free the request (and
+    // hence io) when this is the last outstanding I/O.
+    auto *engine = io->engine;
+    auto *engine_req = io->reqH;
+    spdk_bdev_free_io(bdev_io);
+    --engine->inFlight_;
+    engine->completeOne(engine_req, success ? NIXL_SUCCESS : NIXL_ERR_BACKEND);
+}
+
+void
+nixlSpdkProgressEngine::ioWaitRetry(void *cb_arg) {
+    auto *io = static_cast<nixlSpdkIoContext *>(cb_arg);
+    io->ioWaitQueued = false;
+    io->engine->submitOne(io);
+}
+
+void
+nixlSpdkProgressEngine::bdevEventCb(enum spdk_bdev_event_type type,
+                                    struct spdk_bdev *,
+                                    void *event_ctx) {
+    auto *md = static_cast<nixlSpdkBdevMD *>(event_ctx);
+    NIXL_WARN << "SPDK: bdev event " << static_cast<int>(type) << " for " << md->bdevName;
+}

--- a/src/plugins/spdk/spdk_progress_engine.h
+++ b/src/plugins/spdk/spdk_progress_engine.h
@@ -54,6 +54,10 @@ public:
     openBdev(nixlSpdkBdevMD &md);
     void
     closeBdev(nixlSpdkBdevMD &md);
+    // Open and validate the shared KV device on first use: it must support NVMe
+    // passthru and identify as the KV command set.
+    [[nodiscard]] nixl_status_t
+    ensureKvBdev();
 
     [[nodiscard]] nixl_status_t
     postXfer(nixlSpdkBackendReqH *req_h);
@@ -125,13 +129,27 @@ private:
     bdevComplete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
     static void
     ioWaitRetry(void *cb_arg);
+    // One callback per context type. A single callback cannot serve both: the
+    // registration-owned bdevs pass a nixlSpdkBdevMD and the shared KV device
+    // passes the engine, and the callback has no way to tell them apart.
     static void
     bdevEventCb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *event_ctx);
+    static void
+    kvBdevEventCb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *event_ctx);
+    // Release the channel and descriptor of an open bdev and clear the handles.
+    static void
+    releaseBdevHandles(spdk_bdev_desc *&desc, spdk_bdev *&bdev, spdk_io_channel *&channel);
 
     std::string name_ = "nixl_spdk";
     std::string jsonConfig_;
     std::string jsonConfigFile_;
     std::string coreMask_;
+    // Shared by every OBJ_SEG registration; closed at finalization.
+    std::string objBdevName_;
+    spdk_bdev_desc *kvDesc_ = nullptr;
+    spdk_bdev *kvBdev_ = nullptr;
+    spdk_io_channel *kvChannel_ = nullptr;
+    bool kvOpened_ = false;
     std::size_t msgMempoolSize_ = 0;
     std::atomic<bool> initErr_{false};
     // Whether this backend holds a reference on the process-wide SPDK runtime.
@@ -145,6 +163,10 @@ private:
     // it needs no synchronization. The progress loop polls while it is non-zero
     // and blocks when it (and the work queue) are empty.
     std::size_t inFlight_ = 0;
+    // Count of I/Os parked on a bdev io_wait queue after -ENOMEM. They are not
+    // yet on the device, so inFlight_ does not cover them, but the poll loop
+    // must keep running: nothing else will drive the retry callback.
+    std::size_t ioWaiting_ = 0;
     spdk_thread *spdkThread_ = nullptr;
     std::thread progressThread_;
     mutable std::mutex execMutex_;

--- a/src/plugins/spdk/spdk_progress_engine.h
+++ b/src/plugins/spdk/spdk_progress_engine.h
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_PLUGINS_SPDK_SPDK_PROGRESS_ENGINE_H
+#define NIXL_SRC_PLUGINS_SPDK_SPDK_PROGRESS_ENGINE_H
+
+#include <atomic>
+#include <concepts>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include "nixl_params.h"
+#include "nixl_types.h"
+#include "spdk_backend.h"
+
+extern "C" {
+#include <spdk/bdev.h>
+}
+
+struct spdk_thread;
+
+class nixlBackendInitParams;
+
+class nixlSpdkProgressEngine {
+public:
+    explicit nixlSpdkProgressEngine(const nixlBackendInitParams *init_params);
+    ~nixlSpdkProgressEngine();
+
+    // Owns the SPDK runtime slot, the progress thread and the SPDK thread; the
+    // queued work captures 'this', so the engine must stay put.
+    nixlSpdkProgressEngine(const nixlSpdkProgressEngine &) = delete;
+    nixlSpdkProgressEngine &
+    operator=(const nixlSpdkProgressEngine &) = delete;
+
+    [[nodiscard]] bool
+    hasInitError() const noexcept {
+        return initErr_.load(std::memory_order_acquire);
+    }
+
+    [[nodiscard]] nixl_status_t
+    registerDram(nixlSpdkDramMD &md);
+    [[nodiscard]] nixl_status_t
+    deregisterDram(nixlSpdkDramMD &md);
+    [[nodiscard]] nixl_status_t
+    openBdev(nixlSpdkBdevMD &md);
+    void
+    closeBdev(nixlSpdkBdevMD &md);
+
+    [[nodiscard]] nixl_status_t
+    postXfer(nixlSpdkBackendReqH *req_h);
+    [[nodiscard]] nixl_status_t
+    checkXfer(nixlSpdkBackendReqH *req_h);
+    void
+    cancelRequest(nixlSpdkBackendReqH *req_h);
+
+private:
+    enum class ExecMode {
+        CallerSerialized,
+        BackendLocked,
+        ProgressThread,
+    };
+
+    void
+    parseParams(const nixlBackendInitParams *init_params);
+    void
+    runThread();
+    [[nodiscard]] nixl_status_t
+    initRuntime();
+    void
+    finiRuntime();
+    // As finiRuntime(), for callers that already hold the shared-runtime lock.
+    void
+    finiRuntimeLocked();
+    void
+    pollOnce();
+    // Drive the runtime's shared app thread, if this backend can claim it.
+    void
+    pollAppThread();
+    template<std::predicate F>
+    void
+    pollUntil(F &&done);
+    // Run fn in the SPDK thread context and return its result.
+    template<std::invocable F>
+    std::invoke_result_t<F>
+    execute(F &&fn);
+    // Run fn on the runtime's shared app thread, serialized against the other
+    // backends in the process.
+    template<std::invocable F>
+    std::invoke_result_t<F>
+    executeOnAppThread(F &&fn);
+    // As execute(), additionally serialized against other callers when the
+    // backend owns the locking (see ExecMode).
+    template<std::invocable F>
+    std::invoke_result_t<F>
+    executeLocked(F &&fn);
+    // Run fn in the SPDK execution context and wait for its result: handed to
+    // the progress thread when there is one, otherwise run inline under the
+    // backend lock.
+    template<std::invocable F>
+    std::invoke_result_t<F>
+    executeSync(F &&fn);
+    // Stores the callable for later consumption on the progress thread.
+    void
+    enqueueAsync(std::function<void()> fn);
+    void
+    drainQueue();
+    void
+    submitRequest(nixlSpdkBackendReqH *req_h);
+    void
+    submitOne(nixlSpdkIoContext *io);
+    void
+    completeOne(nixlSpdkBackendReqH *req_h, nixl_status_t status);
+    void
+    retireRequest(nixlSpdkBackendReqH *req_h);
+    static void
+    bdevComplete(struct spdk_bdev_io *bdev_io, bool success, void *cb_arg);
+    static void
+    ioWaitRetry(void *cb_arg);
+    static void
+    bdevEventCb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev, void *event_ctx);
+
+    std::string name_ = "nixl_spdk";
+    std::string jsonConfig_;
+    std::string jsonConfigFile_;
+    std::string coreMask_;
+    std::size_t msgMempoolSize_ = 0;
+    std::atomic<bool> initErr_{false};
+    // Whether this backend holds a reference on the process-wide SPDK runtime.
+    bool ownsRuntimeRef_ = false;
+    bool runtimeInitialized_ = false;
+    bool stopThread_ = false;
+    ExecMode execMode_ = ExecMode::BackendLocked;
+    uint64_t threadDelayUs_ = 0;
+    // Count of bdev I/Os submitted to the device and not yet retired. Only the
+    // progress thread reads/writes it (submit and completion both run there), so
+    // it needs no synchronization. The progress loop polls while it is non-zero
+    // and blocks when it (and the work queue) are empty.
+    std::size_t inFlight_ = 0;
+    spdk_thread *spdkThread_ = nullptr;
+    std::thread progressThread_;
+    mutable std::mutex execMutex_;
+    std::mutex queueMutex_;
+    std::condition_variable queueCv_;
+    std::vector<std::function<void()>> producerQueue_;
+    std::vector<std::function<void()>> consumerQueue_;
+};
+
+#endif

--- a/test/unit/plugins/meson.build
+++ b/test/unit/plugins/meson.build
@@ -25,6 +25,12 @@ if enabled_plugins.get('POSIX')
     subdir('posix')
 endif
 
+# Mirrors the gate in src/plugins/meson.build: without the SPDK dependencies the
+# plugin is skipped, so the variables these tests link against do not exist.
+if enabled_plugins.get('SPDK') and spdk_dep_found
+    subdir('spdk')
+endif
+
 if enabled_plugins.get('GPUNETIO')
     if (not cuda_dep.found() or not doca_gpunetio_dep.found()) and is_explicit_enable
         if not cuda_dep.found()

--- a/test/unit/plugins/spdk/meson.build
+++ b/test/unit/plugins/spdk/meson.build
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# When the plugin is baked into libnixl (static_plugins), it (and the SPDK
+# closure) is already inside nixl_dep; linking spdk_backend_interface as well
+# would whole-archive a second copy into the test and duplicate SPDK's global
+# state. So depend on the plugin interface only in the dynamic-plugin build.
+spdk_test_deps = [nixl_dep, nixl_infra]
+if 'SPDK' not in static_plugins
+    spdk_test_deps += spdk_backend_interface
+endif
+
+nixl_spdk_test = executable(
+    'nixl_spdk_test',
+    'nixl_spdk_test.cpp',
+    dependencies: spdk_test_deps,
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    link_args: ['-L' + spdk_library_path,
+                '-Wl,-rpath,' + spdk_library_path,
+                '-Wl,-rpath-link,' + spdk_library_path],
+    install: true)
+
+test('spdk_plugin_test',
+     nixl_spdk_test,
+     env: {'LD_LIBRARY_PATH': spdk_library_path})
+
+nixl_spdk_runtime_test = executable(
+    'nixl_spdk_runtime_test',
+    'nixl_spdk_runtime_test.cpp',
+    dependencies: spdk_test_deps,
+    include_directories: [nixl_inc_dirs, utils_inc_dirs],
+    link_args: ['-L' + spdk_library_path,
+                '-Wl,-rpath,' + spdk_library_path,
+                '-Wl,-rpath-link,' + spdk_library_path],
+    install: true)
+
+test('spdk_plugin_runtime_test',
+     nixl_spdk_runtime_test,
+     env: {'LD_LIBRARY_PATH': spdk_library_path},
+     timeout: 120)

--- a/test/unit/plugins/spdk/nixl_spdk_runtime_test.cpp
+++ b/test/unit/plugins/spdk/nixl_spdk_runtime_test.cpp
@@ -86,8 +86,11 @@ makeParams(const nixl_b_params_t &base, const char *bdevName, const char *spdkNa
     params["bdev_block_size"] = std::to_string(kBlockSize);
     params["spdk_name"] = spdkName;
     // The default SPDK message mempool (256K entries) is far more than this test
-    // needs; a few thousand entries keeps the footprint small.
-    params["msg_mempool_size"] = "4095";
+    // needs; a few thousand entries keeps the footprint small. Only a default:
+    // an explicit value in base (from NIXL_SPDK_TEST_MSG_MEMPOOL_SIZE) wins.
+    if (!params.count("msg_mempool_size")) {
+        params["msg_mempool_size"] = "4095";
+    }
     return params;
 }
 
@@ -184,6 +187,18 @@ runTest(nixlAgent &agent, nixlBackendH *backend, void *dram, size_t dramLen) {
     CHECK_OK(runToCompletion(agent, freq), "final read transfer");
     CHECK_OK(agent.releaseXferReq(freq), "release final read req");
     std::printf("  phase 4 (post-cancel health check): OK\n");
+
+    // --- Phase 5: OBJ_SEG capability detection ---
+    // OBJ_SEG registers one object (key via metaInfo) and only works on a device
+    // that supports NVMe passthru and identifies as the KV command set. The
+    // malloc bdev is neither, so registration must fail cleanly (no crash). A
+    // real KV round trip needs a KV-capable device, which this in-memory
+    // environment lacks.
+    nixl_reg_dlist_t objReg(OBJ_SEG);
+    objReg.addDesc(nixlBlobDesc(0, kIoSize, kDevId, "nixl-kv-key"));
+    nixl_status_t objStatus = agent.registerMem(objReg, &backendParams);
+    CHECK(objStatus != NIXL_SUCCESS, "OBJ_SEG registration on a non-KV device must be rejected");
+    std::printf("  phase 5 (OBJ_SEG rejects non-KV device): OK (status=%d)\n", objStatus);
 
     CHECK_OK(agent.deregisterMem(dramReg, &backendParams), "deregister DRAM");
     CHECK_OK(agent.deregisterMem(bdevReg, &backendParams), "deregister bdev");

--- a/test/unit/plugins/spdk/nixl_spdk_runtime_test.cpp
+++ b/test/unit/plugins/spdk/nixl_spdk_runtime_test.cpp
@@ -1,0 +1,336 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Runtime test for the SPDK plugin. It spins up a private SPDK runtime over an
+// in-memory malloc bdev (no hugepages / no PCI, so it can run unprivileged) and
+// drives real I/O through the public NIXL API to exercise the request-handle
+// lifetime logic: a write/read round trip, a repost of a completed handle, a
+// burst of release-while-in-flight cancellations, and a second backend sharing
+// the process-wide SPDK runtime with the first.
+//
+// If the SPDK environment cannot be brought up (e.g. a CI box with no usable
+// memory backing), the test prints SKIP and exits 0 rather than failing.
+
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <unistd.h>
+
+#include "nixl.h"
+
+namespace {
+
+constexpr const char *kAgentName = "spdk-runtime-test";
+constexpr const char *kBdevName = "Malloc0";
+constexpr uint32_t kBlockSize = 512;
+constexpr uint64_t kNumBlocks = 8192; // 4 MiB malloc bdev
+constexpr uint64_t kBdevBytes = kBlockSize * kNumBlocks;
+constexpr uint64_t kDevId = 1; // user-chosen handle tying DRAM <-> bdev
+constexpr size_t kIoSize = 64 * 1024; // 128 blocks
+constexpr uint64_t kBdevOffset = 1 << 20; // write at 1 MiB into the bdev
+
+#define CHECK(cond, msg)                                                       \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, msg); \
+            return -__LINE__;                                                  \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_OK(status, msg) CHECK((status) == NIXL_SUCCESS, msg)
+
+void
+fillPattern(void *buf, size_t len, uint8_t seed) {
+    auto *p = static_cast<uint8_t *>(buf);
+    for (size_t i = 0; i < len; ++i) {
+        p[i] = static_cast<uint8_t>((i * 31 + seed) & 0xff);
+    }
+}
+
+bool
+verifyPattern(const void *buf, size_t len, uint8_t seed) {
+    const auto *p = static_cast<const uint8_t *>(buf);
+    for (size_t i = 0; i < len; ++i) {
+        if (p[i] != static_cast<uint8_t>((i * 31 + seed) & 0xff)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// Drive a single transfer to completion via the busy-poll status loop.
+nixl_status_t
+runToCompletion(nixlAgent &agent, nixlXferReqH *req) {
+    nixl_status_t status = agent.postXferReq(req);
+    if (status != NIXL_IN_PROG && status != NIXL_SUCCESS) {
+        return status;
+    }
+    do {
+        status = agent.getXferStatus(req);
+    } while (status == NIXL_IN_PROG);
+    return status;
+}
+
+nixl_b_params_t
+makeParams(const nixl_b_params_t &base, const char *bdevName, const char *spdkName) {
+    nixl_b_params_t params = base;
+    params["bdev_type"] = "malloc";
+    params["bdev_name"] = bdevName;
+    params["bdev_num_blocks"] = std::to_string(kNumBlocks);
+    params["bdev_block_size"] = std::to_string(kBlockSize);
+    params["spdk_name"] = spdkName;
+    // The default SPDK message mempool (256K entries) is far more than this test
+    // needs; a few thousand entries keeps the footprint small.
+    params["msg_mempool_size"] = "4095";
+    return params;
+}
+
+int
+runTest(nixlAgent &agent, nixlBackendH *backend, void *dram, size_t dramLen) {
+    nixl_opt_args_t backendParams;
+    backendParams.backends.push_back(backend);
+
+    // Register the DRAM staging buffer and the bdev (by name, via metaInfo).
+    nixl_reg_dlist_t dramReg(DRAM_SEG);
+    dramReg.addDesc(nixlBlobDesc(reinterpret_cast<uintptr_t>(dram), dramLen, kDevId));
+    CHECK_OK(agent.registerMem(dramReg, &backendParams), "register DRAM");
+
+    nixl_reg_dlist_t bdevReg(BLK_SEG);
+    bdevReg.addDesc(nixlBlobDesc(0, kBdevBytes, kDevId, kBdevName));
+    CHECK_OK(agent.registerMem(bdevReg, &backendParams), "register bdev");
+
+    // --- Phase 1: write / read / verify round trip ---
+    fillPattern(dram, kIoSize, 0xa5);
+
+    nixl_xfer_dlist_t wsrc(DRAM_SEG), wdst(BLK_SEG);
+    wsrc.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(dram), kIoSize, kDevId));
+    wdst.addDesc(nixlBasicDesc(kBdevOffset, kIoSize, kDevId));
+
+    nixlXferReqH *wreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_WRITE, wsrc, wdst, kAgentName, wreq, &backendParams),
+             "create write req");
+    CHECK_OK(runToCompletion(agent, wreq), "write transfer");
+    CHECK_OK(agent.releaseXferReq(wreq), "release write req");
+
+    std::memset(dram, 0, kIoSize);
+
+    nixl_xfer_dlist_t rsrc(DRAM_SEG), rdst(BLK_SEG);
+    rsrc.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(dram), kIoSize, kDevId));
+    rdst.addDesc(nixlBasicDesc(kBdevOffset, kIoSize, kDevId));
+
+    nixlXferReqH *rreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_READ, rsrc, rdst, kAgentName, rreq, &backendParams),
+             "create read req");
+    CHECK_OK(runToCompletion(agent, rreq), "read transfer");
+    CHECK_OK(agent.releaseXferReq(rreq), "release read req");
+    CHECK(verifyPattern(dram, kIoSize, 0xa5), "round-trip data mismatch");
+    std::printf("  phase 1 (write/read/verify): OK\n");
+
+    // --- Phase 2: repost a completed handle ---
+    // Post the same handle twice with different data; the second post must
+    // actually re-run the I/O. If completion state is not reset on repost, the
+    // handle reports the stale completion and the new data is never written.
+    nixl_xfer_dlist_t psrc(DRAM_SEG), pdst(BLK_SEG);
+    psrc.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(dram), kIoSize, kDevId));
+    pdst.addDesc(nixlBasicDesc(kBdevOffset, kIoSize, kDevId));
+    nixlXferReqH *preq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_WRITE, psrc, pdst, kAgentName, preq, &backendParams),
+             "create repost req");
+
+    fillPattern(dram, kIoSize, 0x11);
+    CHECK_OK(runToCompletion(agent, preq), "repost write #1");
+    fillPattern(dram, kIoSize, 0x22);
+    CHECK_OK(runToCompletion(agent, preq), "repost write #2");
+    CHECK_OK(agent.releaseXferReq(preq), "release repost req");
+
+    std::memset(dram, 0, kIoSize);
+    nixlXferReqH *vreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_READ, rsrc, rdst, kAgentName, vreq, &backendParams),
+             "create repost-verify req");
+    CHECK_OK(runToCompletion(agent, vreq), "repost verify read");
+    CHECK_OK(agent.releaseXferReq(vreq), "release repost-verify req");
+    CHECK(verifyPattern(dram, kIoSize, 0x22), "repost did not re-run the write");
+    std::printf("  phase 2 (repost): OK\n");
+
+    // --- Phase 3: release while (potentially) in flight ---
+    // Post and immediately release without waiting, many times. This drives the
+    // cancel path and its handle-lifetime election; under ASAN a double-free or
+    // use-after-free here would be caught.
+    constexpr int kCancelIters = 256;
+    for (int i = 0; i < kCancelIters; ++i) {
+        nixl_xfer_dlist_t csrc(DRAM_SEG), cdst(BLK_SEG);
+        csrc.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(dram), kIoSize, kDevId));
+        cdst.addDesc(nixlBasicDesc(kBdevOffset, kIoSize, kDevId));
+        nixlXferReqH *creq = nullptr;
+        CHECK_OK(agent.createXferReq(NIXL_WRITE, csrc, cdst, kAgentName, creq, &backendParams),
+                 "create cancel req");
+        nixl_status_t status = agent.postXferReq(creq);
+        CHECK(status == NIXL_IN_PROG || status == NIXL_SUCCESS, "post cancel req");
+        CHECK_OK(agent.releaseXferReq(creq), "release in-flight req");
+    }
+    std::printf("  phase 3 (release-in-flight x%d): OK\n", kCancelIters);
+
+    // Engine must still be healthy after the cancel burst.
+    std::memset(dram, 0, kIoSize);
+    nixlXferReqH *freq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_READ, rsrc, rdst, kAgentName, freq, &backendParams),
+             "create final read req");
+    CHECK_OK(runToCompletion(agent, freq), "final read transfer");
+    CHECK_OK(agent.releaseXferReq(freq), "release final read req");
+    std::printf("  phase 4 (post-cancel health check): OK\n");
+
+    CHECK_OK(agent.deregisterMem(dramReg, &backendParams), "deregister DRAM");
+    CHECK_OK(agent.deregisterMem(bdevReg, &backendParams), "deregister bdev");
+    return 0;
+}
+
+// The SPDK runtime (env, thread lib, accel, bdev) is a process-wide singleton
+// brought up by the first backend and torn down by the last. Run a second
+// backend, on its own bdev, while the first is still alive: it must attach to
+// the running runtime rather than re-initialize or fail. Then drop the first
+// agent and keep going, which is the harder ordering: the shared control state
+// must not belong to whichever backend happened to start first.
+int
+runSecondBackend(const nixl_b_params_t &base,
+                 bool progThread,
+                 std::unique_ptr<nixlAgent> &first,
+                 void *dram,
+                 size_t dramLen) {
+    constexpr const char *kAgent2 = "spdk-runtime-test-2";
+    constexpr const char *kBdev2 = "Malloc1";
+
+    nixlAgentConfig cfg(progThread);
+    nixlAgent agent(kAgent2, cfg);
+
+    nixlBackendH *backend = nullptr;
+    CHECK_OK(agent.createBackend("SPDK", makeParams(base, kBdev2, "nixl_spdk_rt2"), backend),
+             "create second backend");
+    CHECK(backend != nullptr, "second backend handle");
+
+    nixl_opt_args_t backendParams;
+    backendParams.backends.push_back(backend);
+
+    nixl_reg_dlist_t dramReg(DRAM_SEG);
+    dramReg.addDesc(nixlBlobDesc(reinterpret_cast<uintptr_t>(dram), dramLen, kDevId));
+    CHECK_OK(agent.registerMem(dramReg, &backendParams), "register DRAM (2)");
+
+    nixl_reg_dlist_t bdevReg(BLK_SEG);
+    bdevReg.addDesc(nixlBlobDesc(0, kBdevBytes, kDevId, kBdev2));
+    CHECK_OK(agent.registerMem(bdevReg, &backendParams), "register bdev (2)");
+
+    fillPattern(dram, kIoSize, 0x5a);
+    nixl_xfer_dlist_t src(DRAM_SEG), dst(BLK_SEG);
+    src.addDesc(nixlBasicDesc(reinterpret_cast<uintptr_t>(dram), kIoSize, kDevId));
+    dst.addDesc(nixlBasicDesc(kBdevOffset, kIoSize, kDevId));
+
+    nixlXferReqH *wreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_WRITE, src, dst, kAgent2, wreq, &backendParams),
+             "create write req (2)");
+    CHECK_OK(runToCompletion(agent, wreq), "write transfer (2)");
+    CHECK_OK(agent.releaseXferReq(wreq), "release write req (2)");
+
+    std::memset(dram, 0, kIoSize);
+    nixlXferReqH *rreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_READ, src, dst, kAgent2, rreq, &backendParams),
+             "create read req (2)");
+    CHECK_OK(runToCompletion(agent, rreq), "read transfer (2)");
+    CHECK_OK(agent.releaseXferReq(rreq), "release read req (2)");
+    CHECK(verifyPattern(dram, kIoSize, 0x5a), "second-backend data mismatch");
+
+    // Tear down the backend that brought the runtime up, then keep using this
+    // one.
+    first.reset();
+
+    std::memset(dram, 0, kIoSize);
+    nixlXferReqH *sreq = nullptr;
+    CHECK_OK(agent.createXferReq(NIXL_READ, src, dst, kAgent2, sreq, &backendParams),
+             "create survivor read req");
+    CHECK_OK(runToCompletion(agent, sreq), "survivor read transfer");
+    CHECK_OK(agent.releaseXferReq(sreq), "release survivor read req");
+    CHECK(verifyPattern(dram, kIoSize, 0x5a), "survivor data mismatch");
+
+    CHECK_OK(agent.deregisterMem(dramReg, &backendParams), "deregister DRAM (2)");
+    CHECK_OK(agent.deregisterMem(bdevReg, &backendParams), "deregister bdev (2)");
+    return 0;
+}
+
+} // namespace
+
+int
+main() {
+    // Progress-thread mode by default (exercises the concurrent cancel path);
+    // override with NIXL_SPDK_TEST_PROG_THREAD=0 to run in the caller-driven
+    // backend-locked mode.
+    bool progThread = true;
+    if (const char *v = std::getenv("NIXL_SPDK_TEST_PROG_THREAD")) {
+        progThread = !(v[0] == '0');
+    }
+    nixlAgentConfig cfg(progThread);
+    auto agent = std::make_unique<nixlAgent>(kAgentName, cfg);
+
+    nixl_b_params_t params;
+    nixl_mem_list_t mems;
+    nixl_status_t status = agent->getPluginParams("SPDK", mems, params);
+    if (status != NIXL_SUCCESS) {
+        std::printf("SKIP: SPDK plugin not available (getPluginParams=%d)\n", status);
+        return 0;
+    }
+
+    // Allow overriding any backend param from the environment as
+    // NIXL_SPDK_TEST_<UPPER_KEY> so the harness can be tuned per host without a
+    // rebuild (e.g. NIXL_SPDK_TEST_NO_HUGE=0 on a host with hugepages).
+    for (const char *key : {"msg_mempool_size", "core_mask"}) {
+        std::string envName = "NIXL_SPDK_TEST_";
+        for (const char *c = key; *c; ++c) {
+            envName += static_cast<char>(std::toupper(*c));
+        }
+        if (const char *v = std::getenv(envName.c_str())) {
+            params[key] = v;
+        }
+    }
+
+    nixlBackendH *backend = nullptr;
+    // Configure the malloc bdev via the convenience params (no JSON, no file).
+    status = agent->createBackend("SPDK", makeParams(params, kBdevName, "nixl_spdk_rt"), backend);
+    if (status != NIXL_SUCCESS || backend == nullptr) {
+        std::printf("SKIP: could not start SPDK runtime (createBackend=%d). "
+                    "This usually means no usable DPDK memory in the environment.\n",
+                    status);
+        return 0;
+    }
+
+    // Upstream SPDK registers memory at 4 KiB granularity, so a plain
+    // page-aligned buffer works with no hugepages required (64 KiB here is
+    // 4 KiB-aligned but deliberately not 2 MiB-aligned).
+    void *dram = nullptr;
+    constexpr size_t kPageSize = 4096;
+    const size_t dramLen = kIoSize;
+    if (posix_memalign(&dram, kPageSize, dramLen) != 0 || dram == nullptr) {
+        std::fprintf(stderr, "FAIL: posix_memalign failed\n");
+        return 1;
+    }
+
+    int rc = runTest(*agent, backend, dram, dramLen);
+    if (rc == 0) {
+        // Still inside the first backend's lifetime, so both are live at once.
+        rc = runSecondBackend(params, progThread, agent, dram, dramLen);
+        if (rc == 0) {
+            std::printf("  phase 6 (second concurrent backend, first released first): OK\n");
+        }
+    }
+
+    free(dram);
+
+    if (rc != 0) {
+        std::printf("RESULT: FAILED (%d)\n", rc);
+        return 1;
+    }
+    std::printf("RESULT: PASSED\n");
+    return 0;
+}

--- a/test/unit/plugins/spdk/nixl_spdk_test.cpp
+++ b/test/unit/plugins/spdk/nixl_spdk_test.cpp
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include "backend/backend_plugin.h"
+#include "nixl.h"
+#include "nixl_params.h"
+
+// The plugin's factory entry point differs by build mode: baked-in plugins
+// export createStaticSPDKPlugin() (and have no fini), while dynamic plugins
+// export nixl_plugin_init()/nixl_plugin_fini().
+#ifdef STATIC_PLUGIN_SPDK
+extern nixlBackendPlugin *
+createStaticSPDKPlugin();
+#else
+extern "C" nixlBackendPlugin *
+nixl_plugin_init();
+extern "C" void
+nixl_plugin_fini();
+#endif
+
+namespace {
+
+void
+checkSupportedMems(const std::vector<nixl_mem_t> &mems) {
+    bool hasDram = false;
+    bool hasBlk = false;
+
+    for (auto mem : mems) {
+        hasDram = hasDram || mem == DRAM_SEG;
+        hasBlk = hasBlk || mem == BLK_SEG;
+    }
+
+    assert(hasDram);
+    assert(hasBlk);
+}
+
+void
+checkAdvertisedOptions(const nixl_b_params_t &options) {
+    // The plugin must advertise its configurable knobs so getPluginParams()
+    // surfaces them to users. Both JSON config inputs must be discoverable.
+    assert(options.count("json_config") == 1);
+    assert(options.count("json_config_file") == 1);
+    assert(options.count("msg_mempool_size") == 1);
+    // Convenience single-bdev params must also be discoverable.
+    assert(options.count("bdev_type") == 1);
+    assert(options.count("bdev_name") == 1);
+    // Knobs that only mattered to the DPDK env must not be advertised.
+    assert(options.count("no_pci") == 0);
+    assert(options.count("no_huge") == 0);
+    assert(options.count("mem_size") == 0);
+    assert(options.count("shm_id") == 0);
+    assert(options.count("iova_mode") == 0);
+}
+
+void
+checkMissingConfigFails(nixlBackendPlugin *plugin, nixl_thread_sync_t syncMode) {
+    nixl_b_params_t customParams;
+    nixlBackendInitParams params;
+    params.localAgent = "spdk-test";
+    params.type = "SPDK";
+    params.customParams = &customParams;
+    params.enableProgTh = false;
+    params.syncMode = syncMode;
+    params.pthrDelay = 0;
+    params.enableTelemetry_ = false;
+
+    nixlBackendEngine *engine = plugin->create_engine(&params);
+    assert(engine != nullptr);
+    assert(engine->getInitErr());
+    plugin->destroy_engine(engine);
+}
+
+} // namespace
+
+int
+main() {
+#ifdef STATIC_PLUGIN_SPDK
+    nixlBackendPlugin *plugin = createStaticSPDKPlugin();
+#else
+    nixlBackendPlugin *plugin = nixl_plugin_init();
+#endif
+    assert(plugin != nullptr);
+    assert(std::string(plugin->get_plugin_name()) == "SPDK");
+    checkSupportedMems(plugin->get_backend_mems());
+    checkAdvertisedOptions(plugin->get_backend_options());
+
+    checkMissingConfigFails(plugin, nixl_thread_sync_t::NIXL_THREAD_SYNC_NONE);
+    checkMissingConfigFails(plugin, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT);
+
+#ifndef STATIC_PLUGIN_SPDK
+    nixl_plugin_fini();
+#endif
+    return 0;
+}

--- a/test/unit/plugins/spdk/nixl_spdk_test.cpp
+++ b/test/unit/plugins/spdk/nixl_spdk_test.cpp
@@ -30,14 +30,17 @@ void
 checkSupportedMems(const std::vector<nixl_mem_t> &mems) {
     bool hasDram = false;
     bool hasBlk = false;
+    bool hasObj = false;
 
     for (auto mem : mems) {
         hasDram = hasDram || mem == DRAM_SEG;
         hasBlk = hasBlk || mem == BLK_SEG;
+        hasObj = hasObj || mem == OBJ_SEG;
     }
 
     assert(hasDram);
     assert(hasBlk);
+    assert(hasObj);
 }
 
 void
@@ -47,7 +50,8 @@ checkAdvertisedOptions(const nixl_b_params_t &options) {
     assert(options.count("json_config") == 1);
     assert(options.count("json_config_file") == 1);
     assert(options.count("msg_mempool_size") == 1);
-    // Convenience single-bdev params must also be discoverable.
+    // Convenience single-bdev params must also be discoverable. bdev_name also
+    // names the OBJ_SEG (NVMe-KV) device.
     assert(options.count("bdev_type") == 1);
     assert(options.count("bdev_name") == 1);
     // Knobs that only mattered to the DPDK env must not be advertised.


### PR DESCRIPTION
Adds a NIXL backend plugin that talks to the SPDK (https://spdk.io) bdev library. The first commit adds the plugin and BLK support. The second commit as OBJ support by forwarding NVMe KV commands, which will only work for the NVMe bdev module.
 
 # Key Design Choices
 
 ## No DPDK

The plugin supplies its own implementation of SPDK's env interface instead of spdk_env_dpdk, so DPDK is never linked or initialized.
  
  Consequences:
  - No hugepages required.
  - No local PCI devices, for now. This may (and likely will) be added in the future and will be opt-in since it will reintroduce hugepage or iommu requirements.
  - No dynamically loaded bdev modules — only those statically linked in (malloc, aio, null, nvme, passthru, delay, error, gpt, lvol, raid, split, ftl, virtio). Out of tree bdev module loading may be added in the future.

## Statically linked to SPDK

The plugin statically links SPDK with symbol hiding into its shared object.

Consequences:
- You do not need SPDK installed on a system to use the plugin. It is self contained.
- You can use the plugin inside an application that has its own, different SPDK. They will not conflict.
- Pinned to SPDK v26.05 release. Will periodically receive updates for new releases.

# Transfer model

Transfers are always DRAM ↔ device, expressed as loopback (remote agent name == the agent's own name). NIXL_WRITE is DRAM → device, NIXL_READ is device → DRAM. The plugin reports supportsLocal() == true, supportsRemote() == false, supportsNotif() == false.

Both sides are registered before use. BLK_SEG names its bdev in metaInfo and uses addr as a byte offset. DRAM must be 4 KiB-aligned in address and length — the plugin registers host memory directly for zero-copy DMA and has no bounce-buffer fallback, so it hard-fails rather than silently copying.

OBJ_SEG follows the same per-object convention as NIXL's other OBJ backends: the key comes from the descriptor metaInfo at registration and is recovered via metadataP at transfer, with the local DRAM descriptor as the value. SPDK has no KV bdev abstraction, so the NVMe command is built by hand and forwarded through bdev NVMe passthru. NVMe KV keys are 1–16 bytes and Store/Retrieve are whole-value, so the OBJ descriptor offset must be 0. The device is accepted only if it supports NVMe passthru and identifies as the KV command set, so non-KV devices are rejected at registration.

# Configuration

Bdevs are configured by inline SPDK JSON (json_config), a path to the same (json_config_file), or convenience parameters for the common single-bdev case (bdev_type + bdev_name + a type-specific source). Exactly one source must be given. See src/plugins/spdk/README.md.

# Multiple backends

SPDK's env, thread, accel and bdev subsystems are singletons within this copy of SPDK, so the runtime is shared and refcounted: the first backend brings it up, the last one released tears it down, in any order. Each backend keeps its own SPDK thread and I/O channels. Because the bdev registry is shared, concurrent backends must configure distinct bdev names.

# Testing

Two unit tests under test/unit/plugins/spdk/:

- nixl_spdk_test — plugin metadata and advertised parameters; no SPDK runtime needed.
- nixl_spdk_runtime_test — real I/O over an in-memory malloc bdev, so it runs unprivileged in CI: write/read/verify, repost of a completed handle, a 256-iteration release-while-in-flight burst, OBJ_SEG rejection on a non-KV device, and a second backend sharing the runtime with the first (including releasing the first while the second keeps running). It prints SKIP and exits 0 if the environment cannot back the runtime.

Verified across the dynamic and static (-Dstatic_plugins=SPDK) plugin models with the progress thread both on and off. Exercising the OBJ_SEG data path needs a KV-capable target, which CI lacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SPDK as a supported NIXL storage backend.
  * Enabled DRAM transfers with SPDK block devices and NVMe Key-Value targets.
  * Added configuration options for JSON setup, device name, offset, and message pool size.
  * Added SPDK support to NIXLBench, including `bdev` descriptors and benchmark parameters.
* **Documentation**
  * Added SPDK setup, configuration, usage, limitations, and build guidance.
* **Tests**
  * Added coverage for plugin initialization, transfers, cancellation, and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->