### PR TITLE
CI: raise SGLang/vLLM GPU_MEM_FRACTION default from 0.3 to 0.6

### DIFF
--- a/.gitlab/test_vllm_sglang_sanity.sh
+++ b/.gitlab/test_vllm_sglang_sanity.sh
@@ -41,11 +41,12 @@ DECODE_PORT="${DECODE_PORT:-$(get_next_tcp_port)}"
 PROXY_PORT="${PROXY_PORT:-$(get_next_tcp_port)}"
 PROMPT="${PROMPT:-San Francisco is a}"
 SERVER_TIMEOUT="${SERVER_TIMEOUT:-300}"
-# Fraction of GPU memory each server may claim. The frameworks default to ~0.9, which
-# demands nearly the whole GPU to be free at startup; on the shared GB200 CI nodes other
-# processes may already hold GPU memory. Qwen3-8B weights are ~56.5 GiB; with a GB200
-# that may have only ~170 GiB free (not the full 186), 0.3 (~51 GiB) is too small to
-# fit weights + KV pool. 0.6 (~102 GiB) leaves headroom while not monopolising the GPU.
+# Fraction of GPU memory each server may claim (fraction of total GPU memory).
+# The frameworks default to ~0.9, which demands nearly the whole GPU to be free at
+# startup; on the shared GB200 CI nodes other processes may already hold GPU memory.
+# Qwen3-8B weights are ~56.5 GiB; 0.3 × 186 GiB ≈ 56 GiB is too small to fit
+# weights + KV pool. 0.6 × 186 GiB ≈ 112 GiB leaves headroom while a GB200 that
+# has ~170 GiB free (not the full 186) can still satisfy the request.
 GPU_MEM_FRACTION="${GPU_MEM_FRACTION:-0.6}"
 PROXY_TIMEOUT="${PROXY_TIMEOUT:-120}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-120}"

--- a/.gitlab/test_vllm_sglang_sanity.sh
+++ b/.gitlab/test_vllm_sglang_sanity.sh
@@ -42,10 +42,11 @@ PROXY_PORT="${PROXY_PORT:-$(get_next_tcp_port)}"
 PROMPT="${PROMPT:-San Francisco is a}"
 SERVER_TIMEOUT="${SERVER_TIMEOUT:-300}"
 # Fraction of GPU memory each server may claim. The frameworks default to ~0.9, which
-# demands nearly the whole GPU to be free at startup; the sanity model needs only a small
-# slice (0.3 of a 186 GiB GB200 is ~56 GiB, ample for 8B weights + KV cache), so the lower
-# value leaves room for anything the driver or a previous step has not yet released.
-GPU_MEM_FRACTION="${GPU_MEM_FRACTION:-0.3}"
+# demands nearly the whole GPU to be free at startup; on the shared GB200 CI nodes other
+# processes may already hold GPU memory. Qwen3-8B weights are ~56.5 GiB; with a GB200
+# that may have only ~170 GiB free (not the full 186), 0.3 (~51 GiB) is too small to
+# fit weights + KV pool. 0.6 (~102 GiB) leaves headroom while not monopolising the GPU.
+GPU_MEM_FRACTION="${GPU_MEM_FRACTION:-0.6}"
 PROXY_TIMEOUT="${PROXY_TIMEOUT:-120}"
 REQUEST_TIMEOUT="${REQUEST_TIMEOUT:-120}"
 


### PR DESCRIPTION
## What?

Raise `GPU_MEM_FRACTION` default from `0.3` to `0.6` in `.gitlab/test_vllm_sglang_sanity.sh` and update the stale comment that claimed 0.3 was "ample".

## Why?

Qwen3-8B weights are ~56.5 GiB. On a shared GB200 CI node, only ~170 GiB may be free (not the full 186 GiB), so `0.3 × 186 ≈ 51 GiB` is insufficient to fit the weights plus the KV cache pool. Both prefill and decode servers crash at `init_memory_pool` with:

```
RuntimeError: Not enough memory. Please try to increase --mem-fraction-static
```

The 300 s health-check timeout that follows is a symptom, not the cause. This false-failed two innocent PRs (builds 1255/1257, #2016/#2024; also seen 2026-07-28 on #1991).

## How?

`0.6 × 186 ≈ 102 GiB` comfortably covers weights + KV cache while leaving the other half of the GPU available for concurrent jobs on the same node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default GPU memory allocation to improve support for Qwen3-8B workloads on shared GB200 GPUs.
  * Updated capacity guidance to better reflect expected memory usage and available shared GPU capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->