### PR TITLE
ci: fix CUDA version in the nightly wheel build

### DIFF
--- a/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
@@ -77,9 +77,16 @@ steps:
       fi
       [ -n "${UCX_SHA}" ] || { echo "ERROR: cannot resolve UCX_VERSION=${UCX_VERSION}"; exit 1; }
       printf 'NIXL_SHA=%s\nUCX_SHA=%s\n' "${NIXL_SHA}" "${UCX_SHA}" > wheel_build_ids.env
+      # CUDA MAJOR.MINOR, derived from the leading version in BASE_TAG (e.g.
+      # 12.9-devel-manylinux--25.06 -> 12.9). Dockerfile.manylinux needs it for the
+      # torch cuXXX index and the cu12/cu13 meta-wheel split; deriving keeps BASE_TAG
+      # the single source of truth so a cu12 run cannot build against the cu13 default.
+      CUDA_VERSION="$(echo "${BASE_TAG}" | grep -oE '^[0-9]+\.[0-9]+')"
+      [ -n "${CUDA_VERSION}" ] || { echo "ERROR: cannot derive CUDA version from BASE_TAG=${BASE_TAG}"; exit 1; }
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
+        --cuda-version "${CUDA_VERSION}" \
         --wheel-base "manylinux_${manylinux}" \
         --python-versions "${python_version}" \
         --arch ${arch} \

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -891,8 +891,8 @@
           cron: |
             # Build NIXL wheels nightly ~10 AM for CUDA 13 and CUDA 12 (the cu12
             # run also produces the nixl meta wheel). Both publish to the repo.
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_TAG=13.0-devel-manylinux--25.09
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_TAG=12.9-devel-manylinux--25.06
+            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_TAG=13.0.1-devel-ubi8
+            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_TAG=12.9.1-devel-ubi8
     # Manual build parameters
     parameters:
       - string:
@@ -905,12 +905,12 @@
           description: "UCX version to build against (tag like v1.22.x, branch name, or commit hash)"
       - string:
           name: "BASE_IMAGE"
-          default: "artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/base/cuda"
-          description: "Manylinux base image for the wheel build"
+          default: "nvcr.io/nvidia/cuda"
+          description: "CUDA donor image for the wheel build (ubi8 devel image; the wheel itself builds on the public PyPA manylinux base). Same as the per-PR wheel job."
       - string:
           name: "BASE_TAG"
-          default: "13.0-devel-manylinux--25.09"
-          description: "Base image tag = CUDA version (e.g. 13.0-devel-manylinux--25.09 or 12.9-devel-manylinux--25.06). Mirrored into base/cuda from the dl/dgx/cuda registry."
+          default: "13.0.1-devel-ubi8"
+          description: "Base image tag; must start with the CUDA version (e.g. 13.0.1-devel-ubi8 or 12.9.1-devel-ubi8) - the build derives the torch cuXXX index and the cu12/cu13 wheel split from it."
       - string:
           name: "DEBUG"
           default: 0


### PR DESCRIPTION
## What?
- Nightly wheel build: derive `CUDA_VERSION` from `BASE_TAG` and pass `--cuda-version`.
- Move the nightly job to the same nvcr.io ubi8 CUDA base as the per-PR job (#2009).

## Why?
Since #2009 `CUDA_VERSION` is a Dockerfile ARG defaulting to 13.0, and the nightly never passes it. The cu12 nightly silently builds as cu13 since 2026-07-30: no `nixl` meta wheel published, torch `+cu130` in a 12.9 build.

## How?
`BASE_TAG` is the single source of truth - parse its leading `MAJOR.MINOR`, fail loudly otherwise. No new job param to drift.

Verification (throwaway Devops job, one cu12 cell) in progress.