### PR TITLE
EP/TESTS: Kineto sentinel check

### DIFF
--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -488,8 +488,6 @@ def worker(torch_rank: int, args: argparse.Namespace):
     torch.set_default_device("cuda")
     torch.cuda.set_device(0)
 
-    kineto = args.kineto
-
     tcp_store = store_group.create_client_store(
         master_addr=server_addr,
         port=TCP_STORE_PORT,
@@ -579,7 +577,7 @@ def worker(torch_rank: int, args: argparse.Namespace):
             current_num_ranks,
             max_num_ranks,
             buffer,
-            kineto=kineto,
+            kineto=args.kineto,
             fault_tolerance_test=kill_rank,
         )
         # Query mask buffer to detect rank failures and clean them up

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -50,6 +50,7 @@ from utils import (  # noqa: E402
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
 SINGLE_PROCESS_WORKER_RANK = 0
+KINETO_UNAVAILABLE_MSG = "Kineto profiling was requested but is unavailable"
 
 
 def non_negative_int(value: str) -> int:
@@ -668,18 +669,16 @@ def main():
 
     args = parser.parse_args()
 
-    if args.kineto:
-        torch.cuda.set_device(SINGLE_PROCESS_WORKER_RANK)
-        if not kineto_cuda_available():
-            raise SystemExit(
-                "Kineto profiling was requested but is unavailable"
-            )
-
     if not args.tcp_server:
         print("Starting TCPStore and rank server locally", flush=True)
         server_process = torch.multiprocessing.Process(target=run_server, daemon=True)
         server_process.start()
         time.sleep(0.5)
+
+    if args.kineto:
+        torch.cuda.set_device(SINGLE_PROCESS_WORKER_RANK)
+        if not kineto_cuda_available():
+            raise SystemExit(KINETO_UNAVAILABLE_MSG)
 
     if args.num_processes == 1:
         worker(SINGLE_PROCESS_WORKER_RANK, args)

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -49,6 +49,7 @@ from utils import (  # noqa: E402
 
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
+SINGLE_PROCESS_WORKER_RANK = 0
 
 
 def non_negative_int(value: str) -> int:
@@ -487,12 +488,6 @@ def worker(torch_rank: int, args: argparse.Namespace):
     torch.cuda.set_device(0)
 
     kineto = args.kineto
-    if kineto and not kineto_cuda_available():
-        print(
-            f"[rank {global_rank}] Kineto profiling is unavailable; running without profiler",
-            flush=True,
-        )
-        kineto = False
 
     tcp_store = store_group.create_client_store(
         master_addr=server_addr,
@@ -673,6 +668,13 @@ def main():
 
     args = parser.parse_args()
 
+    if args.kineto:
+        torch.cuda.set_device(SINGLE_PROCESS_WORKER_RANK)
+        if not kineto_cuda_available():
+            raise SystemExit(
+                "Kineto profiling was requested but is unavailable"
+            )
+
     if not args.tcp_server:
         print("Starting TCPStore and rank server locally", flush=True)
         server_process = torch.multiprocessing.Process(target=run_server, daemon=True)
@@ -680,7 +682,7 @@ def main():
         time.sleep(0.5)
 
     if args.num_processes == 1:
-        worker(0, args)
+        worker(SINGLE_PROCESS_WORKER_RANK, args)
         return
 
     ctx = torch.multiprocessing.spawn(

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -673,10 +673,8 @@ def main():
         server_process.start()
         time.sleep(0.5)
 
-    if args.kineto:
-        torch.cuda.set_device(SINGLE_PROCESS_WORKER_RANK)
-        if not kineto_cuda_available():
-            raise SystemExit(KINETO_UNAVAILABLE_MSG)
+    if args.kineto and not kineto_cuda_available(SINGLE_PROCESS_WORKER_RANK):
+        raise SystemExit(KINETO_UNAVAILABLE_MSG)
 
     if args.num_processes == 1:
         worker(SINGLE_PROCESS_WORKER_RANK, args)

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -49,8 +49,6 @@ from utils import (  # noqa: E402
 
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
-SINGLE_PROCESS_WORKER_RANK = 0
-KINETO_UNAVAILABLE_MSG = "Kineto profiling was requested but is not supported"
 
 
 def non_negative_int(value: str) -> int:
@@ -673,11 +671,11 @@ def main():
         server_process.start()
         time.sleep(0.5)
 
-    if args.kineto and not kineto_cuda_available(SINGLE_PROCESS_WORKER_RANK):
-        raise SystemExit(KINETO_UNAVAILABLE_MSG)
+    if args.kineto and not kineto_cuda_available(0):
+        raise SystemExit("Kineto profiling was requested but is not supported")
 
     if args.num_processes == 1:
-        worker(SINGLE_PROCESS_WORKER_RANK, args)
+        worker(0, args)
         return
 
     ctx = torch.multiprocessing.spawn(

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -43,6 +43,7 @@ from utils import (  # noqa: E402
     bench_kineto,
     calc_diff,
     hash_tensor,
+    kineto_cuda_available,
     per_token_cast_back,
 )
 
@@ -485,6 +486,14 @@ def worker(torch_rank: int, args: argparse.Namespace):
     torch.set_default_device("cuda")
     torch.cuda.set_device(0)
 
+    kineto = args.kineto
+    if kineto and not kineto_cuda_available():
+        print(
+            f"[rank {global_rank}] Kineto profiling is unavailable; running without profiler",
+            flush=True,
+        )
+        kineto = False
+
     tcp_store = store_group.create_client_store(
         master_addr=server_addr,
         port=TCP_STORE_PORT,
@@ -574,7 +583,7 @@ def worker(torch_rank: int, args: argparse.Namespace):
             current_num_ranks,
             max_num_ranks,
             buffer,
-            kineto=args.kineto,
+            kineto=kineto,
             fault_tolerance_test=kill_rank,
         )
         # Query mask buffer to detect rank failures and clean them up

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -50,7 +50,7 @@ from utils import (  # noqa: E402
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
 SINGLE_PROCESS_WORKER_RANK = 0
-KINETO_UNAVAILABLE_MSG = "Kineto profiling was requested but is unavailable"
+KINETO_UNAVAILABLE_MSG = "Kineto profiling was requested but is not supported"
 
 
 def non_negative_int(value: str) -> int:

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -186,6 +186,37 @@ class suppress_stdout_stderr:
         self.errnull_file.close()
 
 
+def _has_cuda_profiler_events(key_averages) -> bool:
+    for event in key_averages:
+        for attr in (
+            "device_time_total",
+            "self_device_time_total",
+            "cuda_time_total",
+            "self_cuda_time_total",
+        ):
+            try:
+                if getattr(event, attr, 0) > 0:
+                    return True
+            except TypeError:
+                pass
+    return False
+
+
+def _run_cuda_profiler_sentinel():
+    sentinel = torch.empty((1024,), dtype=torch.float, device="cuda")
+    sentinel.fill_(1.0)
+
+
+def kineto_cuda_available() -> bool:
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CUDA]
+    ) as prof:
+        _run_cuda_profiler_sentinel()
+        torch.cuda.synchronize()
+
+    return _has_cuda_profiler_events(prof.key_averages())
+
+
 def bench_kineto(
     fn,
     kernel_names: Union[str, tuple],

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -188,6 +188,8 @@ class suppress_stdout_stderr:
 
 def _has_cuda_profiler_events(key_averages) -> bool:
     for event in key_averages:
+        if getattr(event, "is_legacy", False):
+            continue
         for attr in (
             "device_time_total",
             "self_device_time_total",

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -210,14 +210,17 @@ def _run_cuda_profiler_sentinel():
 
 
 def kineto_cuda_available() -> bool:
-    with suppress_stdout_stderr():
-        with torch.profiler.profile(
-            activities=[torch.profiler.ProfilerActivity.CUDA]
-        ) as prof:
-            _run_cuda_profiler_sentinel()
-            torch.cuda.synchronize()
+    try:
+        with suppress_stdout_stderr():
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CUDA]
+            ) as prof:
+                _run_cuda_profiler_sentinel()
+                torch.cuda.synchronize()
 
-    return _has_cuda_profiler_events(prof.key_averages())
+        return _has_cuda_profiler_events(prof.key_averages())
+    except Exception:
+        return False
 
 
 def bench_kineto(

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -208,11 +208,12 @@ def _run_cuda_profiler_sentinel():
 
 
 def kineto_cuda_available() -> bool:
-    with torch.profiler.profile(
-        activities=[torch.profiler.ProfilerActivity.CUDA]
-    ) as prof:
-        _run_cuda_profiler_sentinel()
-        torch.cuda.synchronize()
+    with suppress_stdout_stderr():
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA]
+        ) as prof:
+            _run_cuda_profiler_sentinel()
+            torch.cuda.synchronize()
 
     return _has_cuda_profiler_events(prof.key_averages())
 

--- a/examples/device/ep/tests/utils.py
+++ b/examples/device/ep/tests/utils.py
@@ -209,8 +209,9 @@ def _run_cuda_profiler_sentinel():
     sentinel.fill_(1.0)
 
 
-def kineto_cuda_available() -> bool:
+def kineto_cuda_available(device_id: int) -> bool:
     try:
+        torch.cuda.set_device(device_id)
         with suppress_stdout_stderr():
             with torch.profiler.profile(
                 activities=[torch.profiler.ProfilerActivity.CUDA]
@@ -219,7 +220,7 @@ def kineto_cuda_available() -> bool:
                 torch.cuda.synchronize()
 
         return _has_cuda_profiler_events(prof.key_averages())
-    except Exception:
+    except RuntimeError:
         return False
 
 


### PR DESCRIPTION
## What?
Check if CUPTI profiler is available before using it

## Why?
CUPTI not support all setups.

## How?
Run simple kernel with profiler and check if it succeeded. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA profiling compatibility in device performance tests.
  * Profiling requests now verify CUDA Kineto support before execution and provide a clear error when unavailable.
  * Enhanced detection of CUDA activity across supported timing configurations.
  * Improved handling of unsupported profiling settings to prevent test failures.
  * Standardized profiling behavior across single-process and multi-process test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->