### PR TITLE
build: clone libxml2 from the GitHub mirror

### DIFF
--- a/ATTRIBUTIONS-CPP.md
+++ b/ATTRIBUTIONS-CPP.md
@@ -737,7 +737,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-## libxml2 - 2.9.14
+## libxml2 - 2.15
 
 - **Repository URL**: https://gitlab.gnome.org/GNOME/libxml2
 - **License URL**: https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/Copyright

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -226,7 +226,7 @@ RUN git clone https://github.com/nvidia/gusli.git && \
      cd ..
 
 # Required for Azure SDK
-RUN git clone --depth 1 https://gitlab.gnome.org/GNOME/libxml2.git --branch 2.15 && \
+RUN git clone --depth 1 https://github.com/GNOME/libxml2.git --branch 2.15 && \
     cd libxml2 && \
     ACLOCAL_PATH=/usr/share/aclocal ./autogen.sh && make -j${NPROC:-$(nproc)} && \
     make install


### PR DESCRIPTION
## Summary

The libxml2 clone from `gitlab.gnome.org` failed twice with HTTP 503 when GNOME's Gitaly backend was unavailable, breaking the manylinux wheel build mid-way:

| Build | Date | Error |
|---|---|---|
| #997 | Jul 13 | `Gitaly is not available` / HTTP 503 |
| #1254 | Jul 31 | `Gitaly is not available` / HTTP 503 |

Clone from the GitHub mirror instead, which is not affected by GNOME GitLab availability.

## Changes

- **`contrib/Dockerfile.manylinux`** - point the libxml2 clone at `https://github.com/GNOME/libxml2.git`
- **`ATTRIBUTIONS-CPP.md`** - correct the libxml2 version from 2.9.14 to 2.15

Everything else about the clone step is unchanged: same `--depth 1`, same `2.15` branch, same build commands.

The attribution recorded 2.9.14 while the Dockerfile has been building the 2.15 branch. It is recorded as `2.15` rather than a patch version because the clone tracks the branch rather than a tag.
