### PR TITLE
ci: build python bindings without pip build isolation

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -44,14 +44,9 @@ then
     # Raise exceptions for logging errors
     export NIXL_DEBUG_LOGGING=yes
 
-    # Install build dependencies
-    if [ -n "$VIRTUAL_ENV" ] ; then
-        # Install full build dependencies in venv
-        $pip3 install --break-system-packages meson meson-python pybind11 patchelf pyYAML click tabulate auditwheel tomlkit 'setuptools>=80.9.0'
-    else
-        # Install minimal build dependencies in system python
-        $pip3 install --break-system-packages tomlkit
-    fi
+    # The install below uses --no-build-isolation, so pip does not provision
+    # [build-system].requires itself.
+    $pip3 install --break-system-packages --upgrade meson meson-python pybind11 patchelf pyYAML click tabulate auditwheel tomlkit 'setuptools>=80.9.0'
     # Set the correct wheel name based on the CUDA version
     cuda_major=$(nvcc --version | grep -oP 'release \K[0-9]+')
     case "$cuda_major" in
@@ -60,7 +55,7 @@ then
     esac
     ./contrib/tomlutil.py --wheel-name "nixl-cu${cuda_major}" pyproject.toml
     # Control ninja parallelism during pip build to prevent OOM (NPROC from common.sh)
-    $pip3 install --break-system-packages --config-settings=compile-args="-j${NPROC}" .
+    $pip3 install --break-system-packages --no-build-isolation --config-settings=compile-args="-j${NPROC}" .
     $pip3 install --break-system-packages dist/nixl-*none-any.whl
 fi
 

--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -46,7 +46,8 @@ then
 
     # The install below uses --no-build-isolation, so pip does not provision
     # [build-system].requires itself.
-    $pip3 install --break-system-packages --upgrade meson meson-python pybind11 patchelf pyYAML click tabulate auditwheel tomlkit 'setuptools>=80.9.0'
+    # --ignore-installed: the distro-packaged copies have no pip RECORD and cannot be uninstalled.
+    $pip3 install --break-system-packages --upgrade --ignore-installed meson meson-python pybind11 patchelf pyYAML click tabulate auditwheel tomlkit 'setuptools>=80.9.0'
     # Set the correct wheel name based on the CUDA version
     cuda_major=$(nvcc --version | grep -oP 'release \K[0-9]+')
     case "$cuda_major" in


### PR DESCRIPTION
## Summary

pip provisions `[build-system].requires` into a fresh PEP 517 build environment on every run. The pinned `torch==2.11.*` can never be satisfied by the torch already in the CI images (an NVIDIA nightly, e.g. `2.13.0a0+8145d630e8.nv26.6`), so pip re-downloaded torch plus its CUDA dependency closure - several GB - on each invocation.

That step normally completes in ~2 min, but stalls for 10-30 min when the index or network degrades, tripping the stage timeout and aborting with exit 143. It caused 10 CI failures between Jul 1 and Aug 3 across `nixl-ci-gpu`, `nixl-ci-non-gpu` and `nixl-ci-dl-gpu`.

CI does not need an isolated build environment, so this builds with `--no-build-isolation` and provisions the build dependencies explicitly. **`[build-system].requires` is left untouched**, so the isolated-build contract for consumers building from source - including `nixl_ep`'s torch requirement - is unchanged.

## Changes

`.gitlab/test_python.sh` only:

- add `--no-build-isolation` to the `pip install .` invocation
- install the build dependencies with `--upgrade`, in a single branch

## Why `--upgrade` matters

Without it pip treats an already-present version as satisfying the requirement and leaves it in place. The images ship **meson 1.3.2**, and that is what the failing runs actually used:

```
Version: 1.3.2
meson setup ... --native-file=.../meson-python-native-file.ini
meson-python: error: Could not map installation path to an equivalent wheel directory: '{prefix}/lib/libcore.so'
```

`contrib/Dockerfile` already installs these same packages with `--upgrade`, so this brings the CI script in line with it.

The two branches previously diverged - the venv branch installed the full set while the system-python branch installed only `tomlkit` and relied on the image for the rest. Both now install the same set, so the build no longer depends on image contents.

## Verification

`bash -n` passes. The stall is environment-dependent and not locally reproducible, so confirmation is a green CI run - specifically that the isolated build environment is no longer provisioned, and that with an upgraded meson the wheel builds without the `{prefix}/lib` mapping error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Installation**
  * Build dependencies are now fully installed and upgraded consistently.
  * Package builds use preinstalled build dependencies for more predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->