### PR TITLE
libfabric: add tracing via nvtx backend

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -135,6 +135,34 @@ backends/PRs):
 | `nixl::prepMemView` | `MemoryR` | `mem_type`, `desc_count` |
 | `nixl::releaseMemView` | `Generic` | - |
 
+The libfabric backend (`src/utils/libfabric`) additionally emits the spans below.
+All of them carry a correlation id of `xfer_id`, so a viewer can join the submit
+span, the per-rail post, and the completion marker (which fires on the progress
+thread) for one logical transfer:
+
+| Span / marker | Kind | Attributes |
+| ------------- | ---- | ---------- |
+| `nixl::libfabric.transfer.write` | `CommSend` | `device_id`, `transfer_size`, `num_rails`, `use_striping`, `xfer_id`, `submitted_count` |
+| `nixl::libfabric.transfer.read` | `CommRecv` | as above |
+| `nixl::libfabric.post_write` | `CommSend` | `device_id`, `rail_id`, `length`, `xfer_id`, `retries`; `deferred`, `failed` on the progress-thread path |
+| `nixl::libfabric.post_read` | `CommRecv` | as above |
+| `nixl::libfabric.post_send` | `CommSend` | `rail_id`, `length`, `xfer_id`, `retries` |
+| `nixl::libfabric.post_deferred.write` | `Metadata` (marker) | - |
+| `nixl::libfabric.post_deferred.read` | `Metadata` (marker) | - |
+| `nixl::libfabric.local_completion.write` | `Metadata` (marker) | - |
+| `nixl::libfabric.local_completion.read` | `Metadata` (marker) | - |
+| `nixl::libfabric.recv_completion` | `CommRecv` (marker) | - |
+| `nixl::libfabric.remote_write_completion` | `CommRecv` (marker) | - |
+
+Where the post span comes from depends on the progress thread. With it disabled,
+`post_write`/`post_read` are emitted inline by the submitting thread, nested
+inside the enclosing `transfer.*` span. With it enabled (the default), submission
+only enqueues onto a per-rail ring -- so `transfer.*` measures enqueue latency,
+a `post_deferred.*` marker records the hand-off, and the post span itself is
+emitted later by the progress thread from `drainPostQueue()` with `deferred=1`.
+In that mode the post span is a sibling of `transfer.*` rather than nested in it,
+and may outlive it; correlate on `xfer_id` rather than on nesting.
+
 Spans cover the synchronous call only; the `nixl::xfer.complete` marker is emitted
 when `getXferStatus` first observes success. How a backend renders attributes and
 dependencies (`addCtrlDep`/`addDataDep`) is backend-specific and documented with each

--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -24,6 +24,10 @@
 #include "nixl_descriptors.h"
 #include "common/nixl_time.h"
 
+namespace nixl::trace {
+class Tracer;
+} // namespace nixl::trace
+
 // Might be removed to be decided by backend, or changed to high
 // level direction or so.
 typedef std::vector<std::pair<std::string, std::string>> notif_list_t;
@@ -54,6 +58,8 @@ class nixlBackendInitParams {
         nixlTime::us_t pthrDelay = 0;
         nixl_thread_sync_t syncMode;
         bool enableTelemetry_ = false;
+
+        nixl::trace::Tracer *tracer_ = nullptr;
 };
 
 // Pure virtual class to have a common pointer type

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -43,6 +43,7 @@ class nixlBackendEngine {
         bool              initErr = false;
         const std::string localAgent;
         const bool enableTelemetry_;
+        nixl::trace::Tracer *const tracer_;
 
         [[nodiscard]] nixl_status_t
         setInitParam(const std::string &key, const std::string &value) {
@@ -78,7 +79,8 @@ class nixlBackendEngine {
             : backendType(init_params->type),
               customParams(*init_params->customParams),
               localAgent(init_params->localAgent),
-              enableTelemetry_(init_params->enableTelemetry_) {}
+              enableTelemetry_(init_params->enableTelemetry_),
+              tracer_(init_params->tracer_) {}
 
         nixlBackendEngine(nixlBackendEngine&&) = delete;
         nixlBackendEngine(const nixlBackendEngine&) = delete;

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -96,15 +96,16 @@ class nixlAgentData {
         std::exception_ptr commThreadException_;
 
         // The order of the following data members is crucial for destruction.
+        // Composite tracer (fans out to every enabled backend); null when no
+        // backend is active. Must be declared before backendHandles_/
+        // backendEngines_: backends now hold a borrowed pointer to tracer_.
+        const std::unique_ptr<nixl::trace::Tracer> tracer_;
         // Bookkeeping for local connection metadata and user handles per backend
         std::unordered_map<nixl_backend_t, std::unique_ptr<nixlBackendH>> backendHandles_;
         std::unordered_map<nixl_backend_t, nixl_blob_t> connMd_;
         backend_map_t backendEngines_;
         std::unordered_map<std::string, nixlRemoteSection> remoteSections_;
         std::unique_ptr<nixlTelemetry> telemetry_;
-        // Composite tracer (fans out to every enabled backend); null when no
-        // backend is active.
-        const std::unique_ptr<nixl::trace::Tracer> tracer_;
         nixlLocalSection localSection_;
 
         void

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -71,7 +71,11 @@ nixl_lib_sources = [
     'telemetry/buffer_exporter.cpp',
     'telemetry/buffer_plugin.cpp',
     'telemetry/nop_plugin.cpp',
+# tracer.cpp is kept separate from the factory so
+# backend plugins that instrument their own tracing code can compile it into their
+# .so to resolve the facade symbols without linking libnixl (otherwise cyclic linking).
     'tracing/tracer.cpp',
+    'tracing/tracer_factory.cpp',
 ]
 
 nixl_lib = library('nixl',

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -380,6 +380,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
+    init_params.tracer_ = data->tracer_.get();
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();

--- a/src/core/tracing/tracer.cpp
+++ b/src/core/tracing/tracer.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-#include <unordered_set>
-
+// Span/Tracer method bodies for the nixl::trace facade.
+// They depend only on trace.h interfaces, so backend plugins that instrument
+// can compile them directly into their .so.
+// Note that makeTracer() factory lives in tracer_factory.cpp, and is not needed
+// by backend plugins.
 #include "tracing/trace.h"
-
-#include "common/nixl_log.h"
-#include "plugin_manager.h"
 
 namespace nixl::trace {
 
@@ -114,49 +114,6 @@ Tracer::popCorrelationId() {
     for (auto &backend : backends_) {
         backend->popCorrelationId();
     }
-}
-
-/*** Factory ***/
-
-std::unique_ptr<Tracer>
-makeTracer(const TracerConfig &config) {
-    std::vector<std::unique_ptr<TraceBackend>> backends;
-    std::unordered_set<std::string> seen;
-
-    auto &plugin_manager = nixlPluginManager::getInstance();
-    const nixlTraceBackendInitParams init_params{config.agentName};
-
-    for (const auto &requested : config.backends) {
-        // Skip blanks and duplicates so e.g. "nvtx,nvtx" activates one backend.
-        if (requested.empty() || !seen.insert(requested).second) {
-            continue;
-        }
-
-        // Each backend is an on-demand .so plugin (libtrace_backend_<name>.so).
-        // A missing plugin is not fatal: warn and skip so the rest still apply.
-        auto handle = plugin_manager.loadTracePlugin(requested);
-        if (!handle) {
-            NIXL_WARN << "nixl::trace: backend '" << requested
-                      << "' requested but plugin libtrace_backend_" << requested
-                      << ".so was not found";
-            continue;
-        }
-
-        auto backend = handle->createBackend(init_params);
-        if (!backend) {
-            NIXL_WARN << "nixl::trace: backend '" << requested << "' failed to initialize";
-            continue;
-        }
-
-        NIXL_DEBUG << "nixl::trace: activated '" << requested << "' backend for agent '"
-                   << config.agentName << "'";
-        backends.push_back(std::move(backend));
-    }
-
-    if (backends.empty()) {
-        return nullptr;
-    }
-    return std::make_unique<Tracer>(std::move(backends));
 }
 
 } // namespace nixl::trace

--- a/src/core/tracing/tracer_factory.cpp
+++ b/src/core/tracing/tracer_factory.cpp
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unordered_set>
+
+#include "tracing/trace.h"
+
+#include "common/nixl_log.h"
+#include "plugin_manager.h"
+
+namespace nixl::trace {
+
+std::unique_ptr<Tracer>
+makeTracer(const TracerConfig &config) {
+    std::vector<std::unique_ptr<TraceBackend>> backends;
+    std::unordered_set<std::string> seen;
+
+    auto &plugin_manager = nixlPluginManager::getInstance();
+    const nixlTraceBackendInitParams init_params{config.agentName};
+
+    for (const auto &requested : config.backends) {
+        // Skip blanks and duplicates so e.g. "nvtx,nvtx" activates one backend.
+        if (requested.empty() || !seen.insert(requested).second) {
+            continue;
+        }
+
+        // Each backend is an on-demand .so plugin (libtrace_backend_<name>.so).
+        // A missing plugin is not fatal: warn and skip so the rest still apply.
+        auto handle = plugin_manager.loadTracePlugin(requested);
+        if (!handle) {
+            NIXL_WARN << "nixl::trace: backend '" << requested
+                      << "' requested but plugin libtrace_backend_" << requested
+                      << ".so was not found";
+            continue;
+        }
+
+        auto backend = handle->createBackend(init_params);
+        if (!backend) {
+            NIXL_WARN << "nixl::trace: backend '" << requested << "' failed to initialize";
+            continue;
+        }
+
+        NIXL_DEBUG << "nixl::trace: activated '" << requested << "' backend for agent '"
+                   << config.agentName << "'";
+        backends.push_back(std::move(backend));
+    }
+
+    if (backends.empty()) {
+        return nullptr;
+    }
+    return std::make_unique<Tracer>(std::move(backends));
+}
+
+} // namespace nixl::trace

--- a/src/plugins/libfabric/libfabric_backend.cpp
+++ b/src/plugins/libfabric/libfabric_backend.cpp
@@ -448,7 +448,7 @@ nixlLibfabricEngine::nixlLibfabricEngine(const nixlBackendInitParams *init_param
     : nixlBackendEngine(init_params),
       progress_thread_enabled_(init_params->enableProgTh),
       progress_thread_delay_(std::chrono::microseconds(init_params->pthrDelay)),
-      rail_manager_(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD),
+      rail_manager_(NIXL_LIBFABRIC_DEFAULT_STRIPING_THRESHOLD, tracer_),
       post_thread_count_(NIXL_LIBFABRIC_DEFAULT_POST_THREADS),
       post_split_batch_size_(NIXL_LIBFABRIC_DEFAULT_POST_SPLIT_BATCH_SIZE),
       runtime_(FI_HMEM_SYSTEM) {

--- a/src/plugins/libfabric/meson.build
+++ b/src/plugins/libfabric/meson.build
@@ -28,6 +28,12 @@ libfabric_plugin_deps = [
 
 compile_flags = ['-DHAVE_LIBFABRIC']
 
+# The nixl::trace facade method bodies (Span/Tracer) live in nixl core, which this
+# plugin cannot link (core loads plugins at runtime).
+# Here, compile those method bodies straight into the plugin so the symbols resolve
+# under -Wl,--no-undefined, when it is not staticaly built.
+nixl_trace_facade_src = files('../../core/tracing/tracer.cpp')
+
 # Add CUDA support if available
 if cuda_dep.found()
     libfabric_plugin_deps += [cuda_dep]
@@ -59,6 +65,7 @@ else
         'libfabric_connection.h',
         'libfabric_handshake.cpp',
         'libfabric_plugin.cpp',
+        nixl_trace_facade_src,
         dependencies: libfabric_plugin_deps,
         include_directories: [nixl_inc_dirs, utils_inc_dirs],
         install: true,

--- a/src/plugins/tracing/nvtx/nvtx_events.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_events.cpp
@@ -38,6 +38,16 @@ namespace {
         "nixl::fetchRemoteMD",
         "nixl::prepMemView",
         "nixl::releaseMemView",
+        // libfabric backend (src/utils/libfabric)
+        "nixl::libfabric.transfer.write",
+        "nixl::libfabric.transfer.read",
+        "nixl::libfabric.post_write",
+        "nixl::libfabric.post_read",
+        "nixl::libfabric.post_send",
+        "nixl::libfabric.local_completion.write",
+        "nixl::libfabric.local_completion.read",
+        "nixl::libfabric.recv_completion",
+        "nixl::libfabric.remote_write_completion",
     };
 
     [[nodiscard]] constexpr std::uint32_t

--- a/src/plugins/tracing/nvtx/nvtx_events.cpp
+++ b/src/plugins/tracing/nvtx/nvtx_events.cpp
@@ -44,6 +44,8 @@ namespace {
         "nixl::libfabric.post_write",
         "nixl::libfabric.post_read",
         "nixl::libfabric.post_send",
+        "nixl::libfabric.post_deferred.write",
+        "nixl::libfabric.post_deferred.read",
         "nixl::libfabric.local_completion.write",
         "nixl::libfabric.local_completion.read",
         "nixl::libfabric.recv_completion",

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -20,6 +20,8 @@
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
 #include "libfabric_common.h"
+#include "tracing/trace.h"
+#include "tracing/trace_macros.h"
 
 #ifdef HAVE_CUDA
 #include <cuda_runtime.h>
@@ -75,6 +77,7 @@ RequestPool::release(nixlLibfabricReq *req) const {
 
     req->in_use = false;
     req->xfer_id = 0;
+    req->device_id = -1;
     req->chunk_offset = 0;
     req->chunk_size = 0;
     req->completion_callback = nullptr;
@@ -391,10 +394,12 @@ DataRequestPool::allocate(nixlLibfabricReq::OpType op_type, uint32_t req_id) {
 
 nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
                                      const std::string &provider,
-                                     uint16_t id)
+                                     uint16_t id,
+                                     nixl::trace::Tracer *tracer)
     : rail_id(id),
       device_name(device),
       provider_name(provider),
+      tracer_(tracer),
       control_request_pool_(NIXL_LIBFABRIC_CONTROL_REQUESTS_PER_RAIL, id),
       data_request_pool_(NIXL_LIBFABRIC_DATA_REQUESTS_PER_RAIL, id),
       provider_supports_hmem_(false) {
@@ -910,6 +915,13 @@ nixlLibfabricRail::processLocalTransferCompletion(struct fi_cq_data_entry *comp,
     // Find the request from context to access the completion callback
     nixlLibfabricReq *req = findRequestFromContext(comp->op_context);
     if (req && req->in_use) { // Only process if request is still valid and in use
+        NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(req->xfer_id));
+        NIXL_TRACE_MARK(tracer_,
+                        req->operation_type == nixlLibfabricReq::WRITE ?
+                            "nixl::libfabric.local_completion.write" :
+                            "nixl::libfabric.local_completion.read",
+                        nixl::trace::Kind::Metadata);
+
         // Call completion callback if it exists
         if (req->completion_callback) {
             NIXL_TRACE << "Calling completion callback for " << operation_type << " request "
@@ -943,6 +955,9 @@ nixlLibfabricRail::processRecvCompletion(struct fi_cq_data_entry *comp) const {
     uint64_t msg_type = NIXL_GET_MSG_TYPE_FROM_IMM(comp->data);
     uint16_t agent_idx = NIXL_GET_AGENT_INDEX_FROM_IMM(comp->data);
     uint32_t xfer_id = NIXL_GET_XFER_ID_FROM_IMM(comp->data);
+
+    NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(xfer_id));
+    NIXL_TRACE_MARK(tracer_, "nixl::libfabric.recv_completion", nixl::trace::Kind::CommRecv);
     NIXL_TRACE << "Received control message type " << msg_type << " agent_idx=" << agent_idx
                << " XFER_ID=" << xfer_id << " imm_data=" << std::hex << comp->data << std::dec;
 
@@ -1013,6 +1028,11 @@ nixlLibfabricRail::processRemoteWriteCompletion(struct fi_cq_data_entry *comp) c
     // For remote write completions, we don't need to post a new receive
     // The write operation doesn't consume a receive buffer
     if (msg_type == NIXL_LIBFABRIC_MSG_TRANSFER) {
+        // Tracing: remote write completion (target side). Correlate on xfer_id to
+        // link with the initiator's write span.
+        NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(xfer_id));
+        NIXL_TRACE_MARK(
+            tracer_, "nixl::libfabric.remote_write_completion", nixl::trace::Kind::CommRecv);
         NIXL_TRACE << "Remote write completion on rail " << rail_id << " - received " << comp->len
                    << " bytes" << " agent_idx=" << agent_idx << " XFER_ID=" << xfer_id
                    << " imm_data=" << std::hex << comp->data << std::dec;
@@ -1087,6 +1107,15 @@ nixlLibfabricRail::postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLi
                << " XFER_ID=" << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr=" << dest_addr << std::dec << " context=" << &req->ctx;
 
+    // Tracing: span covers the (possibly retried) control-message send. xfer_id
+    // is carried in the immediate data on this path; correlate on it.
+    const std::uint64_t send_xfer_id = NIXL_GET_XFER_ID_FROM_IMM(immediate_data);
+    NIXL_TRACE_CORRELATION_SCOPE(tracer_, send_xfer_id);
+    NIXL_TRACE_SCOPE(trace_span, tracer_, "nixl::libfabric.post_send", nixl::trace::Kind::CommSend);
+    NIXL_TRACE_ATTR(trace_span, "rail_id", static_cast<std::int64_t>(rail_id));
+    NIXL_TRACE_ATTR(trace_span, "length", static_cast<std::int64_t>(req->buffer_size));
+    NIXL_TRACE_ATTR(trace_span, "xfer_id", static_cast<std::int64_t>(send_xfer_id));
+
     // Retry indefinitely until senddata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1109,6 +1138,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLi
             NIXL_TRACE << "Send posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_ATTR(trace_span, "retries", static_cast<std::int64_t>(attempt));
             return NIXL_SUCCESS;
         }
 
@@ -1305,6 +1335,16 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
                << " dest_addr=" << dest_addr << " remote_addr=" << (void *)remote_addr
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
+    // Tracing: span covers the (possibly retried) post; correlate on xfer_id to
+    // link with the enclosing transfer span and the completion marker.
+    NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(req->xfer_id));
+    NIXL_TRACE_SCOPE(
+        trace_span, tracer_, "nixl::libfabric.post_write", nixl::trace::Kind::CommSend);
+    NIXL_TRACE_ATTR(trace_span, "device_id", static_cast<std::int64_t>(req->device_id));
+    NIXL_TRACE_ATTR(trace_span, "rail_id", static_cast<std::int64_t>(rail_id));
+    NIXL_TRACE_ATTR(trace_span, "length", static_cast<std::int64_t>(length));
+    NIXL_TRACE_ATTR(trace_span, "xfer_id", static_cast<std::int64_t>(req->xfer_id));
+
     // Retry indefinitely until writedata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1341,6 +1381,7 @@ nixlLibfabricRail::postWrite(const void *local_buffer,
             NIXL_TRACE << "RDMA write posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_ATTR(trace_span, "retries", static_cast<std::int64_t>(attempt));
             return NIXL_SUCCESS;
         }
 
@@ -1401,6 +1442,15 @@ nixlLibfabricRail::postRead(void *local_buffer,
                << " dest_addr=" << dest_addr << " remote_addr=" << (void *)remote_addr
                << " remote_key=" << remote_key << " context=" << &req->ctx;
 
+    // Tracing: span covers the (possibly retried) post; correlate on xfer_id to
+    // link with the enclosing transfer span and the completion marker.
+    NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(req->xfer_id));
+    NIXL_TRACE_SCOPE(trace_span, tracer_, "nixl::libfabric.post_read", nixl::trace::Kind::CommRecv);
+    NIXL_TRACE_ATTR(trace_span, "device_id", static_cast<std::int64_t>(req->device_id));
+    NIXL_TRACE_ATTR(trace_span, "rail_id", static_cast<std::int64_t>(rail_id));
+    NIXL_TRACE_ATTR(trace_span, "length", static_cast<std::int64_t>(length));
+    NIXL_TRACE_ATTR(trace_span, "xfer_id", static_cast<std::int64_t>(req->xfer_id));
+
     // Retry indefinitely until readdata succeeds or fails for all providers
     int ret = -FI_EAGAIN;
     int attempt = 0;
@@ -1424,6 +1474,7 @@ nixlLibfabricRail::postRead(void *local_buffer,
             NIXL_TRACE << "RDMA read posted successfully"
                        << (attempt > 0 ? " after " + std::to_string(attempt + 1) + " attempts" :
                                          "");
+            NIXL_TRACE_ATTR(trace_span, "retries", static_cast<std::int64_t>(attempt));
             return NIXL_SUCCESS;
         }
 

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1107,9 +1107,7 @@ nixlLibfabricRail::postSend(uint64_t immediate_data, fi_addr_t dest_addr, nixlLi
                << " XFER_ID=" << NIXL_GET_XFER_ID_FROM_IMM(immediate_data)
                << " dest_addr=" << dest_addr << std::dec << " context=" << &req->ctx;
 
-    // Tracing: span covers the (possibly retried) control-message send. xfer_id
-    // is carried in the immediate data on this path; correlate on it.
-    const std::uint64_t send_xfer_id = NIXL_GET_XFER_ID_FROM_IMM(immediate_data);
+    [[maybe_unused]] const std::uint64_t send_xfer_id = NIXL_GET_XFER_ID_FROM_IMM(immediate_data);
     NIXL_TRACE_CORRELATION_SCOPE(tracer_, send_xfer_id);
     NIXL_TRACE_SCOPE(trace_span, tracer_, "nixl::libfabric.post_send", nixl::trace::Kind::CommSend);
     NIXL_TRACE_ATTR(trace_span, "rail_id", static_cast<std::int64_t>(rail_id));

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -1202,6 +1202,29 @@ nixlLibfabricRail::drainPostQueue() {
         ++post_req_count;
         int ret = -FI_EAGAIN;
 
+        // Tracing: this is where the post actually happens when a progress thread
+        // is enabled -- postWrite()/postRead() are bypassed entirely on that path
+        // -- so emit the same post span here, or PT mode would show no post at
+        // all. Unlike those two, this runs on the progress thread, where no
+        // correlation id is active (the backend keeps that stack thread_local),
+        // so push xfer_id here to link back to the submitting thread's spans.
+        [[maybe_unused]] const std::uint64_t post_xfer_id = pr.req ? pr.req->xfer_id : 0;
+        [[maybe_unused]] int attempt = 0;
+        NIXL_TRACE_CORRELATION_SCOPE(tracer_, post_xfer_id);
+        NIXL_TRACE_SCOPE(trace_span,
+                         tracer_,
+                         pr.type == nixlLibfabricPostRequest::WRITE ? "nixl::libfabric.post_write" :
+                                                                      "nixl::libfabric.post_read",
+                         pr.type == nixlLibfabricPostRequest::WRITE ? nixl::trace::Kind::CommSend :
+                                                                      nixl::trace::Kind::CommRecv);
+        NIXL_TRACE_ATTR(trace_span, "device_id", static_cast<std::int64_t>(pr.device_id));
+        NIXL_TRACE_ATTR(trace_span, "rail_id", static_cast<std::int64_t>(rail_id));
+        NIXL_TRACE_ATTR(trace_span, "length", static_cast<std::int64_t>(pr.length));
+        NIXL_TRACE_ATTR(trace_span, "xfer_id", static_cast<std::int64_t>(post_xfer_id));
+        // Distinguishes this from a same-named span emitted inline by
+        // postWrite()/postRead(), so a trace shows which path a transfer took.
+        NIXL_TRACE_ATTR(trace_span, "deferred", static_cast<std::int64_t>(1));
+
 #if HAVE_CUDA
         if (pr.is_cuda_vram) {
             // NOTE: for now we do not call engine to try to set context in work-around mode - this
@@ -1289,13 +1312,19 @@ nixlLibfabricRail::drainPostQueue() {
             }
 
             if (ret == -FI_EAGAIN) {
+                ++attempt;
                 pollForCompletions();
             }
         }
 
+        // Recorded on both the success and failure paths, unlike the inline
+        // post_write/post_read spans, so a post that spun on EAGAIN is visible.
+        NIXL_TRACE_ATTR(trace_span, "retries", static_cast<std::int64_t>(attempt));
+
         if (ret != 0) {
             NIXL_ERROR << "drainPostQueue: post failed ret=" << ret << " (" << fi_strerror(-ret)
                        << ") on rail " << rail_id;
+            NIXL_TRACE_ATTR(trace_span, "failed", static_cast<std::int64_t>(1));
             if (pr.req && pr.req->completion_callback) {
                 // completion is notified also for failed requests
                 // (otherwise counters would never match)

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -44,6 +44,7 @@ struct nixlLibfabricReq {
     size_t rail_id; ///< Rail ID that owns this request
     size_t pool_index; ///< Index in the pool for deque compatibility
     uint32_t xfer_id; ///< Pre-assigned globally unique transfer ID
+    int device_id; ///< Source device (GPU) index, for tracing (-1 when unknown)
     void *buffer; ///< Pre-assigned buffer for CONTROL operations, nullptr for DATA
     struct fid_mr *mr; ///< Pre-assigned memory registration for CONTROL, nullptr for DATA
     size_t buffer_size; ///< Pre-assigned buffer size for CONTROL (2KB), 0 for DATA
@@ -64,6 +65,7 @@ struct nixlLibfabricReq {
         : rail_id(0),
           pool_index(0),
           xfer_id(0),
+          device_id(-1),
           buffer(nullptr),
           mr(nullptr),
           buffer_size(0),
@@ -400,7 +402,10 @@ public:
     struct fid_ep *endpoint; ///< Libfabric endpoint handle
 
     /** Initialize libfabric rail with all resources */
-    nixlLibfabricRail(const std::string &device, const std::string &provider, uint16_t id);
+    nixlLibfabricRail(const std::string &device,
+                      const std::string &provider,
+                      uint16_t id,
+                      nixl::trace::Tracer *tracer = nullptr);
 
     /** Destroy rail and cleanup all libfabric resources */
     ~nixlLibfabricRail();
@@ -593,6 +598,8 @@ private:
     std::function<void(const std::string &, uint16_t)> notificationCallback;
     std::function<void(uint64_t, uint16_t)> xferIdCallback;
     std::function<void(const std::string &)> handshakeCallback;
+
+    nixl::trace::Tracer *const tracer_;
 
     // Separate request pools for optimal performance
     ControlRequestPool control_request_pool_;

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -599,7 +599,7 @@ private:
     std::function<void(uint64_t, uint16_t)> xferIdCallback;
     std::function<void(const std::string &)> handshakeCallback;
 
-    nixl::trace::Tracer *const tracer_;
+    [[maybe_unused]] nixl::trace::Tracer *const tracer_;
 
     // Separate request pools for optimal performance
     ControlRequestPool control_request_pool_;

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -653,6 +653,14 @@ nixlLibfabricRailManager::deferTransferRequest(nixlLibfabricReq::OpType op_type,
     pr.fi_flags = fi_flags;
     pr.device_id = device_id;
     pr.is_cuda_vram = is_cuda_vram;
+    // Tracing: marks the hand-off to the progress thread. The enclosing
+    // transfer.write/read span ends here on this path, so without this marker the
+    // gap between submit and the (progress-thread) post span is unexplained.
+    // Correlation comes from the caller's scope, which is still active.
+    NIXL_TRACE_MARK(tracer_,
+                    op_type == nixlLibfabricReq::WRITE ? "nixl::libfabric.post_deferred.write" :
+                                                         "nixl::libfabric.post_deferred.read",
+                    nixl::trace::Kind::Metadata);
     rails_[rail_id]->enqueuePost(pr);
 }
 

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -21,6 +21,8 @@
 #include "libfabric/libfabric_topology.h"
 #include "common/nixl_log.h"
 #include "serdes/serdes.h"
+#include "tracing/trace.h"
+#include "tracing/trace_macros.h"
 #include <sstream>
 #include <algorithm>
 #include <numaif.h>
@@ -192,8 +194,10 @@ private:
     buildNumaDistanceMap();
 };
 
-nixlLibfabricRailManager::nixlLibfabricRailManager(size_t striping_threshold)
+nixlLibfabricRailManager::nixlLibfabricRailManager(size_t striping_threshold,
+                                                   nixl::trace::Tracer *tracer)
     : striping_threshold_(striping_threshold),
+      tracer_(tracer),
       runtime_(FI_HMEM_CUDA) {
     NIXL_DEBUG << "Creating rail manager with striping threshold: " << striping_threshold_
                << " bytes";
@@ -351,7 +355,7 @@ nixlLibfabricRailManager::createRails(const std::vector<std::string> &efa_device
 
         for (size_t i = 0; i < num_rails_; ++i) {
             rails_.emplace_back(std::make_unique<nixlLibfabricRail>(
-                efa_devices[i], provider_name, static_cast<uint16_t>(i)));
+                efa_devices[i], provider_name, static_cast<uint16_t>(i), tracer_));
 
             // Initialize EFA device mapping
             efa_device_to_rail_map[efa_devices[i]] = i;
@@ -403,6 +407,23 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
 
     // Determine striping strategy
     bool use_striping = usesStriping(transfer_size, selected_rails.size());
+
+    // Tracing: one span covers the prepare+submit for this descriptor. Correlate
+    // on xfer_id so it links to the per-rail post spans and the completion marker
+    // (which may fire on the progress thread). The RAII span ends on any return.
+    NIXL_TRACE_CORRELATION_SCOPE(tracer_, static_cast<std::uint64_t>(xfer_id));
+    NIXL_TRACE_SCOPE(trace_span,
+                     tracer_,
+                     op_type == nixlLibfabricReq::WRITE ? "nixl::libfabric.transfer.write" :
+                                                          "nixl::libfabric.transfer.read",
+                     op_type == nixlLibfabricReq::WRITE ? nixl::trace::Kind::CommSend :
+                                                          nixl::trace::Kind::CommRecv);
+    NIXL_TRACE_ATTR(trace_span, "device_id", static_cast<std::int64_t>(device_id));
+    NIXL_TRACE_ATTR(trace_span, "transfer_size", static_cast<std::int64_t>(transfer_size));
+    NIXL_TRACE_ATTR(trace_span, "num_rails", static_cast<std::int64_t>(selected_rails.size()));
+    NIXL_TRACE_ATTR(trace_span, "use_striping", static_cast<std::int64_t>(use_striping ? 1 : 0));
+    NIXL_TRACE_ATTR(trace_span, "xfer_id", static_cast<std::int64_t>(xfer_id));
+
     NIXL_DEBUG << "use_striping=" << use_striping;
     if (!use_striping) {
         // WRITE: group NIXL_LIBFABRIC_FI_MORE_BATCH_SIZE consecutive descriptors on one rail
@@ -427,6 +448,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         }
         // Set completion callback and populate request
         req->completion_callback = completion_callback;
+        req->device_id = device_id;
         req->chunk_offset = 0;
         req->chunk_size = transfer_size;
         req->local_addr = local_addr;
@@ -521,6 +543,7 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
             }
 
             req->completion_callback = completion_callback;
+            req->device_id = device_id;
 
             // Calculate and populate chunk info
             size_t chunk_offset = i * chunk_size;
@@ -594,6 +617,8 @@ nixlLibfabricRailManager::prepareAndSubmitTransfer(
         NIXL_DEBUG << "Striping: submitted " << submitted_count_out << " requests for "
                    << transfer_size << " bytes";
     }
+
+    NIXL_TRACE_ATTR(trace_span, "submitted_count", static_cast<std::int64_t>(submitted_count_out));
 
     NIXL_DEBUG << "Successfully submitted requests for " << transfer_size << " bytes";
 

--- a/src/utils/libfabric/libfabric_rail_manager.h
+++ b/src/utils/libfabric/libfabric_rail_manager.h
@@ -72,9 +72,10 @@ public:
     /** Initialize rail manager with topology discovery and create rails based on available
      * network devices
      * @param striping_threshold Size threshold for enabling multi-rail striping
+     * @param tracer Agent-owned composite tracer. Null when tracing is inactive.
      * @throws std::runtime_error if initialization fails
      */
-    nixlLibfabricRailManager(size_t striping_threshold);
+    nixlLibfabricRailManager(size_t striping_threshold, nixl::trace::Tracer *tracer = nullptr);
     /** Destroy rail manager and cleanup all resources */
     ~nixlLibfabricRailManager();
 
@@ -382,6 +383,8 @@ public:
 
 private:
     size_t striping_threshold_;
+
+    nixl::trace::Tracer *const tracer_;
 
     // System runtime type (determined once at initialization)
     fi_hmem_iface runtime_;

--- a/test/unit/utils/libfabric/meson.build
+++ b/test/unit/utils/libfabric/meson.build
@@ -22,6 +22,8 @@ if cuda_dep.found()
     libfabric_test_cpp_args += [ '-DCUDA_FOUND' ]
 endif
 
+nixl_trace_facade_src = files('../../../../src/core/tracing/tracer.cpp')
+
 if get_option('buildtype') != 'release'
 
     # mock function calls for testing
@@ -35,6 +37,7 @@ if get_option('buildtype') != 'release'
 
     libfabric_topology_test_bin = executable('libfabric_topology_test',
                'libfabric_topology_test.cpp',
+               nixl_trace_facade_src,
                dependencies: libfabric_utils_dep,
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                link_with: libfabric_utils_lib,
@@ -53,6 +56,7 @@ if get_option('buildtype') != 'release'
 
     rail_active_refcount_test_bin = executable('rail_active_refcount_test',
                'rail_active_refcount_test.cpp',
+               nixl_trace_facade_src,
                dependencies: libfabric_utils_dep,
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                link_with: libfabric_utils_lib,


### PR DESCRIPTION
## What?
This PR tries to add tracing in libfabric backend plugin via the new nixl tracing API and nvtx tracing backend.

## How?
Add tracing instrumentation in code.
Changed nixl core code to make tracing facade available to a backend to use.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracing across Libfabric transfers, communication, completions, retries, and deferred operations.
  * Added correlated transfer spans with device, size, rail, striping, and request metadata.
  * Added on-demand tracing backend loading with graceful handling of unavailable or failed backends.
  * Added NVTX events for Libfabric transfer lifecycle operations.

* **Bug Fixes**
  * Request device identifiers are now preserved and reset appropriately during request processing.

* **Documentation**
  * Documented Libfabric tracing spans, markers, attributes, and transfer correlation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->