### PR TITLE
PLUGINS/UCX: Single UCX connection per handle

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -26,7 +26,6 @@
 #include <optional>
 #include <limits>
 #include <future>
-#include <set>
 #include <string.h>
 #include <unistd.h>
 #include "absl/strings/numbers.h"
@@ -67,20 +66,15 @@ constexpr size_t single_ep_request_count = 3;
 
 class nixlUcxBackendReqH : public nixlBackendReqH {
 private:
-    std::set<ucx_connection_ptr_t> connections_;
+    ucx_connection_ptr_t conn_;
     std::vector<nixlUcxReq> requests_;
     nixlUcxWorker *worker_ = nullptr;
 
     [[nodiscard]] nixl_status_t
     checkConnection(const nixl_status_t status = NIXL_SUCCESS) const {
-        NIXL_ASSERT(!connections_.empty());
-        for (const auto &conn : connections_) {
-            const nixl_status_t conn_status = conn->getEp(getWorkerId())->checkTxState();
-            if (conn_status != NIXL_SUCCESS) {
-                return conn_status;
-            }
-        }
-        return status;
+        NIXL_ASSERT(conn_ != nullptr);
+        const nixl_status_t conn_status = conn_->getEp(getWorkerId())->checkTxState();
+        return (conn_status != NIXL_SUCCESS) ? conn_status : status;
     }
 
 protected:
@@ -114,30 +108,22 @@ public:
     void
     reserve(size_t size) {
         requests_.reserve(size);
-        NIXL_ASSERT(connections_.empty());
+        NIXL_ASSERT(conn_ == nullptr);
     }
 
     [[nodiscard]] nixl_status_t
     append(nixl_status_t status, nixlUcxReq req, const ucx_connection_ptr_t &conn) {
-        switch (status) {
-        case NIXL_IN_PROG:
+        if (status == NIXL_IN_PROG) [[likely]] {
             requests_.push_back(req);
-            connections_.insert(conn);
-            break;
-        case NIXL_SUCCESS:
-            connections_.insert(conn);
-            break;
-        default:
+        } else if (status != NIXL_SUCCESS) {
             // Error. Release all previously initiated ops and exit:
             release();
             return status;
         }
-        return NIXL_SUCCESS;
-    }
 
-    [[nodiscard]] const std::set<ucx_connection_ptr_t> &
-    getConnections() const noexcept {
-        return connections_;
+        NIXL_ASSERT(conn_ == nullptr || conn_ == conn);
+        conn_ = conn;
+        return NIXL_SUCCESS;
     }
 
     [[nodiscard]] virtual bool
@@ -158,14 +144,14 @@ public:
             worker_->reqRelease(req);
         }
         requests_.clear();
-        connections_.clear();
+        conn_.reset();
     }
 
     [[nodiscard]] virtual nixl_status_t
     status() {
         if (requests_.empty()) {
             /* No pending transmissions */
-            connections_.clear();
+            conn_.reset();
             return NIXL_SUCCESS;
         }
 
@@ -202,7 +188,7 @@ public:
 
         requests_.resize(incomplete_reqs);
         if (requests_.empty()) {
-            connections_.clear();
+            conn_.reset();
         }
         return out_ret;
     }
@@ -1154,56 +1140,6 @@ nixl_status_t nixlUcxEngine::estimateXferCost (const nixl_xfer_op_t &operation,
     return NIXL_SUCCESS;
 }
 
-nixlUcxEngine::batchResult
-nixlUcxEngine::sendXferRangeBatch(nixlUcxEp &ep,
-                                  nixl_xfer_op_t operation,
-                                  const nixl_meta_dlist_t &local,
-                                  const nixl_meta_dlist_t &remote,
-                                  size_t worker_id,
-                                  size_t start_idx,
-                                  size_t end_idx) {
-    batchResult result = {NIXL_SUCCESS, 0, nullptr};
-
-    for (size_t i = start_idx; i < end_idx; ++i) {
-        void *laddr = (void *)local[i].addr;
-        size_t lsize = local[i].len;
-        uint64_t raddr = static_cast<uint64_t>(remote[i].addr);
-        NIXL_ASSERT(lsize == remote[i].len);
-
-        const auto lmd = static_cast<nixlUcxPrivateMetadata *>(local[i].metadataP);
-        const auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[i].metadataP);
-        auto &rmd_ep = rmd->conn->getEp(worker_id);
-        if (rmd_ep.get() != &ep) [[unlikely]] {
-            break;
-        }
-
-        ++result.size;
-        nixlUcxReq req;
-        const nixl_status_t ret = operation == NIXL_READ ?
-            ep.read(raddr, rmd->getRkey(worker_id), laddr, lmd->mem, lsize, req) :
-            ep.write(laddr, lmd->mem, raddr, rmd->getRkey(worker_id), lsize, req);
-
-        if (ret == NIXL_IN_PROG) {
-            if (result.req != nullptr) [[likely]] {
-                ucp_request_free(result.req);
-            }
-            result.req = req;
-        } else if (ret != NIXL_SUCCESS) {
-            result.status = ret;
-            if (result.req != nullptr) {
-                ucp_request_free(result.req);
-                result.req = nullptr;
-            }
-            break;
-        }
-    }
-
-    if (result.status == NIXL_SUCCESS && result.req) {
-        result.status = NIXL_IN_PROG;
-    }
-    return result;
-}
-
 #ifdef HAVE_UCX_SGL_API
 nixl_status_t
 nixlUcxEngine::prepXferSgl(const nixl_meta_dlist_t &local,
@@ -1270,34 +1206,59 @@ nixlUcxEngine::sendXferRange(const nixl_xfer_op_t &operation,
 
     int_handle->reserve(single_ep_request_count);
 
-    for (size_t i = start_idx; i < end_idx;) {
-        /* Send requests to a single EP */
+    const ucx_connection_ptr_t &conn =
+        static_cast<nixlUcxPublicMetadata *>(remote[start_idx].metadataP)->conn;
+    auto &ep = conn->getEp(worker_id);
+
+    nixl_status_t status = NIXL_SUCCESS;
+    nixlUcxReq pending_req = nullptr;
+
+    for (size_t i = start_idx; i < end_idx; ++i) {
+        void *laddr = (void *)local[i].addr;
+        size_t lsize = local[i].len;
+        uint64_t raddr = static_cast<uint64_t>(remote[i].addr);
+        NIXL_ASSERT(lsize == remote[i].len);
+
+        const auto lmd = static_cast<nixlUcxPrivateMetadata *>(local[i].metadataP);
         const auto rmd = static_cast<nixlUcxPublicMetadata *>(remote[i].metadataP);
-        auto &ep = rmd->conn->getEp(worker_id);
-        const batchResult result =
-            sendXferRangeBatch(*ep, operation, local, remote, worker_id, i, end_idx);
+        NIXL_ASSERT(rmd->conn->getEp(worker_id).get() == ep.get());
 
-        /* Append a single pending request for the entire EP batch */
-        const nixl_status_t ret = int_handle->append(result.status, result.req, rmd->conn);
-        if (ret != NIXL_SUCCESS) {
-            return ret;
+        nixlUcxReq req;
+        const nixl_status_t ret = operation == NIXL_READ ?
+            ep->read(raddr, rmd->getRkey(worker_id), laddr, lmd->mem, lsize, req) :
+            ep->write(laddr, lmd->mem, raddr, rmd->getRkey(worker_id), lsize, req);
+
+        if (ret == NIXL_IN_PROG) {
+            if (pending_req != nullptr) [[likely]] {
+                ucp_request_free(pending_req);
+            }
+            pending_req = req;
+        } else if (ret != NIXL_SUCCESS) {
+            status = ret;
+            if (pending_req != nullptr) {
+                ucp_request_free(pending_req);
+                pending_req = nullptr;
+            }
+            break;
         }
+    }
 
-        i += result.size;
+    if (status == NIXL_SUCCESS && pending_req) {
+        status = NIXL_IN_PROG;
+    }
+
+    if (int_handle->append(status, pending_req, conn) != NIXL_SUCCESS) {
+        return status;
     }
 
     /*
      * Flush keeps int_handle non-empty until the operation is actually
      * completed, which can happen after local requests completion.
-     * We need to flush all distinct connections to ensure that the operation
-     * is actually completed.
      */
-    for (auto &conn : int_handle->getConnections()) {
-        nixlUcxReq req;
-        const nixl_status_t ret = conn->getEp(worker_id)->flushEp(req);
-        if (int_handle->append(ret, req, conn) != NIXL_SUCCESS) {
-            return ret;
-        }
+    nixlUcxReq flush_req;
+    const nixl_status_t flush_ret = ep->flushEp(flush_req);
+    if (int_handle->append(flush_ret, flush_req, conn) != NIXL_SUCCESS) {
+        return flush_ret;
     }
 
     return NIXL_SUCCESS;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -272,21 +272,6 @@ private:
     ucx_connection_ptr_t
     getConnection(const std::string &remote_agent) const;
 
-    struct batchResult {
-        nixl_status_t status;
-        size_t size;
-        nixlUcxReq req;
-    };
-
-    static batchResult
-    sendXferRangeBatch(nixlUcxEp &ep,
-                       nixl_xfer_op_t operation,
-                       const nixl_meta_dlist_t &local,
-                       const nixl_meta_dlist_t &remote,
-                       size_t worker_id,
-                       size_t start_idx,
-                       size_t end_idx);
-
 #ifdef HAVE_UCX_SGL_API
     nixl_status_t
     prepXferSgl(const nixl_meta_dlist_t &local,


### PR DESCRIPTION
## What?
Keep just a single connection pointer per handle, not set of them
- Simplify the code and reasoning about handle connection
- Improve performance (no set nodes allocation on heap)
- Improve debuggability

## Why?
A transfer handle targets exactly one remote agent, since createXferReq/prepXferReq take a single remote_agent and resolve the remote descriptors only against that agent's section. The engine keeps at most one connection per agent in remoteConnMap, and each nixlUcxPublicMetadata::conn is a const shared_ptr copied from that entry, so one agent means one nixlUcxConnection. The handle is also pinned to one worker, and a connection owns one endpoint per worker, so the whole descriptor list resolves to a single nixlUcxEp. 

## Testing
BW and post latency improves by 1% on low dimensions
```
UCX_TLS=^cuda_ipc nixlbench --initiator_seg_type=VRAM --target_seg_type=VRAM --start_block_size=4096 --max_block_size=4096 --num_iter=100000

Block Size (B)      Batch Size     B/W (GB/Sec)   Avg Lat. (us)  Avg Prep (us)  P99 Prep (us)  Avg Post (us)  P99 Post (us)  Avg Tx (us)    P99 Tx (us)
----------------------------------------------------------------------------------------------------------------------------------------------------------------
4096                1              0.943396       4.3            12.0           12.0           1.1           2.0            3.2            4.0
4096                1              0.952939       4.3            12.0           12.0           1.0           2.0            3.2            4.0
```
This also improves sglang performance by 1-2%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UCX connection handling to prevent conflicting connection assignments.
  * Increased transfer reliability by consistently using and validating a single endpoint for grouped requests.
  * Improved request cleanup and completion tracking after transfers.
  * Improved error handling by releasing pending transfer requests when operations fail.
  * Simplified transfer processing to improve consistency and reliability during range-based transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->