### PR TITLE
plugins: de-duplicate static/dynamic entry-point boilerplate

### DIFF
--- a/src/api/cpp/backend/backend_plugin.h
+++ b/src/api/cpp/backend/backend_plugin.h
@@ -110,6 +110,32 @@ private:
     }
 };
 
+// Most plugins expose the exact same pair of entry points (a "createStatic<X>Plugin"
+// function for static builds, or nixl_plugin_init/nixl_plugin_fini for dynamic
+// loading), differing only in which one is compiled based on STATIC_PLUGIN_<X>.
+// These helper macros let a plugin's .cpp file define the actual plugin-creation
+// logic exactly once (typically via nixlBackendPluginCreator<T>::create(...)) and
+// avoid re-stating that call, along with the boilerplate around it, for both the
+// static and dynamic entry points.
+//
+// Usage:
+//   nixlBackendPlugin *createFooPluginInstance() { return foo_plugin_t::create(...); }
+//
+//   #ifdef STATIC_PLUGIN_FOO
+//   NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticFOOPlugin, createFooPluginInstance)
+//   #else
+//   NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createFooPluginInstance)
+//   #endif
+#define NIXL_STATIC_PLUGIN_ENTRYPOINT(FuncName, CreateInstanceFn) \
+    nixlBackendPlugin *FuncName() {                               \
+        return CreateInstanceFn();                                \
+    }
+
+#define NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(CreateInstanceFn)                  \
+    extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *nixl_plugin_init() { \
+        return CreateInstanceFn();                                        \
+    }                                                                     \
+    extern "C" NIXL_PLUGIN_EXPORT void nixl_plugin_fini() {}
 
 // Creator Function type for static plugins
 typedef nixlBackendPlugin* (*nixlStaticPluginCreatorFunc)();

--- a/src/plugins/azure_blob/azure_blob_plugin.cpp
+++ b/src/plugins/azure_blob/azure_blob_plugin.cpp
@@ -24,19 +24,16 @@
 // Plugin type alias for convenience
 using azure_blob_plugin_t = nixlBackendPluginCreator<nixlAzureBlobEngine>;
 
-#ifdef STATIC_PLUGIN_AZURE
+namespace {
 nixlBackendPlugin *
-createStaticAZUREPlugin() {
+createAzureBlobPluginInstance() {
     return azure_blob_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "AZURE_BLOB", "0.1.0", {}, {DRAM_SEG, OBJ_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return azure_blob_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "AZURE_BLOB", "0.1.0", {}, {DRAM_SEG, OBJ_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_AZURE
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticAZUREPlugin, createAzureBlobPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createAzureBlobPluginInstance)
 #endif

--- a/src/plugins/cuda_gds/gds_plugin.cpp
+++ b/src/plugins/cuda_gds/gds_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,19 +22,16 @@
 // Plugin type alias for convenience
 using gds_plugin_t = nixlBackendPluginCreator<nixlGdsEngine>;
 
-#ifdef STATIC_PLUGIN_GDS
+namespace {
 nixlBackendPlugin *
-createStaticGDSPlugin() {
+createGdsPluginInstance() {
     return gds_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "GDS", "0.1.1", {}, {DRAM_SEG, VRAM_SEG, FILE_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return gds_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "GDS", "0.1.1", {}, {DRAM_SEG, VRAM_SEG, FILE_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_GDS
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticGDSPlugin, createGdsPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createGdsPluginInstance)
 #endif

--- a/src/plugins/gds_mt/gds_mt_plugin.cpp
+++ b/src/plugins/gds_mt/gds_mt_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,19 +24,16 @@
 // Plugin type alias for convenience
 using gds_mt_plugin_t = nixlBackendPluginCreator<nixlGdsMtEngine>;
 
-#ifdef STATIC_PLUGIN_GDS_MT
+namespace {
 nixlBackendPlugin *
-createStaticGDS_MTPlugin() {
+createGdsMtPluginInstance() {
     return gds_mt_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "GDS_MT", "0.1.0", {}, {DRAM_SEG, VRAM_SEG, FILE_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return gds_mt_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "GDS_MT", "0.1.0", {}, {DRAM_SEG, VRAM_SEG, FILE_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_GDS_MT
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticGDS_MTPlugin, createGdsMtPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createGdsMtPluginInstance)
 #endif

--- a/src/plugins/gusli/gusli_plugin.cpp
+++ b/src/plugins/gusli/gusli_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,25 +30,19 @@ get_gusli_backend_options() {
     return params;
 }
 
-#ifdef STATIC_PLUGIN_GUSLI
+namespace {
 nixlBackendPlugin *
-createStaticGusliPlugin() {
+createGusliPluginInstance() {
     return gusli_plugin_t::create(NIXL_PLUGIN_API_VERSION,
                                   "GUSLI",
                                   "0.1.0",
                                   get_gusli_backend_options(),
                                   {BLK_SEG, DRAM_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return gusli_plugin_t::create(NIXL_PLUGIN_API_VERSION,
-                                  "GUSLI",
-                                  "0.1.0",
-                                  get_gusli_backend_options(),
-                                  {BLK_SEG, DRAM_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_GUSLI
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticGusliPlugin, createGusliPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createGusliPluginInstance)
 #endif

--- a/src/plugins/hf3fs/hf3fs_plugin.cpp
+++ b/src/plugins/hf3fs/hf3fs_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,19 +23,16 @@
 // Plugin type alias for convenience
 using hf3fs_plugin_t = nixlBackendPluginCreator<nixlHf3fsEngine>;
 
-#ifdef STATIC_PLUGIN_HF3FS
+namespace {
 nixlBackendPlugin *
-createStaticHF3FSPlugin() {
+createHf3fsPluginInstance() {
     return hf3fs_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "HF3FS", "0.1.0", {}, {FILE_SEG, DRAM_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return hf3fs_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "HF3FS", "0.1.0", {}, {FILE_SEG, DRAM_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_HF3FS
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticHF3FSPlugin, createHf3fsPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createHf3fsPluginInstance)
 #endif

--- a/src/plugins/infinia/infinia_plugin.cpp
+++ b/src/plugins/infinia/infinia_plugin.cpp
@@ -24,25 +24,19 @@ using infinia_plugin_t = nixlBackendPluginCreator<infinia_engine>;
 
 static const nixl_mem_list_t supported_segments = {DRAM_SEG, VRAM_SEG, OBJ_SEG};
 
-#ifdef STATIC_PLUGIN_INFINIA
+namespace {
 nixlBackendPlugin *
-createStaticInfiniaPlugin() {
+createInfiniaPluginInstance() {
     return infinia_plugin_t::create(NIXL_PLUGIN_API_VERSION,
                                     INFINIA_PLUGIN_NAME,
                                     INFINIA_PLUGIN_VERSION,
                                     {},
                                     supported_segments);
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return infinia_plugin_t::create(NIXL_PLUGIN_API_VERSION,
-                                    INFINIA_PLUGIN_NAME,
-                                    INFINIA_PLUGIN_VERSION,
-                                    {},
-                                    supported_segments);
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_INFINIA
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticInfiniaPlugin, createInfiniaPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createInfiniaPluginInstance)
 #endif

--- a/src/plugins/libfabric/libfabric_plugin.cpp
+++ b/src/plugins/libfabric/libfabric_plugin.cpp
@@ -30,25 +30,19 @@ getLibfabricBackendOptions() {
     };
 }
 
-#ifdef STATIC_PLUGIN_LIBFABRIC
+namespace {
 nixlBackendPlugin *
-createStaticLIBFABRICPlugin() {
+createLibfabricPluginInstance() {
     return libfabric_plugin_t::create(NIXL_PLUGIN_API_VERSION,
                                       "LIBFABRIC",
                                       "0.1.0",
                                       getLibfabricBackendOptions(),
                                       {DRAM_SEG, VRAM_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return libfabric_plugin_t::create(NIXL_PLUGIN_API_VERSION,
-                                      "LIBFABRIC",
-                                      "0.1.0",
-                                      getLibfabricBackendOptions(),
-                                      {DRAM_SEG, VRAM_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_LIBFABRIC
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticLIBFABRICPlugin, createLibfabricPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createLibfabricPluginInstance)
 #endif

--- a/src/plugins/mooncake/mooncake_plugin.cpp
+++ b/src/plugins/mooncake/mooncake_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,19 +30,16 @@ get_mooncake_options() {
 // Plugin type alias for convenience
 using mooncake_plugin_t = nixlBackendPluginCreator<nixlMooncakeEngine>;
 
-#ifdef STATIC_PLUGIN_MOONCAKE
+namespace {
 nixlBackendPlugin *
-createStaticMOONCAKEPlugin() {
+createMooncakePluginInstance() {
     return mooncake_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "MOONCAKE", "0.1.0", get_mooncake_options(), {DRAM_SEG, VRAM_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return mooncake_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "MOONCAKE", "0.1.0", get_mooncake_options(), {DRAM_SEG, VRAM_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_MOONCAKE
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticMOONCAKEPlugin, createMooncakePluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createMooncakePluginInstance)
 #endif

--- a/src/plugins/obj/obj_plugin.cpp
+++ b/src/plugins/obj/obj_plugin.cpp
@@ -25,17 +25,15 @@ using obj_plugin_t = nixlBackendPluginCreator<nixlObjEngine>;
 
 static const nixl_mem_list_t supported_segments = {DRAM_SEG, OBJ_SEG};
 
-#ifdef STATIC_PLUGIN_OBJ
+namespace {
 nixlBackendPlugin *
-createStaticOBJPlugin() {
+createObjPluginInstance() {
     return obj_plugin_t::create(NIXL_PLUGIN_API_VERSION, "OBJ", "0.10.0", {}, supported_segments);
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return obj_plugin_t::create(NIXL_PLUGIN_API_VERSION, "OBJ", "0.10.0", {}, supported_segments);
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_OBJ
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticOBJPlugin, createObjPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createObjPluginInstance)
 #endif

--- a/src/plugins/posix/posix_plugin.cpp
+++ b/src/plugins/posix/posix_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,19 +22,16 @@
 // Plugin type alias for convenience
 using posix_plugin_t = nixlBackendPluginCreator<nixlPosixEngine>;
 
-#ifdef STATIC_PLUGIN_POSIX
+namespace {
 nixlBackendPlugin *
-createStaticPOSIXPlugin() {
+createPosixPluginInstance() {
     return posix_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "POSIX", "0.1.0", {}, {DRAM_SEG, FILE_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return posix_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "POSIX", "0.1.0", {}, {DRAM_SEG, FILE_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_POSIX
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticPOSIXPlugin, createPosixPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createPosixPluginInstance)
 #endif

--- a/src/plugins/uccl/uccl_plugin.cpp
+++ b/src/plugins/uccl/uccl_plugin.cpp
@@ -33,19 +33,16 @@ get_uccl_options() {
 // Plugin type alias for convenience
 using uccl_plugin_t = nixlBackendPluginCreator<nixlUcclEngine>;
 
-#ifdef STATIC_PLUGIN_UCCL
+namespace {
 nixlBackendPlugin *
-createStaticUCCLPlugin() {
+createUcclPluginInstance() {
     return uccl_plugin_t::create(
         NIXL_PLUGIN_API_VERSION, "UCCL", "0.1.0", get_uccl_options(), {DRAM_SEG, VRAM_SEG});
 }
-#else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return uccl_plugin_t::create(
-        NIXL_PLUGIN_API_VERSION, "UCCL", "0.1.0", get_uccl_options(), {DRAM_SEG, VRAM_SEG});
-}
+} // namespace
 
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+#ifdef STATIC_PLUGIN_UCCL
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticUCCLPlugin, createUcclPluginInstance)
+#else
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createUcclPluginInstance)
 #endif

--- a/src/plugins/ucx/ucx_plugin.cpp
+++ b/src/plugins/ucx/ucx_plugin.cpp
@@ -80,16 +80,7 @@ createUcxPlugin() {
 } // namespace
 
 #ifdef STATIC_PLUGIN_UCX
-nixlBackendPlugin *
-createStaticUCXPlugin() {
-    return createUcxPlugin();
-}
+NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticUCXPlugin, createUcxPlugin)
 #else
-extern "C" NIXL_PLUGIN_EXPORT nixlBackendPlugin *
-nixl_plugin_init() {
-    return createUcxPlugin();
-}
-
-extern "C" NIXL_PLUGIN_EXPORT void
-nixl_plugin_fini() {}
+NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createUcxPlugin)
 #endif


### PR DESCRIPTION
## Summary

Every backend plugin's `*_plugin.cpp` file (POSIX, GDS, GDS_MT, HF3FS,
AZURE_BLOB, OBJ, MOONCAKE, UCCL, GUSLI, INFINIA, LIBFABRIC, UCX) defined
the exact same `nixlBackendPluginCreator<T>::create(...)` call **twice**:
once in the `#ifdef STATIC_PLUGIN_<X>` branch (for `createStatic<X>Plugin()`)
and again in the `#else` branch (for `nixl_plugin_init()`), along with the
identical `extern "C"` / `NIXL_PLUGIN_EXPORT` wrapper boilerplate around it.

This is pure copy-paste duplication with no functional purpose, and it's
a latent bug risk: nothing stops the static and dynamic variants from
silently drifting apart if someone edits a version string, backend
option, or supported mem-list in only one of the two branches.

## Change

Added two small helper macros to `src/api/cpp/backend/backend_plugin.h`:

- `NIXL_STATIC_PLUGIN_ENTRYPOINT(FuncName, CreateInstanceFn)`
- `NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(CreateInstanceFn)`

Each plugin now defines its creation logic **exactly once** in a small
helper function (e.g. `createPosixPluginInstance()`), and wires it up to
both entry points via the macros:

```cpp
namespace {
nixlBackendPlugin *
createPosixPluginInstance() {
    return posix_plugin_t::create(
        NIXL_PLUGIN_API_VERSION, "POSIX", "0.1.0", {}, {DRAM_SEG, FILE_SEG});
}
} // namespace

#ifdef STATIC_PLUGIN_POSIX
NIXL_STATIC_PLUGIN_ENTRYPOINT(createStaticPOSIXPlugin, createPosixPluginInstance)
#else
NIXL_DYNAMIC_PLUGIN_ENTRYPOINT(createPosixPluginInstance)
#endif
```

`ucx_plugin.cpp` already isolated its create expression into a helper
function (`createUcxPlugin()`); only its entry-point boilerplate was
switched over to the new macros.

`gpunetio_plugin.cpp` was intentionally left untouched since it doesn't
use the `nixlBackendPluginCreator<T>` template at all (it hand-rolls the
`nixlBackendPlugin` struct), so it isn't part of this duplication pattern
and converting it would be a larger, separate change.

This is purely mechanical: exported symbol names
(`createStatic<X>Plugin`, `nixl_plugin_init`, `nixl_plugin_fini`) and
their arguments are unchanged, so no other callers need to change.

## Testing

Built with meson/ninja in a sandbox lacking the various vendor SDKs
(UCX, AWS SDK, HF3FS, libfabric, mooncake, uccl, gusli), so only
POSIX, GDS, and GDS_MT plugins actually compile+link end-to-end there;
the rest were verified by inspection since they follow the identical
mechanical transformation.

- Full `ninja` build succeeds (all buildable targets, including
  `test/gtest/gtest` and `test/gtest/unit/unit`).
- `test/gtest/gtest --gtest_filter="*Plugin*"` passes (plugin-manager
  tests unaffected; UCX/GDS-specific subtests skip due to missing deps,
  same as on unmodified `main`).
- Compared full `gtest`/`unit` suite results against an unmodified
  `main` build: identical set of pre-existing failures/skips (all due
  to missing UCX in this sandbox), plus one pre-existing flaky test
  (`singleAgentSessionFixture.RegisterDeregisterMemRepeatedTest`) that
  fails intermittently on both branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized plugin registration across supported backends for static and dynamic builds.
  * Unified plugin creation and lifecycle handling behind consistent entry points.
  * Preserved existing plugin loading behavior while reducing implementation differences between backends.
  * Improved consistency across Azure Blob, CUDA GDS, GDS MT, GUSLI, HF3FS, Infinia, Libfabric, Mooncake, OBJ, POSIX, UCCL, and UCX integrations.
  * Simplified backend integration and ongoing maintenance without changing plugin capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->