### PR TITLE
test: reduce ucx_backend_test transfer volume

### DIFF
--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -422,7 +422,7 @@ test_intra_agent_transfer(bool p_thread, nixlUcxEngine *ucx, nixl_mem_t mem_type
     std::cout << "Local connection complete\n";
 
     // Number of transfer descriptors
-    int desc_cnt = 64;
+    int desc_cnt = 8;
     // Size of a single descriptor
     size_t desc_size = 1 * 1024 * 1024;
     size_t len = desc_cnt * desc_size;
@@ -514,7 +514,7 @@ test_inter_agent_transfer(bool p_thread,
     std::cout << "Synchronous handshake complete\n";
 
     // Number of transfer descriptors
-    int desc_cnt = 64;
+    int desc_cnt = 8;
     // Size of a single descriptor
     size_t desc_size = 1 * 1024 * 1024;
     size_t len = desc_cnt * desc_size;


### PR DESCRIPTION
## Summary

The TSan leg of `nixl-ci-test-sanitizers` was being killed at its 40 minute cap while `ucx_backend_test` was still making steady progress.

In build #649 the stage started at 10:08:23 and was killed at 10:48:22 — exactly 40:00. `ucx_backend_test` ran from 10:10:16 to the kill (~38 min), printing data-verification output every 8-12s with a largest gap of ~15s, and was cut off mid-WRITE in the last of its four configurations. Not a hang, and not a sanitizer finding — it simply does not fit. Build #632 hit the same wall.

Each configuration moves and verifies `desc_cnt * desc_size` bytes. At 64 descriptors of 1 MB that is 64 MB per configuration, and under ThreadSanitizer every access on that data path is instrumented.

## Changes

- **`test/unit/plugins/ucx/ucx_backend_test.cpp`** — drop `desc_cnt` from 64 to 8 in `test_intra_agent_transfer` and `test_inter_agent_transfer`

## Why this does not reduce coverage

- The configuration matrix (progress thread on/off x handler reuse on/off) is **unchanged**, so every code path is still exercised. Dropping configurations would have cost real coverage; reducing the volume of identical work does not.
- 8 descriptors still exercise the multi-descriptor list handling in `populateDescs` and the descriptor-list transfer paths.
- `desc_size` deliberately stays at 1 MB, so transfers remain in the same UCX protocol regime — shrinking the payload instead could cross the eager/rendezvous threshold and silently change which transport path is tested.
- ThreadSanitizer reports races from happens-before analysis on the accesses it observes, not from stress. A race on a given code path is flagged regardless of how many times that path repeats, so 8 descriptors detect what 64 would.

Net effect is ~8x less data per configuration, which brings the stage well inside its budget without touching the timeout.

## Verification

Confirmation is a green `nixl-ci-test-sanitizers` run with the tsan leg completing inside 40 minutes. The asan_ubsan leg was already passing and is unaffected in kind, just faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced the number of transfer descriptors used in UCX transfer tests while preserving descriptor sizing and overall transfer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->