### PR TITLE
CI: point LLM container build at the new release wheel repo

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -13,7 +13,9 @@
 # verification stays isolated to the NIXL change.
 #
 # Wheels are pulled from Artifactory at:
-#   sw-dynamo-nixl-pypi-local/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/<arch>/
+#   sw-nbu-swx-nixl-pypi-local/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/
+# The directory is flat - both architectures share it, the arch is part of the
+# wheel filename. Reads need the svc-nixl Artifactory credentials.
 #
 # Runtime: podman (no docker). Cross-arch aarch64 builds on x86_64 hosts use
 # `podman build --platform linux/arm64` with QEMU registered via
@@ -58,7 +60,7 @@ env:
   REGISTRY_REPO_NAME: "sw-nbu-swx-nixl-docker-local"
   REGISTRY_REPO_PATH: "verification/llm"
   ARTIFACTORY_REGISTRY_URL: "${REGISTRY_HOST_NAME}/${REGISTRY_REPO_NAME}/${REGISTRY_REPO_PATH}"
-  WHEELS_REPO_NAME: "sw-dynamo-nixl-pypi-local"
+  WHEELS_REPO_NAME: "sw-nbu-swx-nixl-pypi-local"
   WHEELS_ARTIFACTORY_URL: "https://${REGISTRY_HOST_NAME}/artifactory/${WHEELS_REPO_NAME}"
   WHEELS_DIR: "${WORKSPACE}/llm-wheels"
   MAIL_FROM: "jenkins@nvidia.com"
@@ -153,7 +155,7 @@ steps:
       rm -rf "${DEST}"
       mkdir -p "${DEST}"
 
-      BASE="${WHEELS_ARTIFACTORY_URL}/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}/${arch}"
+      BASE="${WHEELS_ARTIFACTORY_URL}/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}"
       WHEELS=(
         "nixl-${NIXL_VERSION}-py3-none-any.whl"
         "nixl_cu12-${NIXL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -624,7 +624,7 @@
       • Builds 4 inference container variants per release: <b>vllm-cu12-nixl</b>, <b>vllm-cu13-nixl</b>, <b>sglang-cu12-nixl</b>, <b>sglang-cu13-nixl</b><br/>
       • Builds for x86_64 and aarch64 (aarch64 via podman with QEMU)<br/>
       • Publishes multi-arch manifests after both arches succeed<br/>
-      • Wheels pulled from <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/</code><br/>
+      • Wheels pulled from <code>sw-nbu-swx-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/</code><br/>
       • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ under <code>verification/llm/{{vllm-cu12-nixl,vllm-cu13-nixl,sglang-cu12-nixl,sglang-cu13-nixl}}</code><br/>
       • For <b>rc0</b> leave the <code>BASE_IMAGE_*</code> params empty to use upstream defaults<br/>
       • For <b>rcN, N&gt;0</b> set each <code>BASE_IMAGE_*</code> to the matching rc0 image to isolate the verification to the NIXL change<br/>
@@ -659,8 +659,10 @@
           name: "WHEEL_BUILD_ID"
           default: ""
           description: >
-            Artifactory build id for the wheel set (e.g. <code>48633863</code>).<br/>
-            Full wheel URL: <code>sw-dynamo-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/&lt;arch&gt;/nixl*.whl</code>
+            First 8 chars of the NIXL commit sha the wheels were built from, which
+            is the folder name the release wheel pipeline publishes under
+            (e.g. <code>51a42f86</code>).<br/>
+            Full wheel URL: <code>sw-nbu-swx-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/nixl*.whl</code>
       - string:
           name: "PYTHON_TAG"
           default: "cp312"


### PR DESCRIPTION
## What?

Point `nixl-ci-build-llm-container` at the new release wheel location:

- repo: `sw-dynamo-nixl-pypi-local` -> `sw-nbu-swx-nixl-pypi-local`
- path: drop the `/<arch>` segment (the release layout is flat, arch is in the wheel filename)
- update the matching JJB descriptions

## Why?

Release wheels moved to `sw-nbu-swx-nixl-pypi-local/release/<ver>/<sha8>/`, so every run 404s in `Download Wheels` and blocks release verification.

Verified with test build [#24](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/blue/organizations/jenkins/nixl-ci-build-llm-container/detail/nixl-ci-build-llm-container/24/pipeline/) (`ci_refspec=refs/pull/2043/head`, vllm-cu13, 1.4.0/rc1/51a42f86): wheels download on both arches, smoke test prints `vllm 0.22.1 nixl 1.4.0`, multi-arch manifest published. Test tag removed afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use the consolidated wheel repository and release directory structure.
  * Improved architecture-specific wheel discovery during container builds.
  * Updated build documentation to reflect the current artifact location and release identification format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->