### PR TITLE
PLUGINS/UCX: wait for in-flight transfers before release() returns

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -26,6 +26,7 @@
 #include <optional>
 #include <limits>
 #include <future>
+#include <thread>
 #include <string.h>
 #include <unistd.h>
 #include "absl/strings/numbers.h"
@@ -133,18 +134,71 @@ public:
 
     virtual void
     release() {
-        // TODO: Error log: uncompleted requests found! Cancelling ...
         for (nixlUcxReq req : requests_) {
             const nixl_status_t ret = nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req));
             if (ret == NIXL_IN_PROG) {
-                // TODO: Need process this properly.
-                // it may not be enough to cancel UCX request
+                // A no-op for RMA - ucp_request_cancel() only acts on tag receives - but
+                // kept so tag-based operations still get cancelled before the drain.
                 worker_->reqCancel(req);
+                if (!drainRequest(req)) {
+                    NIXL_ERROR << "Request " << req
+                               << " is still in flight after the drain timeout. It is not "
+                                  "safe to deregister the memory backing this transfer yet: "
+                                  "UCX dereferences the ucp_mem_h when the operation "
+                                  "eventually completes.";
+                }
             }
             worker_->reqRelease(req);
         }
         requests_.clear();
         conn_.reset();
+    }
+
+    // Progress the worker until req reaches a terminal state, so that UCX is done with the
+    // ucp_mem_h before the caller is free to deregister it. Returns false if the request is
+    // still in flight when the deadline expires.
+    //
+    // RMA operations are posted with UCP_OP_ATTR_FIELD_MEMH, and UCX keeps that ucp_mem_h in
+    // the request as a plain pointer (ucp_datatype_iter contig.memh): a user memh is not
+    // reference counted. On completion ucp_datatype_iter_cleanup() calls ucp_memh_put() on
+    // it, which dereferences memh->context and memh->parent. If the caller deregistered in
+    // the meantime, ucp_mem_unmap() has already ucs_free()d the memh and the completion
+    // faults inside ucp_memh_put().
+    //
+    // Releasing the request object itself is safe either way: ucp_request_free() on an
+    // uncompleted request only marks it released, and UCX returns it to the request pool
+    // when it completes. What the drain protects is the memory handle, not the request.
+    //
+    // The deadline keeps release() from blocking forever when a transfer is wedged on an
+    // endpoint that is alive but no longer making progress.
+    [[nodiscard]] bool
+    drainRequest(nixlUcxReq req) const {
+        using namespace std::chrono_literals;
+
+        const auto timeout =
+            nixl::config::getValueDefaulted("NIXL_UCX_REQUEST_DRAIN_TIMEOUT", 10'000ms);
+        const auto warning_interval =
+            nixl::config::getValueDefaulted("NIXL_UCX_WARNING_TIMEOUT", 5'000ms);
+        auto next_warning = warning_interval;
+
+        const auto start = std::chrono::steady_clock::now();
+        while (nixl::ucx::ucsToNixlStatus(ucp_request_check_status(req)) == NIXL_IN_PROG) {
+            const auto elapsed = std::chrono::steady_clock::now() - start;
+            if (elapsed > timeout) {
+                return false;
+            }
+
+            if (elapsed > next_warning) {
+                NIXL_WARN << "Still draining in-flight request " << req << " after "
+                          << next_warning.count() << " ms";
+                next_warning += warning_interval;
+            }
+
+            if (worker_->progress() == 0) {
+                std::this_thread::sleep_for(1ms);
+            }
+        }
+        return true;
     }
 
     [[nodiscard]] virtual nixl_status_t

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -601,10 +601,57 @@ public:
         if (sharedState_) {
             // Set failed status to stop progress chunks
             sharedState_->status.store(NIXL_ERR_NOT_FOUND);
+
+            if (!waitForPendingChunks()) {
+                NIXL_ERROR << *this << " still has " << sharedState_->pendingReqs.load()
+                           << " chunk request(s) in flight after the drain timeout; "
+                              "deregistering the memory backing this transfer is not safe.";
+            }
+
             // Reset shared state - it will be effectively released when the last chunk
             // resets the shared state pointer
             sharedState_.reset();
         }
+    }
+
+    // Wait for chunks already in flight to finish. Setting the failed status stops new
+    // chunks from starting, but it does not complete requests that are already posted,
+    // and resetting the shared state only drops our reference to it. Returns false if
+    // chunks are still in flight when the deadline expires.
+    //
+    // Returning while a chunk request is still in flight lets the caller deregister its
+    // memory: ucp_mem_unmap() then frees the memory handle while a zcopy completion is
+    // still pending, and that completion later dereferences the freed handle on a
+    // progress thread (use-after-free inside ucp_memh_put).
+    //
+    // The deadline keeps release() from blocking forever when a chunk is wedged on an
+    // endpoint that is alive but no longer making progress.
+    [[nodiscard]] bool
+    waitForPendingChunks() const {
+        using namespace std::chrono_literals;
+
+        const auto timeout =
+            nixl::config::getValueDefaulted("NIXL_UCX_REQUEST_DRAIN_TIMEOUT", 10'000ms);
+        const auto warning_interval =
+            nixl::config::getValueDefaulted("NIXL_UCX_WARNING_TIMEOUT", 5'000ms);
+        auto next_warning = warning_interval;
+
+        const auto start = std::chrono::steady_clock::now();
+        while (sharedState_->pendingReqs.load() > 0) {
+            const auto elapsed = std::chrono::steady_clock::now() - start;
+            if (elapsed > timeout) {
+                return false;
+            }
+
+            if (elapsed > next_warning) {
+                NIXL_WARN << *this << " still waiting for " << sharedState_->pendingReqs.load()
+                          << " in-flight chunk(s) after " << next_warning.count() << " ms";
+                next_warning += warning_interval;
+            }
+
+            std::this_thread::yield();
+        }
+        return true;
     }
 
     [[nodiscard]] nixl_status_t

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -774,6 +774,9 @@ TEST_P(TestTransferRelease, InFlightXferIsDrainedBeforeReleaseReturns) {
 
 NIXL_INSTANTIATE_TEST(ucx, TestTransferRelease, "UCX", true, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_no_pt, TestTransferRelease, "UCX", false, 2, 0, "");
+// The threadpool parameterisations take the composite handle path.
+NIXL_INSTANTIATE_TEST(ucx_threadpool, TestTransferRelease, "UCX", true, 6, 4, "");
+NIXL_INSTANTIATE_TEST(ucx_threadpool_no_pt, TestTransferRelease, "UCX", false, 6, 4, "");
 
 NIXL_INSTANTIATE_TEST(ucx, TestTransfer, "UCX", true, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_no_pt, TestTransfer, "UCX", false, 2, 0, "");

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -26,7 +26,10 @@
 #include <absl/strings/str_format.h>
 #include <absl/time/clock.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <atomic>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <optional>
@@ -663,6 +666,114 @@ TEST_P(TestTransferTelemetry, GetXferTelemetryDisabled) {
     runTelemetryTransferTest(512, NIXL_ERR_NO_TELEMETRY, false);
     EXPECT_LE(lig.getIgnoredCount(), 1);
 }
+
+// Releasing a transfer handle while its requests are still in flight must not return until
+// UCX is done with the memory handles the transfer was posted with. NIXL posts RMA with
+// UCP_OP_ATTR_FIELD_MEMH, and UCX keeps that ucp_mem_h in the request as a plain pointer,
+// dereferencing it from ucp_memh_put() when the operation completes. A caller that
+// deregisters as soon as release() returns therefore frees the memh from under UCX.
+//
+// The data path is pinned to TCP so that a large transfer is genuinely asynchronous: over
+// shm/self UCX copies inline, the post completes immediately and there is nothing in flight
+// for release() to drain.
+class TestTransferRelease : public TestTransfer {
+protected:
+    void
+    SetUp() override {
+        env.addVar("NIXL_TELEMETRY_ENABLE", "n");
+        env.addVar("UCX_TLS", "tcp");
+        addAgent(0);
+        addAgent(1);
+    }
+
+    static void
+    fillBuffers(const std::vector<MemBuffer> &buffers, uint8_t value) {
+        for (const auto &buffer : buffers) {
+            std::memset(
+                reinterpret_cast<void *>(static_cast<uintptr_t>(buffer)), value, buffer.getSize());
+        }
+    }
+
+    static size_t
+    countBytes(const std::vector<MemBuffer> &buffers, uint8_t value) {
+        size_t found = 0;
+        for (const auto &buffer : buffers) {
+            const auto *data = reinterpret_cast<const uint8_t *>(static_cast<uintptr_t>(buffer));
+            found += static_cast<size_t>(std::count(data, data + buffer.getSize(), value));
+        }
+        return found;
+    }
+};
+
+TEST_P(TestTransferRelease, InFlightXferIsDrainedBeforeReleaseReturns) {
+    // The descriptor count is above the fixture's split_batch_size so that the threadpool
+    // parameterisations exercise the composite handle rather than the plain one.
+    constexpr size_t size = 1024 * 1024;
+    constexpr size_t count = 64;
+    constexpr uint8_t src_pattern = 0xab;
+    constexpr uint8_t dst_pattern = 0x00;
+
+    std::vector<MemBuffer> local_buffers, remote_buffers;
+    createRegisteredMem(getAgent(0), size, count, DRAM_SEG, local_buffers);
+    createRegisteredMem(getAgent(1), size, count, DRAM_SEG, remote_buffers);
+    fillBuffers(remote_buffers, src_pattern);
+    fillBuffers(local_buffers, dst_pattern);
+
+    exchangeMD(0, 1);
+
+    nixlXferReqH *xfer_req = nullptr;
+    ASSERT_EQ(getAgent(0).createXferReq(NIXL_READ,
+                                        makeDescList<nixlBasicDesc>(local_buffers, DRAM_SEG),
+                                        makeDescList<nixlBasicDesc>(remote_buffers, DRAM_SEG),
+                                        getAgentName(1),
+                                        xfer_req),
+              NIXL_SUCCESS);
+    ASSERT_NE(xfer_req, nullptr);
+
+    const nixl_status_t post_status = getAgent(0).postXferReq(xfer_req);
+    ASSERT_TRUE((post_status == NIXL_SUCCESS) || (post_status == NIXL_IN_PROG));
+
+    // release() only progresses the local worker. Over TCP the peer has to progress too, so
+    // stand in for a live remote process while the drain runs; without a progress thread
+    // nothing else would advance agent 1.
+    std::atomic<bool> pump_peer{true};
+    std::thread peer_thread([&]() {
+        nixl_notifs_t notifs;
+        while (pump_peer.load(std::memory_order_relaxed)) {
+            getAgent(1).getNotifs(notifs);
+        }
+    });
+
+    // A timed-out drain is a failure of this test, not of the run, so keep it out of the
+    // global problem counter and assert on it here instead.
+    const LogIgnoreGuard lig_drain("Still draining in-flight request");
+    const LogIgnoreGuard lig_timeout("is still in flight after the drain timeout");
+
+    const nixl_status_t release_status = getAgent(0).releaseXferReq(xfer_req);
+    pump_peer = false;
+    peer_thread.join();
+
+    EXPECT_EQ(release_status, NIXL_SUCCESS);
+    EXPECT_EQ(lig_timeout.getIgnoredCount(), 0u) << "release() gave up before the read finished";
+
+    // A read completes only once the data has landed locally, so a release() that drained
+    // implies the whole destination is written by the time it returns. Without the drain the
+    // read is still outstanding here and the destination is only partly filled.
+    if (post_status == NIXL_IN_PROG) {
+        EXPECT_EQ(countBytes(local_buffers, src_pattern), size * count)
+            << "releaseXferReq() returned while the read was still in flight";
+    } else {
+        Logger() << "transfer completed inline, nothing was in flight to drain";
+    }
+
+    // Deregistering is what would free the ucp_mem_h from under an in-flight request.
+    invalidateMD(0, 1);
+    deregisterMem(getAgent(0), local_buffers, DRAM_SEG);
+    deregisterMem(getAgent(1), remote_buffers, DRAM_SEG);
+}
+
+NIXL_INSTANTIATE_TEST(ucx, TestTransferRelease, "UCX", true, 2, 0, "");
+NIXL_INSTANTIATE_TEST(ucx_no_pt, TestTransferRelease, "UCX", false, 2, 0, "");
 
 NIXL_INSTANTIATE_TEST(ucx, TestTransfer, "UCX", true, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_no_pt, TestTransfer, "UCX", false, 2, 0, "");


### PR DESCRIPTION
## What?

Make `release()` wait for UCX to be done with a transfer's memory before it returns, on both the simple-handle and the composite/threadpool path.

- **Commit 1** drains the worker in `nixlUcxBackendReqH::release()` until every in-flight request has reached a terminal state.
- **Commit 2** makes `nixlUcxCompositeBackendReqH::release()` wait for `pendingReqs` to drain before resetting the shared state.

Two commits because they touch different classes and each has its own negative control, but they are **one invariant and neither half closes the window alone** - see below. This supersedes #2045, which was folded in here so the argument only has to be evaluated once.

## Correction to the original description

@brminich is right, and the first version of this PR was wrong on the mechanism. It claimed `ucp_request_free()` "does not synchronously complete internal requests" and implied the use-after-free came from freeing an in-flight request. In `ucp_request_release_common()`:

```c
if (ucs_likely(flags & UCP_REQUEST_FLAG_COMPLETED)) {
    ucp_request_put(req);
} else {
    req->flags = (flags | UCP_REQUEST_FLAG_RELEASED) & ~cb_flag;
}
```

An uncompleted request is only marked `UCP_REQUEST_FLAG_RELEASED`; it goes back to the pool from `ucp_request_complete()` when it finally completes. So `ucp_request_free()` on an in-flight request is safe and is the supported way to hand it back.

The first version also *leaked* the request when the drain deadline expired, on the theory that freeing it was the hazard. That was strictly worse than the code it replaced: a genuine `req_mp` leak for no benefit. It is gone - `reqRelease()` is unconditional, exactly as before this PR.

## Why? (re-derived)

`ucp_request_cancel()` is a no-op for RMA: it only acts on requests carrying `UCP_REQUEST_FLAG_RECV_TAG`. So `release()` can return with the operation still outstanding. That much of the original TODO holds.

The hazard that creates is on the **memory handle**, not on the request. NIXL posts RMA with `UCP_OP_ATTR_FIELD_MEMH` and a memh from `ucp_mem_map()` (`nixlUcxEp::read`/`write` in `ucx_utils.cpp`). UCX stores that pointer in the request without taking a reference, because a user memh is not reference counted:

```c
/* ucp_datatype_contig_iter_init(), src/ucp/dt/datatype_iter.inl */
if (param->op_attr_mask & UCP_OP_ATTR_FIELD_MEMH) {
    ...
    dt_iter->type.contig.memh = param->memh;   /* plain pointer, no ucp_memh_get() */
}
```

When the operation completes, `ucp_datatype_iter_cleanup()` calls `ucp_datatype_iter_mem_dereg_single()` -> `ucp_memh_put()`, which dereferences `memh->context` and `memh->parent` before doing anything else. If the caller has deregistered in the meantime, `ucp_mem_unmap()` -> `ucp_memh_cleanup()` has already `ucs_free()`d that memh, and the completion faults inside `ucp_memh_put()`. That matches the SIGSEGV we saw in production.

More generally, the operation is still reading and writing the caller's buffers and still holds the endpoint. So the invariant `release()` has to establish is not "the request object is reclaimed" but "UCX is done with this transfer's memory before the caller may unmap or free it".

Distinct from the rkey-unpack / endpoint-teardown race fixed in #1987 - that one races unpack against teardown, this one races RMA completion against the caller reclaiming memory.

## Why both halves are needed

On the threadpool path the two changes interlock:

- Composite `release()` sets the shared status to a failure, which makes the owning worker run `nixlUcxChunkBackendReqH::complete()` -> `nixlUcxBackendReqH::release()` on the chunk. **Without commit 1** that release does not drain, so the chunk's requests can still be in flight when it returns.
- **Without commit 2** composite `release()` does not wait for that to happen at all - it returns before the worker has even looked at the chunk.

The controls below show this directly: reverting commit 1 alone breaks all four parameterisations, including the threadpool ones that still have commit 2.

## Unit test

@brminich asked for a test showing the fix works. `TestTransferRelease.InFlightXferIsDrainedBeforeReleaseReturns` in `test/gtest/test_transfer.cpp`:

- registers 64 x 1 MiB on each of two agents and posts a **READ**,
- releases the handle while the read is still in flight (`postXferReq()` returned `NIXL_IN_PROG`),
- checks the destination is fully written by the time `releaseXferReq()` returns,
- then deregisters, which is the call that would free the memh from under UCX.

A read completes only once its data has landed locally, so this observes the drain directly rather than relying on a crash. The data path is pinned to `UCX_TLS=tcp`, because over shm/self UCX copies inline and nothing is ever in flight to drain. 64 descriptors puts the batch above the fixture's `split_batch_size`, so the `ucx_threadpool*` parameterisations take the composite path. No RDMA hardware needed; the four cases take 0.2-0.6 s each.

### Negative control 1 - revert commit 1 (simple-path drain), keep commit 2

| parameterisation | bytes landed when `releaseXferReq()` returned |
|---|---|
| `ucx` | 0 - 35 698 / 67 108 864 (varies by run) |
| `ucx_no_pt` | 0 / 67 108 864 |
| `ucx_threadpool` | 0 / 67 108 864 |
| `ucx_threadpool_no_pt` | 0 / 67 108 864 |

All four fail, including the threadpool cases that still have the composite wait - the wait is meaningless if the chunk release it waits for does not drain.

**5 of 14 runs also died inside UCX** with its own fatal assertion, rather than just failing the data check:

```
Assertion `0' failed
  uct_tcp_ep_pending_purge_cb (tcp/tcp_ep.c:2172)
  uct_tcp_ep_pending_purge (tcp/tcp_ep.c:2186)
  uct_tcp_ep_t_cleanup (tcp/tcp_ep.c:379)
  ucp_worker_discard_uct_ep_destroy_progress (core/ucp_worker.c:2765)
```

That is UCX refusing to destroy a TCP endpoint that still has operations queued on it.

### Negative control 2 - revert commit 2 (composite wait), keep commit 1

| parameterisation | bytes landed when `releaseXferReq()` returned |
|---|---|
| `ucx`, `ucx_no_pt` | 67 108 864 / 67 108 864 (pass - covered by commit 1) |
| `ucx_threadpool` | 3 464 592 - 27 532 784 / 67 108 864 (varies by run) |
| `ucx_threadpool_no_pt` | 0 / 67 108 864 |

**1 of 3 runs segfaulted** instead, with the read landing in a buffer the caller had already freed:

```
__memcpy_avx512_unaligned_erms
ucp_memcpy_unpack (src/ucp/dt/dt.h:82)
ucp_datatype_iter_unpack (src/ucp/dt/datatype_iter.inl:447)
ucp_get_rep_handler (rma/rma_sw.c:284)
...
ucp_worker_progress (core/ucp_worker.c:3071)
nixlUcxBackendReqH::drainRequest (src/plugins/ucx/ucx_backend.cpp:197)
nixlUcxBackendReqH::release (src/plugins/ucx/ucx_backend.cpp:143)
nixlUcxChunkBackendReqH::complete (src/plugins/ucx/ucx_backend.cpp:534)
nixlUcxDedicatedThread::run (src/plugins/ucx/ucx_backend.cpp:722)
```

The chunk drain does run, but on the threadpool worker, after the composite `release()` has already returned and the caller has freed the destination.

To be precise about what these do and do not show: neither control reproduces the exact `ucp_memh_put()` SIGSEGV we saw in production - these are over TCP, not RDMA, and the fault lands at a different site. They are the same root cause (`release()` returning while the RMA is live) surfacing wherever the transport happens to touch the reclaimed resource first.

With both commits, **25 consecutive runs** of the four cases: no failures, no crashes.

## Test plan

- [x] Ubuntu 24.04 / gcc 13.3, meson `debugoptimized`, UCX 1.20, built clean from this branch
- [x] `test/gtest/unit`: 84/84
- [x] `test/gtest` `*TestTransfer*`: 57/57, including the four new cases
- [x] Both negative controls reproduce, on demand, on this branch
- [x] 25/25 clean runs with the fix in place
- [x] `clang-format-diff-19` clean on every line added against `main`

## What this does not fix

@iyastreb is right that this is not an abort, and I do not want to oversell it.

The drain closes the window whenever the transfer can still make progress - which is the ordinary `releaseXferReq()`-mid-transfer case the test reproduces. It does **not** help when the transfer can never complete: after the deadline `release()` returns anyway, the operation is still outstanding, and the caller's memory still is not safe to reclaim. All the timeout buys there is an error message instead of silence.

That residual case needs the real abort primitive you are discussing, and if you would rather this waited for that, we are happy to hold it. What we would like to avoid is `release()` continuing to return, in the ordinary case, while UCX still holds the caller's buffers and endpoint.

Separately, on the `NIXL_IN_PROG`/`FAILED`-endpoint point from the other thread: production UCX debug logs from a wedged pod back your diagnosis - 156 `set_ep_failed status Endpoint timeout on lane[N]` events over the wedge, 27 on the exact rank whose handle stalled, all while NIXL reported `NIXL_IN_PROG`. Written up in #2047, which we have reframed as a backstop rather than a fix for that.
