### PR TITLE
DOCS: Document UCX backend initialization options

### DIFF
--- a/docs/BackendGuide.md
+++ b/docs/BackendGuide.md
@@ -166,6 +166,33 @@ When user asks for a specific backend for its name, alongside a list of paramete
 
 In this step, if the plugin supports talking to remote agents, the required connection data for other agents to talk to it is acquired through **getConnInfo** in SB API. And/or if it supports within node transfers, a **connection** call to itself is called, as some backends might require that.
 
+#### UCX backend initialization options
+
+The UCX plugin exposes its initialization options through `getPluginParams("UCX", ...)` in C++
+or `get_plugin_params("UCX")` in Python. The returned map contains the defaults, which can be
+overridden before passing it to `createBackend` in C++ or `create_backend` in Python.
+
+| Option key | Default | Description |
+| ---------- | ------- | ----------- |
+| `ucx_error_handling_mode` | `peer` | UCX endpoint error handling policy. `peer` requests peer failure reporting; `none` disables it. |
+
+`ucx_error_handling_mode` affects UCP transport lane selection, not only error reporting.
+NIXL creates endpoints with `err_mode` set from this option, and UCP only selects lanes whose
+transport advertises peer failure support. A transport that does not advertise it is therefore
+excluded from `peer` endpoints even when it is otherwise available and faster.
+
+Setting `none` makes such lanes eligible, but removes the failure guarantees NIXL depends on.
+Under `none`, UCX does not invoke the endpoint error handler and does not guarantee error
+notification or clean completion of pending operations after a peer failure. NIXL installs an
+error handler on every endpoint and uses it to move the endpoint to its failed state, which is
+what produces `NIXL_ERR_REMOTE_DISCONNECT`. Without that callback the endpoint stays in its
+connected state and pending transfers may remain incomplete and unreported, so a remote failure
+can go undetected instead of surfacing as an error.
+
+`none` therefore trades remote failure visibility for transport availability. Prefer fixing lane
+eligibility in the transport over changing this option in deployments that need remote failure
+reporting.
+
 ### Make connections (optional):
 
 When a connection is requested to an remote agent, which is possible if the remote agent’s metadata is already loaded, the local Agent would look for common backend plugins between itself and the remote agent, and for each of them initiate a connect by using the **connect** API in SB API of such backends.

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -32,6 +32,27 @@ To build from source, follow the main build instructions in the README.md, then 
 pip install .
 ```
 
+## Backend initialization parameters
+
+Backends expose their initialization parameters through `get_plugin_params(backend)`, which
+returns the defaults. Override the values you need before passing the map to `create_backend`:
+
+```python
+from nixl import nixl_agent, nixl_agent_config
+
+# backends=[] leaves backend creation to the caller. The default config
+# initializes UCX, and a backend can only be created once per agent.
+agent = nixl_agent("example_agent", nixl_agent_config(backends=[]))
+
+params = agent.get_plugin_params("UCX")
+params["ucx_error_handling_mode"] = "peer"   # or "none"
+agent.create_backend("UCX", params)
+```
+
+See [UCX backend initialization options](BackendGuide.md#ucx-backend-initialization-options)
+for the supported UCX keys and their semantics. Note that `ucx_error_handling_mode` influences
+UCP transport lane selection in addition to error reporting.
+
 ## Examples
 
 See the [Python examples](../examples/python/) directory for complete working examples including:


### PR DESCRIPTION
## What?

Documents the UCX plugin's initialization options and the generic mechanism for
overriding backend init parameters.

- `docs/BackendGuide.md`: new `#### UCX backend initialization options` under
  "Create transfer backends", where parameter passing is already described. Adds
  the option table for `ucx_error_handling_mode` (default `peer`, alternative
  `none`), then explains the lane-selection consequence and the tradeoff of
  each value.
- `docs/python_api.md`: new `## Backend initialization parameters` section with
  the `get_plugin_params` -> override -> `create_backend` snippet, cross-linked
  to the backend guide.

Documentation only. No functional change.

## Why?

`ucx_error_handling_mode` is exposed through `getPluginParams`/`get_plugin_params`
but was undocumented, and its effect is easy to misread as "error reporting only".
It also affects UCP transport lane selection: NIXL sets `ep_params.err_mode` from
this option, and UCP only selects lanes whose transport advertises peer failure
support. A transport that does not advertise it is excluded from `peer` endpoints
even when it is available and faster.

ROCm IPC is the concrete case. `rocm_ipc` in UCX 1.22 reports
`error handling: none`, so it is not selected for NIXL's default `peer` endpoints.
This is a contributing factor to the transport-selection behavior reported in
#2039, where large ROCm VRAM RMA falls back to `software emulation | tcp/bond0`
instead of `rocm_ipc`.

The docs deliberately do not present `none` as the fix. It restores lane
eligibility but disables the peer failure detection NIXL relies on to move an
endpoint to its failed state and report `NIXL_ERR_REMOTE_DISCONNECT`, so it
trades remote failure visibility for transport availability. The guidance is to
fix lane eligibility in the transport where remote failure reporting is needed.

Related: #2039


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring UCX backend initialization parameters through C++ and Python APIs.
  * Documented how to retrieve defaults, override settings, and create the backend.
  * Explained `ucx_error_handling_mode` options, including their effects on transport selection and remote failure reporting.
  * Added references to supported UCX configuration options and clarified behavior for peer and disabled error-handling modes.
  * Clarified how error-handling settings influence available transport lanes and failure notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->