### PR TITLE
Skip UCCL nixlbench ASIO tests due to flakiness

### DIFF
--- a/.gitlab/test_nixlbench.sh
+++ b/.gitlab/test_nixlbench.sh
@@ -92,15 +92,17 @@ for op_type in READ WRITE; do
     done
 done
 
-if $HAS_GPU ; then
-    for op_type in READ WRITE; do
-        for initiator in $seg_types; do
-            for target in $seg_types; do
-                run_nixlbench_two_workers_asio --backend UCCL --op_type $op_type --initiator_seg_type $initiator --target_seg_type $target --check_consistency
-            done
-        done
-    done
-fi
+# TODO: remove this once https://github.com/ai-dynamo/nixl/issues/1999 is fixed
+# Skip UCCL nixlbench transfer tests to reduce CI flakiness
+# if $HAS_GPU ; then
+#     for op_type in READ WRITE; do
+#         for initiator in $seg_types; do
+#             for target in $seg_types; do
+#                 run_nixlbench_two_workers_asio --backend UCCL --op_type $op_type --initiator_seg_type $initiator --target_seg_type $target --check_consistency
+#             done
+#         done
+#     done
+# fi
 
 run_nixlbench_two_workers_etcd() {
     args="$@"


### PR DESCRIPTION
## What?
Skip UCCL nixlbench test due to frequent issues on teardown
Follow up for https://github.com/ai-dynamo/nixl/pull/2000

## Why?
See https://github.com/ai-dynamo/nixl/issues/1999

Summary from triage agent:

The UCCL backend crashes on teardown (the benchmark row printed and both processes logged "Destroying Engine…/Engine destroyed", then task 0 segfaulted — a race/crash in UCCL engine cleanup, not a hang or timeout). This is the known-flaky UCCL nixlbench issue https://github.com/ai-dynamo/nixl/issues/1999. Commit https://github.com/ai-dynamo/nixl/pull/2000 attempted to mitigate it but only commented out the ETCD-based UCCL loop (test_nixlbench.sh lines 122-132); the ASIO-based UCCL loop (lines 95-103) remained active and is what ran and crashed. The pairwise ucx-v1.22.x variant (stage 351) passed, confirming the failure is a nondeterministic UCCL crash. (The extensive pin_thread_to_numa/selectNICs ERROR/WARN lines are benign noise from the CI node's NUMA topology, not the cause.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled the GPU-gated UCCL ASIO transfer benchmark tests due to CI flakiness.
  * Added a follow-up reference to track re-enabling the tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->