### PR TITLE
nixl_ep: round max tokens up to a multiple of 4 for TMA in elastic.py 

### DIFF
--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -147,6 +147,7 @@ class Buffer:
 
         Arguments:
             num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
+                `num_ranks * num_max_dispatch_tokens_per_rank` must be a multiple of 4 to match `low_latency_dispatch()`.
             hidden: the hidden dimension of each token.
             num_ranks: rank capacity used to size the low-latency buffers.
             num_experts: expert capacity, normally num_ranks * num_experts_per_rank.
@@ -353,6 +354,7 @@ class Buffer:
             topk_idx: `torch.Tensor` with `nixl_ep.topk_idx_t`, shaped as `[num_tokens, num_topk]`, only several top-k shapes
                 are supported. `-1` indices (not selecting any expert) are supported.
             num_max_dispatch_tokens_per_rank: the maximum number of tokens to dispatch, all the ranks must hold the same value.
+                `num_ranks * num_max_dispatch_tokens_per_rank` must be a multiple of 4 for TMA alignment.
             num_experts: deprecated optional parameter. This value is ignored by low-latency
                 dispatch; the number of experts is determined from the `num_experts_per_rank`
                 passed to `update_memory_buffers()` and the currently active ranks.

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -49,6 +49,17 @@ from utils import (  # noqa: E402
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
 
+# NIXL EP stores FP8 scales channel-major, so the gap between channel blocks is
+# 4 * num_ranks * max_tokens_per_rank bytes and TMA needs it 16-byte aligned,
+# i.e. num_ranks * max_tokens_per_rank must be a multiple of 4.
+TMA_TOKEN_ALIGNMENT = 4
+
+
+def tma_aligned_max_tokens(num_tokens: int) -> int:
+    return (
+        (num_tokens + TMA_TOKEN_ALIGNMENT - 1) // TMA_TOKEN_ALIGNMENT
+    ) * TMA_TOKEN_ALIGNMENT
+
 
 def non_negative_int(value: str) -> int:
     try:
@@ -90,6 +101,7 @@ def self_kill():
 
 def test_main(
     num_tokens: int,
+    max_tokens_per_rank: int,
     hidden: int,
     num_experts: int,
     num_topk: int,
@@ -208,7 +220,7 @@ def test_main(
                                 buffer.dispatch(
                                     current_x,
                                     topk_idx,
-                                    num_tokens,
+                                    max_tokens_per_rank,
                                     num_experts,
                                     use_fp8=dispatch_use_fp8,
                                     round_scale=round_scale,
@@ -389,7 +401,7 @@ def test_main(
         recv_x, recv_count, handle, event, hook = buffer.dispatch(
             current_x,
             topk_idx,
-            num_tokens,
+            max_tokens_per_rank,
             num_experts,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats,
             use_fp8=True,
@@ -491,8 +503,15 @@ def worker(torch_rank: int, args: argparse.Namespace):
     )
 
     # Initialize nixl_ep buffer
+    max_tokens_per_rank = tma_aligned_max_tokens(args.num_tokens)
+    if local_rank == 0 and max_tokens_per_rank != args.num_tokens:
+        print(
+            f"Rounding max tokens per rank {args.num_tokens} -> {max_tokens_per_rank} "
+            f"for TMA alignment; dispatching {args.num_tokens} tokens",
+            flush=True,
+        )
     num_rdma_bytes = nixl_ep.Buffer.get_rdma_size_hint(
-        args.num_tokens,
+        max_tokens_per_rank,
         args.hidden_dim,
         max_num_ranks,
         args.num_experts_per_rank * max_num_ranks,
@@ -567,6 +586,7 @@ def worker(torch_rank: int, args: argparse.Namespace):
 
         test_main(
             args.num_tokens,
+            max_tokens_per_rank,
             args.hidden_dim,
             current_num_experts,
             args.num_topk,

--- a/examples/device/ep/tests/elastic/elastic.py
+++ b/examples/device/ep/tests/elastic/elastic.py
@@ -49,9 +49,6 @@ from utils import (  # noqa: E402
 TCP_STORE_PORT = 9999
 RANK_SERVER_PORT = 10000
 
-# NIXL EP stores FP8 scales channel-major, so the gap between channel blocks is
-# 4 * num_ranks * max_tokens_per_rank bytes and TMA needs it 16-byte aligned,
-# i.e. num_ranks * max_tokens_per_rank must be a multiple of 4.
 TMA_TOKEN_ALIGNMENT = 4
 
 
@@ -504,12 +501,6 @@ def worker(torch_rank: int, args: argparse.Namespace):
 
     # Initialize nixl_ep buffer
     max_tokens_per_rank = tma_aligned_max_tokens(args.num_tokens)
-    if local_rank == 0 and max_tokens_per_rank != args.num_tokens:
-        print(
-            f"Rounding max tokens per rank {args.num_tokens} -> {max_tokens_per_rank} "
-            f"for TMA alignment; dispatching {args.num_tokens} tokens",
-            flush=True,
-        )
     num_rdma_bytes = nixl_ep.Buffer.get_rdma_size_hint(
         max_tokens_per_rank,
         args.hidden_dim,


### PR DESCRIPTION
Low-latency dispatch aborts with "TMA requires the number of tokens to be
multiple of 4" whenever active_rank_bound * num_max_dispatch_tokens_per_rank is not a multiple of 4. For example: two ranks with an odd max_tokens could not
run. Four nightly cases fail on this.
 
Round the maximum tokens up in elastic.py instead of hitting the assert. Note
this rounds the declared capacity only, the actual token count is untouched.
 
Applied where elastic.py hands the value to NIXL EP: get_rdma_size_hint() and
the two dispatch() calls. 
 
The constraint comes from the FP8 scale tensor. Scales are stored channel-major: all M token slots for one channel block, then the next, where M = num_ranks * max_tokens. Each slot is 4 bytes in both quantization modes, so the gap between blocks is 4M bytes, and TMA needs that to be a multiple of 16 -- i.e. M a multiple of 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token-capacity handling for TMA alignment by rounding capacities up to multiples of four.
  * Ensured aligned capacities are used for buffer allocation and dispatch while preserving the actual workload token count.

* **Documentation**
  * Documented the requirement for low-latency buffer sizes and dispatch token capacities to be multiples of four.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->