### PR TITLE
PLUGINS/UCX: Improve the performance by specifying memory type in sendAm().

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -238,8 +238,9 @@ nixlUcxEp::sendAm(nixl::ucx::am_cb_op_t msg_id,
     }
 
     ucp_request_param_t param;
-    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
+    param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS | UCP_OP_ATTR_FIELD_MEMORY_TYPE;
     param.flags = flags;
+    param.memory_type = UCS_MEMORY_TYPE_HOST;
 
     nixl_ucx_am_cb_ctx_ptr_t ctx;
     if (deleter) {


### PR DESCRIPTION
## What?
This PR improves the performance of NIXL by specifying memory type in sendAm().

## Why?
Each nixlbench batch triggers a notification (in postXfer function). The notification calls sendAm without providing mh or memory type, in which case UCX must detect the memory type of the notification buffer in ucp_memory_detect_internal.

If memtype cache is NULL, ucp_memory_detect_internal enters the slow path and then queries all possible memory domians, including CUDA memory, which introduces significant overhead.

Below is the experiment result with block size of 1024B:

| Batch | no-opt BW (GB/s) | opt BW (GB/s) | Gain |
|:-------:|:--------------------------:|:-----------------------:|:-----:|
| 32    | 0.823 | 0.844 | 2.55% |
| 64    | 0.944 | 0.961 | 1.80% |
| 128   | 1.037 | 1.059 | 2.12% |
| 256   | 1.103 | 1.121 | 1.63% |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and reliability for host-memory data transfers over UCX.
  * Preserved existing transfer flags and callback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->