### PR TITLE
Docs/python: Use docstring standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,6 +363,35 @@ Document public APIs and complex implementations:
  */
 ```
 
+### Python Docstrings
+
+Document public Python modules, classes, methods, and functions according to
+[PEP 257](https://peps.python.org/pep-0257/) and use
+[Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+for structured sections. The docstring must be the first statement in the documented object.
+
+Start with a concise summary and add the standard `Args:`, `Returns:`, `Raises:`,
+`Examples:`, and `Notes:` sections when applicable. Keep types and defaults in the
+Python signature rather than duplicating them in parameter descriptions. This format is
+readable through Python's built-in help system and can be consumed by API documentation
+generators.
+
+```python
+def connect(host: str, timeout_s: float = 10.0) -> Connection:
+    """Connect to a remote agent.
+
+    Args:
+        host: Hostname or address of the remote agent.
+        timeout_s: Maximum time to wait for the connection.
+
+    Returns:
+        The established connection.
+
+    Raises:
+        ConnectionError: If the remote agent cannot be reached.
+    """
+```
+
 ### PR Documentation
 
 Use the provided template in `.github/pull_request_template.md`:

--- a/src/api/python/_api.py
+++ b/src/api/python/_api.py
@@ -46,15 +46,15 @@ def _is_torch_tensor(obj: object) -> bool:
 DEFAULT_COMM_PORT = nixlBind.DEFAULT_COMM_PORT
 
 
-"""
-@brief Opaque handle wrapper for a prepared transfer descriptor list.
-       Use release() to explicitly free resources; __del__ performs best-effort cleanup.
-@param agent Owning nixl_agent used to perform release operations.
-@param value Internal handle
-"""
-
-
 class nixl_prepped_dlist_handle:
+    """Opaque handle wrapper for a prepared transfer descriptor list.
+    Use release() to explicitly free resources; __del__ performs best-effort cleanup.
+
+    Args:
+        agent: Owning nixl_agent used to perform release operations.
+        value: Internal handle
+    """
+
     __slots__ = ("_handle", "_agent", "_released")
 
     def __init__(self, agent, value: int):
@@ -86,18 +86,18 @@ class nixl_prepped_dlist_handle:
                     pass
 
 
-"""
-@brief Opaque handle wrapper for a transfer request.
-       Use release() to explicitly free resources. If transfer was not complete, this will initiate
-       the abort process (if available) and will raise an exception.
-       __del__ calls release() and if it fails, it logs the failure and defers release by queuing
-       the handle in leaked xfer handles list, which will be re-released during agent destruction
-@param agent Owning nixl_agent used to perform release operations.
-@param value Internal handle
-"""
-
-
 class nixl_xfer_handle:
+    """Opaque handle wrapper for a transfer request.
+    Use release() to explicitly free resources. If transfer was not complete, this will initiate
+    the abort process (if available) and will raise an exception.
+    __del__ calls release() and if it fails, it logs the failure and defers release by queuing
+    the handle in leaked xfer handles list, which will be re-released during agent destruction
+
+    Args:
+        agent: Owning nixl_agent used to perform release operations.
+        value: Internal handle
+    """
+
     __slots__ = ("_handle", "_agent", "_released")
 
     def __init__(self, agent, value: int):
@@ -135,35 +135,32 @@ class nixl_xfer_handle:
 # Opaque handle for backend can be just int, as it's not passed to the user
 nixl_backend_handle = int
 
-"""
-@brief Enumeration of supported thread synchronization modes.
-"""
-
 
 class nixl_thread_sync_t(Enum):
+    """Enumeration of supported thread synchronization modes."""
+
     NIXL_THREAD_SYNC_NONE = nixlBind.NIXL_THREAD_SYNC_NONE
     NIXL_THREAD_SYNC_STRICT = nixlBind.NIXL_THREAD_SYNC_STRICT
     NIXL_THREAD_SYNC_RW = nixlBind.NIXL_THREAD_SYNC_RW
     NIXL_THREAD_SYNC_DEFAULT = nixlBind.NIXL_THREAD_SYNC_DEFAULT
 
 
-"""
-@brief Configuration class for NIXL agent.
-
-@param enable_prog_thread Whether to enable the progress thread, if available.
-@param enable_listen_thread Whether to enable the listener thread for metadata communication.
-@param listen_port Specify the port for the listener thread to listen on.
-@param capture_telemetry Whether to enable telemetry capture.
-@param num_threads Specify number of threads for the supported multi-threaded backends.
-@param backends List of backend names for agent to initialize.
-        Default is UCX, other backends can be added to the list, or after
-        agent creation, can be initialized with create_backend.
-@param sync_mode Thread synchronization mode to use for the agent.
-        If None, sync_mode is set based on the enable_listen flag.
-"""
-
-
 class nixl_agent_config:
+    """Configuration class for NIXL agent.
+
+    Args:
+        enable_prog_thread: Whether to enable the progress thread, if available.
+        enable_listen_thread: Whether to enable the listener thread for metadata communication.
+        listen_port: Specify the port for the listener thread to listen on.
+        capture_telemetry: Whether to enable telemetry capture.
+        num_threads: Specify number of threads for the supported multi-threaded backends.
+        backends: List of backend names for agent to initialize.
+            Default is UCX, other backends can be added to the list, or after
+            agent creation, can be initialized with create_backend.
+        sync_mode: Thread synchronization mode to use for the agent.
+            If None, sync_mode is set based on the enable_listen flag.
+    """
+
     def __init__(
         self,
         enable_prog_thread: bool = True,
@@ -189,18 +186,17 @@ class nixl_agent_config:
         self.sync_mode = sync_mode
 
 
-"""
-@brief Main class for creating a NIXL agent and performing transfers.
-        This class provides methods for initializing backends, creating descriptor lists,
-        registering memory, performing data transfers, and destroying NIXL objects.
-
-@param agent_name Name of the agent, should be unique for clarity.
-@param nixl_conf Optional configuration for the agent, described in nixl_agent_config.
-@param instantiate_all Whether to instantiate all available backend plugins.
-"""
-
-
 class nixl_agent:
+    """Main class for creating a NIXL agent and performing transfers.
+    This class provides methods for initializing backends, creating descriptor lists,
+    registering memory, performing data transfers, and destroying NIXL objects.
+
+    Args:
+        agent_name: Name of the agent, should be unique for clarity.
+        nixl_conf: Optional configuration for the agent, described in nixl_agent_config.
+        instantiate_all: Whether to instantiate all available backend plugins.
+    """
+
     def __init__(
         self,
         agent_name: str,
@@ -299,12 +295,6 @@ class nixl_agent:
                         pass
             self._leaked_xfer_handles.clear()
 
-    """
-    @brief Get the list of available plugins.
-
-    @return List of plugin names.
-    """
-
     def _load_plugin_params(self, plugin: str):
         if plugin not in self.plugin_list:
             return
@@ -316,16 +306,22 @@ class nixl_agent:
             logger.warning("Failed to load params for plugin %s", plugin, exc_info=True)
 
     def get_plugin_list(self) -> list[str]:
+        """Get the list of available plugins.
+
+        Returns:
+            List of plugin names.
+        """
         return self.plugin_list
 
-    """
-    @brief Get the memory types supported by a plugin.
-
-    @param backend Name of the plugin.
-    @return List of supported memory types.
-    """
-
     def get_plugin_mem_types(self, backend: str) -> list[str]:
+        """Get the memory types supported by a plugin.
+
+        Args:
+            backend: Name of the plugin.
+
+        Returns:
+            List of supported memory types.
+        """
         if backend not in self.plugin_mem_types:
             self._load_plugin_params(backend)
         if backend not in self.plugin_mem_types:
@@ -335,15 +331,16 @@ class nixl_agent:
             return []
         return self.plugin_mem_types[backend]
 
-    """
-    @brief Get the initialization parameters of a plugin.
-           This is a dictionary of strings (option name) to strings (default value for that option).
-
-    @param backend Name of the plugin to get params for.
-    @return Dictionary of plugin parameters, described above.
-    """
-
     def get_plugin_params(self, backend: str) -> dict[str, str]:
+        """Get the initialization parameters of a plugin.
+        This is a dictionary of strings (option name) to strings (default value for that option).
+
+        Args:
+            backend: Name of the plugin to get params for.
+
+        Returns:
+            Dictionary of plugin parameters, described above.
+        """
         if backend not in self.plugin_b_options:
             self._load_plugin_params(backend)
         if backend not in self.plugin_b_options:
@@ -351,17 +348,18 @@ class nixl_agent:
             return {}
         return self.plugin_b_options[backend]
 
-    """
-    @brief  Get the memory types supported by a backend.
-            Here, a backend means an initialized plugin.
-            After a plugin is initialized, the supported memory types might have changed.
-            This function is for getting a refreshed list of those memory types.
-
-    @param backend Name of the backend.
-    @return List of supported memory types.
-    """
-
     def get_backend_mem_types(self, backend: str) -> list[str]:
+        """Get the memory types supported by a backend.
+        Here, a backend means an initialized plugin.
+        After a plugin is initialized, the supported memory types might have changed.
+        This function is for getting a refreshed list of those memory types.
+
+        Args:
+            backend: Name of the backend.
+
+        Returns:
+            List of supported memory types.
+        """
         if backend in self.backend_mems:
             return self.backend_mems[backend]
         else:
@@ -370,17 +368,18 @@ class nixl_agent:
             )
             return []
 
-    """
-    @brief  Get the parameters of a backend.
-            Here, a backend means an initialized plugin.
-            Available initialization parameters (described above) might have changed after initialization.
-            This function is for getting a refreshed list of those parameters.
-
-    @param backend Name of the backend.
-    @return Dictionary of backend parameters, described in get_plugin_params.
-    """
-
     def get_backend_params(self, backend: str) -> dict[str, str]:
+        """Get the parameters of a backend.
+        Here, a backend means an initialized plugin.
+        Available initialization parameters (described above) might have changed after initialization.
+        This function is for getting a refreshed list of those parameters.
+
+        Args:
+            backend: Name of the backend.
+
+        Returns:
+            Dictionary of backend parameters, described in get_plugin_params.
+        """
         if backend in self.backend_options:
             return self.backend_options[backend]
         else:
@@ -389,14 +388,13 @@ class nixl_agent:
             )
             return {}
 
-    """
-    @brief  Initialize a backend with the specified initialization parameters, described above.
-
-    @param backend Name of the backend.
-    @param initParams Dictionary of initialization parameters.
-    """
-
     def create_backend(self, backend: str, initParams: dict[str, str] = {}):
+        """Initialize a backend with the specified initialization parameters, described above.
+
+        Args:
+            backend: Name of the backend.
+            initParams: Dictionary of initialization parameters.
+        """
         self.backends[backend] = self.agent.createBackend(backend, initParams)
 
         (backend_options, mem_types) = self.agent.getBackendParams(
@@ -406,22 +404,23 @@ class nixl_agent:
         self.backend_options[backend] = backend_options
         logger.info("Backend %s was instantiated", backend)
 
-    """
-    @brief Register memory regions, optionally with specified backends.
-
-    @param reg_list List of either memory regions, tensors, or nixlRegDList to register.
-    @param mem_type Optional memory type, necessary if specifying a list of memory regions.
-    @param backends Optional list of backend names for registration, otherwise NIXL will try to
-            register with all backends that support this memory type.
-    @return nixlRegDList for the registered memory, can be used with deregister_memory.
-    """
-
     def register_memory(
         self,
         reg_list,
         mem_type: Optional[str] = None,
         backends: list[str] = [],
     ) -> nixlBind.nixlRegDList:
+        """Register memory regions, optionally with specified backends.
+
+        Args:
+            reg_list: List of either memory regions, tensors, or nixlRegDList to register.
+            mem_type: Optional memory type, necessary if specifying a list of memory regions.
+            backends: Optional list of backend names for registration, otherwise NIXL will try to
+                register with all backends that support this memory type.
+
+        Returns:
+            nixlRegDList for the registered memory, can be used with deregister_memory.
+        """
         reg_descs = self.get_reg_descs(reg_list, mem_type)
 
         handle_list = []
@@ -431,34 +430,34 @@ class nixl_agent:
 
         return reg_descs
 
-    """
-    @brief Deregister memory regions from the specified backends.
-
-    @param dereg_list nixlRegDList of memory to deregister, received from register_memory or get_reg_descs.
-    @param backends Optional list of backend names for deregistration, otherwise NIXL will deregister
-            with all the backends that have these memory regions registered.
-    """
-
     def deregister_memory(
         self, dereg_list: nixlBind.nixlRegDList, backends: list[str] = []
     ):
+        """Deregister memory regions from the specified backends.
+
+        Args:
+            dereg_list: nixlRegDList of memory to deregister, received from register_memory or get_reg_descs.
+            backends: Optional list of backend names for deregistration, otherwise NIXL will deregister
+                with all the backends that have these memory regions registered.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
         self.agent.deregisterMem(dereg_list, handle_list)
 
-    """
-    @brief Query information about memory/storage for a specific backend.
-
-    @param reg_list List of either memory regions, tensors, or nixlRegDList to query.
-    @param backend Backend name for querying.
-    @param mem_type Optional memory type, necessary if specifying a list of memory regions.
-    @return List of query results where each item is either None if not found, or a dictionary with the info
-    """
-
     def query_memory(
         self, reg_list, backend: str, mem_type: Optional[str] = None
     ) -> list[Optional[dict[str, str]]]:
+        """Query information about memory/storage for a specific backend.
+
+        Args:
+            reg_list: List of either memory regions, tensors, or nixlRegDList to query.
+            backend: Backend name for querying.
+            mem_type: Optional memory type, necessary if specifying a list of memory regions.
+
+        Returns:
+            List of query results where each item is either None if not found, or a dictionary with the info
+        """
         reg_descs = self.get_reg_descs(reg_list, mem_type)
 
         # Get the backend handle
@@ -469,45 +468,22 @@ class nixl_agent:
 
         return self.agent.queryMem(reg_descs, self.backends[backend])
 
-    """
-    @brief  Proactively establish a connection with a remote agent,
-            which will reduce the time spent in the first transfer between the two agents.
-            NIXL will establish the connection for all the backends that talk to that remote
-            agent, or limit to the set of backends passed through the backends argument.
-            This function is optional.
-
-    @param backends Optional list of backend names to limit the connections to specific backends
-    @param remote_agent Name of the remote agent.
-    """
-
     def make_connection(self, remote_agent: str, backends: list[str] = []):
+        """Proactively establish a connection with a remote agent,
+        which will reduce the time spent in the first transfer between the two agents.
+        NIXL will establish the connection for all the backends that talk to that remote
+        agent, or limit to the set of backends passed through the backends argument.
+        This function is optional.
+
+        Args:
+            backends: Optional list of backend names to limit the connections to specific backends
+            remote_agent: Name of the remote agent.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
 
         self.agent.makeConnection(remote_agent, handle_list)
-
-    """
-    @brief  Prepare a transfer descriptor list for data transfer.
-            Later, elements from this list can be used to create a transfer request by index.
-            It should be done on the initiator agent, and for both sides of a transfer.
-            Considering loopback, there are 3 modes for agent_name:
-              - For local descriptors, it is set to NIXL_INIT_AGENT,
-                indicating that this is a local preparation to be used as local_side handle.
-              - For remote descriptors, it is set to the remote name, indicating
-                that this is remote side preparation to be used for remote_side handle.
-              - For loopback descriptors, it is set to local agent's name, indicating that
-                this is for a loopback (local) transfer to be used for remote_side handle
-            Preparation succeeds if there exists at least one backend that can handle all
-            elements in the descriptor list.
-
-    @param agent_name Name of the agent. It can be "NIXL_INIT_AGENT", local agent name, or remote agent name
-    @param xfer_list List of transfer descriptors, can be list of memory region tuples, tensors,
-                     Nx3 numpy array, or nixlXferDList. See get_xfer_descs for more details on the structure.
-    @param mem_type Optional memory type necessary for list of memory regions.
-    @param backends Optional list of backend names to limit which backends are used during preparation
-    @return Opaque handle to the prepared transfer descriptor list.
-    """
 
     def prep_xfer_dlist(
         self,
@@ -516,6 +492,29 @@ class nixl_agent:
         mem_type: Optional[str] = None,
         backends: list[str] = [],
     ) -> nixl_prepped_dlist_handle:
+        """Prepare a transfer descriptor list for data transfer.
+        Later, elements from this list can be used to create a transfer request by index.
+        It should be done on the initiator agent, and for both sides of a transfer.
+        Considering loopback, there are 3 modes for agent_name:
+        - For local descriptors, it is set to NIXL_INIT_AGENT,
+        indicating that this is a local preparation to be used as local_side handle.
+        - For remote descriptors, it is set to the remote name, indicating
+        that this is remote side preparation to be used for remote_side handle.
+        - For loopback descriptors, it is set to local agent's name, indicating that
+        this is for a loopback (local) transfer to be used for remote_side handle
+        Preparation succeeds if there exists at least one backend that can handle all
+        elements in the descriptor list.
+
+        Args:
+            agent_name: Name of the agent. It can be "NIXL_INIT_AGENT", local agent name, or remote agent name
+            xfer_list: List of transfer descriptors, can be list of memory region tuples, tensors,
+                Nx3 numpy array, or nixlXferDList. See get_xfer_descs for more details on the structure.
+            mem_type: Optional memory type necessary for list of memory regions.
+            backends: Optional list of backend names to limit which backends are used during preparation
+
+        Returns:
+            Opaque handle to the prepared transfer descriptor list.
+        """
         descs = self.get_xfer_descs(xfer_list, mem_type)
 
         is_local = agent_name == "NIXL_INIT_AGENT" or agent_name == ""
@@ -532,39 +531,22 @@ class nixl_agent:
             handle = self.agent.prepXferDlist(agent_name, descs, handle_list)
         return nixl_prepped_dlist_handle(self.agent, handle)
 
-    """
-    @brief Estimate the cost of a transfer operation.
-           Times are in microseconds and the method indicates how the estimation was performed.
-
-    @param req_handle Handle to the transfer operation.
-    @return Tuple of duration, error margin, method
-    """
-
     def estimate_xfer_cost(self, req_handle: nixl_xfer_handle) -> tuple[int, int, int]:
+        """Estimate the cost of a transfer operation.
+        Times are in microseconds and the method indicates how the estimation was performed.
+
+        Args:
+            req_handle: Handle to the transfer operation.
+
+        Returns:
+            Tuple of duration, error margin, method
+        """
         duration, err_margin, method = self.agent.estimateXferCost(req_handle._handle)
         if method == nixlBind.NIXL_COST_ANALYTICAL_BACKEND:
             method = "ANALYTICAL_BACKEND"
         else:
             method = "UNKNOWN"
         return duration, err_margin, method
-
-    """
-    @brief Prepare a transfer operation using prep_xfer_dlist handles.
-
-    @param operation Type of operation ("WRITE" or "READ").
-    @param local_xfer_side Handle to the local transfer descriptor list,
-            received from prep_xfer_dlist.
-    @param local_indices List or numpy array (dtype=int32) of indices for selecting local descriptors.
-    @param remote_xfer_side Handle to the remote (or loopback) transfer descriptor list,
-            received from prep_xfer_dlist.
-    @param remote_indices List or numpy array (dtype=int32) of indices for selecting remote descriptors.
-    @param notif_msg Optional notification message to send after transfer is done.
-           notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
-    @param backends Optional list of backend names to limit which backends NIXL can use.
-    @param skip_desc_merge Deprecated: Whether to skip descriptor merging optimization.
-    @return Opaque handle for posting/checking transfer.
-            The handle can be released by calling release_xfer_handle from agent, or release() method on itself.
-    """
 
     def make_prepped_xfer(
         self,
@@ -577,6 +559,25 @@ class nixl_agent:
         backends: list[str] = [],
         skip_desc_merge: bool = False,
     ) -> nixl_xfer_handle:
+        """Prepare a transfer operation using prep_xfer_dlist handles.
+
+        Args:
+            operation: Type of operation ("WRITE" or "READ").
+            local_xfer_side: Handle to the local transfer descriptor list,
+                received from prep_xfer_dlist.
+            local_indices: List or numpy array (dtype=int32) of indices for selecting local descriptors.
+            remote_xfer_side: Handle to the remote (or loopback) transfer descriptor list,
+                received from prep_xfer_dlist.
+            remote_indices: List or numpy array (dtype=int32) of indices for selecting remote descriptors.
+            notif_msg: Optional notification message to send after transfer is done.
+                notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
+            backends: Optional list of backend names to limit which backends NIXL can use.
+            skip_desc_merge: Deprecated: Whether to skip descriptor merging optimization.
+
+        Returns:
+            Opaque handle for posting/checking transfer.
+                The handle can be released by calling release_xfer_handle from agent, or release() method on itself.
+        """
         op = self.nixl_ops[operation]
         handle_list = []
         for backend_string in backends:
@@ -595,24 +596,6 @@ class nixl_agent:
 
         return nixl_xfer_handle(self.agent, handle)
 
-    """
-    @brief  Initialize a transfer operation. This is a combined API, to create a transfer request
-            from two descriptor lists, where NIXL prepares the descriptor lists and then the transfer.
-            If there are common descriptors across different transfer requests, using
-            this combined API will result in repeated computation, such as validity checks and
-            pre-processing done in the preparation step.
-
-    @param operation Type of operation ("WRITE" or "READ").
-    @param local_descs List of local transfer descriptors, from get_xfer_descs.
-    @param remote_descs List of remote (or loopback) transfer descriptors, from get_xfer_descs.
-    @param remote_agent Name of the remote agent.
-    @param notif_msg Optional notification message.
-           notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
-    @param backends Optional list of backend names to limit which backends NIXL can use.
-    @return Opaque handle for posting/checking transfer.
-            The handle can be released by calling release_xfer_handle from agent, or release() method on itself.
-    """
-
     def initialize_xfer(
         self,
         operation: str,
@@ -622,6 +605,25 @@ class nixl_agent:
         notif_msg: bytes = b"",
         backends: list[str] = [],
     ) -> nixl_xfer_handle:
+        """Initialize a transfer operation. This is a combined API, to create a transfer request
+        from two descriptor lists, where NIXL prepares the descriptor lists and then the transfer.
+        If there are common descriptors across different transfer requests, using
+        this combined API will result in repeated computation, such as validity checks and
+        pre-processing done in the preparation step.
+
+        Args:
+            operation: Type of operation ("WRITE" or "READ").
+            local_descs: List of local transfer descriptors, from get_xfer_descs.
+            remote_descs: List of remote (or loopback) transfer descriptors, from get_xfer_descs.
+            remote_agent: Name of the remote agent.
+            notif_msg: Optional notification message.
+                notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
+            backends: Optional list of backend names to limit which backends NIXL can use.
+
+        Returns:
+            Opaque handle for posting/checking transfer.
+                The handle can be released by calling release_xfer_handle from agent, or release() method on itself.
+        """
         op = self.nixl_ops[operation]
         handle_list = []
         for backend_string in backends:
@@ -633,19 +635,20 @@ class nixl_agent:
 
         return nixl_xfer_handle(self.agent, handle)
 
-    """
-    @brief  Initiate a data transfer operation.
-            After calling this, the transfer state can be checked asynchronously till completion.
-            In case of small transfers that are completed as part of the call itself, return value
-            will be "DONE", otherwise "PROC" or "ERR".
-
-    @param handle Handle to the transfer operation, from make_prepped_xfer, or initialize_xfer.
-    @param notif_msg Optional notification message can be specified or updated per transfer call.
-           notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
-    @return Status of the transfer operation ("DONE", "PROC", or "ERR").
-    """
-
     def transfer(self, handle: nixl_xfer_handle, notif_msg: bytes = b"") -> str:
+        """Initiate a data transfer operation.
+        After calling this, the transfer state can be checked asynchronously till completion.
+        In case of small transfers that are completed as part of the call itself, return value
+        will be "DONE", otherwise "PROC" or "ERR".
+
+        Args:
+            handle: Handle to the transfer operation, from make_prepped_xfer, or initialize_xfer.
+            notif_msg: Optional notification message can be specified or updated per transfer call.
+                notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
+
+        Returns:
+            Status of the transfer operation ("DONE", "PROC", or "ERR").
+        """
         status = self.agent.postXferReq(handle._handle, notif_msg)
         if status == nixlBind.NIXL_SUCCESS:
             return "DONE"
@@ -654,14 +657,15 @@ class nixl_agent:
         else:
             return "ERR"
 
-    """
-    @brief Check the state of a transfer operation.
-
-    @param handle Handle to the transfer operation, from make_prepped_xfer, or initialize_xfer.
-    @return Status of the transfer operation ("DONE", "PROC", or "ERR").
-    """
-
     def check_xfer_state(self, handle: nixl_xfer_handle) -> str:
+        """Check the state of a transfer operation.
+
+        Args:
+            handle: Handle to the transfer operation, from make_prepped_xfer, or initialize_xfer.
+
+        Returns:
+            Status of the transfer operation ("DONE", "PROC", or "ERR").
+        """
         status = self.agent.getXferStatus(handle._handle)
         if status == nixlBind.NIXL_SUCCESS:
             return "DONE"
@@ -670,30 +674,32 @@ class nixl_agent:
         else:
             return "ERR"
 
-    """
-    @brief Get telemetry information of a transfer request.
-           The output object has three time values fields in microseconds
-           (startTime, postDuration, xferDuration), as well as integer totalBytes transferred
-           for the request, and integer descCount representing number of descriptors involved
-           (for example if there was some merging of descriptors).
-
-    @param handle Handle to the transfer operation, from make_prepped_xfer or initialize_xfer.
-    @return nixlXferTelemetry object
-    """
-
     def get_xfer_telemetry(
         self, handle: nixl_xfer_handle
     ) -> nixlBind.nixlXferTelemetry:
+        """Get telemetry information of a transfer request.
+        The output object has three time values fields in microseconds
+        (startTime, postDuration, xferDuration), as well as integer totalBytes transferred
+        for the request, and integer descCount representing number of descriptors involved
+        (for example if there was some merging of descriptors).
+
+        Args:
+            handle: Handle to the transfer operation, from make_prepped_xfer or initialize_xfer.
+
+        Returns:
+            nixlXferTelemetry object
+        """
         return self.agent.getXferTelemetry(handle._handle)
 
-    """
-    @brief Query the backend that was chosen for a transfer operation.
-
-    @param handle Handle to the transfer operation.
-    @return Name of the backend decided for the transfer.
-    """
-
     def query_xfer_backend(self, handle: nixl_xfer_handle) -> str:
+        """Query the backend that was chosen for a transfer operation.
+
+        Args:
+            handle: Handle to the transfer operation.
+
+        Returns:
+            Name of the backend decided for the transfer.
+        """
         b_handle = self.agent.queryXferBackend(handle._handle)
         # this works because there should not be multiple matching handles in the Dict
         return next(
@@ -702,66 +708,54 @@ class nixl_agent:
             if backendH == b_handle
         )
 
-    """
-    @brief  Releases a transfer handle, which internally frees the memory used for the handle.
-            If the transfer is active, NIXL will attempt to cancel it.
-            If it cannot be canceled, an error will be returned and the handle will not be freed.
-
-    @param handle Handle to the transfer operation from initialize_xfer or make_xfer.
-    """
-
     def release_xfer_handle(self, handle: nixl_xfer_handle):
+        """Releases a transfer handle, which internally frees the memory used for the handle.
+        If the transfer is active, NIXL will attempt to cancel it.
+        If it cannot be canceled, an error will be returned and the handle will not be freed.
+
+        Args:
+            handle: Handle to the transfer operation from initialize_xfer or make_xfer.
+        """
         handle.release()
-
-    """
-    @brief Release a descriptor list handle, which internally frees the memory used for the handle.
-
-    @param handle Handle to the descriptor list from make_prepped_dlist.
-    """
 
     def release_dlist_handle(self, handle: nixl_prepped_dlist_handle):
+        """Release a descriptor list handle, which internally frees the memory used for the handle.
+
+        Args:
+            handle: Handle to the descriptor list from make_prepped_dlist.
+        """
         handle.release()
 
-    """
-    @brief Get new notifications that have come to the agent.
-
-    @param backends Optional list of backend names to limit which backends are checked for notifications.
-    @return Dictionary of new notifications.
-            Return Dict is a map of remote agent names to a list of notification messages from that agent.
-    """
-
     def get_new_notifs(self, backends: list[str] = []) -> dict[str, list[bytes]]:
+        """Get new notifications that have come to the agent.
+
+        Args:
+            backends: Optional list of backend names to limit which backends are checked for notifications.
+
+        Returns:
+            Dictionary of new notifications.
+                Return Dict is a map of remote agent names to a list of notification messages from that agent.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
         return self.agent.getNotifs({}, handle_list)
 
-    """
-    @brief Update notifications in a map
-            Same as get_new_notifs, but returns all unhandled notifications in agent.
-
-    @param backends Optional list of backend names to limit which backends are checked for notifications.
-    @return Dictionary of updated notifications.
-    """
-
     def update_notifs(self, backends: list[str] = []) -> dict[str, list[bytes]]:
+        """Update notifications in a map
+        Same as get_new_notifs, but returns all unhandled notifications in agent.
+
+        Args:
+            backends: Optional list of backend names to limit which backends are checked for notifications.
+
+        Returns:
+            Dictionary of updated notifications.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
         self.notifs = self.agent.getNotifs(self.notifs, handle_list)  # Adds new notifs
         return self.notifs
-
-    """
-    @brief Check if a remote transfer is done with a specific notification.
-           Will only remove the notification that is found.
-
-    @param remote_agent_name Name of the remote agent.
-    @param lookup_tag A tag to match against available messages in the notification map.
-           The tag Can be the same as the entire expected message.
-    @param backends Optional list of backend names to limit which backends are checked for notifications.
-    @param tag_is_prefix Optionally specify that the tag you want to search with is just a prefix, or can be search as a substring of the full message.
-    @return True if the notification is found, False otherwise.
-    """
 
     def check_remote_xfer_done(
         self,
@@ -770,6 +764,19 @@ class nixl_agent:
         backends: list[str] = [],
         tag_is_prefix=True,
     ) -> bool:
+        """Check if a remote transfer is done with a specific notification.
+        Will only remove the notification that is found.
+
+        Args:
+            remote_agent_name: Name of the remote agent.
+            lookup_tag: A tag to match against available messages in the notification map.
+                The tag Can be the same as the entire expected message.
+            backends: Optional list of backend names to limit which backends are checked for notifications.
+            tag_is_prefix: Optionally specify that the tag you want to search with is just a prefix, or can be search as a substring of the full message.
+
+        Returns:
+            True if the notification is found, False otherwise.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
@@ -789,42 +796,29 @@ class nixl_agent:
             self.notifs[remote_agent_name].remove(message)
         return found
 
-    """
-    @brief Send a standalone notification to a remote agent, not bound to a transfer.
-
-    @param remote_agent_name Name of the remote agent.
-    @param notif_msg Message to send, it will be received as bytes.
-           notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
-    @param backends Optional a backend name to use to send the notifications.
-    """
-
     def send_notif(
         self, remote_agent_name: str, notif_msg: bytes, backend: Optional[str] = None
     ):
+        """Send a standalone notification to a remote agent, not bound to a transfer.
+
+        Args:
+            remote_agent_name: Name of the remote agent.
+            notif_msg: Message to send, it will be received as bytes.
+                notif_msg should be bytes, as that is what will be returned to the target, but will work with str too.
+            backends: Optional a backend name to use to send the notifications.
+        """
         if backend is None:
             self.agent.genNotif(remote_agent_name, notif_msg)
         else:
             self.agent.genNotif(remote_agent_name, notif_msg, self.backends[backend])
 
-    """
-    @brief Get the full metadata of the local agent.
-
-    @return Metadata of the local agent, in bytes.
-    """
-
     def get_agent_metadata(self) -> bytes:
+        """Get the full metadata of the local agent.
+
+        Returns:
+            Metadata of the local agent, in bytes.
+        """
         return self.agent.getLocalMD()
-
-    """
-    @brief Get partial metadata of the local agent.
-
-    @param descs         The list of descriptors to include metadata about.
-                         List can be empty if only trying to send connection info.
-    @param inc_conn_info Whether to include connection info in the metadata.
-    @param backends      List of backends to consider when constructing partial metadata.
-
-    @return Metadata of the local agent, in bytes.
-    """
 
     def get_partial_agent_metadata(
         self,
@@ -832,60 +826,55 @@ class nixl_agent:
         inc_conn_info: bool = False,
         backends: list[str] = [],
     ) -> bytes:
+        """Get partial metadata of the local agent.
+
+        Args:
+            descs: The list of descriptors to include metadata about.
+                List can be empty if only trying to send connection info.
+            inc_conn_info: Whether to include connection info in the metadata.
+            backends: List of backends to consider when constructing partial metadata.
+
+        Returns:
+            Metadata of the local agent, in bytes.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
         return self.agent.getLocalPartialMD(descs, inc_conn_info, handle_list)
 
-    """
-    @brief Add a remote agent using its metadata. After this call, current agent can
-            initiate transfers towards the remote agent.
-
-    @param metadata Metadata of the remote agent, received out-of-band in bytes.
-    @return Name of the added remote agent.
-    """
-
     def add_remote_agent(self, metadata: bytes) -> str:
+        """Add a remote agent using its metadata. After this call, current agent can
+        initiate transfers towards the remote agent.
+
+        Args:
+            metadata: Metadata of the remote agent, received out-of-band in bytes.
+
+        Returns:
+            Name of the added remote agent.
+        """
         agent_name = self.agent.loadRemoteMD(metadata)
         return agent_name
 
-    """
-    @brief Remove a remote agent. After this call, current agent cannot initiate
-            transfers towards the remote agent specified in the call anymore.
-            This call will also result in a disconnect between the two agents.
-
-    @param agent Name of the remote agent.
-    """
-
     def remove_remote_agent(self, agent: str):
+        """Remove a remote agent. After this call, current agent cannot initiate
+        transfers towards the remote agent specified in the call anymore.
+        This call will also result in a disconnect between the two agents.
+
+        Args:
+            agent: Name of the remote agent.
+        """
         self.agent.invalidateRemoteMD(agent)
 
-    """
-    @brief Send all of your metadata to a peer or central metadata server.
-
-    @param ip_addr If specified, will only send metadata to one peer by IP address.
-                   Otherwise, metadata will be sent to central metadata server, if supported.
-    @param port    If specified next to ip_addr, will try to send to this specific port of a peer.
-                   Ignored when sending to a central metadata server.
-    """
-
     def send_local_metadata(self, ip_addr: str = "", port: int = DEFAULT_COMM_PORT):
+        """Send all of your metadata to a peer or central metadata server.
+
+        Args:
+            ip_addr: If specified, will only send metadata to one peer by IP address.
+                Otherwise, metadata will be sent to central metadata server, if supported.
+            port: If specified next to ip_addr, will try to send to this specific port of a peer.
+                Ignored when sending to a central metadata server.
+        """
         self.agent.sendLocalMD(ip_addr, port)
-
-    """
-    @brief Send partial metadata of the local agent to a peer or central metadata server.
-
-    @param descs         The list of descriptors to include metadata about.
-                         List can be empty if only trying to send connection info.
-    @param inc_conn_info Whether to include connection info in the metadata.
-    @param backends      List of backends to consider when constructing partial metadata.
-    @param ip_addr       If specified, will only send metadata to one peer by IP address.
-                         Otherwise, metadata will be sent to central metadata server, if supported.
-    @param port          If specified next to ip_addr, will try to send to this specific port of a peer.
-                         Ignored when sending to a central metadata server.
-    @param label         Label to use for the metadata when sending to central metadata server.
-                         Ignored when sending to a peer.
-    """
 
     def send_partial_agent_metadata(
         self,
@@ -896,19 +885,26 @@ class nixl_agent:
         port: int = DEFAULT_COMM_PORT,
         label: str = "",
     ):
+        """Send partial metadata of the local agent to a peer or central metadata server.
+
+        Args:
+            descs: The list of descriptors to include metadata about.
+                List can be empty if only trying to send connection info.
+            inc_conn_info: Whether to include connection info in the metadata.
+            backends: List of backends to consider when constructing partial metadata.
+            ip_addr: If specified, will only send metadata to one peer by IP address.
+                Otherwise, metadata will be sent to central metadata server, if supported.
+            port: If specified next to ip_addr, will try to send to this specific port of a peer.
+                Ignored when sending to a central metadata server.
+            label: Label to use for the metadata when sending to central metadata server.
+                Ignored when sending to a peer.
+        """
         handle_list = []
         for backend_string in backends:
             handle_list.append(self.backends[backend_string])
         self.agent.sendLocalPartialMD(
             descs, inc_conn_info, handle_list, ip_addr, port, label
         )
-
-    """
-    @brief Request metadata be retrieved from central metadata server or sent by peer.
-
-    @param ip_addr If specified, will request metadata from one peer by IP address.
-    @param port    If specified, will try to request on specific port.
-    """
 
     def fetch_remote_metadata(
         self,
@@ -917,32 +913,37 @@ class nixl_agent:
         port: int = DEFAULT_COMM_PORT,
         label: str = "",
     ):
+        """Request metadata be retrieved from central metadata server or sent by peer.
+
+        Args:
+            ip_addr: If specified, will request metadata from one peer by IP address.
+            port: If specified, will try to request on specific port.
+        """
         self.agent.fetchRemoteMD(remote_agent, ip_addr, port, label)
-
-    """
-    @brief Invalidate your own metadata in the central metadata server, or from a specific peer.
-
-    @param ip_addr If specified, will only send invalidation to one peer by IP address.
-    @param port    If specified, will try to send to specific port.
-    """
 
     def invalidate_local_metadata(
         self, ip_addr: str = "", port: int = DEFAULT_COMM_PORT
     ):
+        """Invalidate your own metadata in the central metadata server, or from a specific peer.
+
+        Args:
+            ip_addr: If specified, will only send invalidation to one peer by IP address.
+            port: If specified, will try to send to specific port.
+        """
         self.agent.invalidateLocalMD(ip_addr, port)
-
-    """
-    @brief Check if the remote metadata for a specific agent is available.
-           When partial metadata methods are used, the descriptor list in question can be specified.
-
-    @param agent Name of the remote agent.
-
-    @return True if available, False otherwise
-    """
 
     def check_remote_metadata(
         self, agent: str, descs: nixlBind.nixlXferDList = None
     ) -> bool:
+        """Check if the remote metadata for a specific agent is available.
+        When partial metadata methods are used, the descriptor list in question can be specified.
+
+        Args:
+            agent: Name of the remote agent.
+
+        Returns:
+            True if available, False otherwise
+        """
         if descs is None:  # Just empty list, mem_type not important
             descs = nixlBind.nixlXferDList(nixlBind.DRAM_SEG)
         if self.agent.checkRemoteMD(agent, descs) == nixlBind.NIXL_SUCCESS:
@@ -954,20 +955,6 @@ class nixl_agent:
     def _tensor_mem_type(tensor: torch.Tensor) -> str:
         return "DRAM" if tensor.get_device() == -1 else "VRAM"
 
-    """
-    @brief Get nixlXferDList from different input types:
-            a) list of 3 element tuples (address, len, device ID) alongside a mandatory memory type
-            b) a tensor
-            c) a list of tensors
-            d) a Nx3 2D numpy array, each row defines a single descriptor (address, len, device ID),
-               alongside a mandatory memory type
-            e) passes along if an xfer_dlist is given.
-
-    @param descs List of any of the above types
-    @param mem_type Optional memory type necessary for (a).
-    @return Transfer descriptor list, nixlXferDList.
-    """
-
     def get_xfer_descs(
         self,
         descs,
@@ -975,6 +962,21 @@ class nixl_agent:
     ) -> nixlBind.nixlXferDList:
         # can add check for DLPack input
 
+        """Get nixlXferDList from different input types:
+        a) list of 3 element tuples (address, len, device ID) alongside a mandatory memory type
+        b) a tensor
+        c) a list of tensors
+        d) a Nx3 2D numpy array, each row defines a single descriptor (address, len, device ID),
+        alongside a mandatory memory type
+        e) passes along if an xfer_dlist is given.
+
+        Args:
+            descs: List of any of the above types
+            mem_type: Optional memory type necessary for (a).
+
+        Returns:
+            Transfer descriptor list, nixlXferDList.
+        """
         if isinstance(descs, nixlBind.nixlXferDList):
             return descs
         elif isinstance(descs, nixlBind.nixlRegDList):
@@ -1037,20 +1039,6 @@ class nixl_agent:
 
         return new_descs
 
-    """
-    @brief Get nixlRegDList from different input types:
-            a) list of 4 element tuples (address, len, device ID, meta info) alongside a mandatory memory type
-            b) a tensor
-            c) a list of tensors
-            d) a Nx3 2D numpy array, each row defines a single descriptor (address, len, device ID),
-               alongside a mandatory memory type. Empty meta info will be considered for each descriptor.
-            e) passes along if a reg_dlist is given.
-
-    @param descs List of any of the above types
-    @param mem_type Optional memory type necessary for (a).
-    @return Registration descriptor list, nixlRegDList.
-    """
-
     def get_reg_descs(
         self,
         descs,
@@ -1058,6 +1046,21 @@ class nixl_agent:
     ) -> nixlBind.nixlRegDList:
         # can add check for DLPack input
 
+        """Get nixlRegDList from different input types:
+        a) list of 4 element tuples (address, len, device ID, meta info) alongside a mandatory memory type
+        b) a tensor
+        c) a list of tensors
+        d) a Nx3 2D numpy array, each row defines a single descriptor (address, len, device ID),
+        alongside a mandatory memory type. Empty meta info will be considered for each descriptor.
+        e) passes along if a reg_dlist is given.
+
+        Args:
+            descs: List of any of the above types
+            mem_type: Optional memory type necessary for (a).
+
+        Returns:
+            Registration descriptor list, nixlRegDList.
+        """
         if isinstance(descs, nixlBind.nixlRegDList):
             return descs
         elif isinstance(descs, nixlBind.nixlXferDList):
@@ -1120,22 +1123,24 @@ class nixl_agent:
 
         return new_descs
 
-    """
-    @brief Serialize NIXL descriptor list with pickle.
-
-    @param descs NIXL list to serialize.
-    @return Serialized descriptor list.
-    """
-
     def get_serialized_descs(self, descs) -> bytes:
+        """Serialize NIXL descriptor list with pickle.
+
+        Args:
+            descs: NIXL list to serialize.
+
+        Returns:
+            Serialized descriptor list.
+        """
         return pickle.dumps(descs)
 
-    """
-    @brief Deserialize NIXL descriptor list.
-
-    @param serialized_descs Serialized NIXL descriptor list.
-    @return Deserialized NIXL descriptor list.
-    """
-
     def deserialize_descs(self, serialized_descs: bytes):
+        """Deserialize NIXL descriptor list.
+
+        Args:
+            serialized_descs: Serialized NIXL descriptor list.
+
+        Returns:
+            Deserialized NIXL descriptor list.
+        """
         return pickle.loads(serialized_descs)


### PR DESCRIPTION
## What?
Change the doxygen-like docstrings into standard python docstrings.

## Why?

The Python API currently places documentation strings before classes and functions and uses tags such as `@brief`, `@args`, `@param`, and `@return`. In that position they are ordinary, discarded string expressions rather than Python docstrings, so Python documentation tools do not pick them up; a Python docstring must be the first statement inside the class or function it documents.

This PR standardizes the Python API on PEP 257 docstrings with Google-style structured sections, following the format now documented in `CONTRIBUTING.md`. First commits updates `CONTRIBUTING.md`, the second commit moves the docstrings into that format. No text changes are done in this PR.

I have already experimented with automatic documentation generation for Fern (docs.nvidia.com) and this format is supported by a python docs generator (handsdown, see comment https://github.com/ai-dynamo/nixl/pull/1946#issuecomment-5216012849 ). I couldn't find any that would process the current format.

Note, due to the dynamic imports in `nixl.py` the docstrings still do not show up in VSCode (and i presume other IDEs) autocomplete, but if the dynamic import is replaced with a static one, they do show up in the autocomplete. Nevertheless, for interactive documentation query using the `.__doc__` property, these strings now show up:

## Verification

Before:

```bash
$ cd /workspace/nixl-upstream
$ LD_LIBRARY_PATH="$PWD/.venv/lib" .venv/bin/python3 -c 'import nixl; print(nixl.nixl_agent_config.__doc__)'
None
```

After:

```bash
$ cd /workspace/nixl-pydoc-std
$ LD_LIBRARY_PATH="$PWD/.venv/lib" .venv/bin/python3 -c 'import nixl; print(nixl.nixl_agent_config.__doc__)'
Configuration class for NIXL agent.

    Args:
        enable_prog_thread: Whether to enable the progress thread, if available.
        enable_listen_thread: Whether to enable the listener thread for metadata communication.
        listen_port: Specify the port for the listener thread to listen on.
        capture_telemetry: Whether to enable telemetry capture.
        num_threads: Specify number of threads for the supported multi-threaded backends.
        backends: List of backend names for agent to initialize.
            Default is UCX, other backends can be added to the list, or after
            agent creation, can be initialized with create_backend.
        sync_mode: Thread synchronization mode to use for the agent.
            If None, sync_mode is set based on the enable_listen flag.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Python docstring standards covering PEP 257, Google-style formatting, placement, summaries, and examples.
  * Improved API documentation across Python interfaces with consistent, clearer docstrings.
  * No runtime behavior or public API signatures were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->