### PR TITLE
GTEST/UCX: Added more test cases for UCX

### DIFF
--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -167,7 +167,7 @@ private:
     Agent        m_Initiator;
     Agent        m_Target;
     std::string  m_backend_name;
-    bool progThread_;
+    const bool progThread_;
     size_t numWorkers_;
     size_t numThreads_;
 };

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -125,7 +125,7 @@ class TestErrorHandling : public nixl_test_t {
 
     private:
         std::string m_name;
-        bool                       m_progThread = false;
+        bool m_progThread = false;
         nixlBackendH*              m_backend = nullptr;
         std::unique_ptr<nixlAgent> m_priv    = nullptr;
         std::string                m_MetaRemote;
@@ -262,8 +262,7 @@ TestErrorHandling::Agent::waitForCompletion(nixlXferReqH *req_handle,
 }
 
 nixl_status_t
-TestErrorHandling::Agent::waitForNotif(const std::string &expectedNotif,
-                                       nixl_notifs_t &notifs) {
+TestErrorHandling::Agent::waitForNotif(const std::string &expectedNotif, nixl_notifs_t &notifs) {
     const auto deadline = std::chrono::steady_clock::now() + wait_timeout;
 
     while (notifs[m_MetaRemote].empty()) {

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <algorithm>
+#include <chrono>
 #include <gtest/gtest.h>
 #include <nixl_types.h>
 #include "common.h"
@@ -25,6 +26,9 @@
 #endif
 
 namespace gtest {
+
+constexpr std::chrono::seconds wait_timeout{100};
+
 namespace nixl {
     constexpr const char* ucx_err_handling_mode_key  = "ucx_error_handling_mode";
     constexpr const char* ucx_err_handling_mode_peer = "peer";
@@ -67,8 +71,7 @@ namespace nixl {
     }
 } // namespace nixl
 
-// Tuple fields are: backend_name, num_workers, num_threads
-class TestErrorHandling : public testing::TestWithParam<std::tuple<std::string, size_t, size_t>> {
+class TestErrorHandling : public nixl_test_t {
     class Agent {
         struct MemDesc {
             MemDesc() : m_dlist(DRAM_SEG), m_desc() {}
@@ -97,6 +100,7 @@ class TestErrorHandling : public testing::TestWithParam<std::tuple<std::string, 
         void
         init(const std::string &name,
              const std::string &backend_name,
+             bool use_prog_thread,
              size_t num_workers,
              size_t num_threads);
 
@@ -112,13 +116,16 @@ class TestErrorHandling : public testing::TestWithParam<std::tuple<std::string, 
         nixl_status_t postXferReq(nixlXferReqH* req_handle) const;
         nixl_status_t
         releaseXferReq(nixlXferReqH *req_handle) const;
-        nixl_status_t waitForCompletion(nixlXferReqH* req_handle);
-        nixl_status_t waitForNotif(const std::string& expectedNotif);
+        nixl_status_t
+        waitForCompletion(nixlXferReqH *req_handle, Agent &peer, nixl_notifs_t &peer_notifs);
+        nixl_status_t
+        waitForNotif(const std::string &expectedNotif, nixl_notifs_t &notifs);
         void fillData();
         bool dataCmp(const Agent& other) const;
 
     private:
         std::string m_name;
+        bool                       m_progThread = false;
         nixlBackendH*              m_backend = nullptr;
         std::unique_ptr<nixlAgent> m_priv    = nullptr;
         std::string                m_MetaRemote;
@@ -136,6 +143,8 @@ protected:
 
     TestErrorHandling();
     template<TestType test_type, enum nixl_xfer_op_t op> void testXfer();
+    void
+    testNotifAfterFail();
 
 private:
     template<TestType test_type>
@@ -158,6 +167,7 @@ private:
     Agent        m_Initiator;
     Agent        m_Target;
     std::string  m_backend_name;
+    bool progThread_;
     size_t numWorkers_;
     size_t numThreads_;
 };
@@ -165,10 +175,14 @@ private:
 void
 TestErrorHandling::Agent::init(const std::string &name,
                                const std::string &backend_name,
+                               bool use_prog_thread,
                                size_t num_workers,
                                size_t num_threads) {
     nixlAgentConfig cfg;
-    cfg.useProgThread = true;
+    m_progThread = use_prog_thread;
+    cfg.useProgThread = use_prog_thread;
+    // TODO: remove once access to dedicated workers is properly serialized.
+    cfg.syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW;
     m_priv = std::make_unique<nixlAgent>(name, cfg);
     // At the moment, only UCX backend is tested for error handling support.
     m_backend = nixl::createUcxBackend(*m_priv, backend_name, num_workers, num_threads);
@@ -228,13 +242,19 @@ TestErrorHandling::Agent::releaseXferReq(nixlXferReqH *req_handle) const {
 }
 
 nixl_status_t
-TestErrorHandling::Agent::waitForCompletion(nixlXferReqH *req_handle) {
+TestErrorHandling::Agent::waitForCompletion(nixlXferReqH *req_handle,
+                                            Agent &peer,
+                                            nixl_notifs_t &peer_notifs) {
+    const auto deadline = std::chrono::steady_clock::now() + wait_timeout;
     nixl_status_t status;
 
     do {
         status = m_priv->getXferStatus(req_handle);
         EXPECT_NE(NIXL_ERR_NOT_POSTED, status);
-    } while (status == NIXL_IN_PROG);
+        if (!peer.m_progThread && peer.m_priv != nullptr) {
+            peer.m_priv->getNotifs(peer_notifs);
+        }
+    } while ((status == NIXL_IN_PROG) && (std::chrono::steady_clock::now() < deadline));
 
     m_priv->releaseXferReq(req_handle);
 
@@ -242,16 +262,22 @@ TestErrorHandling::Agent::waitForCompletion(nixlXferReqH *req_handle) {
 }
 
 nixl_status_t
-TestErrorHandling::Agent::waitForNotif(const std::string& expectedNotif) {
-    nixl_notifs_t notif_map;
+TestErrorHandling::Agent::waitForNotif(const std::string &expectedNotif,
+                                       nixl_notifs_t &notifs) {
+    const auto deadline = std::chrono::steady_clock::now() + wait_timeout;
 
-    do {
-        EXPECT_EQ(NIXL_SUCCESS, m_priv->getNotifs(notif_map));
-    } while (notif_map.empty());
+    while (notifs[m_MetaRemote].empty()) {
+        const nixl_status_t status = m_priv->getNotifs(notifs);
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            return NIXL_IN_PROG;
+        }
+    }
 
-    std::vector<std::string> notifs = notif_map[m_MetaRemote];
-    EXPECT_EQ(1u, notifs.size());
-    EXPECT_EQ(expectedNotif, notifs.front());
+    EXPECT_EQ(1u, notifs[m_MetaRemote].size());
+    EXPECT_EQ(expectedNotif, notifs[m_MetaRemote].front());
     return NIXL_SUCCESS;
 }
 
@@ -264,9 +290,10 @@ bool TestErrorHandling::Agent::dataCmp(const TestErrorHandling::Agent& other) co
 }
 
 TestErrorHandling::TestErrorHandling()
-    : m_backend_name(std::get<0>(GetParam())),
-      numWorkers_(std::get<1>(GetParam())),
-      numThreads_(std::get<2>(GetParam())) {
+    : m_backend_name(GetParam().backendName),
+      progThread_(GetParam().progressThreadEnabled),
+      numWorkers_(GetParam().numWorkers),
+      numThreads_(GetParam().numThreads) {
     m_env.addVar("UCX_RC_TIMEOUT", "100us");
     m_env.addVar("UCX_RC_RETRY_COUNT", "4");
     m_env.addVar("UCX_UD_TIMEOUT", "3s");
@@ -277,13 +304,14 @@ template<TestErrorHandling::TestType test_type, enum nixl_xfer_op_t op>
 void TestErrorHandling::testXfer() {
     const std::string initiator_name = "initiator";
     const std::string target_name = "target";
-    m_Initiator.init(initiator_name, m_backend_name, numWorkers_, numThreads_);
-    m_Target.init(target_name, m_backend_name, numWorkers_, numThreads_);
+    m_Initiator.init(initiator_name, m_backend_name, progThread_, numWorkers_, numThreads_);
+    m_Target.init(target_name, m_backend_name, progThread_, numWorkers_, numThreads_);
 
     exchangeMetaData();
 
     for (size_t i = 0; i < numIter<test_type>(); ++i) {
         nixl_status_t status;
+        nixl_notifs_t target_notifs;
         auto result = postXfer<test_type>(op, i);
         if (std::holds_alternative<nixl_status_t>(result)) {
             // Transfer completed immediately
@@ -291,7 +319,7 @@ void TestErrorHandling::testXfer() {
         } else {
             // Transfer was posted, wait for completion
             nixlXferReqH *req_handle = std::get<nixlXferReqH *>(result);
-            status = m_Initiator.waitForCompletion(req_handle);
+            status = m_Initiator.waitForCompletion(req_handle, m_Target, target_notifs);
         }
 
         if (isFailure<test_type>(i)) {
@@ -302,12 +330,12 @@ void TestErrorHandling::testXfer() {
             }
 
             if (test_type == TestType::XFER_FAIL_RESTORE) {
-                m_Target.init(target_name, m_backend_name, numWorkers_, numThreads_);
+                m_Target.init(target_name, m_backend_name, progThread_, numWorkers_, numThreads_);
                 exchangeMetaData();
             }
         } else {
             EXPECT_EQ(NIXL_SUCCESS, status);
-            EXPECT_EQ(NIXL_SUCCESS, m_Target.waitForNotif("notification"));
+            EXPECT_EQ(NIXL_SUCCESS, m_Target.waitForNotif("notification", target_notifs));
             EXPECT_TRUE(m_Target.dataCmp(m_Initiator));
 
             // Update the data for the next iteration
@@ -456,8 +484,8 @@ TEST_P(TestErrorHandling, XferPostThenFail) {
 #ifdef HAVE_UCX_BACKEND
 TEST_P(TestErrorHandling, ErrorCallbackMarksEndpointFailedWithoutClosingIt) {
     std::vector<std::string> devices;
-    const size_t num_workers = std::get<1>(GetParam());
-    const bool use_progress_thread = std::get<2>(GetParam()) > 0;
+    const size_t num_workers = GetParam().numWorkers;
+    const bool use_progress_thread = GetParam().progressThreadEnabled;
     nixlUcxContext consumer_context(
         devices, use_progress_thread, num_workers, nixl_thread_sync_t::NIXL_THREAD_SYNC_STRICT, 1);
     nixlUcxContext producer_context(
@@ -476,9 +504,9 @@ TEST_P(TestErrorHandling, ErrorCallbackMarksEndpointFailedWithoutClosingIt) {
 }
 #endif
 
-INSTANTIATE_TEST_SUITE_P(ucx, TestErrorHandling, testing::Values(std::make_tuple("UCX", 1, 0)));
-INSTANTIATE_TEST_SUITE_P(ucx_threadpool,
-                         TestErrorHandling,
-                         testing::Values(std::make_tuple("UCX", 2, 1)));
+NIXL_INSTANTIATE_TEST(ucx, TestErrorHandling, "UCX", true, 1, 0, "");
+NIXL_INSTANTIATE_TEST(ucx_no_pt, TestErrorHandling, "UCX", false, 1, 0, "");
+NIXL_INSTANTIATE_TEST(ucx_threadpool, TestErrorHandling, "UCX", true, 2, 1, "");
+NIXL_INSTANTIATE_TEST(ucx_threadpool_no_pt, TestErrorHandling, "UCX", false, 2, 1, "");
 
 } // namespace gtest

--- a/test/gtest/error_handling.cpp
+++ b/test/gtest/error_handling.cpp
@@ -252,7 +252,11 @@ TestErrorHandling::Agent::waitForCompletion(nixlXferReqH *req_handle,
         status = m_priv->getXferStatus(req_handle);
         EXPECT_NE(NIXL_ERR_NOT_POSTED, status);
         if (!peer.m_progThread && peer.m_priv != nullptr) {
-            peer.m_priv->getNotifs(peer_notifs);
+            const nixl_status_t peer_status = peer.m_priv->getNotifs(peer_notifs);
+            EXPECT_EQ(NIXL_SUCCESS, peer_status);
+            if (peer_status != NIXL_SUCCESS) {
+                break;
+            }
         }
     } while ((status == NIXL_IN_PROG) && (std::chrono::steady_clock::now() < deadline));
 

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -379,6 +379,7 @@ protected:
                const std::string &from_name,
                nixlAgent &to,
                const std::string &to_name,
+               nixl_xfer_op_t op,
                size_t size,
                size_t count,
                size_t repeat,
@@ -399,7 +400,7 @@ protected:
 
                 nixlXferReqH *xfer_req = nullptr;
                 nixl_status_t status = from.createXferReq(
-                        NIXL_WRITE,
+                        op,
                         makeDescList<nixlBasicDesc>(src_buffers, src_mem_type),
                         makeDescList<nixlBasicDesc>(dst_buffers, dst_mem_type), to_name,
                         xfer_req, &extra_params);
@@ -431,8 +432,9 @@ protected:
                 auto bandwidth  = total_size / total_time / (1024 * 1024 * 1024);
                 {
                     const std::lock_guard<std::mutex> lock(logger_mutex);
-                    Logger() << "Thread " << thread << ": " << size << "x" << count << "x" << repeat
-                             << "=" << total_size << " bytes in " << total_time << " seconds "
+                    Logger() << "Thread " << thread << " " << nixlEnumStrings::xferOpStr(op) << ": "
+                             << size << "x" << count << "x" << repeat << "=" << total_size
+                             << " bytes in " << total_time << " seconds "
                              << "(" << bandwidth << " GB/s)";
                 }
 
@@ -519,6 +521,7 @@ protected:
                    getAgentName(0),
                    getAgent(1),
                    getAgentName(1),
+                   NIXL_WRITE,
                    size,
                    count,
                    repeat,
@@ -555,18 +558,21 @@ TEST_P(TestTransfer, RandomSizes)
         createRegisteredMem(getAgent(1), size, count, mem_type, dst_buffers);
 
         exchangeMD(0, 1);
-        doTransfer(getAgent(0),
-                   getAgentName(0),
-                   getAgent(1),
-                   getAgentName(1),
-                   size,
-                   count,
-                   repeat,
-                   num_threads,
-                   mem_type,
-                   src_buffers,
-                   mem_type,
-                   dst_buffers);
+        for (const auto op : {NIXL_WRITE, NIXL_READ}) {
+            doTransfer(getAgent(0),
+                       getAgentName(0),
+                       getAgent(1),
+                       getAgentName(1),
+                       op,
+                       size,
+                       count,
+                       repeat,
+                       num_threads,
+                       mem_type,
+                       src_buffers,
+                       mem_type,
+                       dst_buffers);
+        }
         invalidateMD(0, 1);
         deregisterMem(getAgent(0), src_buffers, mem_type);
         deregisterMem(getAgent(1), dst_buffers, mem_type);
@@ -584,10 +590,12 @@ TEST_P(TestTransfer, remoteMDFromSocket)
     createRegisteredMem(getAgent(1), size, count, mem_type, dst_buffers);
 
     exchangeMDIP(0, 1);
-    doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
-               size, count, 1, 1,
-               mem_type, src_buffers,
-               mem_type, dst_buffers);
+    for (const auto op : {NIXL_WRITE, NIXL_READ}) {
+        doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
+                   op, size, count, 1, 1,
+                   mem_type, src_buffers,
+                   mem_type, dst_buffers);
+    }
 
     invalidateMD(0, 1);
     deregisterMem(getAgent(0), src_buffers, mem_type);
@@ -742,6 +750,7 @@ protected:
                    getAgentName(0),
                    getAgent(1),
                    getAgentName(1),
+                   NIXL_WRITE,
                    size,
                    count,
                    repeat,
@@ -809,6 +818,7 @@ TEST_P(TestTransferTracing, NvtxDemoWalkthrough) {
                getAgentName(0),
                getAgent(1),
                getAgentName(1),
+               NIXL_WRITE,
                size,
                count,
                /*repeat=*/1,

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -634,7 +634,9 @@ TEST_P(TestTransfer, EmptyNotificationPayload) {
         getAgent(0), getAgentName(0), getAgent(1), getAgentName(1), repeat, num_threads, "");
 }
 
-TEST_P(TestTransfer, ListenerCommSize) {
+class TestListener : public TestTransfer {};
+
+TEST_P(TestListener, CommSize) {
     std::vector<MemBuffer> buffers;
     createRegisteredMem(getAgent(1), 64, 10000, DRAM_SEG, buffers);
     auto status = fetchRemoteMD(0, 1);
@@ -643,6 +645,8 @@ TEST_P(TestTransfer, ListenerCommSize) {
         wait_until_true([&]() { return checkRemoteMD(0, 1) == NIXL_SUCCESS; }));
     deregisterMem(getAgent(1), buffers, DRAM_SEG);
 }
+
+NIXL_INSTANTIATE_TEST(ucx, TestListener, "UCX", true, 1, 0, "");
 
 TEST_P(TestTransferTelemetry, GetXferTelemetryFile) {
     env.addVar("NIXL_TELEMETRY_ENABLE", "y");

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -399,11 +399,13 @@ protected:
                 extra_params.notif = notif_msg;
 
                 nixlXferReqH *xfer_req = nullptr;
-                nixl_status_t status = from.createXferReq(
-                        op,
-                        makeDescList<nixlBasicDesc>(src_buffers, src_mem_type),
-                        makeDescList<nixlBasicDesc>(dst_buffers, dst_mem_type), to_name,
-                        xfer_req, &extra_params);
+                nixl_status_t status =
+                    from.createXferReq(op,
+                                       makeDescList<nixlBasicDesc>(src_buffers, src_mem_type),
+                                       makeDescList<nixlBasicDesc>(dst_buffers, dst_mem_type),
+                                       to_name,
+                                       xfer_req,
+                                       &extra_params);
                 ASSERT_EQ(status, NIXL_SUCCESS);
                 EXPECT_NE(xfer_req, nullptr);
 
@@ -591,10 +593,19 @@ TEST_P(TestTransfer, remoteMDFromSocket)
 
     exchangeMDIP(0, 1);
     for (const auto op : {NIXL_WRITE, NIXL_READ}) {
-        doTransfer(getAgent(0), getAgentName(0), getAgent(1), getAgentName(1),
-                   op, size, count, 1, 1,
-                   mem_type, src_buffers,
-                   mem_type, dst_buffers);
+        doTransfer(getAgent(0),
+                   getAgentName(0),
+                   getAgent(1),
+                   getAgentName(1),
+                   op,
+                   size,
+                   count,
+                   1,
+                   1,
+                   mem_type,
+                   src_buffers,
+                   mem_type,
+                   dst_buffers);
     }
 
     invalidateMD(0, 1);


### PR DESCRIPTION
## What?
Added no-progress-thread variants to error handling tests
Added READ operation to transfer tests
Run Listener test only with ucx (to reduce exec time by 90s), no need to spawn it with different configs.

## Why?
Improve test coverage of different test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded transfer coverage to validate both read and write operations across transfer scenarios.
  * Improved error-handling tests for progress-thread configurations, worker counts, and notification delivery.
  * Added coverage for notifications received after a failed operation.
  * Enhanced transfer logs to identify the operation being performed.
  * Updated listener communication tests and broadened callback coverage for additional configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->