### PR TITLE
bindings/rust: add prepMemView/releaseMemView to the C API and nixl-sys

### DIFF
--- a/src/bindings/rust/README.md
+++ b/src/bindings/rust/README.md
@@ -63,3 +63,17 @@ cargo test -- --test-threads=1
 ```
 
 **Note**: Tests cannot be run with the `stub-api` feature as they require actual NIXL functionality.
+
+The memory view tests allocate VRAM, so they are compiled only where the build
+script finds a CUDA toolkit, searched for under `CUDA_PATH`, `CUDA_HOME`, then
+`/usr/local/cuda`. Without one they are absent from the suite and nothing links
+against CUDA. With a toolkit but no device they skip at run time.
+
+`test_prep_mem_view_remote` additionally needs a device-capable RDMA lane, which
+UCX only offers over accelerated IB, so it is opt-in:
+
+```bash
+NIXL_TEST_DEVICE_LANE=1 cargo test --test mem_view -- --test-threads=1
+```
+
+It is not skipped on failure, so where it runs, a failure is a real one.

--- a/src/bindings/rust/build.rs
+++ b/src/bindings/rust/build.rs
@@ -273,9 +273,39 @@ fn run_build(use_stub_api: bool) {
     }
 }
 
+/// Locates a CUDA toolkit, returning its library directory.
+fn find_cuda_lib_dir() -> Option<PathBuf> {
+    ["CUDA_PATH", "CUDA_HOME"]
+        .iter()
+        .filter_map(|var| env::var_os(var).map(PathBuf::from))
+        .chain(std::iter::once(PathBuf::from("/usr/local/cuda")))
+        .flat_map(|root| [root.join("lib64"), root.join("lib")])
+        .find(|dir| dir.join("libcudart.so").exists())
+}
+
+/// Gates the memory view tests on a CUDA toolkit being present, so a build
+/// without one links no CUDA symbols.
+fn probe_cuda() {
+    println!("cargo::rustc-check-cfg=cfg(has_cuda)");
+    println!("cargo:rerun-if-env-changed=CUDA_PATH");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+
+    if let Some(lib_dir) = find_cuda_lib_dir() {
+        println!(
+            "cargo:rerun-if-changed={}",
+            lib_dir.join("libcudart.so").display()
+        );
+        let lib_dir = lib_dir.display();
+        println!("cargo:rustc-link-search=native={lib_dir}");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
+        println!("cargo:rustc-cfg=has_cuda");
+    }
+}
+
 fn main() {
     // Check if we're building with stub API
     let use_stub_api = cfg!(feature = "stub-api");
 
     run_build(use_stub_api);
+    probe_cuda();
 }

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 use super::*;
-use crate::descriptors::{QueryResponseList, RegDescList};
+use crate::descriptors::{QueryResponseList, RegDescList, RemoteDescList};
 use crate::bindings::{
     nixl_capi_agent_config_s as nixl_capi_agent_config_t,
     nixl_capi_thread_sync_t, nixl_capi_create_configured_agent};
@@ -347,6 +347,77 @@ impl Agent {
 
         match status {
             NIXL_CAPI_SUCCESS => Ok(resp),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Prepares a memory view for local buffers
+    ///
+    /// # Arguments
+    /// * `descs` - Descriptor list for the local buffers
+    /// * `opt_args` - Optional arguments, carrying the backend hint
+    ///
+    /// # Safety
+    /// The buffers must stay allocated and registered until the view is dropped.
+    pub unsafe fn prep_mem_view_local(
+        &self,
+        descs: &XferDescList,
+        opt_args: Option<&OptArgs>,
+    ) -> Result<MemView, NixlError> {
+        let mut view = std::ptr::null_mut();
+        let inner_guard = self.inner.write().unwrap();
+
+        let status = unsafe {
+            nixl_capi_prep_mem_view_local(
+                inner_guard.handle.as_ptr(),
+                descs.handle(),
+                &mut view,
+                opt_args.map_or(std::ptr::null_mut(), |args| args.inner.as_ptr()),
+            )
+        };
+
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(MemView::new(
+                self.inner.clone(),
+                NonNull::new(view).ok_or(NixlError::InvalidDataPointer)?,
+            )),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Prepares a memory view for remote buffers
+    ///
+    /// # Arguments
+    /// * `descs` - Descriptor list for the remote buffers, each naming its
+    ///   owning agent
+    /// * `opt_args` - Optional arguments, carrying the backend hint
+    ///
+    /// # Safety
+    /// The buffers must stay allocated and registered until the view is dropped.
+    pub unsafe fn prep_mem_view_remote(
+        &self,
+        descs: &RemoteDescList,
+        opt_args: Option<&OptArgs>,
+    ) -> Result<MemView, NixlError> {
+        let mut view = std::ptr::null_mut();
+        let inner_guard = self.inner.write().unwrap();
+
+        let status = unsafe {
+            nixl_capi_prep_mem_view_remote(
+                inner_guard.handle.as_ptr(),
+                descs.handle(),
+                &mut view,
+                opt_args.map_or(std::ptr::null_mut(), |args| args.inner.as_ptr()),
+            )
+        };
+
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(MemView::new(
+                self.inner.clone(),
+                NonNull::new(view).ok_or(NixlError::InvalidDataPointer)?,
+            )),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
             _ => Err(NixlError::BackendError),
         }

--- a/src/bindings/rust/src/descriptors.rs
+++ b/src/bindings/rust/src/descriptors.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@ use super::*;
 
 mod query;
 mod reg;
+mod remote;
 mod sync_manager;
 mod xfer;
 mod xfer_dlist_handle;
 
 pub use query::{QueryResponse, QueryResponseIterator, QueryResponseList};
 pub use reg::{RegDescList, RegDescriptor};
+pub use remote::{RemoteDescList, RemoteDescriptor};
 pub use sync_manager::{BackendSyncable, SyncManager};
 pub use xfer::{XferDescList, XferDescriptor};
 pub use xfer_dlist_handle::XferDlistHandle;

--- a/src/bindings/rust/src/descriptors/remote.rs
+++ b/src/bindings/rust/src/descriptors/remote.rs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+/// A remote buffer descriptor, naming the agent that owns it. `None` is a
+/// null-agent placeholder, which keeps descriptor indices aligned when only
+/// some peers are being addressed.
+#[derive(Debug)]
+pub struct RemoteDescriptor<'a> {
+    pub addr: usize,
+    pub len: usize,
+    pub dev_id: u64,
+    pub remote_agent: Option<&'a str>,
+}
+
+/// A descriptor list for remote buffers, where each descriptor carries the name
+/// of the agent that owns it.
+#[derive(Debug)]
+pub struct RemoteDescList {
+    inner: NonNull<bindings::nixl_capi_remote_dlist_s>,
+}
+
+impl RemoteDescList {
+    pub fn new(mem_type: MemType) -> Result<Self, NixlError> {
+        let mut dlist = ptr::null_mut();
+        let status =
+            unsafe { nixl_capi_create_remote_dlist(mem_type as nixl_capi_mem_type_t, &mut dlist) };
+
+        match status {
+            // SAFETY: on success dlist is non-null
+            NIXL_CAPI_SUCCESS => Ok(Self {
+                inner: unsafe { NonNull::new_unchecked(dlist) },
+            }),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Adds a descriptor to the list. The native list copies the descriptor
+    /// data, so it does not borrow from `descriptor`.
+    pub fn add_desc(&mut self, descriptor: &RemoteDescriptor<'_>) -> Result<(), NixlError> {
+        let c_agent = descriptor.remote_agent.map(CString::new).transpose()?;
+        let status = unsafe {
+            nixl_capi_remote_dlist_add_desc(
+                self.inner.as_ptr(),
+                descriptor.addr as uintptr_t,
+                descriptor.len,
+                descriptor.dev_id,
+                c_agent.as_ref().map_or(ptr::null(), |name| name.as_ptr()),
+            )
+        };
+
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    pub(crate) fn handle(&self) -> *mut bindings::nixl_capi_remote_dlist_s {
+        self.inner.as_ptr()
+    }
+}
+
+impl Drop for RemoteDescList {
+    fn drop(&mut self) {
+        let status = unsafe { nixl_capi_destroy_remote_dlist(self.inner.as_ptr()) };
+        if status != NIXL_CAPI_SUCCESS {
+            tracing::debug!(status, "Failed to destroy remote descriptor list");
+        }
+    }
+}

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -212,6 +212,11 @@ impl MemView {
     }
 }
 
+// SAFETY: a view is only released in Drop, and nixlAgent serializes prepMemView
+// and releaseMemView under its own lock, so releasing from a different thread
+// than prepared it is safe. AgentInner is already Send + Sync.
+unsafe impl Send for MemView {}
+
 impl Drop for MemView {
     fn drop(&mut self) {
         tracing::trace!(view = ?self.inner, "Dropping memory view");

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,9 @@ use bindings::{
     nixl_capi_make_xfer_req, nixl_capi_get_local_partial_md,
     nixl_capi_send_local_partial_md, nixl_capi_query_xfer_backend, nixl_capi_opt_args_set_ip_addr,
     nixl_capi_opt_args_set_port, nixl_capi_get_xfer_telemetry,
-    nixl_capi_create_params, nixl_capi_params_add, nixl_capi_is_stub
+    nixl_capi_create_params, nixl_capi_params_add, nixl_capi_is_stub,
+    nixl_capi_prep_mem_view_local, nixl_capi_prep_mem_view_remote, nixl_capi_release_mem_view,
+    nixl_capi_create_remote_dlist, nixl_capi_destroy_remote_dlist, nixl_capi_remote_dlist_add_desc
 };
 
 // Re-export status codes
@@ -185,6 +187,40 @@ impl Drop for RegistrationHandle {
         );
         if let Err(e) = self.deregister() {
             tracing::debug!(error = ?e, "Failed to deregister memory");
+        }
+    }
+}
+
+/// A prepared memory view, released on drop
+#[derive(Debug)]
+pub struct MemView {
+    agent: Arc<RwLock<AgentInner>>,
+    inner: NonNull<bindings::nixl_capi_mem_view_s>,
+}
+
+impl MemView {
+    pub(crate) fn new(
+        agent: Arc<RwLock<AgentInner>>,
+        inner: NonNull<bindings::nixl_capi_mem_view_s>,
+    ) -> Self {
+        Self { agent, inner }
+    }
+
+    /// The underlying `nixlMemViewH`, for passing to device-side transfer code
+    pub fn as_ptr(&self) -> *mut std::ffi::c_void {
+        self.inner.as_ptr().cast()
+    }
+}
+
+impl Drop for MemView {
+    fn drop(&mut self) {
+        tracing::trace!(view = ?self.inner, "Dropping memory view");
+        let agent_guard = self.agent.write().unwrap_or_else(|e| e.into_inner());
+        let status = unsafe {
+            nixl_capi_release_mem_view(agent_guard.handle.as_ptr(), self.inner.as_ptr())
+        };
+        if status != NIXL_CAPI_SUCCESS {
+            tracing::debug!(status, "Failed to release memory view");
         }
     }
 }

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -925,6 +925,63 @@ nixl_capi_query_mem(nixl_capi_agent_t agent,
     return real(agent, descs, resp, opt_args);
 }
 
+// ---- Memory view functions ----
+
+nixl_capi_status_t
+nixl_capi_prep_mem_view_local(nixl_capi_agent_t agent,
+                              nixl_capi_xfer_dlist_t descs,
+                              nixl_capi_mem_view_t *mvh,
+                              nixl_capi_opt_args_t opt_args) {
+    using fn_t = nixl_capi_status_t (*)(
+        nixl_capi_agent_t, nixl_capi_xfer_dlist_t, nixl_capi_mem_view_t *, nixl_capi_opt_args_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_prep_mem_view_local");
+    return real(agent, descs, mvh, opt_args);
+}
+
+nixl_capi_status_t
+nixl_capi_prep_mem_view_remote(nixl_capi_agent_t agent,
+                               nixl_capi_remote_dlist_t descs,
+                               nixl_capi_mem_view_t *mvh,
+                               nixl_capi_opt_args_t opt_args) {
+    using fn_t = nixl_capi_status_t (*)(
+        nixl_capi_agent_t, nixl_capi_remote_dlist_t, nixl_capi_mem_view_t *, nixl_capi_opt_args_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_prep_mem_view_remote");
+    return real(agent, descs, mvh, opt_args);
+}
+
+nixl_capi_status_t
+nixl_capi_create_remote_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_remote_dlist_t *dlist) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_mem_type_t, nixl_capi_remote_dlist_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_create_remote_dlist");
+    return real(mem_type, dlist);
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_remote_dlist(nixl_capi_remote_dlist_t dlist) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_remote_dlist_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_destroy_remote_dlist");
+    return real(dlist);
+}
+
+nixl_capi_status_t
+nixl_capi_remote_dlist_add_desc(nixl_capi_remote_dlist_t dlist,
+                                uintptr_t addr,
+                                size_t len,
+                                uint64_t dev_id,
+                                const char *remote_agent) {
+    using fn_t =
+        nixl_capi_status_t (*)(nixl_capi_remote_dlist_t, uintptr_t, size_t, uint64_t, const char *);
+    static fn_t real = (fn_t)resolve("nixl_capi_remote_dlist_add_desc");
+    return real(dlist, addr, len, dev_id, remote_agent);
+}
+
+nixl_capi_status_t
+nixl_capi_release_mem_view(nixl_capi_agent_t agent, nixl_capi_mem_view_t mvh) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_agent_t, nixl_capi_mem_view_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_release_mem_view");
+    return real(agent, mvh);
+}
+
 // ---- Telemetry functions ----
 
 nixl_capi_status_t

--- a/src/bindings/rust/tests/common/mod.rs
+++ b/src/bindings/rust/tests/common/mod.rs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+//! Helpers shared by the integration test binaries.
+#![allow(dead_code)]
+
+use nixl_sys::*;
+
+pub fn create_agent_with_backend(name: &str) -> Result<(Agent, OptArgs), NixlError> {
+    let agent = Agent::new(name).expect("Failed to create agent");
+    let plugins = agent.get_available_plugins().expect("Failed to get available plugins");
+    let plugin_name = find_plugin(&plugins, "UCX").expect("Failed to find plugin");
+    let (_mems, params) = agent.get_plugin_params(&plugin_name).expect("Failed to get plugin params");
+    agent.create_backend(&plugin_name, &params).expect("Failed to create backend");
+
+    let mut opt_args = OptArgs::new().expect("Failed to create opt args");
+    let _ = opt_args.add_backend(&agent.get_backend("UCX").unwrap());
+
+    Ok((agent, opt_args))
+}
+
+pub fn exchange_metadata(agent1: &Agent, agent2: &Agent) -> Result<(), NixlError> {
+    let metadata1 = agent1.get_local_md().expect("Failed to get local metadata");
+    let metadata2 = agent2.get_local_md().expect("Failed to get local metadata");
+    agent1.load_remote_md(&metadata2).expect("Failed to load remote metadata");
+    agent2.load_remote_md(&metadata1).expect("Failed to load remote metadata");
+    Ok(())
+}
+
+// Helper function to find a plugin by name
+pub fn find_plugin(plugins: &StringList, name: &str) -> Result<String, NixlError> {
+    plugins
+        .iter()
+        .filter_map(Result::ok)
+        .find(|&plugin| plugin == name)
+        .map(ToString::to_string)
+        .or_else(|| plugins.get(0).ok().map(ToString::to_string))
+        .ok_or(NixlError::InvalidParam)
+}

--- a/src/bindings/rust/tests/mem_view.rs
+++ b/src/bindings/rust/tests/mem_view.rs
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// Tests for the memory view API. Memory views are consumed device-side, so
+// these allocate VRAM, mirroring test/gtest/device_api/single_write_test.cu.
+// Compiled only where build.rs found a CUDA toolkit.
+#![cfg(has_cuda)]
+
+use nixl_sys::*;
+use std::time::{Duration, Instant};
+use std::thread;
+
+mod common;
+use common::*;
+
+#[link(name = "cudart")]
+extern "C" {
+    fn cudaMalloc(dev_ptr: *mut *mut std::ffi::c_void, size: usize) -> i32;
+    fn cudaFree(dev_ptr: *mut std::ffi::c_void) -> i32;
+    fn cudaSetDevice(device: i32) -> i32;
+    fn cudaGetDeviceCount(count: *mut i32) -> i32;
+}
+
+fn has_cuda_gpu() -> bool {
+    let mut count = 0;
+    unsafe { cudaGetDeviceCount(&mut count) == 0 && count > 0 }
+}
+
+/// Selects the CUDA device before any agent is created, so UCX picks the NICs
+/// closest to it. Otherwise the endpoint gets lanes on every NIC and none
+/// matches the buffer's system device.
+fn select_gpu() {
+    assert_eq!(unsafe { cudaSetDevice(0) }, 0, "Failed to set CUDA device 0");
+}
+
+#[derive(Debug)]
+struct VramStorage {
+    ptr: *mut std::ffi::c_void,
+    size: usize,
+}
+
+unsafe impl Send for VramStorage {}
+unsafe impl Sync for VramStorage {}
+
+impl VramStorage {
+    fn new(size: usize) -> Option<Self> {
+        let mut ptr = std::ptr::null_mut();
+        let rc = unsafe { cudaMalloc(&mut ptr, size) };
+        if rc != 0 || ptr.is_null() {
+            return None;
+        }
+        Some(Self { ptr, size })
+    }
+}
+
+impl Drop for VramStorage {
+    fn drop(&mut self) {
+        unsafe { cudaFree(self.ptr) };
+    }
+}
+
+impl MemoryRegion for VramStorage {
+    unsafe fn as_ptr(&self) -> *const u8 {
+        self.ptr as *const u8
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+}
+
+impl NixlDescriptor for VramStorage {
+    fn mem_type(&self) -> MemType {
+        MemType::Vram
+    }
+
+    fn device_id(&self) -> u64 {
+        0
+    }
+}
+
+/// Allocates one VRAM buffer and registers it with the agent. `None` when the
+/// allocation fails.
+fn vram_buffer(agent: &Agent, opt_args: &OptArgs) -> Option<(VramStorage, RegistrationHandle)> {
+    let storage = VramStorage::new(4096)?;
+
+    let handle = agent
+        .register_memory(&storage, Some(opt_args))
+        .expect("Failed to register VRAM");
+    Some((storage, handle))
+}
+
+fn vram_dlist(storage: &VramStorage) -> XferDescList<'_> {
+    let mut dlist = XferDescList::new(MemType::Vram).expect("Failed to create XferDescList");
+    unsafe { dlist.add_desc(storage.as_ptr() as usize, storage.size(), 0) };
+    dlist
+}
+
+fn vram_remote_desc<'a>(
+    storage: &VramStorage,
+    remote_agent: Option<&'a str>,
+) -> RemoteDescriptor<'a> {
+    RemoteDescriptor {
+        addr: unsafe { storage.as_ptr() } as usize,
+        len: storage.size(),
+        dev_id: 0,
+        remote_agent,
+    }
+}
+
+fn vram_remote_dlist(descriptor: &RemoteDescriptor<'_>) -> RemoteDescList {
+    let mut dlist = RemoteDescList::new(MemType::Vram).expect("Failed to create RemoteDescList");
+    dlist
+        .add_desc(descriptor)
+        .expect("Failed to add remote descriptor");
+    dlist
+}
+
+#[test]
+fn test_prep_mem_view_local() {
+    if !has_cuda_gpu() {
+        eprintln!("skipping test_prep_mem_view_local: no CUDA-capable GPU");
+        return;
+    }
+    select_gpu();
+
+    let (agent, opt_args) = create_agent_with_backend("mem_view_local").expect("Failed to create agent");
+    let (storage, _handle) = vram_buffer(&agent, &opt_args).expect("Failed to allocate VRAM");
+
+    // SAFETY: storage outlives the view
+    let view = unsafe { agent.prep_mem_view_local(&vram_dlist(&storage), Some(&opt_args)) }
+        .expect("prep_mem_view_local failed");
+    assert!(!view.as_ptr().is_null());
+}
+
+/// A remote memory view has no device lane until the endpoint is wired up.
+/// Mirrors `DeviceApiTestBase::completeWireup`.
+fn complete_wireup(from: &Agent, to: &Agent, to_name: &str) {
+    from.send_notification(to_name, b"wireup", None)
+        .expect("Failed to send wireup notification");
+
+    let mut notifs = NotificationMap::new().expect("Failed to create notification map");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while notifs.is_empty().expect("Failed to query notification map") {
+        assert!(Instant::now() < deadline, "Timed out waiting for wireup notification");
+        to.get_notifications(&mut notifs, None)
+            .expect("Failed to get notifications");
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Opt-in: needs a device-capable RDMA lane, which UCX offers only over
+/// accelerated IB. Run with:
+///     NIXL_TEST_DEVICE_LANE=1 cargo test --test mem_view -- --test-threads=1
+#[test]
+fn test_prep_mem_view_remote() {
+    if std::env::var_os("NIXL_TEST_DEVICE_LANE").is_none() {
+        eprintln!(
+            "skipping test_prep_mem_view_remote: set NIXL_TEST_DEVICE_LANE=1 to run it, \
+             on a host with accelerated IB"
+        );
+        return;
+    }
+    if !has_cuda_gpu() {
+        eprintln!("skipping test_prep_mem_view_remote: no CUDA-capable GPU");
+        return;
+    }
+    select_gpu();
+
+    let (agent1, opt_args1) = create_agent_with_backend("mem_view_initiator").expect("Failed to create agent");
+    let (agent2, opt_args2) = create_agent_with_backend("mem_view_target").expect("Failed to create agent");
+
+    let (local, _local_handle) = vram_buffer(&agent1, &opt_args1).expect("Failed to allocate VRAM");
+    let (remote, _remote_handle) = vram_buffer(&agent2, &opt_args2).expect("Failed to allocate VRAM");
+
+    exchange_metadata(&agent1, &agent2).expect("Failed to exchange metadata");
+    complete_wireup(&agent1, &agent2, "mem_view_target");
+
+    // SAFETY: local and remote outlive the views
+    let _local_view =
+        unsafe { agent1.prep_mem_view_local(&vram_dlist(&local), Some(&opt_args1)) }
+            .expect("prep_mem_view_local failed");
+
+    let remote_desc = vram_remote_desc(&remote, Some("mem_view_target"));
+    let view = unsafe {
+        agent1.prep_mem_view_remote(&vram_remote_dlist(&remote_desc), Some(&opt_args1))
+    }
+    .expect("prep_mem_view_remote failed");
+    assert!(!view.as_ptr().is_null());
+}
+
+#[test]
+fn test_prep_mem_view_remote_unknown_agent() {
+    if !has_cuda_gpu() {
+        eprintln!("skipping test_prep_mem_view_remote_unknown_agent: no CUDA-capable GPU");
+        return;
+    }
+    select_gpu();
+
+    let (agent, opt_args) = create_agent_with_backend("mem_view_unknown").expect("Failed to create agent");
+    let (storage, _handle) = vram_buffer(&agent, &opt_args).expect("Failed to allocate VRAM");
+
+    // SAFETY: storage outlives the call
+    let desc = vram_remote_desc(&storage, Some("no_such_agent"));
+    let result =
+        unsafe { agent.prep_mem_view_remote(&vram_remote_dlist(&desc), Some(&opt_args)) };
+    // NIXL_ERR_NOT_FOUND; change to NotFound once the C API maps it.
+    assert!(result.is_err(), "Expected an error for an unknown remote agent");
+}
+
+/// A null-agent descriptor is a placeholder, not an addressed peer, so a list
+/// holding only placeholders has no backend to prepare against. `nixl_ep` mixes
+/// them with real agents to keep descriptor indices aligned with rank numbers.
+#[test]
+fn test_prep_mem_view_remote_null_agent_only() {
+    if !has_cuda_gpu() {
+        eprintln!("skipping test_prep_mem_view_remote_null_agent_only: no CUDA-capable GPU");
+        return;
+    }
+    select_gpu();
+
+    let (agent, opt_args) = create_agent_with_backend("mem_view_null_agent").expect("Failed to create agent");
+    let (storage, _handle) = vram_buffer(&agent, &opt_args).expect("Failed to allocate VRAM");
+
+    // SAFETY: storage outlives the call
+    let desc = vram_remote_desc(&storage, None);
+    let result =
+        unsafe { agent.prep_mem_view_remote(&vram_remote_dlist(&desc), Some(&opt_args)) };
+    // NIXL_ERR_NOT_FOUND; change to NotFound once the C API maps it.
+    assert!(result.is_err(), "Expected an error for a list of only null agents");
+}

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -26,6 +26,9 @@ use std::collections::HashMap;
 
 mod env_guard;
 use env_guard::EnvGuard;
+
+mod common;
+use common::*;
 // Helper function to create an agent with error handling
 fn create_test_agent(name: &str) -> Result<Agent, NixlError> {
     Agent::new(name)
@@ -62,18 +65,6 @@ fn enable_telemetry_with_temp_dir(env_guard: &EnvGuard, test_name: &str) -> temp
     telemetry_dir
 }
 
-fn create_agent_with_backend(name: &str) -> Result<(Agent, OptArgs), NixlError> {
-    let agent = Agent::new(name).expect("Failed to create agent");
-    let plugins = agent.get_available_plugins().expect("Failed to get available plugins");
-    let plugin_name = find_plugin(&plugins, "UCX").expect("Failed to find plugin");
-    let (_mems, params) = agent.get_plugin_params(&plugin_name).expect("Failed to get plugin params");
-    agent.create_backend(&plugin_name, &params).expect("Failed to create backend");
-
-    let mut opt_args = OptArgs::new().expect("Failed to create opt args");
-    let _ = opt_args.add_backend(&agent.get_backend("UCX").unwrap());
-
-    Ok((agent, opt_args))
-}
 
 // Trait for testing common descriptor list operations
 trait DescListTestTrait: PartialEq + std::fmt::Debug {
@@ -131,24 +122,6 @@ fn create_dlist<'a>(storage_list: &'a mut Vec<SystemStorage>) -> Result<XferDesc
     Ok(dlist)
 }
 
-fn exchange_metadata(agent1: &Agent, agent2: &Agent) -> Result<(), NixlError> {
-    let metadata1 = agent1.get_local_md().expect("Failed to get local metadata");
-    let metadata2 = agent2.get_local_md().expect("Failed to get local metadata");
-    agent1.load_remote_md(&metadata2).expect("Failed to load remote metadata");
-    agent2.load_remote_md(&metadata1).expect("Failed to load remote metadata");
-    Ok(())
-}
-
-// Helper function to find a plugin by name
-fn find_plugin(plugins: &StringList, name: &str) -> Result<String, NixlError> {
-    plugins
-        .iter()
-        .filter_map(Result::ok)
-        .find(|&plugin| plugin == name)
-        .map(ToString::to_string)
-        .or_else(|| plugins.get(0).ok().map(ToString::to_string))
-        .ok_or(NixlError::InvalidParam)
-}
 
 /// Helper function to create and initialize a POSIX backend with optional arguments
 /// Returns (backend, opt_args) if POSIX is available, or None if not available
@@ -1309,6 +1282,7 @@ fn test_prep_xfer_dlist_invalid_agent() {
         );
     }
 }
+
 
 // Tests for make_xfer_req API
 #[test]

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <exception>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
 #include <chrono>
@@ -99,6 +100,13 @@ struct nixl_capi_notif_map_s {
 struct nixl_capi_query_resp_list_s {
     std::vector<nixl_query_resp_t> responses;
 };
+
+struct nixl_capi_remote_dlist_s {
+    nixl_remote_dlist_t *dlist;
+};
+
+static nixl_capi_status_t
+nixl_capi_status_from_nixl_status(nixl_status_t status);
 
 nixl_capi_status_t
 nixl_capi_create_agent(const char* name, nixl_capi_agent_t* agent)
@@ -1895,6 +1903,124 @@ nixl_capi_query_mem(nixl_capi_agent_t agent,
         nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
         nixl_status_t ret = agent->inner->queryMem(*descs->dlist, resp->responses, args);
         return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+// Memory view functions
+nixl_capi_status_t
+nixl_capi_prep_mem_view_local(nixl_capi_agent_t agent,
+                              nixl_capi_xfer_dlist_t descs,
+                              nixl_capi_mem_view_t *mvh,
+                              nixl_capi_opt_args_t opt_args) {
+    if (!agent || !descs || !mvh) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixlMemViewH view = nullptr;
+        nixl_status_t ret = agent->inner->prepMemView(*descs->dlist, view, args);
+        if (ret != NIXL_SUCCESS) {
+            return nixl_capi_status_from_nixl_status(ret);
+        }
+        *mvh = static_cast<nixl_capi_mem_view_t>(view);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_prep_mem_view_remote(nixl_capi_agent_t agent,
+                               nixl_capi_remote_dlist_t descs,
+                               nixl_capi_mem_view_t *mvh,
+                               nixl_capi_opt_args_t opt_args) {
+    if (!agent || !descs || !mvh) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
+        nixlMemViewH view = nullptr;
+        nixl_status_t ret = agent->inner->prepMemView(*descs->dlist, view, args);
+        if (ret != NIXL_SUCCESS) {
+            return nixl_capi_status_from_nixl_status(ret);
+        }
+        *mvh = static_cast<nixl_capi_mem_view_t>(view);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_create_remote_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_remote_dlist_t *dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        auto d = std::make_unique<nixl_capi_remote_dlist_s>();
+        auto inner = std::make_unique<nixl_remote_dlist_t>(static_cast<nixl_mem_t>(mem_type));
+        d->dlist = inner.release();
+        *dlist = d.release();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_destroy_remote_dlist(nixl_capi_remote_dlist_t dlist) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        delete dlist->dlist;
+        delete dlist;
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_remote_dlist_add_desc(nixl_capi_remote_dlist_t dlist,
+                                uintptr_t addr,
+                                size_t len,
+                                uint64_t dev_id,
+                                const char *remote_agent) {
+    if (!dlist) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        dlist->dlist->addDesc(
+            nixlRemoteDesc(addr, len, dev_id, remote_agent ? remote_agent : nixl_null_agent));
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_release_mem_view(nixl_capi_agent_t agent, nixl_capi_mem_view_t mvh) {
+    if (!agent || !mvh) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        agent->inner->releaseMemView(static_cast<nixlMemViewH>(mvh));
+        return NIXL_CAPI_SUCCESS;
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -58,6 +58,8 @@ struct nixl_capi_reg_dlist_s;
 struct nixl_capi_xfer_req_s;
 struct nixl_capi_notif_map_s;
 struct nixl_capi_query_resp_list_s;
+struct nixl_capi_remote_dlist_s;
+struct nixl_capi_mem_view_s;
 
 struct nixl_capi_xfer_telemetry_s {
     uint64_t start_time_us; // Start time in microseconds since epoch
@@ -81,6 +83,8 @@ typedef struct nixl_capi_reg_dlist_s* nixl_capi_reg_dlist_t;
 typedef struct nixl_capi_xfer_req_s* nixl_capi_xfer_req_t;
 typedef struct nixl_capi_notif_map_s* nixl_capi_notif_map_t;
 typedef struct nixl_capi_query_resp_list_s *nixl_capi_query_resp_list_t;
+typedef struct nixl_capi_remote_dlist_s *nixl_capi_remote_dlist_t;
+typedef struct nixl_capi_mem_view_s *nixl_capi_mem_view_t;
 
 // Thread sync enum matching nixl_thread_sync_t
 typedef enum {
@@ -348,6 +352,96 @@ nixl_capi_query_mem(nixl_capi_agent_t agent,
                     nixl_capi_reg_dlist_t descs,
                     nixl_capi_query_resp_list_t resp,
                     nixl_capi_opt_args_t opt_args);
+
+/**
+ * @brief Prepare a memory view handle for local buffers.
+ *
+ * The caller owns @a mvh and must release it with @ref nixl_capi_release_mem_view
+ * before @a agent is destroyed. @a descs may be destroyed once this returns.
+ *
+ * @param  agent     [in]  Agent the buffers are registered with
+ * @param  descs     [in]  Descriptor list for the local buffers
+ * @param  mvh       [out] Memory view handle
+ * @param  opt_args  [in]  Optional arguments, carrying the backend hint
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
+nixl_capi_status_t
+nixl_capi_prep_mem_view_local(nixl_capi_agent_t agent,
+                              nixl_capi_xfer_dlist_t descs,
+                              nixl_capi_mem_view_t *mvh,
+                              nixl_capi_opt_args_t opt_args);
+
+/**
+ * @brief Prepare a memory view handle for remote buffers.
+ *
+ * Ownership is as for @ref nixl_capi_prep_mem_view_local. A view can span peers,
+ * so each descriptor in @a descs names the agent that owns it.
+ *
+ * @param  agent     [in]  Initiator agent
+ * @param  descs     [in]  Descriptor list for the remote buffers
+ * @param  mvh       [out] Memory view handle
+ * @param  opt_args  [in]  Optional arguments, carrying the backend hint
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
+nixl_capi_status_t
+nixl_capi_prep_mem_view_remote(nixl_capi_agent_t agent,
+                               nixl_capi_remote_dlist_t descs,
+                               nixl_capi_mem_view_t *mvh,
+                               nixl_capi_opt_args_t opt_args);
+
+/**
+ * @brief Create a descriptor list for remote buffers.
+ *
+ * The caller owns @a dlist and must destroy it with
+ * @ref nixl_capi_destroy_remote_dlist.
+ *
+ * @param  mem_type  [in]  NIXL memory type of the descriptor list
+ * @param  dlist     [out] Created descriptor list
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
+nixl_capi_status_t
+nixl_capi_create_remote_dlist(nixl_capi_mem_type_t mem_type, nixl_capi_remote_dlist_t *dlist);
+
+/**
+ * @brief Destroy a remote descriptor list.
+ *
+ * @param  dlist  [in] Descriptor list to destroy
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
+nixl_capi_status_t
+nixl_capi_destroy_remote_dlist(nixl_capi_remote_dlist_t dlist);
+
+/**
+ * @brief Add a descriptor to a remote descriptor list.
+ *
+ * @param  dlist         [in] Descriptor list to add to
+ * @param  addr          [in] Start of the remote buffer
+ * @param  len           [in] Length of the remote buffer
+ * @param  dev_id        [in] deviceID/BlockID/bufferID (remote ID)
+ * @param  remote_agent  [in] Name of the agent that owns the buffer. NULL means
+ *                            nixl_null_agent, a placeholder that keeps
+ *                            descriptor indices aligned when only some peers
+ *                            are addressed
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
+nixl_capi_status_t
+nixl_capi_remote_dlist_add_desc(nixl_capi_remote_dlist_t dlist,
+                                uintptr_t addr,
+                                size_t len,
+                                uint64_t dev_id,
+                                const char *remote_agent);
+
+/**
+ * @brief Release a memory view handle.
+ *
+ * @param  agent  [in] Agent that prepared @a mvh
+ * @param  mvh    [in] Memory view handle to release
+ * @return nixl_capi_status_t Error code if call was not successful. A handle
+ *         prepared by a different agent is not reported, as the underlying C++
+ *         call returns void and logs a warning
+ */
+nixl_capi_status_t
+nixl_capi_release_mem_view(nixl_capi_agent_t agent, nixl_capi_mem_view_t mvh);
 
 // Telemetry structure for transfer requests
 typedef struct nixl_capi_xfer_telemetry_s *nixl_capi_xfer_telemetry_t;


### PR DESCRIPTION
Needed for the LPU backend: `prepMemView` resolves a registered buffer into the
`nixlMemViewH` that the device-side send and receive calls take as input on the
GPU. Without a Rust binding the backend cannot prepare its data-plane views, so
the whole device data path is unreachable.

## What?

Binds `prepMemView` / `releaseMemView` into the Rust C API layer and `nixl-sys`.

- C API: `prep_mem_view_local` / `_remote` / `release_mem_view`, plus
  `create_remote_dlist` / `_add_desc` / `_destroy_remote_dlist`, with matching
  `stubs.cpp` forwarders.
- nixl-sys: `Agent::prep_mem_view_local` / `_remote` returning a `MemView` that
  releases on `Drop`, and `RemoteDescList` / `RemoteDescriptor` beside
  `RegDescList` / `XferDescList`.
- Four tests in `tests/mem_view.rs`: local and remote happy paths, unknown
  remote agent, all-null-agent list. Helpers shared with `tests.rs` live in
  `tests/common/mod.rs`.

## Why?

The device API is GPU-initiated: `prepMemView` returns the `nixlMemViewH` a
kernel passes to `nixlPut` or `nixlSend`. Its consumers so far have been CUDA
C++, where host and device code share one program and a C boundary buys nothing,
so it was never bound. It is needed once Rust owns the agent and view lifecycle
while a thin CUDA shim launches the kernels.

## How?

**The remote overload binds `nixl_remote_dlist_t`, not a single agent name.** A
view can span peers: `nixl_ep` puts several agents in one list, using
`nixl_null_agent` for unaddressed ranks so descriptor indices stay aligned with
rank numbers (`examples/device/ep/csrc/nixl_ep.cpp:1328-1333`).

**`prep_mem_view_*` are `unsafe`.** A view holds the registration handles of its
buffers and is stored for the lifetime of the endpoint alongside them, so a
lifetime bound would make the owning struct self-referential. `RemoteDescList`
carries no lifetime: `nixl_capi_remote_dlist_add_desc` constructs a
`nixlRemoteDesc` by value with a `std::string` agent name and `nixlDescList`
stores `std::vector<T>`, so nothing borrows once the call returns.

**The tests are gated on a CUDA toolkit.** They allocate VRAM, so `build.rs`
probes `CUDA_PATH`, `CUDA_HOME`, then `/usr/local/cuda` in turn, and compiles
them only if it finds one; a build without CUDA links no CUDA symbols. With a
toolkit but no device they skip at run time.

**`test_prep_mem_view_remote` is opt-in behind `NIXL_TEST_DEVICE_LANE=1`.** It is
the only one needing a device-capable RDMA lane, which UCX offers only over
accelerated IB; without one it fails at `ucp_device.c: lane not found for
element 0`, which no up-front check can predict. Gating it rather than skipping
on failure keeps a real regression a failure.

## Testing

104 tests pass on `cargo test` — 96 in `tests.rs`, 4 in `mem_view.rs`, 4 in
`test_sync_manager.rs` — on UCX 1.21 with a CUDA device, against `libnixl` built
from this branch's base. Three of the four memory-view tests exercise the path by
default; the fourth was confirmed to run and pass with `NIXL_TEST_DEVICE_LANE=1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust support for preparing local and remote memory views.
  * Added remote buffer descriptors, descriptor lists, and memory-view lifecycle management.
  * Added CUDA toolkit detection for GPU-enabled builds.

* **Bug Fixes**
  * Improved error handling for invalid memory-view and remote descriptor operations.

* **Tests**
  * Added CUDA-based local and remote memory-view integration tests.
  * Documented CUDA, RDMA, and NIXL test prerequisites and opt-in behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->