### PR TITLE
ci: raise the registry push retry budget

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -264,6 +264,39 @@ new tag and triggers a rebuild automatically.
 **You never need to manually update `CI_IMAGE_TAG`.** The `CI_MANAGED`
 placeholder signals this clearly.
 
+## Registry push retries
+
+Transient `HTTP 503 Service Unavailable` responses from Artifactory were failing
+otherwise-green builds at the push step, after the image had already built
+successfully. Every image push now retries, but the mechanism differs because
+`--retry` was only added in podman 5.0 and most push steps run on an older one.
+
+**`build-container-matrix.yaml`** runs on `quay.io/podman/stable:v5.7.1` and uses
+the native `--retry 5`. podman already retries this class of error —
+`go.podman.io/common/pkg/retry` treats HTTP 502-504 and network errors as
+retryable, while failing fast on unauthorized, denied and unknown
+name/manifest, so a larger budget never delays a genuine failure. `--retry N`
+counts retries *after* the initial push, and the backoff is `2^attempt` seconds
+plus 10% jitter. The default of 3 retries therefore spans 1+2+4 = 7 seconds,
+which the outages above outlasted; `--retry 5` extends it to 1+2+4+8+16 = 31
+seconds over 6 attempts. `--retry-delay` is left unset on purpose: passing it
+replaces the exponential backoff with a fixed delay.
+
+**`test-matrix.yaml`, `test-dl-matrix.yaml`, `test-dl-ep-matrix.yaml` and
+`build-wheel-matrix.yaml`** push from a `Dockerfile.build_helper` container,
+which installs podman from Ubuntu 24.04 apt (4.9.x). podman 5 is not available
+for 24.04 — not in `noble`, `noble-updates` or `noble-backports` — so these use
+a shell retry loop deliberately matched to the flag: 6 attempts with 1, 2, 4, 8
+and 16 second delays. The one behavioural difference is that the loop retries on
+any failure, so an auth error waits out the backoff instead of failing
+immediately.
+
+`build-wheel-matrix.yaml` is the easy one to get wrong: its `Prepare` step
+symlinks `docker` to `podman` in two different containers, and the push in
+`Build sanity image` runs in the `build_helper_(vllm|sglang)` one, not the
+`manylinux` runner. Check the step's `containerSelector` against
+`runs_on_dockers`, not just whether `docker` is podman.
+
 ## Related docs
 
 - [Build Wheel Matrix CI Job Documentation](build-wheel-matrix-ci.md) — deep dive into `nixl-ci-build-wheel`.

--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -182,7 +182,7 @@ steps:
         local target_tag="$1"
         echo "Creating tag: ${target_tag}"
         docker tag "${LOCAL_TAG_BASE}${arch}" "${ARTIFACTORY_REGISTRY}:${target_tag}"
-        docker push "${ARTIFACTORY_REGISTRY}:${target_tag}"
+        docker push --retry 5 "${ARTIFACTORY_REGISTRY}:${target_tag}"
         curl --fail -H "Authorization: Bearer ${ARTIFACTORY_PASSWORD}" -X PUT \
           "${ARTIFACTORY_API}/${target_tag}?properties=${IMAGE_PROPERTIES}"
       }

--- a/.ci/jenkins/lib/build-wheel-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-matrix.yaml
@@ -331,7 +331,11 @@ steps:
       # 2. Copy the whole workspace in (test script + helpers), like the other pipelines.
       printf 'FROM %s\nCOPY . /workspace/nixl\nWORKDIR /workspace/nixl\n' "${IMG}" \
         | docker build --platform linux/${arch} -t "${IMG}" -f - .
-      docker push "${IMG}"
+      for i in {1..6}; do
+          docker push "${IMG}" && break
+          [ "$i" = 6 ] && exit 1
+          sleep $((2 ** (i - 1)))
+      done
 
   - name: Allocate Environment
     containerSelector: "{name: 'build_helper_(vllm|sglang)'}"

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -121,7 +121,11 @@ steps:
       --build-arg BASE_IMAGE=${registry_host}${registry_path}/${arch}/nixl-ci-dl-gpu-ep-base-pytorch26.06-cuda13.3-ubuntu24.04:${CI_IMAGE_TAG} \
       --tag ${PR_IMAGE} \
       -f .ci/dockerfiles/Dockerfile.gpu-test .
-      podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE}
+      for i in {1..6}; do
+          podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE} && break
+          [ "$i" = 6 ] && exit 1
+          sleep $((2 ** (i - 1)))
+      done
 
   - name: Allocate DL EP Environment
     containerSelector: "{name: 'build_helper_dl_ep'}"

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -112,7 +112,11 @@ steps:
       --build-arg BASE_IMAGE=${registry_host}${registry_path}/${arch}/nixl-ci-dl-gpu-base-pytorch26.06-cuda13.3-ubuntu24.04:${CI_IMAGE_TAG} \
       --tag ${PR_IMAGE} \
       -f .ci/dockerfiles/Dockerfile.gpu-test .
-      podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE}
+      for i in {1..6}; do
+          podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE} && break
+          [ "$i" = 6 ] && exit 1
+          sleep $((2 ** (i - 1)))
+      done
 
   - name: Allocate DL Environment
     containerSelector: "{name: 'build_helper_dl'}"

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -114,7 +114,11 @@ steps:
       --build-arg BASE_IMAGE=${registry_host}${registry_path}/${arch}/nixl-ci-gpu-base-pytorch26.06-cuda13.3-ubuntu24.04:${CI_IMAGE_TAG} \
       --tag ${PR_IMAGE} \
       -f .ci/dockerfiles/Dockerfile.gpu-test .
-      podman push ${PR_IMAGE}
+      for i in {1..6}; do
+          podman push ${PR_IMAGE} && break
+          [ "$i" = 6 ] && exit 1
+          sleep $((2 ** (i - 1)))
+      done
 
   - name: Allocate Environment
     containerSelector: "{name: 'build_helper'}"


### PR DESCRIPTION
## Summary

Transient `HTTP 503` responses from Artifactory were failing otherwise-green builds at the push step, after the image had already built successfully:

```
Error: trying to reuse blob sha256:3cbead0c... at destination: checking whether a blob
exists in artifactory.nvidia.com/...: received unexpected HTTP status: 503 Service Unavailable
Compiling NIXL Docker Image failed with exit code=125
```

Seen on `nixl-ci-gpu` #3107 (503, Aug 9) and #2651 (502 Bad Gateway, Jul 9). In both cases the build, install and image commit all succeeded and the stage failed only on the push, with steady blob-copy progress right up to the error - registry availability, not a hang or a code defect.

## Changes

Every push now retries. The mechanism differs by job because the two runner images ship different podman versions.

### Native flag - `build-wheel-matrix.yaml`, `build-container-matrix.yaml`

These run on `quay.io/podman/stable:v5.7.1`, so they use `--retry 5`.

podman already retries this class of error: `go.podman.io/common/pkg/retry` treats HTTP 502-504 and network errors as retryable, while returning `false` for unauthorized, denied, unknown name and unknown manifest - so a larger budget never delays a genuine failure. The problem is the budget, not the mechanism: the default of 3 attempts with a `2^attempt` second backoff spans only 1+2+4 = **7 seconds**, which both outages outlasted. `--retry 5` extends it to 1+2+4+8+16 = **31 seconds**.

`--retry-delay` is left unset deliberately - passing it replaces the exponential backoff with a fixed delay.

Both files invoke `docker push`, but `docker` is symlinked to `podman` in those jobs (`ln -sfT $(type -p podman) /usr/bin/docker`), so the flag applies.

### Shell loop - `test-matrix.yaml`, `test-dl-matrix.yaml`, `test-dl-ep-matrix.yaml`

These push from the `build_helper` container, which installs podman from Ubuntu 24.04 apt (4.9.x). `--retry` was added in **podman 5.0**, so the flag aborts the step outright:

```
+ podman push --retry 5 artifactory.nvidia.com/.../nixl-ci-gpu-test:3116
Error: unknown flag: --retry
```

Upgrading is not a practical option on this base - podman 5.x is not in `noble`, `noble-updates` or `noble-backports` (it first appears in Ubuntu 25.10), and `Dockerfile.build_helper` deliberately pins apt to the internal mirror with public archives removed. So these use a retry loop with the same 2, 4, 8, 16 second backoff.

If `build_helper` ever moves to podman 5.0+, the loop can be replaced by the flag - noted in the docs.

## Verification

All five matrix files parse as YAML, and the loop was checked for both the recovery path and a non-zero exit on exhaustion. The retry path only exercises on a registry failure, so a green run confirms the commands are accepted, not that the backoff helps; the real test is the next transient 503.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Container, wheel, and GPU test image publishing now retries up to five times for transient registry or network failures.
  * GPU test workflows use increasing delays between attempts and stop immediately after a successful push.
  * Authentication and manifest errors remain non-retriable, while temporary service interruptions are handled automatically.

* **Documentation**
  * Added guidance on retry behavior, retryable failures, non-retriable errors, retry windows, and container selection across publishing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->