### PR TITLE
NIXL Services Utility Agent

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -40,6 +40,7 @@ ARG LIBFABRIC_INSTALL_PATH="/usr/local"
 ARG BUILD_TYPE="release"
 ARG ABSL_TAG="lts_2025_08_14"
 ARG GRPC_TAG="v1.73.0"
+ARG NVCOMP_VERSION="5.3.0"
 
 # Install build dependencies from Ubuntu repository
 RUN apt-get update -y && \
@@ -71,6 +72,18 @@ RUN apt-get update -y && \
     libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev \
     # azure-sdk-for-cpp dependencies
     libxml2-dev
+
+# Install nvCOMP package.
+RUN ARCH_SUFFIX=$(if [ "${ARCH}" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi) && \
+    CUDA_MAJOR="$(echo "${CUDA_VERSION}" | cut -d. -f1)" && \
+    NVCOMP_OS="$(. /etc/lsb-release; echo ${DISTRIB_ID}${DISTRIB_RELEASE} | tr A-Z a-z | tr -d .)" && \
+    wget --tries=3 --waitretry=5 --no-verbose \
+    https://developer.download.nvidia.com/compute/nvcomp/${NVCOMP_VERSION}/local_installers/nvcomp-local-repo-${NVCOMP_OS}-${NVCOMP_VERSION}_${NVCOMP_VERSION}-1_${ARCH_SUFFIX}.deb \
+    -O nvcomp-local-repo.deb && \
+    dpkg -i nvcomp-local-repo.deb && \
+    cp /var/nvcomp-local-repo-${NVCOMP_OS}-${NVCOMP_VERSION}/nvcomp-*-keyring.gpg /usr/share/keyrings/ && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "nvcomp-cuda-${CUDA_MAJOR}"
 
 # Add DOCA repo + upgrade always so the RDMA reinstall below resolves MLNX/DOCA versions.
 # Skip only the DOCA SDK install when the base image already ships it.
@@ -300,7 +313,7 @@ RUN rm -rf build && \
     else \
         NIXL_EP_FLAG=""; \
     fi && \
-    meson setup -Ducx_path=$UCX_PREFIX -Dlibfabric_path=$LIBFABRIC_INSTALL_PATH $NIXL_EP_FLAG build/ --prefix=$NIXL_PREFIX --buildtype=$BUILD_TYPE && \
+    meson setup -Ducx_path=$UCX_PREFIX -Dlibfabric_path=$LIBFABRIC_INSTALL_PATH $NIXL_EP_FLAG build/ --prefix=$NIXL_PREFIX --buildtype=$BUILD_TYPE -Dbuild_nixl_service=true && \
     cd build && \
     ninja -j${NPROC:-$(nproc)} && \
     ninja install
@@ -312,6 +325,10 @@ RUN echo "$NIXL_PREFIX/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
 # Set environment variables for NIXL EP
 ENV NIXL_PLUGIN_DIR=$NIXL_PLUGIN_DIR
 ENV PYTHONPATH=/workspace/nixl/build/examples/device/ep
+
+# Set environment variables for NIXL service
+ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages:$PYTHONPATH
+ENV UCX_TLS=^cuda_ipc
 
 RUN cd src/bindings/rust && cargo build --release --locked
 

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -74,6 +74,7 @@ ARG BUILD_NIXL_EP="true"
 ARG ABSL_TAG="lts_2025_08_14"
 ARG GRPC_TAG="v1.73.0"
 ARG NPROC
+ARG NVCOMP_VERSION="5.3.0"
 
 RUN yum groupinstall -y 'Development Tools' &&  \
     dnf install -y almalinux-release-synergy epel-release && \
@@ -110,6 +111,17 @@ RUN yum groupinstall -y 'Development Tools' &&  \
     pciutils-devel \
     wget \
     zlib
+
+# Install nvCOMP package.
+RUN CUDA_MAJOR="$(echo "${CUDA_VERSION}" | cut -d. -f1)" && \
+    NVCOMP_OS="rhel$(rpm -E '%{rhel}')" && \
+    wget --tries=3 --waitretry=5 --no-verbose \
+        "https://developer.download.nvidia.com/compute/nvcomp/${NVCOMP_VERSION}/local_installers/nvcomp-local-repo-${NVCOMP_OS}-${NVCOMP_VERSION}-${NVCOMP_VERSION}-1.${ARCH}.rpm" \
+        -O nvcomp-local-repo.rpm && \
+    rpm --install nvcomp-local-repo.rpm && \
+    dnf clean expire-cache && \
+    dnf install -y "nvcomp-cuda-${CUDA_MAJOR}" && \
+    rm -f nvcomp-local-repo.rpm
 
 # Build latest hwloc from source to avoid older RHEL8 API limitations.
 RUN cd /tmp && \
@@ -483,6 +495,7 @@ RUN rm -rf build && \
     meson setup build/ --prefix=/usr/local/nixl --buildtype=$BUILD_TYPE $NIXL_EP_FLAG -Ducx_path=/usr/local \
     -Dcudapath_lib="/usr/local/cuda/lib64" \
     -Dcudapath_inc="/usr/local/cuda/include" \
+    -Dbuild_nixl_service=true \
     -Drelease_wheel=true && \
     cd build && \
     ninja && \
@@ -491,6 +504,10 @@ RUN rm -rf build && \
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib64/:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/nixl/lib64/plugins:$LD_LIBRARY_PATH
 ENV NIXL_PLUGIN_DIR=/usr/local/nixl/lib64/plugins
+
+# Set environment variables for NIXL service
+ENV PYTHONPATH=/usr/local/nixl/lib/python3/dist-packages:$PYTHONPATH
+ENV UCX_TLS=^cuda_ipc
 
 RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
     echo "/usr/local/nixl/lib/$ARCH-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \

--- a/examples/python/service_api_example.py
+++ b/examples/python/service_api_example.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from nixl_cu13 import _service_api as svc
+
+# Repeating 0..255 byte pattern used to seed the data-source buffer. It is cheap
+# to build (a 256-byte source tensor) yet order-sensitive, so the sink's check
+# catches dropped, duplicated, or mis-ordered bytes - not merely "something
+# arrived". The transfer size below is a multiple of this period.
+PATTERN_PERIOD = 256
+
+TRANSFER_BYTES = 512 * 1024 * 1024
+
+
+def print_rank(name, message):
+    print(f"[{name}] {message}", flush=True)
+
+
+def _known_pattern(device):
+    return torch.arange(PATTERN_PERIOD, dtype=torch.uint8, device=device)
+
+
+def init_agent(name, rank):
+    torch.cuda.set_device(rank)
+
+    print_rank(name, "Initializing service agent and marshal settings...")
+
+    # Configuring marshal mode
+    mode = svc.nixlMarshalCompressConfig()
+
+    # Creating service-aware agent configs and agents
+    cfg = svc.nixl_service_agent_config(mode=mode)
+    agent = svc.nixl_service_agent(name, nixl_conf=cfg)
+
+    # Getting recommended service pool sizing
+    svc_mem_bytes = svc.recommendServiceMemSize(mode, maxConcurrentTransfers=1)
+
+    # Allocating data transfer buffers
+    num_bytes = TRANSFER_BYTES
+    assert num_bytes % PATTERN_PERIOD == 0, "transfer size must be a multiple of the pattern period"
+    data_buf = torch.empty(num_bytes, dtype=torch.uint8, device="cuda")
+
+    # Allocating and registering service buffers
+    svc_buf = torch.empty(svc_mem_bytes, dtype=torch.uint8, device="cuda")
+    agent.register_service_memory([svc_buf])
+
+    # IMPORTANT: descriptors of 64 MiB or less are served by native NIXL, so
+    # their memory must also be registered with `register_memory`. Descriptors
+    # larger than that are served by the service and need no registration
+    # beyond the service buffers above. The threshold applies per descriptor of
+    # a transfer, so a request may need both registrations.
+    #
+    # Every descriptor here is 512 MiB, hence `data_buf` is left unregistered.
+
+    print_rank(name, "Exchanging metadata...")
+
+    dist.init_process_group(backend="gloo", rank=rank, world_size=2)
+
+    # Getting local agent metadata
+    local_md = bytes(agent.get_agent_metadata())
+    dev_id = torch.cuda.current_device()
+
+    # Gathering metadata from all agents
+    gathered_md = [None] * 2
+    dist.all_gather_object(gathered_md, {
+        "metadata": local_md,
+        "data_ptr": data_buf.data_ptr(),
+        "dev_id": dev_id
+    })
+
+    return agent, gathered_md, num_bytes, data_buf
+
+
+def run_initiator(name, agent, gathered_md, num_bytes, direction):
+    # Adding remote agent (the peer, rank 1)
+    remote_md = gathered_md[1]["metadata"]
+    remote_name = agent.add_remote_agent(remote_md).decode()
+
+    # ``local`` is always this rank's (rank 0) own buffer and ``remote`` the
+    # peer's - the same two descriptor lists for both operations.  For WRITE,
+    # local is the source and remote the destination; for READ the roles invert
+    # (local is where the pulled data lands, remote is the peer's source), but
+    # rank 0 stays the active initiator that posts, polls, and - on completion -
+    # notifies the peer either way.
+    local_descs = agent.get_xfer_descs([(
+        gathered_md[0]["data_ptr"],
+        num_bytes,
+        gathered_md[0]["dev_id"]
+    )], mem_type="VRAM")
+
+    remote_descs = agent.get_xfer_descs([(
+        gathered_md[1]["data_ptr"],
+        num_bytes,
+        gathered_md[1]["dev_id"]
+    )], mem_type="VRAM")
+
+    op = direction.upper()
+    print_rank(name, f"Initiating and executing {op} with {remote_name}...")
+    req = agent.initialize_xfer(
+        op,
+        local_descs,
+        remote_descs,
+        remote_agent=remote_name,
+        notif_msg=b"SVC_DONE",
+    )
+    agent.transfer(req, notif_msg=b"SVC_DONE")
+
+    print_rank(name, "Polling transfer state until completion...")
+    while agent.check_xfer_state(req) == "PROC":
+        pass
+
+    req.release()
+
+
+def run_peer(name, agent, gathered_md):
+    # Adding remote agent (the initiator, rank 0)
+    remote_md = gathered_md[0]["metadata"]
+    remote_name = agent.add_remote_agent(remote_md).decode()
+
+    # The passive side for both directions: the agent's progress thread services
+    # an incoming WRITE (data lands in this rank's buffer) or an incoming READ
+    # (this rank is the source and the service pushes its data to the
+    # initiator).  Either way completion is signalled by a single notification
+    # from the initiator, keyed by the initiator's name.
+    print_rank(name, "Waiting for the initiator's completion notification...")
+
+    got_notif = False
+    while not got_notif:
+        notifs = agent.get_new_notifs()
+        got_notif = remote_name in notifs and len(notifs[remote_name]) >= 1
+
+
+def worker(rank, direction):
+    agent_name = f"Agent-{rank}"
+    print_rank(agent_name, f"Starting worker {rank} (direction={direction})...")
+
+    agent, gathered_md, num_bytes, data_buf = init_agent(agent_name, rank)
+
+    # rank 0 is always the active initiator; rank 1 is always the passive peer.
+    # The data source is the WRITE initiator (rank 0) or the READ peer (rank 1);
+    # the other rank is the sink that receives and then verifies the bytes.
+    is_initiator = rank == 0
+    is_source = (direction == "write") == is_initiator
+
+    if is_source:
+        # Seed the source with the pattern the sink will check for.
+        data_buf.view(-1, PATTERN_PERIOD).copy_(_known_pattern(data_buf.device))
+    else:
+        # Zero the landing buffer so a successful transfer is unambiguous.
+        data_buf.zero_()
+    torch.cuda.synchronize()
+
+    # Barrier so the source is filled (and the sink zeroed) before the initiator
+    # starts the transfer - otherwise a late zero could clobber a WRITE, or a
+    # late fill could be missed by a READ.
+    dist.barrier()
+
+    if is_initiator:
+        run_initiator(agent_name, agent, gathered_md, num_bytes, direction)
+    else:
+        run_peer(agent_name, agent, gathered_md)
+
+    if not is_source:
+        # The sink verifies the bytes it received against the known pattern.
+        pattern = _known_pattern(data_buf.device)
+        matches = bool((data_buf.view(-1, PATTERN_PERIOD) == pattern).all().item())
+        if not matches:
+            raise AssertionError(
+                f"[{agent_name}] verification FAILED: received data does not match the expected pattern"
+            )
+        print_rank(agent_name, f"Verification PASSED: {num_bytes} received bytes match the expected pattern.")
+
+    print_rank(agent_name, f"Worker {rank} done.")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="NIXL service-agent WRITE/READ example over two local GPUs."
+    )
+    parser.add_argument(
+        "--direction",
+        choices=("write", "read"),
+        default="write",
+        help="transfer direction: 'write' (default) has rank 0 push into rank 1's "
+             "buffer; 'read' has rank 0 pull from rank 1's buffer instead. rank 0 is "
+             "the active initiator either way - only the data-source/sink roles invert.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = "29500"
+
+    mp.spawn(worker, args=(args.direction,), nprocs=2, join=True)

--- a/meson.build
+++ b/meson.build
@@ -332,6 +332,36 @@ if wheel_variant != ''
     cuda_wheel_dir = 'nixl_' + wheel_variant
 endif
 
+nvcomp_inc_path = get_option('nvcomp_path_inc')
+nvcomp_lib_path = get_option('nvcomp_path_lib')
+nvcomp_dep = disabler()
+
+# Prioritize the user-provided paths: if they are set, load nvCOMP from there.
+if nvcomp_lib_path != ''
+    nvcomp_lib = cpp.find_library('nvcomp', dirs: nvcomp_lib_path, required : false)
+    if nvcomp_lib.found()
+        if nvcomp_inc_path == '' or cpp.has_header('nvcomp.h', args : '-I' + nvcomp_inc_path)
+            if nvcomp_inc_path == ''
+                nvcomp_dep = declare_dependency(dependencies : nvcomp_lib)
+            else
+                nvcomp_dep = declare_dependency(
+                    include_directories : include_directories(nvcomp_inc_path),
+                    dependencies : nvcomp_lib)
+            endif
+        endif
+    endif
+endif
+
+if not nvcomp_dep.found()
+    message('nvCOMP not found via explicit paths, falling back to system discovery.')
+    nvcomp_dep = dependency('nvcomp', required : false)
+endif
+
+if not nvcomp_dep.found()
+    nvcomp_dep = disabler()
+    warning('nvCOMP not found. Compression marshal backend will be disabled.')
+endif
+
 # Check for etcd-cpp-api - use multiple methods for discovery
 etcd_dep = dependency('etcd-cpp-api', required : false)
 etcd_inc_path = get_option('etcd_inc_path')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -35,6 +35,8 @@ option('build_docs', type: 'boolean', value: false, description: 'Build Doxygen 
 option('release_wheel', type: 'boolean', value: false, description: 'Add nixl-cu12 and nixl-cu13 dependencies to the meta wheel')
 option('log_level', type: 'combo', choices: ['trace', 'debug', 'info', 'warning', 'error', 'fatal', 'auto'], value: 'auto', description: 'Log Level (auto: auto-detect based on build type: trace for debug builds, info for release builds)')
 option('rust', type: 'boolean', value: false, description: 'Build Rust bindings')
+option('nvcomp_path_inc', type: 'string', value: '', description: 'Include path for nvCOMP')
+option('nvcomp_path_lib', type: 'string', value: '', description: 'Library path for nvCOMP')
 option('sanitizer', type: 'combo',
        choices: ['none', 'address', 'undefined', 'thread', 'address,undefined'],
        value: 'none',
@@ -43,6 +45,7 @@ option('sanitizer', type: 'combo',
 # Tracing (nixl::trace)
 option('with_trace', type: 'boolean', value: true, description: 'Build the nixl::trace tracing facade')
 option('trace_backends', type: 'string', value: 'nvtx', description: 'Comma-separated tracing backends to compile in (e.g. nvtx, chakra)')
+option('build_nixl_service', type: 'boolean', value: false, description: 'Build nixlServiceAgent')
 
 # Tests
 option('build_tests', type: 'boolean', value: true, description: 'Build all tests')

--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -20,6 +20,8 @@
 #include <mutex>
 #include <string>
 #include "common/nixl_log.h"
+#include <functional>
+
 #include "nixl_types.h"
 #include "nixl_descriptors.h"
 #include "common/nixl_time.h"
@@ -38,6 +40,10 @@ struct nixlBackendOptionalArgs {
 
 using nixl_opt_b_args_t = nixlBackendOptionalArgs;
 
+struct nixlNotifCallbackArgs {
+    std::string raw_notif;
+    std::string remote_agent;
+};
 
 // A base class to point to backend initialization data
 // User doesn't know about fields such as local_agent but can access it
@@ -54,6 +60,13 @@ class nixlBackendInitParams {
         nixlTime::us_t pthrDelay = 0;
         nixl_thread_sync_t syncMode;
         bool enableTelemetry_ = false;
+
+        /**
+         * @brief A map of notification callbacks.
+         *        The key is a prefix which if prepended to the notification message, will match the
+         * callback function.
+         */
+        std::unordered_map<std::string, std::function<void(nixlNotifCallbackArgs)>> notifCallbacks_;
 };
 
 // Pure virtual class to have a common pointer type

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -43,6 +43,8 @@ class nixlBackendEngine {
         bool              initErr = false;
         const std::string localAgent;
         const bool enableTelemetry_;
+        const std::unordered_map<std::string, std::function<void(nixlNotifCallbackArgs)>>
+            notifCallbacks_;
 
         [[nodiscard]] nixl_status_t
         setInitParam(const std::string &key, const std::string &value) {
@@ -78,7 +80,8 @@ class nixlBackendEngine {
             : backendType(init_params->type),
               customParams(*init_params->customParams),
               localAgent(init_params->localAgent),
-              enableTelemetry_(init_params->enableTelemetry_) {}
+              enableTelemetry_(init_params->enableTelemetry_),
+              notifCallbacks_(init_params->notifCallbacks_) {}
 
         nixlBackendEngine(nixlBackendEngine&&) = delete;
         nixlBackendEngine(const nixlBackendEngine&) = delete;
@@ -109,7 +112,13 @@ class nixlBackendEngine {
 
         // Determines if a backend supports sending notifications. Related methods are not
         // pure virtual, and return errors, as parent shouldn't call if supportsNotif is false.
-        virtual bool supportsNotif() const = 0;
+        virtual bool
+        supportsNotif() const = 0;
+
+        virtual bool
+        supportsNotifInjection() const {
+            return false;
+        }
 
         virtual nixl_mem_list_t getSupportedMems() const = 0;  // TODO: Return by const-reference and mark noexcept?
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -50,7 +50,7 @@ class nixlAgent {
         /**
          * @brief Destructor for nixlAgent object
          */
-        ~nixlAgent ();
+        virtual ~nixlAgent();
 
         /* It is unsafe to move nixlAgent object */
         nixlAgent(nixlAgent&&) noexcept = delete;

--- a/src/api/cpp/nixl_params.h
+++ b/src/api/cpp/nixl_params.h
@@ -19,7 +19,11 @@
 
 #include <string>
 #include <cstdint>
+#include <functional>
+
 #include "nixl_types.h"
+
+struct nixlNotifCallbackArgs;
 
 /**
  * @struct nixlAgentConfig
@@ -103,6 +107,11 @@ struct nixlAgentConfig {
           pthrDelay(pthr_delay_us),
           lthrDelay(lthr_delay_us),
           etcdWatchTimeout(etcd_watch_timeout) {}
+
+protected:
+    friend class nixlAgent;
+    friend class nixlServiceAgent;
+    std::unordered_map<std::string, std::function<void(nixlNotifCallbackArgs)>> notifCallbacks_;
 };
 
 #endif

--- a/src/api/python/__init__.py
+++ b/src/api/python/__init__.py
@@ -34,3 +34,22 @@ __all__ = [
     "nixl_thread_sync_t",
     "nixl_xfer_handle",
 ]
+
+try:
+    from ._service_api import (
+        nixl_service_agent,
+        nixl_service_agent_config,
+        nixlMarshalCompressConfig,
+        nixlMarshalDirectConfig,
+        nixlMarshalStagingConfig,
+    )
+
+    __all__ += [
+        "nixl_service_agent",
+        "nixl_service_agent_config",
+        "nixlMarshalDirectConfig",
+        "nixlMarshalStagingConfig",
+        "nixlMarshalCompressConfig",
+    ]
+except ImportError:
+    pass

--- a/src/api/python/_service_api.py
+++ b/src/api/python/_service_api.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""High-level Pythonic API for :class:`nixlServiceAgent`.
+
+This module mirrors :mod:`._api` but backs every agent with the service-layer
+``nixlServiceAgent`` instead of the base ``nixlAgent``.  The public interface
+is intentionally identical.
+
+Service-specific features (marshal modes, service memory pool, per-transfer
+marshal opt-args) are available through additional config options and methods.
+"""
+
+from typing import Optional, Union
+
+import numpy as np
+
+from . import _bindings as nixlBind  # type: ignore
+from . import _service_bindings as svcBind  # type: ignore
+from ._api import (
+    nixl_agent,
+    nixl_agent_config,
+    nixl_backend_handle,
+    nixl_prepped_dlist_handle,
+    nixl_xfer_handle,
+)
+from .logging import get_logger
+
+logger = get_logger(__name__)
+
+# Re-export marshal config types so callers never need _service_bindings.
+nixlMarshalDirectConfig = svcBind.nixlMarshalDirectConfig
+nixlMarshalStagingConfig = svcBind.nixlMarshalStagingConfig
+nixlMarshalCompressConfig = svcBind.nixlMarshalCompressConfig
+
+nixlMarshalDirectOptArgs = svcBind.nixlMarshalDirectOptArgs
+nixlMarshalStagingOptArgs = svcBind.nixlMarshalStagingOptArgs
+nixlMarshalCompressOptArgs = svcBind.nixlMarshalCompressOptArgs
+nixl_marshal_compress_algo_t = svcBind.nixl_marshal_compress_algo_t
+
+recommendServiceMemSize = svcBind.recommendServiceMemSize
+
+
+class nixl_service_agent_config(nixl_agent_config):
+    """Configuration for a service agent.
+
+    Extends :class:`nixl_agent_config` with a ``mode`` field that selects the
+    marshal pipeline (direct, staging, or compress).  All base-config
+    parameters are forwarded unchanged.
+
+    :param mode: Marshal-mode configuration object.  Defaults to
+        :class:`nixlMarshalDirectConfig` (passthrough, no staging memory).
+    """
+
+    def __init__(
+        self,
+        mode=None,
+        enable_prog_thread: bool = True,
+        enable_listen_thread: bool = False,
+        listen_port: int = 0,
+        capture_telemetry: bool = False,
+        num_threads: int = 0,
+        backends: list[str] = ["UCX"],
+    ):
+        super().__init__(
+            enable_prog_thread=enable_prog_thread,
+            enable_listen_thread=enable_listen_thread,
+            listen_port=listen_port,
+            capture_telemetry=capture_telemetry,
+            num_threads=num_threads,
+            backends=backends,
+        )
+        self.mode = mode if mode is not None else svcBind.nixlMarshalDirectConfig()
+
+
+class nixl_service_agent(nixl_agent):
+    """Drop-in replacement for :class:`nixl_agent` backed by ``nixlServiceAgent``.
+
+    The public interface is identical to :class:`nixl_agent`.
+    Service-specific features are exposed through extra config options and a
+    handful of additional methods.
+
+    Because ``nixlServiceAgent`` IS-A ``nixlAgent`` in the C++ hierarchy, all
+    inherited Python methods (``register_memory``, ``get_xfer_descs``,
+    ``prep_xfer_dlist``, ``make_prepped_xfer``, ``transfer``,
+    ``check_xfer_state``, etc.) dispatch to the correct service overloads
+    automatically.
+    """
+
+    def __init__(
+        self,
+        agent_name: str,
+        nixl_conf: Optional[nixl_service_agent_config] = None,
+        instantiate_all: bool = False,
+    ):
+        if nixl_conf is not None and instantiate_all:
+            instantiate_all = False
+            logger.warning(
+                "Ignoring instantiate_all based on the provided config in agent creation."
+            )
+
+        if nixl_conf is None:
+            nixl_conf = nixl_service_agent_config()
+
+        thread_config = (
+            nixlBind.NIXL_THREAD_SYNC_STRICT
+            if nixl_conf.enable_listen
+            else nixlBind.NIXL_THREAD_SYNC_NONE
+        )
+
+        svc_config = svcBind.nixlServiceAgentConfig()
+        svc_config.useProgThread = nixl_conf.enable_pthread
+        svc_config.useListenThread = nixl_conf.enable_listen
+        svc_config.listenPort = nixl_conf.port
+        svc_config.syncMode = thread_config
+        svc_config.pthrDelay = 0
+        svc_config.lthrDelay = 100000
+        svc_config.captureTelemetry = nixl_conf.capture_telemetry
+        svc_config.mode = nixl_conf.mode
+
+        # Create the service agent (IS-A nixlAgent).
+        self.agent = svcBind.nixlServiceAgent(agent_name, svc_config)
+
+        self.name = agent_name
+        self._leaked_xfer_handles: list[int] = []
+        self.notifs: dict[str, list[bytes]] = {}
+        self.backends: dict[str, nixl_backend_handle] = {}
+        self.backend_mems: dict[str, list[str]] = {}
+        self.backend_options: dict[str, dict[str, str]] = {}
+
+        self.plugin_list = self.agent.getAvailPlugins()
+        if len(self.plugin_list) == 0:
+            logger.error("No plugins available, cannot start transfers!")
+            raise RuntimeError("No plugins available for NIXL, cannot start transfers!")
+
+        self.plugin_b_options: dict[str, dict[str, str]] = {}
+        self.plugin_mem_types: dict[str, list[str]] = {}
+        for plugin in self.plugin_list:
+            (backend_options, mem_types) = self.agent.getPluginParams(plugin)
+            self.plugin_b_options[plugin] = backend_options
+            self.plugin_mem_types[plugin] = mem_types
+
+        if instantiate_all:
+            nixl_conf.backends = self.plugin_list
+
+        for bknd in nixl_conf.backends:
+            if bknd not in self.plugin_list:
+                logger.warning(
+                    "Skipping backend registration %s due to the missing plugin.",
+                    bknd,
+                )
+            else:
+                init: dict[str, str] = {}
+                if nixl_conf.num_threads > 0:
+                    if bknd == "UCX" or bknd == "OBJ":
+                        init["num_threads"] = str(nixl_conf.num_threads)
+                    elif bknd == "GDS_MT":
+                        init["thread_count"] = str(nixl_conf.num_threads)
+                    elif bknd == "UCCL":
+                        init["num_cpus"] = str(nixl_conf.num_threads)
+                self.create_backend(bknd, init)
+
+        self.nixl_mems = {
+            "DRAM": nixlBind.DRAM_SEG,
+            "VRAM": nixlBind.VRAM_SEG,
+            "FILE": nixlBind.FILE_SEG,
+            "BLOCK": nixlBind.BLK_SEG,
+            "OBJ": nixlBind.OBJ_SEG,
+            "cpu": nixlBind.DRAM_SEG,
+            "cuda": nixlBind.VRAM_SEG,
+        }
+        self.nixl_ops = {
+            "WRITE": nixlBind.NIXL_WRITE,
+            "READ": nixlBind.NIXL_READ,
+        }
+
+        logger.info("Initialized NIXL service agent: %s", agent_name)
+
+    # ------------------------------------------------------------------
+    # Service-specific methods
+    # ------------------------------------------------------------------
+
+    def register_service_memory(
+        self,
+        reg_list,
+        mem_type: Optional[str] = None,
+        backends: list[str] = [],
+    ) -> nixlBind.nixlRegDList:
+        """Register a staging / compression memory pool with the service layer."""
+        reg_descs = self.get_reg_descs(reg_list, mem_type)
+        backends_list = [self.backends[b] for b in backends]
+        self.agent.registerServiceMem(reg_descs, backends_list)
+        return reg_descs
+
+    def deregister_service_memory(
+        self,
+        dereg_list: nixlBind.nixlRegDList,
+        backends: list[str] = [],
+    ):
+        """Deregister previously-registered service memory."""
+        backends_list = [self.backends[b] for b in backends]
+        self.agent.deregisterServiceMem(dereg_list, backends_list)
+
+    # ------------------------------------------------------------------
+    # Transfer overrides that forward marshal_opt_args
+    # ------------------------------------------------------------------
+
+    def initialize_xfer(
+        self,
+        operation: str,
+        local_descs: nixlBind.nixlXferDList,
+        remote_descs: nixlBind.nixlXferDList,
+        remote_agent: str,
+        notif_msg: bytes = b"",
+        backends: list[str] = [],
+        marshal_opt_args=None,
+    ) -> nixl_xfer_handle:
+        op = self.nixl_ops[operation]
+        handle_list = [self.backends[b] for b in backends]
+        handle = self.agent.createXferReq(
+            op, local_descs, remote_descs, remote_agent, notif_msg,
+            handle_list, marshal_opt_args,
+        )
+        return nixl_xfer_handle(self.agent, handle)
+
+    def make_prepped_xfer(
+        self,
+        operation: str,
+        local_xfer_side: nixl_prepped_dlist_handle,
+        local_indices: Union[list[int], np.ndarray],
+        remote_xfer_side: nixl_prepped_dlist_handle,
+        remote_indices: Union[list[int], np.ndarray],
+        notif_msg: bytes = b"",
+        backends: list[str] = [],
+        skip_desc_merge: bool = False,
+        marshal_opt_args=None,
+    ) -> nixl_xfer_handle:
+        op = self.nixl_ops[operation]
+        handle_list = [self.backends[b] for b in backends]
+        handle = self.agent.makeXferReq(
+            op,
+            local_xfer_side._handle,
+            local_indices,
+            remote_xfer_side._handle,
+            remote_indices,
+            notif_msg,
+            handle_list,
+            skip_desc_merge,
+            marshal_opt_args,
+        )
+        return nixl_xfer_handle(self.agent, handle)

--- a/src/bindings/python/meson.build
+++ b/src/bindings/python/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,5 +31,14 @@ py.extension_module('_utils',
            subdir: (cuda_wheel_dir),
            dependencies: [pybind_dep],
            install: true)
+
+if get_option('build_nixl_service')
+    py.extension_module('_service_bindings',
+                ['nixl_service_bindings.cpp'],
+                subdir: (cuda_wheel_dir),
+                dependencies: [nixl_dep, nixl_service_dep, nixl_service_deps, pybind_dep],
+                include_directories: [nixl_inc_dirs, utils_inc_dirs, nixl_service_inc],
+                install: true)
+endif
 
 subdir('nixl-meta')

--- a/src/bindings/python/nixl-meta/nixl/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl/__init__.py
@@ -47,11 +47,24 @@ def _load_cuda_backend() -> str:
 
 _pkg = sys.modules[_load_cuda_backend()]
 
-submodules = ["_api", "_bindings", "_utils", "logging"]
-for sub_name in submodules:
-    # Import submodule from actual wheel
-    module = importlib.import_module(f"{_pkg.__name__}.{sub_name}")
-    # Make it accessible as nixl._api, nixl._utils, nixl.logging
+# (name, required) — required submodules raise ImportError when missing,
+# optional ones are silently skipped so a plain build (no -Dbuild_nixl_service)
+# still yields a working `import nixl`.
+submodules: list[tuple[str, bool]] = [
+    ("_api", True),
+    ("_bindings", True),
+    ("_utils", True),
+    ("logging", True),
+    ("_service_bindings", False),
+]
+for sub_name, required in submodules:
+    try:
+        module = importlib.import_module(f"{_pkg.__name__}.{sub_name}")
+    except ModuleNotFoundError:
+        if required:
+            raise
+        continue
+    # Make it accessible as nixl._api, nixl._utils, nixl.logging, ...
     sys.modules[f"nixl.{sub_name}"] = module
     # Also add the submodule itself to the nixl namespace
     setattr(sys.modules[__name__], sub_name, module)

--- a/src/bindings/python/nixl_service_bindings.cpp
+++ b/src/bindings/python/nixl_service_bindings.cpp
@@ -1,0 +1,560 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nixl_service_bindings.cpp
+ * @brief Standalone pybind11 bindings for nixlServiceAgent.
+ *
+ * This module is layered on top of the core `_bindings` extension (which
+ * owns the bindings for nixlAgent, nixlAgentConfig, descriptor lists, enums,
+ * and NIXL exception types).  Loading `_service_bindings` requires
+ * `_bindings` to have been imported first so that nixlAgent/nixlAgentConfig
+ * are already registered; pybind11 then stitches the inheritance edges on
+ * nixlServiceAgent -> nixlAgent and nixlServiceAgentConfig -> nixlAgentConfig
+ * without duplicating the base class.
+ *
+ * Exception translation is local to this module: because the `nixl*Error`
+ * classes in nixl_bindings.cpp have internal linkage (anonymous-namespace
+ * style), this translation unit maintains its own equivalent hierarchy to
+ * avoid an ODR hazard.  Python code that catches `RuntimeError` or the
+ * subclass by name continues to work; catching by the exact Python class
+ * object requires importing from this module.
+ */
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "nixl.h"
+#include "nixl_service.h"
+#include "nixl_service_types.h"
+
+namespace py = pybind11;
+
+namespace {
+
+using nixl_py_notifs_t = std::map<std::string, std::vector<py::bytes>>;
+
+// ---------------------------------------------------------------------------
+// Exception hierarchy (mirrors nixl_bindings.cpp; kept local to this TU)
+// ---------------------------------------------------------------------------
+class nixlNotPostedError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlInvalidParamError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlBackendError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlNotFoundError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlMismatchError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlNotAllowedError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlRepostActiveError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlUnknownError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlNotSupportedError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlRemoteDisconnectError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlCancelledError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+class nixlNoTelemetryError : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+void
+throw_nixl_exception(nixl_status_t status) {
+    const auto msg = nixlEnumStrings::statusStr(status);
+    switch (status) {
+    case NIXL_IN_PROG:
+    case NIXL_SUCCESS:
+        return;
+    case NIXL_ERR_NOT_POSTED:
+        throw nixlNotPostedError(msg.c_str());
+    case NIXL_ERR_INVALID_PARAM:
+        throw nixlInvalidParamError(msg.c_str());
+    case NIXL_ERR_BACKEND:
+        throw nixlBackendError(msg.c_str());
+    case NIXL_ERR_NOT_FOUND:
+        throw nixlNotFoundError(msg.c_str());
+    case NIXL_ERR_MISMATCH:
+        throw nixlMismatchError(msg.c_str());
+    case NIXL_ERR_NOT_ALLOWED:
+        throw nixlNotAllowedError(msg.c_str());
+    case NIXL_ERR_REPOST_ACTIVE:
+        throw nixlRepostActiveError(msg.c_str());
+    case NIXL_ERR_UNKNOWN:
+        throw nixlUnknownError(msg.c_str());
+    case NIXL_ERR_NOT_SUPPORTED:
+        throw nixlNotSupportedError(msg.c_str());
+    case NIXL_ERR_REMOTE_DISCONNECT:
+        throw nixlRemoteDisconnectError(msg.c_str());
+    case NIXL_ERR_CANCELED:
+        throw nixlCancelledError(msg.c_str());
+    case NIXL_ERR_NO_TELEMETRY:
+        throw nixlNoTelemetryError(msg.c_str());
+    default:
+        throw std::runtime_error("BAD_STATUS");
+    }
+}
+
+// Collect backend handles from a Python-side list of uintptr_t into a
+// nixl_opt_args_t (or a derived type).  Templated so both the base args and
+// nixl_service_opt_args_t work without duplication.
+template<typename ArgsT>
+void
+set_backends(ArgsT &args, const std::vector<uintptr_t> &backends) {
+    for (uintptr_t backend : backends) {
+        args.backends.push_back(reinterpret_cast<nixlBackendH *>(backend));
+    }
+}
+
+} // namespace
+
+PYBIND11_MODULE(_service_bindings, m) {
+    m.doc() = "pybind11 bindings for nixlServiceAgent.  Import nixl._bindings "
+              "before this module so the nixlAgent / nixlAgentConfig base "
+              "classes and descriptor/enum types are registered.";
+
+    // -----------------------------------------------------------------------
+    // Exception types — register with Python so they inherit from RuntimeError.
+    // These are distinct Python class objects from the ones in _bindings, even
+    // though they share names.  Catching RuntimeError still works.
+    // -----------------------------------------------------------------------
+    py::register_exception<nixlNotPostedError>(m, "nixlNotPostedError");
+    py::register_exception<nixlInvalidParamError>(m, "nixlInvalidParamError");
+    py::register_exception<nixlBackendError>(m, "nixlBackendError");
+    py::register_exception<nixlNotFoundError>(m, "nixlNotFoundError");
+    py::register_exception<nixlMismatchError>(m, "nixlMismatchError");
+    py::register_exception<nixlNotAllowedError>(m, "nixlNotAllowedError");
+    py::register_exception<nixlRepostActiveError>(m, "nixlRepostActiveError");
+    py::register_exception<nixlUnknownError>(m, "nixlUnknownError");
+    py::register_exception<nixlNotSupportedError>(m, "nixlNotSupportedError");
+    py::register_exception<nixlRemoteDisconnectError>(m, "nixlRemoteDisconnectError");
+    py::register_exception<nixlCancelledError>(m, "nixlCancelledError");
+    py::register_exception<nixlNoTelemetryError>(m, "nixlNoTelemetryError");
+
+    // -----------------------------------------------------------------------
+    // Marshal config types (init-time configuration)
+    //
+    // nixl_marshal_config_t is std::variant<nixlMarshalDirectConfig,
+    // nixlMarshalStagingConfig, nixlMarshalCompressConfig>.  pybind11's
+    // <stl.h> variant caster converts any alternative when assigned to the
+    // `mode` field on nixlServiceAgentConfig.
+    // -----------------------------------------------------------------------
+    py::enum_<nixl_marshal_compress_algo_t>(m, "nixl_marshal_compress_algo_t")
+        .value("ANS", nixl_marshal_compress_algo_t::ANS)
+        .value("ANS_DELTA", nixl_marshal_compress_algo_t::ANS_DELTA)
+        .value("BITCOMP", nixl_marshal_compress_algo_t::BITCOMP)
+        .export_values();
+
+    py::class_<nixlMarshalDirectConfig>(m, "nixlMarshalDirectConfig")
+        .def(py::init<>())
+        .def("__repr__", [](const nixlMarshalDirectConfig &) {
+            return std::string("nixlMarshalDirectConfig()");
+        });
+
+    py::class_<nixlMarshalStagingConfig>(m, "nixlMarshalStagingConfig")
+        .def(py::init<>())
+        .def("__repr__", [](const nixlMarshalStagingConfig &) {
+            return std::string("nixlMarshalStagingConfig()");
+        });
+
+    py::class_<nixlMarshalDeltaConfig>(m, "nixlMarshalDeltaConfig")
+        .def(py::init<>())
+        .def("__repr__", [](const nixlMarshalDeltaConfig &) {
+            return std::string("nixlMarshalDeltaConfig()");
+        });
+
+    py::class_<nixlMarshalCompressConfig>(m, "nixlMarshalCompressConfig")
+        .def(py::init<>())
+        .def(py::init([](nixl_marshal_compress_algo_t algo) {
+                 nixlMarshalCompressConfig cfg;
+                 cfg.algo = algo;
+                 return cfg;
+             }),
+             py::arg("algo") = nixl_marshal_compress_algo_t::ANS)
+        .def_readwrite("algo", &nixlMarshalCompressConfig::algo);
+
+    // -----------------------------------------------------------------------
+    // Marshal optional args (passed via nixl_service_opt_args_t)
+    //
+    // nixl_marshal_opt_args_t mirrors nixl_marshal_config_t: the variant
+    // alternative must match the configured mode at call time. Placeholder
+    // empty structs for now; per-mode knobs are added incrementally.
+    // -----------------------------------------------------------------------
+    py::class_<nixlMarshalDirectOptArgs>(m, "nixlMarshalDirectOptArgs")
+        .def(py::init<>())
+        .def("__repr__", [](const nixlMarshalDirectOptArgs &) {
+            return std::string("nixlMarshalDirectOptArgs()");
+        });
+
+    py::class_<nixlMarshalStagingOptArgs>(m, "nixlMarshalStagingOptArgs")
+        .def(py::init<>())
+        .def("__repr__", [](const nixlMarshalStagingOptArgs &) {
+            return std::string("nixlMarshalStagingOptArgs()");
+        });
+
+    py::class_<nixlMarshalDeltaOptArgs>(m, "nixlMarshalDeltaOptArgs")
+        .def(py::init([](uintptr_t sender_ref,
+                         uintptr_t receiver_ref,
+                         nixl_mem_t sender_mem_type,
+                         nixl_mem_t receiver_mem_type,
+                         size_t element_size) {
+                 nixlMarshalDeltaOptArgs args;
+                 args.senderRef = reinterpret_cast<std::byte *>(sender_ref);
+                 args.receiverRef = reinterpret_cast<std::byte *>(receiver_ref);
+                 args.senderMemType = sender_mem_type;
+                 args.receiverMemType = receiver_mem_type;
+                 args.elementSize = element_size;
+                 return args;
+             }),
+             py::arg("senderRef"),
+             py::arg("receiverRef"),
+             py::arg("senderMemType"),
+             py::arg("receiverMemType"),
+             py::arg("elementSize"))
+        .def_readwrite("senderMemType", &nixlMarshalDeltaOptArgs::senderMemType)
+        .def_readwrite("receiverMemType", &nixlMarshalDeltaOptArgs::receiverMemType)
+        .def_readwrite("elementSize", &nixlMarshalDeltaOptArgs::elementSize)
+        .def_property(
+            "sender_ref",
+            [](const nixlMarshalDeltaOptArgs &self) {
+                return reinterpret_cast<uintptr_t>(self.senderRef);
+            },
+            [](nixlMarshalDeltaOptArgs &self, uintptr_t ptr) {
+                self.senderRef = reinterpret_cast<std::byte *>(ptr);
+            })
+        .def_property(
+            "receiver_ref",
+            [](const nixlMarshalDeltaOptArgs &self) {
+                return reinterpret_cast<uintptr_t>(self.receiverRef);
+            },
+            [](nixlMarshalDeltaOptArgs &self, uintptr_t ptr) {
+                self.receiverRef = reinterpret_cast<std::byte *>(ptr);
+            })
+        .def("__repr__", [](const nixlMarshalDeltaOptArgs &self) {
+            return "nixlMarshalDeltaOptArgs(senderMemType=" +
+                std::to_string(static_cast<int>(self.senderMemType)) +
+                ", receiverMemType=" + std::to_string(static_cast<int>(self.receiverMemType)) +
+                ", sender_ref=" + std::to_string(reinterpret_cast<uintptr_t>(self.senderRef)) +
+                ", receiver_ref=" + std::to_string(reinterpret_cast<uintptr_t>(self.receiverRef)) +
+                ", elementSize=" + std::to_string(self.elementSize) + ")";
+        });
+
+    py::class_<nixlMarshalCompressOptArgs>(m, "nixlMarshalCompressOptArgs")
+        .def(py::init<>())
+        .def(py::init([](std::optional<nixlMarshalDeltaOptArgs> delta) {
+                 nixlMarshalCompressOptArgs args;
+                 args.delta = delta;
+                 return args;
+             }),
+             py::arg("delta") = std::nullopt)
+        .def_readwrite("delta", &nixlMarshalCompressOptArgs::delta)
+        .def("__repr__", [](const nixlMarshalCompressOptArgs &) {
+            return std::string("nixlMarshalCompressOptArgs()");
+        });
+
+    // -----------------------------------------------------------------------
+    // Marshal sizing recommendation
+    //
+    // The ValueError below is pybind's mapping of the C++ std::invalid_argument.
+    // -----------------------------------------------------------------------
+    m.def(
+        "recommendServiceMemSize",
+        [](const nixl_marshal_config_t &mode, uint32_t max_concurrent_transfers) {
+            return nixlService::recommendServiceMemSize(mode, max_concurrent_transfers);
+        },
+        py::arg("mode"),
+        py::arg("maxConcurrentTransfers") = 1,
+        "Recommend the service memory, in bytes per descriptor, to register for the "
+        "given marshal mode.  Raises ValueError for nixlMarshalDirectConfig.");
+
+    // -----------------------------------------------------------------------
+    // nixlServiceAgentConfig
+    //
+    // Inherits from nixlAgentConfig, which must already be registered by
+    // _bindings (import nixl._bindings before _service_bindings).
+    // -----------------------------------------------------------------------
+    py::class_<nixlServiceAgentConfig, nixlAgentConfig>(m, "nixlServiceAgentConfig")
+        .def(py::init<>())
+        .def_readwrite("mode", &nixlServiceAgentConfig::mode);
+
+    // -----------------------------------------------------------------------
+    // nixl_service_opt_args_t — optional args carrier. The configured agent
+    // marshal mode is used by default; explicit per-transfer override must be
+    // direct or match the configured marshal mode.
+    // -----------------------------------------------------------------------
+    py::class_<nixl_service_opt_args_t>(m, "nixl_service_opt_args_t")
+        .def(py::init<>())
+        .def_readwrite("marshalOptArgs", &nixl_service_opt_args_t::marshalOptArgs);
+
+    // -----------------------------------------------------------------------
+    // nixlServiceAgent
+    //
+    // IS-A nixlAgent — every method on nixlAgent is inherited.  We rebind
+    // the transfer-handle methods here because:
+    //   * they take nixlServiceXferReqH* instead of nixlXferReqH*; and
+    //   * the C++ `= delete`d base-type overloads in nixl_service.h do not
+    //     propagate through pybind11 — without an explicit rebind, Python
+    //     users of a nixlServiceAgent instance would silently get the base
+    //     implementation back (and no service features).
+    //
+    // Handles are passed across the Python boundary as uintptr_t, matching
+    // the convention for nixlXferReqH / nixlDlistH / nixlBackendH.
+    // -----------------------------------------------------------------------
+    py::class_<nixlServiceAgent, nixlAgent>(m, "nixlServiceAgent")
+        .def(py::init<std::string, nixlServiceAgentConfig>(), py::arg("name"), py::arg("cfg"))
+
+        .def("getLocalMD",
+             [](const nixlServiceAgent &agent) -> py::bytes {
+                 std::string md;
+                 throw_nixl_exception(agent.getLocalMD(md));
+                 return py::bytes(md);
+             })
+
+        .def(
+            "loadRemoteMD",
+            [](nixlServiceAgent &agent, const std::string &remote_metadata) -> py::bytes {
+                std::string remote_name;
+                {
+                    py::gil_scoped_release release;
+                    throw_nixl_exception(agent.loadRemoteMD(remote_metadata, remote_name));
+                }
+                return py::bytes(remote_name);
+            },
+            py::arg("remote_metadata"))
+
+        .def(
+            "registerServiceMem",
+            [](nixlServiceAgent &agent,
+               const nixl_reg_dlist_t &descs,
+               const std::vector<uintptr_t> &backends) -> nixl_status_t {
+                nixl_opt_args_t extra_params;
+                set_backends(extra_params, backends);
+
+                const nixl_status_t ret = agent.registerServiceMem(descs, &extra_params);
+                throw_nixl_exception(ret);
+                return ret;
+            },
+            py::arg("descs"),
+            py::arg("backends") = std::vector<uintptr_t>{},
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "deregisterServiceMem",
+            [](nixlServiceAgent &agent,
+               const nixl_reg_dlist_t &descs,
+               const std::vector<uintptr_t> &backends) -> nixl_status_t {
+                nixl_opt_args_t extra_params;
+                set_backends(extra_params, backends);
+
+                const nixl_status_t ret = agent.deregisterServiceMem(descs, &extra_params);
+                throw_nixl_exception(ret);
+                return ret;
+            },
+            py::arg("descs"),
+            py::arg("backends") = std::vector<uintptr_t>{},
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "createXferReq",
+            [](nixlServiceAgent &agent,
+               const nixl_xfer_op_t &operation,
+               const nixl_xfer_dlist_t &local_descs,
+               const nixl_xfer_dlist_t &remote_descs,
+               const std::string &remote_agent,
+               const std::string &notif_msg,
+               const std::vector<uintptr_t> &backends,
+               const std::optional<nixl_marshal_opt_args_t> &marshal_opt_args) -> uintptr_t {
+                nixlServiceXferReqH *handle = nullptr;
+                nixl_service_opt_args_t extra_params{};
+                set_backends(extra_params, backends);
+                if (!notif_msg.empty()) {
+                    extra_params.notif = notif_msg;
+                }
+                if (marshal_opt_args.has_value()) {
+                    extra_params.marshalOptArgs = *marshal_opt_args;
+                }
+
+                throw_nixl_exception(agent.createXferReq(
+                    operation, local_descs, remote_descs, remote_agent, handle, &extra_params));
+                return reinterpret_cast<uintptr_t>(handle);
+            },
+            py::arg("operation"),
+            py::arg("local_descs"),
+            py::arg("remote_descs"),
+            py::arg("remote_agent"),
+            py::arg("notif_msg") = std::string{},
+            py::arg("backends") = std::vector<uintptr_t>{},
+            py::arg("marshal_opt_args") = std::nullopt,
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "makeXferReq",
+            [](nixlServiceAgent &agent,
+               const nixl_xfer_op_t &operation,
+               uintptr_t local_side,
+               const std::vector<int> &local_indices,
+               uintptr_t remote_side,
+               const std::vector<int> &remote_indices,
+               const std::string &notif_msg,
+               const std::vector<uintptr_t> &backends,
+               bool skip_desc_merge,
+               const std::optional<nixl_marshal_opt_args_t> &marshal_opt_args) -> uintptr_t {
+                nixlServiceXferReqH *handle = nullptr;
+                nixl_service_opt_args_t extra_params{};
+                set_backends(extra_params, backends);
+                if (!notif_msg.empty()) {
+                    extra_params.notif = notif_msg;
+                }
+                extra_params.skipDescMerge = skip_desc_merge;
+                if (marshal_opt_args.has_value()) {
+                    extra_params.marshalOptArgs = *marshal_opt_args;
+                }
+
+                throw_nixl_exception(agent.makeXferReq(operation,
+                                                       reinterpret_cast<nixlDlistH *>(local_side),
+                                                       local_indices,
+                                                       reinterpret_cast<nixlDlistH *>(remote_side),
+                                                       remote_indices,
+                                                       handle,
+                                                       &extra_params));
+                return reinterpret_cast<uintptr_t>(handle);
+            },
+            py::arg("operation"),
+            py::arg("local_side"),
+            py::arg("local_indices"),
+            py::arg("remote_side"),
+            py::arg("remote_indices"),
+            py::arg("notif_msg") = std::string{},
+            py::arg("backends") = std::vector<uintptr_t>{},
+            py::arg("skip_desc_merge") = false,
+            py::arg("marshal_opt_args") = std::nullopt)
+
+        .def(
+            "postXferReq",
+            [](nixlServiceAgent &agent,
+               uintptr_t reqh,
+               const std::string &notif_msg,
+               const std::optional<nixl_marshal_opt_args_t> &marshal_opt_args) -> nixl_status_t {
+                nixl_status_t ret;
+                auto *h = reinterpret_cast<nixlServiceXferReqH *>(reqh);
+                if (!notif_msg.empty() || marshal_opt_args.has_value()) {
+                    nixl_service_opt_args_t extra_params{};
+                    if (!notif_msg.empty()) {
+                        extra_params.notif = notif_msg;
+                    }
+                    if (marshal_opt_args.has_value()) {
+                        extra_params.marshalOptArgs = *marshal_opt_args;
+                    }
+                    ret = agent.postXferReq(h, &extra_params);
+                } else {
+                    ret = agent.postXferReq(h);
+                }
+                throw_nixl_exception(ret);
+                return ret;
+            },
+            py::arg("reqh"),
+            py::arg("notif_msg") = std::string{},
+            py::arg("marshal_opt_args") = std::nullopt,
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "getXferStatus",
+            [](nixlServiceAgent &agent, uintptr_t reqh) -> nixl_status_t {
+                const nixl_status_t ret =
+                    agent.getXferStatus(reinterpret_cast<nixlServiceXferReqH *>(reqh));
+                throw_nixl_exception(ret);
+                return ret;
+            },
+            py::arg("reqh"),
+            py::call_guard<py::gil_scoped_release>())
+
+        .def(
+            "releaseXferReq",
+            [](nixlServiceAgent &agent, uintptr_t reqh) -> nixl_status_t {
+                const nixl_status_t ret =
+                    agent.releaseXferReq(reinterpret_cast<nixlServiceXferReqH *>(reqh));
+                throw_nixl_exception(ret);
+                return ret;
+            },
+            py::arg("reqh"))
+
+        .def(
+            "getNotifs",
+            [](nixlServiceAgent &agent,
+               nixl_py_notifs_t &notif_map,
+               const std::vector<uintptr_t> &backends) -> nixl_py_notifs_t {
+                nixl_notifs_t new_notifs;
+                nixl_opt_args_t extra_params;
+                {
+                    py::gil_scoped_release release;
+                    set_backends(extra_params, backends);
+                    throw_nixl_exception(agent.getNotifs(new_notifs, &extra_params));
+                }
+
+                for (const auto &pair : new_notifs) {
+                    for (const auto &str : pair.second) {
+                        notif_map[pair.first].push_back(py::bytes(str));
+                    }
+                }
+                return notif_map;
+            },
+            py::arg("notif_map"),
+            py::arg("backends") = std::vector<uintptr_t>{});
+}

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -387,6 +387,7 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     init_params.pthrDelay = data->config_.pthrDelay;
     init_params.syncMode = data->config_.syncMode;
     init_params.enableTelemetry_ = (data->telemetry_ != nullptr);
+    init_params.notifCallbacks_ = data->config_.notifCallbacks_;
 
     // First, try to load the backend as a plugin
     auto& plugin_manager = nixlPluginManager::getInstance();
@@ -446,6 +447,13 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     if (backend->supportsRemote()) {
         data->notifEngines.push_back(backend.get());
         data->connMd_[type] = conn_info;
+    }
+
+    if (!backend->supportsNotifInjection() && !data->config_.notifCallbacks_.empty()) {
+        NIXL_ERROR_FUNC << "backend '" << type
+                        << "' does not support notification injection but notification callbacks "
+                           "are configured";
+        return NIXL_ERR_BACKEND;
     }
 
     // TODO: Simplify, e.g. by making nixlBackendH's c'tor public?

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,10 @@ subdir('utils')
 subdir('infra')
 subdir('plugins')
 subdir('core')
+
+if get_option('build_nixl_service')
+    subdir('services')
+endif
 
 # Test utilities library - created after nixl_dep is available to avoid circular dependencies
 nixl_test_utils_lib = library('nixl_test_utils',

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -1388,6 +1388,15 @@ nixlUcxEngine::notifAmCb(void *arg, const void *header,
     std::string remote_name = ser_des.getStr("name");
     std::string msg = ser_des.getStr("msg");
 
+    for (const auto &callback : engine->notifCallbacks_) {
+        if (msg.rfind(callback.first, 0) == 0) {
+            nixlNotifCallbackArgs args{msg, remote_name};
+            callback.second(args);
+
+            return UCS_OK;
+        }
+    }
+
     engine->appendNotif(std::move(remote_name), std::move(msg));
     return UCS_OK;
 }

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -115,6 +115,11 @@ public:
         return true;
     }
 
+    bool
+    supportsNotifInjection() const override {
+        return true;
+    }
+
     nixl_mem_list_t
     getSupportedMems() const override;
 

--- a/src/services/CHANGELOG.md
+++ b/src/services/CHANGELOG.md
@@ -1,0 +1,17 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Changelog
+
+All notable changes to the NIXL service (marshal-based compression utilities) are documented in this file.
+
+## [0.1.0] - 2026-08-10
+
+Initial experimental release of the NIXL service layer on top of `nixlAgent`, with pluggable marshal backends including nvCOMP-based compression.
+
+### Added
+
+- Marshalled **WRITE** and **READ** transfers with transparent GPU compression and decompression via nvCOMP (`nixlMarshalCompressConfig`), plus pass-through mode (`nixlMarshalDirectConfig`).
+- Python bindings for the service API and an example (`examples/python/service_api_example.py`) covering marshalled WRITE (default) and READ (`--direction read`).

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,79 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NIXL Compression Support with nvCOMP (Experimental)
+
+This directory contains an experimental service utility agent built on top of `nixlAgent`.  
+It adds pluggable marshal-based services, including compression support, on top of the native NIXL agent API.
+
+[License](https://opensource.org/licenses/Apache-2.0)
+
+## Feature Overview
+
+### What is it ?
+
+A transparent data compression and decompression service integrated into NVIDIA’s Inference Xfer Library (NIXL). It uses nvCOMP, NVIDIA’s GPU-accelerated data (de)compression library, to reduce payload sizes and help reduce transfer times for frequently accessed data in AI inference workloads.
+
+### Problem it solves
+
+Frequent model-weight transfers in reinforcement learning (RL) workflows and growing KV caches in inference workloads move increasingly large volumes of data. Transferring these payloads uncompressed can create bottlenecks in network bandwidth, transfer latency, and storage capacity.
+
+This repository addresses these bottlenecks by integrating nvCOMP-based compression and decompression into the NIXL transfer path, reducing the amount of data that must be transferred and stored.
+
+### How it works
+
+- Pluggable service layer operates like NIXL's backend plugins
+- Automatically compresses data before transmission and decompresses it upon reaching the target.
+- Zero-touch for applications, handles compression transparently
+
+### Current Status
+
+- Experimental branch feature; API and behavior may change.
+- Current focus is GPU compression with **WRITE** and **READ** transfers.
+
+## Available Services (Marshal Modes)
+
+- `nixlMarshalDirectConfig`
+  - Pass-through mode (minimal service processing).
+- `nixlMarshalCompressConfig`
+  - nvCOMP-based compression mode (only available when nvCOMP is found at build time).
+
+## nvCOMP Installation
+
+For this branch, use the **official nvCOMP 5.3 release package**.
+
+Download and install the official package from [https://developer.nvidia.com/nvcomp-downloads](https://developer.nvidia.com/nvcomp-downloads).
+
+## Build / Compilation Flags (Meson)
+
+Enable service builds:
+
+```bash
+meson setup build \
+  -Dbuild_nixl_service=true \
+  -Dbuild_tests=true
+
+# Optional overrides (use only if nvCOMP is not in default search paths):
+#   -Dnvcomp_path_inc=/path/to/nvcomp/include
+#   -Dnvcomp_path_lib=/path/to/nvcomp/lib
+
+ninja -C build install
+```
+
+## Run Python Service Example
+
+```bash
+# Marshalled WRITE (default): rank 0 pushes into rank 1's buffer.
+python ./examples/python/service_api_example.py
+
+# Marshalled READ: rank 0 pulls from rank 1's buffer instead.
+python ./examples/python/service_api_example.py --direction read
+```
+
+## Notes
+
+1. **nvCOMP + supported NVIDIA CUDA hardware are required** for compression service scenarios.
+2. Tested with UCX RDMA transport (`UCX_TLS=^cuda_ipc`).
+3. Tested on H100.

--- a/src/services/marshal/compression/compression_backend.cpp
+++ b/src/services/marshal/compression/compression_backend.cpp
@@ -1,0 +1,834 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "compression_backend.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <optional>
+#include <numeric>
+#include <nvcomp/ans.h>
+#include "absl/strings/str_cat.h"
+#include "absl/types/span.h"
+#include "delta_kernel.cuh"
+
+namespace nixlMarshal {
+namespace {
+
+    const std::vector<mem_space_t> kSupportedMemSpaces = {mem_space_t::DEVICE};
+
+    struct marshalOverhead {
+        size_t slotOverheadSize;
+        size_t workspaceSize;
+    };
+
+    constexpr size_t min_payload = 1 << 18; // 256 KB
+    // TODO: tune this value based on delta_ans / ans
+    constexpr double overhead_multiplier = 2.6; // Base 1.0 + 1.6 Overhead
+
+    constexpr size_t nvcomp_chunk_size = 1 << 18; // 256 KB
+    constexpr size_t nvcomp_chunk_default_alignment = 8;
+    constexpr size_t max_sub_chunk_count = 8;
+
+    const nvcompBatchedANSCompressOpts_t kANSCompressOpts = {
+        nvcomp_rANS,
+        NVCOMP_TYPE_FLOAT16,
+        max_sub_chunk_count,
+        {0}}; // TODO: add options in config, test NVCOMP_TYPE_uint8
+
+    const nvcompBatchedANSDecompressOpts_t kANSDecompressOpts =
+        nvcompBatchedANSDecompressDefaultOpts;
+
+
+    constexpr size_t workspace_size_per_chunk =
+        sizeof(void *) * 6; // input ptrs, output ptrs, input sizes, output
+                            // sizes, decompress sizes, statuses
+
+
+    using algo_t = nixl_marshal_compress_algo_t;
+
+    inline void
+    throwIfCuda(cudaError_t e, const char *what) {
+        if (e != cudaSuccess) {
+            throw std::runtime_error(absl::StrCat(what, ": ", cudaGetErrorString(e)));
+        }
+    }
+
+    inline void
+    throwIfNvcomp(nvcompStatus_t s, const char *what) {
+        if (s != nvcompSuccess) {
+            throw std::runtime_error(absl::StrCat(what, ": nvcomp status=", static_cast<int>(s)));
+        }
+    }
+
+    // alignment is a power of two
+    template<typename T>
+    constexpr T
+    alignUp(T value, size_t alignment) noexcept {
+        return (value + alignment - 1) & ~(alignment - 1);
+    }
+
+    template<typename T>
+    constexpr bool
+    isAlignedTo(T value, size_t alignment) noexcept {
+        return (value & (alignment - 1)) == 0;
+    }
+
+    inline size_t
+    getNvcompChunkStride() {
+        size_t max_output_compressed_size;
+        throwIfNvcomp(nvcompBatchedANSCompressGetMaxOutputChunkSize(
+                          nvcomp_chunk_size, kANSCompressOpts, &max_output_compressed_size),
+                      "getNvcompChunkStride: get max output chunk size");
+        max_output_compressed_size =
+            alignUp(max_output_compressed_size, nvcomp_chunk_default_alignment);
+        return std::max(max_output_compressed_size, nvcomp_chunk_size);
+    }
+
+    // Extra scratch space for a preprocessing stage, carved out of the per-slot workspace.
+    size_t
+    algoWorkspaceOverhead(algo_t algo, size_t chunked_payload_size) {
+        switch (algo) {
+        // ANS_DELTA stages a full-payload copy for the delta kernel
+        case algo_t::ANS_DELTA:
+            return chunked_payload_size;
+        case algo_t::ANS:
+            return 0;
+        case algo_t::BITCOMP:
+            break;
+        }
+        throw std::runtime_error("CompressionBackend: unsupported compression algo");
+    }
+
+    marshalOverhead
+    computeMarshalOverhead(size_t chunked_payload_size, algo_t algo) {
+        nvcompAlignmentRequirements_t alignment_requirements_compress;
+        throwIfNvcomp(nvcompBatchedANSCompressGetRequiredAlignments(
+                          kANSCompressOpts, &alignment_requirements_compress),
+                      "CompressionBackend: get required alignments");
+
+        nvcompAlignmentRequirements_t alignment_requirements_decompress;
+        throwIfNvcomp(nvcompBatchedANSDecompressGetRequiredAlignments(
+                          kANSDecompressOpts, &alignment_requirements_decompress),
+                      "CompressionBackend: get required alignments");
+
+        size_t nvcomp_num_chunks =
+            (chunked_payload_size + nvcomp_chunk_size - 1) / nvcomp_chunk_size;
+
+        size_t temp_compressed_size;
+        throwIfNvcomp(nvcompBatchedANSCompressGetTempSizeAsync(nvcomp_num_chunks,
+                                                               nvcomp_chunk_size,
+                                                               kANSCompressOpts,
+                                                               &temp_compressed_size,
+                                                               chunked_payload_size),
+                      "CompressionBackend: get compressed temp size");
+
+        size_t temp_decompressed_size;
+        throwIfNvcomp(nvcompBatchedANSDecompressGetTempSizeAsync(nvcomp_num_chunks,
+                                                                 nvcomp_chunk_size,
+                                                                 kANSDecompressOpts,
+                                                                 &temp_decompressed_size,
+                                                                 chunked_payload_size),
+                      "CompressionBackend: get uncompressed temp size");
+
+
+        size_t workspace_size = workspace_size_per_chunk * nvcomp_num_chunks +
+            std::max(temp_compressed_size + alignment_requirements_compress.temp,
+                     temp_decompressed_size + alignment_requirements_decompress.temp) +
+            algoWorkspaceOverhead(algo, chunked_payload_size);
+        workspace_size = alignUp(workspace_size, MarshalBackendSizing::slot_stride_alignment);
+
+        size_t slot_overhead_size =
+            getNvcompChunkStride() * nvcomp_num_chunks - chunked_payload_size;
+
+        return {slot_overhead_size, workspace_size};
+    }
+
+    size_t
+    alignedPhysicalSlotStrideSize(size_t chunked_payload_size, algo_t algo) {
+        const auto overhead = computeMarshalOverhead(chunked_payload_size, algo);
+        const size_t raw_physical_slot_size =
+            chunked_payload_size + overhead.slotOverheadSize + overhead.workspaceSize;
+        return alignUp(raw_physical_slot_size, MarshalBackendSizing::slot_stride_alignment);
+    }
+
+    size_t
+    recommendAnsServiceMemSize(size_t chunked_payload_size,
+                               uint32_t max_concurrent_transfers,
+                               algo_t algo) {
+        const size_t actual = std::max(chunked_payload_size, min_payload);
+        const size_t slot_stride = alignedPhysicalSlotStrideSize(actual, algo);
+        const size_t min_pool_bytes =
+            slot_stride * MarshalBackendSizing::slots_per_transfer * max_concurrent_transfers;
+        // TODO: I think this is redundant
+        const double raw_total = actual * overhead_multiplier *
+            MarshalBackendSizing::slots_per_transfer * max_concurrent_transfers;
+        size_t total_buffer_size = static_cast<size_t>(std::ceil(raw_total));
+        if (total_buffer_size < min_pool_bytes) {
+            total_buffer_size = min_pool_bytes;
+        }
+        const auto remainder = total_buffer_size % slot_stride;
+        if (remainder != 0) {
+            total_buffer_size += slot_stride - remainder;
+        }
+        return total_buffer_size;
+    }
+
+    class cudaEvent {
+        cudaEvent_t event_ = nullptr;
+
+    public:
+        explicit cudaEvent(cudaStream_t stream) {
+            throwIfCuda(cudaEventCreateWithFlags(&event_, cudaEventDisableTiming),
+                        "compression: cudaEventCreateWithFlags");
+            if (auto err = cudaEventRecord(event_, stream); err != cudaSuccess) {
+                cudaEventDestroy(event_);
+                event_ = nullptr;
+                throwIfCuda(err, "compression: cudaEventRecord failed");
+            }
+        }
+
+        cudaEvent(const cudaEvent &) = delete;
+        cudaEvent &
+        operator=(const cudaEvent &) = delete;
+        cudaEvent(cudaEvent &&) = delete;
+        cudaEvent &
+        operator=(cudaEvent &&) = delete;
+
+        ~cudaEvent() {
+            if (event_) {
+                cudaEventDestroy(event_);
+            }
+        }
+
+        bool
+        ready() const {
+            const auto err = cudaEventQuery(event_);
+            if (err == cudaSuccess) {
+                return true;
+            }
+            if (err == cudaErrorNotReady) {
+                return false;
+            }
+            throwIfCuda(err, "compression: cudaEventQuery failed");
+            return false;
+        }
+    };
+
+    class ansWorkspaceLayout {
+    public:
+        ansWorkspaceLayout(absl::Span<std::byte> workspace,
+                           size_t temp_align,
+                           size_t nvcomp_num_chunks)
+            : nvcompNumChunks_(nvcomp_num_chunks) {
+            std::byte *p = workspace.data();
+
+            inputPtrs_ = place<void *>(p);
+            outputPtrs_ = place<void *>(p);
+            inputSizes_ = place<size_t>(p);
+            outputSizes_ = place<size_t>(p);
+            decompressSizes_ = place<size_t>(p);
+            statuses_ = place<nvcompStatus_t>(p);
+
+            p = reinterpret_cast<std::byte *>(alignUp(reinterpret_cast<uintptr_t>(p), temp_align));
+            if (p > workspace.end()) {
+                throw std::runtime_error("AnsWorkspaceLayout: workspace is too small");
+            }
+            tempPtr_ = reinterpret_cast<void *>(p);
+            workspaceActualSize_ = static_cast<size_t>(p - workspace.data());
+        }
+
+        [[nodiscard]] void **
+        getInputPtrsPlace() const noexcept {
+            return inputPtrs_;
+        }
+
+        [[nodiscard]] size_t *
+        getInputSizesPlace() const noexcept {
+            return inputSizes_;
+        }
+
+        [[nodiscard]] void **
+        getOutputPtrsPlace() const noexcept {
+            return outputPtrs_;
+        }
+
+        [[nodiscard]] size_t *
+        getOutputSizesPlace() const noexcept {
+            return outputSizes_;
+        }
+
+        [[nodiscard]] size_t *
+        getDecompressSizesPlace() const noexcept {
+            return decompressSizes_;
+        }
+
+        [[nodiscard]] nvcompStatus_t *
+        getStatusesPlace() const noexcept {
+            return statuses_;
+        }
+
+        [[nodiscard]] void *
+        getTempPtr() const noexcept {
+            return tempPtr_;
+        }
+
+        [[nodiscard]] size_t
+        getWorkspaceActualSize() const noexcept {
+            return workspaceActualSize_;
+        }
+
+    private:
+        template<typename T>
+        [[nodiscard]] T *
+        place(std::byte *&p) noexcept {
+            constexpr std::size_t align = alignof(T);
+
+            auto raw = reinterpret_cast<uintptr_t>(p);
+            auto aligned = alignUp(raw, align);
+
+            p = reinterpret_cast<std::byte *>(aligned);
+
+            T *out = reinterpret_cast<T *>(p);
+
+            p += sizeof(T) * nvcompNumChunks_;
+
+            return out;
+        }
+
+        size_t nvcompNumChunks_;
+        void **inputPtrs_ = nullptr;
+        void **outputPtrs_ = nullptr;
+        size_t *inputSizes_ = nullptr;
+        size_t *outputSizes_ = nullptr;
+        size_t *decompressSizes_ = nullptr;
+        nvcompStatus_t *statuses_ = nullptr;
+        void *tempPtr_ = nullptr;
+        size_t workspaceActualSize_ = 0;
+    };
+
+    size_t *
+    launchAnsCompress(const runtimeBuffer &src,
+                      const runtimeBuffer &dst,
+                      const runtimeBuffer &workspace,
+                      cudaStream_t stream) {
+
+        nvcompAlignmentRequirements_t alignment_requirements;
+        throwIfNvcomp(nvcompBatchedANSCompressGetRequiredAlignments(kANSCompressOpts,
+                                                                    &alignment_requirements),
+                      "launchAnsCompress: get required alignments");
+        if (!isAlignedTo(reinterpret_cast<uintptr_t>(src.data), alignment_requirements.input)) {
+            throw std::runtime_error(
+                "launchAnsCompress: input address is not aligned, the required alignment is " +
+                std::to_string(alignment_requirements.input) + " the actual alignment is " +
+                std::to_string(reinterpret_cast<uintptr_t>(src.data) &
+                               (alignment_requirements.input - 1)));
+        }
+        if (!isAlignedTo(reinterpret_cast<uintptr_t>(dst.data), alignment_requirements.output)) {
+            throw std::runtime_error(
+                "launchAnsCompress: output address is not aligned, the required alignment is " +
+                std::to_string(alignment_requirements.output) + " the actual alignment is " +
+                std::to_string(reinterpret_cast<uintptr_t>(dst.data) &
+                               (alignment_requirements.output - 1)));
+        }
+
+        // here we populate workspace appropriate pointers
+        size_t nvcomp_num_chunks = (src.size + nvcomp_chunk_size - 1) / nvcomp_chunk_size;
+        ansWorkspaceLayout workspace_layout(absl::Span<std::byte>(workspace.data, workspace.size),
+                                            alignment_requirements.temp,
+                                            nvcomp_num_chunks);
+        auto d_in_ptrs = workspace_layout.getInputPtrsPlace();
+        auto d_in_sizes = workspace_layout.getInputSizesPlace();
+        auto d_out_ptrs = workspace_layout.getOutputPtrsPlace();
+
+        std::vector<void *> h_in_ptrs(nvcomp_num_chunks);
+        std::vector<void *> h_out_ptrs(nvcomp_num_chunks);
+        std::vector<size_t> h_in_sizes(nvcomp_num_chunks, nvcomp_chunk_size);
+        size_t last_chunk_size = src.size - nvcomp_chunk_size * (nvcomp_num_chunks - 1);
+        h_in_sizes[nvcomp_num_chunks - 1] = last_chunk_size;
+        size_t chunk_stride = getNvcompChunkStride();
+
+        // TODO: optimize this, maybe cuda kernel directly to device
+        for (size_t i = 0; i < nvcomp_num_chunks; i++) {
+            h_in_ptrs[i] = reinterpret_cast<void *>(src.data + i * nvcomp_chunk_size);
+            h_out_ptrs[i] = reinterpret_cast<void *>(dst.data + i * chunk_stride);
+        }
+
+        throwIfCuda(cudaMemcpyAsync(d_in_ptrs,
+                                    h_in_ptrs.data(),
+                                    sizeof(void *) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsCompress: in_ptrs copy");
+        throwIfCuda(cudaMemcpyAsync(d_out_ptrs,
+                                    h_out_ptrs.data(),
+                                    sizeof(void *) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsCompress: out_ptrs copy");
+        throwIfCuda(cudaMemcpyAsync(d_in_sizes,
+                                    h_in_sizes.data(),
+                                    sizeof(size_t) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsCompress: in_sizes copy");
+
+        auto d_out_sizes = workspace_layout.getOutputSizesPlace();
+        auto temp_data = workspace_layout.getTempPtr();
+
+        throwIfNvcomp(
+            nvcompBatchedANSCompressAsync(
+                d_in_ptrs,
+                d_in_sizes,
+                nvcomp_chunk_size,
+                nvcomp_num_chunks,
+                temp_data,
+                workspace.size - workspace_layout.getWorkspaceActualSize(),
+                d_out_ptrs,
+                d_out_sizes,
+                kANSCompressOpts,
+                nullptr, // TODO: add to workspace, this is per chunk status array on the device
+                stream),
+            "launchAnsCompress: nvcompBatchedANSCompressAsync");
+
+        return d_out_sizes;
+    }
+
+    size_t *
+    launchAnsDecompress(const runtimeBuffer &src,
+                        const runtimeBuffer &dst,
+                        const runtimeBuffer &workspace,
+                        const std::vector<size_t> &segments_sizes,
+                        cudaStream_t stream) {
+
+        nvcompAlignmentRequirements_t alignment_requirements;
+        throwIfNvcomp(nvcompBatchedANSDecompressGetRequiredAlignments(kANSDecompressOpts,
+                                                                      &alignment_requirements),
+                      "launchAnsDecompress: get required alignments");
+
+        if (!isAlignedTo(reinterpret_cast<uintptr_t>(src.data), alignment_requirements.input)) {
+            throw std::runtime_error(
+                "launchAnsDecompress: input address is not aligned, the required alignment is " +
+                std::to_string(alignment_requirements.input) + " the actual alignment is " +
+                std::to_string(reinterpret_cast<uintptr_t>(src.data) &
+                               (alignment_requirements.input - 1)));
+        }
+        if (!isAlignedTo(reinterpret_cast<uintptr_t>(dst.data), alignment_requirements.output)) {
+            throw std::runtime_error(
+                "launchAnsDecompress: output address is not aligned, the required alignment is " +
+                std::to_string(alignment_requirements.output) + " the actual alignment is " +
+                std::to_string(reinterpret_cast<uintptr_t>(dst.data) &
+                               (alignment_requirements.output - 1)));
+        }
+        size_t nvcomp_num_chunks = segments_sizes.size();
+
+        // here we populate workspace appropriate pointers
+        ansWorkspaceLayout workspace_layout(absl::Span<std::byte>(workspace.data, workspace.size),
+                                            alignment_requirements.temp,
+                                            nvcomp_num_chunks);
+        auto d_in_ptrs = workspace_layout.getInputPtrsPlace();
+        auto d_in_sizes = workspace_layout.getInputSizesPlace();
+        auto d_out_ptrs = workspace_layout.getOutputPtrsPlace();
+        auto d_decompress_sizes = workspace_layout.getDecompressSizesPlace();
+        std::vector<void *> h_in_ptrs(nvcomp_num_chunks);
+        std::vector<void *> h_out_ptrs(nvcomp_num_chunks);
+        std::vector<size_t> h_decompress_sizes(nvcomp_num_chunks, nvcomp_chunk_size);
+        h_decompress_sizes[nvcomp_num_chunks - 1] =
+            dst.size - nvcomp_chunk_size * (nvcomp_num_chunks - 1); // last chunk size
+        size_t chunk_stride = getNvcompChunkStride();
+
+        for (size_t i = 0; i < nvcomp_num_chunks; i++) {
+            h_in_ptrs[i] = reinterpret_cast<void *>(src.data + i * chunk_stride);
+            h_out_ptrs[i] = reinterpret_cast<void *>(dst.data + i * nvcomp_chunk_size);
+        }
+
+        throwIfCuda(cudaMemcpyAsync(d_in_ptrs,
+                                    h_in_ptrs.data(),
+                                    sizeof(void *) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsDecompress: in_ptrs copy");
+        throwIfCuda(cudaMemcpyAsync(d_out_ptrs,
+                                    h_out_ptrs.data(),
+                                    sizeof(void *) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsDecompress: out_ptrs copy");
+        throwIfCuda(cudaMemcpyAsync(d_in_sizes,
+                                    segments_sizes.data(),
+                                    sizeof(size_t) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsDecompress: in_sizes copy");
+        throwIfCuda(cudaMemcpyAsync(d_decompress_sizes,
+                                    h_decompress_sizes.data(),
+                                    sizeof(size_t) * nvcomp_num_chunks,
+                                    cudaMemcpyHostToDevice,
+                                    stream),
+                    "launchAnsDecompress: decompress_sizes copy");
+
+
+        auto d_out_sizes = workspace_layout.getOutputSizesPlace();
+        auto d_statuses = workspace_layout.getStatusesPlace();
+        auto temp_data = workspace_layout.getTempPtr();
+
+        throwIfNvcomp(nvcompBatchedANSDecompressAsync(d_in_ptrs,
+                                                      d_in_sizes,
+                                                      d_decompress_sizes,
+                                                      d_out_sizes,
+                                                      nvcomp_num_chunks,
+                                                      temp_data,
+                                                      workspace.size -
+                                                          workspace_layout.getWorkspaceActualSize(),
+                                                      d_out_ptrs,
+                                                      kANSDecompressOpts,
+                                                      d_statuses,
+                                                      stream),
+                      "launchAnsDecompress: nvcompBatchedANSDecompressAsync");
+
+        return d_out_sizes;
+    }
+
+    void
+    submitDeltaKernel(const runtimeBuffer &src,
+                      const runtimeBuffer &dst,
+                      const runtimeBuffer &ref,
+                      size_t element_size,
+                      cudaStream_t stream) {
+        switch (element_size) {
+        case 1: {
+            throwIfCuda(cudaXorKernel<uint8_t>(dst.data, src.data, ref.data, src.size, stream),
+                        "delta submitDeltaKernel: cudaXorKernel failed");
+            break;
+        }
+        case 2: {
+            throwIfCuda(cudaXorKernel<uint16_t>(dst.data, src.data, ref.data, src.size, stream),
+                        "delta submitDeltaKernel: cudaXorKernel failed");
+            break;
+        }
+        case 4: {
+            throwIfCuda(cudaXorKernel<uint32_t>(dst.data, src.data, ref.data, src.size, stream),
+                        "delta submitDeltaKernel: cudaXorKernel failed");
+            break;
+        }
+        case 8: {
+            throwIfCuda(cudaXorKernel<uint64_t>(dst.data, src.data, ref.data, src.size, stream),
+                        "delta submitDeltaKernel: cudaXorKernel failed");
+            break;
+        }
+        default:
+            throw std::invalid_argument("delta submitDeltaKernel: unsupported element size");
+        }
+    }
+
+    void
+    validateProcessSlotArgs(const slotBuffers &buffers,
+                            const process_slot_input_options_t &opts,
+                            algo_t algo) {
+        if (buffers.src.size == 0 || buffers.dst.size == 0 ||
+            buffers.src.space != mem_space_t::DEVICE || buffers.dst.space != mem_space_t::DEVICE) {
+            throw std::runtime_error("validateProcessSlotArgs: invalid arguments");
+        }
+        auto ws_it = opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY);
+        if (ws_it == opts.end()) {
+            throw std::runtime_error(
+                "validateProcessSlotArgs: writeable workspace memory is required");
+        }
+        auto workspace_opt =
+            std::get_if<WriteableWorkspaceMemory::processSlotInput>(&ws_it->second);
+        if (!workspace_opt) {
+            throw std::runtime_error(
+                "validateProcessSlotArgs: writeable workspace memory is required");
+        }
+        if (workspace_opt->workspace.space != mem_space_t::DEVICE) {
+            throw std::runtime_error(
+                "validateProcessSlotArgs: writeable workspace memory is required");
+        }
+
+
+        auto stream_it = opts.find(option_t::USER_CUDA_STREAM);
+        if (stream_it == opts.end()) {
+            throw std::runtime_error("validateProcessSlotArgs: user cuda stream is required");
+        }
+
+        auto user_stream_opt = std::get_if<UserCudaStream::processSlotInput>(&stream_it->second);
+        if (!user_stream_opt || user_stream_opt->stream == nullptr) {
+            throw std::runtime_error("validateProcessSlotArgs: user cuda stream is required");
+        }
+
+        if (algo == algo_t::ANS_DELTA) {
+            auto ref_it = opts.find(option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY);
+            if (ref_it == opts.end()) {
+                throw std::runtime_error(
+                    "validateProcessSlotArgs: read only reference structured memory is required");
+            }
+            auto ref_opt =
+                std::get_if<ReadOnlyReferenceStructuredMemory::processSlotInput>(&ref_it->second);
+            if (!ref_opt || ref_opt->ref.space != mem_space_t::DEVICE) {
+                throw std::runtime_error(
+                    "validateProcessSlotArgs: read only reference structured memory is required");
+            }
+        }
+    }
+
+
+} // namespace
+
+class compressionInboundHandle final
+    : public asyncHandleImpl<compressionInboundHandle, inboundSlotCompletionData> {
+public:
+    explicit compressionInboundHandle(std::weak_ptr<backend> backend,
+                                      size_t nvcomp_num_chunks,
+                                      size_t *device_output_sizes,
+                                      cudaStream_t stream)
+        : asyncHandleImpl(std::move(backend)),
+          doneEvent_(stream),
+          nvcompNumChunks_(nvcomp_num_chunks),
+          deviceOutputSizes_(device_output_sizes),
+          finalSizes_(nvcomp_num_chunks) {}
+
+    std::optional<inboundSlotCompletionData>
+    checkForCompletionImpl() {
+        if (!doneEvent_.ready()) {
+            return std::nullopt;
+        }
+        throwIfCuda(cudaMemcpy(finalSizes_.data(),
+                               deviceOutputSizes_,
+                               sizeof(size_t) * nvcompNumChunks_,
+                               cudaMemcpyDeviceToHost),
+                    "CompressionInboundHandle: finalSizes copy");
+        size_t total_size = std::reduce(finalSizes_.begin(), finalSizes_.end(), std::size_t{0});
+
+        return inboundSlotCompletionData{total_size};
+    }
+
+private:
+    cudaEvent doneEvent_;
+    size_t nvcompNumChunks_;
+    size_t *deviceOutputSizes_;
+    std::vector<size_t> finalSizes_;
+};
+
+class compressionOutboundHandle final
+    : public asyncHandleImpl<compressionOutboundHandle, outboundSlotCompletionData> {
+public:
+    explicit compressionOutboundHandle(std::weak_ptr<backend> backend,
+                                       size_t nvcomp_num_chunks,
+                                       size_t *device_output_sizes,
+                                       cudaStream_t stream,
+                                       size_t original_payload_size)
+        : asyncHandleImpl(std::move(backend)),
+          doneEvent_(stream),
+          nvcompNumChunks_(nvcomp_num_chunks),
+          deviceOutputSizes_(device_output_sizes),
+          originalPayloadSize_(original_payload_size),
+          finalSizes_(nvcomp_num_chunks) {}
+
+    std::optional<outboundSlotCompletionData>
+    checkForCompletionImpl() {
+        if (!doneEvent_.ready()) {
+            return std::nullopt;
+        }
+        throwIfCuda(cudaMemcpy(finalSizes_.data(),
+                               deviceOutputSizes_,
+                               sizeof(size_t) * nvcompNumChunks_,
+                               cudaMemcpyDeviceToHost),
+                    "CompressionOutboundHandle: finalSizes copy");
+        const size_t chunk_stride = getNvcompChunkStride();
+
+        auto segments = std::make_shared<std::vector<ChunkDivision::segment>>(nvcompNumChunks_);
+        for (size_t i = 0; i < nvcompNumChunks_; ++i) {
+            (*segments)[i] = {i * chunk_stride, finalSizes_[i]};
+        }
+        outboundSlotCompletionData completion_data;
+        completion_data.size = marshal_derived_size;
+        completion_data.options.insert(ChunkDivision::processSlotOutput{std::move(segments)});
+        completion_data.metadata = marshalMetadata_;
+        return completion_data;
+    }
+
+private:
+    cudaEvent doneEvent_;
+    size_t nvcompNumChunks_;
+    size_t *deviceOutputSizes_;
+    size_t originalPayloadSize_;
+    std::vector<size_t> finalSizes_;
+    std::string marshalMetadata_ = "";
+};
+
+size_t
+compressionBackend::recommendServiceMemSize(size_t chunked_payload_size,
+                                            uint32_t max_concurrent_transfers,
+                                            algo_t algo) {
+    // TODO: tune per algo
+    return recommendAnsServiceMemSize(chunked_payload_size, max_concurrent_transfers, algo);
+}
+
+std::shared_ptr<compressionBackend>
+compressionBackend::createBackend(const nixlMarshalCompressConfig &cfg,
+                                  size_t chunked_payload_size) {
+    return std::make_shared<compressionBackend>(passkey{}, cfg, chunked_payload_size);
+}
+
+compressionBackend::compressionBackend(passkey,
+                                       const nixlMarshalCompressConfig &cfg,
+                                       size_t chunked_payload_size)
+    : backend(),
+      cfg_(cfg),
+      memoryRequirements_() {
+    switch (cfg_.algo) {
+    case algo_t::ANS_DELTA:
+        throw std::runtime_error("CompressionBackend: ans_delta not implemented");
+    case algo_t::ANS: {
+
+        auto [slotOverheadSize, workspaceSize] =
+            computeMarshalOverhead(chunked_payload_size, cfg_.algo);
+
+        memoryRequirements_.opts[option_t::WRITEABLE_WORKSPACE_MEMORY] =
+            WriteableWorkspaceMemory::memoryRequirements{workspaceSize};
+        memoryRequirements_.opts[option_t::SLOT_OVERHEAD] =
+            SlotOverhead::memoryRequirements{slotOverheadSize};
+        break;
+    }
+    case algo_t::BITCOMP:
+        throw std::runtime_error("CompressionBackend: bitcomp not supported");
+    default:
+        throw std::runtime_error("CompressionBackend: unsupported compression algo");
+    }
+}
+
+const std::vector<mem_space_t> &
+compressionBackend::getSupportedMemSpaces() const {
+    return kSupportedMemSpaces;
+}
+
+std::unique_ptr<inbound_async_handle_t>
+compressionBackend::inboundProcessSlot(const slotBuffers &buffers,
+                                       const std::string & /*metadata*/,
+                                       const process_slot_input_options_t &opts) {
+    validateProcessSlotArgs(buffers, opts, cfg_.algo);
+    // TODO: move it to args validation
+    const auto chunk_division_it = opts.find(option_t::CHUNK_DIVISION);
+    std::vector<size_t> chunk_sizes;
+    if (chunk_division_it == opts.end()) {
+        chunk_sizes.push_back(buffers.src.size);
+    } else {
+        const auto *chunk_division_value =
+            std::get_if<ChunkDivision::processSlotInput>(&chunk_division_it->second);
+        if (!chunk_division_value || !chunk_division_value->segments ||
+            chunk_division_value->segments->empty()) {
+            throw std::runtime_error(
+                "CompressionBackend inboundProcessSlot: invalid chunk division");
+        }
+        const auto &chunk_segments = *chunk_division_value->segments;
+        chunk_sizes.reserve(chunk_segments.size());
+        for (const auto &seg : chunk_segments) {
+            chunk_sizes.push_back(seg.size);
+        }
+    }
+    // Todo: switch cases based on Metadata
+
+
+    auto comp_stream =
+        std::get<UserCudaStream::processSlotInput>(opts.find(option_t::USER_CUDA_STREAM)->second)
+            .stream;
+
+    size_t *device_output_sizes;
+
+    auto workspace = std::get<WriteableWorkspaceMemory::processSlotInput>(
+                         opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY)->second)
+                         .workspace;
+
+    switch (cfg_.algo) {
+    case algo_t::ANS_DELTA: {
+        runtimeBuffer delta_staging_buffer(absl::Span<std::byte>(workspace.data, buffers.dst.size),
+                                           mem_space_t::DEVICE);
+        workspace.data += delta_staging_buffer.size;
+        workspace.size -= delta_staging_buffer.size;
+        auto ref_mem_opt = std::get<ReadOnlyReferenceStructuredMemory::processSlotInput>(
+            opts.find(option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY)->second);
+        device_output_sizes = launchAnsDecompress(
+            buffers.src, delta_staging_buffer, workspace, chunk_sizes, comp_stream);
+        submitDeltaKernel(delta_staging_buffer,
+                          buffers.dst,
+                          ref_mem_opt.ref,
+                          ref_mem_opt.elementSize,
+                          comp_stream);
+        break;
+    }
+    case algo_t::ANS: {
+        device_output_sizes =
+            launchAnsDecompress(buffers.src, buffers.dst, workspace, chunk_sizes, comp_stream);
+        break;
+    }
+    case algo_t::BITCOMP:
+        throw std::runtime_error("CompressionBackend: bitcomp not supported");
+    default:
+        throw std::runtime_error("CompressionBackend: unsupported compression algo");
+    }
+    return std::make_unique<compressionInboundHandle>(
+        shared_from_this(), chunk_sizes.size(), device_output_sizes, comp_stream);
+}
+
+std::unique_ptr<outbound_async_handle_t>
+compressionBackend::outboundProcessSlot(const slotBuffers &buffers,
+                                        const process_slot_input_options_t &opts) {
+    validateProcessSlotArgs(buffers, opts, cfg_.algo);
+    const size_t nvcomp_num_chunks = (buffers.src.size + nvcomp_chunk_size - 1) / nvcomp_chunk_size;
+    size_t *device_output_sizes;
+    auto comp_stream =
+        std::get<UserCudaStream::processSlotInput>(opts.find(option_t::USER_CUDA_STREAM)->second)
+            .stream;
+    auto workspace = std::get<WriteableWorkspaceMemory::processSlotInput>(
+                         opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY)->second)
+                         .workspace;
+    switch (cfg_.algo) {
+    case algo_t::ANS_DELTA: {
+        runtimeBuffer delta_staging_buffer(absl::Span<std::byte>(workspace.data, buffers.src.size),
+                                           mem_space_t::DEVICE);
+        workspace.data += delta_staging_buffer.size;
+        workspace.size -= delta_staging_buffer.size;
+        auto ref_mem_opt = std::get<ReadOnlyReferenceStructuredMemory::processSlotInput>(
+            opts.find(option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY)->second);
+        submitDeltaKernel(buffers.src,
+                          delta_staging_buffer,
+                          ref_mem_opt.ref,
+                          ref_mem_opt.elementSize,
+                          comp_stream);
+        device_output_sizes =
+            launchAnsCompress(delta_staging_buffer, buffers.dst, workspace, comp_stream);
+        break;
+    }
+    case algo_t::ANS: {
+        device_output_sizes = launchAnsCompress(buffers.src, buffers.dst, workspace, comp_stream);
+        break;
+    }
+    case algo_t::BITCOMP:
+        throw std::runtime_error("CompressionBackend: bitcomp not supported");
+    default:
+        throw std::runtime_error("CompressionBackend: unsupported compression algo");
+    }
+    return std::make_unique<compressionOutboundHandle>(
+        shared_from_this(), nvcomp_num_chunks, device_output_sizes, comp_stream, buffers.src.size);
+}
+
+memoryRequirements
+compressionBackend::getSlotMemoryRequirements() const noexcept {
+    return memoryRequirements_;
+}
+} // namespace nixlMarshal

--- a/src/services/marshal/compression/compression_backend.h
+++ b/src/services/marshal/compression/compression_backend.h
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef COMPRESSION_BACKEND_H
+#define COMPRESSION_BACKEND_H
+
+#include "marshal/marshal_backend.h"
+#include "nixl_service_types.h"
+
+#include <memory>
+#include <vector>
+#include <cuda_runtime.h>
+
+namespace nixlMarshal {
+
+class compressionBackend final : public backend {
+private:
+    struct passkey {
+        explicit passkey() = default;
+    };
+
+    nixlMarshalCompressConfig cfg_;
+    memoryRequirements memoryRequirements_;
+
+
+public:
+    static size_t
+    recommendServiceMemSize(size_t chunked_payload_size,
+                            uint32_t max_concurrent_transfers,
+                            nixl_marshal_compress_algo_t algo);
+
+    static std::shared_ptr<compressionBackend>
+    createBackend(const nixlMarshalCompressConfig &cfg, size_t chunked_payload_size);
+
+    explicit compressionBackend(passkey,
+                                const nixlMarshalCompressConfig &cfg,
+                                size_t chunked_payload_size);
+    ~compressionBackend() override = default;
+
+
+    compressionBackend(const compressionBackend &) = delete;
+    compressionBackend &
+    operator=(const compressionBackend &) = delete;
+    compressionBackend(compressionBackend &&) = delete;
+    compressionBackend &
+    operator=(compressionBackend &&) = delete;
+
+    const std::vector<mem_space_t> &
+    getSupportedMemSpaces() const override;
+
+    std::unique_ptr<inbound_async_handle_t>
+    inboundProcessSlot(const slotBuffers &buffers,
+                       const std::string &metadata,
+                       const process_slot_input_options_t &opts = {}) override;
+
+    std::unique_ptr<outbound_async_handle_t>
+    outboundProcessSlot(const slotBuffers &buffers,
+                        const process_slot_input_options_t &opts = {}) override;
+
+    memoryRequirements
+    getSlotMemoryRequirements() const noexcept override;
+};
+} // namespace nixlMarshal
+#endif // COMPRESSION_BACKEND_H

--- a/src/services/marshal/compression/delta_kernel.cu
+++ b/src/services/marshal/compression/delta_kernel.cu
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "delta_kernel.cuh"
+
+#include <cstdint>
+
+namespace nixlMarshal {
+
+constexpr int threads_per_block = 256;
+
+template<typename T>
+__global__ void
+xorKernel(T *dst, const T *src, const T *ref, size_t n_bytes) {
+    const size_t n_elems = n_bytes / sizeof(T);
+    const auto stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+    for (auto i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < n_elems;
+         i += stride) {
+        dst[i] = src[i] ^ ref[i];
+    }
+}
+
+template<typename T>
+cudaError_t
+cudaXorKernel(void *dst, const void *src, const void *ref, size_t n_bytes, cudaStream_t stream) {
+    if (n_bytes % sizeof(T) != 0) {
+        return cudaErrorInvalidValue;
+    }
+    const auto n_elems = n_bytes / sizeof(T);
+    // blocks = ceil(n_elems / threads_per_block)
+    const auto blocks = static_cast<int>((n_elems + threads_per_block - 1) / threads_per_block);
+    // reinterpret_cast is safe because the buffers are guaranteed to be of type T*
+    xorKernel<T><<<blocks, threads_per_block, 0, stream>>>(reinterpret_cast<T *>(dst),
+                                                           reinterpret_cast<const T *>(src),
+                                                           reinterpret_cast<const T *>(ref),
+                                                           n_bytes);
+    return cudaGetLastError();
+}
+
+// Explicit template instantiations for each supported element type
+template cudaError_t
+cudaXorKernel<uint8_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint16_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint32_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint64_t>(void *, const void *, const void *, size_t, cudaStream_t);
+
+} // namespace nixlMarshal

--- a/src/services/marshal/compression/delta_kernel.cuh
+++ b/src/services/marshal/compression/delta_kernel.cuh
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DELTA_KERNEL_CUH
+#define DELTA_KERNEL_CUH
+
+#include <cuda_runtime.h>
+
+namespace nixlMarshal {
+
+/**
+ * @brief  Element-wise XOR of two device buffers into a third, on a CUDA stream.
+ *
+ * @tparam T        Unsigned integer element type (uint8_t / uint16_t / uint32_t /
+ *                  uint64_t). Only these instantiations are provided.
+ * @param  dst      Device pointer to the destination buffer.
+ * @param  src      Device pointer to the source buffer.
+ * @param  ref      Device pointer to the reference buffer.
+ * @param  n_bytes  Size of each buffer in bytes. Must be a multiple of sizeof(T).
+ * @param  stream   CUDA stream on which to enqueue the kernel.
+ *
+ * @return cudaSuccess on a successful launch (the kernel is asynchronous).
+ *         cudaErrorInvalidValue if n_bytes is not a multiple of sizeof(T).
+ *         Any error returned by cudaGetLastError() after the launch otherwise.
+ */
+template<typename T>
+cudaError_t
+cudaXorKernel(void *dst, const void *src, const void *ref, size_t n_bytes, cudaStream_t stream);
+
+} // namespace nixlMarshal
+
+#endif // DELTA_KERNEL_CUH

--- a/src/services/marshal/compression/meson.build
+++ b/src/services/marshal/compression/meson.build
@@ -13,10 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+compression_inc = include_directories('.')
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+compression_lib = library('nixl_marshal_compression',
+    'compression_backend.cpp',
+    'delta_kernel.cu',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs, marshal_inc, compression_inc, nixl_service_inc],
+    dependencies: nixl_service_deps + [nvcomp_dep],
+    install: true)
+
+compression_dep = declare_dependency(
+    link_with: compression_lib,
+    include_directories: [marshal_inc, compression_inc, nixl_service_inc],
+    dependencies: nixl_service_deps + [nvcomp_dep])

--- a/src/services/marshal/delta/delta_backend.cpp
+++ b/src/services/marshal/delta/delta_backend.cpp
@@ -1,0 +1,203 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "delta_backend.h"
+#include "delta_kernel.cuh"
+#include "nixl.h"
+
+#include <algorithm>
+
+namespace nixlMarshal {
+namespace {
+
+    const std::vector<mem_space_t> kSupportedMemSpaces = {mem_space_t::DEVICE};
+
+    template<typename CompletionT>
+    class deltaEventHandle : public asyncHandleImpl<deltaEventHandle<CompletionT>, CompletionT> {
+    private:
+        cudaEvent_t event_;
+        size_t size_;
+
+    public:
+        deltaEventHandle(std::weak_ptr<backend> backend, cudaStream_t stream, size_t size)
+            : asyncHandleImpl<deltaEventHandle, CompletionT>(std::move(backend)),
+              size_(size) {
+            auto err = cudaEventCreateWithFlags(&event_, cudaEventDisableTiming);
+            if (err != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("DeltaEventHandle: cudaEventCreateWithFlags failed: ") +
+                    cudaGetErrorString(err));
+            }
+            err = cudaEventRecord(event_, stream);
+            if (err != cudaSuccess) {
+                cudaEventDestroy(event_);
+                event_ = nullptr;
+                throw std::runtime_error(std::string("DeltaEventHandle: cudaEventRecord failed: ") +
+                                         cudaGetErrorString(err));
+            }
+        }
+
+        ~deltaEventHandle() override {
+            cudaEventDestroy(event_);
+        }
+
+        std::optional<CompletionT>
+        checkForCompletionImpl() {
+            const auto err = cudaEventQuery(event_);
+            if (err == cudaSuccess) {
+                if constexpr (std::is_same_v<CompletionT, outboundSlotCompletionData>) {
+                    return CompletionT{size_};
+                }
+                if constexpr (std::is_same_v<CompletionT, inboundSlotCompletionData>) {
+                    return CompletionT{size_};
+                }
+                throw std::runtime_error("DeltaEventHandle: unsupported completion type");
+            }
+            if (err == cudaErrorNotReady) {
+                return std::nullopt;
+            }
+            throw std::runtime_error(std::string("DeltaEventHandle: cudaEventQuery failed: ") +
+                                     cudaGetErrorString(err));
+        }
+    };
+
+    struct assertedOpsVals {
+        ReadOnlyReferenceStructuredMemory::processSlotInput refMemOpts;
+        UserCudaStream::processSlotInput streamOpts;
+    };
+
+    assertedOpsVals
+    assertInputValidation(const slotBuffers &b, const process_slot_input_options_t &opts) {
+        const auto supported_end = std::end(kSupportedMemSpaces);
+        if (std::find(std::begin(kSupportedMemSpaces), supported_end, b.src.space) ==
+            supported_end) {
+            throw std::runtime_error("delta processSlot: unsupported source memory space");
+        }
+        if (std::find(std::begin(kSupportedMemSpaces), supported_end, b.dst.space) ==
+            supported_end) {
+            throw std::runtime_error("delta processSlot: unsupported destination memory space");
+        }
+
+        auto it = opts.find(option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY);
+        if (it == opts.end()) {
+            throw std::runtime_error("delta processSlot: delta backend requires a read only "
+                                     "reference structured memory option to be provided");
+        }
+
+        auto ref_mem_opts =
+            std::get_if<ReadOnlyReferenceStructuredMemory::processSlotInput>(&it->second);
+        if (!ref_mem_opts) {
+            throw std::runtime_error("delta processSlot: delta backend requires a ProcessSlotInput "
+                                     "for the reference buffer");
+        }
+        if (std::find(std::begin(kSupportedMemSpaces), supported_end, ref_mem_opts->ref.space) ==
+            supported_end) {
+            throw std::runtime_error("delta processSlot: unsupported reference memory space");
+        }
+
+        if (b.src.size != b.dst.size || b.src.size != ref_mem_opts->ref.size) {
+            throw std::runtime_error("delta processSlot: buffers' sizes don't match");
+        }
+        if (b.src.size == 0) {
+            throw std::runtime_error("delta processSlot: buffers' sizes must be greater than 0");
+        }
+        if ((b.src.size % ref_mem_opts->elementSize) != 0) {
+            throw std::runtime_error(
+                "delta processSlot: buffer size must be a multiple of element size");
+        }
+
+        it = opts.find(option_t::USER_CUDA_STREAM);
+        if (it == opts.end()) {
+            throw std::runtime_error(
+                "delta processSlot: delta kernel requires a CUDA stream option");
+        }
+
+        auto stream_opt = std::get_if<UserCudaStream::processSlotInput>(&it->second);
+        if (!stream_opt) {
+            throw std::runtime_error("delta processSlot: delta kernel requires a ProcessSlotInput "
+                                     "for the CUDA stream option");
+        }
+
+        return {*ref_mem_opts, *stream_opt};
+    }
+
+    void
+    submitDeltaKernel(const slotBuffers &b, const assertedOpsVals &opt_vals) {
+        const auto stream = opt_vals.streamOpts.stream;
+        const auto ref = opt_vals.refMemOpts.ref;
+
+        const auto err = [&] {
+            switch (opt_vals.refMemOpts.elementSize) {
+            case 1:
+                return cudaXorKernel<uint8_t>(b.dst.data, b.src.data, ref.data, b.src.size, stream);
+            case 2:
+                return cudaXorKernel<uint16_t>(
+                    b.dst.data, b.src.data, ref.data, b.src.size, stream);
+            case 4:
+                return cudaXorKernel<uint32_t>(
+                    b.dst.data, b.src.data, ref.data, b.src.size, stream);
+            case 8:
+                return cudaXorKernel<uint64_t>(
+                    b.dst.data, b.src.data, ref.data, b.src.size, stream);
+            default:
+                throw std::runtime_error("delta submitDeltaKernel: unsupported element size");
+            }
+        }();
+
+        if (err != cudaSuccess) {
+            throw std::runtime_error(
+                std::string("delta submitDeltaKernel: cudaXorKernel failed: ") +
+                cudaGetErrorString(err));
+        }
+    }
+
+} // namespace
+
+std::shared_ptr<deltaBackend>
+deltaBackend::createBackend(const nixlMarshalDeltaConfig &cfg) {
+    return std::make_shared<deltaBackend>(passkey{}, cfg);
+}
+
+const std::vector<mem_space_t> &
+deltaBackend::getSupportedMemSpaces() const {
+    return kSupportedMemSpaces;
+}
+
+std::unique_ptr<outbound_async_handle_t>
+deltaBackend::outboundProcessSlot(const slotBuffers &buffers,
+                                  const process_slot_input_options_t &opts) {
+    const auto opt_vals = assertInputValidation(buffers, opts);
+    submitDeltaKernel(buffers, opt_vals);
+    return std::make_unique<deltaEventHandle<outboundSlotCompletionData>>(
+        shared_from_this(), opt_vals.streamOpts.stream, buffers.src.size);
+}
+
+std::unique_ptr<inbound_async_handle_t>
+deltaBackend::inboundProcessSlot(const slotBuffers &buffers,
+                                 const std::string & /*metadata*/,
+                                 const process_slot_input_options_t &opts) {
+    const auto opt_vals = assertInputValidation(buffers, opts);
+    submitDeltaKernel(buffers, opt_vals);
+    return std::make_unique<deltaEventHandle<inboundSlotCompletionData>>(
+        shared_from_this(), opt_vals.streamOpts.stream, buffers.src.size);
+}
+
+memoryRequirements
+deltaBackend::getSlotMemoryRequirements() const noexcept {
+    return memoryRequirements{{}};
+}
+
+} // namespace nixlMarshal

--- a/src/services/marshal/delta/delta_backend.h
+++ b/src/services/marshal/delta/delta_backend.h
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DELTA_BACKEND_H
+#define DELTA_BACKEND_H
+
+#include "marshal_backend.h"
+#include "nixl_service_types.h"
+
+#include <limits>
+#include <stdexcept>
+
+namespace nixlMarshal {
+
+/**
+ * @class deltaBackend
+ * @brief Marshal backend that produces the differences between src and ref buffers
+ */
+class deltaBackend final : public backend {
+private:
+    const nixlMarshalDeltaConfig cfg_;
+
+    struct passkey {
+        explicit passkey() = default;
+    };
+
+public:
+    static std::shared_ptr<deltaBackend>
+    createBackend(const nixlMarshalDeltaConfig &cfg);
+
+    explicit deltaBackend(passkey, const nixlMarshalDeltaConfig &cfg) : backend(), cfg_(cfg) {
+        throw std::runtime_error("DeltaBackend: not implemented");
+    }
+
+    const std::vector<mem_space_t> &
+    getSupportedMemSpaces() const override;
+
+    std::unique_ptr<outbound_async_handle_t>
+    outboundProcessSlot(const slotBuffers &buffers,
+                        const process_slot_input_options_t &opts = {}) override;
+
+    std::unique_ptr<inbound_async_handle_t>
+    inboundProcessSlot(const slotBuffers &buffers,
+                       const std::string &metadata,
+                       const process_slot_input_options_t &opts = {}) override;
+
+    static constexpr size_t
+    recommendServiceMemSize(size_t chunked_payload_size, uint32_t max_concurrent_transfers) {
+        constexpr size_t slots = MarshalBackendSizing::slots_per_transfer;
+        if (chunked_payload_size > std::numeric_limits<size_t>::max() / slots) {
+            throw std::invalid_argument("chunkedPayloadSize too large");
+        }
+        const size_t per_transfer_size = chunked_payload_size * slots;
+        if (max_concurrent_transfers != 0 &&
+            per_transfer_size > std::numeric_limits<size_t>::max() / max_concurrent_transfers) {
+            throw std::invalid_argument("maxConcurrentTransfers too large");
+        }
+        return per_transfer_size * max_concurrent_transfers;
+    }
+
+    memoryRequirements
+    getSlotMemoryRequirements() const noexcept override;
+};
+
+} // namespace nixlMarshal
+
+#endif // DELTA_BACKEND_H

--- a/src/services/marshal/delta/delta_kernel.cu
+++ b/src/services/marshal/delta/delta_kernel.cu
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "delta_kernel.cuh"
+
+#include <cstdint>
+
+namespace nixlMarshal {
+
+constexpr int threads_per_block = 256;
+
+template<typename T>
+__global__ void
+xorKernel(T *dst, const T *src, const T *ref, size_t n_bytes) {
+    const size_t n_elems = n_bytes / sizeof(T);
+    const auto stride = static_cast<size_t>(blockDim.x) * gridDim.x;
+    for (auto i = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < n_elems;
+         i += stride) {
+        dst[i] = src[i] ^ ref[i];
+    }
+}
+
+template<typename T>
+cudaError_t
+cudaXorKernel(void *dst, const void *src, const void *ref, size_t n_bytes, cudaStream_t stream) {
+    if (n_bytes % sizeof(T) != 0) {
+        return cudaErrorInvalidValue;
+    }
+    const auto n_elems = n_bytes / sizeof(T);
+    const auto raw_blocks = (n_elems + threads_per_block - 1) / threads_per_block;
+    const auto blocks = static_cast<int>(std::min<size_t>(raw_blocks, INT_MAX));
+    // reinterpret_cast is safe because the buffers are guaranteed to be of type T*
+    xorKernel<T><<<blocks, threads_per_block, 0, stream>>>(reinterpret_cast<T *>(dst),
+                                                           reinterpret_cast<const T *>(src),
+                                                           reinterpret_cast<const T *>(ref),
+                                                           n_bytes);
+    return cudaGetLastError();
+}
+
+// Explicit template instantiations for each supported element type
+template cudaError_t
+cudaXorKernel<uint8_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint16_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint32_t>(void *, const void *, const void *, size_t, cudaStream_t);
+template cudaError_t
+cudaXorKernel<uint64_t>(void *, const void *, const void *, size_t, cudaStream_t);
+
+} // namespace nixlMarshal

--- a/src/services/marshal/delta/delta_kernel.cuh
+++ b/src/services/marshal/delta/delta_kernel.cuh
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DELTA_KERNEL_CUH
+#define DELTA_KERNEL_CUH
+
+#include <cuda_runtime.h>
+
+namespace nixlMarshal {
+
+/**
+ * @brief  Element-wise XOR of two device buffers into a third, on a CUDA stream.
+ *
+ * @tparam T        Unsigned integer element type (uint8_t / uint16_t / uint32_t /
+ *                  uint64_t). Only these instantiations are provided.
+ * @param  dst      Device pointer to the destination buffer.
+ * @param  src      Device pointer to the source buffer.
+ * @param  ref      Device pointer to the reference buffer.
+ * @param  n_bytes  Size of each buffer in bytes. Must be a multiple of sizeof(T).
+ * @param  stream   CUDA stream on which to enqueue the kernel.
+ *
+ * @return cudaSuccess on a successful launch (the kernel is asynchronous).
+ *         cudaErrorInvalidValue if n_bytes is not a multiple of sizeof(T).
+ *         Any error returned by cudaGetLastError() after the launch otherwise.
+ */
+template<typename T>
+cudaError_t
+cudaXorKernel(void *dst, const void *src, const void *ref, size_t n_bytes, cudaStream_t stream);
+
+} // namespace nixlMarshal
+
+#endif // DELTA_KERNEL_CUH

--- a/src/services/marshal/delta/meson.build
+++ b/src/services/marshal/delta/meson.build
@@ -13,10 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+delta_inc = include_directories('.')
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+delta_lib = library('nixl_marshal_delta',
+    'delta_backend.cpp',
+    'delta_kernel.cu',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs, marshal_inc, delta_inc, nixl_service_inc],
+    dependencies: nixl_service_deps,
+    install: true)
+
+delta_dep = declare_dependency(
+    link_with: delta_lib,
+    include_directories: [marshal_inc, delta_inc, nixl_service_inc],
+    dependencies: nixl_service_deps)

--- a/src/services/marshal/marshal_backend.h
+++ b/src/services/marshal/marshal_backend.h
@@ -1,0 +1,150 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MARSHAL_BACKEND_H
+#define MARSHAL_BACKEND_H
+
+#include "nixl_types.h"
+#include "nixl_descriptors.h"
+#include "absl/types/span.h"
+#include "marshal_types.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace nixlMarshal {
+
+class backend;
+
+/**
+ * @class asyncHandle
+ * @brief Type-erased polymorphic base for an in-flight slot operation, parameterized by the
+ *        completion-data type. Returned by backend::inbound/outboundProcessSlot.
+ */
+template<typename CompletionT> class asyncHandle {
+protected:
+    asyncHandle(std::weak_ptr<backend> backend) : backend_(std::move(backend)) {}
+
+    std::weak_ptr<backend> backend_;
+
+public:
+    virtual ~asyncHandle() = default;
+
+    /**
+     * @brief  Poll for completion of the operation.
+     * @return The completion data on success, std::nullopt while the operation is still pending.
+     * @throw  std::runtime_error if the backend fails while checking for completion.
+     */
+    virtual std::optional<CompletionT>
+    checkForCompletion() = 0;
+};
+
+/**
+ * @class asyncHandleImpl
+ * @brief CRTP layer that backends inherit from. Implements checkForCompletion() once as final and
+ *        statically forwards to Derived::checkForCompletionImpl(), so the per-backend polling logic
+ *        is resolved at compile time (no extra vtable lookup, fully inlinable).
+ */
+template<typename Derived, typename CompletionT>
+class asyncHandleImpl : public asyncHandle<CompletionT> {
+protected:
+    using asyncHandle<CompletionT>::asyncHandle;
+
+public:
+    std::optional<CompletionT>
+    checkForCompletion() final {
+        return static_cast<Derived *>(this)->checkForCompletionImpl();
+    }
+};
+
+using inbound_async_handle_t = asyncHandle<inboundSlotCompletionData>;
+using outbound_async_handle_t = asyncHandle<outboundSlotCompletionData>;
+
+/**
+ * @class backend
+ * @brief Abstract interface for the transformation layer of the marshal sub-service.
+ *
+ * @note The backend must provide a static createBackend function to force creation of a shared
+ * pointer.
+ * @note The backend can provide a sizing suggestion for the total buffer size per descriptor
+ * given the chunked payload size the service agent has picked (see
+ * recommendServiceMemSize in nixl_service.h).
+ */
+class backend : public std::enable_shared_from_this<backend> {
+protected:
+    backend() = default;
+
+public:
+    virtual ~backend() = default;
+
+    /**
+     * @brief  Returns the memory spaces supported by this backend.
+     *
+     * @return std::vector<mem_space_t> A vector (by reference) containing the
+     *         supported mem_space_t values for this backend.
+     */
+    virtual const std::vector<mem_space_t> &
+    getSupportedMemSpaces() const = 0;
+
+    /**
+     * @brief  Asynchronously drain a staging slot to destination descriptors (inbound).
+     *         Submits the GPU operation and returns immediately. The backend must consume or copy
+     *         `metadata` during the call (no retention guarantees).
+     *
+     * @param  buffers   Common per-slot buffers and stream.
+     * @param  metadata  Marshalling metadata received from the remote agent; used to unmarshall
+     *                   the slot data on the destination side.
+     * @param  opts      Optional process inputs. Inbound chunk division is provided as a vector
+     *                   of adjacent piece sizes via option_t::CHUNK_DIVISION.
+     * @return Inbound async handle for the operation.
+     * @throw  std::runtime_error if the backend fails to process the slot.
+     */
+    virtual std::unique_ptr<inbound_async_handle_t>
+    inboundProcessSlot(const slotBuffers &buffers,
+                       const std::string &metadata,
+                       const process_slot_input_options_t &opts = {}) = 0;
+
+    /**
+     * @brief  Asynchronously fill a staging slot from source descriptors (outbound).
+     *         Submits the GPU operation and returns immediately.
+     *
+     * @param  buffers Common per-slot buffers and stream.
+     * @return Outbound async handle for the operation; checkForCompletion yields
+     *         outboundSlotCompletionData (size/output options + metadata produced for the wire).
+     * @throw  std::runtime_error if the backend fails to process the slot.
+     */
+    virtual std::unique_ptr<outbound_async_handle_t>
+    outboundProcessSlot(const slotBuffers &buffers,
+                        const process_slot_input_options_t &opts = {}) = 0;
+
+    /**
+     *  @brief  Calculate the memory requirements for a single slot of the backend from
+     * configuration.
+     *  @note The chunked payload size is the size of the payload that will be transferred in a
+     * single operation. For inbound operations, the backend will not exceed this size in the
+     * destination descriptor. For outbound operations, the nixlServiceAgent will not exceed this
+     * size in the source descriptor.
+     *
+     *  @return memoryRequirements    The memory requirements for a single slot of the backend.
+     */
+    virtual memoryRequirements
+    getSlotMemoryRequirements() const = 0;
+};
+
+} // namespace nixlMarshal
+
+#endif // MARSHAL_BACKEND_H

--- a/src/services/marshal/marshal_types.h
+++ b/src/services/marshal/marshal_types.h
@@ -1,0 +1,190 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MARSHAL_TYPES_H
+#define MARSHAL_TYPES_H
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <variant>
+#include <vector>
+#include <cuda_runtime.h>
+
+#include "absl/types/span.h"
+
+namespace nixlMarshal {
+
+/**
+ * @enum mem_space_t
+ * @brief The memory space of the staging slot.
+ */
+enum class mem_space_t {
+    INVALID,
+    HOST,
+    DEVICE,
+};
+
+struct runtimeBuffer {
+    std::byte *data;
+    size_t size;
+    mem_space_t space;
+
+    runtimeBuffer(absl::Span<std::byte> span, mem_space_t sp)
+        : data(span.data()),
+          size(span.size()),
+          space(sp) {}
+
+    runtimeBuffer() : data(nullptr), size(0), space(mem_space_t::INVALID) {}
+};
+
+// Signals that the marshal layer derives the source size from chunk segments.
+constexpr size_t marshal_derived_size = 0xdeadbeef;
+
+struct inboundSlotCompletionData {
+    size_t size;
+};
+
+namespace ChunkDivision {
+
+    struct segment {
+        size_t offset;
+        size_t size;
+    };
+
+    inline std::shared_ptr<std::vector<segment>>
+    defaultSegments(size_t size) {
+        return std::make_shared<std::vector<segment>>(1, segment{0, size});
+    }
+
+    inline bool
+    isDefaultSizes(const std::vector<size_t> &sizes) noexcept {
+        return sizes.size() == 1;
+    }
+
+    struct processSlotInput {
+        std::shared_ptr<std::vector<segment>> segments;
+    };
+
+    struct processSlotOutput {
+        std::shared_ptr<std::vector<segment>> segments;
+    };
+
+} // namespace ChunkDivision
+
+using process_slot_output_option_t = std::variant<ChunkDivision::processSlotOutput>;
+
+struct processSlotOutputOptionHash {
+    size_t
+    operator()(const process_slot_output_option_t &option) const noexcept {
+        return std::hash<size_t>{}(option.index());
+    }
+};
+
+struct processSlotOutputOptionEqual {
+    bool
+    operator()(const process_slot_output_option_t &lhs,
+               const process_slot_output_option_t &rhs) const noexcept {
+        return lhs.index() == rhs.index();
+    }
+};
+
+using process_slot_output_options_t = std::unordered_set<process_slot_output_option_t,
+                                                         processSlotOutputOptionHash,
+                                                         processSlotOutputOptionEqual>;
+
+struct outboundSlotCompletionData {
+    size_t size;
+    process_slot_output_options_t options = {};
+    // Carried in the wire protocol and consumed by the inbound side to unmarshall.
+    std::string metadata = {};
+};
+
+// TODO-Eyal: remove enum and maps, change to set like process_slot_output_options_t.
+enum class option_t {
+    READ_ONLY_REFERENCE_STRUCTURED_MEMORY,
+    SLOT_OVERHEAD,
+    WRITEABLE_WORKSPACE_MEMORY,
+    USER_CUDA_STREAM,
+    CHUNK_DIVISION,
+};
+
+namespace ReadOnlyReferenceStructuredMemory {
+
+    struct processSlotInput {
+        runtimeBuffer ref;
+        size_t elementSize;
+    };
+
+} // namespace ReadOnlyReferenceStructuredMemory
+
+namespace SlotOverhead {
+
+    struct memoryRequirements {
+        size_t slotOverheadSize;
+    };
+
+} // namespace SlotOverhead
+
+namespace WriteableWorkspaceMemory {
+
+    struct memoryRequirements {
+        size_t slotWorkspaceSize;
+    };
+
+    struct processSlotInput {
+        runtimeBuffer workspace;
+    };
+
+} // namespace WriteableWorkspaceMemory
+
+namespace UserCudaStream {
+
+    struct processSlotInput {
+        cudaStream_t stream;
+    };
+
+} // namespace UserCudaStream
+
+using process_slot_input_value_t = std::variant<ReadOnlyReferenceStructuredMemory::processSlotInput,
+                                                WriteableWorkspaceMemory::processSlotInput,
+                                                UserCudaStream::processSlotInput,
+                                                ChunkDivision::processSlotInput>;
+using process_slot_input_options_t = std::unordered_map<option_t, process_slot_input_value_t>;
+
+using memory_requirement_value_t =
+    std::variant<SlotOverhead::memoryRequirements, WriteableWorkspaceMemory::memoryRequirements>;
+using memory_requirements_options_t = std::unordered_map<option_t, memory_requirement_value_t>;
+
+/**
+ * @struct memoryRequirements
+ * @brief  The backend's per-slot size requirements.
+ */
+struct memoryRequirements {
+    memory_requirements_options_t opts = {};
+};
+
+struct slotBuffers {
+    runtimeBuffer src;
+    runtimeBuffer dst;
+};
+
+} // namespace nixlMarshal
+
+#endif // MARSHAL_TYPES_H

--- a/src/services/marshal/meson.build
+++ b/src/services/marshal/meson.build
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+marshal_inc = include_directories('.')
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+subdir('staging')
+subdir('delta')
+
+if nvcomp_dep.found()
+    subdir('compression')
+endif

--- a/src/services/marshal/staging/meson.build
+++ b/src/services/marshal/staging/meson.build
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+staging_inc = include_directories('.')
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+staging_lib = library('nixl_marshal_staging',
+    'staging_backend.cpp',
+    include_directories: [nixl_inc_dirs, utils_inc_dirs, marshal_inc, staging_inc, nixl_service_inc],
+    dependencies: nixl_service_deps,
+    install: true)
+
+staging_dep = declare_dependency(
+    link_with: staging_lib,
+    include_directories: [marshal_inc, staging_inc, nixl_service_inc],
+    dependencies: nixl_service_deps)

--- a/src/services/marshal/staging/staging_backend.cpp
+++ b/src/services/marshal/staging/staging_backend.cpp
@@ -1,0 +1,197 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "staging_backend.h"
+#include "nixl.h"
+#include "nixl_log.h"
+
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <cuda_runtime.h>
+
+namespace nixlMarshal {
+namespace {
+
+    const std::vector<mem_space_t> kSupportedMemSpaces = {mem_space_t::DEVICE};
+
+    class cudaEvent {
+        cudaEvent_t event_ = nullptr;
+
+    public:
+        explicit cudaEvent(cudaStream_t stream) {
+            if (auto err = cudaEventCreateWithFlags(&event_, cudaEventDisableTiming);
+                err != cudaSuccess) {
+                throw std::runtime_error(std::string("staging: cudaEventCreate failed: ") +
+                                         cudaGetErrorString(err));
+            }
+            if (auto err = cudaEventRecord(event_, stream); err != cudaSuccess) {
+                cudaEventDestroy(event_);
+                event_ = nullptr;
+                throw std::runtime_error(std::string("staging: cudaEventRecord failed: ") +
+                                         cudaGetErrorString(err));
+            }
+        }
+
+        cudaEvent(const cudaEvent &) = delete;
+        cudaEvent &
+        operator=(const cudaEvent &) = delete;
+        cudaEvent(cudaEvent &&) = delete;
+        cudaEvent &
+        operator=(cudaEvent &&) = delete;
+
+        ~cudaEvent() {
+            if (event_) {
+                cudaEventDestroy(event_);
+            }
+        }
+
+        bool
+        ready() const {
+            const auto err = cudaEventQuery(event_);
+            if (err == cudaSuccess) {
+                return true;
+            }
+            if (err == cudaErrorNotReady) {
+                return false;
+            }
+            throw std::runtime_error(std::string("staging: cudaEventQuery failed: ") +
+                                     cudaGetErrorString(err));
+        }
+    };
+
+    class stagingInboundHandle final
+        : public asyncHandleImpl<stagingInboundHandle, inboundSlotCompletionData> {
+        cudaEvent ev_;
+        size_t size_;
+
+    public:
+        stagingInboundHandle(std::weak_ptr<backend> backend, size_t size, cudaStream_t stream)
+            : asyncHandleImpl(std::move(backend)),
+              ev_(stream),
+              size_(size) {}
+
+        std::optional<inboundSlotCompletionData>
+        checkForCompletionImpl() {
+            if (!ev_.ready()) {
+                return std::nullopt;
+            }
+            return inboundSlotCompletionData{size_};
+        }
+    };
+
+    class stagingOutboundHandle final
+        : public asyncHandleImpl<stagingOutboundHandle, outboundSlotCompletionData> {
+        cudaEvent ev_;
+        size_t size_;
+
+    public:
+        stagingOutboundHandle(std::weak_ptr<backend> backend, size_t size, cudaStream_t stream)
+            : asyncHandleImpl(std::move(backend)),
+              ev_(stream),
+              size_(size) {}
+
+        std::optional<outboundSlotCompletionData>
+        checkForCompletionImpl() {
+            if (!ev_.ready()) {
+                return std::nullopt;
+            }
+            // Staging produces no metadata; the wire layer treats empty as "no metadata".
+            return outboundSlotCompletionData{size_};
+        }
+    };
+
+    struct submittedCopy {
+        size_t payloadSize;
+        cudaStream_t stream;
+    };
+
+    submittedCopy
+    submitStagingCopy(const slotBuffers &b, const process_slot_input_options_t &opts) {
+        if (b.src.space != mem_space_t::DEVICE || b.dst.space != mem_space_t::DEVICE) {
+            throw std::runtime_error("staging processSlot: only device memory is supported");
+        }
+
+        auto it = opts.find(option_t::USER_CUDA_STREAM);
+        if (it == opts.end()) {
+            throw std::runtime_error("staging processSlot: VRAM staging requires a CUDA stream");
+        }
+
+        auto user_stream_opt = std::get_if<UserCudaStream::processSlotInput>(&it->second);
+        if (!user_stream_opt) {
+            throw std::runtime_error(
+                "staging processSlot: VRAM staging requires a valid CUDA stream option");
+        }
+
+        if (b.dst.size < b.src.size) {
+            throw std::runtime_error("staging processSlot: destination size smaller than source");
+        }
+
+        cudaStream_t stream = user_stream_opt->stream;
+
+        const auto err = cudaMemcpyAsync(reinterpret_cast<void *>(b.dst.data),
+                                         reinterpret_cast<const void *>(b.src.data),
+                                         b.src.size,
+                                         cudaMemcpyDefault,
+                                         stream);
+        if (err != cudaSuccess) {
+            throw std::runtime_error(std::string("staging processSlot: cudaMemcpyAsync failed: ") +
+                                     cudaGetErrorString(err));
+        }
+
+        return {b.src.size, stream};
+    }
+
+} // namespace
+
+std::shared_ptr<stagingBackend>
+stagingBackend::createBackend(const nixlMarshalStagingConfig &cfg) {
+    return std::make_shared<stagingBackend>(passkey{}, cfg);
+}
+
+stagingBackend::~stagingBackend() = default;
+
+const std::vector<mem_space_t> &
+stagingBackend::getSupportedMemSpaces() const {
+    return kSupportedMemSpaces;
+}
+
+std::unique_ptr<inbound_async_handle_t>
+stagingBackend::inboundProcessSlot(const slotBuffers &buffers,
+                                   const std::string & /*metadata*/,
+                                   const process_slot_input_options_t &opts) {
+    // Staging does not unmarshall, so the inbound metadata is ignored.
+    const auto s = submitStagingCopy(buffers, opts);
+    return std::make_unique<stagingInboundHandle>(
+        std::static_pointer_cast<stagingBackend>(shared_from_this()), s.payloadSize, s.stream);
+}
+
+std::unique_ptr<outbound_async_handle_t>
+stagingBackend::outboundProcessSlot(const slotBuffers &buffers,
+                                    const process_slot_input_options_t &opts) {
+    const auto s = submitStagingCopy(buffers, opts);
+    return std::make_unique<stagingOutboundHandle>(
+        std::static_pointer_cast<stagingBackend>(shared_from_this()), s.payloadSize, s.stream);
+}
+
+memoryRequirements
+stagingBackend::getSlotMemoryRequirements() const noexcept {
+    // The staging backend does not need any per-slot workspace or overhead,
+    // so chunkedPayloadSize is intentionally ignored.
+    return memoryRequirements{{}};
+}
+
+} // namespace nixlMarshal

--- a/src/services/marshal/staging/staging_backend.h
+++ b/src/services/marshal/staging/staging_backend.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef STAGING_BACKEND_H
+#define STAGING_BACKEND_H
+
+#include "marshal_backend.h"
+#include "nixl_service_types.h"
+
+namespace nixlMarshal {
+
+class stagingBackend final : public backend {
+private:
+    const nixlMarshalStagingConfig cfg_;
+
+    struct passkey {
+        explicit passkey() = default;
+    };
+
+public:
+    static std::shared_ptr<stagingBackend>
+    createBackend(const nixlMarshalStagingConfig &cfg);
+
+    static constexpr size_t
+    recommendServiceMemSize(size_t chunked_payload_size, uint32_t max_concurrent_transfers) {
+        return chunked_payload_size * MarshalBackendSizing::slots_per_transfer *
+            max_concurrent_transfers;
+    }
+
+    explicit stagingBackend(passkey, const nixlMarshalStagingConfig &cfg) : backend(), cfg_(cfg) {}
+
+    ~stagingBackend() override;
+
+    const std::vector<mem_space_t> &
+    getSupportedMemSpaces() const override;
+
+    std::unique_ptr<inbound_async_handle_t>
+    inboundProcessSlot(const slotBuffers &buffers,
+                       const std::string &metadata,
+                       const process_slot_input_options_t &opts = {}) override;
+
+    std::unique_ptr<outbound_async_handle_t>
+    outboundProcessSlot(const slotBuffers &buffers,
+                        const process_slot_input_options_t &opts = {}) override;
+
+    memoryRequirements
+    getSlotMemoryRequirements() const noexcept override;
+};
+
+} // namespace nixlMarshal
+
+#endif // STAGING_BACKEND_H

--- a/src/services/meson.build
+++ b/src/services/meson.build
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nixl_service_inc = include_directories('.')
+
+nixl_service_deps = [nixl_dep, nixl_infra, serdes_interface, nixl_common_dep, cuda_dep]
+
+subdir('marshal')
+
+# Exported so consumers (e.g. the _service_bindings Python extension) can
+# compile nixl_service.cpp directly into their own binary without depending
+# on libnixl_service.so at runtime.  files() gives an absolute-path handle
+# that meson accepts across subdir boundaries.
+nixl_service_sources = files('nixl_service.cpp')
+
+nixl_service_compile_args = []
+nixl_service_extra_deps = [staging_dep]
+nixl_service_extra_deps += [delta_dep]
+if nvcomp_dep.found()
+    nixl_service_compile_args += ['-DNIXL_HAVE_NVCOMP=1']
+    nixl_service_extra_deps += [compression_dep]
+endif
+
+nixl_service_lib = library('nixl_service',
+                           nixl_service_sources,
+                           cpp_args: nixl_service_compile_args,
+                           include_directories: [nixl_inc_dirs, utils_inc_dirs, nixl_service_inc],
+                           dependencies: nixl_service_deps + nixl_service_extra_deps,
+                           link_with: nixl_lib,
+                           install: true,
+                           install_rpath: join_paths(get_option('prefix'), get_option('libdir')))
+
+nixl_service_dep = declare_dependency(
+    link_with: nixl_service_lib,
+    include_directories: nixl_service_inc,
+    compile_args: nixl_service_compile_args,
+    dependencies: nixl_service_deps + nixl_service_extra_deps)
+
+if get_option('install_headers')
+    install_headers(
+        'nixl_service.h',
+        'nixl_service_types.h',
+        'marshal/marshal_backend.h',
+        subdir: 'nixl')
+endif

--- a/src/services/nixl_service.cpp
+++ b/src/services/nixl_service.cpp
@@ -1,0 +1,3308 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nixl_service.cpp
+ * @brief Initial scaffold for nixlServiceAgent.  All public methods are
+ *        currently unimplemented and return NIXL_ERR_NOT_SUPPORTED so the
+ *        surface links cleanly while the service implementation is built
+ *        up incrementally.
+ */
+#include "nixl_service.h"
+#include "nixl_service_types.h"
+#include "nixl_types.h"
+#include "marshal/marshal_backend.h"
+#include "marshal/staging/staging_backend.h"
+#include "marshal/delta/delta_backend.h"
+#ifdef NIXL_HAVE_NVCOMP
+#include "marshal/compression/compression_backend.h"
+#endif
+#include "nixl_service_data.h"
+#include "backend/backend_aux.h"
+#include "nixl_log.h"
+#include "serdes/serdes.h"
+#include "absl/cleanup/cleanup.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+using namespace nixlMarshal;
+
+namespace {
+
+constexpr size_t
+alignUp(size_t value, size_t alignment) noexcept {
+    return (value + alignment - 1) & ~(alignment - 1);
+}
+
+// Both peers of a transfer must agree on this (see marshalLayoutFingerprint), so the
+// service fixes it rather than exposing it through nixlServiceAgentConfig.
+constexpr size_t default_chunked_payload_size = 128UL * 1024 * 1024;
+
+constexpr char nixl_s_prefix[] = "_NIXLS_";
+constexpr char nixl_srts_prefix[] = "_NIXLS_RTS_";
+constexpr char nixl_scts_prefix[] = "_NIXLS_CTS_";
+constexpr char nixl_sposted_prefix[] = "_NIXLS_POSTED_";
+constexpr char nixl_srslot_prefix[] = "_NIXLS_RSLOT_";
+constexpr char nixl_sdelete_prefix[] = "_NIXLS_DELETE_";
+// READ protocol: the peer serves the transfer by pushing data back to the initiator.
+constexpr char nixl_srreq_prefix[] = "_NIXLS_RREQ_";
+constexpr char nixl_srposted_prefix[] = "_NIXLS_RPOSTED_";
+constexpr char nixl_srrslot_prefix[] = "_NIXLS_RRSLOT_";
+constexpr char nixl_srabort_prefix[] = "_NIXLS_RABORT_";
+constexpr char nixl_srabortack_prefix[] = "_NIXLS_RABACK_";
+constexpr char nixl_srnak_prefix[] = "_NIXLS_RNAK_";
+
+template<class... Ts> struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+template<typename T>
+void
+writeScalar(char *&cursor, const T &value) noexcept {
+    static_assert(std::is_trivially_copyable_v<T>);
+    std::memcpy(cursor, &value, sizeof(T));
+    cursor += sizeof(T);
+}
+
+void
+writeBytes(char *&cursor, const void *data, size_t size) noexcept {
+    if (size == 0) {
+        return;
+    }
+    std::memcpy(cursor, data, size);
+    cursor += size;
+}
+
+template<typename T>
+T
+readScalar(const char *&cursor, const char *end) noexcept {
+    static_assert(std::is_trivially_copyable_v<T>);
+    NIXL_ASSERT(cursor + sizeof(T) <= end);
+    T value{};
+    std::memcpy(&value, cursor, sizeof(T));
+    cursor += sizeof(T);
+    return value;
+}
+
+void
+readBytes(const char *&cursor, const char *end, void *data, size_t size) noexcept {
+    NIXL_ASSERT(cursor + size <= end);
+    if (size == 0) {
+        return;
+    }
+    std::memcpy(data, cursor, size);
+    cursor += size;
+}
+
+std::string
+readString(const char *&cursor, const char *end, size_t size) noexcept {
+    NIXL_ASSERT(cursor + size <= end);
+    std::string value(cursor, size);
+    cursor += size;
+    return value;
+}
+
+// Fixed-width byte size of a serialized marshalLayoutFingerprint: 3 uint32_t fields
+// (mode, algo, memType) plus 3 uint64_t fields (chunkedPayloadSize, chunkSize,
+// wireDataCapacity). No padding, since fields are written individually via writeScalar
+// rather than as a single struct-sized memcpy.
+constexpr size_t fingerprint_wire_size = 3 * sizeof(uint32_t) + 3 * sizeof(uint64_t);
+
+void
+writeFingerprint(char *&cursor, const marshalLayoutFingerprint &fingerprint) noexcept {
+    writeScalar(cursor, fingerprint.mode);
+    writeScalar(cursor, fingerprint.algo);
+    writeScalar(cursor, fingerprint.chunkedPayloadSize);
+    writeScalar(cursor, fingerprint.chunkSize);
+    writeScalar(cursor, fingerprint.wireDataCapacity);
+    writeScalar(cursor, fingerprint.memType);
+}
+
+// Bounds-checked: throws (rather than asserting) if fewer than fingerprint_wire_size bytes
+// remain between `cursor` and `end`, so a truncated/malformed message can be rejected
+// cleanly by the caller instead of crashing the process on untrusted remote input.
+marshalLayoutFingerprint
+readFingerprint(const char *&cursor, const char *end) {
+    if (static_cast<size_t>(end - cursor) < fingerprint_wire_size) {
+        throw std::runtime_error("readFingerprint: truncated buffer");
+    }
+    marshalLayoutFingerprint fingerprint;
+    fingerprint.mode = readScalar<uint32_t>(cursor, end);
+    fingerprint.algo = readScalar<uint32_t>(cursor, end);
+    fingerprint.chunkedPayloadSize = readScalar<uint64_t>(cursor, end);
+    fingerprint.chunkSize = readScalar<uint64_t>(cursor, end);
+    fingerprint.wireDataCapacity = readScalar<uint64_t>(cursor, end);
+    fingerprint.memType = readScalar<uint32_t>(cursor, end);
+    return fingerprint;
+}
+
+std::shared_ptr<std::vector<ChunkDivision::segment>>
+getOutboundSegments(const outboundSlotCompletionData &completion) {
+    if (completion.size != marshal_derived_size) {
+        return ChunkDivision::defaultSegments(completion.size);
+    }
+
+    const auto chunk_division_it =
+        std::find_if(completion.options.begin(), completion.options.end(), [](const auto &option) {
+            return std::holds_alternative<ChunkDivision::processSlotOutput>(option);
+        });
+    if (chunk_division_it == completion.options.end()) {
+        throw std::runtime_error("outbound completion missing chunk division output");
+    }
+
+    const auto &chunk_division = std::get<ChunkDivision::processSlotOutput>(*chunk_division_it);
+    if (!chunk_division.segments) {
+        throw std::runtime_error("outbound completion chunk division is null");
+    }
+    return chunk_division.segments;
+}
+
+/**
+ * @brief  Dummy backend used when no marshalling is requested. Both processSlot overrides throw
+ *         before constructing any asyncHandle, so no concrete handle subclass is needed here.
+ */
+class nixlMarshalBackendDirect final : public backend {
+private:
+    struct passkey {
+        explicit passkey() = default;
+    };
+
+public:
+    static std::shared_ptr<nixlMarshalBackendDirect>
+    createBackend() {
+        return std::make_shared<nixlMarshalBackendDirect>(passkey{});
+    }
+
+    explicit nixlMarshalBackendDirect(passkey) {}
+
+    const std::vector<mem_space_t> &
+    getSupportedMemSpaces() const override {
+        static const std::vector<mem_space_t> k_none = {};
+        return k_none;
+    }
+
+    std::unique_ptr<inbound_async_handle_t>
+    inboundProcessSlot(const slotBuffers & /*buffers*/,
+                       const std::string & /*metadata*/,
+                       const process_slot_input_options_t & /*opts*/) override {
+        throw std::runtime_error("Not implemented");
+    }
+
+    std::unique_ptr<outbound_async_handle_t>
+    outboundProcessSlot(const slotBuffers & /*buffers*/,
+                        const process_slot_input_options_t & /*opts*/) override {
+        throw std::runtime_error("Not implemented");
+    }
+
+    memoryRequirements
+    getSlotMemoryRequirements() const noexcept override {
+        return memoryRequirements{{}};
+    }
+};
+
+inline mem_space_t
+memSpaceFromNixlMem(nixl_mem_t mem) {
+    switch (mem) {
+    case VRAM_SEG:
+        return mem_space_t::DEVICE;
+    case DRAM_SEG:
+        return mem_space_t::HOST;
+    default:
+        throw std::runtime_error("Invalid memory type");
+    }
+}
+
+inline nixl_mem_t
+nixlMemFromMemSpace(nixlMarshal::mem_space_t mem_space) {
+    switch (mem_space) {
+    case nixlMarshal::mem_space_t::DEVICE:
+        return VRAM_SEG;
+    case nixlMarshal::mem_space_t::HOST:
+        return DRAM_SEG;
+    default:
+        throw std::runtime_error("Invalid memory space");
+    }
+}
+
+inline runtimeBuffer
+runtimeBufferFromDesc(const nixlBlobDesc &desc, nixl_mem_t mem) {
+    return runtimeBuffer(absl::Span<std::byte>(reinterpret_cast<std::byte *>(desc.addr), desc.len),
+                         memSpaceFromNixlMem(mem));
+}
+
+void
+addReferenceOption(process_slot_input_options_t &opts,
+                   std::byte *ref,
+                   size_t offset,
+                   size_t size,
+                   nixl_mem_t mem_type,
+                   size_t element_size) {
+    opts[option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY] =
+        ReadOnlyReferenceStructuredMemory::processSlotInput{
+            runtimeBuffer(absl::Span<std::byte>(ref + offset, size), memSpaceFromNixlMem(mem_type)),
+            element_size};
+}
+
+// True for a READ-serving request draining to quiescence (CANCELLING after an RABORT, or
+// DONE once every chunk is acked). The serve-side slot handlers must let any in-flight
+// async op finish, then mark the slot idle and drop it rather than re-queuing it - only
+// then does "every slot FREE" (checked at end-of-tick) safely imply the request can be
+// freed without a stale queue entry later dereferencing it.
+bool
+isTerminalReadServe(nixl_xfer_op_t op, nixl_service_xfer_state_t state) noexcept {
+    return op == NIXL_READ &&
+        (state == nixl_service_xfer_state_t::CANCELLING ||
+         state == nixl_service_xfer_state_t::DONE);
+}
+
+const nixlMarshalDeltaOptArgs *
+getDeltaOptArgs(const nixl_marshal_opt_args_t &marshal_opt_args) {
+    if (const auto *delta = std::get_if<nixlMarshalDeltaOptArgs>(&marshal_opt_args)) {
+        return delta;
+    }
+    if (const auto *compress = std::get_if<nixlMarshalCompressOptArgs>(&marshal_opt_args)) {
+        if (compress->delta.has_value()) {
+            return &compress->delta.value();
+        }
+    }
+    return nullptr;
+}
+
+std::shared_ptr<backend>
+makeMarshalBackend(const nixl_marshal_config_t &mode, size_t chunked_payload_size) {
+    return std::visit(overloaded{
+                          [](const nixlMarshalDirectConfig &) -> std::shared_ptr<backend> {
+                              return nixlMarshalBackendDirect::createBackend();
+                          },
+                          [](const nixlMarshalStagingConfig &cfg) -> std::shared_ptr<backend> {
+                              return stagingBackend::createBackend(cfg);
+                          },
+                          [](const nixlMarshalDeltaConfig &cfg) -> std::shared_ptr<backend> {
+                              return deltaBackend::createBackend(cfg);
+                          },
+#ifdef NIXL_HAVE_NVCOMP
+                          [chunked_payload_size](
+                              const nixlMarshalCompressConfig &cfg) -> std::shared_ptr<backend> {
+                              return compressionBackend::createBackend(cfg, chunked_payload_size);
+                          },
+#else
+                          [](const nixlMarshalCompressConfig &) -> std::shared_ptr<backend> {
+                              throw std::invalid_argument(
+                                  "Compression marshal backend requires nvCOMP support");
+                          },
+#endif
+                      },
+                      mode);
+}
+
+std::optional<nixl_marshal_opt_args_t>
+getValidMarshalOptArgs(const nixl_service_opt_args_t *extra_params,
+                       const nixl_marshal_config_t &mode) {
+    if (extra_params != nullptr && extra_params->marshalOptArgs.has_value()) {
+        const auto &marshal_opt_args = extra_params->marshalOptArgs.value();
+        if (!std::holds_alternative<nixlMarshalDirectOptArgs>(marshal_opt_args) &&
+            marshal_opt_args.index() != mode.index()) {
+            return std::nullopt;
+        }
+        return marshal_opt_args;
+    }
+
+    return std::visit(overloaded{
+                          [](const nixlMarshalDirectConfig &) -> nixl_marshal_opt_args_t {
+                              return nixlMarshalDirectOptArgs{};
+                          },
+                          [](const nixlMarshalStagingConfig &) -> nixl_marshal_opt_args_t {
+                              return nixlMarshalStagingOptArgs{};
+                          },
+                          [](const nixlMarshalDeltaConfig &) -> nixl_marshal_opt_args_t {
+                              return nixlMarshalDeltaOptArgs{};
+                          },
+                          [](const nixlMarshalCompressConfig &) -> nixl_marshal_opt_args_t {
+                              return nixlMarshalCompressOptArgs{};
+                          },
+                      },
+                      mode);
+}
+
+// Resolves the notification to carry on a READ receive context from `current` (the value
+// captured at an earlier create/post) and `extra_params`, mirroring the base nixlAgent's own
+// precedence (see nixl_agent.cpp's createXferReq/postXferReq): a present extra_params->notif
+// always wins; failing that, the legacy hasNotif/notifMsg pair; a null extra_params leaves
+// `current` untouched (so a bare postXferReq() after a createXferReq(..., extra_params) does
+// not drop the create-time notification); a non-null extra_params carrying neither clears it.
+std::optional<nixl_blob_t>
+resolveReadNotif(std::optional<nixl_blob_t> current, const nixl_opt_args_t *extra_params) {
+    if (extra_params == nullptr) {
+        return current;
+    }
+    if (extra_params->notif.has_value()) {
+        return extra_params->notif;
+    }
+    if (extra_params->hasNotif) {
+        return extra_params->notifMsg;
+    }
+    return std::nullopt;
+}
+
+auto
+makeSlotGroupCleanup(std::list<slotT> &slot_group) {
+    return absl::MakeCleanup([&slot_group]() {
+        while (!slot_group.empty()) {
+            const auto slot = slot_group.front();
+            slot_group.pop_front();
+            NIXL_ASSERT(slot.pool != nullptr);
+            slot.pool->freeSlot(slot);
+        }
+    });
+}
+
+std::array<slotWorkItem, slots_per_xfer>
+slotGroupToWorkItems(const std::list<slotT> &slot_group) {
+    NIXL_ASSERT(slot_group.size() == slots_per_xfer);
+    std::array<slotWorkItem, slots_per_xfer> slot_work_items;
+    size_t i = 0;
+    for (const auto &slot : slot_group) {
+        slot_work_items[i] = slotWorkItem{slot, i};
+        ++i;
+    }
+    return slot_work_items;
+}
+
+int
+countChunksAndVerifyMatch(const nixl_xfer_dlist_t &local_desc_list,
+                          const nixl_xfer_dlist_t &remote_desc_list,
+                          size_t chunk_size) {
+    auto desc_count = local_desc_list.descCount();
+    if (desc_count != remote_desc_list.descCount()) {
+        return -1;
+    }
+    size_t total_chunks = 0;
+    for (int i = 0; i < desc_count; ++i) {
+        auto desc_len = local_desc_list[i].len;
+        if (desc_len != remote_desc_list[i].len) {
+            return -1;
+        }
+        total_chunks += (desc_len + chunk_size - 1) / chunk_size;
+    }
+    return static_cast<int>(total_chunks);
+}
+
+// Resolves an absolute byte offset (relative to the start of dst_list) plus a size into a
+// single concrete address range, or returns std::nullopt if the range does not fall
+// entirely within one descriptor of dst_list. Used to validate a remotely-supplied offset
+// before it is ever dereferenced, rather than trusting a peer's descIndex/chunkIndex pair.
+std::optional<nixlBasicDesc>
+resolveAbsoluteOffset(const nixl_xfer_dlist_t &dst_list, size_t byte_offset, size_t size) {
+    size_t cumulative = 0;
+    for (int i = 0; i < dst_list.descCount(); ++i) {
+        const auto &desc = dst_list[i];
+        if (byte_offset < cumulative + desc.len) {
+            const size_t offset_in_desc = byte_offset - cumulative;
+            // Rearranged from "offset_in_desc + size > desc.len" so the (remotely-supplied,
+            // unvalidated) size is never added to anything: offset_in_desc < desc.len is
+            // already established above, so desc.len - offset_in_desc cannot underflow,
+            // whereas offset_in_desc + size could silently wrap around for a size close to
+            // SIZE_MAX and pass this check when it should not.
+            if (size > desc.len - offset_in_desc) {
+                return std::nullopt;
+            }
+            return nixlBasicDesc(desc.addr + offset_in_desc, size, desc.devId);
+        }
+        cumulative += desc.len;
+    }
+    return std::nullopt;
+}
+
+constexpr size_t direct_desc_threshold = 64 * 1024 * 1024;
+
+struct splitDescLists {
+    nixl_xfer_dlist_t directLocal;
+    nixl_xfer_dlist_t directRemote;
+    nixl_xfer_dlist_t marshalLocal;
+    nixl_xfer_dlist_t marshalRemote;
+    bool valid = true;
+
+    splitDescLists(nixl_mem_t local_type, nixl_mem_t remote_type)
+        : directLocal(local_type),
+          directRemote(remote_type),
+          marshalLocal(local_type),
+          marshalRemote(remote_type) {}
+};
+
+splitDescLists
+splitSmallDescPairs(const nixl_xfer_dlist_t &local_desc_list,
+                    const nixl_xfer_dlist_t &remote_desc_list) {
+    splitDescLists split(local_desc_list.getType(), remote_desc_list.getType());
+    const auto desc_count = local_desc_list.descCount();
+    if (desc_count != remote_desc_list.descCount() || desc_count == 0) {
+        split.valid = false;
+        return split;
+    }
+
+    for (int i = 0; i < desc_count; ++i) {
+        const auto desc_len = local_desc_list[i].len;
+        if (desc_len != remote_desc_list[i].len) {
+            split.valid = false;
+            return split;
+        }
+
+        if (desc_len <= direct_desc_threshold) {
+            split.directLocal.addDesc(local_desc_list[i]);
+            split.directRemote.addDesc(remote_desc_list[i]);
+        } else {
+            split.marshalLocal.addDesc(local_desc_list[i]);
+            split.marshalRemote.addDesc(remote_desc_list[i]);
+        }
+    }
+
+    return split;
+}
+
+template<typename PayloadT>
+void
+notifCallbackTemplate(const char *prefix,
+                      const std::string &sender_agent,
+                      const nixl_blob_t &notif,
+                      spscQueue<serviceNotifWorkItem, spsc_size> &service_notif_queue) {
+    NIXL_ASSERT(notif.rfind(prefix, 0) == 0);
+    // PayloadT's deserializing constructor throws on truncated/malformed input (e.g.
+    // readFingerprint()); this callback runs on the backend's own notification-delivery
+    // thread, so an uncaught exception here would escape across that boundary instead of
+    // just dropping one bad message.
+    std::optional<PayloadT> payload;
+    try {
+        payload.emplace(notif);
+    }
+    catch (const std::exception &e) {
+        NIXL_WARN << "nixlServiceAgentData: dropping malformed notification with prefix '" << prefix
+                  << "' from '" << sender_agent << "': " << e.what();
+        return;
+    }
+    if (!service_notif_queue.push(serviceNotifWorkItem{
+            sender_agent, std::make_shared<service_notif_payload_t>(std::move(*payload))})) {
+        // TODO-Eyal: handle error.
+        NIXL_ASSERT(false);
+    }
+}
+
+} // namespace
+
+nixl_blob_t
+serializeFingerprint(const marshalLayoutFingerprint &fingerprint) noexcept {
+    nixl_blob_t bytes(fingerprint_wire_size, '\0');
+    char *cursor = bytes.data();
+    writeFingerprint(cursor, fingerprint);
+    NIXL_ASSERT(cursor == bytes.data() + fingerprint_wire_size);
+    return bytes;
+}
+
+marshalLayoutFingerprint
+deserializeFingerprint(std::string_view bytes) {
+    const char *cursor = bytes.data();
+    const char *end = bytes.data() + bytes.size();
+    auto fingerprint = readFingerprint(cursor, end);
+    NIXL_ASSERT(cursor == end);
+    return fingerprint;
+}
+
+rtsNotifPayload::rtsNotifPayload(size_t xfer_id, const std::string &dst_list, size_t slot_size)
+    : xferId(xfer_id),
+      serializedDstList(dst_list),
+      slotSize(slot_size) {
+    NIXL_ASSERT(!serializedDstList.empty());
+    NIXL_ASSERT(slotSize > 0);
+}
+
+rtsNotifPayload::rtsNotifPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srts_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srts_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    slotSize = readScalar<size_t>(cursor, end);
+    const auto dst_list_size = readScalar<size_t>(cursor, end);
+    const auto has_delta = readScalar<bool>(cursor, end);
+    if (has_delta) {
+        const auto ref = reinterpret_cast<std::byte *>(readScalar<uintptr_t>(cursor, end));
+        const auto mem_type = readScalar<nixl_mem_t>(cursor, end);
+        const auto element_size = readScalar<size_t>(cursor, end);
+        deltaOptArgs = nixlMarshalDeltaReceiverRefArgs{ref, mem_type, element_size};
+    }
+    serializedDstList = readString(cursor, end, dst_list_size);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rtsNotifPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srts_prefix);
+    const auto has_delta = deltaOptArgs.has_value();
+    const auto serialized_dst_list_size = serializedDstList.size();
+    const auto delta_size = has_delta ?
+        sizeof(uintptr_t) + sizeof(deltaOptArgs->memType) + sizeof(deltaOptArgs->elementSize) :
+        0;
+    const auto base_fields_size =
+        sizeof(xferId) + sizeof(slotSize) + sizeof(serialized_dst_list_size) + sizeof(has_delta);
+    const auto total_size = prefix_len + base_fields_size + delta_size + serialized_dst_list_size;
+    nixl_blob_t rts_msg(total_size, '\0');
+    char *cursor = rts_msg.data();
+    writeBytes(cursor, nixl_srts_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, slotSize);
+    writeScalar(cursor, serialized_dst_list_size);
+    writeScalar(cursor, has_delta);
+    if (has_delta) {
+        const auto ref = reinterpret_cast<uintptr_t>(deltaOptArgs->ref);
+        writeScalar(cursor, ref);
+        writeScalar(cursor, deltaOptArgs->memType);
+        writeScalar(cursor, deltaOptArgs->elementSize);
+    }
+    writeBytes(cursor, serializedDstList.data(), serialized_dst_list_size);
+    NIXL_ASSERT(cursor == rts_msg.data() + total_size);
+    [[maybe_unused]] rtsNotifPayload deserialized(rts_msg);
+    NIXL_ASSERT(deserialized.xferId == xferId);
+    NIXL_ASSERT(deserialized.serializedDstList == serializedDstList);
+    NIXL_ASSERT(deserialized.slotSize == slotSize);
+    NIXL_ASSERT(deserialized.deltaOptArgs.has_value() == deltaOptArgs.has_value());
+    if (deltaOptArgs.has_value()) {
+        NIXL_ASSERT(deserialized.deltaOptArgs->ref == deltaOptArgs->ref);
+        NIXL_ASSERT(deserialized.deltaOptArgs->memType == deltaOptArgs->memType);
+        NIXL_ASSERT(deserialized.deltaOptArgs->elementSize == deltaOptArgs->elementSize);
+    }
+    return rts_msg;
+}
+
+ctsNotifPayload::ctsNotifPayload(
+    size_t xfer_id,
+    const std::array<nixlBasicDesc, slots_per_xfer> &receiver_slot_descriptors,
+    const std::array<nixlMarshal::mem_space_t, slots_per_xfer> &receiver_mem_spaces)
+    : xferId(xfer_id),
+      receiverSlotDescriptors(receiver_slot_descriptors),
+      receiverMemSpaces(receiver_mem_spaces) {}
+
+ctsNotifPayload::ctsNotifPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_scts_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_scts_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    readBytes(cursor, end, receiverSlotDescriptors.data(), sizeof(receiverSlotDescriptors));
+    readBytes(cursor, end, receiverMemSpaces.data(), sizeof(receiverMemSpaces));
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+ctsNotifPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_scts_prefix);
+    const auto total_size =
+        prefix_len + sizeof(xferId) + sizeof(receiverSlotDescriptors) + sizeof(receiverMemSpaces);
+    nixl_blob_t cts_msg(total_size, '\0');
+    char *cursor = cts_msg.data();
+    writeBytes(cursor, nixl_scts_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeBytes(cursor, receiverSlotDescriptors.data(), sizeof(receiverSlotDescriptors));
+    writeBytes(cursor, receiverMemSpaces.data(), sizeof(receiverMemSpaces));
+    NIXL_ASSERT(cursor == cts_msg.data() + total_size);
+    [[maybe_unused]] ctsNotifPayload deserialized(cts_msg);
+    NIXL_ASSERT(deserialized.xferId == xferId);
+    NIXL_ASSERT(deserialized.receiverSlotDescriptors == receiverSlotDescriptors);
+    NIXL_ASSERT(deserialized.receiverMemSpaces == receiverMemSpaces);
+    return cts_msg;
+}
+
+rslotNotifPayload::rslotNotifPayload(size_t xfer_id, size_t slot_index)
+    : xferId(xfer_id),
+      slotIndex(slot_index) {}
+
+rslotNotifPayload::rslotNotifPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srslot_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srslot_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    slotIndex = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rslotNotifPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srslot_prefix);
+    const auto total_size = prefix_len + sizeof(xferId) + sizeof(slotIndex);
+    nixl_blob_t rslot_msg(total_size, '\0');
+    char *cursor = rslot_msg.data();
+    writeBytes(cursor, nixl_srslot_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, slotIndex);
+    NIXL_ASSERT(cursor == rslot_msg.data() + total_size);
+    [[maybe_unused]] rslotNotifPayload deserialized(rslot_msg);
+    NIXL_ASSERT(deserialized.xferId == xferId);
+    NIXL_ASSERT(deserialized.slotIndex == slotIndex);
+    return rslot_msg;
+}
+
+deleteNotifPayload::deleteNotifPayload(size_t xfer_id) : xferId(xfer_id) {}
+
+deleteNotifPayload::deleteNotifPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_sdelete_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_sdelete_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+deleteNotifPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_sdelete_prefix);
+    const auto total_size = prefix_len + sizeof(xferId);
+    nixl_blob_t delete_msg(total_size, '\0');
+    char *cursor = delete_msg.data();
+    writeBytes(cursor, nixl_sdelete_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    NIXL_ASSERT(cursor == delete_msg.data() + total_size);
+    [[maybe_unused]] deleteNotifPayload deserialized(delete_msg);
+    NIXL_ASSERT(deserialized.xferId == xferId);
+    return delete_msg;
+}
+
+postedNotifPayload::postedNotifPayload(
+    size_t xfer_id,
+    size_t slot_index,
+    size_t original_size,
+    std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>> posted_segments,
+    size_t desc_index,
+    size_t chunk_index,
+    std::string md)
+    : xferId(xfer_id),
+      slotIndex(slot_index),
+      originalSize(original_size),
+      postedSegments(std::move(posted_segments)),
+      descIndex(desc_index),
+      chunkIndex(chunk_index),
+      metadata(std::move(md)) {}
+
+postedNotifPayload::postedNotifPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_sposted_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_sposted_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    slotIndex = readScalar<size_t>(cursor, end);
+    originalSize = readScalar<size_t>(cursor, end);
+    const auto posted_segment_count = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(posted_segment_count > 0);
+    postedSegments =
+        std::make_shared<std::vector<nixlMarshal::ChunkDivision::segment>>(posted_segment_count);
+    readBytes(
+        cursor, end, postedSegments->data(), postedSegments->size() * sizeof((*postedSegments)[0]));
+    descIndex = readScalar<size_t>(cursor, end);
+    chunkIndex = readScalar<size_t>(cursor, end);
+    const auto metadata_size = readScalar<size_t>(cursor, end);
+    metadata = readString(cursor, end, metadata_size);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+postedNotifPayload::serialize() const noexcept {
+    NIXL_ASSERT(postedSegments && !postedSegments->empty());
+    const auto prefix_len = std::char_traits<char>::length(nixl_sposted_prefix);
+    const auto posted_segment_count = postedSegments->size();
+    const auto metadata_size = metadata.size();
+    const auto segment_size = posted_segment_count * sizeof((*postedSegments)[0]);
+    const auto base_fields_size = sizeof(xferId) + sizeof(slotIndex) + sizeof(originalSize) +
+        sizeof(posted_segment_count) + sizeof(descIndex) + sizeof(chunkIndex) +
+        sizeof(metadata_size);
+    const auto total_size = prefix_len + base_fields_size + segment_size + metadata_size;
+    nixl_blob_t posted_msg(total_size, '\0');
+    char *cursor = posted_msg.data();
+    writeBytes(cursor, nixl_sposted_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, slotIndex);
+    writeScalar(cursor, originalSize);
+    writeScalar(cursor, posted_segment_count);
+    writeBytes(cursor, postedSegments->data(), segment_size);
+    writeScalar(cursor, descIndex);
+    writeScalar(cursor, chunkIndex);
+    writeScalar(cursor, metadata_size);
+    writeBytes(cursor, metadata.data(), metadata_size);
+    NIXL_ASSERT(cursor == posted_msg.data() + total_size);
+    [[maybe_unused]] postedNotifPayload deserialized(posted_msg);
+    NIXL_ASSERT(deserialized.xferId == xferId);
+    NIXL_ASSERT(deserialized.slotIndex == slotIndex);
+    NIXL_ASSERT(deserialized.originalSize == originalSize);
+    NIXL_ASSERT(deserialized.postedSegments->size() == postedSegments->size());
+    for (size_t i = 0; i < postedSegments->size(); ++i) {
+        NIXL_ASSERT((*deserialized.postedSegments)[i].offset == (*postedSegments)[i].offset);
+        NIXL_ASSERT((*deserialized.postedSegments)[i].size == (*postedSegments)[i].size);
+    }
+    NIXL_ASSERT(deserialized.descIndex == descIndex);
+    NIXL_ASSERT(deserialized.chunkIndex == chunkIndex);
+    NIXL_ASSERT(deserialized.metadata == metadata);
+    return posted_msg;
+}
+
+rReqPayload::rReqPayload(
+    size_t xfer_id,
+    const std::string &serialized_src_list,
+    const std::array<nixlBasicDesc, slots_per_xfer> &recv_slot_descriptors,
+    const std::array<nixlMarshal::mem_space_t, slots_per_xfer> &recv_mem_spaces,
+    const marshalLayoutFingerprint &fingerprint)
+    : xferId(xfer_id),
+      serializedSrcList(serialized_src_list),
+      recvSlotDescriptors(recv_slot_descriptors),
+      recvMemSpaces(recv_mem_spaces),
+      fingerprint(fingerprint) {
+    NIXL_ASSERT(!serializedSrcList.empty());
+}
+
+rReqPayload::rReqPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srreq_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srreq_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    readBytes(cursor, end, recvSlotDescriptors.data(), sizeof(recvSlotDescriptors));
+    readBytes(cursor, end, recvMemSpaces.data(), sizeof(recvMemSpaces));
+    fingerprint = readFingerprint(cursor, end);
+    const auto has_delta = readScalar<bool>(cursor, end);
+    if (has_delta) {
+        const auto ref = reinterpret_cast<std::byte *>(readScalar<uintptr_t>(cursor, end));
+        const auto mem_type = readScalar<nixl_mem_t>(cursor, end);
+        const auto element_size = readScalar<size_t>(cursor, end);
+        deltaOptArgs = nixlMarshalDeltaSenderRefArgs{ref, mem_type, element_size};
+    }
+    const auto src_list_size = readScalar<size_t>(cursor, end);
+    serializedSrcList = readString(cursor, end, src_list_size);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rReqPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srreq_prefix);
+    const auto has_delta = deltaOptArgs.has_value();
+    const auto src_list_size = serializedSrcList.size();
+    const auto delta_size = has_delta ?
+        sizeof(uintptr_t) + sizeof(deltaOptArgs->memType) + sizeof(deltaOptArgs->elementSize) :
+        0;
+    const auto base_fields_size = sizeof(xferId) + sizeof(recvSlotDescriptors) +
+        sizeof(recvMemSpaces) + fingerprint_wire_size + sizeof(has_delta) + sizeof(src_list_size);
+    const auto total_size = prefix_len + base_fields_size + delta_size + src_list_size;
+    nixl_blob_t rreq_msg(total_size, '\0');
+    char *cursor = rreq_msg.data();
+    writeBytes(cursor, nixl_srreq_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeBytes(cursor, recvSlotDescriptors.data(), sizeof(recvSlotDescriptors));
+    writeBytes(cursor, recvMemSpaces.data(), sizeof(recvMemSpaces));
+    writeFingerprint(cursor, fingerprint);
+    writeScalar(cursor, has_delta);
+    if (has_delta) {
+        const auto ref = reinterpret_cast<uintptr_t>(deltaOptArgs->ref);
+        writeScalar(cursor, ref);
+        writeScalar(cursor, deltaOptArgs->memType);
+        writeScalar(cursor, deltaOptArgs->elementSize);
+    }
+    writeScalar(cursor, src_list_size);
+    writeBytes(cursor, serializedSrcList.data(), src_list_size);
+    NIXL_ASSERT(cursor == rreq_msg.data() + total_size);
+    return rreq_msg;
+}
+
+rPostedPayload::rPostedPayload(
+    size_t xfer_id,
+    size_t slot_index,
+    size_t original_size,
+    std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>> posted_segments,
+    size_t dst_byte_offset,
+    std::string md)
+    : xferId(xfer_id),
+      slotIndex(slot_index),
+      originalSize(original_size),
+      postedSegments(std::move(posted_segments)),
+      dstByteOffset(dst_byte_offset),
+      metadata(std::move(md)) {}
+
+rPostedPayload::rPostedPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srposted_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srposted_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    slotIndex = readScalar<size_t>(cursor, end);
+    originalSize = readScalar<size_t>(cursor, end);
+    const auto posted_segment_count = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(posted_segment_count > 0);
+    postedSegments =
+        std::make_shared<std::vector<nixlMarshal::ChunkDivision::segment>>(posted_segment_count);
+    readBytes(
+        cursor, end, postedSegments->data(), postedSegments->size() * sizeof((*postedSegments)[0]));
+    dstByteOffset = readScalar<size_t>(cursor, end);
+    const auto metadata_size = readScalar<size_t>(cursor, end);
+    metadata = readString(cursor, end, metadata_size);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rPostedPayload::serialize() const noexcept {
+    NIXL_ASSERT(postedSegments && !postedSegments->empty());
+    const auto prefix_len = std::char_traits<char>::length(nixl_srposted_prefix);
+    const auto posted_segment_count = postedSegments->size();
+    const auto metadata_size = metadata.size();
+    const auto segment_size = posted_segment_count * sizeof((*postedSegments)[0]);
+    const auto base_fields_size = sizeof(xferId) + sizeof(slotIndex) + sizeof(originalSize) +
+        sizeof(posted_segment_count) + sizeof(dstByteOffset) + sizeof(metadata_size);
+    const auto total_size = prefix_len + base_fields_size + segment_size + metadata_size;
+    nixl_blob_t rposted_msg(total_size, '\0');
+    char *cursor = rposted_msg.data();
+    writeBytes(cursor, nixl_srposted_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, slotIndex);
+    writeScalar(cursor, originalSize);
+    writeScalar(cursor, posted_segment_count);
+    writeBytes(cursor, postedSegments->data(), segment_size);
+    writeScalar(cursor, dstByteOffset);
+    writeScalar(cursor, metadata_size);
+    writeBytes(cursor, metadata.data(), metadata_size);
+    NIXL_ASSERT(cursor == rposted_msg.data() + total_size);
+    return rposted_msg;
+}
+
+rrSlotPayload::rrSlotPayload(size_t xfer_id, size_t slot_index, uint64_t slot_generation)
+    : xferId(xfer_id),
+      slotIndex(slot_index),
+      slotGeneration(slot_generation) {}
+
+rrSlotPayload::rrSlotPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srrslot_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srrslot_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    slotIndex = readScalar<size_t>(cursor, end);
+    slotGeneration = readScalar<uint64_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rrSlotPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srrslot_prefix);
+    const auto total_size =
+        prefix_len + sizeof(xferId) + sizeof(slotIndex) + sizeof(slotGeneration);
+    nixl_blob_t rrslot_msg(total_size, '\0');
+    char *cursor = rrslot_msg.data();
+    writeBytes(cursor, nixl_srrslot_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, slotIndex);
+    writeScalar(cursor, slotGeneration);
+    NIXL_ASSERT(cursor == rrslot_msg.data() + total_size);
+    return rrslot_msg;
+}
+
+rAbortPayload::rAbortPayload(size_t xfer_id) : xferId(xfer_id) {}
+
+rAbortPayload::rAbortPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srabort_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srabort_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rAbortPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srabort_prefix);
+    const auto total_size = prefix_len + sizeof(xferId);
+    nixl_blob_t rabort_msg(total_size, '\0');
+    char *cursor = rabort_msg.data();
+    writeBytes(cursor, nixl_srabort_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    NIXL_ASSERT(cursor == rabort_msg.data() + total_size);
+    return rabort_msg;
+}
+
+rAbortAckPayload::rAbortAckPayload(size_t xfer_id) : xferId(xfer_id) {}
+
+rAbortAckPayload::rAbortAckPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srabortack_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srabortack_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rAbortAckPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srabortack_prefix);
+    const auto total_size = prefix_len + sizeof(xferId);
+    nixl_blob_t raback_msg(total_size, '\0');
+    char *cursor = raback_msg.data();
+    writeBytes(cursor, nixl_srabortack_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    NIXL_ASSERT(cursor == raback_msg.data() + total_size);
+    return raback_msg;
+}
+
+rNakPayload::rNakPayload(size_t xfer_id, int32_t error_code)
+    : xferId(xfer_id),
+      errorCode(error_code) {}
+
+rNakPayload::rNakPayload(std::string_view notif) {
+    NIXL_ASSERT(notif.rfind(nixl_srnak_prefix, 0) == 0);
+    const auto prefix_len = std::char_traits<char>::length(nixl_srnak_prefix);
+    const char *cursor = notif.data() + prefix_len;
+    const char *end = notif.data() + notif.size();
+    xferId = readScalar<size_t>(cursor, end);
+    errorCode = readScalar<int32_t>(cursor, end);
+    NIXL_ASSERT(cursor == end);
+}
+
+nixl_blob_t
+rNakPayload::serialize() const noexcept {
+    const auto prefix_len = std::char_traits<char>::length(nixl_srnak_prefix);
+    const auto total_size = prefix_len + sizeof(xferId) + sizeof(errorCode);
+    nixl_blob_t rnak_msg(total_size, '\0');
+    char *cursor = rnak_msg.data();
+    writeBytes(cursor, nixl_srnak_prefix, prefix_len);
+    writeScalar(cursor, xferId);
+    writeScalar(cursor, errorCode);
+    NIXL_ASSERT(cursor == rnak_msg.data() + total_size);
+    return rnak_msg;
+}
+
+slotT::slotT(slotPool *slot_pool,
+             uintptr_t base_addr,
+             size_t slot_size,
+             cudaStream_t stream,
+             nixl_mem_t type,
+             size_t chunk_size,
+             std::optional<size_t> workspace_size)
+    : pool(slot_pool),
+      baseAddr(base_addr),
+      slotSize(slot_size),
+      workspaceSize(workspace_size),
+      chunkSize(chunk_size),
+      stream(stream),
+      type(type) {
+    cudaGetDevice(&deviceId_);
+}
+
+nixlBasicDesc
+slotT::toDesc(size_t len) const noexcept {
+    NIXL_ASSERT(len <= slotSize);
+    return nixlBasicDesc(baseAddr, len, deviceId_);
+}
+
+runtimeBuffer
+slotT::toRuntimeBuffer() const {
+    const size_t workspace_size = workspaceSize.value_or(0);
+    return runtimeBuffer(
+        absl::Span<std::byte>(reinterpret_cast<std::byte *>(baseAddr), slotSize - workspace_size),
+        memSpaceFromNixlMem(type));
+}
+
+nixlMarshal::process_slot_input_options_t
+slotT::getProcessSlotInputOptions() const {
+    nixlMarshal::process_slot_input_options_t options;
+    options[nixlMarshal::option_t::USER_CUDA_STREAM] =
+        nixlMarshal::UserCudaStream::processSlotInput{stream};
+    const size_t workspace_size = workspaceSize.value_or(0);
+    if (workspace_size) {
+        options[nixlMarshal::option_t::WRITEABLE_WORKSPACE_MEMORY] =
+            nixlMarshal::WriteableWorkspaceMemory::processSlotInput{
+                runtimeBuffer(absl::Span<std::byte>(reinterpret_cast<std::byte *>(
+                                                        baseAddr + slotSize - workspace_size),
+                                                    workspace_size),
+                              memSpaceFromNixlMem(type))};
+    }
+    return options;
+}
+
+slotWorkItem::slotWorkItem(slotT slot, size_t slot_index) : slot(slot), slotIndex(slot_index) {}
+
+slotPool::slotPool(uintptr_t base_addr,
+                   size_t slot_size,
+                   size_t num_slots,
+                   size_t chunk_size,
+                   nixl_mem_t type,
+                   std::optional<size_t> workspace_size)
+    : baseAddr_(base_addr),
+      slotSize_(slot_size),
+      numSlots_(num_slots),
+      chunkSize_(chunk_size),
+      workspaceSize_(workspace_size),
+      type_(type) {
+    // TODO-Eyal: replace this assertion with something more friendly. It's for nvComp.
+    NIXL_ASSERT(base_addr % 8 == 0);
+    NIXL_ASSERT(slot_size % 8 == 0);
+    streams_.reserve(num_slots);
+    freeList_.reserve(num_slots);
+    for (size_t i = 0; i < num_slots; ++i) {
+        streams_.emplace_back();
+        freeList_.push_back(slotT{this,
+                                  baseAddr_ + static_cast<uintptr_t>(i) * slot_size,
+                                  slotSize_,
+                                  streams_.back().get(),
+                                  type_,
+                                  chunkSize_,
+                                  workspaceSize_});
+    }
+}
+
+std::optional<slotT>
+slotPool::allocateSlot() noexcept {
+    if (freeList_.empty()) {
+        return std::nullopt;
+    }
+    slotT item = freeList_.back();
+    freeList_.pop_back();
+    return item;
+}
+
+void
+slotPool::freeSlot(slotT work_item) noexcept {
+    freeList_.push_back(work_item);
+}
+
+size_t
+slotPool::getNumSlots() const noexcept {
+    return numSlots_;
+}
+
+size_t
+slotPool::getSlotSize() const noexcept {
+    return slotSize_;
+}
+
+size_t
+slotPool::getChunkSize() const noexcept {
+    return chunkSize_;
+}
+
+uintptr_t
+slotPool::getBaseAddr() const noexcept {
+    return baseAddr_;
+}
+
+nixl_mem_t
+slotPool::getType() const noexcept {
+    return type_;
+}
+
+nixlServiceXferReqH::nixlServiceXferReqH(
+    const nixl_xfer_dlist_t &src_desc_list,
+    const std::string &serialized_dst_desc_list,
+    const std::string &remote_agent,
+    const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+    size_t xfer_id,
+    size_t total_chunks,
+    const nixl_marshal_opt_args_t &marshal_opt_args)
+    : xferReq(nullptr),
+      nonDirectData(nonDirectDataH{
+          remote_agent,
+          serialized_dst_desc_list,
+          xfer_id,
+          nixl_service_xfer_state_t::PRE_START,
+          chunkIteratorH(src_desc_list, local_slots[0].slot.chunkSize, total_chunks),
+          local_slots,
+          std::array<std::unique_ptr<outbound_async_handle_t>, slots_per_xfer>{},
+          nixlServiceAgent::trackCompressionRatio ? std::make_unique<compressionStats>() : nullptr,
+          std::array<nixlBasicDesc, slots_per_xfer>{},
+          std::array<nixlMarshal::mem_space_t, slots_per_xfer>{},
+          std::array{remote_slot_state_t::NOT_ALLOCATED, remote_slot_state_t::NOT_ALLOCATED},
+          std::array<nixlXferReqH *, slots_per_xfer>{}}),
+      marshalOptArgs(marshal_opt_args) {}
+
+inboundXferReqH::inboundXferReqH(const std::string &remote_agent,
+                                 nixl_xfer_dlist_t &&dst_list,
+                                 const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+                                 size_t xfer_id,
+                                 std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref)
+    : remoteAgent(remote_agent),
+      dstList(std::move(dst_list)),
+      xferId(xfer_id),
+      state(nixl_service_xfer_state_t::IN_PROGRESS),
+      localSlots(local_slots),
+      receiverDeltaRef(receiver_delta_ref) {}
+
+inboundXferReqH::inboundXferReqH(const std::string &remote_agent,
+                                 nixl_xfer_dlist_t &&dst_list,
+                                 const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+                                 size_t xfer_id,
+                                 size_t total_chunks,
+                                 std::string serialized_src_list,
+                                 nixlXferReqH *direct_child,
+                                 std::optional<nixl_blob_t> notif,
+                                 std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref)
+    : remoteAgent(remote_agent),
+      dstList(std::move(dst_list)),
+      xferId(xfer_id),
+      state(nixl_service_xfer_state_t::PRE_START),
+      localSlots(local_slots),
+      receiverDeltaRef(receiver_delta_ref),
+      serializedSrcList(std::move(serialized_src_list)),
+      totalChunks(total_chunks),
+      notif(std::move(notif)),
+      userInitiated(true),
+      directChild(direct_child),
+      directDone(direct_child == nullptr),
+      marshalDone(false) {}
+
+nixlServiceAgentData::nixlServiceAgentData(const nixl_marshal_config_t &mode,
+                                           size_t chunked_payload_size)
+    : mode_(mode),
+      chunkedPayloadSize_(chunked_payload_size),
+      backend_(makeMarshalBackend(mode_, chunkedPayloadSize_)),
+      nextOutboundXferId_(0) {
+    // Direct mode stages nothing, so it has no per-slot requirements to query.
+    if (!std::holds_alternative<nixlMarshalDirectConfig>(mode_)) {
+        marshalSlotMemoryRequirements_ = backend_->getSlotMemoryRequirements();
+    }
+}
+
+marshalLayoutFingerprint
+makeFingerprint(const nixlServiceAgentData &data, const slotPool &pool) {
+    marshalLayoutFingerprint fingerprint;
+    fingerprint.mode = static_cast<uint32_t>(data.mode_.index());
+    if (const auto *compress_cfg = std::get_if<nixlMarshalCompressConfig>(&data.mode_)) {
+        fingerprint.algo = static_cast<uint32_t>(compress_cfg->algo);
+    }
+    fingerprint.chunkedPayloadSize =
+        std::holds_alternative<nixlMarshalDirectConfig>(data.mode_) ? 0 : data.chunkedPayloadSize_;
+    fingerprint.chunkSize = pool.getChunkSize();
+    fingerprint.memType = static_cast<uint32_t>(pool.getType());
+
+    size_t slot_workspace_size = 0;
+    const auto it_workspace =
+        data.marshalSlotMemoryRequirements_.opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY);
+    if (it_workspace != data.marshalSlotMemoryRequirements_.opts.end()) {
+        if (const auto *ws_req =
+                std::get_if<WriteableWorkspaceMemory::memoryRequirements>(&it_workspace->second)) {
+            slot_workspace_size = ws_req->slotWorkspaceSize;
+        }
+    }
+    NIXL_ASSERT(pool.getSlotSize() >= slot_workspace_size);
+    fingerprint.wireDataCapacity = pool.getSlotSize() - slot_workspace_size;
+    return fingerprint;
+}
+
+nixl_status_t
+nixlServiceAgentData::progressService() {
+    std::queue<activeSlotWorkItem> processed_queue;
+    std::unordered_map<std::string, std::set<size_t>> deleted_reqs;
+    for (auto notif_item = serviceNotifQueue_.tryPop(); notif_item.has_value();
+         notif_item = serviceNotifQueue_.tryPop()) {
+        const auto &item = notif_item.value();
+        NIXL_ASSERT(item.payload != nullptr);
+        std::visit(
+            overloaded{[&](const rtsNotifPayload &p) { handleRTS(item.senderAgent, p); },
+                       [&](const ctsNotifPayload &p) { handleCTS(item.senderAgent, p); },
+                       [&](const postedNotifPayload &p) { handlePosted(item.senderAgent, p); },
+                       [&](const rslotNotifPayload &p) { handleRSlot(item.senderAgent, p); },
+                       [&](const deleteNotifPayload &p) {
+                           handleDelete(item.senderAgent, p, deleted_reqs);
+                           NIXL_ASSERT(deleted_reqs.count(item.senderAgent) == 1);
+                           NIXL_ASSERT(deleted_reqs[item.senderAgent].size() >= 1);
+                       },
+                       [&](const rReqPayload &p) { handleRREQ(item.senderAgent, p); },
+                       [&](const rPostedPayload &p) { handleRPosted(item.senderAgent, p); },
+                       [&](const rrSlotPayload &p) { handleRRSlot(item.senderAgent, p); },
+                       [&](const rAbortPayload &p) { handleRAbort(item.senderAgent, p); },
+                       [&](const rAbortAckPayload &p) { handleRAbortAck(item.senderAgent, p); },
+                       [&](const rNakPayload &p) { handleRNak(item.senderAgent, p); }},
+            *item.payload);
+    }
+    while (!activeSlotQueue_.empty()) {
+        auto &work_item = activeSlotQueue_.front();
+        std::visit(overloaded{[&](std::reference_wrapper<nixlServiceXferReqH>) {
+                                  switch (work_item.slot.get().state) {
+                                  case local_slot_state_t::FREE:
+                                      fillLocalSlot(work_item, processed_queue);
+                                      break;
+                                  case local_slot_state_t::BUSY_MARSHAL:
+                                      pollOutboundSlotCompletion(work_item, processed_queue);
+                                      break;
+                                  case local_slot_state_t::READY_TO_SEND:
+                                      trySend(work_item, processed_queue);
+                                      break;
+                                  case local_slot_state_t::BUSY_NIXL:
+                                      pollNixlXferCompletion(work_item, processed_queue);
+                                      break;
+                                  }
+                              },
+                              [&](std::reference_wrapper<inboundXferReqH>) {
+                                  NIXL_ASSERT(work_item.slot.get().state ==
+                                              local_slot_state_t::BUSY_MARSHAL);
+                                  pollInboundSlotCompletion(work_item, processed_queue);
+                              }},
+                   work_item.req);
+        activeSlotQueue_.pop();
+    }
+
+    for (const auto &[sender_agent, xfer_ids] : deleted_reqs) {
+        auto sender_it = inboundXferReqs_.find(sender_agent);
+        if (sender_it == inboundXferReqs_.end()) {
+            continue;
+        }
+        auto &sender_reqs = sender_it->second;
+        for (size_t xfer_id : xfer_ids) {
+            auto req_it = sender_reqs.find(xfer_id);
+            if (req_it == sender_reqs.end()) {
+                continue;
+            }
+            freeSlotGroup(req_it->second->localSlots);
+            sender_reqs.erase(req_it);
+        }
+    }
+
+    // Cleanup for READ serves that finished normally (handleRRSlot, state == DONE) or are
+    // draining after an RABORT (handleRAbort, state == CANCELLING): neither "every chunk
+    // acked" nor "abort requested" implies every local slot has actually gone idle yet, from
+    // this agent's own point of view (an RRSLOT/RABORT is a remote signal, independent of
+    // pollOutboundSlotCompletion/pollNixlXferCompletion noticing the matching local send as
+    // complete) - so this may take several ticks. The authoritative state already lives on
+    // each request, so this scans readServeReqs_ directly rather than tracking a separate
+    // index of "terminal" keys that could desync from it.
+    for (auto agent_it = readServeReqs_.begin(); agent_it != readServeReqs_.end();) {
+        auto &xfer_reqs = agent_it->second;
+        const std::string &initiator_agent = agent_it->first;
+        for (auto xfer_it = xfer_reqs.begin(); xfer_it != xfer_reqs.end();) {
+            NIXL_ASSERT(xfer_it->second->nonDirectData.has_value());
+            auto &req_data = xfer_it->second->nonDirectData.value();
+            if (req_data.state != nixl_service_xfer_state_t::DONE &&
+                req_data.state != nixl_service_xfer_state_t::CANCELLING) {
+                ++xfer_it;
+                continue;
+            }
+            const bool fully_drained = std::all_of(
+                req_data.localSlots.begin(), req_data.localSlots.end(), [](const slotWorkItem &s) {
+                    return s.state == local_slot_state_t::FREE;
+                });
+            if (!fully_drained) {
+                ++xfer_it;
+                continue;
+            }
+            if (req_data.state == nixl_service_xfer_state_t::CANCELLING) {
+                [[maybe_unused]] auto ack_ret = genRAbortAck(initiator_agent, xfer_it->first);
+                // TODO: handle a genNotif failure here.
+            }
+            freeSlotGroup(req_data.localSlots);
+            xfer_it = xfer_reqs.erase(xfer_it);
+        }
+        if (xfer_reqs.empty()) {
+            agent_it = readServeReqs_.erase(agent_it);
+        } else {
+            ++agent_it;
+        }
+    }
+
+    // Same idea, for this agent's own READs currently draining after an RABORT_ACK (see
+    // handleRAbortAck): the peer has confirmed it is done touching these slots
+    // (remoteQuiesced), but any of this agent's own in-flight decodes still need to drain
+    // first. This scan is also the only place a still-in-progress READ's direct child (if
+    // any) gets polled: it lives on this map-owned context rather than the caller-owned
+    // outer handle, so only progressService() (also driven by getNotifs()) can reach it -
+    // see progressReadReceive().
+    for (auto xfer_it = readReceiveReqs_.begin(); xfer_it != readReceiveReqs_.end();) {
+        auto &receive_req = *xfer_it->second;
+        progressReadReceive(receive_req);
+        if (receive_req.state != nixl_service_xfer_state_t::CANCELLING ||
+            !receive_req.remoteQuiesced) {
+            ++xfer_it;
+            continue;
+        }
+        const bool fully_drained =
+            std::all_of(receive_req.localSlots.begin(),
+                        receive_req.localSlots.end(),
+                        [](const slotWorkItem &s) { return s.state == local_slot_state_t::FREE; });
+        if (!fully_drained) {
+            ++xfer_it;
+            continue;
+        }
+        freeSlotGroup(receive_req.localSlots);
+        xfer_it = readReceiveReqs_.erase(xfer_it);
+    }
+
+    activeSlotQueue_.swap(processed_queue);
+    return NIXL_SUCCESS;
+}
+
+void
+nixlServiceAgentData::fillLocalSlot(const activeSlotWorkItem &work_item,
+                                    std::queue<activeSlotWorkItem> &processed_queue) {
+    auto &req_h = std::get<std::reference_wrapper<nixlServiceXferReqH>>(work_item.req).get();
+    auto &req_data = req_h.nonDirectData.value();
+    auto &slot = work_item.slot.get();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        return;
+    }
+    if (req_data.state == nixl_service_xfer_state_t::CANCELLING) {
+        // READ-serving only (WRITE-outbound never reaches CANCELLING): being drained
+        // after an RABORT. Do not start new work on this now-idle slot - simply not
+        // re-queuing it here is what lets it fall out of activeSlotQueue_. The end-of-tick
+        // pass in progressService() notices once every slot of this request has reached
+        // this point and finalizes (frees + sends RABORT_ACK).
+        return;
+    }
+    auto src_addr = req_data.chunkIterator.get();
+    auto chunk_size = req_data.chunkIterator.currentChunkSize();
+    if (!src_addr) {
+        // The sender is done pulling data from the user buffer, however there might still be
+        // xfers/"processSlot" operations in progress.
+        NIXL_ASSERT(chunk_size == 0);
+        return;
+    }
+    NIXL_ASSERT(chunk_size > 0);
+    auto slot_index = slot.slotIndex;
+    const auto current_chunk_local = req_data.chunkIterator.getCurrentChunkLocal();
+    postedNotifPayload posted_notif_payload(
+        req_data.xferId,
+        slot_index,
+        chunk_size,
+        // Placeholder {offset: 0, size: 0}; pollOutboundSlotCompletion replaces it with actual
+        // segments.
+        nixlMarshal::ChunkDivision::defaultSegments(0),
+        req_data.chunkIterator.getCurrentDesc(),
+        current_chunk_local,
+        "");
+    req_data.chunkIterator++;
+    NIXL_ASSERT(slot.state == local_slot_state_t::FREE);
+    slotBuffers buffers;
+    buffers.src = runtimeBuffer(absl::Span<std::byte>(src_addr, chunk_size),
+                                memSpaceFromNixlMem(req_data.chunkIterator.getMemType()));
+    buffers.dst = slot.slot.toRuntimeBuffer();
+
+    auto opts = slot.slot.getProcessSlotInputOptions();
+    if (const auto *delta_opt_args = getDeltaOptArgs(req_h.marshalOptArgs)) {
+        addReferenceOption(opts,
+                           delta_opt_args->senderRef,
+                           current_chunk_local * slot.slot.chunkSize,
+                           chunk_size,
+                           delta_opt_args->senderMemType,
+                           delta_opt_args->elementSize);
+    }
+    req_data.outboundAsyncHandles[slot_index] = backend_->outboundProcessSlot(buffers, opts);
+    slot.state = local_slot_state_t::BUSY_MARSHAL;
+    slot.postedNotif = posted_notif_payload;
+    processed_queue.push(work_item);
+}
+
+void
+nixlServiceAgentData::pollOutboundSlotCompletion(const activeSlotWorkItem &work_item,
+                                                 std::queue<activeSlotWorkItem> &processed_queue) {
+    auto &slot = work_item.slot.get();
+    auto slot_index = slot.slotIndex;
+    auto &req_h = std::get<std::reference_wrapper<nixlServiceXferReqH>>(work_item.req).get();
+    auto &req_data = req_h.nonDirectData.value();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (isTerminalReadServe(req_h.op, req_data.state)) {
+        // Let the in-flight encode finish so the slot buffer is safe to reclaim, then drop
+        // the now-idle slot (do not advance it to READY_TO_SEND / send it during a drain).
+        NIXL_ASSERT(req_data.outboundAsyncHandles[slot_index] != nullptr);
+        NIXL_ASSERT(slot.state == local_slot_state_t::BUSY_MARSHAL);
+        if (!req_data.outboundAsyncHandles[slot_index]->checkForCompletion().has_value()) {
+            processed_queue.push(work_item);
+            return;
+        }
+        req_data.outboundAsyncHandles[slot_index].reset();
+        slot.state = local_slot_state_t::FREE;
+        return;
+    }
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        return;
+    }
+    NIXL_ASSERT(req_data.outboundAsyncHandles[slot_index] != nullptr);
+    NIXL_ASSERT(slot.state == local_slot_state_t::BUSY_MARSHAL);
+
+    auto completion_data = req_data.outboundAsyncHandles[slot_index]->checkForCompletion();
+    if (!completion_data.has_value()) {
+        processed_queue.push(work_item);
+    } else {
+        NIXL_ASSERT(slot.postedNotif.has_value());
+        auto &payload = slot.postedNotif.value();
+        const auto &completion = completion_data.value();
+        payload.postedSegments = getOutboundSegments(completion);
+        payload.metadata = completion.metadata;
+        if constexpr (nixlServiceAgent::trackCompressionRatio) {
+            if (std::holds_alternative<nixlMarshalCompressOptArgs>(req_h.marshalOptArgs)) {
+                NIXL_ASSERT(req_data.compressionStatsHandle != nullptr);
+                size_t outbound_size = 0;
+                for (const auto &segment : *payload.postedSegments) {
+                    outbound_size += segment.size;
+                }
+                auto &stats = *req_data.compressionStatsHandle;
+                const auto ratio =
+                    static_cast<double>(outbound_size) / static_cast<double>(payload.originalSize);
+                if (stats.originalSize == 0) {
+                    stats.minRatio = ratio;
+                    stats.maxRatio = ratio;
+                } else {
+                    stats.minRatio = std::min(stats.minRatio, ratio);
+                    stats.maxRatio = std::max(stats.maxRatio, ratio);
+                }
+                stats.compressedSize += outbound_size;
+                stats.weightedSumSquaredRatio +=
+                    static_cast<double>(payload.originalSize) * ratio * ratio;
+                stats.originalSize += payload.originalSize;
+            }
+        }
+        slot.state = local_slot_state_t::READY_TO_SEND;
+        processed_queue.push(work_item);
+    }
+}
+
+void
+nixlServiceAgentData::trySend(const activeSlotWorkItem &work_item,
+                              std::queue<activeSlotWorkItem> &processed_queue) {
+    auto &slot = work_item.slot.get();
+    auto slot_index = slot.slotIndex;
+    auto &req_h = std::get<std::reference_wrapper<nixlServiceXferReqH>>(work_item.req).get();
+    auto &req_data = req_h.nonDirectData.value();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (isTerminalReadServe(req_h.op, req_data.state)) {
+        // The encode is already complete (READY_TO_SEND); during a drain do not send it,
+        // just drop the now-idle slot.
+        NIXL_ASSERT(slot.state == local_slot_state_t::READY_TO_SEND);
+        req_data.outboundAsyncHandles[slot_index].reset();
+        slot.postedNotif = std::nullopt;
+        slot.state = local_slot_state_t::FREE;
+        return;
+    }
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        return;
+    }
+    NIXL_ASSERT(slot.state == local_slot_state_t::READY_TO_SEND);
+    if (req_data.remoteSlotStates[slot_index] == remote_slot_state_t::FREE) {
+        NIXL_ASSERT(req_data.nixlXferReqs[slot_index] == nullptr);
+        const auto completion =
+            req_data.outboundAsyncHandles[slot_index]->checkForCompletion().value();
+
+        nixl_xfer_dlist_t local_slot_dlist(slot.slot.type);
+        nixl_xfer_dlist_t remote_slot_dlist(
+            nixlMemFromMemSpace(req_data.remoteSlotMemTypes[slot_index]));
+        const auto local_slot_desc = slot.slot.toDesc(slot.slot.slotSize);
+        auto outbound_segments = getOutboundSegments(completion);
+        for (const auto &segment : *outbound_segments) {
+            local_slot_dlist.addDesc(nixlBasicDesc(
+                local_slot_desc.addr + segment.offset, segment.size, local_slot_desc.devId));
+            remote_slot_dlist.addDesc(
+                nixlBasicDesc(req_data.remoteSlotDescriptors[slot_index].addr + segment.offset,
+                              segment.size,
+                              req_data.remoteSlotDescriptors[slot_index].devId));
+        }
+
+        nixlXferReqH *slot_xfer_req = nullptr;
+        nixl_opt_args_t extra_params;
+        NIXL_ASSERT(slot.postedNotif.has_value());
+        const auto &payload = slot.postedNotif.value();
+        if (req_h.op == NIXL_READ) {
+            // Bump this slot's generation before sending, so a stale/duplicate RRSLOT
+            // ack for an earlier fill of this same slot (echoing an older generation) can
+            // be told apart from the ack for this fill - see handleRRSlot.
+            ++req_data.remoteSlotGenerations[slot_index];
+            // RPOSTED carries an absolute destination byte offset rather than
+            // payload.descIndex/chunkIndex directly: the receiver's descriptor list is
+            // guaranteed to have the same per-descriptor lengths as this agent's source
+            // list (validated when the READ was created), but not necessarily the same
+            // chunk size, so the offset must be self-contained rather than an index the
+            // receiver has to reinterpret using its own chunking.
+            const auto dst_byte_offset =
+                req_data.chunkIterator.getByteOffset(payload.descIndex, payload.chunkIndex);
+            rPostedPayload rposted_payload(payload.xferId,
+                                           payload.slotIndex,
+                                           payload.originalSize,
+                                           payload.postedSegments,
+                                           dst_byte_offset,
+                                           payload.metadata);
+            extra_params.notif = rposted_payload.serialize();
+        } else {
+            extra_params.notif = payload.serialize();
+        }
+        auto create_ret = agent_->createXferReq(NIXL_WRITE,
+                                                local_slot_dlist,
+                                                remote_slot_dlist,
+                                                req_data.remoteAgent,
+                                                slot_xfer_req,
+                                                &extra_params);
+        if (create_ret != NIXL_SUCCESS) {
+            // TODO-Eyal: handle error.
+            NIXL_ASSERT(false);
+            return;
+        }
+
+        auto post_ret = agent_->postXferReq(slot_xfer_req, &extra_params);
+        if (post_ret < NIXL_SUCCESS) {
+            // TODO-Eyal: handle error.
+            NIXL_ASSERT(false);
+            return;
+        }
+
+        req_data.nixlXferReqs[slot_index] = slot_xfer_req;
+        slot.state = local_slot_state_t::BUSY_NIXL;
+        slot.postedNotif = std::nullopt;
+        req_data.remoteSlotStates[slot_index] = remote_slot_state_t::BUSY;
+        processed_queue.push(work_item);
+    } else {
+        processed_queue.push(work_item);
+    }
+}
+
+void
+nixlServiceAgentData::pollNixlXferCompletion(const activeSlotWorkItem &work_item,
+                                             std::queue<activeSlotWorkItem> &processed_queue) {
+    auto &slot = work_item.slot.get();
+    auto slot_index = slot.slotIndex;
+    auto &req_h = std::get<std::reference_wrapper<nixlServiceXferReqH>>(work_item.req).get();
+    auto &req_data = req_h.nonDirectData.value();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (isTerminalReadServe(req_h.op, req_data.state)) {
+        // Let the in-flight NIXL_WRITE finish and release it, then drop the now-idle slot.
+        // A failure status is tolerated here (not asserted): the request is already
+        // terminal, so the send's outcome no longer matters, only that it quiesces.
+        NIXL_ASSERT(slot.state == local_slot_state_t::BUSY_NIXL);
+        NIXL_ASSERT(req_data.nixlXferReqs[slot_index] != nullptr);
+        if (agent_->getXferStatus(req_data.nixlXferReqs[slot_index]) == NIXL_IN_PROG) {
+            processed_queue.push(work_item);
+            return;
+        }
+        [[maybe_unused]] auto release_ret =
+            agent_->releaseXferReq(req_data.nixlXferReqs[slot_index]);
+        NIXL_ASSERT(release_ret == NIXL_SUCCESS);
+        req_data.nixlXferReqs[slot_index] = nullptr;
+        slot.state = local_slot_state_t::FREE;
+        return;
+    }
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        return;
+    }
+    NIXL_ASSERT(slot.state == local_slot_state_t::BUSY_NIXL);
+    NIXL_ASSERT(req_data.nixlXferReqs[slot_index] != nullptr);
+
+    auto status = agent_->getXferStatus(req_data.nixlXferReqs[slot_index]);
+    if (status == NIXL_IN_PROG) {
+        processed_queue.push(work_item);
+        return;
+    }
+
+    if (status != NIXL_SUCCESS) {
+        // TODO-Eyal: handle transfer error status.
+        NIXL_ASSERT(false);
+        return;
+    }
+
+    auto release_ret = agent_->releaseXferReq(req_data.nixlXferReqs[slot_index]);
+    NIXL_ASSERT(release_ret == NIXL_SUCCESS);
+    req_data.nixlXferReqs[slot_index] = nullptr;
+    slot.state = local_slot_state_t::FREE;
+    processed_queue.push(work_item);
+}
+
+void
+nixlServiceAgentData::pollInboundSlotCompletion(const activeSlotWorkItem &work_item,
+                                                std::queue<activeSlotWorkItem> &processed_queue) {
+    auto &slot = work_item.slot.get();
+    auto slot_index = slot.slotIndex;
+    auto &inbound_req = std::get<std::reference_wrapper<inboundXferReqH>>(work_item.req).get();
+    if (inbound_req.markedForDeletion) {
+        return;
+    }
+    if (inbound_req.userInitiated) {
+        if (inbound_req.state == nixl_service_xfer_state_t::DONE) {
+            // Fully finalized (or about to be, at end-of-tick); nothing left to do.
+            return;
+        }
+        // Unlike WRITE, a READ receive context can be draining an in-flight decode after
+        // reaching a terminal state: CANCELLING from a mid-transfer release, or FAILED
+        // from a codec-integrity mismatch on a sibling slot. Either way, this decode must
+        // still be allowed to complete and free its slot below - it just should not feed
+        // into the logical READ's own completion bookkeeping anymore (handled further down).
+        NIXL_ASSERT(inbound_req.state == nixl_service_xfer_state_t::IN_PROGRESS ||
+                    inbound_req.state == nixl_service_xfer_state_t::CANCELLING ||
+                    inbound_req.state == nixl_service_xfer_state_t::FAILED);
+    } else {
+        NIXL_ASSERT(inbound_req.state == nixl_service_xfer_state_t::IN_PROGRESS);
+    }
+    NIXL_ASSERT(slot.state == local_slot_state_t::BUSY_MARSHAL);
+    NIXL_ASSERT(inbound_req.asyncHandles[slot_index] != nullptr);
+
+    auto completion_data = inbound_req.asyncHandles[slot_index]->checkForCompletion();
+    if (!completion_data.has_value()) {
+        processed_queue.push(work_item);
+        return;
+    }
+
+    inbound_req.asyncHandles[slot_index].reset();
+    slot.state = local_slot_state_t::FREE;
+
+    if (!inbound_req.userInitiated) {
+        auto gen_rslot_ret = genRSlot(inbound_req.remoteAgent, inbound_req.xferId, slot_index);
+        if (gen_rslot_ret != NIXL_SUCCESS) {
+            // TODO: handle error.
+            NIXL_ASSERT(false);
+            return;
+        }
+        return;
+    }
+
+    if (inbound_req.state != nixl_service_xfer_state_t::IN_PROGRESS) {
+        // Draining (CANCELLING) or already failed: this decode's completion is just
+        // freeing its slot, not contributing to the logical READ's progress anymore. The
+        // end-of-tick pass in progressService() notices once every slot has drained like
+        // this.
+        return;
+    }
+
+    // READ-receive: verify the decode produced exactly the size that was posted, so a
+    // corrupted or mismatched chunk fails the logical request rather than silently landing
+    // a wrong-sized write in the destination buffer.
+    if (completion_data->size != inbound_req.slotExpectedSizes[slot_index]) {
+        inbound_req.state = nixl_service_xfer_state_t::FAILED;
+        inbound_req.terminalStatus = NIXL_ERR_UNKNOWN;
+        return;
+    }
+    inbound_req.decodedChunks++;
+    auto gen_rrslot_ret = genRRSlot(inbound_req.remoteAgent,
+                                    inbound_req.xferId,
+                                    slot_index,
+                                    inbound_req.slotGenerations[slot_index]);
+    if (gen_rrslot_ret != NIXL_SUCCESS) {
+        // TODO: handle error.
+        NIXL_ASSERT(false);
+        return;
+    }
+    if (inbound_req.decodedChunks == inbound_req.totalChunks) {
+        inbound_req.marshalDone = true;
+        tryCompleteReadReceive(inbound_req);
+    }
+}
+
+void
+nixlServiceAgentData::tryCompleteReadReceive(inboundXferReqH &inbound_req) {
+    if (inbound_req.state != nixl_service_xfer_state_t::IN_PROGRESS) {
+        return;
+    }
+    if (!inbound_req.directDone || !inbound_req.marshalDone) {
+        return;
+    }
+    inbound_req.state = nixl_service_xfer_state_t::DONE;
+    if (inbound_req.notif.has_value()) {
+        // Deliver to the peer, mirroring where the direct child's notification would have
+        // gone had it not been withheld at post time (see postXferReq): the base nixlAgent
+        // always addresses a transfer's notification to remote_agent, regardless of
+        // direction.
+        auto notif_ret = agent_->genNotif(inbound_req.remoteAgent, *inbound_req.notif);
+        if (notif_ret != NIXL_SUCCESS) {
+            // TODO: handle error.
+            NIXL_ASSERT(false);
+        }
+    }
+}
+
+void
+nixlServiceAgentData::progressReadReceive(inboundXferReqH &ctx) {
+    if (ctx.state == nixl_service_xfer_state_t::IN_PROGRESS && ctx.directChild != nullptr &&
+        !ctx.directDone) {
+        const nixl_status_t direct_status = agent_->getXferStatus(ctx.directChild);
+        if (direct_status == NIXL_IN_PROG) {
+            return;
+        }
+        if (direct_status != NIXL_SUCCESS) {
+            // The direct sub-transfer failed: that becomes the logical READ's terminal
+            // error.
+            ctx.state = nixl_service_xfer_state_t::FAILED;
+            ctx.terminalStatus = direct_status;
+            return;
+        }
+        ctx.directDone = true;
+    }
+    // Whichever of directDone/marshalDone becomes true last finalizes the request and
+    // delivers the notification; this may be that moment (a no-op otherwise, including for
+    // a marshal-only READ, which reaches DONE via pollInboundSlotCompletion instead).
+    tryCompleteReadReceive(ctx);
+}
+
+std::optional<std::list<slotT>>
+nixlServiceAgentData::allocateSlotGroup() {
+    std::list<slotT> slot_group;
+    // TODO-Eyal: fix once slots are RAII.
+    auto cleanup = makeSlotGroupCleanup(slot_group);
+
+    auto find_slot = [&]() -> std::optional<slotT> {
+        for (auto &pool : localStagingPools_) {
+            auto slot = pool.allocateSlot();
+            if (slot.has_value()) {
+                return slot;
+            }
+        }
+        return std::nullopt;
+    };
+
+    for (size_t i = 0; i < slots_per_xfer; ++i) {
+        auto pending_slot = find_slot();
+        if (!pending_slot.has_value()) {
+            return std::nullopt;
+        }
+        slot_group.push_back(*pending_slot);
+    }
+    std::move(cleanup).Cancel();
+    return slot_group;
+}
+
+void
+nixlServiceAgentData::freeSlotGroup(
+    const std::array<slotWorkItem, slots_per_xfer> &slot_group) noexcept {
+    for (const auto &slot : slot_group) {
+        slot.slot.pool->freeSlot(slot.slot);
+    }
+}
+
+void
+nixlServiceAgentData::serviceNotifCallback(const std::string &sender_agent,
+                                           const nixl_blob_t &notif) {
+    NIXL_ASSERT(notif.rfind(nixl_s_prefix, 0) == 0);
+    if (notif.rfind(nixl_scts_prefix, 0) == 0) {
+        ctsCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srts_prefix, 0) == 0) {
+        rtsCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_sposted_prefix, 0) == 0) {
+        postedCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srslot_prefix, 0) == 0) {
+        rslotCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_sdelete_prefix, 0) == 0) {
+        deleteCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srreq_prefix, 0) == 0) {
+        rreqCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srposted_prefix, 0) == 0) {
+        rpostedCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srrslot_prefix, 0) == 0) {
+        rrslotCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srabort_prefix, 0) == 0) {
+        rabortCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srabortack_prefix, 0) == 0) {
+        rabortAckCallback(sender_agent, notif);
+    } else if (notif.rfind(nixl_srnak_prefix, 0) == 0) {
+        rnakCallback(sender_agent, notif);
+    } else {
+        // Unknown _NIXLS_ subtype: either a future/newer message kind this build does not
+        // understand yet, or a misbehaving peer. Drop it rather than asserting, so an older
+        // service build never crashes on a message it simply doesn't recognize.
+        NIXL_WARN << "nixlServiceAgentData: ignoring unknown service message subtype from '"
+                  << sender_agent << "'";
+    }
+}
+
+void
+nixlServiceAgentData::rtsCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rtsNotifPayload>(
+        nixl_srts_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::ctsCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<ctsNotifPayload>(
+        nixl_scts_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::postedCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<postedNotifPayload>(
+        nixl_sposted_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rslotCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rslotNotifPayload>(
+        nixl_srslot_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::deleteCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<deleteNotifPayload>(
+        nixl_sdelete_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rreqCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rReqPayload>(nixl_srreq_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rpostedCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rPostedPayload>(
+        nixl_srposted_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rrslotCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rrSlotPayload>(
+        nixl_srrslot_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rabortCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rAbortPayload>(
+        nixl_srabort_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rabortAckCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rAbortAckPayload>(
+        nixl_srabortack_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::rnakCallback(const std::string &sender_agent, const nixl_blob_t &notif) {
+    notifCallbackTemplate<rNakPayload>(nixl_srnak_prefix, sender_agent, notif, serviceNotifQueue_);
+}
+
+void
+nixlServiceAgentData::handleRTS(const std::string &sender_agent,
+                                const rtsNotifPayload &rts_payload) {
+    auto &inbound_reqs = inboundXferReqs_.try_emplace(sender_agent).first->second;
+    // TODO-Eyal: update check, instead of checking only the last pool.
+    if (localStagingPools_.size() == 0 ||
+        localStagingPools_.back().getSlotSize() != rts_payload.slotSize) {
+        // TODO-Eyal: send back a bad request notif.
+        NIXL_ASSERT(false);
+        return;
+    }
+    auto slot_group_opt = allocateSlotGroup();
+    if (!slot_group_opt.has_value()) {
+        // TODO-Eyal: send back error notif.
+        NIXL_ASSERT(false);
+        return;
+    }
+    auto slot_group = std::move(slot_group_opt).value();
+    // TODO-Eyal: fix once slots are RAII.
+    auto cleanup = makeSlotGroupCleanup(slot_group);
+    auto slot_work_items = slotGroupToWorkItems(slot_group);
+    auto gen_cts_ret = genCTS(sender_agent, rts_payload.xferId, slot_work_items);
+    if (gen_cts_ret != NIXL_SUCCESS) {
+        // TODO-Eyal: send back error notif.
+        NIXL_ASSERT(false);
+        return;
+    }
+    std::move(cleanup).Cancel();
+    nixlSerDes serdes;
+    auto ret = serdes.importStr(rts_payload.serializedDstList);
+    if (ret != NIXL_SUCCESS) {
+        // TODO-Eyal: handle error.
+        NIXL_ASSERT(false);
+        return;
+    }
+
+    inbound_reqs[rts_payload.xferId] = std::make_unique<inboundXferReqH>(sender_agent,
+                                                                         nixl_xfer_dlist_t(&serdes),
+                                                                         slot_work_items,
+                                                                         rts_payload.xferId,
+                                                                         rts_payload.deltaOptArgs);
+    // TODO-Eyal: check return value.
+}
+
+void
+nixlServiceAgentData::handleCTS(const std::string &sender_agent,
+                                const ctsNotifPayload &cts_payload) {
+    // TODO-Eyal: handle edge cases where xfer was released while waiting for CTS.
+    // (this assertion will fail)
+    if (outboundXferReqs_.count(cts_payload.xferId) == 0) {
+        // This is a mid-transfer release.
+        return;
+    }
+    NIXL_ASSERT(outboundXferReqs_[cts_payload.xferId]->nonDirectData.has_value());
+    auto &req_data = outboundXferReqs_[cts_payload.xferId]->nonDirectData.value();
+    NIXL_ASSERT(req_data.state == nixl_service_xfer_state_t::WAIT_CTS);
+    req_data.state = nixl_service_xfer_state_t::IN_PROGRESS;
+    req_data.remoteSlotDescriptors = cts_payload.receiverSlotDescriptors;
+    req_data.remoteSlotMemTypes = cts_payload.receiverMemSpaces;
+    req_data.remoteSlotStates = std::array{remote_slot_state_t::FREE, remote_slot_state_t::FREE};
+    for (auto i = 0u; i < slots_per_xfer; ++i) {
+        activeSlotQueue_.push(activeSlotWorkItem{std::ref(*outboundXferReqs_[cts_payload.xferId]),
+                                                 std::ref(req_data.localSlots[i])});
+    }
+}
+
+void
+nixlServiceAgentData::handlePosted(const std::string &sender_agent,
+                                   const postedNotifPayload &posted_payload) {
+    NIXL_ASSERT(inboundXferReqs_.count(sender_agent) == 1);
+    if (inboundXferReqs_[sender_agent].count(posted_payload.xferId) == 0) {
+        // This is a mid-transfer release.
+        return;
+    }
+    auto &inbound_req = inboundXferReqs_[sender_agent][posted_payload.xferId];
+    NIXL_ASSERT(inbound_req->state == nixl_service_xfer_state_t::IN_PROGRESS);
+    auto &slot = inbound_req->localSlots[posted_payload.slotIndex];
+    NIXL_ASSERT(slot.state == local_slot_state_t::FREE);
+    slotBuffers buffers;
+    buffers.src = slot.slot.toRuntimeBuffer();
+    // TODO-Eyal: unify buffer structs, we have runtimeBuffer and nixlBasicDesc and slotT.
+    buffers.dst.data =
+        reinterpret_cast<std::byte *>(inbound_req->dstList[posted_payload.descIndex].addr) +
+        posted_payload.chunkIndex * slot.slot.chunkSize;
+    // TODO-Eyal: handle chunk size.
+    buffers.dst.size = posted_payload.originalSize;
+    buffers.dst.space = memSpaceFromNixlMem(inbound_req->dstList.getType());
+    auto process_slot_options = slot.slot.getProcessSlotInputOptions();
+    if (posted_payload.postedSegments->size() > 1) {
+        buffers.src.size = nixlMarshal::marshal_derived_size;
+        process_slot_options[nixlMarshal::option_t::CHUNK_DIVISION] =
+            nixlMarshal::ChunkDivision::processSlotInput{posted_payload.postedSegments};
+    } else {
+        // Single segment case, for marshals which don't support chunk division.
+        buffers.src.size = posted_payload.postedSegments->back().size;
+    }
+    if (inbound_req->receiverDeltaRef.has_value()) {
+        const auto &delta_ref = *inbound_req->receiverDeltaRef;
+        addReferenceOption(process_slot_options,
+                           delta_ref.ref,
+                           posted_payload.chunkIndex * slot.slot.chunkSize,
+                           posted_payload.originalSize,
+                           delta_ref.memType,
+                           delta_ref.elementSize);
+    }
+    inbound_req->asyncHandles[posted_payload.slotIndex] =
+        backend_->inboundProcessSlot(buffers, posted_payload.metadata, process_slot_options);
+    slot.state = local_slot_state_t::BUSY_MARSHAL;
+    activeSlotQueue_.push(activeSlotWorkItem{std::ref(*inbound_req), std::ref(slot)});
+}
+
+void
+nixlServiceAgentData::handleRSlot(const std::string &source_agent,
+                                  const rslotNotifPayload &rslot_payload) {
+    if (outboundXferReqs_.count(rslot_payload.xferId) == 0) {
+        // This is a mid-transfer release.
+        return;
+    }
+    auto &outbound_req = outboundXferReqs_[rslot_payload.xferId];
+    NIXL_ASSERT(outbound_req->nonDirectData.has_value());
+    auto &req_data = outbound_req->nonDirectData.value();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        return;
+    }
+    NIXL_ASSERT(req_data.remoteAgent == source_agent);
+    NIXL_ASSERT(req_data.remoteSlotStates[rslot_payload.slotIndex] == remote_slot_state_t::BUSY);
+    req_data.rslotsReceived++;
+    if (req_data.rslotsReceived == req_data.chunkIterator.getTotalChunks()) {
+        req_data.state = nixl_service_xfer_state_t::DONE;
+        if (req_data.compressionStatsHandle && req_data.compressionStatsHandle->originalSize > 0) {
+            const auto &stats = *req_data.compressionStatsHandle;
+            const auto avg_ratio =
+                static_cast<double>(stats.compressedSize) / static_cast<double>(stats.originalSize);
+            const auto variance =
+                std::max(0.0,
+                         stats.weightedSumSquaredRatio / static_cast<double>(stats.originalSize) -
+                             avg_ratio * avg_ratio);
+            NIXL_INFO << "Compression ratio stats for transfer " << rslot_payload.xferId
+                      << ": min=" << stats.minRatio << " max=" << stats.maxRatio
+                      << " avg=" << avg_ratio << " std=" << std::sqrt(variance);
+        }
+        auto ret = genDelete(source_agent, rslot_payload.xferId);
+        if (ret != NIXL_SUCCESS) {
+            // TODO-Eyal: handle error.
+            NIXL_ASSERT(false);
+            return;
+        }
+        freeSlotGroup(req_data.localSlots);
+        if (!req_data.notifMsg.empty()) {
+            auto ret = agent_->genNotif(source_agent, req_data.notifMsg);
+            if (ret != NIXL_SUCCESS) {
+                // TODO-Eyal: handle error.
+                NIXL_ASSERT(false);
+                return;
+            }
+        }
+    }
+    req_data.remoteSlotStates[rslot_payload.slotIndex] = remote_slot_state_t::FREE;
+}
+
+void
+nixlServiceAgentData::handleDelete(
+    const std::string &sender_agent,
+    const deleteNotifPayload &delete_payload,
+    std::unordered_map<std::string, std::set<size_t>> &deleted_reqs) {
+    NIXL_ASSERT(inboundXferReqs_.count(sender_agent) == 1);
+    NIXL_ASSERT(inboundXferReqs_[sender_agent].count(delete_payload.xferId) == 1);
+    auto &inbound_req = inboundXferReqs_[sender_agent][delete_payload.xferId];
+    inbound_req->markedForDeletion = true;
+    deleted_reqs[sender_agent].insert(delete_payload.xferId);
+}
+
+void
+nixlServiceAgentData::handleRREQ(const std::string &sender_agent, const rReqPayload &rreq_payload) {
+    auto send_r_nak = [&](nixl_status_t error_code) {
+        rNakPayload rnak_payload(rreq_payload.xferId, static_cast<int32_t>(error_code));
+        // TODO: handle a genNotif failure while sending the RNAK itself.
+        [[maybe_unused]] auto gen_ret = agent_->genNotif(sender_agent, rnak_payload.serialize());
+    };
+
+    if (auto agent_it = readServeReqs_.find(sender_agent);
+        agent_it != readServeReqs_.end() && agent_it->second.count(rreq_payload.xferId) != 0) {
+        // Duplicate/retried RREQ for a serve already in progress (or done but not yet
+        // erased) for this (sender, xferId): silently drop it. Overwriting the existing
+        // map entry below would destroy it without returning its slots to the pool first.
+        return;
+    }
+
+    // TODO: update check, instead of checking only the last pool (same limitation as
+    // handleRTS's slotSize check).
+    if (localStagingPools_.empty()) {
+        send_r_nak(NIXL_ERR_NOT_FOUND);
+        return;
+    }
+    const auto &pool = localStagingPools_.back();
+    if (rreq_payload.fingerprint != makeFingerprint(*this, pool)) {
+        // slotSize alone (as RTS/CTS relies on) is not a sufficient compatibility check for
+        // READ - a mode/algo/chunkedPayloadSize/layout/memType mismatch could still yield the
+        // same physical slot size.
+        send_r_nak(NIXL_ERR_INVALID_PARAM);
+        return;
+    }
+
+    nixlSerDes serdes;
+    if (serdes.importStr(rreq_payload.serializedSrcList) != NIXL_SUCCESS) {
+        send_r_nak(NIXL_ERR_INVALID_PARAM);
+        return;
+    }
+    nixl_xfer_dlist_t src_list(&serdes);
+
+    // Best-effort sanity check on the source region: reject descriptor lists of an
+    // unsupported memory type or with a degenerate (zero-length) entry. This is not a real
+    // authorization check - there is currently no way to verify that these descriptors
+    // actually fall within memory the sender registered, so a served READ is only as safe
+    // as the trust relationship between the two agents.
+    // TODO: add real registration-based validation once there is a way to query which
+    // memory ranges an agent has registered.
+    if (src_list.descCount() == 0) {
+        send_r_nak(NIXL_ERR_INVALID_PARAM);
+        return;
+    }
+    mem_space_t src_mem_space;
+    try {
+        src_mem_space = memSpaceFromNixlMem(src_list.getType());
+    }
+    catch (const std::runtime_error &) {
+        send_r_nak(NIXL_ERR_INVALID_PARAM);
+        return;
+    }
+    const auto &supported_mem_spaces = backend_->getSupportedMemSpaces();
+    if (std::find(supported_mem_spaces.begin(), supported_mem_spaces.end(), src_mem_space) ==
+        supported_mem_spaces.end()) {
+        send_r_nak(NIXL_ERR_NOT_SUPPORTED);
+        return;
+    }
+    if (rreq_payload.deltaOptArgs.has_value()) {
+        // Delta (including ANS_DELTA) only supports a single descriptor per side, enforced
+        // at create time on the initiator (createXferReq). Re-validate here: fillLocalSlot
+        // computes each chunk's offset into senderRef as currentChunkLocal * chunkSize,
+        // which is only meaningful within a single contiguous reference buffer - a
+        // multi-descriptor source would silently alias chunk offsets across descriptors
+        // instead of failing loudly.
+        if (src_list.descCount() != 1) {
+            send_r_nak(NIXL_ERR_NOT_SUPPORTED);
+            return;
+        }
+        // Only these element sizes are supported by the delta XOR kernel; matches the
+        // equivalent create-time check on the initiator.
+        const auto element_size = rreq_payload.deltaOptArgs->elementSize;
+        if (element_size != 1 && element_size != 2 && element_size != 4 && element_size != 8) {
+            send_r_nak(NIXL_ERR_INVALID_PARAM);
+            return;
+        }
+    }
+    size_t total_chunks = 0;
+    for (int i = 0; i < src_list.descCount(); ++i) {
+        if (src_list[i].len == 0) {
+            send_r_nak(NIXL_ERR_INVALID_PARAM);
+            return;
+        }
+        // src_list.len is initiator-supplied and otherwise unvalidated: reject a length that
+        // would overflow the round-up-to-chunkSize computation below. Wrapping could produce
+        // a too-small total_chunks (this serve stalls, unnoticed) or a too-large one
+        // (chunkIteratorH::operator++ walks currentDesc past descList.descCount(), guarded
+        // only by an assert that compiles out in a release build).
+        if (src_list[i].len > std::numeric_limits<size_t>::max() - pool.getChunkSize()) {
+            send_r_nak(NIXL_ERR_INVALID_PARAM);
+            return;
+        }
+        total_chunks += (src_list[i].len + pool.getChunkSize() - 1) / pool.getChunkSize();
+    }
+
+    auto slot_group_opt = allocateSlotGroup();
+    if (!slot_group_opt.has_value()) {
+        send_r_nak(NIXL_ERR_NOT_FOUND);
+        return;
+    }
+    auto slot_group = std::move(slot_group_opt).value();
+    // TODO: fix once slots are RAII.
+    auto cleanup = makeSlotGroupCleanup(slot_group);
+    auto slot_work_items = slotGroupToWorkItems(slot_group);
+
+    // Build the marshalOptArgs alternative matching this agent's configured mode, carrying
+    // the delta sender reference from RREQ when present. RREQ ships the sender's own
+    // reference under senderRef; this agent never decodes (it is serving, not receiving),
+    // so receiverRef/receiverMemType are left at their defaults.
+    const nixl_marshal_opt_args_t serving_opt_args = std::visit(
+        overloaded{
+            [](const nixlMarshalDirectConfig &) -> nixl_marshal_opt_args_t {
+                NIXL_ASSERT(false); // unreachable: a direct-mode agent never has staging pools.
+                return nixlMarshalDirectOptArgs{};
+            },
+            [](const nixlMarshalStagingConfig &) -> nixl_marshal_opt_args_t {
+                return nixlMarshalStagingOptArgs{};
+            },
+            [&](const nixlMarshalDeltaConfig &) -> nixl_marshal_opt_args_t {
+                nixlMarshalDeltaOptArgs args;
+                if (rreq_payload.deltaOptArgs.has_value()) {
+                    args.senderRef = rreq_payload.deltaOptArgs->ref;
+                    args.senderMemType = rreq_payload.deltaOptArgs->memType;
+                    args.elementSize = rreq_payload.deltaOptArgs->elementSize;
+                }
+                return args;
+            },
+            [&](const nixlMarshalCompressConfig &) -> nixl_marshal_opt_args_t {
+                nixlMarshalCompressOptArgs args;
+                if (rreq_payload.deltaOptArgs.has_value()) {
+                    nixlMarshalDeltaOptArgs delta_args;
+                    delta_args.senderRef = rreq_payload.deltaOptArgs->ref;
+                    delta_args.senderMemType = rreq_payload.deltaOptArgs->memType;
+                    delta_args.elementSize = rreq_payload.deltaOptArgs->elementSize;
+                    args.delta = delta_args;
+                }
+                return args;
+            },
+        },
+        mode_);
+
+    auto wrapper = std::make_unique<nixlServiceXferReqH>(
+        src_list,
+        std::string(), // no RTS is ever sent for a READ-serving request.
+        sender_agent,
+        slot_work_items,
+        rreq_payload.xferId,
+        total_chunks,
+        serving_opt_args);
+    wrapper->op = NIXL_READ;
+    // RREQ already carries what RTS+CTS would have conveyed separately for a WRITE, so the
+    // serving push starts directly at IN_PROGRESS - there is no CTS wait for READ.
+    auto &serving_req_data = wrapper->nonDirectData.value();
+    serving_req_data.state = nixl_service_xfer_state_t::IN_PROGRESS;
+    serving_req_data.remoteSlotDescriptors = rreq_payload.recvSlotDescriptors;
+    serving_req_data.remoteSlotMemTypes = rreq_payload.recvMemSpaces;
+    serving_req_data.remoteSlotStates =
+        std::array{remote_slot_state_t::FREE, remote_slot_state_t::FREE};
+    std::move(cleanup).Cancel();
+
+    auto &stored_reqs = readServeReqs_[sender_agent];
+    stored_reqs[rreq_payload.xferId] = std::move(wrapper);
+    auto &stored_req = *stored_reqs[rreq_payload.xferId];
+    for (auto i = 0u; i < slots_per_xfer; ++i) {
+        activeSlotQueue_.push(activeSlotWorkItem{
+            std::ref(stored_req), std::ref(stored_req.nonDirectData->localSlots[i])});
+    }
+}
+
+void
+nixlServiceAgentData::handleRPosted(const std::string &sender_agent,
+                                    const rPostedPayload &rposted_payload) {
+    if (readReceiveReqs_.count(rposted_payload.xferId) == 0) {
+        // Mid-transfer release, or a stale message for an already-finished/aborted READ.
+        return;
+    }
+    auto &inbound_req = *readReceiveReqs_[rposted_payload.xferId];
+    if (sender_agent != inbound_req.remoteAgent) {
+        // readReceiveReqs_ is keyed only by this agent's own xfer id (unlike
+        // inboundXferReqs_, which nests by sender), so this check is the only thing
+        // preventing an unrelated agent from injecting data into this READ under a
+        // guessed/colliding xfer id.
+        NIXL_WARN << "nixlServiceAgentData: ignoring RPOSTED for xfer " << rposted_payload.xferId
+                  << " from unexpected sender '" << sender_agent << "' (expected '"
+                  << inbound_req.remoteAgent << "')";
+        return;
+    }
+    if (rposted_payload.slotIndex >= slots_per_xfer) {
+        NIXL_WARN << "nixlServiceAgentData: ignoring RPOSTED for xfer " << rposted_payload.xferId
+                  << " with out-of-range slot index " << rposted_payload.slotIndex;
+        return;
+    }
+    if (inbound_req.state != nixl_service_xfer_state_t::IN_PROGRESS) {
+        // The request already reached a terminal state (a codec-integrity failure on a
+        // sibling slot, or a cancellation) - this slot's async decode may still be
+        // legitimately in flight, but no further decodes should be started for it.
+        return;
+    }
+    auto &slot = inbound_req.localSlots[rposted_payload.slotIndex];
+    if (slot.state != local_slot_state_t::FREE) {
+        // Under normal operation the peer never sends a second RPOSTED for this slot
+        // before this agent acks the first with RRSLOT (see trySend's remoteSlotStates
+        // gating) - reaching this with a busy slot means a duplicate/replayed RPOSTED for
+        // a fill already in flight. Drop it rather than starting a second decode into (or
+        // clobbering the in-flight handle of) the same slot.
+        NIXL_WARN << "nixlServiceAgentData: ignoring RPOSTED for xfer " << rposted_payload.xferId
+                  << " - slot " << rposted_payload.slotIndex << " is not free";
+        return;
+    }
+
+    const auto dst_desc = resolveAbsoluteOffset(
+        inbound_req.dstList, rposted_payload.dstByteOffset, rposted_payload.originalSize);
+    if (!dst_desc.has_value()) {
+        NIXL_WARN << "nixlServiceAgentData: ignoring RPOSTED for xfer " << rposted_payload.xferId
+                  << " with out-of-bounds destination offset " << rposted_payload.dstByteOffset
+                  << " (size " << rposted_payload.originalSize << ")";
+        return;
+    }
+
+    slotBuffers buffers;
+    buffers.src = slot.slot.toRuntimeBuffer();
+    buffers.dst.data = reinterpret_cast<std::byte *>(dst_desc->addr);
+    buffers.dst.size = rposted_payload.originalSize;
+    buffers.dst.space = memSpaceFromNixlMem(inbound_req.dstList.getType());
+    auto process_slot_options = slot.slot.getProcessSlotInputOptions();
+    if (rposted_payload.postedSegments->empty()) {
+        NIXL_WARN << "nixlServiceAgentData: ignoring RPOSTED for xfer " << rposted_payload.xferId
+                  << " with no posted segments";
+        return;
+    }
+    if (rposted_payload.postedSegments->size() > 1) {
+        buffers.src.size = nixlMarshal::marshal_derived_size;
+        process_slot_options[nixlMarshal::option_t::CHUNK_DIVISION] =
+            nixlMarshal::ChunkDivision::processSlotInput{rposted_payload.postedSegments};
+    } else {
+        // Single segment case, for marshals which don't support chunk division.
+        buffers.src.size = rposted_payload.postedSegments->back().size;
+    }
+    if (inbound_req.receiverDeltaRef.has_value()) {
+        const auto &delta_ref = *inbound_req.receiverDeltaRef;
+        addReferenceOption(process_slot_options,
+                           delta_ref.ref,
+                           rposted_payload.dstByteOffset,
+                           rposted_payload.originalSize,
+                           delta_ref.memType,
+                           delta_ref.elementSize);
+    }
+    inbound_req.slotExpectedSizes[rposted_payload.slotIndex] = rposted_payload.originalSize;
+    // Bump this slot's generation to mark it as (re)filled - the matching RRSLOT sent once
+    // this decode completes carries this same value, letting the peer's trySend() (see
+    // remoteSlotGenerations) tell this fill's ack apart from a stale/duplicate one for an
+    // earlier fill of the same slot.
+    ++inbound_req.slotGenerations[rposted_payload.slotIndex];
+    inbound_req.asyncHandles[rposted_payload.slotIndex] =
+        backend_->inboundProcessSlot(buffers, rposted_payload.metadata, process_slot_options);
+    slot.state = local_slot_state_t::BUSY_MARSHAL;
+    activeSlotQueue_.push(activeSlotWorkItem{std::ref(inbound_req), std::ref(slot)});
+}
+
+void
+nixlServiceAgentData::handleRRSlot(const std::string &source_agent,
+                                   const rrSlotPayload &rrslot_payload) {
+    auto agent_it = readServeReqs_.find(source_agent);
+    if (agent_it == readServeReqs_.end() || agent_it->second.count(rrslot_payload.xferId) == 0) {
+        // Mid-transfer release, e.g. this agent already aborted/cleaned up the serving req.
+        return;
+    }
+    auto &serving_req = *agent_it->second[rrslot_payload.xferId];
+    NIXL_ASSERT(serving_req.nonDirectData.has_value());
+    auto &req_data = serving_req.nonDirectData.value();
+    NIXL_ASSERT(req_data.state >= nixl_service_xfer_state_t::IN_PROGRESS);
+    if (req_data.state == nixl_service_xfer_state_t::DONE ||
+        req_data.state == nixl_service_xfer_state_t::CANCELLING) {
+        // Already finished, or being drained after an RABORT: rslotsReceived stops
+        // mattering once cancelling - the drain-completion check in progressService() only
+        // looks at local slot state, so a stale/duplicate RRSLOT here is simply ignored
+        // rather than risking a race with that check.
+        return;
+    }
+    NIXL_ASSERT(req_data.remoteAgent == source_agent);
+    if (rrslot_payload.slotIndex >= slots_per_xfer) {
+        NIXL_WARN << "nixlServiceAgentData: ignoring RRSLOT for xfer " << rrslot_payload.xferId
+                  << " with out-of-range slot index " << rrslot_payload.slotIndex;
+        return;
+    }
+    if (req_data.remoteSlotStates[rrslot_payload.slotIndex] != remote_slot_state_t::BUSY ||
+        rrslot_payload.slotGeneration != req_data.remoteSlotGenerations[rrslot_payload.slotIndex]) {
+        // Stale/duplicate ack: either this slot is not currently awaiting one (already
+        // freed by an earlier, legitimate ack for it), or it echoes an older generation
+        // than the fill currently in flight (superseded by a newer RPOSTED already sent
+        // for this slot). Either way, drop it silently rather than corrupting
+        // remoteSlotStates/rslotsReceived.
+        return;
+    }
+    req_data.rslotsReceived++;
+    if (req_data.rslotsReceived == req_data.chunkIterator.getTotalChunks()) {
+        req_data.state = nixl_service_xfer_state_t::DONE;
+        // Unlike handleRSlot (WRITE), there is no genDelete/user notification here: the
+        // initiator holds the user handle and is responsible for delivering it once its own
+        // receive side also completes (see tryCompleteReadReceive). Freeing this request's
+        // slots must wait for every one of them to actually go idle - progressService()'s
+        // end-of-tick scan of readServeReqs_ handles that once this state change is visible.
+    } else {
+        req_data.remoteSlotStates[rrslot_payload.slotIndex] = remote_slot_state_t::FREE;
+    }
+}
+
+void
+nixlServiceAgentData::handleRAbort(const std::string &sender_agent,
+                                   const rAbortPayload &rabort_payload) {
+    auto agent_it = readServeReqs_.find(sender_agent);
+    if (agent_it == readServeReqs_.end() || agent_it->second.count(rabort_payload.xferId) == 0) {
+        // This agent is not (or no longer) serving this READ - either the RREQ was itself
+        // rejected via RNAK, or the serve already finished and was erased. Either way, it
+        // is not touching the initiator's slots, so it is safe - and necessary, to unblock
+        // the initiator's own drain - to acknowledge immediately.
+        [[maybe_unused]] auto ret = genRAbortAck(sender_agent, rabort_payload.xferId);
+        return;
+    }
+    auto &serving_req = *agent_it->second[rabort_payload.xferId];
+    NIXL_ASSERT(serving_req.nonDirectData.has_value());
+    auto &req_data = serving_req.nonDirectData.value();
+    if (req_data.state == nixl_service_xfer_state_t::CANCELLING) {
+        // Duplicate/retried RABORT while already draining; the end-of-tick pass in
+        // progressService() will acknowledge once fully drained.
+        return;
+    }
+    if (req_data.state == nixl_service_xfer_state_t::DONE) {
+        // Already fully served (rslotsReceived == totalChunks) and pending a fully_drained
+        // erase by progressService()'s end-of-tick scan; not touching the initiator's slots
+        // anymore either.
+        [[maybe_unused]] auto ret = genRAbortAck(sender_agent, rabort_payload.xferId);
+        return;
+    }
+    NIXL_ASSERT(req_data.state == nixl_service_xfer_state_t::IN_PROGRESS);
+    req_data.state = nixl_service_xfer_state_t::CANCELLING;
+}
+
+void
+nixlServiceAgentData::handleRAbortAck(const std::string &sender_agent,
+                                      const rAbortAckPayload &raback_payload) {
+    if (readReceiveReqs_.count(raback_payload.xferId) == 0) {
+        // Already finalized, or a stale/duplicate ack; nothing to do.
+        return;
+    }
+    auto &receive_req = *readReceiveReqs_[raback_payload.xferId];
+    if (sender_agent != receive_req.remoteAgent) {
+        // readReceiveReqs_ is keyed only by this agent's own xfer id (see handleRPosted for
+        // the same concern), so this check is the only thing preventing an unrelated agent
+        // from acknowledging (and so prematurely unblocking the drain of) a READ under a
+        // guessed/colliding xfer id.
+        NIXL_WARN << "nixlServiceAgentData: ignoring RABORT_ACK for xfer " << raback_payload.xferId
+                  << " from unexpected sender '" << sender_agent << "' (expected '"
+                  << receive_req.remoteAgent << "')";
+        return;
+    }
+    if (receive_req.state != nixl_service_xfer_state_t::CANCELLING) {
+        // Not currently draining (e.g. a stale/duplicate ack after finalization, or one
+        // that arrived before this agent ever sent an RABORT); nothing to do.
+        return;
+    }
+    // The peer has confirmed it is no longer touching this agent's receive slots. Any of
+    // this agent's own in-flight decodes still need to drain first, though (see
+    // pollInboundSlotCompletion); the end-of-tick scan in progressService() notices once
+    // every local slot has also gone idle and finalizes.
+    receive_req.remoteQuiesced = true;
+}
+
+void
+nixlServiceAgentData::handleRNak(const std::string &sender_agent, const rNakPayload &rnak_payload) {
+    if (readReceiveReqs_.count(rnak_payload.xferId) == 0) {
+        // Already finalized/released, or a stale/duplicate NAK; nothing to do.
+        return;
+    }
+    auto &receive_req = *readReceiveReqs_[rnak_payload.xferId];
+    if (sender_agent != receive_req.remoteAgent) {
+        // readReceiveReqs_ is keyed only by this agent's own xfer id (see handleRPosted for
+        // the same concern), so this check is the only thing preventing an unrelated agent
+        // from failing a READ under a guessed/colliding xfer id.
+        NIXL_WARN << "nixlServiceAgentData: ignoring RNAK for xfer " << rnak_payload.xferId
+                  << " from unexpected sender '" << sender_agent << "' (expected '"
+                  << receive_req.remoteAgent << "')";
+        return;
+    }
+    if (receive_req.state != nixl_service_xfer_state_t::IN_PROGRESS) {
+        // Not awaiting an RREQ response anymore (a stale/duplicate NAK, or one racing with
+        // a mid-transfer release that already moved this request to CANCELLING); nothing
+        // to do.
+        return;
+    }
+    // The peer never admitted this READ, so it holds no serving state for it (no
+    // readServeReqs_ entry was ever created) - there is nothing to abort or drain on its
+    // side. This request's marshal sub-part will never happen; fail it outright.
+    receive_req.state = nixl_service_xfer_state_t::FAILED;
+    // Only trust the specific codes a conforming peer's send_r_nak() can emit; anything else
+    // (e.g. a malformed or adversarial NIXL_SUCCESS) would otherwise make a failed READ
+    // report success via getXferStatus.
+    switch (rnak_payload.errorCode) {
+    case NIXL_ERR_INVALID_PARAM:
+    case NIXL_ERR_NOT_FOUND:
+    case NIXL_ERR_NOT_SUPPORTED:
+        receive_req.terminalStatus = static_cast<nixl_status_t>(rnak_payload.errorCode);
+        break;
+    default:
+        NIXL_WARN << "nixlServiceAgentData: RNAK for xfer " << rnak_payload.xferId
+                  << " carried unexpected errorCode " << rnak_payload.errorCode;
+        receive_req.terminalStatus = NIXL_ERR_BACKEND;
+        break;
+    }
+}
+
+nixl_status_t
+nixlServiceAgentData::genDelete(const std::string &sender_agent, size_t xfer_id) {
+    deleteNotifPayload delete_payload(xfer_id);
+    return agent_->genNotif(sender_agent, delete_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRTS(nixlServiceXferReqH &xfer_req) {
+    NIXL_ASSERT(xfer_req.nonDirectData.has_value());
+    NIXL_ASSERT(outboundXferReqs_.count(xfer_req.nonDirectData->xferId) == 1);
+    NIXL_ASSERT(xfer_req.nonDirectData->localSlots[0].slot.slotSize ==
+                xfer_req.nonDirectData->localSlots[1].slot.slotSize);
+    rtsNotifPayload rts_payload(xfer_req.nonDirectData->xferId,
+                                xfer_req.nonDirectData->serializedDstDescList,
+                                xfer_req.nonDirectData->localSlots[0].slot.slotSize);
+    if (const auto *delta_opt_args = getDeltaOptArgs(xfer_req.marshalOptArgs)) {
+        rts_payload.deltaOptArgs = nixlMarshalDeltaReceiverRefArgs{delta_opt_args->receiverRef,
+                                                                   delta_opt_args->receiverMemType,
+                                                                   delta_opt_args->elementSize};
+    }
+    return agent_->genNotif(xfer_req.nonDirectData->remoteAgent, rts_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRREQ(nixlServiceXferReqH &xfer_req) {
+    NIXL_ASSERT(xfer_req.readReceiveXferId.has_value());
+    const auto xfer_id = *xfer_req.readReceiveXferId;
+    NIXL_ASSERT(readReceiveReqs_.count(xfer_id) == 1);
+    auto &receive_req = *readReceiveReqs_[xfer_id];
+    NIXL_ASSERT(receive_req.localSlots[0].slot.slotSize == receive_req.localSlots[1].slot.slotSize);
+    NIXL_ASSERT(receive_req.localSlots[0].slot.pool != nullptr);
+
+    rReqPayload rreq_payload(
+        xfer_id,
+        receive_req.serializedSrcList,
+        // TODO: make this invariant to slots_per_xfer > 2 (same TODO as genCTS).
+        std::array{receive_req.localSlots[0].slot.toDesc(receive_req.localSlots[0].slot.slotSize),
+                   receive_req.localSlots[1].slot.toDesc(receive_req.localSlots[1].slot.slotSize)},
+        std::array{memSpaceFromNixlMem(receive_req.localSlots[0].slot.type),
+                   memSpaceFromNixlMem(receive_req.localSlots[1].slot.type)},
+        makeFingerprint(*this, *receive_req.localSlots[0].slot.pool));
+    if (const auto *delta_opt_args = getDeltaOptArgs(xfer_req.marshalOptArgs)) {
+        // RREQ ships this agent's own reference (it is the one encoding), not the peer's
+        // receiverRef - the sender and receiver roles are swapped relative to WRITE's RTS.
+        rreq_payload.deltaOptArgs = nixlMarshalDeltaSenderRefArgs{
+            delta_opt_args->senderRef, delta_opt_args->senderMemType, delta_opt_args->elementSize};
+    }
+    return agent_->genNotif(receive_req.remoteAgent, rreq_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genCTS(const std::string &remote_agent,
+                             size_t xfer_id,
+                             const std::array<slotWorkItem, slots_per_xfer> &slots) {
+    ctsNotifPayload cts_payload(xfer_id,
+                                // TODO-Eyal: make this invariant to slots_per_xfer > 2.
+                                std::array{slots[0].slot.toDesc(slots[0].slot.slotSize),
+                                           slots[1].slot.toDesc(slots[1].slot.slotSize)},
+                                std::array{memSpaceFromNixlMem(slots[0].slot.type),
+                                           memSpaceFromNixlMem(slots[1].slot.type)});
+    return agent_->genNotif(remote_agent, cts_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRSlot(const std::string &remote_agent, size_t xfer_id, size_t slot_index) {
+    // TODO: implement Ready Slot notification format and slot_index payload handling.
+    rslotNotifPayload rslot_payload(xfer_id, slot_index);
+    return agent_->genNotif(remote_agent, rslot_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRRSlot(const std::string &remote_agent,
+                                size_t xfer_id,
+                                size_t slot_index,
+                                uint64_t slot_generation) {
+    rrSlotPayload rrslot_payload(xfer_id, slot_index, slot_generation);
+    return agent_->genNotif(remote_agent, rrslot_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRAbort(const std::string &remote_agent, size_t xfer_id) {
+    rAbortPayload rabort_payload(xfer_id);
+    return agent_->genNotif(remote_agent, rabort_payload.serialize());
+}
+
+nixl_status_t
+nixlServiceAgentData::genRAbortAck(const std::string &remote_agent, size_t xfer_id) {
+    rAbortAckPayload raback_payload(xfer_id);
+    return agent_->genNotif(remote_agent, raback_payload.serialize());
+}
+
+namespace nixlService {
+
+size_t
+recommendServiceMemSize(const nixl_marshal_config_t &mode, uint32_t max_concurrent_transfers) {
+    if (std::holds_alternative<nixlMarshalDirectConfig>(mode)) {
+        throw std::invalid_argument("Direct mode does not use service memory");
+    }
+    if (max_concurrent_transfers == 0) {
+        throw std::invalid_argument("maxConcurrentTransfers must be at least 1");
+    }
+    if (std::holds_alternative<nixlMarshalStagingConfig>(mode)) {
+        return stagingBackend::recommendServiceMemSize(default_chunked_payload_size,
+                                                       max_concurrent_transfers);
+    }
+    if (std::holds_alternative<nixlMarshalDeltaConfig>(mode)) {
+        return deltaBackend::recommendServiceMemSize(default_chunked_payload_size,
+                                                     max_concurrent_transfers);
+    }
+    if (std::holds_alternative<nixlMarshalCompressConfig>(mode)) {
+#ifdef NIXL_HAVE_NVCOMP
+        return compressionBackend::recommendServiceMemSize(
+            default_chunked_payload_size,
+            max_concurrent_transfers,
+            std::get<nixlMarshalCompressConfig>(mode).algo);
+#else
+        throw std::invalid_argument("Compression marshal backend requires nvCOMP support");
+#endif
+    }
+    throw std::invalid_argument("Unknown mode");
+}
+
+} // namespace nixlService
+
+std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>>
+nixlServiceAgent::prepare(nixlServiceAgentConfig cfg) {
+    return prepare(std::move(cfg), default_chunked_payload_size);
+}
+
+std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>>
+nixlServiceAgent::prepare(nixlServiceAgentConfig cfg, size_t chunked_payload_size) {
+    auto data = std::make_shared<nixlServiceAgentData>(cfg.mode, chunked_payload_size);
+
+    cfg.notifCallbacks_[nixl_s_prefix] =
+        [data_weak = std::weak_ptr<nixlServiceAgentData>(data)](nixlNotifCallbackArgs &&args) {
+            auto d = data_weak.lock();
+            if (!d) {
+                return;
+            }
+            d->serviceNotifCallback(args.remote_agent, args.raw_notif);
+        };
+
+    return {std::move(cfg), std::move(data)};
+}
+
+nixlServiceAgent::nixlServiceAgent(
+    const std::string &name,
+    std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>> &&tag)
+    : nixlAgent(name, tag.first),
+      data_(std::move(tag.second)) {
+    data_->agent_ = this;
+    data_->localAgentName_ = name;
+}
+
+nixlServiceAgent::nixlServiceAgent(const std::string &name, nixlServiceAgentConfig cfg)
+    : nixlServiceAgent(name, prepare(std::move(cfg))) {}
+
+nixlServiceAgent::~nixlServiceAgent() = default;
+
+nixl_status_t
+nixlServiceAgent::registerServiceMem(const nixl_reg_dlist_t &descs,
+                                     const nixl_opt_args_t * /*extra_params*/) {
+    return std::visit(
+        overloaded{
+            [this, &descs](const nixlMarshalDirectConfig &) -> nixl_status_t {
+                return NIXL_ERR_NOT_SUPPORTED;
+            },
+            [this, &descs](const auto & /*non_direct_mode*/) -> nixl_status_t {
+                auto mem_space = memSpaceFromNixlMem(descs.getType());
+                auto supported_mem_spaces = data_->backend_->getSupportedMemSpaces();
+                if (std::find(supported_mem_spaces.begin(),
+                              supported_mem_spaces.end(),
+                              mem_space) == supported_mem_spaces.end()) {
+                    return NIXL_ERR_NOT_SUPPORTED;
+                }
+
+                auto const ret = nixlAgent::registerMem(descs);
+                if (ret != NIXL_SUCCESS) {
+                    return ret;
+                }
+
+                const auto chunked_payload_size = data_->chunkedPayloadSize_;
+                size_t slot_workspace_size = 0;
+                auto it_workspace = data_->marshalSlotMemoryRequirements_.opts.find(
+                    option_t::WRITEABLE_WORKSPACE_MEMORY);
+                if (it_workspace != data_->marshalSlotMemoryRequirements_.opts.end()) {
+                    if (auto *ws_req = std::get_if<WriteableWorkspaceMemory::memoryRequirements>(
+                            &it_workspace->second)) {
+                        slot_workspace_size = ws_req->slotWorkspaceSize;
+                    }
+                }
+
+                size_t slot_overhead_size = 0;
+                auto it_overhead =
+                    data_->marshalSlotMemoryRequirements_.opts.find(option_t::SLOT_OVERHEAD);
+                if (it_overhead != data_->marshalSlotMemoryRequirements_.opts.end()) {
+                    if (auto *oh_req =
+                            std::get_if<SlotOverhead::memoryRequirements>(&it_overhead->second)) {
+                        slot_overhead_size = oh_req->slotOverheadSize;
+                    }
+                }
+                const auto marshal_overhead = slot_overhead_size + slot_workspace_size;
+
+                for (const auto &desc : descs) {
+                    /* `chunkedPayloadSize` is the *payload* commitment: the service agent
+                     *  guarantees it will never feed more than that many bytes of source
+                     *  into a single slot. The marshal layer can append up to
+                     *  `marshalOverhead` bytes on top of the payload, so the physical
+                     *  staging slot must reserve `chunkedPayloadSize + marshalOverhead`
+                     *  bytes.
+                     *
+                     *  We round numSlots DOWN, because a partial slot has no usable
+                     *  destination memory.
+                     *
+                     *  Example: desc.len = 1 GB, chunkedPayloadSize = 128 MB, marshalOverhead = 5
+                     * MB physicalSlotSize    = 128 + 5           = 133 MB numSlots            =
+                     * 1024 / 133        = 7 slots payload per slot    = 128 MB            (enforced
+                     * at fill time) total source moved  = 7 * 128           = 896 MB total staging
+                     * used  = 7 * 133           = 931 MB
+                     */
+                    const auto raw_physical_slot_size = chunked_payload_size + marshal_overhead;
+                    const auto slot_stride = alignUp(raw_physical_slot_size,
+                                                     MarshalBackendSizing::slot_stride_alignment);
+                    const auto aligned_base =
+                        alignUp(desc.addr, MarshalBackendSizing::slot_stride_alignment);
+                    if (aligned_base >= desc.addr && aligned_base - desc.addr > desc.len) {
+                        return NIXL_ERR_INVALID_PARAM;
+                    }
+                    const auto leading_slop = aligned_base - desc.addr;
+                    const auto usable_bytes = desc.len - leading_slop;
+                    const auto num_slots = usable_bytes / slot_stride;
+                    if (num_slots < slots_per_xfer) {
+                        return NIXL_ERR_INVALID_PARAM;
+                    }
+                    data_->localStagingPools_.emplace_back(aligned_base,
+                                                           slot_stride,
+                                                           num_slots,
+                                                           chunked_payload_size,
+                                                           descs.getType(),
+                                                           slot_workspace_size);
+                }
+
+                return NIXL_SUCCESS;
+            },
+        },
+        data_->mode_);
+}
+
+nixl_status_t
+nixlServiceAgent::deregisterServiceMem(const nixl_reg_dlist_t &descs,
+                                       const nixl_opt_args_t * /*extra_params*/) {
+    return std::visit(overloaded{
+                          [this, &descs](const nixlMarshalDirectConfig &) -> nixl_status_t {
+                              return NIXL_ERR_NOT_SUPPORTED;
+                          },
+                          [this, &descs](const auto &non_direct_mode) -> nixl_status_t {
+                              auto const ret = nixlAgent::deregisterMem(descs);
+                              if (ret != NIXL_SUCCESS) {
+                                  return ret;
+                              }
+
+                              // TOOD-Eyal: improve if we want to support mid-request
+                              // deregistration.
+                              for (const auto &desc : descs) {
+                                  data_->localStagingPools_.remove_if(
+                                      [desc](const slotPool &pool) -> bool {
+                                          return pool.getBaseAddr() == desc.addr;
+                                      });
+                              }
+
+                              return NIXL_SUCCESS;
+                          },
+                      },
+                      data_->mode_);
+}
+
+nixl_status_t
+nixlServiceAgent::createXferReq(const nixl_xfer_op_t &operation,
+                                const nixl_xfer_dlist_t &local_descs,
+                                const nixl_xfer_dlist_t &remote_descs,
+                                const std::string &remote_agent,
+                                nixlServiceXferReqH *&req_hndl,
+                                const nixl_service_opt_args_t *extra_params) {
+    // nixl_xfer_op_t only has two named values (NIXL_READ, NIXL_WRITE), but as a plain enum
+    // it accepts any integer via a static_cast, e.g. from uninitialized or garbage input.
+    // The non-direct path below assumes operation is one of the two (see e.g. the
+    // NIXL_ASSERT(operation == NIXL_READ) further down), so reject anything else here up
+    // front, making that assert an invariant rather than something a caller could trip.
+    // This also covers postXferReq/getXferStatus/releaseXferReq, since they all act on the
+    // handle this validates.
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    const auto marshal_opt_args = getValidMarshalOptArgs(extra_params, data_->mode_);
+    if (!marshal_opt_args.has_value()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto create_non_direct_xfer =
+        [&](const nixl_marshal_opt_args_t &opt_args,
+            const nixl_xfer_dlist_t &marshal_local_descs,
+            const nixl_xfer_dlist_t &marshal_remote_descs) -> nixl_status_t {
+        if (data_->localStagingPools_.empty()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto total_chunks =
+            countChunksAndVerifyMatch(marshal_local_descs,
+                                      marshal_remote_descs,
+                                      data_->localStagingPools_.begin()->getChunkSize());
+        if (total_chunks == -1) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto slot_group_opt = data_->allocateSlotGroup();
+        if (!slot_group_opt.has_value()) {
+            return NIXL_ERR_NOT_FOUND;
+        }
+        auto slot_group = std::move(slot_group_opt).value();
+        // TODO-Eyal: fix once slots are RAII.
+        auto cleanup = makeSlotGroupCleanup(slot_group);
+        nixlSerDes serdes;
+        const nixl_status_t serialize_ret = marshal_remote_descs.serialize(&serdes);
+        if (serialize_ret != NIXL_SUCCESS) {
+            return serialize_ret;
+        }
+        auto wrapper = std::make_unique<nixlServiceXferReqH>(marshal_local_descs,
+                                                             serdes.exportStr(),
+                                                             remote_agent,
+                                                             slotGroupToWorkItems(slot_group),
+                                                             data_->nextOutboundXferId_++,
+                                                             total_chunks,
+                                                             opt_args);
+        wrapper->op = operation;
+        std::move(cleanup).Cancel();
+        req_hndl = wrapper.get();
+        data_->outboundXferReqs_[req_hndl->nonDirectData->xferId] = std::move(wrapper);
+        return NIXL_SUCCESS;
+    };
+
+    // READ counterpart of createNonDirectXfer(): builds a receive context in
+    // readReceiveReqs_ (this agent is the sink/initiator) instead of an outbound-sender
+    // context in outboundXferReqs_. Unlike the WRITE handle, the returned
+    // nixlServiceXferReqH is not itself map-owned: it is released directly to the caller
+    // (mirroring the direct-only case below), and only carries the id needed to look up the
+    // service-owned receive context.
+    auto create_read_receive_xfer =
+        [&](const nixl_marshal_opt_args_t &opt_args,
+            const nixl_xfer_dlist_t &marshal_dst_descs,
+            const nixl_xfer_dlist_t &marshal_src_descs,
+            nixlXferReqH *direct_child,
+            std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref) -> nixl_status_t {
+        if (data_->localStagingPools_.empty()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto total_chunks =
+            countChunksAndVerifyMatch(marshal_dst_descs,
+                                      marshal_src_descs,
+                                      data_->localStagingPools_.begin()->getChunkSize());
+        if (total_chunks == -1) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto slot_group_opt = data_->allocateSlotGroup();
+        if (!slot_group_opt.has_value()) {
+            return NIXL_ERR_NOT_FOUND;
+        }
+        auto slot_group = std::move(slot_group_opt).value();
+        // TODO: fix once slots are RAII.
+        auto cleanup = makeSlotGroupCleanup(slot_group);
+        // The SOURCE list (the peer's address space) is what genRREQ() must later send to
+        // the peer; the DESTINATION list (marshal_dst_descs, this agent's own memory) is
+        // kept locally and never serialized.
+        nixlSerDes serdes;
+        const nixl_status_t serialize_ret = marshal_src_descs.serialize(&serdes);
+        if (serialize_ret != NIXL_SUCCESS) {
+            return serialize_ret;
+        }
+        const auto xfer_id = data_->nextOutboundXferId_++;
+        auto receive_req =
+            std::make_unique<inboundXferReqH>(remote_agent,
+                                              nixl_xfer_dlist_t(marshal_dst_descs),
+                                              slotGroupToWorkItems(slot_group),
+                                              xfer_id,
+                                              static_cast<size_t>(total_chunks),
+                                              serdes.exportStr(),
+                                              direct_child,
+                                              resolveReadNotif(std::nullopt, extra_params),
+                                              receiver_delta_ref);
+        std::move(cleanup).Cancel();
+        data_->readReceiveReqs_[xfer_id] = std::move(receive_req);
+
+        auto wrapper = std::make_unique<nixlServiceXferReqH>();
+        wrapper->marshalOptArgs = opt_args;
+        wrapper->op = NIXL_READ;
+        wrapper->readReceiveXferId = xfer_id;
+        req_hndl = wrapper.release();
+        return NIXL_SUCCESS;
+    };
+
+    return std::visit(
+        overloaded{
+            [&](const nixlMarshalDirectOptArgs &) -> nixl_status_t {
+                auto wrapper = std::make_unique<nixlServiceXferReqH>();
+                wrapper->op = operation;
+                const nixl_status_t ret = nixlAgent::createXferReq(operation,
+                                                                   local_descs,
+                                                                   remote_descs,
+                                                                   remote_agent,
+                                                                   wrapper->xferReq,
+                                                                   extra_params);
+                if (ret != NIXL_SUCCESS) {
+                    return ret;
+                }
+
+                req_hndl = wrapper.release();
+                return ret;
+            },
+            [&](const auto &non_direct_mode_opt_args) -> nixl_status_t {
+                const nixl_marshal_opt_args_t marshal_opt_args_variant = non_direct_mode_opt_args;
+                if (const auto *delta_opt_args = getDeltaOptArgs(marshal_opt_args_variant)) {
+                    if (delta_opt_args->senderRef == nullptr ||
+                        delta_opt_args->receiverRef == nullptr) {
+                        return NIXL_ERR_INVALID_PARAM;
+                    }
+                    if (local_descs.descCount() != 1 || remote_descs.descCount() != 1) {
+                        return NIXL_ERR_NOT_SUPPORTED;
+                    }
+                    if (delta_opt_args->elementSize != 1 && delta_opt_args->elementSize != 2 &&
+                        delta_opt_args->elementSize != 4 && delta_opt_args->elementSize != 8) {
+                        // Only these element sizes are supported by the delta XOR kernel;
+                        // validate here rather than failing later at GPU submit time.
+                        return NIXL_ERR_INVALID_PARAM;
+                    }
+                }
+                auto split = splitSmallDescPairs(local_descs, remote_descs);
+                if (!split.valid) {
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                if (operation == NIXL_READ && !split.marshalLocal.isEmpty() &&
+                    remote_agent == data_->localAgentName_) {
+                    // Loopback marshalled READ (the same agent both encoding and decoding
+                    // into itself) is untested; gate it explicitly rather than risk silent
+                    // corruption. Direct-only READs are unaffected - the base nixlAgent path
+                    // below already handles loopback fine.
+                    return NIXL_ERR_NOT_SUPPORTED;
+                }
+                NIXL_ASSERT(!split.marshalLocal.isEmpty() || !split.directLocal.isEmpty());
+                nixlXferReqH *xfer_req = nullptr;
+                if (!split.directLocal.isEmpty()) {
+                    const auto ret = nixlAgent::createXferReq(operation,
+                                                              split.directLocal,
+                                                              split.directRemote,
+                                                              remote_agent,
+                                                              xfer_req,
+                                                              extra_params);
+                    if (ret != NIXL_SUCCESS) {
+                        return ret;
+                    }
+                }
+                if (split.marshalLocal.isEmpty()) {
+                    // Direct-only non-direct requests do not use service slots and are not
+                    // tracked in outboundXferReqs_/readReceiveReqs_. This is the only
+                    // marshalled READ sub-case supported so far when the whole request fits
+                    // under direct_desc_threshold.
+                    auto wrapper = std::make_unique<nixlServiceXferReqH>();
+                    wrapper->marshalOptArgs = non_direct_mode_opt_args;
+                    wrapper->op = operation;
+                    wrapper->xferReq = xfer_req;
+                    req_hndl = wrapper.release();
+                    return NIXL_SUCCESS;
+                }
+                if (operation == NIXL_WRITE) {
+                    const nixl_status_t non_direct_ret = create_non_direct_xfer(
+                        non_direct_mode_opt_args, split.marshalLocal, split.marshalRemote);
+                    if (non_direct_ret != NIXL_SUCCESS) {
+                        if (xfer_req != nullptr) {
+                            nixlAgent::releaseXferReq(xfer_req);
+                        }
+                        return non_direct_ret;
+                    }
+                    req_hndl->xferReq = xfer_req;
+                    return NIXL_SUCCESS;
+                }
+
+                NIXL_ASSERT(operation == NIXL_READ);
+                std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref;
+                if (const auto *delta_opt_args = getDeltaOptArgs(marshal_opt_args_variant)) {
+                    receiver_delta_ref =
+                        nixlMarshalDeltaReceiverRefArgs{delta_opt_args->receiverRef,
+                                                        delta_opt_args->receiverMemType,
+                                                        delta_opt_args->elementSize};
+                }
+                const nixl_status_t read_ret = create_read_receive_xfer(non_direct_mode_opt_args,
+                                                                        split.marshalLocal,
+                                                                        split.marshalRemote,
+                                                                        xfer_req,
+                                                                        receiver_delta_ref);
+                if (read_ret != NIXL_SUCCESS) {
+                    if (xfer_req != nullptr) {
+                        nixlAgent::releaseXferReq(xfer_req);
+                    }
+                    return read_ret;
+                }
+                // req_hndl->xferReq is left null: the direct child (xfer_req above) was just
+                // handed to create_read_receive_xfer, which attached it to the receive
+                // context's own directChild instead (see inboundXferReqH), so
+                // progressService() can reach it - req_hndl stays a thin token carrying
+                // only readReceiveXferId.
+                return NIXL_SUCCESS;
+            },
+        },
+        *marshal_opt_args);
+}
+
+nixl_status_t
+nixlServiceAgent::makeXferReq(const nixl_xfer_op_t &operation,
+                              const nixlDlistH *local_side,
+                              const std::vector<int> &local_indices,
+                              const nixlDlistH *remote_side,
+                              const std::vector<int> &remote_indices,
+                              nixlServiceXferReqH *&req_hndl,
+                              const nixl_service_opt_args_t *extra_params) {
+    const auto marshal_opt_args = getValidMarshalOptArgs(extra_params, data_->mode_);
+    if (!marshal_opt_args.has_value()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    return std::visit(overloaded{
+                          [&](const nixlMarshalDirectOptArgs &) -> nixl_status_t {
+                              auto wrapper = std::make_unique<nixlServiceXferReqH>();
+                              wrapper->xferReq = nullptr;
+                              wrapper->op = operation;
+
+                              const nixl_status_t ret = nixlAgent::makeXferReq(operation,
+                                                                               local_side,
+                                                                               local_indices,
+                                                                               remote_side,
+                                                                               remote_indices,
+                                                                               wrapper->xferReq,
+                                                                               extra_params);
+                              if (ret != NIXL_SUCCESS) {
+                                  return ret;
+                              }
+
+                              req_hndl = wrapper.release();
+                              return ret;
+                          },
+                          [&](const auto &non_direct_mode_opt_args) -> nixl_status_t {
+                              // TODO: allocate a pipeline-tracking nixlServiceXferReqH bound to
+                              // the pre-prepared dlist handles.
+                              // TODO-Eyal: implement Dlist serialization and validation.
+                              // This unconditionally rejects the non-direct path regardless of
+                              // `operation`, so both NIXL_WRITE and NIXL_READ are covered.
+                              return NIXL_ERR_NOT_SUPPORTED;
+                          },
+                      },
+                      *marshal_opt_args);
+}
+
+nixl_status_t
+nixlServiceAgent::postXferReq(nixlServiceXferReqH *req_hndl,
+                              const nixl_service_opt_args_t *extra_params) {
+    return std::visit(
+        overloaded{
+            [&](const nixlMarshalDirectOptArgs &) -> nixl_status_t {
+                return nixlAgent::postXferReq(req_hndl->xferReq, extra_params);
+            },
+            [&](const auto &non_direct_mode_opt_args) -> nixl_status_t {
+                // True for either direction's marshal sub-part; at most one of the two is
+                // ever set on a given handle (WRITE never sets readReceiveXferId, READ never
+                // sets nonDirectData), so this does not need to branch on req_hndl->op.
+                const bool has_marshal_part =
+                    req_hndl->nonDirectData.has_value() || req_hndl->readReceiveXferId.has_value();
+
+                // For a READ with a marshal part, the direct child lives on the receive
+                // context (inboundXferReqH::directChild) rather than on req_hndl itself;
+                // look the context up once, up front, so both the repost check and the
+                // direct-child post below can use it. Reject a repost before touching the
+                // direct child: its own repost check (inside nixlAgent::postXferReq below)
+                // only rejects while its own sub-transfer is still NIXL_IN_PROG, so if it
+                // happened to finish first it would otherwise get silently reposted
+                // (re-triggering another RDMA read) even though the logical READ as a whole
+                // must stay non-repostable for as long as the marshal sub-part is
+                // outstanding.
+                inboundXferReqH *receive_req = nullptr;
+                if (req_hndl->op == NIXL_READ && req_hndl->readReceiveXferId.has_value()) {
+                    NIXL_ASSERT(data_->readReceiveReqs_.count(*req_hndl->readReceiveXferId) == 1);
+                    receive_req = data_->readReceiveReqs_[*req_hndl->readReceiveXferId].get();
+                    if (receive_req->state != nixl_service_xfer_state_t::PRE_START) {
+                        return NIXL_ERR_REPOST_ACTIVE;
+                    }
+                }
+
+                // The direct child to post: the receive context's for a marshal READ (mixed
+                // or marshal-only, where it may itself be null), otherwise req_hndl's own
+                // (WRITE, or a direct-only READ, which always has one - createXferReq
+                // requires at least one of direct/marshal to be non-empty).
+                nixlXferReqH *const direct_child =
+                    receive_req != nullptr ? receive_req->directChild : req_hndl->xferReq;
+                nixl_status_t direct_post_ret = NIXL_SUCCESS;
+                if (direct_child != nullptr) {
+                    nixl_service_opt_args_t direct_extra_params;
+                    const nixl_opt_args_t *direct_extra_params_ptr = nullptr;
+                    if (extra_params != nullptr) {
+                        direct_extra_params = *extra_params;
+                        if (has_marshal_part) {
+                            direct_extra_params.notif.reset();
+                        }
+                        direct_extra_params_ptr = &direct_extra_params;
+                    }
+                    if (has_marshal_part && req_hndl->op == NIXL_READ) {
+                        // The receive context owns the (create- or post-time) notification
+                        // and delivers it once both sub-parts finish; the direct child must
+                        // never carry one, including a create-time notif baked into the base
+                        // handle by createXferReq. Unlike WRITE above, this applies
+                        // regardless of extra_params, since for READ (unlike WRITE) the
+                        // receive context also captures the create-time notif, so leaving it
+                        // on the direct child would fire it twice.
+                        direct_extra_params.notif.reset();
+                        direct_extra_params.hasNotif = false;
+                        direct_extra_params_ptr = &direct_extra_params;
+                    }
+                    direct_post_ret = nixlAgent::postXferReq(direct_child, direct_extra_params_ptr);
+                    if (direct_post_ret < NIXL_SUCCESS) {
+                        return direct_post_ret;
+                    }
+                }
+
+                if (req_hndl->op == NIXL_READ) {
+                    if (receive_req == nullptr) {
+                        // Direct-only READ: nothing else to post. Return the direct child's
+                        // own status rather than hard-coding NIXL_SUCCESS, since it may still
+                        // be NIXL_IN_PROG.
+                        return direct_post_ret;
+                    }
+                    NIXL_ASSERT(receive_req->state == nixl_service_xfer_state_t::PRE_START);
+                    const auto gen_rreq_ret = data_->genRREQ(*req_hndl);
+                    if (gen_rreq_ret != NIXL_SUCCESS) {
+                        return gen_rreq_ret;
+                    }
+                    // Unlike WRITE (PRE_START -> WAIT_CTS -> IN_PROGRESS via CTS), READ has
+                    // no CTS: the initiator already advertised its recv slots in RREQ itself.
+                    receive_req->state = nixl_service_xfer_state_t::IN_PROGRESS;
+                    // Only overwrite the notification captured at create time if extra_params
+                    // explicitly supplies one - mirrors the WRITE branch below and the base
+                    // nixlAgent::postXferReq convention, so a bare postXferReq(req_hndl)
+                    // doesn't silently discard a notification set only at createXferReq()
+                    // time.
+                    receive_req->notif = resolveReadNotif(receive_req->notif, extra_params);
+                    return NIXL_IN_PROG;
+                }
+
+                if (!req_hndl->nonDirectData.has_value()) {
+                    return NIXL_SUCCESS;
+                }
+                auto gen_rts_ret = data_->genRTS(*req_hndl);
+                if (gen_rts_ret != NIXL_SUCCESS) {
+                    return gen_rts_ret;
+                }
+                req_hndl->nonDirectData->state = nixl_service_xfer_state_t::WAIT_CTS;
+                if (extra_params != nullptr && extra_params->notif.has_value()) {
+                    // Mixed requests keep the user notification on the marshal path,
+                    // which we assume completes last.
+                    // TODO: reconsider once notification ordering should cover
+                    // both direct and marshal sub-transfers.
+                    req_hndl->nonDirectData->notifMsg = *extra_params->notif;
+                }
+                return NIXL_SUCCESS;
+            },
+        },
+        req_hndl->marshalOptArgs);
+}
+
+nixl_status_t
+nixlServiceAgent::getXferStatus(nixlServiceXferReqH *req_hndl) {
+    if (std::holds_alternative<nixlMarshalDirectOptArgs>(req_hndl->marshalOptArgs)) {
+        return nixlAgent::getXferStatus(req_hndl->xferReq);
+    }
+
+    data_->progressService();
+
+    if (req_hndl->op == NIXL_READ) {
+        if (!req_hndl->readReceiveXferId.has_value()) {
+            // Direct-only READ: nothing else to check.
+            return nixlAgent::getXferStatus(req_hndl->xferReq);
+        }
+        NIXL_ASSERT(data_->readReceiveReqs_.count(*req_hndl->readReceiveXferId) == 1);
+        auto &receive_req = *data_->readReceiveReqs_[*req_hndl->readReceiveXferId];
+        if (receive_req.state == nixl_service_xfer_state_t::FAILED) {
+            return receive_req.terminalStatus;
+        }
+        if (receive_req.state == nixl_service_xfer_state_t::PRE_START) {
+            return NIXL_ERR_NOT_POSTED;
+        }
+        // progressService() above already polled the direct child (if any) and the marshal
+        // sub-part, and finalized state via tryCompleteReadReceive once both are done - see
+        // progressReadReceive() - so there is nothing left to poll here.
+        return (receive_req.state == nixl_service_xfer_state_t::DONE) ? NIXL_SUCCESS : NIXL_IN_PROG;
+    }
+
+    if (req_hndl->xferReq != nullptr) {
+        const nixl_status_t direct_status = nixlAgent::getXferStatus(req_hndl->xferReq);
+        if (direct_status != NIXL_SUCCESS) {
+            return direct_status;
+        }
+    }
+
+    if (!req_hndl->nonDirectData.has_value()) {
+        return NIXL_SUCCESS;
+    }
+    switch (req_hndl->nonDirectData->state) {
+    case nixl_service_xfer_state_t::PRE_START:
+        return NIXL_ERR_NOT_POSTED;
+    case nixl_service_xfer_state_t::WAIT_CTS:
+    case nixl_service_xfer_state_t::IN_PROGRESS:
+        return NIXL_IN_PROG;
+    case nixl_service_xfer_state_t::DONE:
+        return NIXL_SUCCESS;
+    default:
+        NIXL_ASSERT(false);
+        return NIXL_ERR_UNKNOWN;
+    }
+}
+
+nixl_status_t
+nixlServiceAgent::releaseXferReq(nixlServiceXferReqH *req_hndl) {
+    if (!req_hndl) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return std::visit(
+        overloaded{
+            [&](const nixlMarshalDirectOptArgs &) -> nixl_status_t {
+                const nixl_status_t ret = nixlAgent::releaseXferReq(req_hndl->xferReq);
+                delete req_hndl;
+                return ret;
+            },
+            [&](const auto &non_direct_mode_opt_args) -> nixl_status_t {
+                NIXL_ASSERT(req_hndl != nullptr);
+                nixl_status_t direct_ret = NIXL_SUCCESS;
+                if (req_hndl->xferReq != nullptr) {
+                    direct_ret = nixlAgent::releaseXferReq(req_hndl->xferReq);
+                    req_hndl->xferReq = nullptr;
+                }
+
+                if (req_hndl->op == NIXL_READ) {
+                    nixl_status_t read_ret = NIXL_SUCCESS;
+                    if (req_hndl->readReceiveXferId.has_value()) {
+                        const auto xfer_id = *req_hndl->readReceiveXferId;
+                        NIXL_ASSERT(data_->readReceiveReqs_.count(xfer_id) == 1);
+                        auto &receive_req = *data_->readReceiveReqs_[xfer_id];
+                        // For a marshal READ, the direct child (if any - null for
+                        // marshal-only) lives here rather than on req_hndl (see
+                        // inboundXferReqH::directChild), so it is released here instead of
+                        // by the block above. Only clear it once the base release actually
+                        // succeeds: releaseXferReq() returns NIXL_ERR_REPOST_ACTIVE without
+                        // deleting the handle when the backend fails to cancel an in-flight
+                        // transfer, so on that failure directChild is still valid, and
+                        // bailing out here - before touching state or slots - leaves the
+                        // child, the context, and this token exactly as they were, so the
+                        // caller can retry by calling releaseXferReq(req_hndl) again.
+                        if (receive_req.directChild != nullptr) {
+                            direct_ret = nixlAgent::releaseXferReq(receive_req.directChild);
+                            if (direct_ret != NIXL_SUCCESS) {
+                                return direct_ret;
+                            }
+                            receive_req.directChild = nullptr;
+                        }
+                        switch (receive_req.state) {
+                        case nixl_service_xfer_state_t::PRE_START:
+                        case nixl_service_xfer_state_t::DONE:
+                            // Either the peer never learned about this READ (PRE_START), or
+                            // the marshal sub-transfer completed successfully and all of
+                            // its slots are idle (see tryCompleteReadReceive) - free and
+                            // erase immediately.
+                            NIXL_ASSERT(receive_req.directChild == nullptr);
+                            data_->freeSlotGroup(receive_req.localSlots);
+                            data_->readReceiveReqs_.erase(xfer_id);
+                            break;
+                        case nixl_service_xfer_state_t::IN_PROGRESS:
+                        case nixl_service_xfer_state_t::FAILED:
+                            // Mid-transfer release, or a codec-integrity failure on one
+                            // slot while a sibling slot's decode may still be legitimately
+                            // in flight: either way, slots must not be freed yet. Ask the
+                            // peer to quiesce via RABORT and retain the receive context
+                            // (and its slots) until handleRAbortAck confirms it has stopped.
+                            receive_req.state = nixl_service_xfer_state_t::CANCELLING;
+                            read_ret = data_->genRAbort(receive_req.remoteAgent, xfer_id);
+                            if (read_ret != NIXL_SUCCESS) {
+                                // TODO: handle error.
+                                NIXL_ASSERT(false);
+                            }
+                            break;
+                        default:
+                            // WAIT_CTS is WRITE-only; CANCELLING means releaseXferReq was
+                            // somehow called twice on the same handle.
+                            NIXL_ASSERT(false);
+                            break;
+                        }
+                    }
+                    delete req_hndl;
+                    return (direct_ret != NIXL_SUCCESS) ? direct_ret : read_ret;
+                }
+
+                if (!req_hndl->nonDirectData.has_value()) {
+                    delete req_hndl;
+                    return direct_ret;
+                }
+                auto &req_data = req_hndl->nonDirectData.value();
+                // If the state is done, delete was sent and slots were freed.
+                // If the state is pre-start, the receiver doesn't know about the
+                // transfer.
+                if (req_data.state != nixl_service_xfer_state_t::DONE) {
+                    if (req_data.state != nixl_service_xfer_state_t::PRE_START) {
+                        // This path is a mid-transfer release.
+                        auto ret = data_->genDelete(req_data.remoteAgent, req_data.xferId);
+                        if (ret != NIXL_SUCCESS) {
+                            // TODO: handle error.
+                            NIXL_ASSERT(false);
+                            return ret;
+                        }
+                    }
+                    data_->freeSlotGroup(req_data.localSlots);
+                }
+                data_->outboundXferReqs_.erase(
+                    req_data.xferId); // This will delete the req_hndl, since it is
+                                      // the raw pointer in the unique_ptr.
+                return direct_ret;
+            },
+        },
+        req_hndl->marshalOptArgs);
+}
+
+nixl_status_t
+nixlServiceAgent::getNotifs(nixl_notifs_t &notifs, const nixl_opt_args_t *extra_params) {
+    [[maybe_unused]] auto progress_ret = data_->progressService();
+    NIXL_ASSERT(progress_ret == NIXL_SUCCESS || progress_ret == NIXL_IN_PROG);
+    auto notifs_ret = nixlAgent::getNotifs(notifs, extra_params);
+    return notifs_ret;
+}

--- a/src/services/nixl_service.h
+++ b/src/services/nixl_service.h
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @file nixl_service.h
+ * @brief nixlServiceAgent — compression, staging, and encryption services
+ *        layered transparently on top of nixlAgent.
+ */
+#ifndef NIXL_SERVICE_H
+#define NIXL_SERVICE_H
+
+#include "nixl.h"
+#include "nixl_service_types.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+class nixlServiceAgentData;
+struct nixlServiceXferReqH;
+
+namespace nixlService {
+/**
+ * @brief Recommend the service memory, in bytes per descriptor, to register for a given
+ *        marshal mode.
+ *
+ * This is how a caller learns how much memory to hand to
+ * nixlServiceAgent::registerServiceMem.
+ *
+ * @note The recommendation is a minimum: registering more is allowed and yields more slots.
+ * @note Undersizing maxConcurrentTransfers is especially visible for NIXL_READ: a served
+ * READ that finds the peer's slot pool exhausted is rejected outright (RNAK), not
+ * queued, so back-to-back READs on a minimal pool can transiently fail. Size with
+ * headroom for the actual number of concurrent in-flight transfers, not just 1.
+ *
+ * @param mode The marshal mode.
+ * @param maxConcurrentTransfers The maximum expected number of concurrent transfers.
+ * @return The recommended service memory size per descriptor, in bytes.
+ * @throws std::invalid_argument for direct mode, which uses no service memory; for a zero
+ *         maxConcurrentTransfers; and for compression when the library was built without
+ *         nvCOMP.
+ */
+size_t
+recommendServiceMemSize(const nixl_marshal_config_t &mode, uint32_t max_concurrent_transfers = 1);
+}; // namespace nixlService
+
+/**
+ * @class nixlServiceAgent
+ * @brief Extends nixlAgent with transparent marshalling.
+ *
+ * @note DIRECT mode is identical to the base class.
+ */
+class nixlServiceAgent : public nixlAgent {
+public:
+    static constexpr bool trackCompressionRatio = false;
+    /**
+     * @brief Construct a service agent.
+     *
+     * @param name  Agent name (same semantics as nixlAgent)
+     * @param cfg   Service configuration (defaultMode, optional defaultCompAlg).
+     */
+    nixlServiceAgent(const std::string &name, nixlServiceAgentConfig cfg);
+
+    /**
+     * @brief Destructor.  Virtual via nixlAgent.
+     */
+    ~nixlServiceAgent() override;
+
+    // Non-copyable, non-movable (same constraint as nixlAgent)
+    nixlServiceAgent(const nixlServiceAgent &) = delete;
+    nixlServiceAgent &
+    operator=(const nixlServiceAgent &) = delete;
+    nixlServiceAgent(nixlServiceAgent &&) = delete;
+    nixlServiceAgent &
+    operator=(nixlServiceAgent &&) = delete;
+
+    /**
+     * @brief  Register a staging buffer for the given service mode.
+     *
+     * Delegates to the marshal backend for transport registration and any
+     * library-specific setup.
+     *
+     * @param  descs        Staging buffer descriptors
+     * @param  extra_params Optional backend hints
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    registerServiceMem(const nixl_reg_dlist_t &descs,
+                       const nixl_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Deregister previously registered staging memory.
+     *         Must be followed by metadata re-exchange.
+     */
+    nixl_status_t
+    deregisterServiceMem(const nixl_reg_dlist_t &descs,
+                         const nixl_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Create a service transfer request from two descriptor lists.
+     *
+     * @param  operation    NIXL_WRITE or NIXL_READ
+     * @param  local_descs  Local descriptor list
+     * @param  remote_descs Remote descriptor list
+     * @param  remote_agent Remote agent name
+     * @param  req_hndl     [out] Service transfer handle
+     * @param  extra_params Optional per-transfer mode/algorithm overrides
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    createXferReq(const nixl_xfer_op_t &operation,
+                  const nixl_xfer_dlist_t &local_descs,
+                  const nixl_xfer_dlist_t &remote_descs,
+                  const std::string &remote_agent,
+                  nixlServiceXferReqH *&req_hndl,
+                  const nixl_service_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Create a service transfer request from pre-prepared dlist handles.
+     *
+     * @param  operation      NIXL_WRITE or NIXL_READ
+     * @param  local_side     Pre-prepared local dlist handle
+     * @param  local_indices  Descriptor indices to use from local_side
+     * @param  remote_side    Pre-prepared remote dlist handle
+     * @param  remote_indices Descriptor indices to use from remote_side
+     * @param  req_hndl       [out] Service transfer handle
+     * @param  extra_params   Optional per-transfer overrides
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    makeXferReq(const nixl_xfer_op_t &operation,
+                const nixlDlistH *local_side,
+                const std::vector<int> &local_indices,
+                const nixlDlistH *remote_side,
+                const std::vector<int> &remote_indices,
+                nixlServiceXferReqH *&req_hndl,
+                const nixl_service_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Post a service transfer request, initiating the protocol.
+     *
+     * @param  req_hndl    Service transfer handle from createXferReq / makeXferReq
+     * @param  extra_params Optional per-post overrides
+     * @return nixl_status_t  NIXL_IN_PROG or error
+     */
+    nixl_status_t
+    postXferReq(nixlServiceXferReqH *req_hndl,
+                const nixl_service_opt_args_t *extra_params = nullptr);
+
+    /**
+     * @brief  Query transfer status, driving service progress in the process.
+     *
+     * @param  req_hndl  Service transfer handle
+     * @return nixl_status_t  NIXL_SUCCESS (done), NIXL_IN_PROG, or error
+     */
+    nixl_status_t
+    getXferStatus(nixlServiceXferReqH *req_hndl);
+
+    /**
+     * @brief  Release a service transfer handle and free all resources.
+     *
+     * @note   Releasing a NIXL_READ (or NIXL_WRITE) that is still in progress drains
+     *         asynchronously rather than freeing synchronously: the destination buffer must
+     *         not be reused until a prior getXferStatus() reported a terminal status, since
+     *         in-flight local decodes/writes into it may briefly outlive this call.
+     *
+     * @param  req_hndl  Service transfer handle to release
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    releaseXferReq(nixlServiceXferReqH *req_hndl);
+
+    /**
+     * @brief  Collect user-visible notifications, driving service progress first.
+     *
+     * @param  notifs       [in/out] Appended with non-service notifications
+     * @param  extra_params Optional backend filter
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    getNotifs(nixl_notifs_t &notifs, const nixl_opt_args_t *extra_params = nullptr);
+
+    nixl_status_t
+    createXferReq(const nixl_xfer_op_t &,
+                  const nixl_xfer_dlist_t &,
+                  const nixl_xfer_dlist_t &,
+                  const std::string &,
+                  nixlXferReqH *&,
+                  const nixl_opt_args_t * = nullptr) const = delete;
+
+    nixl_status_t
+    makeXferReq(const nixl_xfer_op_t &,
+                const nixlDlistH *,
+                const std::vector<int> &,
+                const nixlDlistH *,
+                const std::vector<int> &,
+                nixlXferReqH *&,
+                const nixl_opt_args_t * = nullptr) const = delete;
+
+    nixl_status_t
+    postXferReq(nixlXferReqH *, const nixl_opt_args_t * = nullptr) const = delete;
+
+    nixl_status_t
+    getXferStatus(nixlXferReqH *) const = delete;
+
+    nixl_status_t
+    releaseXferReq(nixlXferReqH *) const = delete;
+
+    nixl_status_t
+    estimateXferCost(const nixlXferReqH *,
+                     std::chrono::microseconds &,
+                     std::chrono::microseconds &,
+                     nixl_cost_t &,
+                     const nixl_opt_args_t * = nullptr) const = delete;
+
+    nixl_status_t
+    getXferTelemetry(const nixlXferReqH *, nixl_xfer_telem_t &) const = delete;
+
+private:
+    /**
+     * @brief  Pre-create nixlServiceAgentData.
+     */
+    static std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>>
+    prepare(nixlServiceAgentConfig cfg);
+
+protected:
+    /**
+     * @brief  Pre-create nixlServiceAgentData with an explicit chunked payload size.
+     *
+     * @note   Test-only seam. The payload size is baked into the layout fingerprint, so
+     *         production agents must go through the public constructor to stay compatible
+     *         with their peers.
+     */
+    static std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>>
+    prepare(nixlServiceAgentConfig cfg, size_t chunked_payload_size);
+
+    /**
+     * @brief  Delegating constructor that receives the pre-built tag.
+     */
+    nixlServiceAgent(
+        const std::string &name,
+        std::pair<nixlServiceAgentConfig, std::shared_ptr<nixlServiceAgentData>> &&tag);
+
+private:
+    std::shared_ptr<nixlServiceAgentData> data_;
+};
+
+#endif // NIXL_SERVICE_H

--- a/src/services/nixl_service_data.h
+++ b/src/services/nixl_service_data.h
@@ -1,0 +1,1183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NIXL_SERVICE_DATA_H
+#define NIXL_SERVICE_DATA_H
+
+#include "common/nixl_log.h"
+#include "nixl_service_types.h"
+#include "marshal/marshal_backend.h"
+#include "spsc_queue.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <array>
+#include <functional>
+#include <list>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+#include <variant>
+
+#include <cuda_runtime.h>
+
+/**
+ * @class cudaStream
+ * @brief  RAII wrapper around a non-blocking cudaStream_t.
+ */
+class cudaStream {
+public:
+    cudaStream() {
+        const cudaError_t status = cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
+        if (status != cudaSuccess) {
+            throw std::runtime_error(std::string("cudaStreamCreateWithFlags failed: ") +
+                                     cudaGetErrorString(status));
+        }
+    }
+
+    ~cudaStream() noexcept {
+        if (stream_ != nullptr) {
+            cudaStreamDestroy(stream_);
+        }
+    }
+
+    cudaStream(const cudaStream &) = delete;
+    cudaStream &
+    operator=(const cudaStream &) = delete;
+
+    cudaStream(cudaStream &&other) noexcept : stream_(other.stream_) {
+        other.stream_ = nullptr;
+    }
+
+    cudaStream &
+    operator=(cudaStream &&other) noexcept {
+        if (this != &other) {
+            if (stream_ != nullptr) {
+                cudaStreamDestroy(stream_);
+            }
+            stream_ = other.stream_;
+            other.stream_ = nullptr;
+        }
+        return *this;
+    }
+
+    [[nodiscard]] cudaStream_t
+    get() const noexcept {
+        return stream_;
+    }
+
+private:
+    cudaStream_t stream_ = nullptr;
+};
+
+/**
+ * @struct slotT
+ * @brief  Describes an allocated slot handed out by a slotPool.
+ *
+ * @details
+ * @c stream is a non-owning handle.  Ownership of the underlying cudaStream_t
+ * lives in the issuing @c slotPool (see @c slotPool::streams_), and the handle
+ * remains valid for the lifetime of that pool.
+ */
+class slotPool;
+
+struct slotT {
+    slotPool *pool = nullptr;
+    uintptr_t baseAddr;
+    /* Size fields:
+     * slotSize is the total size for the slot in the service memory (slotPool),
+     * pointed to by baseAddr.
+     * chunkSize is the corresponding size in the user buffer. Each chunk is processed to a slot and
+     * vice versa. workspaceSize is included in slotSize (0 <= *workspaceSize < slotSize), needed
+     * for certain marshals e.g. compression.
+     */
+    size_t slotSize;
+    std::optional<size_t> workspaceSize;
+    size_t chunkSize;
+    cudaStream_t stream;
+    nixl_mem_t type;
+
+    slotT() = default;
+    slotT(slotPool *slot_pool,
+          uintptr_t base_addr,
+          size_t slot_size,
+          cudaStream_t stream,
+          nixl_mem_t type,
+          size_t chunk_size,
+          std::optional<size_t> workspace_size = std::nullopt);
+
+    [[nodiscard]] nixlBasicDesc
+    toDesc(size_t len) const noexcept;
+
+    [[nodiscard]] nixlMarshal::runtimeBuffer
+    toRuntimeBuffer() const;
+
+    [[nodiscard]] nixlMarshal::process_slot_input_options_t
+    getProcessSlotInputOptions() const;
+
+private:
+    int deviceId_;
+};
+
+enum class remote_slot_state_t { NOT_ALLOCATED, BUSY, FREE };
+
+enum class local_slot_state_t { BUSY_MARSHAL, READY_TO_SEND, BUSY_NIXL, FREE };
+
+enum class nixl_service_xfer_state_t {
+    PRE_START,
+    WAIT_CTS,
+    IN_PROGRESS,
+    // READ-only: mid-transfer cancellation is in progress (draining in-flight work before
+    // freeing state). Ordered after IN_PROGRESS and before DONE so the existing
+    // `state >= IN_PROGRESS` checks used by the WRITE progress engine continue to hold for
+    // a cancelling/failed READ request (WRITE never enters these two states).
+    CANCELLING,
+    DONE,
+    // READ-only: the request ended in a terminal error (e.g. an RNAK admission rejection).
+    FAILED
+};
+
+static constexpr size_t slots_per_xfer = 2;
+
+class chunkIteratorH {
+protected:
+    const nixl_xfer_dlist_t descList;
+    const size_t chunkSize;
+    const size_t totalChunks;
+    size_t currentChunkGlobal;
+    size_t currentChunkLocal;
+    size_t currentDesc;
+
+public:
+    chunkIteratorH(const nixl_xfer_dlist_t &desc_list, size_t chunk_size, size_t total_chunks)
+        : descList(desc_list),
+          chunkSize(chunk_size),
+          totalChunks(total_chunks),
+          currentChunkGlobal(0),
+          currentChunkLocal(0),
+          currentDesc(0) {}
+
+    [[nodiscard]] std::byte *
+    get() noexcept {
+        if (currentChunkGlobal >= totalChunks) {
+            return nullptr;
+        }
+        return reinterpret_cast<std::byte *>(descList[currentDesc].addr +
+                                             currentChunkLocal * chunkSize);
+    }
+
+    bool
+    operator++(int) noexcept {
+        currentChunkGlobal++;
+        if (currentChunkGlobal >= totalChunks) {
+            return false;
+        }
+        currentChunkLocal++;
+        if (currentChunkLocal >= (descList[currentDesc].len + chunkSize - 1) / chunkSize) {
+            currentChunkLocal = 0;
+            currentDesc++;
+        }
+        NIXL_ASSERT(currentDesc < static_cast<size_t>(descList.descCount()));
+        return true;
+    }
+
+    [[nodiscard]] size_t
+    currentChunkSize() noexcept {
+        if (currentChunkGlobal >= totalChunks) {
+            return 0;
+        }
+        return std::min(
+            chunkSize,
+            static_cast<size_t>(descList[currentDesc].len - currentChunkLocal * chunkSize));
+    }
+
+    [[nodiscard]] size_t
+    getTotalChunks() const noexcept {
+        return totalChunks;
+    }
+
+    [[nodiscard]] size_t
+    getCurrentChunkLocal() const noexcept {
+        return currentChunkLocal;
+    }
+
+    [[nodiscard]] size_t
+    getCurrentDesc() const noexcept {
+        return currentDesc;
+    }
+
+    [[nodiscard]] nixl_mem_t
+    getMemType() const noexcept {
+        return descList.getType();
+    }
+
+    // Absolute byte offset of (desc_index, chunk_index) from the start of this iterator's
+    // descriptor list, using this iterator's own chunk size. Useful for recovering the byte
+    // offset of a chunk already visited (e.g. from a previously-captured descIndex/
+    // chunkIndex pair), without needing to re-walk the iterator itself.
+    [[nodiscard]] size_t
+    getByteOffset(size_t desc_index, size_t chunk_index) const noexcept {
+        size_t offset = 0;
+        for (size_t i = 0; i < desc_index; ++i) {
+            offset += descList[i].len;
+        }
+        return offset + chunk_index * chunkSize;
+    }
+};
+
+struct postedNotifPayload {
+    size_t xferId;
+    size_t slotIndex;
+    size_t originalSize; // size of data pulled from user buffer.
+    std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>>
+        postedSegments; // marshal segments sent. may be of length 1 or greater.
+    size_t descIndex; // index of the desc in the desc list.
+    size_t chunkIndex; // index of the chunk in the desc.
+    std::string metadata; // metadata produced by the marshal layer.
+
+    postedNotifPayload(
+        size_t xfer_id,
+        size_t slot_index,
+        size_t original_size,
+        std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>> posted_segments,
+        size_t desc_index,
+        size_t chunk_index,
+        std::string md);
+    explicit postedNotifPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+struct slotWorkItem {
+    slotT slot;
+    local_slot_state_t state = local_slot_state_t::FREE;
+    size_t slotIndex = 0;
+    std::optional<postedNotifPayload> postedNotif = std::nullopt;
+
+    slotWorkItem() = default;
+    slotWorkItem(slotT slot, size_t slot_index);
+};
+
+struct compressionStats {
+    double minRatio = 0.0;
+    double maxRatio = 0.0;
+    size_t compressedSize = 0;
+    double weightedSumSquaredRatio = 0.0;
+    size_t originalSize = 0;
+};
+
+struct nixlServiceXferReqH {
+    struct nonDirectDataH {
+        const std::string remoteAgent;
+        const std::string serializedDstDescList;
+        const size_t xferId;
+        nixl_service_xfer_state_t state;
+        chunkIteratorH chunkIterator;
+        std::array<slotWorkItem, slots_per_xfer> localSlots;
+        std::array<std::unique_ptr<nixlMarshal::outbound_async_handle_t>, slots_per_xfer>
+            outboundAsyncHandles;
+        std::unique_ptr<compressionStats> compressionStatsHandle;
+        // Remote slots are not const since they are determined by the remote agent and
+        // passed in the CTS notification.
+        std::array<nixlBasicDesc, slots_per_xfer> remoteSlotDescriptors;
+        std::array<nixlMarshal::mem_space_t, slots_per_xfer> remoteSlotMemTypes;
+        std::array<remote_slot_state_t, slots_per_xfer> remoteSlotStates;
+        std::array<nixlXferReqH *, slots_per_xfer> nixlXferReqs;
+        size_t rslotsReceived = 0;
+        std::string notifMsg = "";
+        // READ-serving only (always 0, unused for WRITE): the generation this agent most
+        // recently sent for each remote slot, bumped by trySend() right before dispatching
+        // a new fill. handleRRSlot() compares an incoming RRSLOT's generation against this
+        // to tell a stale/duplicate ack for an earlier fill of the same slot apart from the
+        // ack for the fill currently in flight.
+        std::array<uint64_t, slots_per_xfer> remoteSlotGenerations{};
+    };
+
+    // The direct (<= direct_desc_threshold) sub-transfer's handle for a WRITE, a direct-only
+    // READ, or a fully-direct request. For a READ with a marshal part (mixed or
+    // marshal-only), the direct child instead lives on the receive context's own
+    // directChild (see inboundXferReqH) so progressService() can reach it, and this stays
+    // null - req_hndl is then just a thin token carrying readReceiveXferId.
+    nixlXferReqH *xferReq;
+    std::optional<nonDirectDataH> nonDirectData;
+    nixl_marshal_opt_args_t marshalOptArgs;
+    // Direction this handle was created for. NIXL_WRITE for all handles today; READ handles
+    // set this so postXferReq/getXferStatus/releaseXferReq can branch on direction without
+    // relying on the (direction-agnostic) marshalOptArgs alternative.
+    nixl_xfer_op_t op = NIXL_WRITE;
+    // For a READ handle (op == NIXL_READ) with a marshal part only: the key into
+    // nixlServiceAgentData::readReceiveReqs_ identifying this READ's receive context. Empty
+    // for a WRITE handle, or for a direct-only READ (no marshal part, hence no context).
+    // remoteAgent is deliberately not duplicated here - it is available from the receive
+    // context itself (inboundXferReqH::remoteAgent) once looked up by this id.
+    std::optional<size_t> readReceiveXferId;
+
+    nixlServiceXferReqH(const nixl_xfer_dlist_t &src_desc_list,
+                        const std::string &serialized_dst_desc_list,
+                        const std::string &remote_agent,
+                        const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+                        size_t xfer_id,
+                        size_t total_chunks,
+                        const nixl_marshal_opt_args_t &marshal_opt_args);
+
+    nixlServiceXferReqH() : xferReq(nullptr), marshalOptArgs(nixlMarshalDirectOptArgs{}) {}
+};
+
+struct nixlMarshalDeltaReceiverRefArgs {
+    std::byte *ref = nullptr;
+    nixl_mem_t memType{};
+    size_t elementSize = 0;
+};
+
+// Sender-side counterpart of nixlMarshalDeltaReceiverRefArgs: for a marshalled READ, the
+// peer is the one encoding, so RREQ ships the peer's own delta reference (this struct)
+// rather than the initiator's receiver reference.
+struct nixlMarshalDeltaSenderRefArgs {
+    std::byte *ref = nullptr;
+    nixl_mem_t memType{};
+    size_t elementSize = 0;
+};
+
+struct inboundXferReqH {
+    const std::string remoteAgent;
+    const nixl_xfer_dlist_t dstList;
+    const size_t xferId;
+    nixl_service_xfer_state_t state;
+    bool markedForDeletion = false;
+    std::array<slotWorkItem, slots_per_xfer> localSlots;
+    std::array<std::unique_ptr<nixlMarshal::inbound_async_handle_t>, slots_per_xfer> asyncHandles;
+    std::optional<nixlMarshalDeltaReceiverRefArgs> receiverDeltaRef;
+
+    // --- READ-receive-only bookkeeping (userInitiated == true); left at their defaults for
+    //     a WRITE-inbound request built by handleRTS ---
+
+    // Serialized SOURCE dlist (the peer's address space), captured at createXferReq() time
+    // and sent by genRREQ() when postXferReq() is later called by the user.
+    const std::string serializedSrcList = "";
+    size_t totalChunks = 0;
+    size_t decodedChunks = 0;
+    // The user notification for this READ, delivered to the peer once the whole logical
+    // request (direct + marshal parts) completes. std::optional (not a bare string) so a
+    // present-but-empty notification can be told apart from "no notification at all".
+    std::optional<nixl_blob_t> notif;
+    // True only for a request built by createXferReq(NIXL_READ, ...) on the initiator (a
+    // *receive* context the user holds a handle to); false for a WRITE-inbound request built
+    // by handleRTS (which the user never sees a handle for).
+    bool userInitiated = false;
+    // The direct (<= direct_desc_threshold) sub-transfer's handle for a mixed READ, moved
+    // here (rather than living on the outer nixlServiceXferReqH, which stays a thin token
+    // for any READ with a marshal part) so progressService()'s end-of-tick scan can poll
+    // it - see progressReadReceive(). Null for a marshal-only READ.
+    nixlXferReqH *directChild = nullptr;
+    // Completion of directChild above and the marshal (slot-based) sub-transfer
+    // respectively; the logical READ is done only when both are. directDone is derived
+    // from directChild at construction (null => true, as there is nothing to wait for) and,
+    // for a mixed READ, later updated by progressReadReceive() as directChild's own status
+    // is observed.
+    bool directDone = true;
+    bool marshalDone = false;
+    nixl_status_t terminalStatus = NIXL_IN_PROG;
+    // True once handleRAbortAck confirms the peer has fully quiesced this READ (stopped
+    // touching this agent's receive slots) after an RABORT. Distinguishes "still waiting for
+    // the peer to quiesce" from "peer quiesced, now draining this agent's own in-flight
+    // decodes" - both of which are state == CANCELLING; progressService()'s end-of-tick
+    // scan only frees this request once both remoteQuiesced and every local slot is idle.
+    bool remoteQuiesced = false;
+    // Per-slot generation, incremented each time a slot is (re)filled, so a stale/duplicate
+    // RRSLOT ack cannot free a slot that has since been reused for a later chunk.
+    std::array<uint64_t, slots_per_xfer> slotGenerations{};
+    // Per-slot expected decoded size, set from rPostedPayload::originalSize when a decode is
+    // submitted; compared against the actual decoded size on completion so a corrupted or
+    // mismatched chunk fails the logical request instead of landing a wrong-sized write.
+    std::array<size_t, slots_per_xfer> slotExpectedSizes{};
+
+    // WRITE-inbound constructor: built by handleRTS() when a peer pushes data to us.
+    inboundXferReqH(
+        const std::string &remote_agent,
+        nixl_xfer_dlist_t &&dst_list,
+        const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+        size_t xfer_id,
+        std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref = std::nullopt);
+
+    // READ receive constructor: built by createXferReq(NIXL_READ, ...) on the initiator.
+    // Always sets userInitiated = true, state = PRE_START, and marshalDone = false;
+    // directDone is derived from direct_child (null => no direct sub-part => directDone
+    // starts true, as for a marshal-only READ).
+    inboundXferReqH(
+        const std::string &remote_agent,
+        nixl_xfer_dlist_t &&dst_list,
+        const std::array<slotWorkItem, slots_per_xfer> &local_slots,
+        size_t xfer_id,
+        size_t total_chunks,
+        std::string serialized_src_list,
+        nixlXferReqH *direct_child,
+        std::optional<nixl_blob_t> notif,
+        std::optional<nixlMarshalDeltaReceiverRefArgs> receiver_delta_ref = std::nullopt);
+};
+
+class slotPool {
+private:
+    uintptr_t baseAddr_;
+    size_t slotSize_;
+    size_t numSlots_;
+    size_t chunkSize_;
+    std::optional<size_t> workspaceSize_;
+    // TODO-Eyal: create struct Layout{slotSize, chunkSize, workspaceSize}
+    nixl_mem_t type_;
+    /**
+     * @brief  RAII-owned CUDA streams, one per slot.
+     */
+    std::vector<cudaStream> streams_;
+
+    /**
+     * @brief  LIFO free list of work items.
+     *
+     * @details
+     * Allocation pops the back; free pushes it back.  When non-empty, every
+     * element's @c stream handle refers to one of the streams in @c streams_.
+     */
+    std::vector<slotT> freeList_;
+
+public:
+    slotPool(uintptr_t base_addr,
+             size_t slot_size,
+             size_t num_slots,
+             size_t chunk_size,
+             nixl_mem_t type,
+             std::optional<size_t> workspace_size = std::nullopt);
+
+    slotPool(const slotPool &) = delete;
+    slotPool &
+    operator=(const slotPool &) = delete;
+    slotPool(slotPool &&) noexcept = default;
+    slotPool &
+    operator=(slotPool &&) noexcept = default;
+
+    ~slotPool() = default;
+
+    [[nodiscard]] std::optional<slotT>
+    allocateSlot() noexcept;
+
+    void
+    freeSlot(slotT work_item) noexcept;
+
+    [[nodiscard]] size_t
+    getNumSlots() const noexcept;
+
+    [[nodiscard]] size_t
+    getSlotSize() const noexcept;
+
+    [[nodiscard]] size_t
+    getChunkSize() const noexcept;
+
+    [[nodiscard]] uintptr_t
+    getBaseAddr() const noexcept;
+
+    [[nodiscard]] nixl_mem_t
+    getType() const noexcept;
+};
+
+struct rtsNotifPayload {
+    size_t xferId;
+    std::string serializedDstList;
+    size_t slotSize;
+    std::optional<nixlMarshalDeltaReceiverRefArgs> deltaOptArgs;
+
+    rtsNotifPayload(size_t xfer_id, const std::string &dst_list, size_t slot_size);
+    explicit rtsNotifPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+struct ctsNotifPayload {
+    size_t xferId;
+    std::array<nixlBasicDesc, slots_per_xfer> receiverSlotDescriptors;
+    std::array<nixlMarshal::mem_space_t, slots_per_xfer> receiverMemSpaces;
+
+    ctsNotifPayload(
+        size_t xfer_id,
+        const std::array<nixlBasicDesc, slots_per_xfer> &receiver_slot_descriptors,
+        const std::array<nixlMarshal::mem_space_t, slots_per_xfer> &receiver_mem_spaces);
+    explicit ctsNotifPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+struct rslotNotifPayload {
+    size_t xferId;
+    size_t slotIndex;
+
+    rslotNotifPayload(size_t xfer_id, size_t slot_index);
+    explicit rslotNotifPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+struct deleteNotifPayload {
+    size_t xferId;
+
+    explicit deleteNotifPayload(size_t xfer_id);
+    explicit deleteNotifPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct marshalLayoutFingerprint
+ * @brief Fixed-width descriptor of a marshal-mode configuration and its physical slot
+ *        layout, embedded in RREQ so a peer can validate compatibility with its own
+ *        configuration before serving a READ.
+ *        `slotSize` alone (as used by the existing RTS/CTS handshake) is not a sufficient
+ *        compatibility check, since two different (chunkedPayloadSize, algo) configurations
+ *        can coincidentally yield the same physical slot size. This checks layout/algorithm
+ *        compatibility only, not a protocol version - see handleRREQ's doc comment for the
+ *        matched-build assumption this implies.
+ *
+ * @details
+ * Every field is a fixed-width scalar in a stable order, so the struct can be
+ * (de)serialized without any variable-length framing.
+ */
+struct marshalLayoutFingerprint {
+    // nixl_marshal_config_t variant index (Direct=0, Staging=1, Delta=2, Compress=3).
+    uint32_t mode = 0;
+    // nixl_marshal_compress_algo_t value; only meaningful when mode is Compress.
+    uint32_t algo = 0;
+    uint64_t chunkedPayloadSize = 0;
+    uint64_t chunkSize = 0;
+    // Usable bytes per slot for marshalled data, i.e. slot size excluding the workspace tail.
+    uint64_t wireDataCapacity = 0;
+    // nixl_mem_t value of the registered service memory.
+    uint32_t memType = 0;
+
+    [[nodiscard]] bool
+    operator==(const marshalLayoutFingerprint &other) const noexcept {
+        return mode == other.mode && algo == other.algo &&
+            chunkedPayloadSize == other.chunkedPayloadSize && chunkSize == other.chunkSize &&
+            wireDataCapacity == other.wireDataCapacity && memType == other.memType;
+    }
+
+    [[nodiscard]] bool
+    operator!=(const marshalLayoutFingerprint &other) const noexcept {
+        return !(*this == other);
+    }
+};
+
+/**
+ * @brief Serialize a fingerprint to a fixed-width byte blob. The result carries no framing
+ *        or prefix of its own; callers embed it inline within a larger message (e.g. RREQ).
+ */
+[[nodiscard]] nixl_blob_t
+serializeFingerprint(const marshalLayoutFingerprint &fingerprint) noexcept;
+
+/**
+ * @brief Deserialize a fingerprint from a standalone byte blob.
+ * @throw std::runtime_error if `bytes` is shorter than a fingerprint's fixed-width encoding,
+ *        so a truncated/malformed message is rejected rather than read out of bounds.
+ */
+[[nodiscard]] marshalLayoutFingerprint
+deserializeFingerprint(std::string_view bytes);
+
+/**
+ * @struct rReqPayload
+ * @brief "Read Request" message, sent by the initiator to the peer: the READ counterpart
+ *        of rtsNotifPayload. Unlike RTS, the initiator already knows its own receive slots
+ *        and advertises them here directly, so no CTS round trip is needed.
+ */
+struct rReqPayload {
+    size_t xferId;
+    std::string serializedSrcList;
+    std::array<nixlBasicDesc, slots_per_xfer> recvSlotDescriptors;
+    std::array<nixlMarshal::mem_space_t, slots_per_xfer> recvMemSpaces;
+    marshalLayoutFingerprint fingerprint;
+    // Present only for a delta-mode READ; set after construction, mirroring how
+    // rtsNotifPayload::deltaOptArgs is populated for WRITE.
+    std::optional<nixlMarshalDeltaSenderRefArgs> deltaOptArgs;
+
+    rReqPayload(size_t xfer_id,
+                const std::string &serialized_src_list,
+                const std::array<nixlBasicDesc, slots_per_xfer> &recv_slot_descriptors,
+                const std::array<nixlMarshal::mem_space_t, slots_per_xfer> &recv_mem_spaces,
+                const marshalLayoutFingerprint &fingerprint);
+    explicit rReqPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct rPostedPayload
+ * @brief "Read Posted" message, sent by the peer to the initiator, piggybacked on the slot
+ *        NIXL_WRITE: the READ counterpart of postedNotifPayload. Carries an absolute
+ *        destination byte offset instead of descIndex/chunkIndex, since the peer's chunk
+ *        iterator walks the source descriptor list, which may not match the initiator's
+ *        local chunking.
+ */
+struct rPostedPayload {
+    size_t xferId;
+    size_t slotIndex;
+    size_t originalSize; // size of data pulled from the peer's source buffer.
+    std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>> postedSegments;
+    size_t dstByteOffset; // absolute byte offset into the initiator's destination descriptor list.
+    std::string metadata; // metadata produced by the marshal layer.
+
+    rPostedPayload(
+        size_t xfer_id,
+        size_t slot_index,
+        size_t original_size,
+        std::shared_ptr<std::vector<nixlMarshal::ChunkDivision::segment>> posted_segments,
+        size_t dst_byte_offset,
+        std::string md);
+    explicit rPostedPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct rrSlotPayload
+ * @brief "Read Ready Slot" message, sent by the initiator to the peer: the READ
+ *        counterpart of rslotNotifPayload. Echoes a per-slot generation so a
+ *        stale/duplicate ack cannot free a slot that has since been reused for a later
+ *        chunk.
+ */
+struct rrSlotPayload {
+    size_t xferId;
+    size_t slotIndex;
+    uint64_t slotGeneration;
+
+    rrSlotPayload(size_t xfer_id, size_t slot_index, uint64_t slot_generation);
+    explicit rrSlotPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct rAbortPayload
+ * @brief "Read Abort" message, sent by the initiator to the peer: requests the peer
+ *        quiesce and cancel a served READ mid-transfer.
+ */
+struct rAbortPayload {
+    size_t xferId;
+
+    explicit rAbortPayload(size_t xfer_id);
+    explicit rAbortPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct rAbortAckPayload
+ * @brief "Read Abort Ack" message, sent by the peer to the initiator: sent only after the
+ *        peer has fully quiesced (drained all in-flight writes/CUDA work for the aborted
+ *        transfer) and freed its slots, so the initiator may safely free its own recv
+ *        slots.
+ */
+struct rAbortAckPayload {
+    size_t xferId;
+
+    explicit rAbortAckPayload(size_t xfer_id);
+    explicit rAbortAckPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+/**
+ * @struct rNakPayload
+ * @brief "Read Not Acknowledged" message, sent by the peer to the initiator: admission
+ *        rejection for an RREQ (e.g. fingerprint mismatch, unregistered/unauthorized
+ *        source region, or slot pool exhaustion). `errorCode` is a nixl_status_t value
+ *        narrowed to int32_t for the wire.
+ */
+struct rNakPayload {
+    size_t xferId;
+    int32_t errorCode;
+
+    rNakPayload(size_t xfer_id, int32_t error_code);
+    explicit rNakPayload(std::string_view notif);
+    [[nodiscard]] nixl_blob_t
+    serialize() const noexcept;
+};
+
+using service_notif_payload_t = std::variant<rtsNotifPayload,
+                                             ctsNotifPayload,
+                                             rslotNotifPayload,
+                                             deleteNotifPayload,
+                                             postedNotifPayload,
+                                             rReqPayload,
+                                             rPostedPayload,
+                                             rrSlotPayload,
+                                             rAbortPayload,
+                                             rAbortAckPayload,
+                                             rNakPayload>;
+using service_req_ref_t = std::variant<std::reference_wrapper<nixlServiceXferReqH>,
+                                       std::reference_wrapper<inboundXferReqH>>;
+
+struct serviceNotifWorkItem {
+    std::string senderAgent = "";
+    std::shared_ptr<service_notif_payload_t> payload = nullptr;
+};
+
+struct activeSlotWorkItem {
+    service_req_ref_t req;
+    std::reference_wrapper<slotWorkItem> slot;
+};
+
+class nixlServiceAgentData {
+protected:
+    friend class nixlServiceAgent;
+    friend marshalLayoutFingerprint
+    makeFingerprint(const nixlServiceAgentData &data, const slotPool &pool);
+
+    nixlAgent *agent_ = nullptr;
+    // This agent's own name, set once by nixlServiceAgent's delegating constructor. Used to
+    // detect and reject a loopback READ (remote_agent == self) at createXferReq() time.
+    std::string localAgentName_;
+
+    nixl_marshal_config_t mode_;
+    /** @brief  Payload bytes a single staging slot commits to. Fixed by the service. */
+    size_t chunkedPayloadSize_;
+    std::shared_ptr<nixlMarshal::backend> backend_;
+    std::list<slotPool> localStagingPools_;
+
+    /* The sender allocates the xfer id.
+    Thus outbound reqs are keyed by xfer id, and inbound reqs are keyed by sender agent name and
+    xfer id. */
+    size_t nextOutboundXferId_;
+    std::unordered_map<size_t, std::unique_ptr<nixlServiceXferReqH>> outboundXferReqs_;
+    std::unordered_map<std::string, std::unordered_map<size_t, std::unique_ptr<inboundXferReqH>>>
+        inboundXferReqs_;
+
+    /* READ request maps, role-separated from the WRITE maps above so a READ and a WRITE
+    between the same pair of agents can never collide on xfer id:
+    - readReceiveReqs_: my own READs, keyed by my xfer id (I am the initiator/sink, so my own
+      counter is unique - same reasoning as outboundXferReqs_).
+    - readServeReqs_: peers' READs from me, keyed by (initiator agent, their xfer id) - I am
+      not the initiator here, so the id alone is not unique across peers (same reasoning as
+      inboundXferReqs_). */
+    std::unordered_map<size_t, std::unique_ptr<inboundXferReqH>> readReceiveReqs_;
+    std::unordered_map<std::string,
+                       std::unordered_map<size_t, std::unique_ptr<nixlServiceXferReqH>>>
+        readServeReqs_;
+
+    /* Queue of slots with active asynchronous work. */
+    std::queue<activeSlotWorkItem> activeSlotQueue_;
+    /* The queue for service notifs. The producer is the progress thread, the consumer is the main
+     * thread */
+    spscQueue<serviceNotifWorkItem, spsc_size> serviceNotifQueue_;
+
+    /**
+     * @brief  The memory requirements for a single slot of the marshal layer.
+     *         This is used to calculate the maximum safe source chunk size.
+     */
+    nixlMarshal::memoryRequirements marshalSlotMemoryRequirements_;
+
+    /**
+     * @brief  Callback for service notifications - starting with _NIXLS_.
+     *         The callback is called by the progress thread, and pushes an item to the
+     * serviceNotifQueue_.
+     *
+     * @param  sender_agent The name of the sender agent
+     * @param  notif The notification to handle (raw, unpeeled)
+     */
+    void
+    serviceNotifCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+
+    void
+    rtsCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    ctsCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    postedCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rslotCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    deleteCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rreqCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rpostedCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rrslotCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rabortCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rabortAckCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+    void
+    rnakCallback(const std::string &sender_agent, const nixl_blob_t &notif);
+
+    /**
+     * @brief  Handle a "Request To Send" notification.
+     *
+     * @param  sender_agent The name of the sender agent
+     * @param  rts_payload The payload to handle
+     */
+    void
+    handleRTS(const std::string &sender_agent, const rtsNotifPayload &rts_payload);
+
+    /**
+     * @brief  Handle a "Clear To Send" notification.
+     *
+     * @param  sender_agent The name of the sender agent
+     * @param  cts_payload The payload to handle
+     */
+    void
+    handleCTS(const std::string &sender_agent, const ctsNotifPayload &cts_payload);
+
+    /**
+     * @brief  Handle a "Posted" notification, sent by the sender after a nixl transfer is
+     * completed.
+     *
+     * @param  sender_agent The name of the sender agent
+     * @param  posted_payload The payload to handle
+     */
+    void
+    handlePosted(const std::string &sender_agent, const postedNotifPayload &posted_payload);
+
+    /**
+     * @brief  Handle a "Ready Slot" notification, sent by the receiver after a local slot is
+     * filled.
+     *
+     * @param  source_agent The name of the source agent (the receiver of the xfer)
+     * @param  rslot_payload The payload to handle
+     */
+    void
+    handleRSlot(const std::string &source_agent, const rslotNotifPayload &rslot_payload);
+
+    /**
+     * @brief  Handle a "Delete" notification, sent by the sender after a transfer is finished.
+     *
+     * @param  sender_agent The name of the sender agent
+     * @param  delete_payload The payload to handle
+     */
+    void
+    handleDelete(const std::string &sender_agent,
+                 const deleteNotifPayload &delete_payload,
+                 std::unordered_map<std::string, std::set<size_t>> &deleted_reqs);
+
+    /**
+     * @brief  Handle a "Read Request" notification: the initiator is asking this agent to
+     *         serve a READ. On success, allocates send slots and starts serving the transfer;
+     *         on failure (fingerprint mismatch, unauthorized source region, or slot pool
+     *         exhaustion), replies with an RNAK.
+     *
+     * @note   ASSUMPTION: this serves any well-formed RREQ from a trusted peer running a
+     *         matched build. There is no registration-based authorization of the source
+     *         region - any descriptor list the peer sends is served as-is - and the
+     *         fingerprint checks layout/algo compatibility, not protocol version; both
+     *         agents must run the same build. READ trusts the peer at least as much as
+     *         WRITE already does, just via a different message (RREQ's source list vs.
+     *         RTS's destination list).
+     *
+     * @param  sender_agent The name of the initiator agent
+     * @param  rreq_payload The payload to handle
+     */
+    void
+    handleRREQ(const std::string &sender_agent, const rReqPayload &rreq_payload);
+
+    /**
+     * @brief  Handle a "Read Posted" notification, sent by the peer piggybacked on the slot
+     *         NIXL_WRITE: submits the inbound marshal (decode) operation for the received
+     *         slot into the initiator's destination buffer.
+     *
+     * @param  sender_agent The name of the peer (source) agent
+     * @param  rposted_payload The payload to handle
+     */
+    void
+    handleRPosted(const std::string &sender_agent, const rPostedPayload &rposted_payload);
+
+    /**
+     * @brief  Handle a "Read Ready Slot" notification, sent by the initiator to the peer: a
+     *         receive slot has been drained and its remote counterpart may be reused for
+     *         the next chunk. When this was the last chunk, marks the serving request DONE;
+     *         progressService()'s end-of-tick scan of readServeReqs_ frees it once every
+     *         local slot has actually gone idle - an RRSLOT's arrival reflects the peer's
+     *         decode, not this agent's own send completion, so it must not be erased inline.
+     *
+     * @param  source_agent The name of the initiator agent (the sink of the READ)
+     * @param  rrslot_payload The payload to handle
+     */
+    void
+    handleRRSlot(const std::string &source_agent, const rrSlotPayload &rrslot_payload);
+
+    /**
+     * @brief  Handle a "Read Abort" notification, sent by the initiator: it is cancelling a
+     *         READ we are serving. If already drained (or there was nothing in flight to
+     *         drain), acknowledges immediately; otherwise transitions to CANCELLING,
+     *         stopping fillLocalSlot from starting new work on this request's slots.
+     *         progressService()'s end-of-tick scan of readServeReqs_ acknowledges and frees
+     *         it once every local slot has gone idle.
+     *
+     * @param  sender_agent The name of the initiator agent
+     * @param  rabort_payload The payload to handle
+     */
+    void
+    handleRAbort(const std::string &sender_agent, const rAbortPayload &rabort_payload);
+
+    /**
+     * @brief  Handle a "Read Abort Ack" notification, sent by the peer: it has fully
+     *         quiesced the aborted READ, so this agent may now safely free its own receive
+     *         slots once any of its own still-in-flight decodes also finish draining. Sets
+     *         remoteQuiesced on the receive context; progressService()'s end-of-tick scan
+     *         of readReceiveReqs_ frees and finalizes it once every local slot is also idle.
+     *
+     * @param  sender_agent The name of the peer agent
+     * @param  raback_payload The payload to handle
+     */
+    void
+    handleRAbortAck(const std::string &sender_agent, const rAbortAckPayload &raback_payload);
+
+    /**
+     * @brief  Handle a "Read Not Acknowledged" notification, sent by the peer: it rejected
+     *         an RREQ; store the terminal status so getXferStatus() can surface it.
+     *
+     * @param  sender_agent The name of the peer agent
+     * @param  rnak_payload The payload to handle
+     */
+    void
+    handleRNak(const std::string &sender_agent, const rNakPayload &rnak_payload);
+
+    /**
+     * @brief  Generate a "Delete" notification for a given transfer request.
+     *
+     * @param  remote_agent The name of the remote agent
+     * @param  xfer_id The ID of the transfer request
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genDelete(const std::string &remote_agent, size_t xfer_id);
+
+    /**
+     * @brief  Allocate a local staging slot group for outbound transfer setup.
+     *
+     * @return Allocated slot group on success, std::nullopt on failure.
+     */
+    [[nodiscard]] std::optional<std::list<slotT>>
+    allocateSlotGroup();
+
+    /**
+     * @brief  Free a local staging slot group.
+     *
+     * @param  slot_group The slot group to free
+     */
+    void
+    freeSlotGroup(const std::array<slotWorkItem, slots_per_xfer> &slot_group) noexcept;
+    // TODO-Eyal: Unify the slot-group container across the API
+
+    /**
+     * @brief Fill one local staging slot from the current outbound chunk.
+     *
+     * @param work_item An active slot from the current work queue being processed.
+     * @param processed_queue Output queue for work items that should remain pending
+     *                        after this progress tick.
+     */
+    void
+    fillLocalSlot(const activeSlotWorkItem &work_item,
+                  std::queue<activeSlotWorkItem> &processed_queue);
+
+    /**
+     * @brief Poll completion of an outbound slot processing operation.
+     *
+     * @param work_item An active slot from the current work queue being processed.
+     * @param processed_queue Output queue for work items that should remain pending
+     *                        after this progress tick.
+     */
+    void
+    pollOutboundSlotCompletion(const activeSlotWorkItem &work_item,
+                               std::queue<activeSlotWorkItem> &processed_queue);
+
+    /**
+     * @brief Try to transfer a filled local slot to the remote agent.
+     *        Note: this function is called after the slot is filled,
+     *        but it is not guaranteed that the remote slot is free.
+     *        The service notifications update the remote slot state.
+     *
+     * @param work_item An active slot from the current work queue being processed.
+     * @param processed_queue Output queue for work items that should remain pending
+     *                        after this progress tick.
+     */
+    void
+    trySend(const activeSlotWorkItem &work_item, std::queue<activeSlotWorkItem> &processed_queue);
+
+    /**
+     * @brief Poll completion of a posted NIXL transfer for a slot.
+     *
+     * @param work_item An active slot from the current work queue being processed.
+     * @param processed_queue Output queue for work items that should remain pending
+     *                        after this progress tick.
+     */
+    void
+    pollNixlXferCompletion(const activeSlotWorkItem &work_item,
+                           std::queue<activeSlotWorkItem> &processed_queue);
+
+    /**
+     * @brief Poll completion of an inbound marshal operation for a local slot.
+     *
+     * @param work_item An active slot from the current work queue being processed.
+     * @param processed_queue Output queue for work items that should remain pending
+     *                        after this progress tick.
+     */
+    void
+    pollInboundSlotCompletion(const activeSlotWorkItem &work_item,
+                              std::queue<activeSlotWorkItem> &processed_queue);
+
+    /**
+     * @brief Poll and advance a READ receive context's direct child once per progress tick,
+     *        then try to finalize the request. A no-op unless the context is IN_PROGRESS
+     *        with a not-yet-done direct child (mixed READ only - marshal-only starts with
+     *        directDone already true and directChild null). Idempotent: safe to call every
+     *        tick regardless of the context's current state.
+     *
+     * @param ctx The READ receive context to advance.
+     */
+    void
+    progressReadReceive(inboundXferReqH &ctx);
+
+public:
+    nixlServiceAgentData(const nixl_marshal_config_t &mode, size_t chunked_payload_size);
+
+    /**
+     * @brief  Progress the service work queue and drive service progress.
+     *         Called by nixlServiceAgent::getNotifs() and getXferStatus().
+     *
+     * @return nixl_status_t
+     */
+    nixl_status_t
+    progressService();
+
+    /**
+     * @brief  Generate a "Request To Send" message for a given transfer request.
+     *         This should be sent once per transfer request, before the actual data is sent.
+     *
+     * @param  xfer_req The transfer request handle
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRTS(nixlServiceXferReqH &xfer_req);
+
+    /**
+     * @brief  Generate a "Clear To Send" message for a given remote agent.
+     *         This should be sent once both the receiver's staging chunks are not in use.
+     *
+     * @param  remote_agent The name of the remote agent
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genCTS(const std::string &remote_agent,
+           size_t xfer_id,
+           const std::array<slotWorkItem, slots_per_xfer> &slots);
+
+    /**
+     * @brief  Generate a "Ready Slot" message for a given remote agent.
+     *         Sent by the receiver once a certain slot is clear to be filled.
+     *
+     * @param  remote_agent The name of the remote agent
+     * @param  xfer_id The ID of the transfer request
+     * @param  slot_index The index of the slot to be filled
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRSlot(const std::string &remote_agent, size_t xfer_id, size_t slot_index);
+
+    /**
+     * @brief  Generate a "Read Request" message for a given READ handle. This is the READ
+     *         counterpart of genRTS: it should be sent once per READ, when postXferReq() is
+     *         called. Unlike genRTS, no CTS reply is expected - the receive context (looked
+     *         up via `xfer_req.readReceiveXferId`) already advertises its own recv slots
+     *         directly. Takes the outer handle (rather than the receive context alone,
+     *         mirroring genRTS's signature) because the optional delta sender ref lives in
+     *         `xfer_req.marshalOptArgs`, not on the receive context.
+     *
+     * @param  xfer_req The READ handle returned by createXferReq(NIXL_READ, ...)
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRREQ(nixlServiceXferReqH &xfer_req);
+
+    /**
+     * @brief  Generate a "Read Ready Slot" message for a given remote agent. This is the READ
+     *         counterpart of genRSlot: sent by the initiator once a given receive slot is
+     *         clear to be filled with the next chunk.
+     *
+     * @param  remote_agent The name of the remote (serving) agent
+     * @param  xfer_id The ID of the READ transfer request
+     * @param  slot_index The index of the slot to be filled
+     * @param  slot_generation The current generation of the slot (see slotGenerations)
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRRSlot(const std::string &remote_agent,
+              size_t xfer_id,
+              size_t slot_index,
+              uint64_t slot_generation);
+
+    /**
+     * @brief  Generate a "Read Abort" message for a given remote agent: requests the peer
+     *         quiesce and cancel a READ it is serving. Sent by releaseXferReq() on a
+     *         mid-transfer release of a READ handle.
+     *
+     * @param  remote_agent The name of the remote (serving) agent
+     * @param  xfer_id The ID of the READ transfer request
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRAbort(const std::string &remote_agent, size_t xfer_id);
+
+    /**
+     * @brief  Generate a "Read Abort Ack" message for a given remote agent: confirms this
+     *         agent has fully quiesced (freed all local slots) for a READ it was serving,
+     *         so the initiator may now safely free its own receive slots. Sent by
+     *         handleRAbort() once drained, or immediately if there was nothing to drain.
+     *
+     * @param  remote_agent The name of the remote (initiator) agent
+     * @param  xfer_id The ID of the READ transfer request
+     * @return nixl_status_t error code in case of failure
+     */
+    nixl_status_t
+    genRAbortAck(const std::string &remote_agent, size_t xfer_id);
+
+    /**
+     * @brief  If a READ receive context has finished both its direct and marshal
+     *         sub-transfers, finalizes it (transitions to DONE) and delivers the user
+     *         notification, if one was requested, to the peer. A no-op otherwise, including
+     *         when the request is already done - safe to call from multiple sites (this
+     *         file's pollInboundSlotCompletion and progressReadReceive), whichever of
+     *         directDone/marshalDone happens to become true last.
+     *
+     * @param  inbound_req The READ receive context to check/finalize.
+     */
+    void
+    tryCompleteReadReceive(inboundXferReqH &inbound_req);
+};
+
+/**
+ * @brief  Build the capability/layout fingerprint that identifies `data`'s marshal
+ *         configuration together with `pool`'s physical layout, for embedding in an
+ *         outgoing RREQ.
+ *
+ * @param  data The service agent data whose marshal configuration is being described.
+ * @param  pool A slot pool whose physical layout (chunk size, slot size, workspace) is
+ *              being described.
+ * @return The resulting fingerprint.
+ */
+[[nodiscard]] marshalLayoutFingerprint
+makeFingerprint(const nixlServiceAgentData &data, const slotPool &pool);
+
+#endif // NIXL_SERVICE_DATA_H

--- a/src/services/nixl_service_types.h
+++ b/src/services/nixl_service_types.h
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SERVICE_TYPES_H
+#define NIXL_SERVICE_TYPES_H
+
+#include "nixl_types.h"
+#include "nixl_params.h"
+#include "nixl_descriptors.h"
+
+#include <variant>
+#include <string>
+#include <unordered_map>
+#include <functional>
+
+struct nixlMarshalDirectConfig {};
+
+struct nixlMarshalStagingConfig {};
+
+struct nixlMarshalDeltaConfig {};
+
+enum class nixl_marshal_compress_algo_t {
+    ANS,
+    /**
+     * @brief ANS Delta compression algorithm.
+     *
+     * @details
+     * The ANS Delta compression algorithm gets an extra "other" pointer to a memory buffer that
+     * contains the previous value. Prior to ANS compression, the "src" is compared to the "other"
+     * pointer and unchanged values are treated as zeros, which makes the compression more
+     * efficient.
+     */
+    ANS_DELTA,
+    BITCOMP,
+};
+
+struct nixlMarshalCompressConfig {
+    nixl_marshal_compress_algo_t algo = nixl_marshal_compress_algo_t::ANS;
+};
+
+using nixl_marshal_config_t = std::variant<nixlMarshalDirectConfig,
+                                           nixlMarshalStagingConfig,
+                                           nixlMarshalDeltaConfig,
+                                           nixlMarshalCompressConfig>;
+
+struct nixlMarshalDirectOptArgs {};
+
+struct nixlMarshalStagingOptArgs {};
+
+struct nixlMarshalDeltaOptArgs {
+    // The "ref" pointers' length must match the corresponding "src" pointer length.
+    std::byte *senderRef = nullptr;
+    std::byte *receiverRef = nullptr;
+    nixl_mem_t senderMemType{};
+    nixl_mem_t receiverMemType{};
+    // Supported values are 1/2/4/8 bytes.
+    size_t elementSize = 0;
+};
+
+struct nixlMarshalCompressOptArgs {
+    // Only valid for the ANS_DELTA compression algorithm, must be present.
+    std::optional<nixlMarshalDeltaOptArgs> delta;
+};
+
+using nixl_marshal_opt_args_t = std::variant<nixlMarshalDirectOptArgs,
+                                             nixlMarshalStagingOptArgs,
+                                             nixlMarshalDeltaOptArgs,
+                                             nixlMarshalCompressOptArgs>;
+
+namespace MarshalBackendSizing {
+/**
+ * @brief The number of slots per transfer.
+ *        This is the number of slots that will be used for a single transfer.
+ */
+constexpr size_t slots_per_transfer = 2;
+
+/** @brief Minimum alignment for staging-slot base addresses and strides. */
+constexpr size_t slot_stride_alignment = 8;
+} // namespace MarshalBackendSizing
+
+struct nixlServiceAgentConfig : nixlAgentConfig {
+    nixl_marshal_config_t mode = nixlMarshalDirectConfig{};
+};
+
+struct nixl_service_opt_args_t : nixl_opt_args_t {
+    /**
+     * @brief The marshal optional arguments.
+     *
+     * @details
+     * The marshal optional arguments are used to configure the marshal backend.
+     * The marshal must be direct or the same as the marshal configuration.
+     *
+     * @note If not set or extra_params is nullptr, the transfer uses the marshal
+     *       mode configured in nixlServiceAgentConfig (via makeXferReq and createXferReq).
+     */
+    std::optional<nixl_marshal_opt_args_t> marshalOptArgs = std::nullopt;
+};
+
+#endif // NIXL_SERVICE_TYPES_H

--- a/src/services/spsc_queue.h
+++ b/src/services/spsc_queue.h
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SPSC_QUEUE_H
+#define NIXL_SPSC_QUEUE_H
+
+#include <atomic>
+#include <optional>
+#include <new>
+
+template<typename T, size_t Capacity> class spscQueue {
+private:
+    T buffer_[Capacity];
+
+    // C++17: Automatically align to the target architecture's cache line size
+    // Fallback to 64 if the compiler doesn't support the macro yet
+    /*#ifdef __cpp_lib_hardware_interference_size
+        static constexpr size_t CacheLineSize = std::hardware_destructive_interference_size;
+    #else
+        static constexpr size_t CacheLineSize = 64;
+    #endif*/
+
+    /* TODO-Eyal: I commented out the above because it fails on werror */
+    static constexpr size_t cacheLineSize = 64;
+
+    alignas(cacheLineSize) std::atomic<size_t> head_{0};
+    alignas(cacheLineSize) std::atomic<size_t> tail_{0};
+
+public:
+    bool
+    push(const T &item) {
+        size_t current_head = head_.load(std::memory_order_relaxed);
+        size_t next_head = (current_head + 1) % Capacity;
+
+        if (next_head == tail_.load(std::memory_order_acquire)) {
+            return false;
+        }
+
+        buffer_[current_head] = item;
+        head_.store(next_head, std::memory_order_release);
+        return true;
+    }
+
+    std::optional<T>
+    tryPop() {
+        size_t current_tail = tail_.load(std::memory_order_relaxed);
+
+        if (current_tail == head_.load(std::memory_order_acquire)) {
+            return std::nullopt; // Queue is empty
+        }
+
+        T item = std::move(buffer_[current_tail]);
+
+        tail_.store((current_tail + 1) % Capacity, std::memory_order_release);
+
+        return item;
+    }
+};
+
+static constexpr size_t spsc_size = 64;
+
+#endif // NIXL_SPSC_QUEUE_H

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -32,6 +32,9 @@ unit_test_deps += [descriptors_unit_test_dep]
 subdir('tracing')
 unit_test_deps += [tracing_unit_test_dep]
 
+subdir('services')
+unit_test_deps += [services_unit_test_dep]
+
 cpp = meson.get_compiler('cpp')
 azure_storage_blobs = cpp.find_library('azure-storage-blobs', required: false)
 if enabled_plugins.get('AZURE_BLOB') and azure_storage_blobs.found()

--- a/test/gtest/unit/services/marshals/compression_backend_test.cpp
+++ b/test/gtest/unit/services/marshals/compression_backend_test.cpp
@@ -1,0 +1,511 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+
+#include "compression_backend.h"
+
+namespace gtest {
+namespace services {
+    namespace marshals {
+
+        namespace {
+
+            using nixlMarshal::compressionBackend;
+            using nixlMarshal::mem_space_t;
+            using nixlMarshal::option_t;
+            using nixlMarshal::process_slot_input_options_t;
+            using nixlMarshal::runtimeBuffer;
+            using nixlMarshal::slotBuffers;
+            namespace ChunkDivision = nixlMarshal::ChunkDivision;
+            namespace ReadOnlyReferenceStructuredMemory =
+                nixlMarshal::ReadOnlyReferenceStructuredMemory;
+            namespace SlotOverhead = nixlMarshal::SlotOverhead;
+            namespace UserCudaStream = nixlMarshal::UserCudaStream;
+            namespace WriteableWorkspaceMemory = nixlMarshal::WriteableWorkspaceMemory;
+
+            constexpr size_t payload_bytes = 16 * 1024 * 1024;
+            constexpr size_t ref_element_size = sizeof(uint8_t);
+
+
+            constexpr size_t ref_perturb_stride = 128;
+            constexpr uint8_t ref_perturb_mask = 0xFF;
+            constexpr auto completion_timeout = std::chrono::seconds(5);
+
+            absl::Span<std::byte>
+            asByteSpan(void *p, size_t n) {
+                return absl::Span<std::byte>(reinterpret_cast<std::byte *>(p), n);
+            }
+
+            size_t
+            totalCompressedSize(const std::vector<ChunkDivision::segment> &segments) {
+                size_t total = 0;
+                for (const auto &seg : segments) {
+                    total += seg.size;
+                }
+                return total;
+            }
+
+            const std::vector<ChunkDivision::segment> &
+            chunkSegmentsOf(const nixlMarshal::outboundSlotCompletionData &completion) {
+                EXPECT_FALSE(completion.options.empty());
+                const auto &output =
+                    std::get<ChunkDivision::processSlotOutput>(*completion.options.begin());
+                EXPECT_NE(output.segments, nullptr);
+                return *output.segments;
+            }
+
+            const char *
+            algoName(nixl_marshal_compress_algo_t algo) {
+                switch (algo) {
+                case nixl_marshal_compress_algo_t::ANS:
+                    return "ANS";
+                case nixl_marshal_compress_algo_t::ANS_DELTA:
+                    return "ANS_DELTA";
+                case nixl_marshal_compress_algo_t::BITCOMP:
+                    return "BITCOMP";
+                }
+                return "UNKNOWN";
+            }
+
+        } // namespace
+
+        class compressionBackendTest
+            : public ::testing::TestWithParam<nixl_marshal_compress_algo_t> {
+        protected:
+            std::shared_ptr<compressionBackend> backend_;
+            size_t slotBytes_ = 0;
+            size_t workspaceBytes_ = 0;
+
+            void *gpuSrc_ = nullptr;
+            void *gpuDst_ = nullptr;
+            void *gpuRoundtrip_ = nullptr;
+            void *gpuWorkspace_ = nullptr;
+            void *gpuWorkspaceInbound_ = nullptr;
+            void *gpuRef_ = nullptr;
+            cudaStream_t stream_ = nullptr;
+
+            std::vector<uint8_t> hostSrc_;
+            std::vector<uint8_t> hostRef_;
+
+            [[nodiscard]] bool
+            isDelta() const {
+                return GetParam() == nixl_marshal_compress_algo_t::ANS_DELTA;
+            }
+
+            void
+            SetUp() override {
+                if (isDelta()) {
+                    GTEST_SKIP() << "CompressionBackend: ans_delta not implemented (delta mode "
+                                    "disabled)";
+                }
+                int device_count = 0;
+                ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+                if (device_count <= 0) {
+                    GTEST_SKIP() << "No CUDA device available";
+                }
+                ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+                nixlMarshalCompressConfig cfg{};
+                cfg.algo = GetParam();
+                backend_ = compressionBackend::createBackend(cfg, payload_bytes);
+                ASSERT_NE(backend_, nullptr);
+
+                const auto mem_reqs = backend_->getSlotMemoryRequirements();
+                const auto overhead_it = mem_reqs.opts.find(option_t::SLOT_OVERHEAD);
+                ASSERT_NE(overhead_it, mem_reqs.opts.end());
+                const auto *slot_overhead =
+                    std::get_if<SlotOverhead::memoryRequirements>(&overhead_it->second);
+                ASSERT_NE(slot_overhead, nullptr);
+
+                const auto ws_req_it = mem_reqs.opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY);
+                ASSERT_NE(ws_req_it, mem_reqs.opts.end());
+                const auto *ws_req =
+                    std::get_if<WriteableWorkspaceMemory::memoryRequirements>(&ws_req_it->second);
+                ASSERT_NE(ws_req, nullptr);
+
+                slotBytes_ = payload_bytes + slot_overhead->slotOverheadSize;
+                workspaceBytes_ = ws_req->slotWorkspaceSize;
+
+                ASSERT_EQ(cudaMalloc(&gpuSrc_, payload_bytes), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&gpuDst_, slotBytes_), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&gpuRoundtrip_, payload_bytes), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&gpuWorkspace_, workspaceBytes_), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&gpuWorkspaceInbound_, workspaceBytes_), cudaSuccess);
+                ASSERT_EQ(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking), cudaSuccess);
+
+                hostSrc_.assign(payload_bytes, 0);
+                for (size_t i = 0; i < payload_bytes; ++i) {
+                    hostSrc_[i] = (i * 4) % 256;
+                }
+                ASSERT_EQ(
+                    cudaMemcpy(gpuSrc_, hostSrc_.data(), hostSrc_.size(), cudaMemcpyHostToDevice),
+                    cudaSuccess);
+                ASSERT_EQ(cudaMemset(gpuDst_, 0, slotBytes_), cudaSuccess);
+                ASSERT_EQ(cudaMemset(gpuRoundtrip_, 0, payload_bytes), cudaSuccess);
+                ASSERT_EQ(cudaMemset(gpuWorkspaceInbound_, 0xCD, workspaceBytes_), cudaSuccess);
+
+                if (isDelta()) {
+                    ASSERT_EQ(cudaMalloc(&gpuRef_, payload_bytes), cudaSuccess);
+                    hostRef_ = hostSrc_;
+                    for (size_t i = 0; i < hostRef_.size(); i += ref_perturb_stride) {
+                        hostRef_[i] ^= ref_perturb_mask;
+                    }
+                    ASSERT_EQ(
+                        cudaMemcpy(
+                            gpuRef_, hostRef_.data(), hostRef_.size(), cudaMemcpyHostToDevice),
+                        cudaSuccess);
+                }
+            }
+
+            void
+            TearDown() override {
+                if (stream_) {
+                    cudaStreamDestroy(stream_);
+                }
+                if (gpuWorkspaceInbound_) {
+                    cudaFree(gpuWorkspaceInbound_);
+                }
+                if (gpuWorkspace_) {
+                    cudaFree(gpuWorkspace_);
+                }
+                if (gpuRoundtrip_) {
+                    cudaFree(gpuRoundtrip_);
+                }
+                if (gpuDst_) {
+                    cudaFree(gpuDst_);
+                }
+                if (gpuSrc_) {
+                    cudaFree(gpuSrc_);
+                }
+                if (gpuRef_) {
+                    cudaFree(gpuRef_);
+                }
+            }
+
+            process_slot_input_options_t
+            makeOptions(const runtimeBuffer &workspace) const {
+                process_slot_input_options_t opts{
+                    {option_t::WRITEABLE_WORKSPACE_MEMORY,
+                     WriteableWorkspaceMemory::processSlotInput{workspace}},
+                    {option_t::USER_CUDA_STREAM, UserCudaStream::processSlotInput{stream_}},
+                };
+                if (isDelta()) {
+                    runtimeBuffer ref(asByteSpan(gpuRef_, payload_bytes), mem_space_t::DEVICE);
+                    opts.emplace(
+                        option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY,
+                        ReadOnlyReferenceStructuredMemory::processSlotInput{ref, ref_element_size});
+                }
+                return opts;
+            }
+
+            template<typename Handle>
+            static auto
+            waitForCompletion(Handle &handle) {
+                auto future = std::async(std::launch::async, [&] {
+                    auto result = handle->checkForCompletion();
+                    while (!result.has_value()) {
+                        result = handle->checkForCompletion();
+                    }
+                    return *result;
+                });
+                EXPECT_EQ(future.wait_for(completion_timeout), std::future_status::ready)
+                    << "operation did not complete within timeout";
+                return future.get();
+            }
+        };
+
+        TEST_P(compressionBackendTest, CreateBackendValid) {
+            EXPECT_NE(backend_, nullptr);
+        }
+
+        TEST_P(compressionBackendTest, GetSlotMemoryRequirementsHasOverheadAndWorkspace) {
+            EXPECT_GT(slotBytes_, payload_bytes);
+            EXPECT_GT(workspaceBytes_, 0U);
+        }
+
+        TEST_P(compressionBackendTest, OutboundCompressionProducesNonEmptyOutput) {
+            runtimeBuffer src(asByteSpan(gpuSrc_, payload_bytes), mem_space_t::DEVICE);
+            runtimeBuffer dst(asByteSpan(gpuDst_, slotBytes_), mem_space_t::DEVICE);
+            runtimeBuffer workspace(asByteSpan(gpuWorkspace_, workspaceBytes_),
+                                    mem_space_t::DEVICE);
+
+            auto handle =
+                backend_->outboundProcessSlot(slotBuffers{src, dst}, makeOptions(workspace));
+            ASSERT_NE(handle, nullptr);
+
+            auto completion = waitForCompletion(handle);
+            const auto &segments = chunkSegmentsOf(completion);
+            ASSERT_FALSE(segments.empty());
+            const size_t compressed_size = totalCompressedSize(segments);
+            EXPECT_GT(compressed_size, 0U);
+            EXPECT_LE(compressed_size, slotBytes_);
+
+            std::array<uint8_t, 64> dst_prefix{};
+            ASSERT_EQ(
+                cudaMemcpy(dst_prefix.data(), gpuDst_, dst_prefix.size(), cudaMemcpyDeviceToHost),
+                cudaSuccess);
+            const bool any_non_zero =
+                std::any_of(dst_prefix.begin(), dst_prefix.end(), [](uint8_t v) { return v != 0; });
+            EXPECT_TRUE(any_non_zero) << "compressed output prefix was all-zero";
+        }
+
+        TEST_P(compressionBackendTest, OutboundInboundRoundTripPreservesData) {
+            runtimeBuffer src(asByteSpan(gpuSrc_, payload_bytes), mem_space_t::DEVICE);
+            runtimeBuffer dst(asByteSpan(gpuDst_, slotBytes_), mem_space_t::DEVICE);
+            runtimeBuffer outbound_workspace(asByteSpan(gpuWorkspace_, workspaceBytes_),
+                                             mem_space_t::DEVICE);
+            runtimeBuffer inbound_workspace(asByteSpan(gpuWorkspaceInbound_, workspaceBytes_),
+                                            mem_space_t::DEVICE);
+            const auto outbound_opts = makeOptions(outbound_workspace);
+
+            auto compress_handle =
+                backend_->outboundProcessSlot(slotBuffers{src, dst}, outbound_opts);
+            ASSERT_NE(compress_handle, nullptr);
+            auto compress_completion = waitForCompletion(compress_handle);
+            const auto &outbound_segments = chunkSegmentsOf(compress_completion);
+            ASSERT_FALSE(outbound_segments.empty());
+
+            auto inbound_segments = std::make_shared<std::vector<ChunkDivision::segment>>(
+                outbound_segments.begin(), outbound_segments.end());
+
+            runtimeBuffer roundtrip_dst(asByteSpan(gpuRoundtrip_, payload_bytes),
+                                        mem_space_t::DEVICE);
+
+            auto decompress_opts = makeOptions(inbound_workspace);
+            decompress_opts[option_t::CHUNK_DIVISION] =
+                ChunkDivision::processSlotInput{std::move(inbound_segments)};
+
+            auto decompress_handle = backend_->inboundProcessSlot(
+                slotBuffers{dst, roundtrip_dst}, compress_completion.metadata, decompress_opts);
+            ASSERT_NE(decompress_handle, nullptr);
+
+            auto decompress_completion = waitForCompletion(decompress_handle);
+            EXPECT_EQ(decompress_completion.size, payload_bytes);
+
+            std::vector<uint8_t> host_roundtrip(payload_bytes);
+            ASSERT_EQ(cudaMemcpy(host_roundtrip.data(),
+                                 gpuRoundtrip_,
+                                 host_roundtrip.size(),
+                                 cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_EQ(host_roundtrip, hostSrc_);
+        }
+
+        TEST_P(compressionBackendTest, OutboundInboundRoundTripWithSmallerRuntimePayload) {
+            // The configured payload is an upper bound. A final service slot can be smaller and
+            // must still fit the workspace provisioned from that upper bound. The 1152-byte
+            // shortfall mirrors one KV token in the failing SGLang workload.
+            constexpr size_t runtime_payload_shortfall_bytes = 1152;
+            constexpr size_t runtime_payload_bytes =
+                payload_bytes - runtime_payload_shortfall_bytes;
+
+            runtimeBuffer src(asByteSpan(gpuSrc_, runtime_payload_bytes), mem_space_t::DEVICE);
+            runtimeBuffer dst(asByteSpan(gpuDst_, slotBytes_), mem_space_t::DEVICE);
+            runtimeBuffer outbound_workspace(asByteSpan(gpuWorkspace_, workspaceBytes_),
+                                             mem_space_t::DEVICE);
+            runtimeBuffer inbound_workspace(asByteSpan(gpuWorkspaceInbound_, workspaceBytes_),
+                                            mem_space_t::DEVICE);
+
+            auto compress_handle = backend_->outboundProcessSlot(slotBuffers{src, dst},
+                                                                 makeOptions(outbound_workspace));
+            ASSERT_NE(compress_handle, nullptr);
+            auto compress_completion = waitForCompletion(compress_handle);
+            const auto &outbound_segments = chunkSegmentsOf(compress_completion);
+            ASSERT_FALSE(outbound_segments.empty());
+
+            auto inbound_segments = std::make_shared<std::vector<ChunkDivision::segment>>(
+                outbound_segments.begin(), outbound_segments.end());
+            runtimeBuffer roundtrip_dst(asByteSpan(gpuRoundtrip_, runtime_payload_bytes),
+                                        mem_space_t::DEVICE);
+
+            auto decompress_opts = makeOptions(inbound_workspace);
+            decompress_opts[option_t::CHUNK_DIVISION] =
+                ChunkDivision::processSlotInput{std::move(inbound_segments)};
+            auto decompress_handle = backend_->inboundProcessSlot(
+                slotBuffers{dst, roundtrip_dst}, compress_completion.metadata, decompress_opts);
+            ASSERT_NE(decompress_handle, nullptr);
+
+            auto decompress_completion = waitForCompletion(decompress_handle);
+            EXPECT_EQ(decompress_completion.size, runtime_payload_bytes);
+
+            std::vector<uint8_t> host_roundtrip(runtime_payload_bytes);
+            ASSERT_EQ(cudaMemcpy(host_roundtrip.data(),
+                                 gpuRoundtrip_,
+                                 host_roundtrip.size(),
+                                 cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_TRUE(std::equal(host_roundtrip.begin(), host_roundtrip.end(), hostSrc_.begin()));
+        }
+
+        TEST_P(compressionBackendTest, OutboundInboundRoundTripWithNonAlignedPayload) {
+            constexpr size_t nvcomp_chunk_size_bytes = 1U << 18; // 256 KB, mirrors backend constant
+            constexpr size_t k_remainder_bytes =
+                12340; // even (FP16-safe), non-zero, non-power-of-2
+            constexpr size_t k_non_aligned_payload_bytes =
+                3 * nvcomp_chunk_size_bytes + k_remainder_bytes;
+            constexpr size_t expected_num_chunks = 4;
+            static_assert(k_non_aligned_payload_bytes % nvcomp_chunk_size_bytes != 0,
+                          "payload must not divide evenly into the nvcomp chunk size");
+
+            nixlMarshalCompressConfig cfg{};
+            cfg.algo = GetParam();
+            auto backend = compressionBackend::createBackend(cfg, k_non_aligned_payload_bytes);
+            ASSERT_NE(backend, nullptr);
+
+            const auto mem_reqs = backend->getSlotMemoryRequirements();
+            const auto overhead_it = mem_reqs.opts.find(option_t::SLOT_OVERHEAD);
+            ASSERT_NE(overhead_it, mem_reqs.opts.end());
+            const auto *slot_overhead =
+                std::get_if<SlotOverhead::memoryRequirements>(&overhead_it->second);
+            ASSERT_NE(slot_overhead, nullptr);
+
+            const auto ws_req_it = mem_reqs.opts.find(option_t::WRITEABLE_WORKSPACE_MEMORY);
+            ASSERT_NE(ws_req_it, mem_reqs.opts.end());
+            const auto *ws_req =
+                std::get_if<WriteableWorkspaceMemory::memoryRequirements>(&ws_req_it->second);
+            ASSERT_NE(ws_req, nullptr);
+
+            const size_t slot_bytes = k_non_aligned_payload_bytes + slot_overhead->slotOverheadSize;
+            const size_t ws_bytes = ws_req->slotWorkspaceSize;
+
+            struct cudaScopedAlloc {
+                void *ptr = nullptr;
+
+                ~cudaScopedAlloc() {
+                    if (ptr) {
+                        cudaFree(ptr);
+                    }
+                }
+            };
+
+            cudaScopedAlloc gpu_src, gpu_dst, gpu_roundtrip, gpu_outbound_ws, gpu_inbound_ws,
+                gpu_local_ref;
+            ASSERT_EQ(cudaMalloc(&gpu_src.ptr, k_non_aligned_payload_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&gpu_dst.ptr, slot_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&gpu_roundtrip.ptr, k_non_aligned_payload_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&gpu_outbound_ws.ptr, ws_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&gpu_inbound_ws.ptr, ws_bytes), cudaSuccess);
+
+            std::vector<uint8_t> host_payload(k_non_aligned_payload_bytes);
+            for (size_t i = 0; i < k_non_aligned_payload_bytes; ++i) {
+                host_payload[i] = (i * 4) % 256;
+            }
+            ASSERT_EQ(
+                cudaMemcpy(
+                    gpu_src.ptr, host_payload.data(), host_payload.size(), cudaMemcpyHostToDevice),
+                cudaSuccess);
+            ASSERT_EQ(cudaMemset(gpu_dst.ptr, 0, slot_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMemset(gpu_roundtrip.ptr, 0, k_non_aligned_payload_bytes), cudaSuccess);
+            ASSERT_EQ(cudaMemset(gpu_inbound_ws.ptr, 0xCD, ws_bytes), cudaSuccess);
+
+            std::vector<uint8_t> host_local_ref;
+            if (isDelta()) {
+                ASSERT_EQ(cudaMalloc(&gpu_local_ref.ptr, k_non_aligned_payload_bytes), cudaSuccess);
+                host_local_ref = host_payload;
+                for (size_t i = 0; i < host_local_ref.size(); i += ref_perturb_stride) {
+                    host_local_ref[i] ^= ref_perturb_mask;
+                }
+                ASSERT_EQ(cudaMemcpy(gpu_local_ref.ptr,
+                                     host_local_ref.data(),
+                                     host_local_ref.size(),
+                                     cudaMemcpyHostToDevice),
+                          cudaSuccess);
+            }
+
+            auto build_opts = [&](void *workspace) {
+                process_slot_input_options_t opts{
+                    {option_t::WRITEABLE_WORKSPACE_MEMORY,
+                     WriteableWorkspaceMemory::processSlotInput{
+                         runtimeBuffer(asByteSpan(workspace, ws_bytes), mem_space_t::DEVICE)}},
+                    {option_t::USER_CUDA_STREAM, UserCudaStream::processSlotInput{stream_}},
+                };
+                if (isDelta()) {
+                    opts.emplace(option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY,
+                                 ReadOnlyReferenceStructuredMemory::processSlotInput{
+                                     runtimeBuffer(
+                                         asByteSpan(gpu_local_ref.ptr, k_non_aligned_payload_bytes),
+                                         mem_space_t::DEVICE),
+                                     ref_element_size});
+                }
+                return opts;
+            };
+
+            runtimeBuffer src(asByteSpan(gpu_src.ptr, k_non_aligned_payload_bytes),
+                              mem_space_t::DEVICE);
+            runtimeBuffer dst(asByteSpan(gpu_dst.ptr, slot_bytes), mem_space_t::DEVICE);
+
+            auto compress_handle = backend->outboundProcessSlot(slotBuffers{src, dst},
+                                                                build_opts(gpu_outbound_ws.ptr));
+            ASSERT_NE(compress_handle, nullptr);
+            auto compress_completion = waitForCompletion(compress_handle);
+            const auto &outbound_segments = chunkSegmentsOf(compress_completion);
+            ASSERT_EQ(outbound_segments.size(), expected_num_chunks)
+                << "non-aligned payload should produce ceil(payload / chunkSize) chunks";
+            const size_t compressed_total = totalCompressedSize(outbound_segments);
+            EXPECT_GT(compressed_total, 0U);
+            EXPECT_LE(compressed_total, slot_bytes);
+
+            auto inbound_segments = std::make_shared<std::vector<ChunkDivision::segment>>(
+                outbound_segments.begin(), outbound_segments.end());
+
+            runtimeBuffer roundtrip_dst(asByteSpan(gpu_roundtrip.ptr, k_non_aligned_payload_bytes),
+                                        mem_space_t::DEVICE);
+            auto decompress_opts = build_opts(gpu_inbound_ws.ptr);
+            decompress_opts[option_t::CHUNK_DIVISION] =
+                ChunkDivision::processSlotInput{std::move(inbound_segments)};
+
+            auto decompress_handle = backend->inboundProcessSlot(
+                slotBuffers{dst, roundtrip_dst}, compress_completion.metadata, decompress_opts);
+            ASSERT_NE(decompress_handle, nullptr);
+            auto decompress_completion = waitForCompletion(decompress_handle);
+            EXPECT_EQ(decompress_completion.size, k_non_aligned_payload_bytes);
+
+            std::vector<uint8_t> host_roundtrip(k_non_aligned_payload_bytes);
+            ASSERT_EQ(cudaMemcpy(host_roundtrip.data(),
+                                 gpu_roundtrip.ptr,
+                                 host_roundtrip.size(),
+                                 cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_EQ(host_roundtrip, host_payload);
+        }
+
+        INSTANTIATE_TEST_SUITE_P(
+            Algos,
+            compressionBackendTest,
+            ::testing::Values(nixl_marshal_compress_algo_t::ANS,
+                              nixl_marshal_compress_algo_t::ANS_DELTA),
+            [](const ::testing::TestParamInfo<nixl_marshal_compress_algo_t> &info) {
+                return algoName(info.param);
+            });
+
+    } // namespace marshals
+} // namespace services
+} // namespace gtest

--- a/test/gtest/unit/services/marshals/delta_backend_test.cpp
+++ b/test/gtest/unit/services/marshals/delta_backend_test.cpp
@@ -1,0 +1,186 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+#include "delta_backend.h"
+
+namespace gtest::services::marshals {
+
+constexpr size_t buffer_size = 1024;
+constexpr size_t chunk_size = 64;
+constexpr std::byte host_fill_pattern_a = std::byte{0xA5};
+constexpr std::byte host_fill_pattern_b = std::byte{0x3C};
+constexpr std::byte zero_pattern = std::byte{0x00};
+constexpr std::chrono::seconds timeout{2};
+
+template<typename CompletionT>
+CompletionT
+waitForCompletion(nixlMarshal::asyncHandle<CompletionT> &handle) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (auto result = handle.checkForCompletion(); result.has_value()) {
+            return *result;
+        }
+        std::this_thread::yield();
+    }
+    throw std::runtime_error("Timed out waiting for delta async handle completion");
+}
+
+class deltaBackendTest : public ::testing::Test {
+protected:
+    std::shared_ptr<nixlMarshal::deltaBackend> backend_;
+    cudaStream_t stream_ = nullptr;
+    void *gpuSrc_ = nullptr;
+    void *gpuDst_ = nullptr;
+    void *gpuRef_ = nullptr;
+
+    void
+    SetUp() override {
+        GTEST_SKIP() << "DeltaBackend not implemented (delta mode disabled)";
+        int device_count = 0;
+        ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+        if (device_count == 0) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        ASSERT_EQ(cudaMalloc(&gpuSrc_, buffer_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&gpuDst_, buffer_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&gpuRef_, buffer_size), cudaSuccess);
+        ASSERT_EQ(cudaMemset(gpuSrc_, 0, buffer_size), cudaSuccess);
+        ASSERT_EQ(cudaMemset(gpuDst_, 0, buffer_size), cudaSuccess);
+        ASSERT_EQ(cudaMemset(gpuRef_, 0, buffer_size), cudaSuccess);
+
+        backend_ = nixlMarshal::deltaBackend::createBackend(nixlMarshalDeltaConfig{});
+        ASSERT_NE(backend_, nullptr);
+        ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+    }
+
+    void
+    TearDown() override {
+        if (stream_) {
+            ASSERT_EQ(cudaStreamDestroy(stream_), cudaSuccess);
+        }
+        if (gpuRef_) {
+            ASSERT_EQ(cudaFree(gpuRef_), cudaSuccess);
+        }
+        if (gpuDst_) {
+            ASSERT_EQ(cudaFree(gpuDst_), cudaSuccess);
+        }
+        if (gpuSrc_) {
+            ASSERT_EQ(cudaFree(gpuSrc_), cudaSuccess);
+        }
+    }
+
+    nixlMarshal::slotBuffers
+    makeSlotBuffs(size_t size,
+                  void *src_data = nullptr,
+                  void *dst_data = nullptr,
+                  size_t src_offset = 0,
+                  size_t dst_size = 0) const {
+        void *effective_src = src_data == nullptr ? gpuSrc_ : src_data;
+        void *effective_dst = dst_data == nullptr ? gpuDst_ : dst_data;
+        const size_t effective_dst_size = dst_size == 0 ? size : dst_size;
+        nixlMarshal::runtimeBuffer src(
+            absl::Span<std::byte>(static_cast<std::byte *>(effective_src) + src_offset, size),
+            nixlMarshal::mem_space_t::DEVICE);
+        nixlMarshal::runtimeBuffer dst(
+            absl::Span<std::byte>(static_cast<std::byte *>(effective_dst), effective_dst_size),
+            nixlMarshal::mem_space_t::DEVICE);
+        return nixlMarshal::slotBuffers{src, dst};
+    }
+
+    nixlMarshal::process_slot_input_options_t
+    makeOpts(size_t element_size,
+             void *ref_data,
+             size_t ref_size,
+             bool include_ref = true,
+             bool include_stream = true) const {
+        nixlMarshal::process_slot_input_options_t opts;
+        if (include_ref) {
+            nixlMarshal::runtimeBuffer ref_buf(
+                absl::Span<std::byte>(static_cast<std::byte *>(ref_data), ref_size),
+                nixlMarshal::mem_space_t::DEVICE);
+            opts.emplace(nixlMarshal::option_t::READ_ONLY_REFERENCE_STRUCTURED_MEMORY,
+                         nixlMarshal::ReadOnlyReferenceStructuredMemory::processSlotInput{
+                             ref_buf, element_size});
+        }
+        if (include_stream) {
+            opts.emplace(nixlMarshal::option_t::USER_CUDA_STREAM,
+                         nixlMarshal::UserCudaStream::processSlotInput{stream_});
+        }
+        return opts;
+    }
+};
+
+TEST_F(deltaBackendTest, OutboundThenInbound_SameRef_Roundtrip) {
+    void *gpu_src_a = nullptr;
+    void *gpu_dst_a = nullptr;
+    void *gpu_dst_b = nullptr;
+    void *gpu_ref = nullptr;
+    ASSERT_EQ(cudaMalloc(&gpu_src_a, chunk_size), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&gpu_dst_a, chunk_size), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&gpu_dst_b, chunk_size), cudaSuccess);
+    ASSERT_EQ(cudaMalloc(&gpu_ref, chunk_size), cudaSuccess);
+
+    ASSERT_EQ(cudaMemset(gpu_src_a, std::to_integer<int>(host_fill_pattern_a), chunk_size),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemset(gpu_ref, std::to_integer<int>(host_fill_pattern_b), chunk_size),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemset(gpu_dst_a, 0, chunk_size), cudaSuccess);
+    ASSERT_EQ(cudaMemset(gpu_dst_b, 0, chunk_size), cudaSuccess);
+
+    // Transaction A (outbound): srcA XOR ref -> dstA
+    auto handle_a = backend_->outboundProcessSlot(makeSlotBuffs(chunk_size, gpu_src_a, gpu_dst_a),
+                                                  makeOpts(4, gpu_ref, chunk_size));
+    ASSERT_NE(handle_a, nullptr);
+    const auto completion_a = waitForCompletion(*handle_a);
+
+    EXPECT_EQ(completion_a.size, chunk_size);
+    EXPECT_TRUE(completion_a.options.empty());
+
+    // Transaction B (inbound): dstA (now srcB) XOR ref -> dstB; should equal hostSrcA.
+    auto handle_b = backend_->inboundProcessSlot(makeSlotBuffs(chunk_size, gpu_dst_a, gpu_dst_b),
+                                                 "unused-metadata",
+                                                 makeOpts(4, gpu_ref, chunk_size));
+    ASSERT_NE(handle_b, nullptr);
+    const auto completion_b = waitForCompletion(*handle_b);
+    EXPECT_EQ(completion_b.size, chunk_size);
+
+    std::vector<std::byte> host_dst_b(chunk_size, zero_pattern);
+    ASSERT_EQ(cudaMemcpy(host_dst_b.data(), gpu_dst_b, chunk_size, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    std::vector<std::byte> expected(chunk_size, host_fill_pattern_a);
+    EXPECT_EQ(host_dst_b, expected);
+
+    ASSERT_EQ(cudaFree(gpu_ref), cudaSuccess);
+    ASSERT_EQ(cudaFree(gpu_dst_b), cudaSuccess);
+    ASSERT_EQ(cudaFree(gpu_dst_a), cudaSuccess);
+    ASSERT_EQ(cudaFree(gpu_src_a), cudaSuccess);
+}
+
+} // namespace gtest::services::marshals

--- a/test/gtest/unit/services/marshals/meson.build
+++ b/test/gtest/unit/services/marshals/meson.build
@@ -13,10 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+marshals_unit_test_sources = ['staging_backend_test.cpp', 'delta_backend_test.cpp']
+marshals_unit_test_deps = [staging_dep, nixl_common_dep, delta_dep, cuda_dep]
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+if nvcomp_dep.found()
+    marshals_unit_test_sources += ['compression_backend_test.cpp']
+    marshals_unit_test_deps += [nixl_service_dep]
+endif
+
+marshals_unit_test_dep = declare_dependency(
+    sources: marshals_unit_test_sources,
+    include_directories: [nixl_inc_dirs, gtest_inc_dirs],
+    dependencies: marshals_unit_test_deps,
+)

--- a/test/gtest/unit/services/marshals/staging_backend_test.cpp
+++ b/test/gtest/unit/services/marshals/staging_backend_test.cpp
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <cuda_runtime.h>
+
+#include <future>
+#include <vector>
+
+#include "staging_backend.h"
+
+namespace gtest {
+namespace services {
+    namespace marshals {
+
+        using runtime_buffer_t = nixlMarshal::runtimeBuffer;
+
+        constexpr size_t chunk_size = 1024;
+        constexpr uintptr_t fake_src_addr = 0x1000;
+        constexpr uintptr_t fake_dst_addr = 0x2000;
+        constexpr size_t small_xfer_size = 64;
+        constexpr int fake_device_id = 0;
+
+        class stagingBackendTest : public ::testing::Test {
+        protected:
+            std::shared_ptr<nixlMarshal::stagingBackend> backend_;
+
+            void
+            SetUp() override {
+                backend_ = nixlMarshal::stagingBackend::createBackend(nixlMarshalStagingConfig{});
+            }
+        };
+
+        class stagingBackendGpuTest : public ::testing::Test {
+        protected:
+            std::shared_ptr<nixlMarshal::stagingBackend> backend_;
+            cudaStream_t stream_ = nullptr;
+            void *gpuSrc_;
+            void *gpuDst_;
+            runtime_buffer_t src_;
+            runtime_buffer_t dst_;
+
+            void
+            SetUp() override {
+                int device_count = 0;
+                cudaGetDeviceCount(&device_count);
+                if (device_count == 0) {
+                    GTEST_SKIP() << "No CUDA device available";
+                }
+
+                ASSERT_EQ(cudaMalloc(&gpuSrc_, chunk_size), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&gpuDst_, chunk_size), cudaSuccess);
+                ASSERT_EQ(cudaMemset(gpuSrc_, 0, chunk_size), cudaSuccess);
+                ASSERT_EQ(cudaMemset(gpuDst_, 0, chunk_size), cudaSuccess);
+
+                backend_ = nixlMarshal::stagingBackend::createBackend(nixlMarshalStagingConfig{});
+                ASSERT_EQ(cudaStreamCreate(&stream_), cudaSuccess);
+
+                int dev_id = 0;
+                ASSERT_EQ(cudaGetDevice(&dev_id), cudaSuccess);
+
+                src_ = runtime_buffer_t(
+                    absl::Span<std::byte>(reinterpret_cast<std::byte *>(gpuSrc_), chunk_size),
+                    nixlMarshal::mem_space_t::DEVICE);
+                dst_ = runtime_buffer_t(
+                    absl::Span<std::byte>(reinterpret_cast<std::byte *>(gpuDst_), chunk_size),
+                    nixlMarshal::mem_space_t::DEVICE);
+            }
+
+            void
+            TearDown() override {
+                if (gpuDst_) {
+                    cudaFree(gpuDst_);
+                }
+                if (gpuSrc_) {
+                    cudaFree(gpuSrc_);
+                }
+                if (stream_) {
+                    cudaStreamDestroy(stream_);
+                }
+            }
+        };
+
+        TEST_F(stagingBackendTest, CreateBackendValid) {
+            ASSERT_NE(backend_, nullptr);
+        }
+
+        TEST_F(stagingBackendTest, GetSupportedMemSpacesValid) {
+            auto mems = backend_->getSupportedMemSpaces();
+            ASSERT_FALSE(mems.empty());
+            EXPECT_EQ(mems.front(), nixlMarshal::mem_space_t::DEVICE);
+        }
+
+        TEST_F(stagingBackendTest, GetSlotMemoryRequirementsValid) {
+            auto requirements = backend_->getSlotMemoryRequirements();
+            EXPECT_TRUE(requirements.opts.empty());
+        }
+
+        TEST_F(stagingBackendTest, ProcessSlotWithoutStreamThrows) {
+            runtime_buffer_t src(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_src_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+            runtime_buffer_t dst(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_dst_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+            EXPECT_THROW(
+                backend_->inboundProcessSlot(nixlMarshal::slotBuffers{src, dst}, /*metadata=*/{}),
+                std::runtime_error);
+        }
+
+        TEST_F(stagingBackendTest, MultipleBackendsCoexistIndependently_Throws) {
+            auto backend01 = nixlMarshal::stagingBackend::createBackend(nixlMarshalStagingConfig{});
+            auto backend02 = nixlMarshal::stagingBackend::createBackend(nixlMarshalStagingConfig{});
+            ASSERT_NE(backend01, nullptr);
+            ASSERT_NE(backend02, nullptr);
+
+            runtime_buffer_t src(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_src_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+            runtime_buffer_t dst(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_dst_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+
+            for (const auto &b : {backend_, backend01, backend02}) {
+                EXPECT_THROW(
+                    b->inboundProcessSlot(nixlMarshal::slotBuffers{src, dst}, /*metadata=*/{}),
+                    std::runtime_error);
+            }
+        }
+
+        TEST_F(stagingBackendTest, ProcessSlotUnsupportedSrcTypeThrows) {
+            runtime_buffer_t src(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_src_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::HOST);
+            runtime_buffer_t dst(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_dst_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+            EXPECT_THROW(backend_->outboundProcessSlot(
+                             nixlMarshal::slotBuffers{src, dst},
+                             {{nixlMarshal::option_t::USER_CUDA_STREAM,
+                               nixlMarshal::UserCudaStream::processSlotInput{cudaStream_t{0}}}}),
+                         std::runtime_error);
+        }
+
+        TEST_F(stagingBackendTest, ProcessSlotUnsupportedDstTypeThrows) {
+            runtime_buffer_t src(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_src_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::DEVICE);
+            runtime_buffer_t dst(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_dst_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::HOST);
+            EXPECT_THROW(backend_->outboundProcessSlot(
+                             nixlMarshal::slotBuffers{src, dst},
+                             {{nixlMarshal::option_t::USER_CUDA_STREAM,
+                               nixlMarshal::UserCudaStream::processSlotInput{cudaStream_t{0}}}}),
+                         std::runtime_error);
+        }
+
+        TEST_F(stagingBackendTest, ProcessSlotBothTypesUnsupportedThrows) {
+            runtime_buffer_t src(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_src_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::HOST);
+            runtime_buffer_t dst(absl::Span<std::byte>(reinterpret_cast<std::byte *>(fake_dst_addr),
+                                                       small_xfer_size),
+                                 nixlMarshal::mem_space_t::HOST);
+            EXPECT_THROW(backend_->outboundProcessSlot(
+                             nixlMarshal::slotBuffers{src, dst},
+                             {{nixlMarshal::option_t::USER_CUDA_STREAM,
+                               nixlMarshal::UserCudaStream::processSlotInput{cudaStream_t{0}}}}),
+                         std::runtime_error);
+        }
+
+        TEST_F(stagingBackendGpuTest, ProcessSlotInboundVram_DataMatchesSourceValid) {
+            const uint8_t pattern = 0xAA;
+
+            std::vector<uint8_t> host_src(chunk_size, pattern);
+            ASSERT_EQ(cudaMemcpy(gpuSrc_, host_src.data(), chunk_size, cudaMemcpyHostToDevice),
+                      cudaSuccess);
+
+            auto handle = backend_->outboundProcessSlot(
+                nixlMarshal::slotBuffers{src_, dst_},
+                {{nixlMarshal::option_t::USER_CUDA_STREAM,
+                  nixlMarshal::UserCudaStream::processSlotInput{stream_}}});
+            ASSERT_NE(handle, nullptr);
+
+            auto future = std::async(std::launch::async, [&] {
+                std::optional<nixlMarshal::outboundSlotCompletionData> result;
+                while (!result.has_value()) {
+                    result = handle->checkForCompletion();
+                }
+                return *result;
+            });
+
+            ASSERT_EQ(future.wait_for(std::chrono::seconds(2)), std::future_status::ready)
+                << "Copy did not complete in time";
+
+            auto result = future.get();
+            EXPECT_EQ(result.size, chunk_size);
+            EXPECT_TRUE(result.options.empty());
+            EXPECT_TRUE(result.metadata.empty());
+
+            std::vector<uint8_t> host_dst(chunk_size, 0);
+            ASSERT_EQ(cudaMemcpy(host_dst.data(), gpuDst_, chunk_size, cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            EXPECT_EQ(host_src, host_dst);
+        }
+
+    } // namespace marshals
+} // namespace services
+} // namespace gtest

--- a/test/gtest/unit/services/meson.build
+++ b/test/gtest/unit/services/meson.build
@@ -13,10 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-py = import('python').find_installation('python3', pure: false)
+services_unit_test_deps = []
 
-py.install_sources('_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('_service_api.py', subdir: (cuda_wheel_dir))
-py.install_sources('__init__.py', subdir: (cuda_wheel_dir))
-py.install_sources('py.typed', subdir: (cuda_wheel_dir))
-py.install_sources('logging.py', subdir: (cuda_wheel_dir))
+subdir('marshals')
+services_unit_test_deps += [marshals_unit_test_dep]
+
+service_agent_unit_test_dep = declare_dependency(
+    sources: [
+        'nixl_service_test.cpp',
+    ],
+    include_directories: [nixl_inc_dirs, gtest_inc_dirs],
+    dependencies: [nixl_common_dep, nixl_service_dep],
+)
+services_unit_test_deps += [service_agent_unit_test_dep]
+
+services_unit_test_dep = declare_dependency(
+    dependencies: services_unit_test_deps,
+)

--- a/test/gtest/unit/services/nixl_service_test.cpp
+++ b/test/gtest/unit/services/nixl_service_test.cpp
@@ -1,0 +1,1939 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <cstring>
+#include <limits>
+#include <thread>
+#include <random>
+#include <type_traits>
+#include <vector>
+#include "absl/cleanup/cleanup.h"
+#include "nixl_service.h"
+#include "nixl_service_data.h"
+#include <cuda_runtime.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace gtest {
+namespace services {
+
+    // Infra-free: does not use the agent fixture, so it needs neither etcd nor a CUDA device.
+    TEST(ServiceFingerprint, RoundTrip) {
+        marshalLayoutFingerprint fingerprint;
+        fingerprint.mode = 3;
+        fingerprint.algo = static_cast<uint32_t>(nixl_marshal_compress_algo_t::ANS_DELTA);
+        fingerprint.chunkedPayloadSize = 128 * 1024 * 1024;
+        fingerprint.chunkSize = 128 * 1024;
+        fingerprint.wireDataCapacity = 130 * 1024 * 1024;
+        fingerprint.memType = static_cast<uint32_t>(VRAM_SEG);
+
+        const nixl_blob_t bytes = serializeFingerprint(fingerprint);
+        const marshalLayoutFingerprint deserialized = deserializeFingerprint(bytes);
+        EXPECT_EQ(deserialized, fingerprint);
+        EXPECT_FALSE(deserialized != fingerprint);
+
+        // A truncated buffer must be rejected rather than read out of bounds. The result is
+        // intentionally discarded here (cast to void) since only the thrown exception matters;
+        // deserializeFingerprint() is [[nodiscard]] for every other (non-throwing) call site.
+        const nixl_blob_t truncated = bytes.substr(0, bytes.size() - 1);
+        EXPECT_THROW((void)deserializeFingerprint(truncated), std::runtime_error);
+    }
+
+    // Infra-free round-trip tests for the new READ protocol payloads (RREQ/RPOSTED/RRSLOT/
+    // RABORT/RABORT_ACK/RNAK). None of these are produced or consumed by any code path yet;
+    // these tests only verify each payload's own serialize()/deserialize-ctor fidelity.
+
+    TEST(ServiceReadPayloads, RReqRoundTrip) {
+        marshalLayoutFingerprint fingerprint;
+        fingerprint.mode = 3;
+        fingerprint.algo = static_cast<uint32_t>(nixl_marshal_compress_algo_t::ANS);
+        fingerprint.chunkedPayloadSize = 128 * 1024 * 1024;
+        fingerprint.chunkSize = 128 * 1024;
+        fingerprint.wireDataCapacity = 130 * 1024 * 1024;
+        fingerprint.memType = static_cast<uint32_t>(VRAM_SEG);
+
+        // Embedded null byte, to prove the length-prefixed encoding doesn't rely on
+        // NUL-termination. "fake-serialized-dlist" (21) + '\0' (1) + "with-null" (9) = 31 bytes.
+        const std::string serialized_src_list("fake-serialized-dlist\0with-null", 31);
+        const std::array<nixlBasicDesc, slots_per_xfer> recv_slots{nixlBasicDesc(0x3000, 4096, 0),
+                                                                   nixlBasicDesc(0x4000, 4096, 0)};
+        const std::array<nixlMarshal::mem_space_t, slots_per_xfer> recv_mem_spaces{
+            nixlMarshal::mem_space_t::DEVICE, nixlMarshal::mem_space_t::DEVICE};
+
+        {
+            // Without delta opt-args.
+            rReqPayload payload(7, serialized_src_list, recv_slots, recv_mem_spaces, fingerprint);
+            rReqPayload deserialized(payload.serialize());
+            EXPECT_EQ(deserialized.xferId, 7u);
+            EXPECT_EQ(deserialized.serializedSrcList, serialized_src_list);
+            EXPECT_EQ(deserialized.recvSlotDescriptors, recv_slots);
+            EXPECT_EQ(deserialized.recvMemSpaces, recv_mem_spaces);
+            EXPECT_EQ(deserialized.fingerprint, fingerprint);
+            EXPECT_FALSE(deserialized.deltaOptArgs.has_value());
+        }
+        {
+            // With delta opt-args, set after construction (mirrors rtsNotifPayload's pattern).
+            rReqPayload payload(8, serialized_src_list, recv_slots, recv_mem_spaces, fingerprint);
+            payload.deltaOptArgs = nixlMarshalDeltaSenderRefArgs{
+                reinterpret_cast<std::byte *>(0xABCD0000), VRAM_SEG, 4};
+            rReqPayload deserialized(payload.serialize());
+            EXPECT_EQ(deserialized.xferId, 8u);
+            ASSERT_TRUE(deserialized.deltaOptArgs.has_value());
+            EXPECT_EQ(deserialized.deltaOptArgs->ref, payload.deltaOptArgs->ref);
+            EXPECT_EQ(deserialized.deltaOptArgs->memType, payload.deltaOptArgs->memType);
+            EXPECT_EQ(deserialized.deltaOptArgs->elementSize, payload.deltaOptArgs->elementSize);
+        }
+    }
+
+    TEST(ServiceReadPayloads, RPostedRoundTrip) {
+        auto segments = std::make_shared<std::vector<nixlMarshal::ChunkDivision::segment>>();
+        segments->push_back({0, 4096});
+        segments->push_back({8192, 2048});
+
+        rPostedPayload payload(11, 1, 6144, segments, 0x10000, "compress-metadata");
+        rPostedPayload deserialized(payload.serialize());
+        EXPECT_EQ(deserialized.xferId, 11u);
+        EXPECT_EQ(deserialized.slotIndex, 1u);
+        EXPECT_EQ(deserialized.originalSize, 6144u);
+        ASSERT_EQ(deserialized.postedSegments->size(), segments->size());
+        for (size_t i = 0; i < segments->size(); ++i) {
+            EXPECT_EQ((*deserialized.postedSegments)[i].offset, (*segments)[i].offset);
+            EXPECT_EQ((*deserialized.postedSegments)[i].size, (*segments)[i].size);
+        }
+        EXPECT_EQ(deserialized.dstByteOffset, static_cast<size_t>(0x10000));
+        EXPECT_EQ(deserialized.metadata, "compress-metadata");
+    }
+
+    TEST(ServiceReadPayloads, RRSlotRoundTrip) {
+        rrSlotPayload payload(3, 0, 42);
+        rrSlotPayload deserialized(payload.serialize());
+        EXPECT_EQ(deserialized.xferId, 3u);
+        EXPECT_EQ(deserialized.slotIndex, 0u);
+        EXPECT_EQ(deserialized.slotGeneration, 42u);
+    }
+
+    TEST(ServiceReadPayloads, RAbortRoundTrip) {
+        rAbortPayload payload(5);
+        rAbortPayload deserialized(payload.serialize());
+        EXPECT_EQ(deserialized.xferId, 5u);
+    }
+
+    TEST(ServiceReadPayloads, RAbortAckRoundTrip) {
+        rAbortAckPayload payload(6);
+        rAbortAckPayload deserialized(payload.serialize());
+        EXPECT_EQ(deserialized.xferId, 6u);
+    }
+
+    TEST(ServiceReadPayloads, RNakRoundTrip) {
+        rNakPayload payload(9, static_cast<int32_t>(NIXL_ERR_NOT_SUPPORTED));
+        rNakPayload deserialized(payload.serialize());
+        EXPECT_EQ(deserialized.xferId, 9u);
+        EXPECT_EQ(deserialized.errorCode, static_cast<int32_t>(NIXL_ERR_NOT_SUPPORTED));
+    }
+
+    namespace {
+
+        bool
+        isPortOpen(const char *ip, uint16_t port) {
+            int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+            if (fd < 0) {
+                return false;
+            }
+
+            sockaddr_in addr{};
+            addr.sin_family = AF_INET;
+            addr.sin_port = htons(port);
+            if (::inet_pton(AF_INET, ip, &addr.sin_addr) != 1) {
+                ::close(fd);
+                return false;
+            }
+
+            bool ok = (::connect(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) == 0);
+            ::close(fd);
+            return ok;
+        }
+
+        template<typename MarshalConfig>
+        MarshalConfig
+        makeMarshalConfig(nixl_marshal_compress_algo_t /*algo*/) {
+            return MarshalConfig{};
+        }
+
+        template<>
+        nixlMarshalCompressConfig
+        makeMarshalConfig<nixlMarshalCompressConfig>(nixl_marshal_compress_algo_t algo) {
+            return nixlMarshalCompressConfig{algo};
+        }
+
+        // The service fixes the chunked payload size at 128 MB, which these tests cannot
+        // afford in device memory - and ReadPeerRejectsFingerprintMismatch needs two agents
+        // that disagree on it - so they build agents through the protected prepare() seam.
+        class testServiceAgent : public nixlServiceAgent {
+        public:
+            testServiceAgent(const std::string &name,
+                             nixlServiceAgentConfig cfg,
+                             size_t chunked_payload_size)
+                : nixlServiceAgent(name, prepare(std::move(cfg), chunked_payload_size)) {}
+        };
+
+        template<typename MarshalConfig>
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgsForConfig();
+
+        template<>
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgsForConfig<nixlMarshalStagingConfig>() {
+            return nixlMarshalStagingOptArgs{};
+        }
+
+        template<>
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgsForConfig<nixlMarshalCompressConfig>() {
+            return nixlMarshalCompressOptArgs{};
+        }
+
+        template<>
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgsForConfig<nixlMarshalDeltaConfig>() {
+            return nixlMarshalDeltaOptArgs{};
+        }
+
+    } // namespace
+
+    template<typename MarshalConfig,
+             size_t slotSize,
+             size_t slotPerServiceMem,
+             size_t chunkSize,
+             nixl_marshal_compress_algo_t compressAlgo = nixl_marshal_compress_algo_t::ANS>
+    class nixlServiceTestF : public ::testing::Test {
+    public:
+        using marshal_config_t = MarshalConfig;
+
+    protected:
+        std::unique_ptr<nixlServiceAgent> agent_0_;
+        std::unique_ptr<nixlServiceAgent> agent_1_;
+        bool etcd_valid_ = false;
+        bool cuda_valid_ = false;
+        int device_id_ = 0;
+
+        static constexpr size_t memSize = 1024 * chunkSize;
+        // slot_size/chunk_size stay snake_case (unlike their sibling members above/below):
+        // camelCase would spell them identically to the slotSize/chunkSize template parameters
+        // they're initialized from, which shadows the parameter within its own member
+        // initializer and fails to compile.
+        static constexpr size_t slot_size = slotSize;
+        static constexpr size_t chunk_size = chunkSize;
+        static constexpr size_t svcMemSize = slot_size * slotPerServiceMem;
+        // True for plain delta, and for compression configured with the ANS_DELTA algo - the
+        // two cases that need a delta reference buffer on each side.
+        static constexpr bool usesDelta = std::is_same_v<MarshalConfig, nixlMarshalDeltaConfig> ||
+            (std::is_same_v<MarshalConfig, nixlMarshalCompressConfig> &&
+             compressAlgo == nixl_marshal_compress_algo_t::ANS_DELTA);
+
+        void *mem_agent_0_ = nullptr;
+        void *svc_mem_agent_0_ = nullptr;
+        void *mem_agent_1_ = nullptr;
+        void *svc_mem_agent_1_ = nullptr;
+        void *delta_ref_agent_0_ = nullptr;
+        void *delta_ref_agent_1_ = nullptr;
+        std::vector<unsigned char> src_data_;
+        std::vector<unsigned char> dst_data_;
+
+        void
+        SetUp() override {
+            if constexpr (usesDelta) {
+                GTEST_SKIP() << "DeltaBackend/CompressionBackend ans_delta not implemented "
+                                "(delta mode disabled)";
+            }
+            auto env_etcd_endpoints_set = (std::getenv("NIXL_ETCD_ENDPOINTS") != nullptr);
+            auto etcd_running = isPortOpen("127.0.0.1", 2379);
+            if (env_etcd_endpoints_set && !etcd_running) {
+                GTEST_FAIL()
+                    << "NIXL_ETCD_ENDPOINTS is set, but etcd is not running, skipping test";
+            }
+            nixlServiceAgentConfig cfg;
+            cfg.mode = makeMarshalConfig<MarshalConfig>(compressAlgo);
+            cfg.useProgThread = true;
+            agent_0_ = std::make_unique<testServiceAgent>("agent_0", cfg, chunk_size);
+            agent_1_ = std::make_unique<testServiceAgent>("agent_1", cfg, chunk_size);
+            etcd_valid_ = env_etcd_endpoints_set && etcd_running;
+            if (!etcd_valid_) {
+                return;
+            }
+            nixlBackendH *backend_handle_0 = nullptr;
+            nixlBackendH *backend_handle_1 = nullptr;
+            ASSERT_EQ(agent_0_->createBackend("UCX", {}, backend_handle_0), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1_->createBackend("UCX", {}, backend_handle_1), NIXL_SUCCESS);
+            ASSERT_NE(backend_handle_0, nullptr);
+            ASSERT_NE(backend_handle_1, nullptr);
+
+            int device_count = 0;
+            ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+            if (device_count == 0) {
+                GTEST_FAIL() << "No CUDA device available";
+            }
+            ASSERT_EQ(cudaGetDevice(&device_id_), cudaSuccess);
+
+            ASSERT_EQ(cudaMalloc(&mem_agent_0_, memSize), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&svc_mem_agent_0_, svcMemSize), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&mem_agent_1_, memSize), cudaSuccess);
+            ASSERT_EQ(cudaMalloc(&svc_mem_agent_1_, svcMemSize), cudaSuccess);
+            if constexpr (usesDelta) {
+                ASSERT_EQ(cudaMalloc(&delta_ref_agent_0_, memSize), cudaSuccess);
+                ASSERT_EQ(cudaMalloc(&delta_ref_agent_1_, memSize), cudaSuccess);
+                ASSERT_EQ(cudaMemset(delta_ref_agent_0_, 0, memSize), cudaSuccess);
+                ASSERT_EQ(cudaMemset(delta_ref_agent_1_, 0, memSize), cudaSuccess);
+            }
+
+            src_data_.resize(memSize);
+            dst_data_.assign(memSize, 0);
+            std::fill(src_data_.begin(), src_data_.end(), 0);
+            ASSERT_EQ(cudaMemset(mem_agent_0_, 0, memSize), cudaSuccess);
+            ASSERT_EQ(cudaMemset(mem_agent_1_, 0, memSize), cudaSuccess);
+
+            nixl_reg_dlist_t mem_descs_agent_0(VRAM_SEG);
+            mem_descs_agent_0.addDesc(
+                nixlBlobDesc(reinterpret_cast<uintptr_t>(mem_agent_0_), memSize, device_id_));
+            nixl_reg_dlist_t svc_descs_agent_0(VRAM_SEG);
+            svc_descs_agent_0.addDesc(nixlBlobDesc(
+                reinterpret_cast<uintptr_t>(svc_mem_agent_0_), svcMemSize, device_id_));
+
+            nixl_reg_dlist_t mem_descs_agent_1(VRAM_SEG);
+            mem_descs_agent_1.addDesc(
+                nixlBlobDesc(reinterpret_cast<uintptr_t>(mem_agent_1_), memSize, device_id_));
+            nixl_reg_dlist_t svc_descs_agent_1(VRAM_SEG);
+            svc_descs_agent_1.addDesc(nixlBlobDesc(
+                reinterpret_cast<uintptr_t>(svc_mem_agent_1_), svcMemSize, device_id_));
+
+            ASSERT_EQ(agent_0_->registerMem(mem_descs_agent_0), NIXL_SUCCESS);
+            ASSERT_EQ(agent_0_->registerServiceMem(svc_descs_agent_0), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1_->registerMem(mem_descs_agent_1), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1_->registerServiceMem(svc_descs_agent_1), NIXL_SUCCESS);
+
+            nixl_blob_t md_agent_0;
+            nixl_blob_t md_agent_1;
+            ASSERT_EQ(agent_0_->getLocalMD(md_agent_0), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1_->getLocalMD(md_agent_1), NIXL_SUCCESS);
+
+            std::string remote_name_0;
+            std::string remote_name_1;
+            ASSERT_EQ(agent_1_->loadRemoteMD(md_agent_0, remote_name_1), NIXL_SUCCESS);
+            ASSERT_EQ(remote_name_1, "agent_0");
+            ASSERT_EQ(agent_0_->loadRemoteMD(md_agent_1, remote_name_0), NIXL_SUCCESS);
+            ASSERT_EQ(remote_name_0, "agent_1");
+
+            cuda_valid_ = true;
+        }
+
+        void
+        TearDown() override {
+            // Ensure progress threads stop before freeing registered GPU memory.
+            agent_0_.reset();
+            agent_1_.reset();
+
+            if (delta_ref_agent_1_ != nullptr) {
+                (void)cudaFree(delta_ref_agent_1_);
+                delta_ref_agent_1_ = nullptr;
+            }
+            if (delta_ref_agent_0_ != nullptr) {
+                (void)cudaFree(delta_ref_agent_0_);
+                delta_ref_agent_0_ = nullptr;
+            }
+            if (svc_mem_agent_1_ != nullptr) {
+                (void)cudaFree(svc_mem_agent_1_);
+                svc_mem_agent_1_ = nullptr;
+            }
+            if (mem_agent_1_ != nullptr) {
+                (void)cudaFree(mem_agent_1_);
+                mem_agent_1_ = nullptr;
+            }
+            if (svc_mem_agent_0_ != nullptr) {
+                (void)cudaFree(svc_mem_agent_0_);
+                svc_mem_agent_0_ = nullptr;
+            }
+            if (mem_agent_0_ != nullptr) {
+                (void)cudaFree(mem_agent_0_);
+                mem_agent_0_ = nullptr;
+            }
+        }
+
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgs() const {
+            return makeMarshalOptArgs(delta_ref_agent_0_, delta_ref_agent_1_);
+        }
+
+        nixl_marshal_opt_args_t
+        makeMarshalOptArgs(void *sender_ref, void *receiver_ref) const {
+            auto args = makeMarshalOptArgsForConfig<MarshalConfig>();
+            if constexpr (usesDelta) {
+                nixlMarshalDeltaOptArgs delta;
+                delta.senderRef = reinterpret_cast<std::byte *>(sender_ref);
+                delta.receiverRef = reinterpret_cast<std::byte *>(receiver_ref);
+                delta.senderMemType = VRAM_SEG;
+                delta.receiverMemType = VRAM_SEG;
+                delta.elementSize = 1;
+                if constexpr (std::is_same_v<MarshalConfig, nixlMarshalDeltaConfig>) {
+                    std::get<nixlMarshalDeltaOptArgs>(args) = delta;
+                } else {
+                    // nixlMarshalCompressConfig with the ANS_DELTA algo.
+                    std::get<nixlMarshalCompressOptArgs>(args).delta = delta;
+                }
+            }
+            return args;
+        }
+
+        // Fills the first fill_size bytes of buf with a non-constant pattern, cheaply, so the
+        // byte-for-byte comparisons below can actually detect corruption/truncation/misplacement
+        // - unlike filling every byte via std::uniform_int_distribution, which for these
+        // multi-hundred-MB buffers costs multiple seconds of pure host CPU time, dwarfing the
+        // real transfer this fixture means to exercise. A single tile is generated the slow way,
+        // then replicated with memcpy; the tile size is a prime deliberately not a multiple of
+        // any fixture's chunk_size, so corresponding bytes across chunk boundaries still differ.
+        // Two buffers filled with different seeds are guaranteed distinct patterns, unlike two
+        // buffers drawn from the same rng stream, for tests that need that (e.g. to tell a
+        // WRITE's and a READ's data apart if they were ever cross-wired).
+        static void
+        fillWithRepeatingRandomPattern(std::vector<unsigned char> &buf,
+                                       size_t fill_size,
+                                       uint32_t seed = 42) {
+            constexpr size_t tile_size_max = 1'000'003;
+            std::mt19937 rng(seed);
+            std::uniform_int_distribution<int> dist(0, 4);
+            const size_t tile_size = std::min(tile_size_max, fill_size);
+            for (size_t i = 0; i < tile_size; ++i) {
+                buf[i] = static_cast<unsigned char>(dist(rng));
+            }
+            for (size_t off = tile_size; off < fill_size; off += tile_size) {
+                std::memcpy(buf.data() + off, buf.data(), std::min(tile_size, fill_size - off));
+            }
+        }
+
+        // End-to-end marshalled READ, shared by every mode this fixture is instantiated for:
+        // agent_1_ is the peer being read from (P), its buffer is prefilled and never written
+        // to; agent_0_ is the initiator (I), its buffer starts zeroed and should end up holding
+        // a copy of agent_1_'s data.
+        void
+        runReadValidTest() {
+            if (!etcd_valid_) {
+                GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+            }
+            if (!cuda_valid_) {
+                GTEST_SKIP() << "No CUDA device available";
+            }
+
+            fillWithRepeatingRandomPattern(src_data_, memSize);
+            ASSERT_EQ(cudaMemcpy(mem_agent_1_, src_data_.data(), memSize, cudaMemcpyHostToDevice),
+                      cudaSuccess);
+
+            nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG); // agent_0_'s (I's) destination.
+            local_xfer_descs.addDesc(
+                nixlBasicDesc(reinterpret_cast<uintptr_t>(mem_agent_0_), memSize, device_id_));
+            nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG); // agent_1_'s (P's) source.
+            remote_xfer_descs.addDesc(
+                nixlBasicDesc(reinterpret_cast<uintptr_t>(mem_agent_1_), memSize, device_id_));
+
+            nixlServiceXferReqH *req_hndl = nullptr;
+            nixl_service_opt_args_t extra_params{};
+            // sender_ref/receiver_ref are swapped relative to the no-arg makeMarshalOptArgs()'s
+            // WRITE-oriented default: for a READ, agent_1_ (P) is the one encoding and agent_0_
+            // (I) is the one decoding. A no-op for any mode that doesn't use delta references.
+            extra_params.marshalOptArgs =
+                makeMarshalOptArgs(delta_ref_agent_1_, delta_ref_agent_0_);
+            extra_params.notif = "read_done";
+            ASSERT_EQ(agent_0_->createXferReq(NIXL_READ,
+                                              local_xfer_descs,
+                                              remote_xfer_descs,
+                                              "agent_1",
+                                              req_hndl,
+                                              &extra_params),
+                      NIXL_SUCCESS);
+            ASSERT_NE(req_hndl, nullptr);
+            ASSERT_EQ(agent_0_->getXferStatus(req_hndl), NIXL_ERR_NOT_POSTED);
+            ASSERT_EQ(agent_0_->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG);
+
+            nixl_notifs_t notifs;
+            while (agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+                ASSERT_EQ(agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+                ASSERT_EQ(notifs.size(), 0);
+                // The notification (once delivered) always targets the peer being read from,
+                // not the initiator itself - see tryCompleteReadReceive.
+                ASSERT_EQ(agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+                ASSERT_LE(notifs.size(), 1);
+            }
+            ASSERT_EQ(agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+
+            ASSERT_EQ(cudaMemcpy(dst_data_.data(), mem_agent_0_, memSize, cudaMemcpyDeviceToHost),
+                      cudaSuccess);
+            ASSERT_EQ(dst_data_, src_data_);
+
+            while (notifs.size() == 0) {
+                ASSERT_EQ(agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            }
+            ASSERT_EQ(notifs.size(), 1);
+            ASSERT_EQ(notifs["agent_0"].size(), 1);
+            ASSERT_EQ(notifs["agent_0"].front(), "read_done");
+
+            ASSERT_EQ(agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        }
+    };
+
+    template<typename Fixture> class nixlServiceTest : public Fixture {};
+
+    using nixl_service_test_types_t =
+        ::testing::Types<nixlServiceTestF<nixlMarshalStagingConfig,
+                                          128 * 1024,
+                                          MarshalBackendSizing::slots_per_transfer,
+                                          128 * 1024>,
+                         nixlServiceTestF<nixlMarshalCompressConfig,
+                                          128 * 1024 * 3,
+                                          MarshalBackendSizing::slots_per_transfer,
+                                          128 * 1024>,
+                         nixlServiceTestF<nixlMarshalDeltaConfig,
+                                          128 * 1024,
+                                          MarshalBackendSizing::slots_per_transfer,
+                                          128 * 1024>>;
+
+    TYPED_TEST_SUITE(nixlServiceTest, nixl_service_test_types_t);
+
+    template<typename Fixture> class nixlServiceBidirectionalTest : public Fixture {};
+
+    using nixl_service_bidirectional_test_types_t =
+        ::testing::Types<nixlServiceTestF<nixlMarshalStagingConfig,
+                                          128 * 1024,
+                                          MarshalBackendSizing::slots_per_transfer * 2,
+                                          128 * 1024>,
+                         nixlServiceTestF<nixlMarshalCompressConfig,
+                                          512 * 1024 * 3,
+                                          MarshalBackendSizing::slots_per_transfer * 2,
+                                          512 * 1024>,
+                         nixlServiceTestF<nixlMarshalDeltaConfig,
+                                          512 * 1024,
+                                          MarshalBackendSizing::slots_per_transfer * 2,
+                                          512 * 1024>>;
+
+    TYPED_TEST_SUITE(nixlServiceBidirectionalTest, nixl_service_bidirectional_test_types_t);
+
+    // Compression configured with the ANS_DELTA algo is its own dedicated suite rather than a
+    // fourth entry in nixl_service_test_types_t: every other TYPED_TEST bound to nixlServiceTest
+    // (e.g. MixedSmallAndLargeDescriptors) would otherwise also run against it, and several
+    // of those tests only account for plain nixlMarshalDeltaConfig's single-descriptor
+    // restriction, not the equivalent restriction for compression+ANS_DELTA. ANS_DELTA needs
+    // extra per-slot workspace beyond plain ANS (see algoWorkspaceOverhead) for the delta
+    // kernel's full-payload staging copy, hence the larger slotSize.
+    template<typename Fixture> class nixlServiceAnsDeltaTest : public Fixture {};
+
+    using nixl_service_ans_delta_test_types_t =
+        ::testing::Types<nixlServiceTestF<nixlMarshalCompressConfig,
+                                          512 * 1024 * 6,
+                                          MarshalBackendSizing::slots_per_transfer,
+                                          512 * 1024,
+                                          nixl_marshal_compress_algo_t::ANS_DELTA>>;
+
+    TYPED_TEST_SUITE(nixlServiceAnsDeltaTest, nixl_service_ans_delta_test_types_t);
+
+    TYPED_TEST(nixlServiceTest, CreateAgentValid) {
+        ASSERT_NE(this->agent_0_, nullptr);
+        ASSERT_NE(this->agent_1_, nullptr);
+    }
+
+    // Marshalled (non-direct-split) NIXL_READ is now supported (see createReadReceiveXfer),
+    // but a loopback marshalled READ (remote_agent == self) remains explicitly rejected
+    // until the same agent both encoding and decoding into itself is specifically tested.
+    // memSize (1024 * chunkSize) exceeds direct_desc_threshold (64 MB) for every fixture
+    // type below, so a single memSize-sized descriptor always takes the marshal split path.
+    TYPED_TEST(nixlServiceTest, LoopbackMarshalReadRejected) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        std::vector<unsigned char> zeros(this->memSize, 0);
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_1_, zeros.data(), this->memSize, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), this->memSize, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), this->memSize, this->device_id_));
+
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs = this->makeMarshalOptArgs();
+        nixlServiceXferReqH *req_hndl = nullptr;
+        // "agent_0" is agent_0_'s own name (see the fixture's SetUp) - a genuine loopback.
+        ASSERT_EQ(
+            this->agent_0_->createXferReq(
+                NIXL_READ, local_xfer_descs, remote_xfer_descs, "agent_0", req_hndl, &extra_params),
+            NIXL_ERR_NOT_SUPPORTED);
+        ASSERT_EQ(req_hndl, nullptr);
+
+        // Neither side's buffer should have been touched by the rejected call.
+        std::vector<unsigned char> dst_check(this->memSize);
+        ASSERT_EQ(
+            cudaMemcpy(dst_check.data(), this->mem_agent_0_, this->memSize, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_check, zeros);
+        ASSERT_EQ(
+            cudaMemcpy(dst_check.data(), this->mem_agent_1_, this->memSize, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_check, zeros);
+    }
+
+    // Covers staging, plain-ANS compression, and plain delta - one descriptor per side, which
+    // satisfies delta's single-descriptor restriction. See runReadValidTest()'s definition.
+    TYPED_TEST(nixlServiceTest, ReadValid) {
+        this->runReadValidTest();
+    }
+
+    // Compression configured with the ANS_DELTA algo, in its own dedicated suite (see
+    // nixlServiceAnsDeltaTest's declaration for why).
+    TYPED_TEST(nixlServiceAnsDeltaTest, ReadValid) {
+        this->runReadValidTest();
+    }
+
+    // Regression for a notif-presence bug: postXferReq's READ branch used to unconditionally
+    // overwrite the receive context's notification with postXferReq's own extra_params, even
+    // when that call omitted one entirely - silently discarding a notification that was only
+    // set at createXferReq() time. This sets .notif on a separate object passed only to
+    // createXferReq, then calls postXferReq(req_hndl) with no extra_params at all, mirroring
+    // the base nixlAgent::postXferReq convention of carrying the create-time value over unless
+    // post time explicitly overrides it (see postXferReq's READ branch).
+    TYPED_TEST(nixlServiceTest, ReadNotifPersistsFromCreateWhenPostOmitsIt) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        std::vector<unsigned char> pattern(this->memSize, 0x5A);
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_1_, pattern.data(), this->memSize, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), this->memSize, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), this->memSize, this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t create_params{};
+        create_params.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        create_params.notif = "create_time_notif";
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_READ,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl,
+                                                &create_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        // No extra_params at all here - unlike every other READ test, which reuses the same
+        // populated extra_params object for both calls and so never exercises this path.
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl), NIXL_IN_PROG);
+
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_LE(notifs.size(), 1);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+
+        while (notifs.size() == 0) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs.size(), 1);
+        ASSERT_EQ(notifs["agent_0"].size(), 1);
+        ASSERT_EQ(notifs["agent_0"].front(), "create_time_notif");
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    // TODO-Eyal: add TOs.
+    TYPED_TEST(nixlServiceTest, PostXferReq) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        std::mt19937 rng(42);
+        // TODO-Roee: change to (0, 255) once fallback is implemented.
+        std::uniform_int_distribution<int> dist(0, 4);
+        for (auto &v : this->src_data_) {
+            v = static_cast<unsigned char>(dist(rng));
+        }
+        ASSERT_EQ(
+            cudaMemcpy(
+                this->mem_agent_0_, this->src_data_.data(), this->memSize, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), this->memSize, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), this->memSize, this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs = this->makeMarshalOptArgs();
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl,
+                                                &extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        nixlServiceXferReqH *req_hndl_1 = nullptr;
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_1,
+                                                &extra_params),
+                  NIXL_ERR_NOT_FOUND); // the service memory is just 2 slots, so this should fail.
+        ASSERT_EQ(req_hndl_1, nullptr);
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_ERR_NOT_POSTED);
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl), NIXL_SUCCESS);
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_1,
+                                                &extra_params),
+                  NIXL_SUCCESS); // the first request is done so we have free slots.
+        ASSERT_NE(req_hndl_1, nullptr);
+        ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        ASSERT_EQ(notifs.size(), 0);
+        ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+        ASSERT_EQ(notifs.size(), 0);
+        ASSERT_EQ(
+            cudaMemcpy(
+                this->dst_data_.data(), this->mem_agent_1_, this->memSize, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(this->dst_data_, this->src_data_);
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl_1), NIXL_SUCCESS);
+        for (int i = 0; i < 10; i++) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+        }
+    }
+
+    TYPED_TEST(nixlServiceTest, MixedSmallAndLargeDescriptors) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                     nixlMarshalDeltaConfig>) {
+            GTEST_SKIP() << "Delta mode does not support multiple descriptors";
+        }
+
+        constexpr size_t small_desc_size = 1024;
+        constexpr size_t large_desc_size = 16 * 1024 * 1024 + 1024;
+        constexpr size_t transfer_size = small_desc_size + large_desc_size;
+        static_assert(large_desc_size > 16 * 1024 * 1024); // direct_desc_threshold
+        static_assert(small_desc_size <= 16 * 1024 * 1024); // direct_desc_threshold
+        ASSERT_LE(transfer_size, this->memSize);
+
+        std::mt19937 rng(42);
+        std::uniform_int_distribution<int> dist(0, 4);
+        std::vector<unsigned char> src_data(transfer_size);
+        std::vector<unsigned char> dst_data(transfer_size, 0);
+        for (auto &v : src_data) {
+            v = static_cast<unsigned char>(dist(rng));
+        }
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_0_, src_data.data(), transfer_size, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), small_desc_size, this->device_id_));
+        local_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_0_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), small_desc_size, this->device_id_));
+        remote_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_1_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs = this->makeMarshalOptArgs();
+        nixlServiceXferReqH *req_hndl = nullptr;
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl,
+                                                &extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl, &extra_params), NIXL_SUCCESS);
+
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(
+            cudaMemcpy(dst_data.data(), this->mem_agent_1_, transfer_size, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_data, src_data);
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    // READ counterpart of MixedSmallAndLargeDescriptors: a single READ whose two descriptors span
+    // both the direct (base NIXL_READ) and marshal (RREQ/RPOSTED/RRSLOT) paths. Unlike that WRITE
+    // test, large_desc_size here is sized against the real direct_desc_threshold (64 MB) rather
+    // than the stale 16 MB the WRITE test still (incorrectly, but out of scope to fix here) uses.
+    // Verifies the two children's completion aggregates correctly regardless of which finishes
+    // first, with exactly one user notification delivered only once both are done.
+    TYPED_TEST(nixlServiceTest, ReadMixed) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                     nixlMarshalDeltaConfig>) {
+            GTEST_SKIP() << "Delta mode does not support multiple descriptors";
+        }
+
+        constexpr size_t small_desc_size = 1024;
+        constexpr size_t large_desc_size = 64 * 1024 * 1024 + 1024;
+        constexpr size_t transfer_size = small_desc_size + large_desc_size;
+        static_assert(large_desc_size > 64 * 1024 * 1024); // direct_desc_threshold
+        static_assert(small_desc_size <= 64 * 1024 * 1024); // direct_desc_threshold
+        ASSERT_LE(transfer_size, this->memSize);
+
+        std::vector<unsigned char> src_data(transfer_size);
+        std::vector<unsigned char> dst_data(transfer_size, 0);
+        this->fillWithRepeatingRandomPattern(src_data, transfer_size);
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_1_, src_data.data(), transfer_size, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG); // agent_0_'s (I's) destination.
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), small_desc_size, this->device_id_));
+        local_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_0_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG); // agent_1_'s (P's) source.
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), small_desc_size, this->device_id_));
+        remote_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_1_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        extra_params.notif = "read_mixed_done";
+        ASSERT_EQ(
+            this->agent_0_->createXferReq(
+                NIXL_READ, local_xfer_descs, remote_xfer_descs, "agent_1", req_hndl, &extra_params),
+            NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG);
+
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_LE(notifs.size(), 1);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+
+        ASSERT_EQ(
+            cudaMemcpy(dst_data.data(), this->mem_agent_0_, transfer_size, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_data, src_data);
+
+        while (notifs.size() == 0) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs.size(), 1);
+        ASSERT_EQ(notifs["agent_0"].size(), 1);
+        ASSERT_EQ(notifs["agent_0"].front(), "read_mixed_done");
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    // Regression test for a mixed READ's double-notify bug: the direct child used to carry
+    // over the create-time notif and fire it as soon as its own (small) sub-transfer completed,
+    // in addition to the real, single delivery from tryCompleteReadReceive once both sub-parts
+    // are done. Same two-descriptor setup as ReadMixed, but the notif is captured only via
+    // create_params and postXferReq is called bare - the "create-time-only, bare post" pattern
+    // from ReadNotifPersistsFromCreateWhenPostOmitsIt, applied to a mixed (not marshal-only)
+    // transfer, where the bug actually lived.
+    TYPED_TEST(nixlServiceTest, ReadMixedNotifPersistsFromCreateWhenPostOmitsIt) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                     nixlMarshalDeltaConfig>) {
+            GTEST_SKIP() << "Delta mode does not support multiple descriptors";
+        }
+
+        constexpr size_t small_desc_size = 1024;
+        constexpr size_t large_desc_size = 64 * 1024 * 1024 + 1024;
+        constexpr size_t transfer_size = small_desc_size + large_desc_size;
+        static_assert(large_desc_size > 64 * 1024 * 1024); // direct_desc_threshold
+        static_assert(small_desc_size <= 64 * 1024 * 1024); // direct_desc_threshold
+        ASSERT_LE(transfer_size, this->memSize);
+
+        std::vector<unsigned char> src_data(transfer_size);
+        std::vector<unsigned char> dst_data(transfer_size, 0);
+        this->fillWithRepeatingRandomPattern(src_data, transfer_size);
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_1_, src_data.data(), transfer_size, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), small_desc_size, this->device_id_));
+        local_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_0_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), small_desc_size, this->device_id_));
+        remote_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_1_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t create_params{};
+        create_params.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        create_params.notif = "read_mixed_create_only";
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_READ,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl,
+                                                &create_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        // Bare post: extra_params carries no notif of its own, so the only one in play is the
+        // create-time one. Before the fix, the direct child would still carry it (from
+        // createXferReq's own extra_params) and fire it as soon as it completed.
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl), NIXL_IN_PROG);
+
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+
+        ASSERT_EQ(
+            cudaMemcpy(dst_data.data(), this->mem_agent_0_, transfer_size, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_data, src_data);
+
+        // Both sub-parts are done by now, so any notification - the single correct delivery, or,
+        // if the bug regresses, also the direct child's early spurious one - has already been
+        // sent; this only waits for it to become retrievable, the same settle margin
+        // ReadCancelInEverySlotState uses.
+        for (int i = 0; i < 10; ++i) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+        ASSERT_EQ(notifs.size(), 1);
+        ASSERT_EQ(notifs["agent_0"].size(), 1);
+        ASSERT_EQ(notifs["agent_0"].front(), "read_mixed_create_only");
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    // Regression test for the getXferStatus-driven mixed-READ completion gap: before the fix,
+    // a mixed READ's direct child lived on the caller-owned outer handle, unreachable from
+    // progressService(), so only getXferStatus() (never getNotifs() alone) could advance it to
+    // completion. Same two-descriptor setup as ReadMixed, but the wait loop below deliberately
+    // calls only getNotifs() on both agents - never getXferStatus() - to prove the transfer (and
+    // its single notification) completes without it. Bounded by a wall-clock deadline so a
+    // regression here fails cleanly instead of hanging the whole suite.
+    TYPED_TEST(nixlServiceTest, ReadMixedCompletesViaGetNotifsAlone) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                     nixlMarshalDeltaConfig>) {
+            GTEST_SKIP() << "Delta mode does not support multiple descriptors";
+        }
+
+        constexpr size_t small_desc_size = 1024;
+        constexpr size_t large_desc_size = 64 * 1024 * 1024 + 1024;
+        constexpr size_t transfer_size = small_desc_size + large_desc_size;
+        static_assert(large_desc_size > 64 * 1024 * 1024); // direct_desc_threshold
+        static_assert(small_desc_size <= 64 * 1024 * 1024); // direct_desc_threshold
+        ASSERT_LE(transfer_size, this->memSize);
+
+        std::vector<unsigned char> src_data(transfer_size);
+        std::vector<unsigned char> dst_data(transfer_size, 0);
+        this->fillWithRepeatingRandomPattern(src_data, transfer_size);
+        ASSERT_EQ(
+            cudaMemcpy(this->mem_agent_1_, src_data.data(), transfer_size, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG); // agent_0_'s (I's) destination.
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), small_desc_size, this->device_id_));
+        local_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_0_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG); // agent_1_'s (P's) source.
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), small_desc_size, this->device_id_));
+        remote_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(this->mem_agent_1_) + small_desc_size,
+                          large_desc_size,
+                          this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        extra_params.notif = "read_mixed_getnotifs_done";
+        ASSERT_EQ(
+            this->agent_0_->createXferReq(
+                NIXL_READ, local_xfer_descs, remote_xfer_descs, "agent_1", req_hndl, &extra_params),
+            NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG);
+
+        // Deliberately no getXferStatus() call in this loop: only getNotifs() on both agents may
+        // drive progressService(). The READ's notification always addresses remoteAgent
+        // (agent_1 here - see tryCompleteReadReceive), so that is where it must land.
+        nixl_notifs_t self_notifs;
+        nixl_notifs_t peer_notifs;
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (peer_notifs.size() == 0) {
+            ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+                << "mixed READ did not complete via getNotifs() alone within the time bound";
+            ASSERT_EQ(this->agent_0_->getNotifs(self_notifs), NIXL_SUCCESS);
+            ASSERT_EQ(self_notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(peer_notifs), NIXL_SUCCESS);
+        }
+
+        ASSERT_EQ(
+            cudaMemcpy(dst_data.data(), this->mem_agent_0_, transfer_size, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(dst_data, src_data);
+
+        ASSERT_EQ(peer_notifs.size(), 1);
+        ASSERT_EQ(peer_notifs["agent_0"].size(), 1);
+        ASSERT_EQ(peer_notifs["agent_0"].front(), "read_mixed_getnotifs_done");
+
+        // Completion was already observed via getNotifs() alone above; this single check just
+        // confirms the state machine (not merely the notification) agrees.
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    TYPED_TEST(nixlServiceTest, MidTransferRelease) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), this->memSize, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), this->memSize, this->device_id_));
+
+        nixlServiceXferReqH *req_hndl_0 = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs = this->makeMarshalOptArgs();
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_0,
+                                                &extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl_0, nullptr);
+
+
+        extra_params.notif = "first_req";
+
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl_0, &extra_params), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl_0), NIXL_IN_PROG);
+        nixlServiceXferReqH *req_hndl_1 = nullptr;
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_1,
+                                                &extra_params),
+                  NIXL_ERR_NOT_FOUND); // the service memory is just 2 slots, so this should fail.
+        ASSERT_EQ(req_hndl_1, nullptr);
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl_0),
+                  NIXL_SUCCESS); // Mid transfer release.
+        nixl_notifs_t notifs;
+        for (int i = 0; i < 10; i++) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            // Give time for the DELETE to be processed s.t. the receiver has free slots for the
+            // next request.
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                local_xfer_descs,
+                                                remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_1,
+                                                &extra_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl_1, nullptr);
+        extra_params.notif = "second_req";
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl_1, &extra_params), NIXL_SUCCESS);
+        while (this->agent_0_->getXferStatus(req_hndl_1) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_LE(notifs.size(), 1);
+            if (notifs.size() == 1) {
+                ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl_1), NIXL_SUCCESS);
+            }
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl_1), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl_1), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+        ASSERT_EQ(notifs.count("agent_1"), 0);
+        while (notifs.size() == 0) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs.size(), 1);
+        ASSERT_EQ(notifs["agent_0"].size(), 1);
+        ASSERT_EQ(notifs["agent_0"].front(), "second_req");
+    }
+
+    // Cancels a marshalled READ at a sweep of different points in its lifecycle - before ever
+    // posting, immediately after posting, at a range of increasing delays after posting, and
+    // after letting it fully complete - so that across the sweep a release is likely to land
+    // while a slot is in each of local_slot_state_t's BUSY_MARSHAL/READY_TO_SEND/BUSY_NIXL/FREE at
+    // least once, without needing invasive test-only synchronization hooks. After each release,
+    // confirms (a) no crash/assertion failure and (b) no write lands in the destination buffer
+    // once the cancellation has settled. A leaked slot from any individual trial would already
+    // fail that trial's own (or, since this fixture's whole pool is exactly slots_per_xfer slots,
+    // at latest the next trial's) createXferReq assertion below, so a full, independent READ
+    // (runReadValidTest) only needs to run once at the very end, not after every trial, to prove
+    // the pool is left not just numerically free but functionally correct.
+    TYPED_TEST(nixlServiceTest, ReadCancelInEverySlotState) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), this->memSize, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), this->memSize, this->device_id_));
+
+        const auto make_extra_params = [&] {
+            nixl_service_opt_args_t extra_params{};
+            extra_params.marshalOptArgs =
+                this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+            return extra_params;
+        };
+
+        // Releasing a never-posted READ takes releaseXferReq's PRE_START branch specifically -
+        // exercised once, up front, since it has no "posted" counterpart in the sweep below.
+        {
+            auto extra_params = make_extra_params();
+            nixlServiceXferReqH *req_hndl = nullptr;
+            ASSERT_EQ(this->agent_0_->createXferReq(NIXL_READ,
+                                                    local_xfer_descs,
+                                                    remote_xfer_descs,
+                                                    "agent_1",
+                                                    req_hndl,
+                                                    &extra_params),
+                      NIXL_SUCCESS);
+            ASSERT_NE(req_hndl, nullptr);
+            ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        }
+
+        // A log-scale sweep of delays between posting and releasing, plus std::nullopt meaning
+        // "let it fully complete first" (the DONE release branch).
+        const std::vector<std::optional<std::chrono::microseconds>> release_points = {
+            std::chrono::microseconds(0),
+            std::chrono::microseconds(200),
+            std::chrono::microseconds(2000),
+            std::chrono::microseconds(20000),
+            std::chrono::microseconds(200000),
+            std::nullopt,
+        };
+
+        for (size_t trial = 0; trial < release_points.size(); ++trial) {
+            auto extra_params = make_extra_params();
+            nixlServiceXferReqH *req_hndl = nullptr;
+            ASSERT_EQ(this->agent_0_->createXferReq(NIXL_READ,
+                                                    local_xfer_descs,
+                                                    remote_xfer_descs,
+                                                    "agent_1",
+                                                    req_hndl,
+                                                    &extra_params),
+                      NIXL_SUCCESS)
+                << "trial " << trial;
+            ASSERT_NE(req_hndl, nullptr);
+            ASSERT_EQ(this->agent_0_->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG)
+                << "trial " << trial;
+
+            nixl_notifs_t notifs;
+            if (release_points[trial].has_value()) {
+                std::this_thread::sleep_for(*release_points[trial]);
+            } else {
+                while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+                    ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+                    ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+                }
+            }
+            ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS) << "trial " << trial;
+
+            // Let the drain-to-quiescence (RABORT/RABORT_ACK), or the immediate free path if it
+            // had already reached DONE, fully settle before checking for a stale write. 20ms
+            // steps match the settle loop in ReadPeerRejectsFingerprintMismatch.
+            for (int i = 0; i < 10; ++i) {
+                ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+                ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+
+            std::vector<unsigned char> settled(this->memSize);
+            ASSERT_EQ(
+                cudaMemcpy(
+                    settled.data(), this->mem_agent_0_, this->memSize, cudaMemcpyDeviceToHost),
+                cudaSuccess);
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            std::vector<unsigned char> after_settle(this->memSize);
+            ASSERT_EQ(
+                cudaMemcpy(
+                    after_settle.data(), this->mem_agent_0_, this->memSize, cudaMemcpyDeviceToHost),
+                cudaSuccess);
+            ASSERT_EQ(settled, after_settle)
+                << "trial " << trial << ": destination buffer changed after cancellation settled"
+                << " - a stale write landed after the cancellation was believed complete";
+        }
+
+        // Both agents' slot pools must be fully usable again after the whole sweep above: run one
+        // complete, independent READ end-to-end (see this test's header comment for why once,
+        // here, is enough).
+        this->runReadValidTest();
+    }
+
+    // Injects a batch of malformed/adversarial/duplicate READ protocol messages - targeting a
+    // real in-flight READ's own xfer id where a handler's deeper validation needs one to reach -
+    // via the public genNotif(), the same entry point any peer's messages arrive through. None
+    // of this should be observable in the outcome: every message below must be silently dropped
+    // by the validation added throughout the READ implementation, and the real transfer must
+    // still complete correctly. Deliberately does not test truncated/short messages: every
+    // _NIXLS_* payload (READ's and the pre-existing WRITE ones alike) decodes via readScalar(),
+    // which bounds-checks with NIXL_ASSERT (DCHECK) rather than a graceful, always-enforced
+    // check - a pre-existing protocol-wide design choice, not something introduced by READ.
+    // The real transfer only needs to be large enough for a few rounds of slot reuse to
+    // interleave with the injected messages, not the fixture's full memSize - that many-chunk
+    // pipeline is already covered by ReadValid/ReadMixed/PostXferReq. It does need to stay above
+    // direct_desc_threshold (64 MB, mirrored below - see createXferReq's split), though, or this
+    // silently degrades to a direct-only READ that bypasses the marshal protocol entirely, which
+    // is what every message injected below targets.
+    TYPED_TEST(nixlServiceTest, ReadMalformedAndDuplicateMessagesIgnored) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        constexpr size_t direct_desc_threshold = 64 * 1024 * 1024;
+        constexpr size_t transfer_size =
+            direct_desc_threshold + TestFixture::chunk_size * slots_per_xfer * 2;
+        static_assert(transfer_size > direct_desc_threshold);
+        static_assert(transfer_size <= TestFixture::memSize);
+
+        // A third agent that only exchanges metadata with agent_0_ (never agent_1_), used to
+        // verify handleRPosted's sender check - without it, any agent able to reach agent_0_
+        // could inject data into this READ merely by guessing its xfer id.
+        nixlServiceAgentConfig impostor_cfg;
+        impostor_cfg.mode = nixlMarshalStagingConfig{};
+        impostor_cfg.useProgThread = true;
+        auto impostor =
+            std::make_unique<testServiceAgent>("impostor", impostor_cfg, this->chunk_size);
+        nixlBackendH *impostor_backend = nullptr;
+        ASSERT_EQ(impostor->createBackend("UCX", {}, impostor_backend), NIXL_SUCCESS);
+        nixl_blob_t impostor_md;
+        ASSERT_EQ(impostor->getLocalMD(impostor_md), NIXL_SUCCESS);
+        std::string impostor_remote_name;
+        ASSERT_EQ(this->agent_0_->loadRemoteMD(impostor_md, impostor_remote_name), NIXL_SUCCESS);
+        ASSERT_EQ(impostor_remote_name, "impostor");
+        nixl_blob_t agent_0_md;
+        ASSERT_EQ(this->agent_0_->getLocalMD(agent_0_md), NIXL_SUCCESS);
+        std::string agent_0_remote_name;
+        ASSERT_EQ(impostor->loadRemoteMD(agent_0_md, agent_0_remote_name), NIXL_SUCCESS);
+        ASSERT_EQ(agent_0_remote_name, "agent_0");
+
+        this->fillWithRepeatingRandomPattern(this->src_data_, transfer_size);
+        ASSERT_EQ(
+            cudaMemcpy(
+                this->mem_agent_1_, this->src_data_.data(), transfer_size, cudaMemcpyHostToDevice),
+            cudaSuccess);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_0_), transfer_size, this->device_id_));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(nixlBasicDesc(
+            reinterpret_cast<uintptr_t>(this->mem_agent_1_), transfer_size, this->device_id_));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        extra_params.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        extra_params.notif = "malformed_test_done";
+        ASSERT_EQ(
+            this->agent_0_->createXferReq(
+                NIXL_READ, local_xfer_descs, remote_xfer_descs, "agent_1", req_hndl, &extra_params),
+            NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        ASSERT_TRUE(req_hndl->readReceiveXferId.has_value());
+        const size_t xfer_id =
+            *req_hndl->readReceiveXferId; // Also rReqPayload.xferId - see genRREQ.
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG);
+
+        auto segments = std::make_shared<std::vector<nixlMarshal::ChunkDivision::segment>>();
+        segments->push_back({0, 16});
+
+        // Unrecognized _NIXLS_ subtype: serviceNotifCallback must drop it, not assert.
+        ASSERT_EQ(this->agent_1_->genNotif("agent_0", "_NIXLS_BOGUS_no-such-message-kind"),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->genNotif("agent_1", "_NIXLS_BOGUS_no-such-message-kind"),
+                  NIXL_SUCCESS);
+
+        // RPOSTED for a nonexistent xfer id.
+        ASSERT_EQ(
+            this->agent_1_->genNotif(
+                "agent_0", rPostedPayload(xfer_id + 999983, 0, 16, segments, 0, "").serialize()),
+            NIXL_SUCCESS);
+        // RPOSTED for the real xfer id, but an out-of-range slot index.
+        ASSERT_EQ(this->agent_1_->genNotif(
+                      "agent_0",
+                      rPostedPayload(xfer_id, slots_per_xfer + 7, 16, segments, 0, "").serialize()),
+                  NIXL_SUCCESS);
+        // RPOSTED for the real xfer id and a valid slot index, but a wildly out-of-bounds
+        // destination offset ("oversized" relative to the actual destination region).
+        ASSERT_EQ(this->agent_1_->genNotif(
+                      "agent_0",
+                      rPostedPayload(xfer_id, 0, 16, segments, transfer_size * 4, "").serialize()),
+                  NIXL_SUCCESS);
+        // RPOSTED for the real xfer id from an agent that is not this READ's actual peer.
+        ASSERT_EQ(impostor->genNotif("agent_0",
+                                     rPostedPayload(xfer_id, 0, 16, segments, 0, "").serialize()),
+                  NIXL_SUCCESS);
+        // RPOSTED for the real xfer id and a valid slot index, with dstByteOffset/originalSize
+        // chosen so their sum overflows size_t and wraps back to (in this case, exactly) 0, well
+        // within the destination region's bounds. resolveAbsoluteOffset() must reject this via
+        // the overflow-safe "size > desc.len - offset_in_desc" comparison, not the overflow-prone
+        // "offset_in_desc + size > desc.len" form it replaced (which this would have bypassed).
+        {
+            const size_t overflow_offset = transfer_size / 2;
+            const size_t overflow_size = std::numeric_limits<size_t>::max() - overflow_offset + 1;
+            ASSERT_EQ(this->agent_1_->genNotif(
+                          "agent_0",
+                          rPostedPayload(xfer_id, 0, overflow_size, segments, overflow_offset, "")
+                              .serialize()),
+                      NIXL_SUCCESS);
+        }
+
+        // RRSLOT/RABORT/RABORT_ACK/RNAK for nonexistent xfer ids, sent to whichever side would
+        // real ones of each kind normally go to.
+        ASSERT_EQ(
+            this->agent_0_->genNotif("agent_1", rrSlotPayload(xfer_id + 999983, 0, 0).serialize()),
+            NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_0_->genNotif("agent_1", rAbortPayload(xfer_id + 999983).serialize()),
+                  NIXL_SUCCESS);
+        ASSERT_EQ(
+            this->agent_1_->genNotif("agent_0", rAbortAckPayload(xfer_id + 999983).serialize()),
+            NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->genNotif(
+                      "agent_0",
+                      rNakPayload(xfer_id + 999983, static_cast<int32_t>(NIXL_ERR_INVALID_PARAM))
+                          .serialize()),
+                  NIXL_SUCCESS);
+
+        // RRSLOT for the real xfer id and slot 0, but a generation nothing has used yet:
+        // dropped as stale/mismatched by handleRRSlot's remoteSlotStates/generation check.
+        ASSERT_EQ(this->agent_0_->genNotif(
+                      "agent_1", rrSlotPayload(xfer_id, 0, 0xFFFFFFFFFFFFFFFFull).serialize()),
+                  NIXL_SUCCESS);
+
+        // Duplicate RREQ for the same (sender, xfer id) as the already in-flight serve: dropped
+        // by handleRREQ's own duplicate check, rather than tearing down the real serve's slots.
+        {
+            const marshalLayoutFingerprint bogus_fp{};
+            const std::array<nixlBasicDesc, slots_per_xfer> bogus_slots{
+                nixlBasicDesc(0x1000, 16, 0), nixlBasicDesc(0x2000, 16, 0)};
+            const std::array<nixlMarshal::mem_space_t, slots_per_xfer> bogus_mem_spaces{
+                nixlMarshal::mem_space_t::DEVICE, nixlMarshal::mem_space_t::DEVICE};
+            // rReqPayload's constructor requires a non-empty serialized source list; its
+            // content is irrelevant here since handleRREQ's duplicate check (below) returns
+            // before ever parsing it.
+            const rReqPayload duplicate_rreq(
+                xfer_id, std::string("unused"), bogus_slots, bogus_mem_spaces, bogus_fp);
+            ASSERT_EQ(this->agent_0_->genNotif("agent_1", duplicate_rreq.serialize()),
+                      NIXL_SUCCESS);
+        }
+
+        // None of the above should have disturbed the real transfer: it must still run to
+        // completion normally, ending up byte-for-byte equal to the source, with exactly one
+        // notification delivered to the peer.
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_LE(notifs.size(), 1);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl), NIXL_SUCCESS);
+        // Compares the full (memSize) buffers, not just the transferred transfer_size prefix:
+        // both remain zero-filled past transfer_size (untouched since SetUp), so this doubles as
+        // a check that the transfer didn't write anywhere beyond its own descriptor.
+        ASSERT_EQ(
+            cudaMemcpy(
+                this->dst_data_.data(), this->mem_agent_0_, this->memSize, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(this->dst_data_, this->src_data_);
+        while (notifs.size() == 0) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs.size(), 1);
+        ASSERT_EQ(notifs["agent_0"].size(), 1);
+        ASSERT_EQ(notifs["agent_0"].front(), "malformed_test_done");
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl), NIXL_SUCCESS);
+    }
+
+    // The peer's own RREQ admission check (handleRREQ) rejects a mismatched
+    // marshalLayoutFingerprint - here, by giving each agent a different chunk size - via RNAK,
+    // and the initiator surfaces the resulting terminal error through getXferStatus rather than
+    // hanging. Deliberately not built on the shared nixlServiceTestF fixture, which forces both
+    // agents to share one nixlServiceAgentConfig; staging-only, since the mismatch itself is
+    // what is under test, not any particular marshal mode.
+    TEST(NixlServiceReadRobustness, ReadPeerRejectsFingerprintMismatch) {
+        const auto env_etcd_endpoints_set = (std::getenv("NIXL_ETCD_ENDPOINTS") != nullptr);
+        const auto etcd_running = isPortOpen("127.0.0.1", 2379);
+        if (env_etcd_endpoints_set && !etcd_running) {
+            GTEST_FAIL() << "NIXL_ETCD_ENDPOINTS is set, but etcd is not running, skipping test";
+        }
+        if (!env_etcd_endpoints_set) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+
+        constexpr size_t chunk_size_initiator = 128 * 1024;
+        constexpr size_t chunk_size_peer = 256 * 1024; // Deliberately mismatched.
+        constexpr size_t mem_size = 1024 * chunk_size_initiator; // Exceeds direct_desc_threshold.
+        constexpr size_t svc_mem_size_initiator =
+            chunk_size_initiator * MarshalBackendSizing::slots_per_transfer;
+        constexpr size_t svc_mem_size_peer =
+            chunk_size_peer * MarshalBackendSizing::slots_per_transfer;
+
+        nixlServiceAgentConfig cfg_initiator;
+        cfg_initiator.mode = nixlMarshalStagingConfig{};
+        cfg_initiator.useProgThread = true;
+        nixlServiceAgentConfig cfg_peer;
+        cfg_peer.mode = nixlMarshalStagingConfig{};
+        cfg_peer.useProgThread = true;
+
+        auto agent_0 =
+            std::make_unique<testServiceAgent>("agent_0", cfg_initiator, chunk_size_initiator);
+        auto agent_1 = std::make_unique<testServiceAgent>("agent_1", cfg_peer, chunk_size_peer);
+
+        nixlBackendH *backend_handle_0 = nullptr;
+        nixlBackendH *backend_handle_1 = nullptr;
+        ASSERT_EQ(agent_0->createBackend("UCX", {}, backend_handle_0), NIXL_SUCCESS);
+        ASSERT_EQ(agent_1->createBackend("UCX", {}, backend_handle_1), NIXL_SUCCESS);
+
+        int device_count = 0;
+        ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+        if (device_count == 0) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        int device_id = 0;
+        ASSERT_EQ(cudaGetDevice(&device_id), cudaSuccess);
+
+        void *mem_agent_0 = nullptr;
+        void *svc_mem_agent_0 = nullptr;
+        void *mem_agent_1 = nullptr;
+        void *svc_mem_agent_1 = nullptr;
+        ASSERT_EQ(cudaMalloc(&mem_agent_0, mem_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&svc_mem_agent_0, svc_mem_size_initiator), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&mem_agent_1, mem_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&svc_mem_agent_1, svc_mem_size_peer), cudaSuccess);
+        // Stop the agents (and their progress threads) before freeing the GPU memory they have
+        // registered, so no in-flight progress can touch freed device memory. absl::Cleanup runs
+        // in reverse construction order, so a single combined cleanup makes the ordering explicit
+        // rather than relying on the relative declaration order of two separate cleanups.
+        absl::Cleanup cleanup = [&] {
+            agent_0.reset();
+            agent_1.reset();
+            (void)cudaFree(mem_agent_0);
+            (void)cudaFree(svc_mem_agent_0);
+            (void)cudaFree(mem_agent_1);
+            (void)cudaFree(svc_mem_agent_1);
+        };
+        ASSERT_EQ(cudaMemset(mem_agent_0, 0, mem_size), cudaSuccess);
+        ASSERT_EQ(cudaMemset(mem_agent_1, 0, mem_size), cudaSuccess);
+
+        nixl_reg_dlist_t mem_descs_agent_0(VRAM_SEG);
+        mem_descs_agent_0.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(mem_agent_0), mem_size, device_id));
+        nixl_reg_dlist_t svc_descs_agent_0(VRAM_SEG);
+        svc_descs_agent_0.addDesc(nixlBlobDesc(
+            reinterpret_cast<uintptr_t>(svc_mem_agent_0), svc_mem_size_initiator, device_id));
+        nixl_reg_dlist_t mem_descs_agent_1(VRAM_SEG);
+        mem_descs_agent_1.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(mem_agent_1), mem_size, device_id));
+        nixl_reg_dlist_t svc_descs_agent_1(VRAM_SEG);
+        svc_descs_agent_1.addDesc(nixlBlobDesc(
+            reinterpret_cast<uintptr_t>(svc_mem_agent_1), svc_mem_size_peer, device_id));
+
+        ASSERT_EQ(agent_0->registerMem(mem_descs_agent_0), NIXL_SUCCESS);
+        ASSERT_EQ(agent_0->registerServiceMem(svc_descs_agent_0), NIXL_SUCCESS);
+        ASSERT_EQ(agent_1->registerMem(mem_descs_agent_1), NIXL_SUCCESS);
+        ASSERT_EQ(agent_1->registerServiceMem(svc_descs_agent_1), NIXL_SUCCESS);
+
+        nixl_blob_t md_agent_0;
+        nixl_blob_t md_agent_1;
+        ASSERT_EQ(agent_0->getLocalMD(md_agent_0), NIXL_SUCCESS);
+        ASSERT_EQ(agent_1->getLocalMD(md_agent_1), NIXL_SUCCESS);
+        std::string remote_name_0;
+        std::string remote_name_1;
+        ASSERT_EQ(agent_1->loadRemoteMD(md_agent_0, remote_name_1), NIXL_SUCCESS);
+        ASSERT_EQ(agent_0->loadRemoteMD(md_agent_1, remote_name_0), NIXL_SUCCESS);
+
+        nixl_xfer_dlist_t local_xfer_descs(VRAM_SEG);
+        local_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(mem_agent_0), mem_size, device_id));
+        nixl_xfer_dlist_t remote_xfer_descs(VRAM_SEG);
+        remote_xfer_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(mem_agent_1), mem_size, device_id));
+
+        nixlServiceXferReqH *req_hndl = nullptr;
+        nixl_service_opt_args_t extra_params{};
+        // Unlike nixlServiceTestF's tests, there is no fixture default here - without this,
+        // marshalOptArgs stays nixlMarshalDirectOptArgs{}, which takes createXferReq's
+        // direct-path branch and never sends an RREQ (a plain RDMA READ that bypasses the
+        // service protocol entirely, so the two agents' differing staging configs would never
+        // even be compared).
+        extra_params.marshalOptArgs = nixlMarshalStagingOptArgs{};
+        ASSERT_EQ(
+            agent_0->createXferReq(
+                NIXL_READ, local_xfer_descs, remote_xfer_descs, "agent_1", req_hndl, &extra_params),
+            NIXL_SUCCESS);
+        ASSERT_NE(req_hndl, nullptr);
+        ASSERT_EQ(agent_0->postXferReq(req_hndl, &extra_params), NIXL_IN_PROG);
+
+        nixl_notifs_t notifs;
+        nixl_status_t status = NIXL_IN_PROG;
+        for (int i = 0; i < 200 && status == NIXL_IN_PROG; ++i) {
+            status = agent_0->getXferStatus(req_hndl);
+            ASSERT_EQ(agent_0->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1->getNotifs(notifs), NIXL_SUCCESS);
+            if (status == NIXL_IN_PROG) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            }
+        }
+        // handleRREQ's fingerprint check rejects the mismatched chunk size with
+        // send_r_nak(NIXL_ERR_INVALID_PARAM), which handleRNak surfaces on the initiator as this
+        // same terminal status, rather than leaving the request hanging in NIXL_IN_PROG forever.
+        EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+        std::vector<unsigned char> zeros(mem_size, 0);
+        std::vector<unsigned char> dst_check(mem_size);
+        ASSERT_EQ(cudaMemcpy(dst_check.data(), mem_agent_0, mem_size, cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        EXPECT_EQ(dst_check, zeros)
+            << "a rejected READ must not have written any data to the destination";
+
+        ASSERT_EQ(agent_0->releaseXferReq(req_hndl), NIXL_SUCCESS);
+        // Let the RABORT/RABORT_ACK round trip settle before the agents are torn down below.
+        for (int i = 0; i < 10; ++i) {
+            ASSERT_EQ(agent_0->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(agent_1->getNotifs(notifs), NIXL_SUCCESS);
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+    }
+
+    TYPED_TEST(nixlServiceBidirectionalTest, SimultaneousBidirectionalTransfers) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+
+        const size_t transfer_size = this->memSize / 4;
+        const size_t avg_desc_size = transfer_size / 4;
+        const size_t src_offset = 0;
+        const size_t dst_offset = transfer_size;
+        const std::vector<size_t> desc_sizes = {
+            avg_desc_size - 256,
+            avg_desc_size + 256,
+            avg_desc_size + 512,
+            avg_desc_size - 512,
+        };
+
+        std::mt19937 rng(42);
+        std::uniform_int_distribution<int> dist(0, 4);
+        std::vector<unsigned char> agent_0_src(transfer_size);
+        std::vector<unsigned char> agent_1_src(transfer_size);
+        std::vector<unsigned char> agent_0_dst(transfer_size, 0);
+        std::vector<unsigned char> agent_1_dst(transfer_size, 0);
+        for (auto &v : agent_0_src) {
+            v = static_cast<unsigned char>(dist(rng));
+        }
+        for (auto &v : agent_1_src) {
+            v = static_cast<unsigned char>(dist(rng));
+        }
+
+        ASSERT_EQ(cudaMemcpy(reinterpret_cast<char *>(this->mem_agent_0_) + src_offset,
+                             agent_0_src.data(),
+                             transfer_size,
+                             cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(reinterpret_cast<char *>(this->mem_agent_1_) + src_offset,
+                             agent_1_src.data(),
+                             transfer_size,
+                             cudaMemcpyHostToDevice),
+                  cudaSuccess);
+
+        const auto add_descs = [&](nixl_xfer_dlist_t &descs, void *base, size_t offset) {
+            const auto addr = reinterpret_cast<uintptr_t>(base) + offset;
+            if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                         nixlMarshalDeltaConfig>) {
+                descs.addDesc(nixlBasicDesc(addr, transfer_size, this->device_id_));
+            } else {
+                size_t desc_offset = 0;
+                for (const auto desc_size : desc_sizes) {
+                    descs.addDesc(nixlBasicDesc(addr + desc_offset, desc_size, this->device_id_));
+                    desc_offset += desc_size;
+                }
+                ASSERT_EQ(desc_offset, transfer_size);
+            }
+        };
+
+        nixl_xfer_dlist_t agent_0_local_xfer_descs(VRAM_SEG);
+        add_descs(agent_0_local_xfer_descs, this->mem_agent_0_, src_offset);
+        nixl_xfer_dlist_t agent_1_remote_xfer_descs(VRAM_SEG);
+        add_descs(agent_1_remote_xfer_descs, this->mem_agent_1_, dst_offset);
+
+        nixl_xfer_dlist_t agent_1_local_xfer_descs(VRAM_SEG);
+        add_descs(agent_1_local_xfer_descs, this->mem_agent_1_, src_offset);
+        nixl_xfer_dlist_t agent_0_remote_xfer_descs(VRAM_SEG);
+        add_descs(agent_0_remote_xfer_descs, this->mem_agent_0_, dst_offset);
+
+        nixl_service_opt_args_t extra_params_0{};
+        extra_params_0.marshalOptArgs = this->makeMarshalOptArgs();
+        nixlServiceXferReqH *req_hndl_0 = nullptr;
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                agent_0_local_xfer_descs,
+                                                agent_1_remote_xfer_descs,
+                                                "agent_1",
+                                                req_hndl_0,
+                                                &extra_params_0),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl_0, nullptr);
+
+        nixl_service_opt_args_t extra_params_1{};
+        extra_params_1.marshalOptArgs =
+            this->makeMarshalOptArgs(this->delta_ref_agent_1_, this->delta_ref_agent_0_);
+        nixlServiceXferReqH *req_hndl_1 = nullptr;
+        ASSERT_EQ(this->agent_1_->createXferReq(NIXL_WRITE,
+                                                agent_1_local_xfer_descs,
+                                                agent_0_remote_xfer_descs,
+                                                "agent_0",
+                                                req_hndl_1,
+                                                &extra_params_1),
+                  NIXL_SUCCESS);
+        ASSERT_NE(req_hndl_1, nullptr);
+
+        ASSERT_EQ(this->agent_0_->postXferReq(req_hndl_0, &extra_params_0), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->postXferReq(req_hndl_1, &extra_params_1), NIXL_SUCCESS);
+
+        nixl_notifs_t notifs;
+        while (this->agent_0_->getXferStatus(req_hndl_0) == NIXL_IN_PROG ||
+               this->agent_1_->getXferStatus(req_hndl_1) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs), NIXL_SUCCESS);
+            ASSERT_EQ(notifs.size(), 0);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(req_hndl_0), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->getXferStatus(req_hndl_1), NIXL_SUCCESS);
+
+        ASSERT_EQ(cudaMemcpy(agent_1_dst.data(),
+                             reinterpret_cast<char *>(this->mem_agent_1_) + dst_offset,
+                             transfer_size,
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(agent_0_dst.data(),
+                             reinterpret_cast<char *>(this->mem_agent_0_) + dst_offset,
+                             transfer_size,
+                             cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        ASSERT_EQ(agent_1_dst, agent_0_src);
+        ASSERT_EQ(agent_0_dst, agent_1_src);
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(req_hndl_0), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->releaseXferReq(req_hndl_1), NIXL_SUCCESS);
+    }
+
+    // A READ and a WRITE, in opposite directions between the same two agents, landing under the
+    // same numeric xfer id but in different, role-separated maps: agent_0_'s own WRITE
+    // (outboundXferReqs_[0]) alongside its serving of agent_1_'s READ (readServeReqs_[0]); and
+    // symmetrically on agent_1_, the WRITE arriving (inboundXferReqs_[0]) alongside its own READ
+    // (readReceiveReqs_[0]). Both agents are freshly constructed by SetUp(), so each one's own
+    // first marshalled transfer naturally gets xferId 0 - no seed hook needed to force the
+    // collision. Runs on nixlServiceBidirectionalTest (4 slots/agent) since a marshalled WRITE and
+    // READ-serve run concurrently on one agent, each needing its own 2-slot group. Uses dedicated
+    // buffers sized above the marshal threshold instead of sub-regions of the fixture's own (too
+    // small to fit two such regions for every fixture type). Skips delta: its sender/receiver refs
+    // are tied to mem_agent_0_/mem_agent_1_'s own content, not these dedicated buffers.
+    TYPED_TEST(nixlServiceBidirectionalTest, SimultaneousReadAndWriteSameId) {
+        if (!this->etcd_valid_) {
+            GTEST_SKIP() << "NIXL_ETCD_ENDPOINTS is not set or etcd is not running";
+        }
+        if (!this->cuda_valid_) {
+            GTEST_SKIP() << "No CUDA device available";
+        }
+        if constexpr (std::is_same_v<typename TestFixture::marshal_config_t,
+                                     nixlMarshalDeltaConfig>) {
+            GTEST_SKIP() << "See this test's header comment on why delta is out of scope here";
+        }
+
+        constexpr size_t region_size = 64 * 1024 * 1024 + 4096; // > direct_desc_threshold (64 MB).
+
+        void *write_src = nullptr; // agent_0_: source of its WRITE to agent_1_.
+        void *write_dst = nullptr; // agent_1_: destination of that WRITE.
+        void *read_src = nullptr; // agent_0_: source agent_1_ reads from (agent_0_ is the peer).
+        void *read_dst = nullptr; // agent_1_: destination of its READ from agent_0_.
+        ASSERT_EQ(cudaMalloc(&write_src, region_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&write_dst, region_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&read_src, region_size), cudaSuccess);
+        ASSERT_EQ(cudaMalloc(&read_dst, region_size), cudaSuccess);
+
+        nixl_reg_dlist_t agent_0_new_descs(VRAM_SEG);
+        agent_0_new_descs.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(write_src), region_size, this->device_id_));
+        agent_0_new_descs.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(read_src), region_size, this->device_id_));
+        ASSERT_EQ(this->agent_0_->registerMem(agent_0_new_descs), NIXL_SUCCESS);
+        nixl_reg_dlist_t agent_1_new_descs(VRAM_SEG);
+        agent_1_new_descs.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(write_dst), region_size, this->device_id_));
+        agent_1_new_descs.addDesc(
+            nixlBlobDesc(reinterpret_cast<uintptr_t>(read_dst), region_size, this->device_id_));
+        ASSERT_EQ(this->agent_1_->registerMem(agent_1_new_descs), NIXL_SUCCESS);
+
+        // Deregister these buffers from the (still-alive, fixture-owned) agents before freeing the
+        // device memory, so neither agent's progress thread can touch a freed region during the
+        // fixture's later TearDown(). Declared after registration so the deregister dlists are in
+        // scope, and (via reverse-order cleanup) so cudaFree runs only after deregistration.
+        absl::Cleanup free_bufs = [&] {
+            (void)this->agent_0_->deregisterMem(agent_0_new_descs);
+            (void)this->agent_1_->deregisterMem(agent_1_new_descs);
+            (void)cudaFree(write_src);
+            (void)cudaFree(write_dst);
+            (void)cudaFree(read_src);
+            (void)cudaFree(read_dst);
+        };
+
+        // Refresh the metadata each agent holds for the other, so these newly-registered regions
+        // (registered after the fixture's own SetUp()-time exchange) are addressable remotely.
+        nixl_blob_t md_agent_0;
+        nixl_blob_t md_agent_1;
+        ASSERT_EQ(this->agent_0_->getLocalMD(md_agent_0), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->getLocalMD(md_agent_1), NIXL_SUCCESS);
+        std::string remote_name_0;
+        std::string remote_name_1;
+        ASSERT_EQ(this->agent_1_->loadRemoteMD(md_agent_0, remote_name_1), NIXL_SUCCESS);
+        ASSERT_EQ(remote_name_1, "agent_0");
+        ASSERT_EQ(this->agent_0_->loadRemoteMD(md_agent_1, remote_name_0), NIXL_SUCCESS);
+        ASSERT_EQ(remote_name_0, "agent_1");
+
+        std::vector<unsigned char> write_src_data(region_size);
+        std::vector<unsigned char> read_src_data(region_size);
+        // Different seeds: write_src_data and read_src_data must stay distinguishable, so a
+        // WRITE/READ cross-wiring bug can't hide behind both sides happening to hold equal data.
+        this->fillWithRepeatingRandomPattern(write_src_data, region_size, 42);
+        this->fillWithRepeatingRandomPattern(read_src_data, region_size, 43);
+        ASSERT_EQ(cudaMemcpy(write_src, write_src_data.data(), region_size, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(read_src, read_src_data.data(), region_size, cudaMemcpyHostToDevice),
+                  cudaSuccess);
+        ASSERT_EQ(cudaMemset(write_dst, 0, region_size), cudaSuccess);
+        ASSERT_EQ(cudaMemset(read_dst, 0, region_size), cudaSuccess);
+
+        nixl_xfer_dlist_t write_local_descs(VRAM_SEG); // agent_0_'s source.
+        write_local_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(write_src), region_size, this->device_id_));
+        nixl_xfer_dlist_t write_remote_descs(VRAM_SEG); // agent_1_'s destination.
+        write_remote_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(write_dst), region_size, this->device_id_));
+
+        nixl_xfer_dlist_t read_local_descs(VRAM_SEG); // agent_1_'s destination.
+        read_local_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(read_dst), region_size, this->device_id_));
+        nixl_xfer_dlist_t read_remote_descs(VRAM_SEG); // agent_0_'s source.
+        read_remote_descs.addDesc(
+            nixlBasicDesc(reinterpret_cast<uintptr_t>(read_src), region_size, this->device_id_));
+
+        nixl_service_opt_args_t write_params{};
+        write_params.marshalOptArgs = this->makeMarshalOptArgs();
+        write_params.notif = "write_done";
+        nixlServiceXferReqH *write_hndl = nullptr;
+        ASSERT_EQ(this->agent_0_->createXferReq(NIXL_WRITE,
+                                                write_local_descs,
+                                                write_remote_descs,
+                                                "agent_1",
+                                                write_hndl,
+                                                &write_params),
+                  NIXL_SUCCESS);
+        ASSERT_NE(write_hndl, nullptr);
+
+        nixl_service_opt_args_t read_params{};
+        read_params.marshalOptArgs = this->makeMarshalOptArgs();
+        read_params.notif = "read_done";
+        nixlServiceXferReqH *read_hndl = nullptr;
+        ASSERT_EQ(
+            this->agent_1_->createXferReq(
+                NIXL_READ, read_local_descs, read_remote_descs, "agent_0", read_hndl, &read_params),
+            NIXL_SUCCESS);
+        ASSERT_NE(read_hndl, nullptr);
+
+        ASSERT_EQ(this->agent_0_->postXferReq(write_hndl, &write_params), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->postXferReq(read_hndl, &read_params), NIXL_IN_PROG);
+
+        // getNotifs() only ever appends newly-arrived notifications, so a single shared map
+        // accumulates both transfers' notifications correctly regardless of which of the two
+        // completes (and so delivers its notification) first.
+        nixl_notifs_t notifs_at_agent_0; // Will hold the READ's notif, keyed "agent_1".
+        nixl_notifs_t notifs_at_agent_1; // Will hold the WRITE's notif, keyed "agent_0".
+        while (this->agent_0_->getXferStatus(write_hndl) == NIXL_IN_PROG ||
+               this->agent_1_->getXferStatus(read_hndl) == NIXL_IN_PROG) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs_at_agent_0), NIXL_SUCCESS);
+            ASSERT_LE(notifs_at_agent_0.size(), 1);
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs_at_agent_1), NIXL_SUCCESS);
+            ASSERT_LE(notifs_at_agent_1.size(), 1);
+        }
+        ASSERT_EQ(this->agent_0_->getXferStatus(write_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->getXferStatus(read_hndl), NIXL_SUCCESS);
+
+        std::vector<unsigned char> write_dst_check(region_size);
+        std::vector<unsigned char> read_dst_check(region_size);
+        ASSERT_EQ(
+            cudaMemcpy(write_dst_check.data(), write_dst, region_size, cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        ASSERT_EQ(cudaMemcpy(read_dst_check.data(), read_dst, region_size, cudaMemcpyDeviceToHost),
+                  cudaSuccess);
+        ASSERT_EQ(write_dst_check, write_src_data) << "the WRITE's data was corrupted or misrouted";
+        ASSERT_EQ(read_dst_check, read_src_data) << "the READ's data was corrupted or misrouted";
+
+        // The WRITE's notif goes to its receiver (agent_1_); the READ's notif goes to its peer
+        // (agent_0_) - see tryCompleteReadReceive. Both statuses are terminal at this point, but
+        // the very last progressService() tick that set a status terminal may be the same one
+        // that queued its notif, so one more round of polling may still be needed to observe it.
+        while (notifs_at_agent_1.empty()) {
+            ASSERT_EQ(this->agent_1_->getNotifs(notifs_at_agent_1), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs_at_agent_1.size(), 1);
+        ASSERT_EQ(notifs_at_agent_1["agent_0"].size(), 1);
+        ASSERT_EQ(notifs_at_agent_1["agent_0"].front(), "write_done");
+        while (notifs_at_agent_0.empty()) {
+            ASSERT_EQ(this->agent_0_->getNotifs(notifs_at_agent_0), NIXL_SUCCESS);
+        }
+        ASSERT_EQ(notifs_at_agent_0.size(), 1);
+        ASSERT_EQ(notifs_at_agent_0["agent_1"].size(), 1);
+        ASSERT_EQ(notifs_at_agent_0["agent_1"].front(), "read_done");
+
+        ASSERT_EQ(this->agent_0_->releaseXferReq(write_hndl), NIXL_SUCCESS);
+        ASSERT_EQ(this->agent_1_->releaseXferReq(read_hndl), NIXL_SUCCESS);
+    }
+} // namespace services
+} // namespace gtest

--- a/test/python/service_bench.py
+++ b/test/python/service_bench.py
@@ -1,0 +1,1218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Single-node WRITE/READ benchmark over ``nixlServiceAgent``.
+
+The script spawns one worker process per configured rank/GPU on the local
+node.  Each worker runs ``benchmark``, which:
+
+* builds a ``nixlServiceAgent`` named after its rank id (DIRECT mode by
+  default; any marshal mode via ``--service-mode``);
+* registers one VRAM send buffer + one VRAM recv buffer, plus (for
+  ``--direction read``) a dedicated per-peer destination buffer on rank 0;
+* publishes each rank's MD blob, addresses, and (for RL modes) ping-pong
+  reference addresses via ``torch.distributed.all_gather_object``;
+* for ``--direction write`` (default): issues one one-sided WRITE per peer
+  rank 0 sends to, into ``peer.recv_buffer``, and waits for the matching
+  notifications on the receiving peers;
+* for ``--direction read``: issues one one-sided READ per peer rank 0
+  reads from, pulling into a dedicated per-peer region of its own; peers
+  serve the READ passively - and, for RL modes, run the per-iteration
+  perturbation themselves, since the source/encoder role moves to them -
+  and drain the completion notification exactly as a WRITE destination
+  does (notifications always target ``remote_agent``, the peer, regardless
+  of direction);
+* verifies contents on whichever side ends up holding the transferred
+  data - WRITE destinations, or the READ initiator (rank 0).
+
+Run with::
+
+    python test/python/service_bench.py
+    python test/python/service_bench.py --direction read --service-mode staging
+"""
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from dataclasses import dataclass
+import os
+import time
+import warnings
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+import nixl_cu13._bindings as bindings
+import nixl_cu13._service_bindings as svc
+
+# Number of ranks/GPUs in the benchmark.
+DEFAULT_NUM_RANKS = 2
+MAX_NUM_RANKS = 8
+
+# Default per-peer slot size as a base-2 byte exponent.  30 means 1 GiB.
+DEFAULT_BUFFER_BYTES_EXP = 30
+
+# Element type of the send/recv buffers.  Must be 4 bytes wide for the
+# arange-based fill pattern below (no overflow for buffers up to ~8 GiB).
+BUFFER_DTYPE = torch.int32
+BUFFER_ELEM_SIZE = torch.iinfo(BUFFER_DTYPE).bits // 8
+BUFFER_ALIGNMENT = 8
+
+# NIXL backend plugin used for all transfers.
+NIXL_BACKEND = "UCX"
+
+DEFAULT_ITERATIONS = 50
+DEFAULT_WARMUPS = 10
+
+DEFAULT_CONCURRENT_XFERS = 1
+
+# Transfer direction. "write" (default): rank 0 pushes into every peer's
+# buffer. "read": rank 0 pulls from every peer's buffer instead - the
+# source/destination and (for RL modes) encoder/decoder roles all invert,
+# see the module docstring.
+DIRECTIONS = ("write", "read")
+DEFAULT_DIRECTION = "write"
+
+
+def _format_size(num_bytes: int) -> str:
+    if num_bytes < (1 << 20):
+        value = num_bytes / (1 << 10)
+        suffix = "KB"
+    elif num_bytes < (1 << 30):
+        value = num_bytes / (1 << 20)
+        suffix = "MB"
+    elif num_bytes < (1 << 40):
+        value = num_bytes / (1 << 30)
+        suffix = "GB"
+    else:
+        value = num_bytes / (1 << 40)
+        suffix = "TB"
+    return f"{value:g} {suffix}"
+
+
+@dataclass(frozen=True)
+class ServiceModeDefinition:
+    uses_service_mem: bool
+    is_rl: bool # RL = Reinforcement Learning
+    make_config: Callable[[], object]
+    # (sender_ref_addr, receiver_ref_addr) -> opt_args; non-RL modes ignore it
+    make_opt_args: Callable[[int, int], object]
+
+
+@dataclass(frozen=True)
+class ResolvedServiceMode:
+    config: object
+    service_mem_bytes: int
+    max_concurrent_transfers: int
+
+
+SERVICE_MODE_DEFINITIONS = {
+    "direct": ServiceModeDefinition(
+        uses_service_mem=False,
+        is_rl=False,
+        make_config=lambda: svc.nixlMarshalDirectConfig(),
+        make_opt_args=lambda _sr, _rr: svc.nixlMarshalDirectOptArgs(),
+    ),
+    "staging": ServiceModeDefinition(
+        uses_service_mem=True,
+        is_rl=False,
+        make_config=lambda: svc.nixlMarshalStagingConfig(),
+        make_opt_args=lambda _sr, _rr: svc.nixlMarshalStagingOptArgs(),
+    ),
+    "compress": ServiceModeDefinition(
+        uses_service_mem=True,
+        is_rl=False,
+        make_config=lambda: svc.nixlMarshalCompressConfig(
+            algo=svc.nixl_marshal_compress_algo_t.ANS,
+        ),
+        make_opt_args=lambda _sr, _rr: svc.nixlMarshalCompressOptArgs(),
+    ),
+    "delta": ServiceModeDefinition(
+        uses_service_mem=True,
+        is_rl=True,
+        make_config=lambda: svc.nixlMarshalDeltaConfig(),
+        make_opt_args=lambda sr, rr: svc.nixlMarshalDeltaOptArgs(
+            senderRef=sr,
+            receiverRef=rr,
+            senderMemType=bindings.nixl_mem_t.VRAM_SEG,
+            receiverMemType=bindings.nixl_mem_t.VRAM_SEG,
+            elementSize=BUFFER_ELEM_SIZE,
+        ),
+    ),
+    "compress_ans_delta": ServiceModeDefinition(
+        uses_service_mem=True,
+        is_rl=True,
+        make_config=lambda: svc.nixlMarshalCompressConfig(
+            algo=svc.nixl_marshal_compress_algo_t.ANS_DELTA,
+        ),
+        make_opt_args=lambda sr, rr: svc.nixlMarshalCompressOptArgs(
+            delta=svc.nixlMarshalDeltaOptArgs(
+                senderRef=sr,
+                receiverRef=rr,
+                senderMemType=bindings.nixl_mem_t.VRAM_SEG,
+                receiverMemType=bindings.nixl_mem_t.VRAM_SEG,
+                elementSize=BUFFER_ELEM_SIZE,
+            ),
+        ),
+    ),
+}
+
+# Available service modes for ``--service-mode``.  "direct" maps to the
+# passthrough marshal mode (no staging/compression), every other entry
+# triggers the staging-pool path through ``registerServiceMem``.
+SERVICE_MODES = tuple(SERVICE_MODE_DEFINITIONS)
+
+
+def _align_down(num_bytes: int, alignment: int = BUFFER_ALIGNMENT) -> int:
+    return num_bytes - (num_bytes % alignment)
+
+
+def _align_up(num_bytes: int, alignment: int = BUFFER_ALIGNMENT) -> int:
+    return num_bytes + ((alignment - (num_bytes % alignment)) % alignment)
+
+
+def _cuda_tensor_1d_aligned(
+    num_elems: int,
+    dtype: torch.dtype,
+    *,
+    alignment: int = BUFFER_ALIGNMENT,
+    device: str | torch.device = "cuda",
+) -> torch.Tensor:
+    """Return a 1-D CUDA tensor whose storage starts at *alignment* bytes.
+
+    Requires ``num_elems * dtype.element_size()`` (the buffer size in bytes) to
+    be a multiple of *alignment* (default ``BUFFER_ALIGNMENT``). Raises
+    ``AssertionError`` when ``nbytes % alignment != 0``. Callers that need a
+    size that is not a multiple of *alignment* should pad via ``_align_up`` first.
+    """
+    assert alignment > 0 and (alignment & (alignment - 1)) == 0
+    elem_size = torch.empty((), dtype=dtype).element_size()
+    nbytes = num_elems * elem_size
+    assert nbytes % alignment == 0, (
+        f"{nbytes} byte buffer must be a multiple of {alignment}"
+    )
+    storage = torch.empty(nbytes + alignment - 1, dtype=torch.uint8, device=device)
+    offset = (-storage.data_ptr()) % alignment
+    return storage[offset:offset + nbytes].view(dtype)
+
+
+def _assert_ptr_aligned(ptr: int, alignment: int, name: str) -> None:
+    assert ptr % alignment == 0, (
+        f"{name} pointer {ptr:#x} is not {alignment}-byte aligned"
+    )
+
+
+def _fill_pattern(rank: int, num_elems: int) -> torch.Tensor:
+    """Per-rank deterministic, non-zero fill pattern for the send buffer.
+
+    ``arange(N) + (rank + 1)`` so that:
+      * no element is ever zero (the +rank+1 shift),
+      * every rank produces a distinct sequence (validation can detect a
+        write from the wrong peer or no write at all), and
+      * the receiver can reconstruct the expected slot contents from
+        ``(peer_rank, num_elems)`` alone — no extra metadata exchange.
+    """
+    return (
+        (torch.arange(num_elems, dtype=BUFFER_DTYPE, device="cuda") + (rank + 1)) % 5
+    )
+
+
+PER_RL_STEP_WEIGHTS_DIFF_PERCENTAGE = 0.01
+DELTA_MAX_MAGNITUDE = 256
+DELTA_FILL_SEED = 1234
+DELTA_CHANGE_SEED = 5678
+
+
+def _fill_ref_pattern(num_elems: int) -> torch.Tensor:
+    """Shared random fill for the delta reference buffer.
+
+    Deterministic (fixed seed), so every rank - including a READ initiator
+    that never talks to the peer about its data - can independently
+    reconstruct the exact same baseline tensor without any communication.
+    """
+    gen = torch.Generator(device="cuda").manual_seed(DELTA_FILL_SEED)
+    return torch.randint(
+        torch.iinfo(BUFFER_DTYPE).min, torch.iinfo(BUFFER_DTYPE).max + 1,
+        (num_elems,), generator=gen, dtype=BUFFER_DTYPE, device="cuda",
+    )
+
+
+def _precompute_delta_changes(
+    num_elems: int, num_perturbations: int, device: str | torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Precompute the random changes per iteration for the RL delta.
+
+    Deterministic (fixed seed), so whichever rank actually applies the
+    perturbation each iteration (the WRITE sender, or - for READ - the
+    peer/source) and whichever rank verifies the result afterward (the
+    WRITE receiver, or the READ initiator) always agree on the sequence
+    without exchanging it.
+    """
+    num_changes = max(1, int(num_elems * PER_RL_STEP_WEIGHTS_DIFF_PERCENTAGE))
+    gen = torch.Generator(device=device).manual_seed(DELTA_CHANGE_SEED)
+    change_idx = torch.randint(
+        0, num_elems, (num_perturbations, num_changes),
+        generator=gen, device=device,
+    )
+    change_vals = torch.randint(
+        1, DELTA_MAX_MAGNITUDE, (num_perturbations, num_changes),
+        generator=gen, dtype=BUFFER_DTYPE, device=device,
+    )
+    return change_idx, change_vals
+
+
+def _load_safetensors_payload(safetensors_file: str, device: str) -> torch.Tensor:
+    """Concatenate every tensor in *safetensors_file* into one 1-D
+    ``BUFFER_DTYPE`` tensor on *device*, truncated to a ``BUFFER_ALIGNMENT``
+    multiple so the byte length is safely divisible by the element size."""
+    from safetensors import safe_open
+    chunks: list[torch.Tensor] = []
+    with safe_open(safetensors_file, framework="pt", device=device) as f:
+        for key in f.keys():
+            raw_bytes = f.get_tensor(key).contiguous().untyped_storage()
+            chunks.append(
+                torch.tensor([], dtype=torch.uint8, device=device)
+                .set_(raw_bytes).clone()
+            )
+    raw = torch.cat(chunks)
+    usable_bytes = _align_down(raw.numel(), BUFFER_ALIGNMENT)
+    assert usable_bytes >= BUFFER_ALIGNMENT, (
+        f"safetensors payload ({raw.numel()} bytes) is too small for an "
+        f"{BUFFER_ALIGNMENT}-byte aligned buffer"
+    )
+    return raw[:usable_bytes].view(BUFFER_DTYPE)
+
+
+def _make_buffers(
+    rank: int,
+    dev_id: int,
+    buffer_bytes: int,
+    safetensors_file: str | None,
+    num_concurrent_xfers: int,
+    is_rl: bool = False,
+    random_src: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Build the transfer buffers as ``(send_buffer, recv_buffer, buffer_bytes)``.
+
+    Every rank calls this unconditionally, regardless of ``--direction``:
+    ``send_buffer`` is this rank's own data (used as the WRITE source when
+    this rank is rank 0 under ``write``, as the READ source when this rank
+    is a peer under ``read``, and otherwise only as a local baseline for
+    content verification), and ``recv_buffer``/``rl_pair`` similarly always
+    exist so the RL ping-pong and W0 baseline are available on every rank
+    regardless of which role it ends up playing this run.
+
+    ``recv_buffer``'s purpose depends on the mode:
+
+    * non-RL -- a fresh zeroed landing zone for an incoming WRITE.
+    * RL -- the delta *reference* baseline: the sender perturbs it and the
+      receiver reconstructs into it in place, and ``send_buffer`` starts as a
+      copy of it.
+
+    The initial send contents come from one of three sources, in order:
+
+    1. *safetensors_file* -- the file's concatenated tensor payload.  The
+       returned ``buffer_bytes`` reflects the actual (aligned) payload size.
+    2. *is_rl* or *random_src* without safetensors -- a shared deterministic
+       random pattern (``_fill_ref_pattern``), identical on every rank.
+       ``random_src`` lets non-RL modes use the same random data as RL.
+    3. Default -- a per-rank synthetic pattern (``_fill_pattern``).
+
+    ``num_concurrent_xfers`` slots are stored contiguously in each buffer.
+    The returned ``buffer_bytes`` is the *per-slot* size.
+    """
+    device = f"cuda:{dev_id}"
+
+    if safetensors_file:
+        contents = _load_safetensors_payload(safetensors_file, device)
+        buffer_bytes = contents.numel() * BUFFER_ELEM_SIZE
+    else:
+        assert buffer_bytes > 0
+        assert buffer_bytes % BUFFER_ALIGNMENT == 0, (
+            f"buffer_bytes ({buffer_bytes}) must be a multiple of "
+            f"{BUFFER_ALIGNMENT}"
+        )
+        num_elems = buffer_bytes // BUFFER_ELEM_SIZE
+        contents = (
+            _fill_ref_pattern(num_elems) if (is_rl or random_src)
+            else _fill_pattern(rank, num_elems)
+        )
+
+    slot_elems = contents.numel()
+    total_elems = slot_elems * num_concurrent_xfers
+
+    send_buffer = _cuda_tensor_1d_aligned(total_elems, BUFFER_DTYPE, device=device)
+    # Identical initial content is replicated into every concurrent slot
+    send_buffer.view(num_concurrent_xfers, slot_elems).copy_(contents)
+    del contents
+    recv_buffer = _cuda_tensor_1d_aligned(total_elems, BUFFER_DTYPE, device=device)
+    if is_rl:
+        # RL: recv_buffer is the delta reference; it starts identical to send_buffer.
+        recv_buffer.copy_(send_buffer)
+    else:
+        recv_buffer.zero_()
+    return send_buffer, recv_buffer, buffer_bytes
+
+
+def _make_read_initiator_buffers(
+    dev_id: int,
+    buffer_bytes: int,
+    num_concurrent_xfers: int,
+    num_peers: int,
+    is_rl: bool,
+) -> torch.Tensor:
+    """Per-peer destination buffer for a READ initiator: one contiguous
+    ``num_concurrent_xfers * buffer_bytes`` region per peer, laid out
+    contiguously in the same order as the initiator's ``send_to`` list
+    (see ``benchmark``'s use of ``peer_idx``).
+
+    For RL modes each region doubles as that peer's decode reference, so it
+    must start at the exact baseline the peer's own encode reference starts
+    at (``_fill_ref_pattern``). Both sides derive that baseline
+    independently from the same fixed seed - no data exchange is needed for
+    delta reconstruction to line up (mirrors how ``_make_buffers`` seeds
+    ``recv_buffer``/``send_buffer`` identically on every rank for RL modes).
+    For non-RL modes each region simply starts zeroed, so a successful READ
+    is unambiguous.
+
+    Returns a zero-length tensor when ``num_peers == 0`` (this rank plays no
+    READ-initiator role this run).
+    """
+    device = f"cuda:{dev_id}"
+    slot_elems = buffer_bytes // BUFFER_ELEM_SIZE
+    total_elems = num_peers * num_concurrent_xfers * slot_elems
+    dst_buffer = _cuda_tensor_1d_aligned(total_elems, BUFFER_DTYPE, device=device)
+    if num_peers == 0:
+        return dst_buffer
+    if is_rl:
+        dst_buffer.view(num_peers * num_concurrent_xfers, slot_elems).copy_(
+            _fill_ref_pattern(slot_elems)
+        )
+    else:
+        dst_buffer.zero_()
+    return dst_buffer
+
+
+def _resolve_service_mode(
+    service_mode: str,
+    max_concurrent_transfers: int,
+) -> ResolvedServiceMode:
+    """Resolve mode config and service-memory sizing for one benchmark run."""
+    mode_definition = SERVICE_MODE_DEFINITIONS[service_mode]
+    config = mode_definition.make_config()
+
+    if not mode_definition.uses_service_mem:
+        return ResolvedServiceMode(
+            config=config,
+            service_mem_bytes=0,
+            max_concurrent_transfers=max_concurrent_transfers,
+        )
+
+    return ResolvedServiceMode(
+        config=config,
+        service_mem_bytes=svc.recommendServiceMemSize(
+            config,
+            maxConcurrentTransfers=max_concurrent_transfers,
+        ),
+        max_concurrent_transfers=max_concurrent_transfers,
+    )
+
+
+def _make_service_agent(name: str, mode_config: object):
+    """Construct a service agent with the chosen marshal mode + UCX backend."""
+    cfg = svc.nixlServiceAgentConfig()
+    cfg.useProgThread = True
+    cfg.useListenThread = False
+    cfg.listenPort = 0
+    cfg.syncMode = bindings.NIXL_THREAD_SYNC_NONE
+    cfg.pthrDelay = 0
+    cfg.lthrDelay = 100000
+    cfg.captureTelemetry = False
+    cfg.mode = mode_config
+
+    agent = svc.nixlServiceAgent(name, cfg)
+    backend_handle = agent.createBackend(NIXL_BACKEND, {})
+    return agent, backend_handle
+
+
+def _build_traffic_pattern(rank: int, num_ranks: int) -> tuple[list[int], list[int]]:
+    """Return ``(active_peers, passive_from)`` for rank 0 vs. every peer.
+
+    Direction-agnostic: rank 0 is always the one that actively creates,
+    posts, and polls transfer handles against every entry in
+    ``active_peers`` (the peers it *writes to* under ``--direction write``,
+    or *reads from* under ``--direction read``); every other rank is
+    passive and only drains notifications from ``passive_from`` (always
+    ``[0]``, since rank 0 is always the one calling ``postXferReq`` and a
+    notification always targets ``remote_agent`` - the peer - keyed by the
+    caller's own name, regardless of direction).
+    """
+    if rank == 0:
+        return [r for r in range(num_ranks) if r != 0], []
+    return [], [0]
+
+
+def benchmark(rank: int, num_ranks: int,
+                    iterations: int, warmups: int,
+                    buffer_bytes: int,
+                    service_mode: str,
+                    num_concurrent_xfers: int,
+                    random_src: bool = False,
+                    safetensors_file: str | None = None,
+                    direction: str = DEFAULT_DIRECTION):
+    """Run the configured WRITE or READ step ``warmups + iterations`` times.
+
+    Setup (registration + MD exchange + xfer-request creation) happens once.
+    Each iteration uses a distinct per-peer request handle and a fresh
+    notification tag that includes the global iteration index, so warmup and
+    measurement steps stay disjoint and notifications can't leak between
+    them.  Only the last ``iterations`` steps are timed; the per-rank send
+    buffer fill, the recv-buffer reset before timing starts, and the final
+    content validation are all outside the timed window.
+
+    Rank 0 is always the active side: it writes to (``direction="write"``,
+    the default) or reads from (``direction="read"``) every other rank.
+    Non-zero ranks are always passive: they hold the other end of the
+    transfer and drain the completion notification, which always targets
+    ``remote_agent`` - the peer - regardless of direction.  For READ, the
+    source/destination and (for RL modes) encoder/decoder roles invert
+    relative to WRITE: peers become the data source and, for RL modes, run
+    the per-iteration ping-pong perturbation themselves instead of rank 0.
+
+    The ``service_mode`` selects the marshal mode of the underlying service
+    agent.  For ``"direct"`` no service memory is registered.  For every
+    other mode a runtime-sized VRAM slab is allocated and handed to
+    ``registerServiceMem`` so the marshal backend has a staging pool.
+    """
+    assert dist.is_initialized(), "torch.distributed must be initialized"
+    assert num_ranks == dist.get_world_size()
+    assert rank == dist.get_rank()
+    assert iterations > 0
+    assert warmups >= 0
+    assert service_mode in SERVICE_MODES, service_mode
+    assert direction in DIRECTIONS, direction
+
+    dev_id = torch.cuda.current_device()
+    mode = SERVICE_MODE_DEFINITIONS[service_mode]
+
+    # Every rank builds both buffers unconditionally, regardless of
+    # direction/role - see _make_buffers' docstring for why the "unused"
+    # ones still matter (RL baselines, and READ-initiator verification
+    # against its own send_buffer for the shared-data case).
+    send_buffer, recv_buffer, buffer_bytes = _make_buffers(
+        rank, dev_id, buffer_bytes, safetensors_file, num_concurrent_xfers,
+        mode.is_rl, random_src)
+    is_rl = mode.is_rl
+    # RL uses the data source's two buffers as a ping-pong pair: each
+    # iteration the src buffer becomes this iteration's ref and vice versa.
+    rl_pair = [recv_buffer, send_buffer] if is_rl else None
+    fan_out = max(num_ranks - 1, 1) if rank == 0 else 1
+    resolved_mode = _resolve_service_mode(
+        service_mode,
+        max_concurrent_transfers=fan_out * num_concurrent_xfers,
+    )
+    assert (
+        not mode.uses_service_mem
+        or resolved_mode.service_mem_bytes > 0
+    )
+
+    send_to, recv_from = _build_traffic_pattern(rank, num_ranks)
+    # Whichever side plays the data-source (encoder) role for this
+    # direction: rank 0 for WRITE, the peer for READ. RL perturbation
+    # always runs on this side, regardless of which physical rank it is -
+    # see evolve_own_rl_buffers below.
+    is_data_source = (
+        (direction == "write" and bool(send_to))
+        or (direction == "read" and bool(recv_from))
+    )
+
+    # TODO-Roee: support compression backend.
+    agent, backend = _make_service_agent(str(rank), resolved_mode.config)
+
+    slot_elems = buffer_bytes // BUFFER_ELEM_SIZE
+
+    # RL: precompute the perturbations per iteration on whichever side is
+    # the data source this run (see is_data_source above).
+    change_idx = change_vals = None
+    rl_w0 = None
+    if is_rl:
+        rl_w0 = recv_buffer.clone()
+        if is_data_source:
+            change_idx, change_vals = _precompute_delta_changes(
+                slot_elems, max(warmups, iterations), device=send_buffer.device,
+            )
+
+    _assert_ptr_aligned(send_buffer.data_ptr(), BUFFER_ALIGNMENT, "send_buffer")
+    _assert_ptr_aligned(recv_buffer.data_ptr(), BUFFER_ALIGNMENT, "recv_buffer")
+    assert buffer_bytes % BUFFER_ALIGNMENT == 0
+
+    total_buffer_bytes = num_concurrent_xfers * buffer_bytes
+    send_reg = bindings.nixlRegDList(
+        bindings.VRAM_SEG,
+        [(send_buffer.data_ptr(), total_buffer_bytes, dev_id, "")],
+    )
+    recv_reg = bindings.nixlRegDList(
+        bindings.VRAM_SEG,
+        [(recv_buffer.data_ptr(), total_buffer_bytes, dev_id, "")],
+    )
+
+    # Service-memory pool — only allocated/registered for non-DIRECT modes.
+    # DIRECT is a passthrough that has no use for staging memory; allocating
+    # it anyway would just waste VRAM.  For all other modes the marshal
+    # backend stages payloads through this region, so we hand it a runtime-sized
+    # slab of VRAM and register it via the dedicated
+    # service-mem path (NOT registerMem — that's the user data path).
+    svc_buffer = None
+    svc_reg = None
+
+    # READ-initiator destination buffer — only allocated on the active rank
+    # (rank 0) when direction=="read": one region per peer in send_to, which
+    # doubles as that peer's decode reference for RL modes.  None (unused)
+    # for direction=="write", or on any passive (non-zero) rank.
+    read_dst_buffer = None
+    read_dst_reg = None
+
+    # rank -> list of active request handles (one per slot) for the current iteration.
+    peer_handles: dict[int, list[int]] = {}
+    try:
+        agent.registerMem(send_reg, [backend])
+        agent.registerMem(recv_reg, [backend])
+
+        if mode.uses_service_mem:
+            # C++ sizing (recommendServiceMemSize) should already return a
+            # BUFFER_ALIGNMENT-rounded size.  Call _align_up defensively so we
+            # never under-allocate if the C++ side ever returns a non-aligned
+            # value; this is a no-op in normal operation.  _assert_ptr_aligned
+            # on svc_buffer validates the allocator's pointer alignment.
+            service_mem_bytes = _align_up(
+                resolved_mode.service_mem_bytes, BUFFER_ALIGNMENT,
+            )
+            if service_mem_bytes != resolved_mode.service_mem_bytes:
+                warnings.warn(
+                    f"C++ service_mem_bytes ({resolved_mode.service_mem_bytes}) is not "
+                    f"{BUFFER_ALIGNMENT}-byte aligned; padded to {service_mem_bytes}",
+                    stacklevel=2,
+                )
+            svc_buffer = _cuda_tensor_1d_aligned(
+                service_mem_bytes, torch.uint8,
+            )
+            _assert_ptr_aligned(
+                svc_buffer.data_ptr(), BUFFER_ALIGNMENT, "svc_buffer",
+            )
+            svc_reg = bindings.nixlRegDList(
+                bindings.VRAM_SEG,
+                [(svc_buffer.data_ptr(), service_mem_bytes, dev_id, "")],
+            )
+            agent.registerServiceMem(svc_reg, [backend])
+
+        if direction == "read" and send_to:
+            read_dst_buffer = _make_read_initiator_buffers(
+                dev_id, buffer_bytes, num_concurrent_xfers, len(send_to), is_rl,
+            )
+            _assert_ptr_aligned(
+                read_dst_buffer.data_ptr(), BUFFER_ALIGNMENT, "read_dst_buffer",
+            )
+            read_dst_reg = bindings.nixlRegDList(
+                bindings.VRAM_SEG,
+                [(
+                    read_dst_buffer.data_ptr(),
+                    len(send_to) * num_concurrent_xfers * buffer_bytes,
+                    dev_id,
+                    "",
+                )],
+            )
+            agent.registerMem(read_dst_reg, [backend])
+
+        # Bootstrap: publish this rank's MD blob, device id, and every
+        # address a peer might need depending on direction/mode - the WRITE
+        # destination address, the READ source address, and (for RL modes)
+        # the two RL ping-pong base addresses, indexed the same way
+        # evolve_own_rl_buffers indexes rl_pair (index `ping_pong_idx % 2` is
+        # the "ref" side).  The MD installs rkeys/auth in every peer's local
+        # backend; agent name == rank id, so peers address each other by
+        # rank without any extra mapping.
+        local_info = {
+            "md": bytes(agent.getLocalMD()),
+            "dev_id": dev_id,
+            "write_dst_addr": recv_buffer.data_ptr(),
+            "read_src_addr": send_buffer.data_ptr(),
+            "read_rl_ref_addrs": (
+                (rl_pair[0].data_ptr(), rl_pair[1].data_ptr()) if is_rl else None
+            ),
+        }
+
+        dist.barrier()
+        gathered: list = [None] * num_ranks
+        dist.all_gather_object(gathered, local_info)
+
+        for r in range(num_ranks):
+            if r == rank:
+                continue
+            peer_name = agent.loadRemoteMD(gathered[r]["md"]).decode()
+            assert peer_name == str(r), (peer_name, r)
+
+        def evolve_own_rl_buffers(ping_pong_idx: int) -> tuple[int, int]:
+            # Return (ref_base, src_base) base pointers for this iteration,
+            # ping-ponging THIS rank's own rl_pair and applying this step's
+            # perturbation - but only when this rank is the data source for
+            # the configured direction (is_data_source); otherwise a no-op
+            # returning (0, send_buffer.data_ptr()), since this rank's own
+            # buffers are then either used read-only (WRITE destination) or
+            # not used for the transfer at all (READ initiator, which has
+            # read_dst_buffer instead). Callers always pass the local,
+            # reset-relative index (w during warmup, i during timed - never
+            # the globally-unique it), so create_peer_handles's ping_pong_idx
+            # parameter can index a peer's published addresses identically.
+            if not (is_rl and is_data_source):
+                return 0, send_buffer.data_ptr()
+            ref_buf = rl_pair[ping_pong_idx % 2]
+            src_buf = rl_pair[(ping_pong_idx + 1) % 2]
+            # each buffer is the previous iteration's result switched src <-> ref
+            # so starting the second iteration, we should apply both the current perturbation
+            # in addition to last one's catching up.
+            src_view = src_buf.view(num_concurrent_xfers, slot_elems)
+            if ping_pong_idx > 0:
+                src_view.index_add_(
+                    1, change_idx[ping_pong_idx - 1],
+                    change_vals[ping_pong_idx - 1].repeat(num_concurrent_xfers, 1),
+                )
+            src_view.index_add_(
+                1, change_idx[ping_pong_idx],
+                change_vals[ping_pong_idx].repeat(num_concurrent_xfers, 1),
+            )
+            # Sync so the perturbation lands before the marshal reads it.
+            torch.cuda.synchronize()
+            return ref_buf.data_ptr(), src_buf.data_ptr()
+
+        def create_peer_handles(
+            it: int, ping_pong_idx: int, sender_ptrs: tuple[int, int],
+        ) -> None:
+            """Build this iteration's handles for every peer in ``send_to``.
+
+            ``it`` is the globally-unique index used only for notification
+            tags (distinct across warmup and timed steps, so a stray
+            straggler can't be mistaken for the wrong iteration).
+            ``ping_pong_idx`` is the *local* (per-phase, reset-relative)
+            index used for RL ping-pong role selection - it must match
+            whatever index the data source's own ``evolve_own_rl_buffers``
+            call used this step, which is ``it`` during warmup but the
+            local ``i`` (not ``it = warmups + i``) during the timed loop,
+            since the reset-before-timing block restarts the ping-pong from
+            a common baseline. For WRITE this arrives pre-applied inside
+            ``sender_ptrs`` (rank 0 computed it locally, same process); for
+            READ this rank (the initiator) never perturbs anything itself,
+            so it must index the peer's published addresses with the exact
+            same ``ping_pong_idx`` the peer used, or it will race a stale or
+            not-yet-perturbed buffer half the time.
+            """
+            if direction == "write":
+                ref_base, src_base = sender_ptrs
+                for r in send_to:
+                    peer_dst_addr = gathered[r]["write_dst_addr"]
+                    peer_dev_id = gathered[r]["dev_id"]
+                    concurrent_handles: list[int] = []
+                    for j in range(num_concurrent_xfers):
+                        slot_off = j * buffer_bytes
+                        sender_ref_ptr = ref_base + slot_off if ref_base else 0
+                        sender_src_ptr = src_base + slot_off
+                        dst_slot_addr = peer_dst_addr + slot_off
+                        src = bindings.nixlXferDList(
+                            bindings.VRAM_SEG,
+                            [(sender_src_ptr, buffer_bytes, dev_id)],
+                        )
+                        dst = bindings.nixlXferDList(
+                            bindings.VRAM_SEG,
+                            [(dst_slot_addr, buffer_bytes, peer_dev_id)],
+                        )
+                        opt_args = mode.make_opt_args(sender_ref_ptr, dst_slot_addr)
+                        reqh = agent.createXferReq(
+                            bindings.NIXL_WRITE,
+                            src,
+                            dst,
+                            str(r),
+                            f"from-{rank}-init-{it}-{j}",
+                            [backend],
+                            opt_args,
+                        )
+                        assert reqh != 0
+                        concurrent_handles.append(reqh)
+                    peer_handles[r] = concurrent_handles
+            else:  # direction == "read"
+                # sender_ptrs is unused here: rank 0 (the READ initiator) is
+                # never the data source, so it carries no ping-pong state of
+                # its own - each peer's CURRENT (src, ref) addresses are
+                # derived below from its published read_rl_ref_addrs base
+                # pointers plus ping_pong_idx % 2, exactly mirroring how that
+                # peer's own evolve_own_rl_buffers indexes its local rl_pair.
+                for peer_idx, r in enumerate(send_to):
+                    peer_dev_id = gathered[r]["dev_id"]
+                    if is_rl:
+                        peer_ref_addr = gathered[r]["read_rl_ref_addrs"][ping_pong_idx % 2]
+                        peer_src_addr = gathered[r]["read_rl_ref_addrs"][(ping_pong_idx + 1) % 2]
+                    else:
+                        peer_ref_addr = 0
+                        peer_src_addr = gathered[r]["read_src_addr"]
+                    peer_region_base = peer_idx * num_concurrent_xfers * buffer_bytes
+                    concurrent_handles: list[int] = []
+                    for j in range(num_concurrent_xfers):
+                        slot_off = j * buffer_bytes
+                        my_dst_addr = read_dst_buffer.data_ptr() + peer_region_base + slot_off
+                        peer_src_slot = peer_src_addr + slot_off
+                        peer_ref_slot = peer_ref_addr + slot_off if peer_ref_addr else 0
+                        local_descs = bindings.nixlXferDList(
+                            bindings.VRAM_SEG,
+                            [(my_dst_addr, buffer_bytes, dev_id)],
+                        )
+                        remote_descs = bindings.nixlXferDList(
+                            bindings.VRAM_SEG,
+                            [(peer_src_slot, buffer_bytes, peer_dev_id)],
+                        )
+                        # senderRef = the peer's own (encoder's) reference;
+                        # receiverRef = this rank's own (decoder's)
+                        # reference - swapped relative to WRITE, where rank
+                        # 0 is the encoder.
+                        opt_args = mode.make_opt_args(peer_ref_slot, my_dst_addr)
+                        reqh = agent.createXferReq(
+                            bindings.NIXL_READ,
+                            local_descs,
+                            remote_descs,
+                            str(r),
+                            f"from-{rank}-init-{it}-{j}",
+                            [backend],
+                            opt_args,
+                        )
+                        assert reqh != 0
+                        concurrent_handles.append(reqh)
+                    peer_handles[r] = concurrent_handles
+
+        def release_peer_handles() -> None:
+            for concurrent_handles in peer_handles.values():
+                for reqh in concurrent_handles:
+                    agent.releaseXferReq(reqh)
+            peer_handles.clear()
+
+        notifs: dict[str, list[bytes]] = {}
+
+        def run_iteration(it: int) -> None:
+            # ``notifs`` accumulates across iterations because a peer can be
+            # one step ahead and deliver iteration-(it+1) tags while we're
+            # still draining iteration-(it).  pybind11 STL casters deep-copy
+            # the dict on the C++ boundary, so we must rebind from the
+            # return value (the parameter is effectively in-only).
+            nonlocal notifs
+
+            # Active side (no-op when ``send_to`` is empty): creates+posts
+            # the transfer regardless of direction - a READ initiator calls
+            # postXferReq/getXferStatus exactly as a WRITE sender does, only
+            # the descriptor roles built by create_peer_handles differ.
+            for peer_r in send_to:
+                for j, reqh in enumerate(peer_handles[peer_r]):
+                    status = agent.postXferReq(reqh, f"from-{rank}-{it}-{j}")
+                    assert status in (bindings.NIXL_SUCCESS, bindings.NIXL_IN_PROG), (
+                        peer_r, j, status,
+                    )
+            outstanding_sends = {
+                reqh for peer_r in send_to for reqh in peer_handles[peer_r]
+            }
+            while outstanding_sends:
+                for reqh in list(outstanding_sends):
+                    if agent.getXferStatus(reqh) != bindings.NIXL_IN_PROG:
+                        outstanding_sends.remove(reqh)
+
+            # Passive side (no-op when ``recv_from`` is empty).  Expect one
+            # notification per (active rank, slot) tag - regardless of
+            # direction, the notification always targets remote_agent (this
+            # rank) keyed by the caller's own name (always "0" in this
+            # star topology, since rank 0 is always the one calling
+            # postXferReq above).
+            outstanding = {
+                str(r): {
+                    f"from-{r}-{it}-{j}".encode()
+                    for j in range(num_concurrent_xfers)
+                }
+                for r in recv_from
+            }
+            while outstanding:
+                notifs = agent.getNotifs(notifs, [backend])
+                for name in list(outstanding):
+                    bucket = notifs.get(name)
+                    if not bucket:
+                        continue
+                    wanted = outstanding[name]
+                    for tag in [t for t in wanted if t in bucket]:
+                        bucket.remove(tag)
+                        wanted.discard(tag)
+                    if not bucket:
+                        del notifs[name]
+                    if not wanted:
+                        del outstanding[name]
+
+        # RL+READ needs the peer to perturb (and CUDA-sync) before rank 0
+        # may safely read this iteration's data, and rank 0 must finish
+        # reading before the peer perturbs again for the next iteration -
+        # both barriers below sit outside rank 0's own timed window.
+        # Non-RL READ and both RL/non-RL WRITE need neither: the WRITE
+        # sender perturbs and builds handles inline in the same process, and
+        # non-RL READ has no perturbation step at all.
+        needs_rl_read_barriers = is_rl and direction == "read"
+
+        for w in range(warmups):
+            if needs_rl_read_barriers:
+                evolve_own_rl_buffers(w)  # no-op on rank 0; perturbs on peers
+                dist.barrier()  # B1: every peer has perturbed for `w`
+                sender_ptrs = (0, send_buffer.data_ptr())  # unused by the READ branch
+            else:
+                sender_ptrs = evolve_own_rl_buffers(w)
+            try:
+                create_peer_handles(w, w, sender_ptrs)
+                run_iteration(w)
+            finally:
+                release_peer_handles()
+            if needs_rl_read_barriers:
+                dist.barrier()  # B2: rank 0 finished reading `w`
+
+        torch.cuda.synchronize()
+        dist.barrier()
+
+        # Reset outside the timed window so validation proves the *timed*
+        # iterations moved data, not the warmups.  cuda.synchronize() below
+        # makes sure the reset kernels finished before peers write here.
+        # Non-RL zeroes its recv buffer; RL reconstructs into recv_buffer in
+        # place, so instead we restore both ping-pong buffers to W0.  The
+        # READ initiator's own read_dst_buffer (unused above for WRITE) is
+        # reset the same way, mirroring _make_read_initiator_buffers' own
+        # initial fill.
+        if not is_rl:
+            recv_buffer.zero_()
+        else:
+            for buf in rl_pair:
+                buf.copy_(rl_w0)
+        if read_dst_buffer is not None:
+            if is_rl:
+                read_dst_buffer.view(-1, slot_elems).copy_(_fill_ref_pattern(slot_elems))
+            else:
+                read_dst_buffer.zero_()
+        torch.cuda.synchronize()
+
+        dist.barrier()
+        elapsed_s = 0.0
+        for i in range(iterations):
+            it = warmups + i
+            # Perturbation (either branch) uses the local ground-zero i, not
+            # it: the reset-before-timing block above restored rl_pair (and,
+            # for a READ initiator, read_dst_buffer) to the shared W0
+            # baseline, so the timed loop's perturbation sequence - and the
+            # verification below, which mirrors it via [:iterations] - both
+            # restart from index 0 rather than continuing from warmups.
+            if needs_rl_read_barriers:
+                evolve_own_rl_buffers(i)  # no-op on rank 0; perturbs on peers
+                dist.barrier()  # B1: every peer has perturbed for `i`
+                sender_ptrs = (0, send_buffer.data_ptr())  # unused by the READ branch
+            else:
+                sender_ptrs = evolve_own_rl_buffers(i)
+            t0 = time.perf_counter()
+            try:
+                create_peer_handles(it, i, sender_ptrs)
+                run_iteration(it)
+                elapsed_s += time.perf_counter() - t0
+            finally:
+                release_peer_handles()
+            if needs_rl_read_barriers:
+                dist.barrier()  # B2: rank 0 finished reading `it`
+        dist.barrier()
+
+        per_iter_s = elapsed_s / iterations
+        # Active-rank iterations move len(send_to) peers' worth of data;
+        # passive ranks move len(recv_from) (always 1 in this star
+        # topology) peer's worth - regardless of direction, this is "how
+        # many peer-slots did I move this iteration".
+        bytes_per_iter = (
+            len(send_to) if send_to else len(recv_from)
+        ) * num_concurrent_xfers * buffer_bytes
+        bw_gbps = bytes_per_iter / per_iter_s / 1e9 if per_iter_s > 0 else float("inf")
+
+        if direction == "write":
+            # Verify final contents only on receiver ranks
+            for r in recv_from:
+                if is_rl:
+                    # W0 plus every timed perturbation should result in the final received buffer
+                    sender_idx, sender_vals = _precompute_delta_changes(
+                        slot_elems, max(warmups, iterations), device=recv_buffer.device,
+                    )
+                    expected_slot = (
+                        rl_w0.view(num_concurrent_xfers, slot_elems)[0].clone()
+                    )
+                    expected_slot.index_add_(
+                        0,
+                        sender_idx[:iterations].reshape(-1),
+                        sender_vals[:iterations].reshape(-1),
+                    )
+                    expected = expected_slot.repeat(num_concurrent_xfers)
+                    assert torch.equal(recv_buffer, expected), (
+                        f"rank {rank}: mismatch from sender {r}"
+                    )
+                else:
+                    # safetensors/random_src: all ranks load the same data, so local send_buffer matches sender's.
+                    # synthetic: _fill_pattern() reconstructs sender's pattern deterministically.
+                    expected = (
+                        send_buffer if (safetensors_file or random_src)
+                        else _fill_pattern(r, slot_elems).repeat(num_concurrent_xfers)
+                    )
+                    assert torch.equal(recv_buffer, expected), (
+                        f"rank {rank}: content mismatch from sender {r}"
+                    )
+        else:  # direction == "read"
+            # Verify final contents only on the initiator (rank 0), one
+            # per-peer region of read_dst_buffer at a time.
+            for peer_idx, r in enumerate(send_to):
+                region_start = peer_idx * num_concurrent_xfers * slot_elems
+                region_elems = num_concurrent_xfers * slot_elems
+                region = read_dst_buffer[region_start:region_start + region_elems]
+                if is_rl:
+                    # W0 plus every timed perturbation should result in the final read region.
+                    source_idx, source_vals = _precompute_delta_changes(
+                        slot_elems, max(warmups, iterations), device=region.device,
+                    )
+                    expected_slot = _fill_ref_pattern(slot_elems)
+                    expected_slot.index_add_(
+                        0,
+                        source_idx[:iterations].reshape(-1),
+                        source_vals[:iterations].reshape(-1),
+                    )
+                    expected = expected_slot.repeat(num_concurrent_xfers)
+                    assert torch.equal(region, expected), (
+                        f"rank {rank}: READ mismatch from source {r}"
+                    )
+                else:
+                    # safetensors/random_src: all ranks load the same data, so local send_buffer matches source's.
+                    # synthetic: _fill_pattern() reconstructs the source's pattern deterministically.
+                    expected = (
+                        send_buffer if (safetensors_file or random_src)
+                        else _fill_pattern(r, slot_elems).repeat(num_concurrent_xfers)
+                    )
+                    assert torch.equal(region, expected), (
+                        f"rank {rank}: READ content mismatch from source {r}"
+                    )
+
+        return (
+            elapsed_s,
+            per_iter_s,
+            bw_gbps,
+            buffer_bytes,
+            resolved_mode.service_mem_bytes,
+            resolved_mode.max_concurrent_transfers,
+        )
+    except Exception as exc:
+        print(f"[service_bench][rank {rank}] benchmark failed: {exc}")
+        raise
+
+
+def _worker(rank: int, num_ranks: int,
+            iterations: int, warmups: int,
+            buffer_bytes: int,
+            service_mode: str,
+            safetensors_file: str | None,
+            random_src: bool,
+            num_concurrent_xfers: int,
+            direction: str,
+            master_addr: str, master_port: int,
+            dist_backend: str) -> None:
+    """Per-rank entry point launched by ``torch.multiprocessing.spawn``.
+
+    Pins this process to GPU ``rank``, brings up the ``torch.distributed``
+    process group used purely for the metadata bootstrap, then runs the
+    benchmark.  The actual data path is NIXL — torch.distributed never
+    touches the buffers.
+    """
+    assert torch.cuda.device_count() >= num_ranks, (
+        f"need >= {num_ranks} CUDA devices on this node, "
+        f"got {torch.cuda.device_count()}"
+    )
+    torch.cuda.set_device(rank)
+
+    os.environ["MASTER_ADDR"] = master_addr
+    os.environ["MASTER_PORT"] = str(master_port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(num_ranks)
+
+    dist.init_process_group(
+        backend=dist_backend,
+        rank=rank,
+        world_size=num_ranks,
+    )
+
+    try:
+        (
+            elapsed_s,
+            per_iter_s,
+            bw_gbps,
+            buffer_bytes,
+            service_mem_bytes,
+            max_concurrent_transfers,
+        ) = benchmark(
+            rank, num_ranks, iterations, warmups, buffer_bytes,
+            service_mode, num_concurrent_xfers, random_src,
+            safetensors_file, direction,
+        )
+        send_to, recv_from = _build_traffic_pattern(rank, num_ranks)
+        if direction == "write":
+            role = "send+recv" if send_to and recv_from else (
+                "send" if send_to else "recv"
+            )
+        else:
+            role = "read-init+served" if send_to and recv_from else (
+                "read-init" if send_to else "served"
+            )
+        result_line = (
+            f"\n============ Rank {rank} Results =============\n"
+            f"svc={service_mode}\n"
+            f"direction={direction}\n"
+            f"role={role}\n"
+            f"warmups={warmups}\n"
+            f"iters={iterations}\n"
+            f"total={elapsed_s * 1e3:.3f}ms\n"
+            f"per_iter={per_iter_s * 1e6:.1f}us\n"
+            f"bw={bw_gbps:.3f} GB/s\n"
+            f"=========================================\n"
+        )
+        rank_results = [None] * num_ranks
+        dist.all_gather_object(
+            rank_results,
+            {
+                "rank": rank,
+                "per_iter_s": per_iter_s,
+                "result_line": result_line,
+            },
+        )
+        if rank == 0:
+            mean_per_iter_s = (
+                sum(result["per_iter_s"] for result in rank_results) / num_ranks
+            )
+            outlier_results = [
+                result for result in rank_results
+                if abs(result["per_iter_s"] - mean_per_iter_s) / mean_per_iter_s > 0.05
+            ]
+            if outlier_results:
+                outlier_ranks = [result["rank"] for result in outlier_results]
+                print(
+                    "WARNING: per-rank per_iter differs by more than 5% "
+                    f"from the mean on ranks {outlier_ranks}; printing all ranks.",
+                    flush=True,
+                )
+                for result in rank_results:
+                    print(result["result_line"], flush=True)
+            else:
+                print(rank_results[0]["result_line"], flush=True)
+            mode = SERVICE_MODE_DEFINITIONS[service_mode]
+            summary = "\n========== Test Configuration ===========\n"
+            summary += f"direction={direction}\n"
+            summary += f"buffer_size={_format_size(buffer_bytes)}\n"
+            summary += f"concurrent_xfers={num_concurrent_xfers}\n"
+            if mode.uses_service_mem:
+                summary += (
+                    f"max_concurrent_transfers={max_concurrent_transfers}\n"
+                    f"service_mem={_format_size(service_mem_bytes)}"
+                )
+            if mode.is_rl:
+                summary += f"\nPER_RL_STEP_WEIGHTS_DIFF_PERCENTAGE={PER_RL_STEP_WEIGHTS_DIFF_PERCENTAGE}"
+            summary += f"\n=========================================\n"
+            print(summary, flush=True)
+    finally:
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-ranks", type=int, default=DEFAULT_NUM_RANKS,
+                        help="number of ranks/GPUs to use on this node "
+                             f"(default: {DEFAULT_NUM_RANKS}, max: {MAX_NUM_RANKS})")
+    parser.add_argument("--iterations", "-N", type=int, default=DEFAULT_ITERATIONS,
+                        help=f"number of timed iterations (default: {DEFAULT_ITERATIONS})")
+    parser.add_argument("--warmups", "-K", type=int, default=DEFAULT_WARMUPS,
+                        help="number of warmup iterations, not timed "
+                             f"(default: {DEFAULT_WARMUPS})")
+    parser.add_argument("--buffer-bytes-exp", type=int,
+                        default=DEFAULT_BUFFER_BYTES_EXP,
+                        help="base-2 exponent for the per-peer slot size in "
+                             "bytes; this is also the per-rank send buffer "
+                             "size. For example, 10 means 1 KiB and 20 means "
+                             f"1 MiB (default: {DEFAULT_BUFFER_BYTES_EXP}, "
+                             "1 GiB)")
+    parser.add_argument("--concurrent-xfers", type=int,
+                        default=DEFAULT_CONCURRENT_XFERS,
+                        help="number of identical transfers the active rank "
+                             "posts concurrently to/from each peer per "
+                             "iteration "
+                             f"(default: {DEFAULT_CONCURRENT_XFERS})")
+    parser.add_argument("--direction", default=DEFAULT_DIRECTION,
+                        choices=DIRECTIONS,
+                        help="transfer direction. 'write' (default) has "
+                             "rank 0 push into every peer's buffer; 'read' "
+                             "has rank 0 pull from every peer's buffer "
+                             "instead - peers become the data source and, "
+                             "for RL modes, run the per-iteration "
+                             "perturbation themselves "
+                             f"(default: {DEFAULT_DIRECTION})")
+    parser.add_argument("--service-mode", default="direct",
+                        choices=SERVICE_MODES,
+                        help="marshal mode for the nixlServiceAgent. "
+                             "'direct' (default) is a passthrough and "
+                             "allocates no service memory; any other mode "
+                             "sizes its service-memory allocation from "
+                             "recommendServiceMemSize")
+    parser.add_argument("--safetensors-file", type=str, default=None,
+                        help="path to a .safetensors file whose tensor data "
+                             "will be used as the send buffer instead of "
+                             "synthetic fill patterns. When given, "
+                             "--buffer-bytes-exp is ignored and the transfer "
+                             "size equals the file's total tensor payload")
+    parser.add_argument("--random-src", action="store_true",
+                        help="fill the non-RL send buffer with the shared "
+                             "seeded random pattern (same as RL modes) instead "
+                             "of the synthetic simple pattern. Use this to "
+                             "compare 'compress' vs 'compress_ans_delta' on the "
+                             "same data. No effect for RL modes or when "
+                             "--safetensors-file is given.")
+    parser.add_argument("--dist-backend", default="gloo",
+                        choices=("gloo", "nccl"),
+                        help="torch.distributed backend for the bootstrap "
+                             "collective (data path is NIXL, not torch)")
+    parser.add_argument("--master-addr", default="127.0.0.1")
+    parser.add_argument("--master-port", type=int, default=29500)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.num_ranks < 1 or args.num_ranks > MAX_NUM_RANKS:
+        raise ValueError(
+            f"--num-ranks must be between 1 and {MAX_NUM_RANKS}, "
+            f"got {args.num_ranks}"
+        )
+    if args.concurrent_xfers < 1:
+        raise ValueError(
+            f"--concurrent-xfers must be >= 1, got {args.concurrent_xfers}"
+        )
+    buffer_bytes = 1 << args.buffer_bytes_exp
+
+    mp.spawn(
+        _worker,
+        args=(args.num_ranks, args.iterations, args.warmups, buffer_bytes,
+              args.service_mode, args.safetensors_file,
+              args.random_src, args.concurrent_xfers, args.direction,
+              args.master_addr, args.master_port, args.dist_backend),
+        nprocs=args.num_ranks,
+        join=True,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What?
An experimental service utility agent built on top of `nixlAgent`. It adds pluggable marshal-based services, including compression support, on top of the native NIXL agent API.

## Why?
Frequent model-weight transfers in reinforcement learning (RL) workflows and growing KV caches in inference workloads move increasingly large volumes of data. Transferring these payloads uncompressed can create bottlenecks in network bandwidth, transfer latency, and storage capacity. This PR addresses these bottlenecks by integrating nvCOMP-based compression and decompression into the NIXL transfer path, reducing the amount of data that must be transferred and stored.

## How?
A transparent data compression and decompression service integrated into NVIDIA’s Inference Xfer Library (NIXL). It uses nvCOMP, NVIDIA’s GPU-accelerated data (de)compression library, to reduce payload sizes and help reduce transfer times for frequently accessed data in AI inference workloads.