### PR TITLE
fix(posix): clean up io slot on AIO failure instead of leaking

### DIFF
--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -114,7 +114,18 @@ nixlPosixIOQueueAIO::post(void) {
 
         if (ret < 0) {
             NIXL_ERROR << "aio_submit failed: " << nixl_strerror(-ret);
-            ios_to_submit_.push_front(io);
+            // Submission failed immediately (e.g. EBADF when the fd was
+            // closed before submission). Previously this pushed the io
+            // back to ios_to_submit_, leaking the slot forever (it was
+            // never returned to free_ios_) and re-submitting the same
+            // broken request on every subsequent post() -- producing
+            // unbounded error spam and eventually exhausting the io
+            // pool. Instead, notify the callback of the failure, and
+            // return the io to the free pool so the slot is reusable.
+            if (io->clb_) {
+                io->clb_(io->ctx_, 0, -1);
+            }
+            free_ios_.push_back(io);
             return NIXL_ERR_BACKEND;
         }
 
@@ -138,7 +149,17 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
             ssize_t ret = aio_return(&io->aio_);
             if (ret < 0 || ret != static_cast<ssize_t>(io->aio_.aio_nbytes)) {
                 NIXL_ERROR << "aio_return failed: " << nixl_strerror(-ret);
-                ios_in_flight_.push_front(io);
+                // IO completed with error: call callback, remove from
+                // in-flight, and return to free pool. Previously this
+                // pushed the io back to ios_in_flight_ and returned
+                // NIXL_ERR_BACKEND, which leaked the slot (it was never
+                // returned to free_ios_) and caused every subsequent
+                // poll() to re-check the same failed request forever.
+                if (io->clb_) {
+                    io->clb_(io->ctx_, ret, -1);
+                }
+                it = ios_in_flight_.erase(it);
+                free_ios_.push_back(io);
                 return NIXL_ERR_BACKEND;
             }
             if (io->clb_) {
@@ -150,7 +171,18 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
             return NIXL_IN_PROG;
         } else {
             NIXL_ERROR << "aio_error failed: " << nixl_strerror(-status);
-            ios_in_flight_.push_front(io);
+            // AIO error (e.g. EBADF when the file was closed while I/O
+            // was in flight). Previously this pushed the io back to
+            // ios_in_flight_, leaking the slot and re-checking the same
+            // failed request on every subsequent poll() which produced
+            // thousands of repeated EBADF errors. Instead, call the
+            // callback with an error, remove the io from in-flight, and
+            // return it to the free pool.
+            if (io->clb_) {
+                io->clb_(io->ctx_, 0, -1);
+            }
+            it = ios_in_flight_.erase(it);
+            free_ios_.push_back(io);
             return NIXL_ERR_BACKEND;
         }
 

--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -156,7 +156,7 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
                 // returned to free_ios_) and caused every subsequent
                 // poll() to re-check the same failed request forever.
                 if (io->clb_) {
-                    io->clb_(io->ctx_, ret, -1);
+                    io->clb_(io->ctx_, 0, -1);
                 }
                 it = ios_in_flight_.erase(it);
                 free_ios_.push_back(io);
@@ -178,6 +178,11 @@ nixlPosixIOQueueAIO::doCheckCompleted(void) {
             // thousands of repeated EBADF errors. Instead, call the
             // callback with an error, remove the io from in-flight, and
             // return it to the free pool.
+            // POSIX requires aio_return() to be called exactly once after
+            // aio_error() reports a non-EINPROGRESS status, to release the
+            // aiocb's internal state.  The return value is discarded since
+            // the operation already failed.
+            aio_return(&io->aio_);
             if (io->clb_) {
                 io->clb_(io->ctx_, 0, -1);
             }


### PR DESCRIPTION
## Summary

Three failure paths in `posix_aio_io_queue.cpp` pushed the io back onto its source list (`ios_to_submit_` or `ios_in_flight_`) and returned `NIXL_ERR_BACKEND` **without ever returning the slot to `free_ios_`**. This caused:

1. **io slot leak** — the slot was never recycled, eventually exhausting the pool (`enqueue` returns `NIXL_ERR_NOT_ALLOWED`)
2. **infinite retry loop** — the same failed request was re-submitted/re-checked on every subsequent `post()`/`poll()`, producing unbounded error spam

## The three bugs

### Bug 1: `post()` — aio_submit failed (line 117)

When `aio_read`/`aio_write` fails immediately (e.g. EBADF — fd closed before submission), the io was pushed back to `ios_to_submit_`. Every subsequent `post()` re-submitted the same broken request → unbounded error spam + pool exhaustion.

```cpp
// BEFORE (buggy)
if (ret < 0) {
    NIXL_ERROR << "aio_submit failed: " << nixl_strerror(-ret);
    ios_to_submit_.push_front(io);   // ← leaked: never returned to free_ios_
    return NIXL_ERR_BACKEND;
}
```

### Bug 2: `doCheckCompleted()` — aio_return failed (line 141)

IO completed with error (short read or negative return). The io was pushed back to `ios_in_flight_` and re-checked on every subsequent `poll()` forever.

### Bug 3: `doCheckCompleted()` — aio_error failed (line 153)

AIO error (e.g. EBADF — file closed while I/O in flight). Same infinite re-check loop as Bug 2.

## The fix

On any failure: invoke the done callback with an error code, erase the io from its current list, and return it to `free_ios_`:

```cpp
// AFTER (fixed) — same pattern for all three paths
if (io->clb_) {
    io->clb_(io->ctx_, 0, -1);    // notify callback of failure
}
free_ios_.push_back(io);          // return slot to pool
return NIXL_ERR_BACKEND;
```

A one-shot failure no longer becomes a permanent leak.

## When does EBADF occur?

EBADF is a normal failure mode, not a bug in itself:
- A file is deregistered (`deregisterMem` → `delete MD` → `~FileFd` → `close`) while an AIO is still in flight
- `aio_error()` then returns EBADF (-9) for the closed fd

The bug is that the plugin's error handling turned this one-shot failure into a permanent leak + infinite retry. The fix ensures the failure is reported once and the slot is recycled.

## Verification

### A/B test: invalid fd → failure → subsequent normal writes

| Scenario | Original plugin | Fixed plugin |
|---|---|---|
| N invalid-fd failures | 30 × 0.1s | 200 × 0.5s |
| **Normal write after failures** | **❌ ERR (pool polluted)** | ✅ DONE |
| 500 consecutive normal writes after failures | — | ✅ 500/500 |
| Error spam | infinite re-check on every poll | single error per failure |

### Production verification (AMD MI308X, 8-GPU, GLM-5.2)

| Metric | Before fix | After fix |
|---|---|---|
| `aio_error failed` count | 2697 (growing linearly) | **0** |
| `pages failed` | 1310 | **0** |
| io pool exhaustion | yes (NIXL_ERR_NOT_ALLOWED) | no |
| zero-byte files (write failures) | 23895 | **0** |

## Notes

- The callback signature `clb_(ctx_, bytes, status)` with `status=-1` signals failure to the caller, which can then handle the error appropriately (e.g. raise an exception)
- The `erase + push_back` pattern for in-flight ios is safe because we `return` immediately after, so the iterator is not used again
- This fix is complementary to the sglang-side fix (sgl-project/sglang) that prevents the EBADF trigger source (devId collision in deregister)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed failed asynchronous I/O operations being retried indefinitely.
  * Errors are now reported promptly through operation callbacks.
  * Failed operations correctly release their resources, preventing slot exhaustion and improving queue reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->