### PR TITLE
nixlbench: validate --op_type argument

### DIFF
--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -498,6 +498,11 @@ xferBenchConfig::loadParams(void) {
     scheme = NB_ARG(scheme);
     mode = NB_ARG(mode);
     op_type = NB_ARG(op_type);
+    if (op_type != XFERBENCH_OP_READ && op_type != XFERBENCH_OP_WRITE) {
+        std::cerr << "Invalid op type: " << op_type << ". Must be one of [READ, WRITE]"
+                  << std::endl;
+        return -1;
+    }
     check_consistency = NB_ARG(check_consistency);
     total_buffer_size = NB_ARG(total_buffer_size);
     num_initiator_dev = NB_ARG(num_initiator_dev);


### PR DESCRIPTION
## What?

Validate the `--op_type` argument at config parse time. Only `READ` and `WRITE` are accepted; any other value now exits with an error:

    Invalid op type: REA. Must be one of [READ, WRITE]

## Why?

An invalid `--op_type` value (for example a typo like `REA`) is silently treated as WRITE, since the only check performed downstream is:

    nixl_xfer_op_t xfer_op = XFERBENCH_OP_READ == xferBenchConfig::op_type ? NIXL_READ : NIXL_WRITE;

I hit this while benchmarking GDS. A typo produced a full result table that looked like a READ run (the config banner prints `Op type : REA` as given), but it was actually running WRITE, which invalidated a READ vs WRITE comparison until I noticed.

It also affects `--check_consistency`: an invalid value matches neither the READ nor the WRITE branch in `validateTransfer()`, so the consistency check is silently skipped.

## How?

Added the check right after parsing in `xferBenchConfig::loadParams()`, following the existing validation pattern used for `--posix_api_type`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for transfer operation types.
  * Invalid values now produce an error and prevent benchmark configuration from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->