### PR TITLE
cuda_gds: fail backend creation on invalid batch_limit

### DIFF
--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -62,9 +62,22 @@ nixlGdsEngine::nixlGdsEngine(const nixlBackendInitParams* init_params)
         return;
     }
 
-    // Initialize the batch pool
+    // Initialize the batch pool. Validate each batch so that an invalid
+    // batch_limit (e.g. above cuFile's maximum batch size, 128 by default)
+    // fails backend creation with a single clear error instead of flooding
+    // the log with a setup error per pool entry and then failing every
+    // transfer at submission time.
     for (unsigned int i = 0; i < batch_pool_size; i++) {
-        batch_pool.push_back(new nixlGdsIOBatch(batch_limit));
+        auto *batch = new nixlGdsIOBatch(batch_limit);
+        if (batch->initStatus() != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to create GDS IO batch of size " << batch_limit
+                       << "; batch_limit must not exceed cuFile's maximum batch size"
+                       << " (properties.io_batchsize in cufile.json, 128 by default)";
+            delete batch;
+            this->initErr = true;
+            return;
+        }
+        batch_pool.push_back(batch);
     }
 
 }

--- a/src/plugins/cuda_gds/gds_utils.cpp
+++ b/src/plugins/cuda_gds/gds_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,10 @@ nixlGdsIOBatch::~nixlGdsIOBatch()
         current_status == NIXL_ERR_NOT_POSTED) {
             delete[] io_batch_events;
             delete[] io_batch_params;
-            cuFileBatchIODestroy(batch_handle);
+            // The batch handle is only valid if cuFileBatchIOSetUp succeeded
+            if (init_err.err == CU_FILE_SUCCESS) {
+                cuFileBatchIODestroy(batch_handle);
+            }
     } else {
             NIXL_ERROR << "Attempting to delete a batch before completion";
     }

--- a/src/plugins/cuda_gds/gds_utils.h
+++ b/src/plugins/cuda_gds/gds_utils.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,13 @@ class nixlGdsIOBatch {
         nixl_status_t submitBatch(int flags);
         nixl_status_t checkStatus();
         nixl_status_t cancelBatch();
-        void reset();
+        void
+        reset();
+
+        nixl_status_t
+        initStatus() const {
+            return (init_err.err == CU_FILE_SUCCESS) ? NIXL_SUCCESS : NIXL_ERR_BACKEND;
+        }
 
     private:
         CUfileBatchHandle_t batch_handle;


### PR DESCRIPTION
## What

Validate the batch pool during GDS engine construction. If a batch fails `cuFileBatchIOSetUp`, backend creation now fails immediately with a single actionable error, instead of flooding the log and failing later at transfer time. This happens when `batch_limit` is set above cuFile's maximum batch size (`properties.io_batchsize` in cufile.json, 128 by default).

Also skip `cuFileBatchIODestroy` in the `nixlGdsIOBatch` destructor when setup failed, since the batch handle is not valid in that case.

## Why

Running nixlbench with `--gds_batch_limit 256` produced 33 repeated `Error in setting up Batch` lines, one per pool entry plus one at transfer time. The `nixlGdsIOBatch` constructor stores the `cuFileBatchIOSetUp` failure in `init_err`, but nothing ever checks it. Backend creation still reported success, so the benchmark proceeded and failed only when posting the first transfer, with nothing pointing at the actual cause.

The destructor issue is related: deleting a batch whose setup failed called `cuFileBatchIODestroy` on an uninitialized handle.

## How

Added an `initStatus()` accessor to `nixlGdsIOBatch` and checked it while populating the pool in the engine constructor. On failure the engine logs the configured limit and where the limit comes from, then sets `initErr`.

Verified on a B200 system with `--gds_batch_limit 256`. Before: 33 repeated setup errors followed by a transfer-time failure. After: a single error at `createBackend`:

```
Failed to create GDS IO batch of size 256; batch_limit must not exceed cuFile's maximum batch size (properties.io_batchsize in cufile.json, 128 by default)
```

Default runs are unaffected (verified with a 512KiB x batch 32 sweep).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA GDS initialization validation for preallocated I/O batches.
  * Invalid batches are now rejected immediately instead of being retained.
  * Prevented cleanup errors when batch setup fails.
  * Construction now reports initialization failures with an appropriate backend error status.
  * Improved reliability when configured batch limits exceed supported CUDA GDS limits.
  * Ensured failed initialization cannot leave unusable I/O resources behind.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->