### PR TITLE
Upgrade vLLM and SGLang versions used in CI

### DIFF
--- a/.ci/dockerfiles/Dockerfile.sglang-base
+++ b/.ci/dockerfiles/Dockerfile.sglang-base
@@ -20,7 +20,7 @@
 # wheels on top of this image.
 # BASE_IMAGE is pinned to a concrete version so the per-PR gsm8k accuracy gate is
 # reproducible; bump it (and CI_IMAGE_TAG) deliberately to move to a newer SGLang.
-ARG BASE_IMAGE=docker.io/lmsysorg/sglang:v0.5.13.post1
+ARG BASE_IMAGE=docker.io/lmsysorg/sglang:v0.5.17
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 
 ARG MODEL_ID=Qwen/Qwen3-8B

--- a/.ci/dockerfiles/Dockerfile.vllm-base
+++ b/.ci/dockerfiles/Dockerfile.vllm-base
@@ -20,7 +20,7 @@
 # wheels on top of this image.
 # BASE_IMAGE is pinned to a concrete version so the per-PR sanity gate is reproducible;
 # bump it (and CI_IMAGE_TAG) deliberately to move to a newer vLLM.
-ARG BASE_IMAGE=docker.io/vllm/vllm-openai:v0.23.0
+ARG BASE_IMAGE=docker.io/vllm/vllm-openai:v0.27.1
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE}
 
 ARG MODEL_ID=Qwen/Qwen3-8B


### PR DESCRIPTION
## What?
Upgrade vLLM and SGLang versions used in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SGLang runtime to version 0.5.17.
  * Updated the vLLM runtime to version 0.27.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->