### PR TITLE
CI: Suppress credentials in logs

### DIFF
--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -77,12 +77,14 @@ steps:
       podman info
       ln -sfT $(type -p podman) /usr/bin/docker
       # Login to Artifactory
+      set +x -v
       echo "$ARTIFACTORY_PASSWORD" | docker login "${REGISTRY_HOST_NAME}" -u "$ARTIFACTORY_USERNAME" --password-stdin
       # Login to the GitLab registry so DLFW base images hosted there can be pulled.
       # GitLab accepts any username with a read_registry token, so the username is a placeholder.
       if [ -n "${GITLAB_REGISTRY_TOKEN:-}" ]; then
         echo "$GITLAB_REGISTRY_TOKEN" | docker login gitlab-master.nvidia.com:5005 -u nixl-ci --password-stdin
       fi
+      set +v -x
 
       yum install -y gettext
 

--- a/.ci/jenkins/lib/test-dl-ep-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-ep-matrix.yaml
@@ -111,6 +111,7 @@ steps:
       if [ -n "${UCX_VER}" ]; then UCX_ARG="--build-arg UCX_VERSION=${UCX_VER}"; fi
       export PR_IMAGE=${registry_host}${registry_path}/pr/${arch}/nixl-ci-dl-gpu-ep-test:${BUILD_NUMBER}
       rm -rf /etc/containers/storage.conf && rm -f /usr/share/containers/storage.conf
+      set +x -v
       podman build --network host --creds ${REPO_USER}:${REPO_PASS} \
       ${UCX_ARG} \
       --build-arg PRE_INSTALLED_ENV="true" \

--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -103,6 +103,7 @@ steps:
       if [ -n "${UCX_VER}" ]; then UCX_ARG="--build-arg UCX_VERSION=${UCX_VER}"; fi
       export PR_IMAGE=${registry_host}${registry_path}/pr/${arch}/nixl-ci-dl-gpu-test:${BUILD_NUMBER}
       rm -rf /etc/containers/storage.conf && rm -f /usr/share/containers/storage.conf
+      set +x -v
       podman build --network host --creds ${REPO_USER}:${REPO_PASS} \
       ${UCX_ARG} \
       --build-arg PRE_INSTALLED_ENV="true" \

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -104,7 +104,9 @@ steps:
       if [ -n "${UCX_VER}" ]; then UCX_ARG="--build-arg UCX_VERSION=${UCX_VER}"; fi
       export PR_IMAGE=${registry_host}${registry_path}/pr/${arch}/nixl-ci-gpu-test:${BUILD_NUMBER}
       rm -rf /etc/containers/storage.conf && rm -f /usr/share/containers/storage.conf
+      set +x -v
       echo "$REPO_PASS" | podman login "https://${registry_host}" -u "$REPO_USER" --password-stdin
+      set +v -x
       podman build --network host \
       ${UCX_ARG} \
       --build-arg PRE_INSTALLED_ENV="true" \

--- a/.ci/scripts/run_slurm_allocation.sh
+++ b/.ci/scripts/run_slurm_allocation.sh
@@ -156,8 +156,10 @@ readonly SLURM_GET_JOB_ID_CMD="squeue --noheader --name=${slurm_job_name} --form
 case "${slurm_head_node}" in
     scctl)
         echo "INFO: Using scctl client to connect and allocate Slurm resources"
+        set +x -v
         export SCCTL_USER=${SERVICE_USER_USERNAME}
         export SCCTL_PASSWORD=${SERVICE_USER_PASSWORD}
+        set +v -x
         scctl -v
         scctl --raw-errors upgrade
         scctl --raw-errors login

--- a/.ci/scripts/stop_slurm_allocation.sh
+++ b/.ci/scripts/stop_slurm_allocation.sh
@@ -93,8 +93,10 @@ echo "INFO: Stopping SLURM job: ${slurm_job_id}"
 case "${slurm_head_node}" in
     scctl)
         echo "INFO: Using scctl client to stop Slurm resources"
+        set +x -v
         export SCCTL_USER=${SERVICE_USER_USERNAME}
         export SCCTL_PASSWORD=${SERVICE_USER_PASSWORD}
+        set +v -x
         scctl -v
         scctl --raw-errors upgrade
         scctl --raw-errors login


### PR DESCRIPTION
## What?
Switch those lines to verbose-only and restore xtrace afterwards, so the values are never traced regardless of how credentials are injected.

## Why?
set -x expanded sensitive values into the job log. 
[HPCINFRA-3435](https://jirasw.nvidia.com/browse/HPCINFRA-3435)

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive registry and service credentials are no longer exposed in shell command logs during authentication and resource allocation workflows.

* **Build and Operations**
  * Improved command tracing around container image builds, pushes, registry logins, and allocation steps to support easier troubleshooting.
  * Shell tracing is automatically restored after protected commands complete, maintaining consistent diagnostic output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->