### PR TITLE
EP: support Kimi-K3 (top-16 routing and hidden 3584)

### DIFF
--- a/examples/device/ep/csrc/kernels/launch.cuh
+++ b/examples/device/ep/csrc/kernels/launch.cuh
@@ -102,6 +102,7 @@ cfg.dynamicSmemBytes = smem_size;
         case 2048: case_macro(2048); \
         case 2560: case_macro(2560); \
         case 3072: case_macro(3072); /*for gpt-oss*/ \
+        case 3584: case_macro(3584); /* For kimi-k3 */ \
         case 4096: case_macro(4096); \
         case 5120: case_macro(5120); \
         case 6144: case_macro(6144); /* For qwen3 coder */ \

--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -409,7 +409,7 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
               uint64_t timeout_cycles,
               void* workspace, int num_device_sms,
               cudaStream_t stream, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
-    constexpr int kNumMaxTopK = 11;
+    constexpr int kNumMaxTopK = 16;
     const int active_expert_bound = active_rank_bound * num_experts_per_rank;
     const int num_warp_groups = ceil_div(active_expert_bound, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;
@@ -1028,7 +1028,7 @@ void combine(void* combined_x,
              bool use_logfmt, uint64_t timeout_cycles,
              void* workspace, int num_device_sms,
              cudaStream_t stream, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx) {
-    constexpr int kNumMaxTopk = 11;
+    constexpr int kNumMaxTopk = 16;
     const int active_expert_bound = active_rank_bound * num_experts_per_rank;
     const int num_warp_groups = ceil_div(active_expert_bound, num_device_sms);
     const int num_warps_per_group = 32 / num_warp_groups;


### PR DESCRIPTION
Kimi-K3 routes top-16 experts and dispatches a 3584 latent-MoE hidden size; both are rejected by the current low-latency limits.

- nixl_ep_ll.cu: raise the dispatch and combine top-k caps from 11 to 16
- launch.cuh: add hidden 3584 to SWITCH_HIDDEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hidden size `3584` configurations.
  * Increased the maximum supported top-k value from 11 to 16 for dispatch and combine operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->