### PR TITLE
Mooncake plugin: fix checkXfer use-after-free, postXfer null deref, and an uninitialized test length

### DIFF
--- a/src/plugins/mooncake/mooncake_backend.cpp
+++ b/src/plugins/mooncake/mooncake_backend.cpp
@@ -281,7 +281,7 @@ nixlMooncakeEngine::postXfer(const nixl_xfer_op_t &operation,
         request[index].target_id = segment_id;
     }
     int rc = 0;
-    if (opt_args->hasNotif) {
+    if (opt_args && opt_args->hasNotif) {
         notify_msg_t notify_msg;
         notify_msg.name = const_cast<char *>(local_agent_name_.c_str());
         notify_msg.msg = const_cast<char *>(opt_args->notifMsg.c_str());

--- a/src/plugins/mooncake/mooncake_backend.cpp
+++ b/src/plugins/mooncake/mooncake_backend.cpp
@@ -226,8 +226,8 @@ struct nixlMooncakeBackendReqH : public nixlBackendReqH {
 
     virtual ~nixlMooncakeBackendReqH() {}
 
-    uint64_t batch_id;
-    size_t request_count;
+    uint64_t batch_id = INVALID_BATCH;
+    size_t request_count = 0;
 };
 
 nixl_status_t
@@ -298,6 +298,12 @@ nixlMooncakeEngine::postXfer(const nixl_xfer_op_t &operation,
 nixl_status_t
 nixlMooncakeEngine::checkXfer(nixlBackendReqH *handle) const {
     auto priv = (nixlMooncakeBackendReqH *)handle;
+    // Once every request completed, the batch is freed below and batch_id is
+    // reset to INVALID_BATCH. A later checkXfer() on the same handle must not
+    // reach the engine: getTransferStatus() and freeBatchID() cast the batch
+    // id to a BatchDesc pointer and dereference it, so passing INVALID_BATCH
+    // (UINT64_MAX) crashes. Report the already-reached terminal state instead.
+    if (priv->batch_id == INVALID_BATCH) return NIXL_SUCCESS;
     bool has_failed = false;
     for (size_t index = 0; index < priv->request_count; ++index) {
         transfer_status_t status;
@@ -313,6 +319,7 @@ nixlMooncakeEngine::checkXfer(nixlBackendReqH *handle) const {
         // where the same nixlBackendReqH could be used to post multiple transfer.
         freeBatchID(engine_, priv->batch_id);
         priv->batch_id = INVALID_BATCH;
+        priv->request_count = 0;
     }
     return has_failed ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
 }

--- a/src/plugins/mooncake/mooncake_backend.cpp
+++ b/src/plugins/mooncake/mooncake_backend.cpp
@@ -303,7 +303,9 @@ nixlMooncakeEngine::checkXfer(nixlBackendReqH *handle) const {
     // reach the engine: getTransferStatus() and freeBatchID() cast the batch
     // id to a BatchDesc pointer and dereference it, so passing INVALID_BATCH
     // (UINT64_MAX) crashes. Report the already-reached terminal state instead.
-    if (priv->batch_id == INVALID_BATCH) return NIXL_SUCCESS;
+    if (priv->batch_id == INVALID_BATCH) {
+        return NIXL_SUCCESS;
+    }
     bool has_failed = false;
     for (size_t index = 0; index < priv->request_count; ++index) {
         transfer_status_t status;

--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/plugins/mooncake/mooncake_backend_test.cpp
+++ b/test/unit/plugins/mooncake/mooncake_backend_test.cpp
@@ -293,6 +293,7 @@ allocateWrongGPUTest(nixlBackendEngine *mooncake, int dev_id) {
     nixlBackendMD *md;
     void *buf;
 
+    desc.len = 4096;
     allocateBuffer(VRAM_SEG, dev_id, desc.len, buf);
 
     desc.devId = dev_id;


### PR DESCRIPTION
Three independent fixes in the Mooncake plugin and its unit test, found while
working on TENT-mode support (RFC: #2083).

1. **checkXfer crashes when polled again after completion.** The batch is
   freed on completion but `request_count` is not reset, so a later poll
   dereferences the stale batch id as a descriptor pointer. Clear both fields
   and guard the entry.
2. **postXfer dereferences `opt_args` without a null check.** The SB API
   declares the parameter nullable.
3. **`allocateWrongGPUTest` reads `desc.len` uninitialized** before
   `allocateBuffer()` uses it as the allocation size (found via a random-size
   registration failure on a multi-GPU machine).

Verified on an 8×H20 / 5×RoCE-HCA server (Ubuntu 22.04, CUDA 13): upstream
`mooncake_backend_test` passes its DRAM and VRAM transfer sections (599 data
verifications, 300 notification checks). Note: the final `allocateWrongGPUTest`
assertion itself expects `NIXL_ERR_NOT_SUPPORTED`, which the plugin has never
returned — that pre-existing test/plugin mismatch aborts the run on any
multi-GPU machine and is unrelated to these fixes; happy to address it in a
follow-up once the intended semantics are clarified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved reliability when checking completed transfer batches.
* Notifications now handle missing optional arguments safely.
* Request and batch state is initialized and reset consistently.

## Tests

* Updated GPU buffer allocation coverage with an explicit buffer size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->