### PR TITLE
telemetry: reuse the drained staging buffer

### DIFF
--- a/src/core/telemetry/telemetry.cpp
+++ b/src/core/telemetry/telemetry.cpp
@@ -273,10 +273,10 @@ nixlTelemetry::startExportTask() {
 
 bool
 nixlTelemetry::flushPendingEvents() {
-    auto pending = stagingQueue_.takePending();
+    const auto pending = stagingQueue_.drainPending();
 
     exporter_->withBatch([&] {
-        for (auto &event : pending) {
+        for (const auto &event : pending) {
             // Deactivated metrics never enter the queue (filtered at the source),
             // so everything here is already exportable.
             exporter_->exportEvent(event);

--- a/src/core/telemetry/telemetry_staging_queue.cpp
+++ b/src/core/telemetry/telemetry_staging_queue.cpp
@@ -17,17 +17,18 @@
 #include "telemetry_staging_queue.h"
 
 nixlTelemetryStagingQueue::nixlTelemetryStagingQueue(size_t capacity) : capacity_(capacity) {
-    events_.reserve(capacity_);
+    live_.reserve(capacity_);
+    drained_.reserve(capacity_);
 }
 
 bool
 nixlTelemetryStagingQueue::tryPush(const nixlTelemetryEvent &event) {
     const std::lock_guard<std::mutex> lock(mutex_);
-    if (events_.size() >= capacity_) {
+    if (live_.size() >= capacity_) {
         numDroppedEvents_.fetch_add(1, std::memory_order_relaxed);
         return false;
     }
-    events_.push_back(event);
+    live_.push_back(event);
     return true;
 }
 
@@ -37,23 +38,22 @@ nixlTelemetryStagingQueue::tryPushBatch(std::span<const nixlTelemetryEvent> even
         return true;
     }
     const std::lock_guard<std::mutex> lock(mutex_);
-    if (events.size() > capacity_ - events_.size()) {
+    if (events.size() > capacity_ - live_.size()) {
         numDroppedEvents_.fetch_add(events.size(), std::memory_order_relaxed);
         return false;
     }
-    events_.insert(events_.end(), events.begin(), events.end());
+    live_.insert(live_.end(), events.begin(), events.end());
     return true;
 }
 
-std::vector<nixlTelemetryEvent>
-nixlTelemetryStagingQueue::takePending() {
-    std::vector<nixlTelemetryEvent> pending;
-    pending.reserve(capacity_);
+std::span<const nixlTelemetryEvent>
+nixlTelemetryStagingQueue::drainPending() {
     {
         const std::lock_guard<std::mutex> lock(mutex_);
-        events_.swap(pending);
+        drained_.clear();
+        live_.swap(drained_);
     }
-    return pending;
+    return drained_;
 }
 
 uint64_t

--- a/src/core/telemetry/telemetry_staging_queue.cpp
+++ b/src/core/telemetry/telemetry_staging_queue.cpp
@@ -48,11 +48,9 @@ nixlTelemetryStagingQueue::tryPushBatch(std::span<const nixlTelemetryEvent> even
 
 std::span<const nixlTelemetryEvent>
 nixlTelemetryStagingQueue::drainPending() {
-    {
-        const std::lock_guard<std::mutex> lock(mutex_);
-        drained_.clear();
-        live_.swap(drained_);
-    }
+    const std::lock_guard<std::mutex> lock(mutex_);
+    drained_.clear();
+    live_.swap(drained_);
     return drained_;
 }
 

--- a/src/core/telemetry/telemetry_staging_queue.h
+++ b/src/core/telemetry/telemetry_staging_queue.h
@@ -45,10 +45,11 @@ public:
     /**
      * @brief Construct a queue that retains at most @p capacity events.
      *
-     * Reserves storage for @p capacity events up front so the producer path
-     * never reallocates. Any @p capacity is accepted (a zero capacity yields a
-     * queue that drops every push); rejecting a zero telemetry buffer size is
-     * the caller's responsibility (see nixlTelemetry construction).
+     * Reserves both staging buffers for @p capacity events up front, so neither
+     * the producer nor the drain path ever reallocates. Any @p capacity is
+     * accepted (a zero capacity yields a queue that drops every push); rejecting
+     * a zero telemetry buffer size is the caller's responsibility (see
+     * nixlTelemetry construction).
      * @param capacity Maximum number of events retained before pushes are dropped.
      */
     explicit nixlTelemetryStagingQueue(size_t capacity);
@@ -78,14 +79,18 @@ public:
     tryPushBatch(std::span<const nixlTelemetryEvent> events);
 
     /**
-     * @brief Swap the live queue with an empty capacity-reserved vector and
-     *        return the drained events in insertion order.
+     * @brief Swap the two staging buffers and return the drained events in
+     *        insertion order.
      *
      * The swap happens under the mutex; producers can write to the fresh live
-     * vector while the consumer processes the returned one.
+     * buffer while the consumer reads the returned one. Single consumer only.
+     *
+     * The returned view borrows storage owned by the queue. It is invalidated by
+     * the next drainPending() call, which hands that storage back to producers,
+     * so events that must outlive a drain have to be copied out.
      */
-    [[nodiscard]] std::vector<nixlTelemetryEvent>
-    takePending();
+    [[nodiscard]] std::span<const nixlTelemetryEvent>
+    drainPending();
 
     /**
      * @brief Atomically take and reset the number of staging drops accumulated
@@ -99,7 +104,8 @@ public:
 
 private:
     const size_t capacity_;
-    std::vector<nixlTelemetryEvent> events_;
+    std::vector<nixlTelemetryEvent> live_;
+    std::vector<nixlTelemetryEvent> drained_;
     std::mutex mutex_;
     std::atomic<uint64_t> numDroppedEvents_{0};
 };

--- a/test/gtest/unit/telemetry/telemetry_staging_queue_test.cpp
+++ b/test/gtest/unit/telemetry/telemetry_staging_queue_test.cpp
@@ -191,12 +191,13 @@ TEST(telemetryStagingQueueTest, DrainViewCarriesOnlyTheCurrentDrain) {
     ASSERT_TRUE(queue.tryPush(makeEvent(2)));
     const auto first = queue.drainPending();
     ASSERT_EQ(first.size(), 2u);
+    const auto *const firstStorage = first.data();
 
     ASSERT_TRUE(queue.tryPush(makeEvent(3)));
     const auto second = queue.drainPending();
     ASSERT_EQ(second.size(), 1u);
     EXPECT_EQ(second[0].value_, 3u);
-    EXPECT_NE(second.data(), first.data());
+    EXPECT_NE(second.data(), firstStorage);
 }
 
 TEST(telemetryStagingQueueTest, TakeNumDroppedReturnsDeltaOnceThenZero) {

--- a/test/gtest/unit/telemetry/telemetry_staging_queue_test.cpp
+++ b/test/gtest/unit/telemetry/telemetry_staging_queue_test.cpp
@@ -23,6 +23,7 @@
 #include <span>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "telemetry/telemetry_staging_queue.h"
@@ -39,14 +40,14 @@ makeEvent(uint64_t value) {
 TEST(telemetryStagingQueueTest, ConstructorRetainsCapacityEmptyNoDrops) {
     nixlTelemetryStagingQueue queue(8);
     EXPECT_EQ(queue.capacity(), 8u);
-    EXPECT_TRUE(queue.takePending().empty());
+    EXPECT_TRUE(queue.drainPending().empty());
     EXPECT_EQ(queue.takeNumDropped(), 0u);
 }
 
 TEST(telemetryStagingQueueTest, SinglePushPreservesTypeAndValue) {
     nixlTelemetryStagingQueue queue(4);
     ASSERT_TRUE(queue.tryPush({nixl_telemetry_event_type_t::AGENT_XFER_TIME, 42}));
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 1u);
     EXPECT_EQ(pending[0].eventType_, nixl_telemetry_event_type_t::AGENT_XFER_TIME);
     EXPECT_EQ(pending[0].value_, 42u);
@@ -72,7 +73,7 @@ TEST(telemetryStagingQueueTest, FittingBatchAppendedCompletelyInOrder) {
     nixlTelemetryStagingQueue queue(8);
     const std::vector<nixlTelemetryEvent> batch = {makeEvent(10), makeEvent(20), makeEvent(30)};
     ASSERT_TRUE(queue.tryPushBatch(batch));
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 3u);
     EXPECT_EQ(pending[0].value_, 10u);
     EXPECT_EQ(pending[1].value_, 20u);
@@ -86,7 +87,7 @@ TEST(telemetryStagingQueueTest, NonFittingBatchRejectedWithoutPartialInsertion) 
     ASSERT_TRUE(queue.tryPush(makeEvent(2)));
     const std::vector<nixlTelemetryEvent> batch = {makeEvent(3), makeEvent(4), makeEvent(5)};
     EXPECT_FALSE(queue.tryPushBatch(batch));
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 2u);
     EXPECT_EQ(pending[0].value_, 1u);
     EXPECT_EQ(pending[1].value_, 2u);
@@ -106,42 +107,96 @@ TEST(telemetryStagingQueueTest, EmptyBatchSucceedsWithoutChangingState) {
     ASSERT_TRUE(queue.tryPush(makeEvent(7)));
     EXPECT_TRUE(queue.tryPushBatch({}));
     EXPECT_EQ(queue.takeNumDropped(), 0u);
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 1u);
     EXPECT_EQ(pending[0].value_, 7u);
 }
 
-TEST(telemetryStagingQueueTest, TakePendingReturnsAllInOrderAndEmpties) {
+TEST(telemetryStagingQueueTest, DrainPendingReturnsAllInOrderAndEmpties) {
     nixlTelemetryStagingQueue queue(4);
     for (uint64_t i = 0; i < 3; ++i) {
         ASSERT_TRUE(queue.tryPush(makeEvent(i)));
     }
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 3u);
     for (uint64_t i = 0; i < 3; ++i) {
         EXPECT_EQ(pending[i].value_, i);
     }
-    EXPECT_TRUE(queue.takePending().empty());
+    EXPECT_TRUE(queue.drainPending().empty());
 }
 
 TEST(telemetryStagingQueueTest, SecondDrainIsEmpty) {
     nixlTelemetryStagingQueue queue(4);
     ASSERT_TRUE(queue.tryPush(makeEvent(1)));
-    EXPECT_EQ(queue.takePending().size(), 1u);
-    EXPECT_TRUE(queue.takePending().empty());
+    EXPECT_EQ(queue.drainPending().size(), 1u);
+    EXPECT_TRUE(queue.drainPending().empty());
 }
 
 TEST(telemetryStagingQueueTest, AcceptsEventsAfterDrain) {
     nixlTelemetryStagingQueue queue(2);
     ASSERT_TRUE(queue.tryPush(makeEvent(1)));
     ASSERT_TRUE(queue.tryPush(makeEvent(2)));
-    (void)queue.takePending();
+    (void)queue.drainPending();
     ASSERT_TRUE(queue.tryPush(makeEvent(3)));
     ASSERT_TRUE(queue.tryPush(makeEvent(4)));
-    auto pending = queue.takePending();
+    auto pending = queue.drainPending();
     ASSERT_EQ(pending.size(), 2u);
     EXPECT_EQ(pending[0].value_, 3u);
     EXPECT_EQ(pending[1].value_, 4u);
+}
+
+TEST(telemetryStagingQueueTest, DrainAlternatesBetweenTwoBuffersWithoutReallocating) {
+    constexpr size_t kCapacity = 32;
+    constexpr size_t kCycles = 200;
+    nixlTelemetryStagingQueue queue(kCapacity);
+
+    std::unordered_set<const nixlTelemetryEvent *> storages;
+    const nixlTelemetryEvent *previous = nullptr;
+    for (size_t cycle = 0; cycle < kCycles; ++cycle) {
+        const size_t count = 1 + cycle % kCapacity;
+        for (uint64_t i = 0; i < count; ++i) {
+            ASSERT_TRUE(queue.tryPush(makeEvent(i)));
+        }
+
+        const auto pending = queue.drainPending();
+        ASSERT_EQ(pending.size(), count);
+        EXPECT_NE(pending.data(), previous);
+        storages.insert(pending.data());
+        previous = pending.data();
+    }
+
+    EXPECT_EQ(storages.size(), 2u);
+    EXPECT_EQ(queue.takeNumDropped(), 0u);
+}
+
+TEST(telemetryStagingQueueTest, CapacitySurvivesAlternatingDrains) {
+    constexpr size_t kCapacity = 4;
+    nixlTelemetryStagingQueue queue(kCapacity);
+    for (uint64_t cycle = 0; cycle < 5; ++cycle) {
+        ASSERT_TRUE(queue.tryPush(makeEvent(cycle)));
+        ASSERT_EQ(queue.drainPending().size(), 1u);
+    }
+
+    for (uint64_t i = 0; i < kCapacity; ++i) {
+        EXPECT_TRUE(queue.tryPush(makeEvent(i)));
+    }
+    EXPECT_FALSE(queue.tryPush(makeEvent(kCapacity)));
+    EXPECT_EQ(queue.takeNumDropped(), 1u);
+    EXPECT_EQ(queue.drainPending().size(), kCapacity);
+}
+
+TEST(telemetryStagingQueueTest, DrainViewCarriesOnlyTheCurrentDrain) {
+    nixlTelemetryStagingQueue queue(4);
+    ASSERT_TRUE(queue.tryPush(makeEvent(1)));
+    ASSERT_TRUE(queue.tryPush(makeEvent(2)));
+    const auto first = queue.drainPending();
+    ASSERT_EQ(first.size(), 2u);
+
+    ASSERT_TRUE(queue.tryPush(makeEvent(3)));
+    const auto second = queue.drainPending();
+    ASSERT_EQ(second.size(), 1u);
+    EXPECT_EQ(second[0].value_, 3u);
+    EXPECT_NE(second.data(), first.data());
 }
 
 TEST(telemetryStagingQueueTest, TakeNumDroppedReturnsDeltaOnceThenZero) {
@@ -166,11 +221,11 @@ TEST(telemetryStagingQueueTest, ConcurrentProducersConserveEventSlots) {
     std::vector<nixlTelemetryEvent> drained;
     std::thread consumer([&]() {
         while (!done.load(std::memory_order_acquire)) {
-            auto pending = queue.takePending();
+            auto pending = queue.drainPending();
             drained.insert(drained.end(), pending.begin(), pending.end());
             std::this_thread::yield();
         }
-        auto pending = queue.takePending();
+        auto pending = queue.drainPending();
         drained.insert(drained.end(), pending.begin(), pending.end());
     });
 


### PR DESCRIPTION
## What?

`nixlTelemetryStagingQueue` allocated and freed one capacity-sized vector on every drain. It now keeps two capacity-reserved buffers and alternates them, so no allocation happens after construction.

The drain contract changes from an owning `std::vector` to a borrowed `std::span<const nixlTelemetryEvent>` valid until the next drain, and `takePending()` is renamed to `drainPending()`.

Capacity, drop-newest overflow, all-or-none batches, drop accounting, drain order and shutdown behaviour are unchanged.

## Why?

NIX-1641, from review feedback on the staging-queue extraction: the drain was the last allocation left in the telemetry event path, recurring once per flush interval for the life of the process. The drain is now constant work; it previously contained a fixed-size malloc/free pair whose latency depends on heap state rather than on how many events were staged.

It is also a prerequisite for NIX-1544 (low-lock queue): with a borrowed-view drain contract, that change can return a view straight over its retired buffer instead of copying into an owning vector, leaving it to be purely about removing the producer mutex.

<details>
<summary>How? — design, contract change, and validation</summary>

### What the drain used to cost

`takePending()` called `reserve(capacity_)` unconditionally, so every flush allocated a fixed 64 KiB (4096 events × 16 B at the default `NIXL_TELEMETRY_BUFFER_SIZE`) regardless of occupancy, and freed it when the returned vector died at the end of `flushPendingEvents()`. Both ends sat outside the critical section, so this never widened the window producers block on — the win is bounded, which is why the NIX-1544 prerequisite leads.

### Double buffering

The queue holds `live_` (producers append here) and `drained_` (handed to the consumer). The drain discards the previous drain's contents, swaps the two buffers, and returns a view over `drained_`:

    std::span<const nixlTelemetryEvent>
    nixlTelemetryStagingQueue::drainPending() {
        const std::lock_guard<std::mutex> lock(mutex_);
        drained_.clear();
        live_.swap(drained_);
        return drained_;
    }

Both vectors are `reserve()`d to capacity at construction. `clear()` keeps capacity, and `swap()` is a constant-time exchange of the two vectors' internals — no element is copied or moved — so steady state is allocation-free. Clearing before the swap (not after) is what keeps the previous drain's storage available for reuse as the next `live_`. The lock is held across the `return` so the span's pointer and size are captured in the same critical section as the swap.

Colin's original note suggested moving off `std::vector` to a raw buffer plus a `used` index. Kept as vectors deliberately: `nixlTelemetryEvent` is trivially destructible, so `clear()` is already just a size reset and `swap()` is already a constant-time pointer exchange — the raw buffer would add hand-managed storage for no measurable gain.

Residency grows from one to two capacity-sized buffers — 128 KiB at the default 4096-event capacity — in exchange for zero per-flush allocator traffic.

### Why the rename

The single call site is `nixlTelemetry::flushPendingEvents()`, which held the result in `auto`. A `std::span` binds to `auto` just as happily as a `vector` does, so keeping the name would have let the call site compile unchanged while silently acquiring the new lifetime rule. Renaming to `drainPending()` forces every call site to be looked at.

### Thread safety

Unchanged in structure: producers only ever mutate `live_`, always under the mutex, and the swap happens under the same mutex, so a producer never observes a buffer mid-swap and the unlock publishes their writes to the consumer.

The borrowed view is valid until the next drain, which is safe under the queue's documented single-consumer contract: the flush runs on a one-thread pool that re-arms only after the callback returns, so two drains cannot overlap; the destructor joins that pool before members are destroyed; and every exporter copies out of the `const &` rather than retaining a pointer into the span.

### Tests

The 13 existing queue unit tests are adapted to the new name and view return. Three were added for the properties that make this correct rather than merely working:

- `DrainAlternatesBetweenTwoBuffersWithoutReallocating` — exactly two distinct storage addresses across 200 drain cycles, which is the allocation-free proof;
- `CapacitySurvivesAlternatingDrains` — the logical capacity still holds after alternation (this is what fails if the `clear()` is dropped);
- `DrainViewCarriesOnlyTheCurrentDrain` — the second view is a different buffer carrying only the new events.

### Validation

- Staging-queue unit tests: 16/16 pass in the normal, TSan and UBSan builds, stable over `--gtest_repeat=5`.
- Telemetry gtest suites: 61/61 pass in the normal build, and 61/61 under both TSan and UBSan with no ThreadSanitizer warning and no UBSan runtime error.
- DOCA: `doca_test`, `doca_nixl_test`, `histogram_parity_test` and `telemetry_benchmark` pass against a local DOCA 3.3.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved telemetry event draining to reduce memory allocations and preserve buffer capacity.
  * Enhanced handling of concurrent telemetry collection and processing.

* **Reliability**
  * Ensured drained telemetry batches remain isolated while new events continue being collected.
  * Improved zero-capacity queue handling and predictable batch lifetimes.

* **Tests**
  * Added coverage for repeated draining, buffer reuse, capacity preservation, isolation, and concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->