### PR TITLE
EXAMPLES/DEVICE/EP/CSRC: Disabled UCX CUDA IPC cache.

### DIFF
--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1412,6 +1412,7 @@ void Buffer::_nixl_agent_init() {
     init_params["ucx_num_device_channels"] = num_channels_env ? num_channels_env : "4";
     init_params["ucx_error_handling_mode"] = "none";
     init_params["num_workers"] = std::to_string(1);
+    init_params["engine_config"] = "CUDA_IPC_CACHE=n";
 
     nixlBackendH* ucx_backend = nullptr;
     status = agent->createBackend("UCX", init_params, ucx_backend);


### PR DESCRIPTION
## What?
Disabled UCX CUDA IPC cache.

## Why?
The previous fix of memory leak (https://github.com/ai-dynamo/nixl/pull/1846) was reverted (https://github.com/ai-dynamo/nixl/pull/1996).

These changes (https://github.com/openucx/ucx/pull/11288, https://github.com/openucx/ucx/pull/11730) help eliminate the memory leak by disabling CUDA IPC cache.