### PR TITLE
CODERABBIT: Updated instructions to C++20.

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,6 @@ reviews:
     - "!subprojects/**"
   path_instructions:
     - path: "src/**/*.cpp"
-      instructions: "Follow docs/CodeStyle.md. C++17."
+      instructions: "Follow docs/CodeStyle.md. C++20."
     - path: "src/**/*.h"
-      instructions: "Follow docs/CodeStyle.md. C++17."
+      instructions: "Follow docs/CodeStyle.md. C++20."


### PR DESCRIPTION
## What?
Updated coderabbit instructions for C++ source files to C++20 instead of C++17.

## Why?
https://github.com/ai-dynamo/nixl/pull/1571