### PR TITLE
test/gtest: stop the inert-tracer test depending on NIXL_PLUGIN_DIR

### DIFF
--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -39,6 +39,8 @@ resolveTraceBackends(const std::optional<std::string> &explicit_spec, bool under
 
 namespace {
 
+constexpr const char *kUnloadableBackend = "definitely-not-a-backend";
+
 // Records the calls a single backend receives, so tests can assert that one
 // call site fanned out to every backend.
 struct CallLog {
@@ -317,7 +319,7 @@ TEST(Tracing, MakeTracerUnknownBackendReturnsNull) {
     {
         // No plugin exists for this backend, so it resolves to null with a warning.
         const gtest::LogIgnoreGuard ignore("requested but plugin");
-        const auto tracer = nixl::trace::makeTracer({"agent", {"definitely-not-a-backend"}});
+        const auto tracer = nixl::trace::makeTracer({"agent", {kUnloadableBackend}});
         EXPECT_EQ(tracer, nullptr);
     }
 
@@ -325,16 +327,15 @@ TEST(Tracing, MakeTracerUnknownBackendReturnsNull) {
     EXPECT_EQ(none, nullptr);
 }
 
-// The no-backend runtime path: a backend is requested but its plugin is not
-// available (no libtrace_backend_*.so is registered in this unit binary), so
-// makeTracer yields a null tracer. Call sites then fall back to a
-// default-constructed Span -- the stub path that does essentially nothing -- and
-// it must stay safe. NVTX's functional coverage lives in the e2e transfer tests,
-// which load the real plugin.
+// The no-backend runtime path: a backend is requested but no plugin provides
+// it, so makeTracer yields a null tracer. Call sites then fall back to a
+// default-constructed Span -- the stub path that does essentially nothing --
+// and it must stay safe. NVTX's functional coverage lives in the e2e transfer
+// tests, which load the real plugin.
 TEST(Tracing, RequestedBackendWithoutPluginIsInert) {
     {
         const gtest::LogIgnoreGuard ignore("requested but plugin");
-        const auto tracer = nixl::trace::makeTracer({"stub_agent", {"nvtx"}});
+        const auto tracer = nixl::trace::makeTracer({"stub_agent", {kUnloadableBackend}});
         EXPECT_EQ(tracer, nullptr);
     }
 


### PR DESCRIPTION
## What?

`Tracing.RequestedBackendWithoutPluginIsInert` asked `makeTracer` for the `nvtx` backend and expected a null tracer. It now asks for a backend name no plugin can provide, matching what the sibling test `Tracing.MakeTracerUnknownBackendReturnsNull` already did; the name lives in one `kUnloadableBackend` constant used by both.

## Why?

The old assertion rested on a property of the *environment*, not of the code: its own comment said "no `libtrace_backend_*.so` is registered in this unit binary". Whenever a real `libtrace_backend_nvtx.so` is discoverable, the plugin loads, `makeTracer` correctly returns a live tracer, and the test fails. That is the case in the dev container, where `NIXL_PLUGIN_DIR` points at an install tree containing the NVTX trace plugin, and it would be the case in any CI leg that installs NIXL before running the `unit` suite.

The test has been permanently red locally for weeks and was written off as "pre-existing, unrelated" in the validation notes of three telemetry PRs (#1952, #2054, #2086). Beyond the recurring explanation, a genuine regression in the null-tracer / inert-`Span` path would have been indistinguishable from the known-red state.

Coverage is unchanged: this test exists to prove that a null tracer leaves call sites on the safe default-constructed `Span` path, which never required NVTX specifically. Real NVTX behaviour stays covered by the e2e `TestTransferTracing` tests, which load the actual plugin.

Tracking: NIX-1710.

<details>
<summary>Rejected alternative, and verification</summary>

Clearing `NIXL_PLUGIN_DIR` inside the test via the existing `gtest::ScopedEnv` helper does not work reliably: `getPluginDir()` is read once in the `nixlPluginManager` constructor and cached in `plugin_dirs_` for the process lifetime, so the outcome would depend on whether an earlier test in the binary already touched the plugin manager.

Verified both directions with the container's default `NIXL_PLUGIN_DIR`, i.e. with no workaround applied:

- Baseline (this change stashed, rebuilt): exactly one failure, `RequestedBackendWithoutPluginIsInert`, reporting a live tracer pointer where `nullptr` was expected.
- With the change: all 17 `Tracing.*` tests pass, and the full `unit` suite is 157 passed / 2 skipped / 3 failed — the three failures being `objCrtTestFixture.TransferBelowThreshold` and the two `ObjClientTests/objParamTestFixture.ReadTransfer` params, which need an object-storage endpoint this container does not provide.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved tracing plugin-loading tests to consistently cover environments where the requested backend is unavailable.
  * Updated inert-tracer coverage to validate behavior when no tracing plugin can be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->