### PR TITLE
libfabric: disable shm provider on Neuron hosts

### DIFF
--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -29,6 +29,21 @@
 #include <stdexcept>
 #include <stack>
 
+namespace {
+
+// Whether libfabric's shared memory (shm) provider can move data for an HMEM runtime.
+//
+// shm has no Neuron HMEM support. Every other runtime keeps shm, so that intra-node
+// transfers retain its acceleration.
+//
+// Update this when a runtime's shm support changes.
+bool
+shmProviderSupportsRuntime(enum fi_hmem_iface runtime) {
+    return runtime != FI_HMEM_NEURON;
+}
+
+} // namespace
+
 // RequestPool Base Class Implementation
 
 RequestPool::RequestPool(size_t pool_size, size_t rail_id)
@@ -391,13 +406,15 @@ DataRequestPool::allocate(nixlLibfabricReq::OpType op_type, uint32_t req_id) {
 
 nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
                                      const std::string &provider,
-                                     uint16_t id)
+                                     uint16_t id,
+                                     enum fi_hmem_iface runtime)
     : rail_id(id),
       device_name(device),
       provider_name(provider),
       control_request_pool_(NIXL_LIBFABRIC_CONTROL_REQUESTS_PER_RAIL, id),
       data_request_pool_(NIXL_LIBFABRIC_DATA_REQUESTS_PER_RAIL, id),
-      provider_supports_hmem_(false) {
+      provider_supports_hmem_(false),
+      runtime_(runtime) {
     // Initialize all pointers to nullptr
     info = nullptr;
     fabric = nullptr;
@@ -527,6 +544,26 @@ nixlLibfabricRail::nixlLibfabricRail(const std::string &device,
         if (ret) {
             NIXL_ERROR << "fi_ep_bind av failed for rail " << rail_id << ": " << fi_strerror(-ret);
             throw std::runtime_error("fi_ep_bind av failed for rail " + std::to_string(rail_id));
+        }
+
+        // On runtimes the shm provider cannot serve, disable it so that intra-node
+        // transfers stay on the EFA path.
+        if (!shmProviderSupportsRuntime(runtime_)) {
+            const bool shared_memory_permitted = false;
+            ret = fi_setopt(&endpoint->fid,
+                            FI_OPT_ENDPOINT,
+                            FI_OPT_SHARED_MEMORY_PERMITTED,
+                            &shared_memory_permitted,
+                            sizeof(shared_memory_permitted));
+            if (ret) {
+                NIXL_ERROR << "fi_setopt FI_OPT_SHARED_MEMORY_PERMITTED failed for rail " << rail_id
+                           << " (provider: " << provider_name << "): " << fi_strerror(-ret);
+                throw std::runtime_error(
+                    "fi_setopt FI_OPT_SHARED_MEMORY_PERMITTED failed for rail " +
+                    std::to_string(rail_id));
+            }
+            NIXL_INFO << "Disabled shared memory provider for rail " << rail_id
+                      << " (runtime has no shm support)";
         }
 
         if (provider_name == "efa") {

--- a/src/utils/libfabric/libfabric_rail.h
+++ b/src/utils/libfabric/libfabric_rail.h
@@ -400,7 +400,10 @@ public:
     struct fid_ep *endpoint; ///< Libfabric endpoint handle
 
     /** Initialize libfabric rail with all resources */
-    nixlLibfabricRail(const std::string &device, const std::string &provider, uint16_t id);
+    nixlLibfabricRail(const std::string &device,
+                      const std::string &provider,
+                      uint16_t id,
+                      enum fi_hmem_iface runtime);
 
     /** Destroy rail and cleanup all libfabric resources */
     ~nixlLibfabricRail();
@@ -600,6 +603,9 @@ private:
 
     // Provider capability flags
     bool provider_supports_hmem_;
+
+    // System runtime type (CUDA, NEURON, or SYSTEM) this rail was created for
+    enum fi_hmem_iface runtime_;
 
     void
     pollForCompletions();

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -351,7 +351,7 @@ nixlLibfabricRailManager::createRails(const std::vector<std::string> &efa_device
 
         for (size_t i = 0; i < num_rails_; ++i) {
             rails_.emplace_back(std::make_unique<nixlLibfabricRail>(
-                efa_devices[i], provider_name, static_cast<uint16_t>(i)));
+                efa_devices[i], provider_name, static_cast<uint16_t>(i), runtime_));
 
             // Initialize EFA device mapping
             efa_device_to_rail_map[efa_devices[i]] = i;


### PR DESCRIPTION
## What?
Pass the detected system runtime (`fi_hmem_iface`) into `nixlLibfabricRail` and, when it is `FI_HMEM_NEURON`, call `fi_setopt` with `FI_OPT_SHARED_MEMORY_PERMITTED = false` on each rail's endpoint so intra-node transfers stay on the EFA path.

## Why?
The libfabric shm provider has no Neuron HMEM support. On Neuron hosts, libfabric can pick the shm provider for intra-node transfers, which cannot handle Neuron device memory.

## How?
- `nixlLibfabricRail` ctor takes an extra `enum fi_hmem_iface runtime` argument, stored as `runtime_`.
- `nixlLibfabricRailManager::createRails()` forwards its existing `runtime_` member when constructing each rail.
- After `fi_ep_bind` of the AV, Neuron rails call `fi_setopt(FI_OPT_SHARED_MEMORY_PERMITTED, false)` to disable shm provider.
- Rail creation is never failed by this: providers that do not implement the option return `-FI_ENOSYS`/`-FI_ENOPROTOOPT`, which we warn about and continue past.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accelerator-aware libfabric initialization by disabling shared-memory transfers when unsupported by the detected runtime.
  * Initialization failures related to shared-memory configuration are now logged clearly and stop setup instead of proceeding with an invalid configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->