### PR TITLE
CI: Replace Blue Ocean with pipeline-overview URL

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -23,16 +23,15 @@
 def matrix = new com.mellanox.cicd.Matrix()
 
 def githubHelper = null
-def blueOceanUrl = ""
+def pipelineOverviewUrl = ""
 
 import ipp.blossom.*
 if (params.githubData) {
     withCredentials([usernamePassword(credentialsId: 'svc-nixl-github-token', passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
         githubHelper = GithubHelper.getInstance("${GIT_PASSWORD}", params.githubData)
     }
-    def blueOceanJobPath = env.JOB_NAME.replace('/', '%2F')
-    blueOceanUrl = "${JENKINS_URL}blue/organizations/jenkins/${blueOceanJobPath}/detail/${env.JOB_BASE_NAME}/${env.BUILD_NUMBER}/pipeline/"
-    githubHelper.updateCommitStatus(blueOceanUrl, "Test started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
+    pipelineOverviewUrl = "${env.BUILD_URL}/pipeline-overview/"
+    githubHelper.updateCommitStatus(pipelineOverviewUrl, "Test started", GitHubCommitState.PENDING, env.JOB_BASE_NAME)
     currentBuild.description = githubHelper.getBuildDescription()
 } else if (params.UCX_VER) {
     // Non-PR run (nightly orchestrator or manual) - label it by the UCX ref under test
@@ -71,7 +70,7 @@ try {
 } finally {
     if (params.githubData) {
         githubHelper.updateCommitStatus(
-            blueOceanUrl,
+            pipelineOverviewUrl,
             "Test completed",
             currentBuild.resultIsBetterOrEqualTo('SUCCESS') ? GitHubCommitState.SUCCESS : GitHubCommitState.FAILURE,
             env.JOB_BASE_NAME

--- a/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
@@ -79,10 +79,10 @@ if (currentPrNumber) {
   }
 }
 
-def blueOceanJobPath = env.JOB_NAME.replace('/', '%2F')
-def blueOceanUrl = "${JENKINS_URL}blue/organizations/jenkins/${blueOceanJobPath}/detail/${env.JOB_BASE_NAME}/${env.BUILD_NUMBER}/pipeline/"
+def pipelineOverviewUrl = "${env.BUILD_URL}/pipeline-overview/"
+
 // Update GitHub commit status
-githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI started", GitHubCommitState.PENDING)
+githubHelper.updateCommitStatus(pipelineOverviewUrl, "NIXL CI started", GitHubCommitState.PENDING)
 currentBuild.description = githubHelper.getBuildDescription()
 
 // Leaf jobs to dispatch, keyed by parallel-branch name
@@ -115,9 +115,9 @@ try {
         }]
     })
 
-    githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.SUCCESS)
+    githubHelper.updateCommitStatus(pipelineOverviewUrl, "NIXL CI ended", GitHubCommitState.SUCCESS)
 } catch(Exception ex) {
     println ex
-    githubHelper.updateCommitStatus(blueOceanUrl, "NIXL CI ended", GitHubCommitState.FAILURE)
+    githubHelper.updateCommitStatus(pipelineOverviewUrl, "NIXL CI ended", GitHubCommitState.FAILURE)
     throw ex
 }


### PR DESCRIPTION
## What?
Replace GitHub commit status links to point to Jenkins' pipeline-overview page instead of Blue Ocean UI.

## Why?
Blue Ocean plugin is deprecated

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build status links to open the Jenkins Pipeline Overview page instead of the deprecated Blue Ocean view.
  * Ensured pending, successful, and failed build statuses reference the correct pipeline URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->