### PR TITLE
Disable cmake install skip based on mtime

### DIFF
--- a/.ci/dockerfiles/Dockerfile.rocm
+++ b/.ci/dockerfiles/Dockerfile.rocm
@@ -78,6 +78,14 @@ ENV PIP_CERT=${SYSTEM_CA_BUNDLE} \
 # libgrpc_plugin_support.so from /opt/nixl/lib. Every stage inherits this ENV.
 ENV LD_LIBRARY_PATH="${NIXL_INSTALL_DIR}/lib:${NIXL_INSTALL_DIR}/lib64:/usr/local/lib:/usr/local/lib64"
 
+# Force CMake to always copy files in install directives, rather than skip based on file modification timestamp.
+# File modification timestamp check in CMake uses 1 second resolution.
+# This causes problems for fast builds that install, patch then reinstall the same file, as the final install step
+# may be incorrectly skipped.
+# Seen in CI as flaky ASAN failure due to inconsistent Azure SDK headers causing memory corruption.
+# Inherited by every *-build stage and `final`.
+ENV CMAKE_INSTALL_ALWAYS=1
+
 # Some ROCm base images ship broken cmake configs for these.
 RUN rm -rf /usr/lib/cmake/grpc /usr/lib/cmake/protobuf
 

--- a/.gitlab/build-rocm.sh
+++ b/.gitlab/build-rocm.sh
@@ -23,6 +23,13 @@ set -e
 set -x
 set -o pipefail
 
+# Force CMake to always copy files in install directives, rather than skip based on file modification timestamp.
+# File modification timestamp check in CMake uses 1 second resolution.
+# This causes problems for fast builds that install, patch then reinstall the same file, as the final install step
+# may be incorrectly skipped.
+# Seen in CI as flaky ASAN failure due to inconsistent Azure SDK headers causing memory corruption.
+export CMAKE_INSTALL_ALWAYS=1
+
 # Parse commandline arguments with first argument being the install directory
 # and second argument being the UCX installation directory.
 # Source dependency options grouped with dep download/build/install steps.

--- a/.gitlab/build.sh
+++ b/.gitlab/build.sh
@@ -21,6 +21,13 @@ set -e
 set -x
 set -o pipefail
 
+# Force CMake to always copy files in install directives, rather than skip based on file modification timestamp.
+# File modification timestamp check in CMake uses 1 second resolution.
+# This causes problems for fast builds that install, patch then reinstall the same file, as the final install step
+# may be incorrectly skipped.
+# Seen in CI as flaky ASAN failure due to inconsistent Azure SDK headers causing memory corruption.
+export CMAKE_INSTALL_ALWAYS=1
+
 # Parse commandline arguments with first argument being the install directory
 # and second argument being the UCX installation directory.
 INSTALL_DIR=$1

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -108,6 +108,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
 
 WORKDIR /workspace
 
+# Force CMake to always copy files in install directives, rather than skip based on file modification timestamp.
+# File modification timestamp check in CMake uses 1 second resolution.
+# This causes problems for fast builds that install, patch then reinstall the same file, as the final install step
+# may be incorrectly skipped.
+# Seen in CI as flaky ASAN failure due to inconsistent Azure SDK headers causing memory corruption.
+ENV CMAKE_INSTALL_ALWAYS=1
+
 # Build Abseil from source (required for absl/log).
 RUN git clone https://github.com/abseil/abseil-cpp.git && \
     cd abseil-cpp && \

--- a/contrib/Dockerfile.manylinux
+++ b/contrib/Dockerfile.manylinux
@@ -66,6 +66,15 @@ ENV PATH=/opt/rh/gcc-toolset-14/root/usr/bin:${PATH} \
 # cmake_minimum_required(VERSION < 3.5). Some bundled deps (e.g. gRPC's c-ares)
 # still declare ancient minimums. This tells CMake 4.x to accept them.
 ENV CMAKE_POLICY_VERSION_MINIMUM=3.5
+
+# Force CMake to always copy files in install directives, rather than skip based on file modification timestamp.
+# File modification timestamp check in CMake uses 1 second resolution.
+# This causes problems for fast builds that install, patch then reinstall the same file, as the final install step
+# may be incorrectly skipped.
+# Seen in CI as flaky ASAN failure due to inconsistent Azure SDK headers causing memory corruption.
+# Inherited by the wheel stage below via FROM $wheel_base.
+ENV CMAKE_INSTALL_ALWAYS=1
+
 # === end Option B header ======================================================
 ARG LIBFABRIC_VERSION="v1.21.0"
 ARG HWLOC_VERSION="2.12.2"


### PR DESCRIPTION
## What?
Disable CMake optimization to skip install step based on file modification timestamp

## Why?
CMake optimization to skip install step based on mtime uses 1 second resolution timestamps.

Complex CMake scripts sometimes have directives with the pattern:
- install file
- patch file
- install same file again

The 2nd install step may be skipped if the build machine is very fast and is executed less than 1 second after the first install step. This results into incorrect installation.

[Seen in CI](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/blue/organizations/jenkins/nixl-ci-test-sanitizers/detail/nixl-ci-test-sanitizers/760/pipeline/242/) in Azure SDK installation from source, that sometimes causes inconsistent headers to be installed, with different values of RTTI macro, resulting in memory corruption in the Azure storage plugin init/destroy.

## How?
Set [CMAKE_INSTALL_ALWAYS=1](https://github.com/Kitware/CMake/blob/f0952e573f5557b61847f8ee60641d51b36ef352/Source/cmFileInstaller.cxx#L32) which turns off the mtime-based install skip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by ensuring installation steps consistently copy generated files, even when timestamps have not changed.
  * Reduced the risk of incomplete or stale artifacts in standard, ROCm, Docker, and manylinux builds.

* **Chores**
  * Applied consistent installation behavior across supported container and package build environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->