### PR TITLE
ci: list pushed image URLs in build-container completion mail

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -185,6 +185,8 @@ their own nightly/manual trigger. They split into two groups:
 ### `nixl-ci-build-container` (standalone)
 - **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the DLFW PyTorch daily image, ~3–4 AM), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).
 - **What it does:** Builds and pushes x86_64/aarch64 NIXL/NIXLBench container images to Artifactory, then sets build metadata properties on each image via the Artifactory REST API. The Push step runs with `set -eo pipefail` so auth or API failures abort the build immediately.
+- **Image tag:** `pipeline_start` resolves the NIXL and UCX commits once (`NIXL_SHA`, `UCX_SHA`) and exports `IMAGE_TAG_BASE`; both arches build from those exact commits and tag from that base, and `pipeline_stop` reuses it to name the images. Previously each arch re-resolved UCX independently, so a branch moving mid-build could ship two arches from different UCX commits under one tag.
+- **Completion mail:** When `MAIL_TO` is set, `pipeline_stop` mails the build result, listing the pushed image URLs (and the `-latest` tags when `UPDATE_LATEST`) so the verification team can pull them directly. The list is included only on `SUCCESS` — a failed run may not have pushed, and a link to a missing image is worse than no link.
 - **Automatic on every PR:** No — standalone/nightly + manual only.
 
 ### `nixl-ci-build-wheel-nightly` (standalone)

--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -64,10 +64,18 @@ pipeline_start:
     if (params.UCX_VERSION ==~ /^[a-f0-9]{8,40}$/) {
       env.UCX_SHA = params.UCX_VERSION.take(8)
     } else {
+      // Single-quoted, so UCX_VERSION reaches git as an argument via the
+      // environment rather than as shell source.
       env.UCX_SHA = sh(
         returnStdout: true,
-        label: "Resolve UCX ${params.UCX_VERSION}",
-        script: "git ls-remote https://github.com/openucx/ucx.git '${params.UCX_VERSION}' | head -n1 | cut -c1-8"
+        label: 'Resolve UCX ref',
+        script: '''
+          REFS=$(git ls-remote https://github.com/openucx/ucx.git "$UCX_VERSION" "$UCX_VERSION^{}")
+          # An annotated tag lists both the tag object and the peeled commit; take the commit.
+          SHA=$(echo "$REFS" | awk 'index($2,"^"){print $1; exit}')
+          [ -n "$SHA" ] || SHA=$(echo "$REFS" | awk 'NR==1{print $1}')
+          echo "$SHA" | cut -c1-8
+        '''
       ).trim()
     }
     if (!env.UCX_SHA) {

--- a/.ci/jenkins/lib/build-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-container-matrix.yaml
@@ -57,10 +57,28 @@ pipeline_start:
     currentBuild.displayName += "-${buildName}-${params.NIXL_VERSION}-${params.UCX_VERSION}${suffix}"
     env.ENABLE_NIXL_BUILD = params.BUILD_TARGET == 'nixl' ? 'true' : 'false'
     env.ENABLE_NIXLBENCH_BUILD = params.BUILD_TARGET == 'nixlbench' ? 'true' : 'false'
+
+    // Resolve the NIXL/UCX commits once, here, so both arches build and tag the
+    // exact same sources and pipeline_stop can name the images in the mail.
+    env.NIXL_SHA = env.GIT_COMMIT.take(8)
+    if (params.UCX_VERSION ==~ /^[a-f0-9]{8,40}$/) {
+      env.UCX_SHA = params.UCX_VERSION.take(8)
+    } else {
+      env.UCX_SHA = sh(
+        returnStdout: true,
+        label: "Resolve UCX ${params.UCX_VERSION}",
+        script: "git ls-remote https://github.com/openucx/ucx.git '${params.UCX_VERSION}' | head -n1 | cut -c1-8"
+      ).trim()
+    }
+    if (!env.UCX_SHA) {
+      error("Failed to resolve UCX_VERSION=${params.UCX_VERSION}")
+    }
+    env.IMAGE_TAG_BASE = "${params.BASE_IMAGE_TAG}-nixl-${env.NIXL_SHA}-ucx-${env.UCX_SHA}"
     echo "ENABLE_NIXL_BUILD: ${env.ENABLE_NIXL_BUILD}"
     echo "ENABLE_NIXLBENCH_BUILD: ${env.ENABLE_NIXLBENCH_BUILD}"
     echo "BUILD_TARGET: ${params.BUILD_TARGET}"
     echo "BUILD_NIXL_EP: ${params.BUILD_NIXL_EP}"
+    echo "IMAGE_TAG_BASE: ${env.IMAGE_TAG_BASE}"
 
 # Build pipeline
 steps:
@@ -92,7 +110,7 @@ steps:
     run: |
       # Clone UCX source for nixlbench
       git clone https://github.com/openucx/ucx.git ucx-src
-      git -C ucx-src checkout "${UCX_VERSION}"
+      git -C ucx-src checkout "${UCX_SHA}"
 
       "benchmark/nixlbench/contrib/build.sh" \
         --base-image "${BASE_IMAGE}" \
@@ -108,7 +126,7 @@ steps:
     enable: ${ENABLE_NIXL_BUILD}
     containerSelector: "{name: 'podman'}"
     run: |
-      export UCX_REF="${UCX_VERSION}"
+      export UCX_REF="${UCX_SHA}"
 
       NIXL_EP_FLAG=""
       if [[ "${BUILD_NIXL_EP}" == "true" ]]; then
@@ -128,33 +146,15 @@ steps:
   - name: Add Version Info
     containerSelector: "{name: 'podman'}"
     run: |
-      git config --global --add safe.directory '*'
-      # Extract standardized 8-char commit hash for UCX version info:
-      if [[ "$BUILD_TARGET" == "nixlbench" ]]; then
-        CLEAN_UCX=$(cd "$WORKSPACE/ucx-src" && git rev-parse --short=8 HEAD)
-      else
-        UCX_REF="$UCX_VERSION"
-
-        # Hash? if yes truncate, else ls-remote then truncate
-        if [[ "$UCX_REF" =~ ^[a-f0-9]{8,40}$ ]]; then
-          CLEAN_UCX="${UCX_REF:0:8}"
-        else
-          CLEAN_UCX=$(git ls-remote https://github.com/openucx/ucx.git "$UCX_REF" | head -n1 | cut -c1-8)
-        fi
-
-        # Verify
-        [[ -n "$CLEAN_UCX" ]] || { echo "ERROR: failed to resolve UCX_REF=$UCX_REF"; exit 1; }
-      fi
-
-      # Calculate tag name
-      NIXL_VERSION="$(git rev-parse --short=8 HEAD)"
-      TAG_NAME="${BASE_IMAGE_TAG}-nixl-${NIXL_VERSION}-ucx-${CLEAN_UCX}-${arch}${TAG_SUFFIX:+-${TAG_SUFFIX}}"
+      # NIXL_SHA/UCX_SHA/IMAGE_TAG_BASE are resolved once in pipeline_start, so the
+      # tag here matches the one pipeline_stop reports in the completion mail.
+      TAG_NAME="${IMAGE_TAG_BASE}-${arch}${TAG_SUFFIX:+-${TAG_SUFFIX}}"
 
       # Generate version info file from template
       export BUILD_TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
              BUILD_TARGET BASE_IMAGE BASE_IMAGE_TAG arch \
              BUILD_NUMBER BUILD_URL JOB_NAME NODE_NAME WORKSPACE \
-             NIXL_VERSION UCX_VERSION="${CLEAN_UCX}" TAG_NAME
+             NIXL_VERSION="${NIXL_SHA}" UCX_VERSION="${UCX_SHA}" TAG_NAME
       envsubst < .ci/assets/nixl-version-info.template > version-info
 
       # Add version info to the image
@@ -228,6 +228,23 @@ pipeline_stop:
 
         def userName = currentBuild.rawBuild.getCause(hudson.model.Cause.UserIdCause)?.userName ?: 'schedule'
 
+        // Only list the images on SUCCESS - a failed run may not have pushed them,
+        // and a link to a missing image is worse than no link.
+        def imagesSection = ''
+        if (jobStatus == 'SUCCESS') {
+            def suffix = params.TAG_SUFFIX ? "-${params.TAG_SUFFIX}" : ""
+            def repo = "${env.ARTIFACTORY_REGISTRY_URL}/${params.BUILD_TARGET}"
+            def images = []
+            for (arch in ['x86_64', 'aarch64']) {
+                images << "${repo}:${env.IMAGE_TAG_BASE}-${arch}${suffix}"
+                if (params.UPDATE_LATEST) {
+                    images << "${repo}:${params.BASE_IMAGE_TAG}-${arch}-latest"
+                }
+            }
+            def imageList = images.collect { "<li>${it}</li>" }.join('')
+            imagesSection = "<p>Images:</p><ul>${imageList}</ul>"
+        }
+
         mail(
             from: env.MAIL_FROM,
             to: params.MAIL_TO,
@@ -246,6 +263,7 @@ pipeline_stop:
                 <p>Architectures: <b>x86_64, aarch64</b></p>
                 ${params.UPDATE_LATEST ? '<p>Latest tag updated: <b>Yes</b></p>' : ''}
                 ${params.BUILD_NIXL_EP ? "<p>Build NIXL EP: <b>Yes</b></p>" : ''}
+                ${imagesSection}
             """
         )
     }


### PR DESCRIPTION
The verification team consumes the containers `nixl-ci-build-container` publishes. `nixl-ci-build-llm-container` already names its images in the completion mail; this brings the same behaviour to `nixl-ci-build-container`.

The image tag was resolved per-arch inside the matrix pods, so `pipeline_stop` had no way to know it. The tag resolution moves to `pipeline_start` instead, where it happens once and is shared by both the build steps and the mail.

- `pipeline_start` resolves the NIXL commit (from ci-demo's `GIT_COMMIT`) and the UCX commit (one `git ls-remote`, or truncation when `UCX_VERSION` is already a hash), and exports `NIXL_SHA`, `UCX_SHA` and `IMAGE_TAG_BASE`.
- `Add Version Info` consumes `IMAGE_TAG_BASE` instead of re-deriving both SHAs per arch, dropping ~18 lines.
- Both build steps now use `UCX_SHA` rather than re-resolving `UCX_VERSION`. Each arch cloned UCX independently before, so a branch moving mid-build could ship two arches built from different UCX commits under a single tag.
- `pipeline_stop` lists the pushed image URLs, plus the `-latest` tags when `UPDATE_LATEST` is set. The list is included only on `SUCCESS` — a failed run may not have pushed, and a link to a missing image is worse than no link.
- `.ci/docs/ci-overview.md` updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that NIXL and UCX revisions are resolved once per build and reused across architectures.
  - Documented image tag generation and successful completion emails with pushed image URLs and optional latest tags.

- **Bug Fixes**
  - Improved build consistency by centralizing revision metadata and validating UCX revision resolution.
  - Ensured successful-build emails include the appropriate image tags and are not sent for failed builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->