### PR TITLE
PLUGINS/UCX: close endpoints synchronously in disconnect() to avoid reconnect race

### DIFF
--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -868,6 +868,16 @@ nixl_status_t nixlUcxEngine::disconnect(const std::string &remote_agent) {
         return NIXL_ERR_NOT_FOUND;
     }
 
+    // Close and wait before erasing, to avoid racing add_remote_agent().
+    auto &conn = it->second;
+    for (size_t wid = 0; wid < workers_.size(); wid++) {
+        nixl_status_t status = conn->getEp(wid)->closeSync(workers_[wid]->get());
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to close endpoint for " << remote_agent << " (worker " << wid
+                       << "): " << status;
+        }
+    }
+
     // thread safety?
     remoteConnMap.erase(it);
     return NIXL_SUCCESS;

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -160,6 +160,60 @@ nixlUcxEp::closeImpl() {
     std::terminate();
 }
 
+nixl_status_t
+nixlUcxEp::closeSync(ucp_worker_h worker) {
+    ucs_status_ptr_t request = nullptr;
+    const nixl::ucx::ep_state_t current_state = state_;
+    const ucp_request_param_t req_param = {.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS,
+                                           .flags = closeFlags_};
+
+    switch (current_state) {
+    case nixl::ucx::ep_state_t::UNINITIALIZED:
+        // The EP has not been connected.
+        // Nothing to do.
+        NIXL_ASSERT(eph == nullptr);
+        return NIXL_SUCCESS;
+    case nixl::ucx::ep_state_t::FAILED: {
+        const ucp_request_param_t force_req_param = {
+            .op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS,
+            .flags = UCP_EP_CLOSE_FLAG_FORCE,
+        };
+        request = ucp_ep_close_nbx(eph, &force_req_param);
+        if (UCS_PTR_IS_PTR(request)) {
+            ucp_request_free(request);
+        }
+        eph = nullptr;
+        return NIXL_ERR_REMOTE_DISCONNECT;
+    }
+    case nixl::ucx::ep_state_t::CONNECTED:
+        request = ucp_ep_close_nbx(eph, &req_param);
+        if (request == nullptr) {
+            eph = nullptr;
+            setState(nixl::ucx::ep_state_t::UNINITIALIZED);
+            return NIXL_SUCCESS;
+        }
+
+        if (UCS_PTR_IS_ERR(request)) {
+            eph = nullptr;
+            setState(nixl::ucx::ep_state_t::UNINITIALIZED);
+            return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
+        }
+
+        ucs_status_t status;
+        do {
+            ucp_worker_progress(worker);
+            status = ucp_request_check_status(request);
+        } while (status == UCS_INPROGRESS);
+        ucp_request_free(request);
+
+        eph = nullptr;
+        setState(nixl::ucx::ep_state_t::UNINITIALIZED);
+        return nixl::ucx::ucsToNixlStatus(status);
+    }
+    NIXL_FATAL << "Invalid endpoint state: " << current_state;
+    std::terminate();
+}
+
 nixlUcxEp::nixlUcxEp(ucp_worker_h worker,
                      void *addr,
                      ucp_err_handling_mode_t err_handling_mode,

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -78,6 +78,10 @@ public:
     nixlUcxEp &
     operator=(const nixlUcxEp &) = delete;
 
+    // Like closeImpl(), but waits for the close to complete.
+    nixl_status_t
+    closeSync(ucp_worker_h worker);
+
     using am_cleanup_t = std::function<void(void *request, void *buffer)>;
 
     /* Active message handling */


### PR DESCRIPTION
`remove_remote_agent()` immediately followed by `add_remote_agent()` for the same peer intermittently fails with `NIXL_ERR_REMOTE_DISCONNECT` / `UCS_ERR_CONNECTION_RESET`.

This happens in Ray's RDT `nixl_tensor_transport.py`: when a remote agent's cached metadata version is stale (because the sender deregistered memory), the receiver evicts and re-adds that agent to pick up the new metadata — with no delay between the two calls.

**Root cause**

`nixlUcxEp::closeImpl()` closes the UCX endpoint fire-and-forget: it calls `ucp_ep_close_nbx()` and immediately `ucp_request_free()`s the request without waiting for completion. If `add_remote_agent()` creates a new endpoint to the same peer before the old endpoint's close has actually completed on the wire, the peer can still be processing the old close when the new connection attempt arrives, causing `UCS_ERR_CONNECTION_RESET`.

**Fix**

Add `nixlUcxEp::closeSync()`, which closes the endpoint and busy-waits (`ucp_worker_progress()` + `ucp_request_check_status()`) until the close actually completes. `nixlUcxEngine::disconnect()` now calls it explicitly on each endpoint before erasing the connection from `remoteConnMap`, since `nixlUcxConnection` is refcounted and erasing it doesn't guarantee `~nixlUcxEp()` runs synchronously.

**Testing**

Verified against a CPU→16×GPU scatter benchmark via Ray's RDT NIXL transport, which reliably crashed within 1-2 iterations on unmodified `main` (9824e1cb) and on v1.3.0/v1.4.0. With this fix applied, the same benchmark passes consistently across multiple runs.
