### PR TITLE
PLUGINS/UCX: apply a CUDA context on the progress threads

### DIFF
--- a/src/plugins/ucx/meson.build
+++ b/src/plugins/ucx/meson.build
@@ -38,12 +38,22 @@ ucx_backend_dependencies = [asio_dep,
 ucx_backend_include_directories = [nixl_inc_dirs,
                                    utils_inc_dirs]
 
+ucx_backend_compile_flags = []
+
+# The progress threads must re-apply a CUDA context before driving UCX transports that call into
+# the CUDA driver (see nixlUcxEngine::vramApplyCtx).
+if cuda_dep.found()
+    ucx_backend_dependencies += [cuda_dep]
+    ucx_backend_compile_flags += ['-DHAVE_CUDA']
+endif
+
 if 'UCX' in static_plugins
     ucx_backend_lib = static_library('UCX',
                ucx_backend_sources,
                dependencies: ucx_backend_dependencies,
                include_directories: ucx_backend_include_directories,
                install: false,
+               cpp_args : ucx_backend_compile_flags,
                name_prefix: 'libplugin_')  # Custom prefix for plugin libraries
 else
     ucx_backend_lib = shared_library('UCX',
@@ -51,7 +61,7 @@ else
                dependencies: ucx_backend_dependencies,
                include_directories: ucx_backend_include_directories,
                install: true,
-               cpp_args : ['-fPIC'],
+               cpp_args : ['-fPIC'] + ucx_backend_compile_flags,
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries
                install_dir: plugin_install_dir,
                build_rpath: get_option('ucx_path') != '' ? get_option('ucx_path') + '/lib' : '',

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -33,6 +33,10 @@
 #include "absl/strings/str_split.h"
 #include <asio.hpp>
 
+#ifdef HAVE_CUDA
+#include <cuda.h>
+#endif
+
 namespace {
 [[nodiscard]] uint32_t
 epCloseFlags(const nixl_b_params_t *custom_params) {
@@ -276,6 +280,11 @@ protected:
     virtual void
     run() = 0;
 
+    const nixlUcxEngine *
+    getEngine() const noexcept {
+        return engine_;
+    }
+
 private:
     const nixlUcxEngine *engine_;
     std::vector<nixlUcxWorker *> workers_;
@@ -330,6 +339,10 @@ protected:
         bool timeout = true;
         bool pthr_stop = false;
         while (!pthr_stop) {
+            /* progressLoop() and arm() reach the CUDA driver through UCX's cuda_copy transport,
+             * which needs a current context on this thread. */
+            getEngine()->vramApplyCtx();
+
             for (size_t i = 0; i < pollFds_.size() - 1; i++) {
                 if (!(pollFds_[i].revents & POLLIN) && !timeout) continue;
                 pollFds_[i].revents = 0;
@@ -608,6 +621,10 @@ protected:
         NIXL_DEBUG << "dedicated " << *this << " running";
 
         while (!io_.stopped()) {
+            /* status() below drives progressLoop(), which reaches the CUDA driver through UCX's
+             * cuda_copy transport and needs a current context on this thread. */
+            getEngine()->vramApplyCtx();
+
             if (!requests_.empty()) {
                 io_.poll_one();
             } else {
@@ -823,6 +840,98 @@ nixlUcxEngine::nixlUcxEngine(const nixlBackendInitParams &init_params, size_t nu
     auto &worker = workers_.front();
     workerAddr = worker->epAddr();
     worker->regAmCallback(nixl::ucx::am_cb_op_t::NOTIF_STR, notifAmCb, this);
+
+    /* Derived engines start their progress threads right after this constructor returns, before
+     * any memory is registered, so seed the context here rather than leaving those threads without
+     * one until the first registerMem(). */
+    vramCaptureCurrentCtx();
+}
+
+/****************************************
+ * CUDA context management
+ *
+ * The progress threads below never had a CUDA context made current, but the UCX transports they
+ * drive call into the CUDA driver: with cuda_copy in UCX_TLS, ucp_worker_arm() reaches
+ * uct_cuda_base_iface_event_fd_arm(), which calls cuEventQuery() and segfaults when no context is
+ * current. Capture a context on a thread that has one and re-apply it on the progress threads.
+ * The libfabric plugin does the same thing via vramApplyCtx() (issue #1157).
+ *****************************************/
+
+void
+nixlUcxEngine::vramCaptureCurrentCtx() {
+#ifdef HAVE_CUDA
+    CUcontext ctx = nullptr;
+
+    /* Runs on the thread constructing the engine, which is also the thread that owns the GPU this
+     * agent transfers from. Provisional: a VRAM registration later supersedes it. */
+    if (cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || ctx == nullptr) {
+        return;
+    }
+
+    cudaCtx_.store(ctx, std::memory_order_release);
+    NIXL_DEBUG << "captured current CUDA context " << ctx << " for the UCX progress threads";
+#else
+    /* cudaCtx_ is declared unconditionally so that the header stays ABI-identical between CUDA and
+     * non-CUDA builds; touch it here to keep -Wunused-private-field quiet. */
+    cudaCtx_.store(nullptr, std::memory_order_relaxed);
+#endif
+}
+
+void
+nixlUcxEngine::vramUpdateCtx(const void *address) {
+#ifdef HAVE_CUDA
+    CUmemorytype mem_type = CU_MEMORYTYPE_HOST;
+    CUcontext ctx = nullptr;
+    CUpointer_attribute attr_types[2] = {CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
+                                         CU_POINTER_ATTRIBUTE_CONTEXT};
+    void *attr_data[2] = {&mem_type, &ctx};
+
+    if (cuPointerGetAttributes(2, attr_types, attr_data, (CUdeviceptr)address) != CUDA_SUCCESS) {
+        return;
+    }
+
+    if (mem_type != CU_MEMORYTYPE_DEVICE || ctx == nullptr) {
+        return;
+    }
+
+    /* The context that owns the registered memory is authoritative over whatever was current at
+     * construction time, so it wins. Registrations from a second context are not handled: one
+     * valid context is enough to keep the driver from faulting, and a per-worker context would
+     * need the worker-to-device mapping UCX does not expose here. */
+    if (cudaCtx_.exchange(ctx, std::memory_order_acq_rel) != ctx) {
+        NIXL_DEBUG << "using CUDA context " << ctx << " from the registered VRAM segment "
+                   << address << " for the UCX progress threads";
+    }
+#else
+    (void)address;
+#endif
+}
+
+void
+nixlUcxEngine::vramApplyCtx() const {
+#ifdef HAVE_CUDA
+    void *ctx = cudaCtx_.load(std::memory_order_acquire);
+    if (ctx == nullptr) {
+        return;
+    }
+
+    /* cuCtxGetCurrent is a thread-local read, so the steady state costs no driver work. The set
+     * has to stay inside the progress loop rather than run once at thread start: the thread is
+     * created in the engine constructor, before any memory is registered, so the context it should
+     * use is not known yet at that point. */
+    CUcontext current = nullptr;
+    if (cuCtxGetCurrent(&current) == CUDA_SUCCESS && current == static_cast<CUcontext>(ctx)) {
+        return;
+    }
+
+    const CUresult res = cuCtxSetCurrent(static_cast<CUcontext>(ctx));
+    if (res != CUDA_SUCCESS) {
+        const char *err_str = nullptr;
+        cuGetErrorString(res, &err_str);
+        NIXL_WARN << "cuCtxSetCurrent(" << ctx
+                  << ") on progress thread failed: " << (err_str ? err_str : "unknown error");
+    }
+#endif
 }
 
 nixl_mem_list_t nixlUcxEngine::getSupportedMems () const {
@@ -912,11 +1021,19 @@ nixl_status_t nixlUcxEngine::registerMem (const nixlBlobDesc &mem,
     if (ret) {
         return NIXL_ERR_BACKEND;
     }
+
     priv->rkeyStr = uc->packRkey(priv->mem);
 
     if (priv->rkeyStr.empty()) {
         return NIXL_ERR_BACKEND;
     }
+
+    if (nixl_mem == VRAM_SEG) {
+        /* Runs on the caller's thread, which has the owning context current, so this is where the
+         * progress threads can learn which context to use. */
+        vramUpdateCtx((const void *)mem.addr);
+    }
+
     out = priv.release();
     return NIXL_SUCCESS;
 }

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -187,6 +187,24 @@ public:
     void
     progressLoop();
 
+    /**
+     * CUDA context management for the progress threads.
+     *
+     * Progress threads are created by NIXL, so no CUDA context is current on them. UCX transports
+     * reached from progressLoop()/arm() call into the CUDA driver regardless -- cuda_copy's
+     * uct_cuda_base_iface_event_fd_arm() calls cuEventQuery() -- and the driver faults when there
+     * is no current context. Capture a context on a thread that has one and re-apply it on the
+     * progress threads. Same fix as the libfabric plugin's vramApplyCtx() (see issue #1157).
+     *
+     * All three are no-ops when built without CUDA.
+     */
+    void
+    vramCaptureCurrentCtx();
+    void
+    vramUpdateCtx(const void *address);
+    void
+    vramApplyCtx() const;
+
     nixl_status_t
     getNotifs(notif_list_t &notif_list) override;
     nixl_status_t
@@ -302,6 +320,11 @@ private:
     std::string workerAddr;
     mutable std::atomic<size_t> sharedWorkerIndex_;
     const bool sglEnabled_;
+
+    /* CUcontext the progress threads make current, kept as void* so that cuda.h stays out of this
+     * header. Written at engine construction and on the first VRAM registration, read by the
+     * progress threads on every iteration. */
+    std::atomic<void *> cudaCtx_{nullptr};
 
     // Map of agent name to saved nixlUcxConnection info
     std::unordered_map<std::string, ucx_connection_ptr_t> remoteConnMap;


### PR DESCRIPTION
Fixes #2102.

## Problem

The UCX progress threads are created by NIXL, so no CUDA context is ever made current on them. The
UCX transports they drive call into the CUDA driver anyway: with `cuda_copy` in `UCX_TLS`,
`ucp_worker_arm()` reaches `uct_cuda_base_iface_event_fd_arm()`, which calls `cuEventQuery()` and
segfaults when there is no current context.

```
cuEventQuery
uct_cuda_base_iface_event_fd_arm
ucp_worker_arm
nixlUcxWorker::arm() const
nixlUcxSharedThread::run()
```

This is the same defect class as #1157 in the libfabric plugin, which was fixed there by applying
the context inside the progress loop. That issue's description states the UCX backend "handles this
correctly by restarting the thread when the context changes" — it does not. A repo-wide grep for
`vramApplyCtx|pthrCudaCtx|cuCtxSetCurrent|cuCtxPushCurrent` returns hits only under
`src/plugins/libfabric/`; the UCX plugin has no CUDA context handling at all.

Every agent with a progress thread is exposed, not only ones that request a thread pool:
`nixlUcxThreadEngine` constructs `nixlUcxSharedThread` whenever `enableProgTh` is set (default
true), and `num_threads` only adds the dedicated pool on top. In practice the initiator side is
what crashes, since it is what drives `cuda_copy` activity through the worker the progress thread
arms.

Observed at roughly one crash per 4.8 hours of steady traffic on an 8xB200 SGLang PD deployment
(9 crashes in 43 hours). It is very likely the unexplained cause behind sgl-project/sglang#23489
and sgl-project/sglang#23499, both closed without a root cause.

## Change

- `vramCaptureCurrentCtx()` — provisional capture via `cuCtxGetCurrent()` in the engine
  constructor, so the progress threads have a context from their first iteration rather than
  waiting for a registration that has not happened yet.
- `vramUpdateCtx(addr)` — authoritative capture from the first VRAM `registerMem()` via
  `cuPointerGetAttributes(CU_POINTER_ATTRIBUTE_CONTEXT)`, on the caller's thread.
- `vramApplyCtx()` — called at the top of both `nixlUcxSharedThread::run()` and
  `nixlUcxDedicatedThread::run()`.

The apply has to stay inside the loop rather than run once at thread start, because the threads are
created in the engine constructor, before any memory is registered, so the correct context is not
known at that point. Steady-state cost is one `cuCtxGetCurrent()`, a thread-local read;
`cuCtxSetCurrent()` is only called when the context actually differs.

The context is stored as `std::atomic<void *>` so that `cuda.h` stays out of `ucx_backend.h` and
the class layout is identical between CUDA and non-CUDA builds. All three helpers compile out
without CUDA.

`src/plugins/ucx/meson.build` now picks up `cuda_dep` and `-DHAVE_CUDA` the same way
`src/plugins/libfabric/meson.build` does. This is consistent with `src/core/meson.build`, which
already adds `cuda_dep` alongside a statically linked UCX plugin, and it makes the existing
"CUDA not found. UCX backend will be built without CUDA support" warning in the top-level
`meson.build` accurate for the first time.

## Notes and open questions for reviewers

- **Multiple contexts are not handled.** A registration from a second context replaces the stored
  one. One valid current context is enough to stop the driver from faulting, but a strictly correct
  fix would key the context per worker, which needs a worker-to-device mapping the plugin does not
  currently have. Happy to take direction here if you would prefer that shape.
- **No unit test.** The natural test needs a constructed `nixlUcxEngine`, so it needs UCX and a GPU.
  Pointers to where this would fit in the existing test layout are welcome.
- I have verified the new code compiles cleanly with `-Wall -Wextra -Werror` against CUDA 12.9
  headers in both the CUDA and non-CUDA configurations, that all four driver symbols used
  (`cuCtxGetCurrent`, `cuCtxSetCurrent`, `cuPointerGetAttributes`, `cuGetErrorString`) resolve
  against `libcuda`, and that the added lines are clean under the repo's `.clang-format`. A full
  build and GPU soak are still pending on my side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA-aware UCX support when CUDA is available.
  * Improved GPU memory registration and context handling across UCX progress threads.
  * Applied CUDA contexts consistently for shared and dedicated progress operations.

* **Bug Fixes**
  * Improved reliability of UCX progress processing involving VRAM and CUDA contexts.
  * Added error reporting when CUDA context application fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->