### PR TITLE
Guard postXferReq/estimateXferCost against stale-generation xfer handles (#2027)

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1082,12 +1082,15 @@ nixlAgent::estimateXferCost(const nixlXferReqH *req_hndl,
 
     // Check if the remote agent connection info is still valid
     // (assuming cost estimation requires connection info like transfers)
-    if (!req_hndl->remoteAgent.empty() &&
-        (data->remoteSections_.count(req_hndl->remoteAgent) == 0)) {
-        NIXL_ERROR_FUNC << "invalid request handle, remote agent was invalidated "
-                           "after transfer request creation";
-        data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
-        return NIXL_ERR_NOT_FOUND;
+    if (!req_hndl->remoteAgent.empty()) {
+        const auto sec_it = data->remoteSections_.find(req_hndl->remoteAgent);
+        if (sec_it == data->remoteSections_.end() ||
+            sec_it->second.getGeneration() != req_hndl->remoteGeneration_) {
+            NIXL_ERROR_FUNC << "invalid request handle, remote agent was invalidated "
+                               "after transfer request creation";
+            data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
+            return NIXL_ERR_NOT_FOUND;
+        }
     }
 
     if (!req_hndl->engine) {
@@ -1144,9 +1147,19 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 
     std::shared_lock<nixlLock> read_lock(data->lock);
     // Check if the remote was invalidated before post/repost
-    if (data->remoteSections_.count(req_hndl->remoteAgent) == 0) {
+    const auto sec_it = data->remoteSections_.find(req_hndl->remoteAgent);
+    if (sec_it == data->remoteSections_.end()) {
         NIXL_ERROR_FUNC << "remote agent '" << req_hndl->remoteAgent
                         << "' was invalidated after transfer request creation";
+        data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
+        return NIXL_ERR_NOT_FOUND;
+    }
+    if (sec_it->second.getGeneration() != req_hndl->remoteGeneration_) {
+        NIXL_ERROR_FUNC << "remote agent '" << req_hndl->remoteAgent
+                        << "' was re-registered after transfer request creation; "
+                           "refusing to post a stale-generation handle (created gen "
+                        << req_hndl->remoteGeneration_ << ", live gen "
+                        << sec_it->second.getGeneration() << ")";
         data->addErrorTelemetry(NIXL_ERR_NOT_FOUND);
         return NIXL_ERR_NOT_FOUND;
     }


### PR DESCRIPTION
Cherry pick of #2027

---------

Follow-up to #1811 / #1987.

`postXferReq` guards the remote section by name only, so after a disconnect invalidates (frees) gen-N metadata and the peer is re-registered (gen-N+1), posting a gen-N xfer handle dereferences the freed `nixlUcxPublicMetadata` pinned in `targetDescs` — segfault in `sendXferRangeBatch`/`ucp_put_nbx`.
Reject stale-generation handles with `NIXL_ERR_NOT_FOUND` (same guard in `estimateXferCost`, which dereferences the same metadata). Verified with a fault-injection reproducer: without the fix the crash reproduces reliably; with it, none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
* Prevented remote transfer requests from using outdated metadata after the associated remote resource is re-registered.
* Added validation to reject invalid or stale handles during cost estimation and transfer submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
