### PR TITLE
ci: fix nightly wheel build broken by wheel_base caching

### DIFF
--- a/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
@@ -10,7 +10,6 @@ failFast: false
 timeout_minutes: 240
 
 registry_host: artifactory.nvidia.com
-registry_path: /sw-nbu-swx-nixl-docker-local/ci
 
 credentials:
   - credentialsId: 'svc-nixl-new-artifactory-token'
@@ -25,16 +24,9 @@ kubernetes:
   requests: '{memory: 24Gi, cpu: 16000m}'
 
 # podman-in-container runner; build-container.sh runs docker/podman inside it.
-# wheel_base is a cached deps image (no step runs in it) — ci-demo builds it
-# when Dockerfile.manylinux changes and it is reused via --wheel-base-image.
+# The nightly builds wheel_base from scratch on every run — no caching.
 runs_on_dockers:
   - { name: "manylinux", url: "quay.io/podman/stable:v5.7.1", privileged: true }
-  - {
-      file: 'contrib/Dockerfile.manylinux',
-      name: "${WHEEL_BASE_IMAGE_NAME}",
-      tag: "${CI_IMAGE_TAG}",
-      build_args: '--build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_IMAGE_TAG=${BASE_TAG} --build-arg MANYLINUX_IMAGE=${MANYLINUX_IMAGE} --build-arg MANYLINUX_IMAGE_TAG=${MANYLINUX_IMAGE_TAG} --build-arg CUDA_VERSION=${CUDA_VERSION} --build-arg ARCH=${arch} --build-arg NPROC=${NPROC} --build-arg GRPC_NPROC=${GRPC_NPROC} --target wheel_base'
-    }
 
 matrix:
   axes:
@@ -54,10 +46,8 @@ matrix:
 env:
   NPROC: 16
   GRPC_NPROC: 10
-  CI_IMAGE_TAG: "CI_MANAGED"
   MANYLINUX_IMAGE: "quay.io/pypa/manylinux_2_28"
   MANYLINUX_IMAGE_TAG: "2026.06.06-1"
-  WHEEL_BASE_IMAGE_NAME: "nixl-wheel-base-cu${CUDA_VARIANT}-manylinux_2_28"
   # TORCH_VERSIONS comes from the JJB job parameter (default 2.12,2.13 for cu13;
   # the cu12 cron overrides it to 2.11,2.12,2.13). Not set here to avoid the
   # matrix env overriding the per-run parameter value.
@@ -93,16 +83,18 @@ steps:
       fi
       [ -n "${UCX_SHA}" ] || { echo "ERROR: cannot resolve UCX_VERSION=${UCX_VERSION}"; exit 1; }
       printf 'NIXL_SHA=%s\nUCX_SHA=%s\n' "${NIXL_SHA}" "${UCX_SHA}" > wheel_build_ids.env
-      # torch 2.11 is not published on the cu13 index; derive the correct set
-      # from CUDA_VARIANT so manual runs can't accidentally drop 2.11 for cu12.
+      # Derive CUDA major from BASE_TAG for torch version selection.
+      # BASE_TAG format: <major>.<minor>.<patch>-devel-ubi8; CUDA_VERSION is
+      # derived automatically inside build-container.sh.
+      CUDA_MAJOR="$(echo "${BASE_TAG}" | cut -d. -f1)"
+      # torch 2.11 is not published on the cu13 index; auto-select unless overridden.
       if [ -z "${TORCH_VERSIONS:-}" ]; then
-        if [ "${CUDA_VARIANT}" = "12" ]; then TORCH_VERSIONS="2.11,2.12,2.13"
+        if [ "${CUDA_MAJOR}" = "12" ]; then TORCH_VERSIONS="2.11,2.12,2.13"
         else TORCH_VERSIONS="2.12,2.13"; fi
       fi
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
-        --cuda-version "${CUDA_VERSION}" \
         --manylinux-image "${MANYLINUX_IMAGE}" \
         --manylinux-image-tag "${MANYLINUX_IMAGE_TAG}" \
         --wheel-base "manylinux_${manylinux}" \
@@ -111,8 +103,7 @@ steps:
         --ucx-ref "${UCX_SHA}" \
         --torch-versions "${TORCH_VERSIONS}" \
         --tag "${WHEEL_IMAGE_TAG}" \
-        --dockerfile contrib/Dockerfile.manylinux \
-        --wheel-base-image "${registry_host}${registry_path}/${arch}/${WHEEL_BASE_IMAGE_NAME}:${CI_IMAGE_TAG}"
+        --dockerfile contrib/Dockerfile.manylinux
 
   - name: Publish
     credentialsId: 'svc-nixl-new-artifactory-token'

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -905,8 +905,8 @@
           cron: |
             # Build NIXL wheels nightly ~10 AM for CUDA 13 and CUDA 12 (the cu12
             # run also produces the nixl meta wheel). Both publish to the repo.
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;CUDA_VARIANT=13;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=13.2.1-devel-ubi8;CUDA_VERSION=13.2;TORCH_VERSIONS=2.12,2.13
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;CUDA_VARIANT=12;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=12.9.1-devel-ubi8;CUDA_VERSION=12.9;TORCH_VERSIONS=2.11,2.12,2.13
+            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=13.2.1-devel-ubi8
+            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=12.9.1-devel-ubi8
     # Manual build parameters
     parameters:
       - string:
@@ -918,25 +918,17 @@
           default: "v1.22.x"
           description: "UCX version to build against (tag like v1.22.x, branch name, or commit hash)"
       - string:
-          name: "CUDA_VARIANT"
-          default: "13"
-          description: "CUDA major version for the wheel build (13 or 12)"
-      - string:
           name: "BASE_IMAGE"
           default: "nvcr.io/nvidia/cuda"
           description: "NGC CUDA source image for the manylinux wheel build"
       - string:
           name: "BASE_TAG"
           default: "13.2.1-devel-ubi8"
-          description: "NGC CUDA image tag (e.g. 13.2.1-devel-ubi8 for CUDA 13 cuObject support, or 12.9.1-devel-ubi8 for CUDA 12)"
-      - string:
-          name: "CUDA_VERSION"
-          default: "13.2"
-          description: "CUDA toolkit major.minor directory copied from the source image (e.g. 13.2 or 12.9)"
+          description: "NGC CUDA image tag (e.g. 13.2.1-devel-ubi8 for CUDA 13 cuObject support, or 12.9.1-devel-ubi8 for CUDA 12). CUDA_VERSION is derived from this automatically."
       - string:
           name: "TORCH_VERSIONS"
-          default: "2.12,2.13"
-          description: "Comma-separated PyTorch versions to build EP extensions for (torch 2.11 is not on the cu13 index; use 2.11,2.12,2.13 for CUDA 12 runs)"
+          default: ""
+          description: "Comma-separated PyTorch versions to build EP extensions for. Leave empty to auto-derive from CUDA major version (cu13: 2.12,2.13; cu12: 2.11,2.12,2.13)."
       - string:
           name: "DEBUG"
           default: 0

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -353,6 +353,13 @@ BUILD_ARGS+=" --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BASE_IMAGE_TAG=$BAS
 BUILD_ARGS+=" --build-arg MANYLINUX_IMAGE=$MANYLINUX_IMAGE --build-arg MANYLINUX_IMAGE_TAG=$MANYLINUX_IMAGE_TAG"
 BUILD_ARGS+=" --build-arg WHL_PYTHON_VERSIONS=$WHL_PYTHON_VERSIONS"
 BUILD_ARGS+="${WHL_TORCH_VERSIONS:+ --build-arg WHL_TORCH_VERSIONS=$WHL_TORCH_VERSIONS}"
+# For Dockerfile.manylinux, derive CUDA_VERSION from BASE_IMAGE_TAG if not
+# set explicitly (BASE_IMAGE_TAG format: <major>.<minor>.<patch>-devel-ubi8).
+case "$DOCKER_FILE" in
+    *Dockerfile.manylinux)
+        CUDA_VERSION="${CUDA_VERSION:-$(echo "$BASE_IMAGE_TAG" | grep -oE '^[0-9]+\.[0-9]+')}"
+        ;;
+esac
 BUILD_ARGS+=" --build-arg CUDA_VERSION=$CUDA_VERSION"
 BUILD_ARGS+=" --build-arg WHL_PLATFORM=$WHL_PLATFORM"
 BUILD_ARGS+=" --build-arg ARCH=$ARCH"


### PR DESCRIPTION
## What
Fix the nightly wheel build broken by #1971, and simplify the nightly's CUDA version handling.

## Why?
PR #1971 added the PR CI's cached wheel_base mechanism to build-wheel-nightly-matrix.yaml. The nightly builds everything from scratch on every run and has no pre-built wheel_base image to pull, so ci-demo's attempt to build/pull nixl-wheel-base-cu${CUDA_VARIANT}-manylinux_2_28:CI_MANAGED fails immediately.                                               Additionally, PR #1971 added CUDA_VERSION and CUDA_VARIANT as explicit JJB parameters and cron arguments, which are redundant since the CUDA version is already encoded in BASE_TAG (e.g. 13.2.1-devel-ubi8).

## How?                                                                                                                        

Remove from build-wheel-nightly-matrix.yaml:
  - registry_path at the job level
  - The runs_on_dockers wheel_base entry
  - CI_IMAGE_TAG and WHEEL_BASE_IMAGE_NAME from env
  - --cuda-version and --wheel-base-image from the Build Wheel step

Keep the cuObject additions from #1971 that the nightly needs:
  - MANYLINUX_IMAGE / MANYLINUX_IMAGE_TAG in env
  - --manylinux-image, --manylinux-image-tag, --torch-versions in Build Wheel step
  - TORCH_VERSIONS auto-selection based on CUDA major version derived from BASE_TAG

Simplify proj-jjb.yaml:
  - Remove CUDA_VERSION and CUDA_VARIANT JJB params and cron arguments — BASE_TAG already carries this information
  - TORCH_VERSIONS default is now empty (auto-derived) rather than hardcoded

Extend build-container.sh:                                                                                                  
  - When building Dockerfile.manylinux, auto-derive CUDA_VERSION from BASE_IMAGE_TAG if not set explicitly, so callers don't need to pass it separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly wheel builds now support simplified CUDA 12 and CUDA 13 scheduling.
  * CUDA and PyTorch versions can be derived automatically from the selected base image.
  * Builds now create wheels directly from the manylinux Dockerfile without requiring a prebuilt wheel image.

* **Improvements**
  * Removed redundant CUDA configuration options from nightly build settings.
  * Added support for selecting the base image directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->