### PR TITLE
test: cover prometheus_mp telemetry dir hardening

### DIFF
--- a/test/gtest/telemetry_mp_exporter_test.cpp
+++ b/test/gtest/telemetry_mp_exporter_test.cpp
@@ -251,15 +251,32 @@ TEST_F(MpExporterTest, CreatedTelemetryDirIsPrivate) {
               std::filesystem::perms::owner_all);
 }
 
-TEST_F(MpExporterTest, LooseTelemetryDirWarns) {
-    const auto sub = dir_ / "loose";
+TEST_F(MpExporterTest, GroupWritableTelemetryDirWarns) {
+    const auto sub = dir_ / "group-loose";
     std::filesystem::create_directory(sub);
-    std::filesystem::permissions(
-        sub, std::filesystem::perms::all, std::filesystem::perm_options::replace);
+    std::filesystem::permissions(sub,
+                                 std::filesystem::perms::owner_all |
+                                     std::filesystem::perms::group_write,
+                                 std::filesystem::perm_options::replace);
     env_.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", sub.string());
 
     const gtest::LogIgnoreGuard lig("is writable by group or other");
-    nixlTelemetryPrometheusMpExporter exporter(initParams("agent-loose"));
+    nixlTelemetryPrometheusMpExporter exporter(initParams("agent-group-loose"));
+    EXPECT_TRUE(exporter.isExporter());
+    EXPECT_EQ(lig.getIgnoredCount(), 1);
+}
+
+TEST_F(MpExporterTest, WorldWritableTelemetryDirWarns) {
+    const auto sub = dir_ / "world-loose";
+    std::filesystem::create_directory(sub);
+    std::filesystem::permissions(sub,
+                                 std::filesystem::perms::owner_all |
+                                     std::filesystem::perms::others_write,
+                                 std::filesystem::perm_options::replace);
+    env_.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", sub.string());
+
+    const gtest::LogIgnoreGuard lig("is writable by group or other");
+    nixlTelemetryPrometheusMpExporter exporter(initParams("agent-world-loose"));
     EXPECT_TRUE(exporter.isExporter());
     EXPECT_EQ(lig.getIgnoredCount(), 1);
 }

--- a/test/gtest/telemetry_mp_exporter_test.cpp
+++ b/test/gtest/telemetry_mp_exporter_test.cpp
@@ -241,6 +241,7 @@ TEST_F(MpExporterTest, LoadsThroughPluginManager) {
 
 TEST_F(MpExporterTest, CreatedTelemetryDirIsPrivate) {
     const auto sub = dir_ / "created";
+    ASSERT_FALSE(std::filesystem::exists(sub));
     env_.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", sub.string());
 
     nixlTelemetryPrometheusMpExporter exporter(initParams("agent-private"));

--- a/test/gtest/telemetry_mp_exporter_test.cpp
+++ b/test/gtest/telemetry_mp_exporter_test.cpp
@@ -239,6 +239,30 @@ TEST_F(MpExporterTest, LoadsThroughPluginManager) {
     EXPECT_FALSE(singleStoreFile().empty());
 }
 
+TEST_F(MpExporterTest, CreatedTelemetryDirIsPrivate) {
+    const auto sub = dir_ / "created";
+    env_.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", sub.string());
+
+    nixlTelemetryPrometheusMpExporter exporter(initParams("agent-private"));
+
+    ASSERT_TRUE(std::filesystem::is_directory(sub));
+    EXPECT_EQ(std::filesystem::status(sub).permissions() & std::filesystem::perms::mask,
+              std::filesystem::perms::owner_all);
+}
+
+TEST_F(MpExporterTest, LooseTelemetryDirWarns) {
+    const auto sub = dir_ / "loose";
+    std::filesystem::create_directory(sub);
+    std::filesystem::permissions(
+        sub, std::filesystem::perms::all, std::filesystem::perm_options::replace);
+    env_.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", sub.string());
+
+    const gtest::LogIgnoreGuard lig("is writable by group or other");
+    nixlTelemetryPrometheusMpExporter exporter(initParams("agent-loose"));
+    EXPECT_TRUE(exporter.isExporter());
+    EXPECT_EQ(lig.getIgnoredCount(), 1);
+}
+
 TEST(MpExporterStandaloneTest, MissingMultiprocDirThrows) {
     gtest::ScopedEnv env;
     env.addVar("NIXL_TELEMETRY_MULTIPROC_DIR", "");


### PR DESCRIPTION
## What?

Three gtest cases for the `prometheus_mp` telemetry-directory hardening in `resolveMultiprocDir()`: a directory the exporter creates is 0700, and an existing group-writable or world-writable one warns and still serves. Tests only, no production change.

## Why?

Deferred from the diff freeze on #1920 (NIX-1683). None of it could be observed before: the mp fixture hands the exporter a directory it already created at 0700, so the warning can never fire and the production `chmod` is indistinguishable from the fixture's own. Dropping the `created` guard, or reordering `permissions` before `create_directories`, broke nothing visible.

The foreign-owner branch (`st_uid != geteuid()`) is left uncovered by design, not by oversight — see below.

## How?

All three tests point `NIXL_TELEMETRY_MULTIPROC_DIR` at a **subdirectory** of the fixture's directory. That child path is free to be absent or loose without any fixture surgery, and the fixture still needs its own 0700 chmod to stop a permissive CI umask from reddening the suite.

<details>
<summary>Mutation testing, the two loose cases, and the uncovered branch</summary>

Each test was verified against the mutation it exists to catch, and confirmed to fail on that one alone:

| Mutation | Result |
|---|---|
| Drop the `permissions(..., owner_all, replace)` call | `CreatedTelemetryDirIsPrivate` fails: mode is the umask default 0755 |
| Drop the `created` guard (chmod unconditionally) | `WorldWritable...`/`GroupWritable...` fail: the loose directory is silently fixed before `stat()`, so the warning count falls to 0 |
| Narrow the mask to `S_IWGRP` alone | `WorldWritableTelemetryDirWarns` fails; the group case still warns |
| Narrow the mask to `S_IWOTH` alone | `GroupWritableTelemetryDirWarns` fails; the world case still warns |

The last two are why the loose case is 0720 and 0702 rather than a single 0777: 0777 sets both bits, so it cannot tell the halves of the mask apart. Either single-bit case subsumes 0777. They are two `TEST_F`s rather than a `TEST_P` because the fixture derives its directory from the suite and test name, and an instantiated parameterised suite puts a `/` in both, nesting that directory and leaving the intermediate level behind `TearDown`.

`CreatedTelemetryDirIsPrivate` also asserts the subdirectory is absent first: otherwise `create_directories()` reports `created == false`, the `chmod` never runs, and the 0700 assertion is satisfied by whatever left the directory behind — which a failed `TearDown` under `--gtest_repeat` could do, since every iteration reuses the same path.

All mutations were reverted. Verified with `--gtest_repeat=5`: 93 tests per iteration, all passing, no un-ignored warnings.

**Foreign owner.** Covering it needs `chown`, so the test would run only as root and skip on every unprivileged lane — an assertion whose meaning depends on the environment, which is the shape NIX-1710 just removed from the tracing suite, and which NIX-1623 is trying to make fatal. The prerequisite is a second unprivileged uid in the test container; that is CI infrastructure and belongs in its own change.

</details>
