### PR TITLE
bindings/rust: report real statuses instead of collapsing them to backend

### DIFF
--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -443,16 +443,15 @@ impl Agent {
 
         let data = data as *const u8;
 
-        if data.is_null() {
-            tracing::trace!(
-                error = "invalid_data_pointer",
-                "Failed to get local metadata"
-            );
-            return Err(NixlError::InvalidDataPointer);
-        }
-
         match status {
             NIXL_CAPI_SUCCESS => {
+                if data.is_null() {
+                    tracing::trace!(
+                        error = "invalid_data_pointer",
+                        "Failed to get local metadata"
+                    );
+                    return Err(NixlError::InvalidDataPointer);
+                }
                 let bytes = unsafe {
                     let slice = std::slice::from_raw_parts(data, len);
                     let vec = slice.to_vec();
@@ -1237,18 +1236,20 @@ impl AgentInner {
     }
 
     fn invalidate_remote_md(&mut self, remote_agent: &str) -> Result<(), NixlError> {
+        if !self.remotes.contains(remote_agent) {
+            return Err(NixlError::InvalidParam);
+        }
         let status = unsafe {
-            if self.remotes.remove(remote_agent) {
-                nixl_capi_invalidate_remote_md(
-                    self.handle.as_ptr(),
-                    CString::new(remote_agent)?.as_ptr().cast(),
-                )
-            } else {
-                return Err(NixlError::InvalidParam);
-            }
+            nixl_capi_invalidate_remote_md(
+                self.handle.as_ptr(),
+                CString::new(remote_agent)?.as_ptr().cast(),
+            )
         };
         match status {
-            NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_SUCCESS => {
+                self.remotes.remove(remote_agent);
+                Ok(())
+            }
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
             NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
@@ -1256,19 +1257,8 @@ impl AgentInner {
     }
 
     fn invalidate_all_remotes(&mut self) -> Result<(), NixlError> {
-        for remote in self.remotes.drain() {
-            let status = unsafe {
-                nixl_capi_invalidate_remote_md(
-                    self.handle.as_ptr(),
-                    CString::new(remote.as_str())?.as_ptr().cast(),
-                )
-            };
-            match status {
-                NIXL_CAPI_SUCCESS => {}
-                NIXL_CAPI_ERROR_INVALID_PARAM => return Err(NixlError::InvalidParam),
-                NIXL_CAPI_ERROR_NOT_FOUND => return Err(NixlError::NotFound),
-                _ => return Err(NixlError::BackendError),
-            }
+        for remote in self.remotes.iter().cloned().collect::<Vec<_>>() {
+            self.invalidate_remote_md(&remote)?;
         }
         Ok(())
     }

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -1246,12 +1246,12 @@ impl AgentInner {
             )
         };
         match status {
-            NIXL_CAPI_SUCCESS => {
+            // NOT_FOUND means the agent already dropped it, which is the goal state
+            NIXL_CAPI_SUCCESS | NIXL_CAPI_ERROR_NOT_FOUND => {
                 self.remotes.remove(remote_agent);
                 Ok(())
             }
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
-            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -738,6 +738,10 @@ impl Agent {
                 );
                 Err(NixlError::InvalidParam)
             }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to send local metadata to etcd");
+                Err(NixlError::NotFound)
+            }
             _ => {
                 tracing::error!(
                     error = "backend_error",
@@ -815,6 +819,10 @@ impl Agent {
                 tracing::trace!(remote_agent = %remote_name, "Successfully fetched remote metadata from etcd");
                 Ok(())
             }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", remote_agent = %remote_name, "Failed to fetch remote metadata from etcd");
+                Err(NixlError::NotFound)
+            }
             NIXL_CAPI_ERROR_INVALID_PARAM => {
                 tracing::error!(error = "invalid_param", remote_agent = %remote_name, "Failed to fetch remote metadata from etcd");
                 Err(NixlError::InvalidParam)
@@ -853,6 +861,10 @@ impl Agent {
                     "Failed to invalidate local metadata in etcd"
                 );
                 Err(NixlError::InvalidParam)
+            }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to invalidate local metadata in etcd");
+                Err(NixlError::NotFound)
             }
             _ => {
                 tracing::error!(
@@ -914,6 +926,10 @@ impl Agent {
             NIXL_CAPI_ERROR_INVALID_PARAM => {
                 tracing::error!(error = "invalid_param", remote_agent = %remote_agent, "Failed to send notification");
                 Err(NixlError::InvalidParam)
+            }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", remote_agent = %remote_agent, "Failed to send notification");
+                Err(NixlError::NotFound)
             }
             _ => {
                 tracing::error!(error = "backend_error", remote_agent = %remote_agent, "Failed to send notification");
@@ -1221,26 +1237,37 @@ impl AgentInner {
     }
 
     fn invalidate_remote_md(&mut self, remote_agent: &str) -> Result<(), NixlError> {
-        unsafe {
+        let status = unsafe {
             if self.remotes.remove(remote_agent) {
                 nixl_capi_invalidate_remote_md(
                     self.handle.as_ptr(),
                     CString::new(remote_agent)?.as_ptr().cast(),
-                );
+                )
             } else {
                 return Err(NixlError::InvalidParam);
             }
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
+            _ => Err(NixlError::BackendError),
         }
-        Ok(())
     }
 
     fn invalidate_all_remotes(&mut self) -> Result<(), NixlError> {
-        unsafe {
-            for remote in self.remotes.drain() {
+        for remote in self.remotes.drain() {
+            let status = unsafe {
                 nixl_capi_invalidate_remote_md(
                     self.handle.as_ptr(),
                     CString::new(remote.as_str())?.as_ptr().cast(),
-                );
+                )
+            };
+            match status {
+                NIXL_CAPI_SUCCESS => {}
+                NIXL_CAPI_ERROR_INVALID_PARAM => return Err(NixlError::InvalidParam),
+                NIXL_CAPI_ERROR_NOT_FOUND => return Err(NixlError::NotFound),
+                _ => return Err(NixlError::BackendError),
             }
         }
         Ok(())

--- a/src/bindings/rust/src/agent.rs
+++ b/src/bindings/rust/src/agent.rs
@@ -313,6 +313,7 @@ impl Agent {
                 mem_type: descriptor.mem_type(),
             }),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -348,6 +349,7 @@ impl Agent {
         match status {
             NIXL_CAPI_SUCCESS => Ok(resp),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -383,6 +385,7 @@ impl Agent {
                 NonNull::new(view).ok_or(NixlError::InvalidDataPointer)?,
             )),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -419,6 +422,7 @@ impl Agent {
                 NonNull::new(view).ok_or(NixlError::InvalidDataPointer)?,
             )),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -461,6 +465,10 @@ impl Agent {
             NIXL_CAPI_ERROR_INVALID_PARAM => {
                 tracing::error!(error = "invalid_param", "Failed to get local metadata");
                 Err(NixlError::InvalidParam)
+            }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to get local metadata");
+                Err(NixlError::NotFound)
             }
             _ => {
                 tracing::error!(error = "backend_error", "Failed to get local metadata");
@@ -508,6 +516,10 @@ impl Agent {
                 tracing::error!(error = "invalid_param", "Failed to get local partial metadata");
                 Err(NixlError::InvalidParam)
             }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to get local partial metadata");
+                Err(NixlError::NotFound)
+            }
             _ => {
                 tracing::error!(error = "backend_error", "Failed to get local partial metadata");
                 Err(NixlError::BackendError)
@@ -545,6 +557,10 @@ impl Agent {
                 tracing::error!(error = "invalid_param", "Failed to load remote metadata");
                 Err(NixlError::InvalidParam)
             }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to load remote metadata");
+                Err(NixlError::NotFound)
+            }
             _ => {
                 tracing::error!(error = "backend_error", "Failed to load remote metadata");
                 Err(NixlError::BackendError)
@@ -567,6 +583,7 @@ impl Agent {
         match status {
             NIXL_CAPI_SUCCESS => Ok(()),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -593,6 +610,8 @@ impl Agent {
 
         match status {
             NIXL_CAPI_SUCCESS => Ok(XferDlistHandle::new(dlist_hndl, inner_guard.handle)),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -625,6 +644,7 @@ impl Agent {
                 self.inner.clone(),
             )),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -751,6 +771,10 @@ impl Agent {
             NIXL_CAPI_ERROR_INVALID_PARAM => {
                 tracing::error!(error = "invalid_param", "Failed to send local partial metadata to etcd");
                 Err(NixlError::InvalidParam)
+            }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to send local partial metadata to etcd");
+                Err(NixlError::NotFound)
             }
             _ => Err(NixlError::BackendError)
         }
@@ -981,6 +1005,7 @@ impl Agent {
         match status {
             NIXL_CAPI_SUCCESS => Ok((duration_us, err_margin_us, CostMethod::from(method))),
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -1029,6 +1054,10 @@ impl Agent {
                 tracing::error!(error = "invalid_param", "Failed to post transfer request");
                 Err(NixlError::InvalidParam)
             }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to post transfer request");
+                Err(NixlError::NotFound)
+            }
             _ => {
                 tracing::error!(error = "backend_error", "Failed to post transfer request");
                 Err(NixlError::BackendError)
@@ -1051,6 +1080,7 @@ impl Agent {
             NIXL_CAPI_SUCCESS => Ok(XferStatus::Success), // Transfer completed
             NIXL_CAPI_IN_PROG => Ok(XferStatus::InProgress),  // Transfer in progress
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -1080,6 +1110,7 @@ impl Agent {
                 Ok(Backend{ inner: NonNull::new(backend).ok_or(NixlError::FailedToCreateBackend)? })
             }
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            NIXL_CAPI_ERROR_NOT_FOUND => Err(NixlError::NotFound),
             _ => Err(NixlError::BackendError),
         }
     }
@@ -1112,6 +1143,10 @@ impl Agent {
             NIXL_CAPI_ERROR_INVALID_PARAM => {
                 tracing::error!(error = "invalid_param", "Failed to get notifications");
                 Err(NixlError::InvalidParam)
+            }
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to get notifications");
+                Err(NixlError::NotFound)
             }
             _ => {
                 tracing::error!(error = "backend_error", "Failed to get notifications");

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -79,7 +79,8 @@ pub use bindings::{
     nixl_capi_status_t_NIXL_CAPI_ERROR_INVALID_PARAM as NIXL_CAPI_ERROR_INVALID_PARAM,
     nixl_capi_status_t_NIXL_CAPI_IN_PROG as NIXL_CAPI_IN_PROG,
     nixl_capi_status_t_NIXL_CAPI_SUCCESS as NIXL_CAPI_SUCCESS,
-    nixl_capi_status_t_NIXL_CAPI_ERROR_NO_TELEMETRY as NIXL_CAPI_ERROR_NO_TELEMETRY
+    nixl_capi_status_t_NIXL_CAPI_ERROR_NO_TELEMETRY as NIXL_CAPI_ERROR_NO_TELEMETRY,
+    nixl_capi_status_t_NIXL_CAPI_ERROR_NOT_FOUND as NIXL_CAPI_ERROR_NOT_FOUND
 };
 
 mod agent;
@@ -119,6 +120,8 @@ pub enum NixlError {
     FailedToCreateBackend,
     #[error("Telemetry is not enabled or transfer is not complete")]
     NoTelemetry,
+    #[error("Not found")]
+    NotFound,
 }
 
 /// A safe wrapper around NIXL memory list

--- a/src/bindings/rust/src/xfer.rs
+++ b/src/bindings/rust/src/xfer.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/bindings/rust/src/xfer.rs
+++ b/src/bindings/rust/src/xfer.rs
@@ -103,6 +103,10 @@ impl XferRequest {
                 tracing::error!(error = "telemetry_not_enabled", "Telemetry not enabled");
                 Err(NixlError::NoTelemetry)
             },
+            NIXL_CAPI_ERROR_NOT_FOUND => {
+                tracing::error!(error = "not_found", "Failed to get transfer telemetry from request");
+                Err(NixlError::NotFound)
+            },
             _ => {
                 tracing::error!(error = "backend_error", "Failed to get transfer telemetry from request");
                 Err(NixlError::BackendError)

--- a/src/bindings/rust/tests/mem_view.rs
+++ b/src/bindings/rust/tests/mem_view.rs
@@ -217,8 +217,10 @@ fn test_prep_mem_view_remote_unknown_agent() {
     let desc = vram_remote_desc(&storage, Some("no_such_agent"));
     let result =
         unsafe { agent.prep_mem_view_remote(&vram_remote_dlist(&desc), Some(&opt_args)) };
-    // NIXL_ERR_NOT_FOUND; change to NotFound once the C API maps it.
-    assert!(result.is_err(), "Expected an error for an unknown remote agent");
+    assert!(
+        matches!(result, Err(NixlError::NotFound)),
+        "Expected NotFound for an unknown remote agent"
+    );
 }
 
 /// A null-agent descriptor is a placeholder, not an addressed peer, so a list
@@ -239,6 +241,8 @@ fn test_prep_mem_view_remote_null_agent_only() {
     let desc = vram_remote_desc(&storage, None);
     let result =
         unsafe { agent.prep_mem_view_remote(&vram_remote_dlist(&desc), Some(&opt_args)) };
-    // NIXL_ERR_NOT_FOUND; change to NotFound once the C API maps it.
-    assert!(result.is_err(), "Expected an error for a list of only null agents");
+    assert!(
+        matches!(result, Err(NixlError::NotFound)),
+        "Expected NotFound for a list of only null agents"
+    );
 }

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -1383,10 +1383,9 @@ fn test_get_local_partial_md_success() {
             println!("Partial metadata size: {}", metadata.len());
         }
         Err(e) => {
-            // May fail if no partial metadata exists yet, which is acceptable
             assert!(
-                matches!(e, NixlError::BackendError) || matches!(e, NixlError::InvalidParam),
-                "Expected BackendError or InvalidParam, got: {:?}", e
+                matches!(e, NixlError::NotFound),
+                "Expected NotFound, got: {:?}", e
             );
         }
     }

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -1277,8 +1277,8 @@ fn test_prep_xfer_dlist_invalid_agent() {
         let result = agent.prepare_xfer_dlist("invalid_agent", &dlist, None);
 
         assert!(
-            result.is_err_and(|e| matches!(e, NixlError::BackendError)),
-            "Expected InvalidParam for invalid agent name"
+            result.is_err_and(|e| matches!(e, NixlError::NotFound)),
+            "Expected NotFound for invalid agent name"
         );
     }
 }

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -1360,7 +1360,7 @@ fn test_make_xfer_req_invalid_indices() {
             &invalid_indices,    // Out-of-bounds remote index
             None
         );
-        assert!(result.is_err_and(|e| matches!(e, NixlError::BackendError)), "Expected InvalidParam for out-of-bounds indices");
+        assert!(result.is_err_and(|e| matches!(e, NixlError::InvalidParam)), "Expected InvalidParam for out-of-bounds indices");
     }
 }
 

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -231,7 +231,7 @@ nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
         // Copy the data
         memcpy(*data, blob.data(), blob.size());
         *len = blob.size();
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -280,7 +280,7 @@ nixl_capi_invalidate_remote_md(nixl_capi_agent_t agent, const char* remote_agent
 
   try {
     nixl_status_t ret = agent->inner->invalidateRemoteMD(std::string(remote_agent));
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -297,7 +297,7 @@ nixl_capi_send_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_args)
   try {
     nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
     nixl_status_t ret = agent->inner->sendLocalMD(args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -314,7 +314,7 @@ nixl_capi_send_local_partial_md(nixl_capi_agent_t agent,
     try {
         nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
         nixl_status_t ret = agent->inner->sendLocalPartialMD(*descs->dlist, args);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -331,7 +331,7 @@ nixl_capi_fetch_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl
   try {
     nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
     nixl_status_t ret = agent->inner->fetchRemoteMD(std::string(remote_name), args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -348,7 +348,7 @@ nixl_capi_invalidate_local_md(nixl_capi_agent_t agent, nixl_capi_opt_args_t opt_
   try {
     nixl_opt_args_t* args = opt_args ? &opt_args->args : nullptr;
     nixl_status_t ret = agent->inner->invalidateLocalMD(args);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -367,10 +367,10 @@ nixl_capi_check_remote_md(nixl_capi_agent_t agent, const char* remote_name, nixl
     if (!descs) {
         nixl_xfer_dlist_t empty_list(DRAM_SEG);
         nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, empty_list);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     } else {
         nixl_status_t ret = agent->inner->checkRemoteMD(remote_name, *descs->dlist);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
   }
   catch (...) {
@@ -1360,7 +1360,7 @@ nixl_capi_register_mem(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, nix
     printf("** Registered memory\n");
 #endif
     nixl_status_t ret = agent->inner->registerMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1381,7 +1381,7 @@ nixl_capi_deregister_mem(nixl_capi_agent_t agent, nixl_capi_reg_dlist_t dlist, n
     printf("** Deregistered memory\n");
 #endif
     nixl_status_t ret = agent->inner->deregisterMem(*dlist->dlist, opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1398,7 +1398,7 @@ nixl_capi_status_t nixl_capi_agent_make_connection(
   try {
     nixl_status_t ret = agent->inner->makeConnection(std::string(remote_agent),
                                                     opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1421,7 +1421,7 @@ nixl_capi_prep_xfer_dlist(nixl_capi_agent_t agent,
                                                         *descs->dlist,
                                                         (*dlist_handle)->handle,
                                                         opt_args ? &opt_args->args : nullptr);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -1438,7 +1438,7 @@ nixl_capi_release_xfer_dlist_handle(nixl_capi_agent_t agent,
     try {
         nixl_status_t ret = agent->inner->releasedDlistH(dlist_handle->handle);
         delete dlist_handle;
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -1530,7 +1530,7 @@ nixl_capi_estimate_xfer_cost(
     *duration_us = duration_us_ref.count();
     *err_margin_us = err_margin_us_ref.count();
     *method = static_cast<nixl_capi_cost_t>(method_ref);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1585,7 +1585,7 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
             return NIXL_CAPI_ERROR_BACKEND;
         }
         *backend = backend_handle;
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -1624,7 +1624,7 @@ nixl_capi_release_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req)
     if (ret == NIXL_SUCCESS) {
       req->req = nullptr;  // Prevent double-free in destroy
     }
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1666,7 +1666,7 @@ nixl_capi_gen_notif(nixl_capi_agent_t agent, const char* remote_agent,
     // Call the C++ function with the correct signature
     nixl_status_t ret = agent->inner->genNotif(std::string(remote_agent), msg,
                                               opt_args ? &opt_args->args : nullptr);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1902,7 +1902,7 @@ nixl_capi_query_mem(nixl_capi_agent_t agent,
     try {
         nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
         nixl_status_t ret = agent->inner->queryMem(*descs->dlist, resp->responses, args);
-        return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : NIXL_CAPI_ERROR_BACKEND;
+        return nixl_capi_status_from_nixl_status(ret);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -2036,6 +2036,10 @@ nixl_capi_status_from_nixl_status(nixl_status_t status) {
         return NIXL_CAPI_IN_PROG;
     case NIXL_ERR_NO_TELEMETRY:
         return NIXL_CAPI_ERROR_NO_TELEMETRY;
+    case NIXL_ERR_INVALID_PARAM:
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    case NIXL_ERR_NOT_FOUND:
+        return NIXL_CAPI_ERROR_NOT_FOUND;
     default:
         return NIXL_CAPI_ERROR_BACKEND;
     }

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -186,7 +186,7 @@ nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len)
     nixl_blob_t blob;
     nixl_status_t ret = agent->inner->getLocalMD(blob);
     if (ret != NIXL_SUCCESS) {
-      return nixl_capi_status_from_nixl_status(ret);
+        return nixl_capi_status_from_nixl_status(ret);
     }
 
     // Allocate memory for the blob data
@@ -254,7 +254,7 @@ nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, 
     // Load the metadata
     nixl_status_t ret = agent->inner->loadRemoteMD(blob, name);
     if (ret != NIXL_SUCCESS) {
-      return nixl_capi_status_from_nixl_status(ret);
+        return nixl_capi_status_from_nixl_status(ret);
     }
 
     // Allocate and copy the agent name
@@ -1645,7 +1645,7 @@ nixl_capi_get_notifs(nixl_capi_agent_t agent, nixl_capi_notif_map_t notif_map, n
   try {
     nixl_status_t ret = agent->inner->getNotifs(notif_map->notif_map, opt_args ? &opt_args->args : nullptr);
     if (ret != NIXL_SUCCESS) {
-      return nixl_capi_status_from_nixl_status(ret);
+        return nixl_capi_status_from_nixl_status(ret);
     }
     return NIXL_CAPI_SUCCESS;
   }

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -186,7 +186,7 @@ nixl_capi_get_local_md(nixl_capi_agent_t agent, void** data, size_t* len)
     nixl_blob_t blob;
     nixl_status_t ret = agent->inner->getLocalMD(blob);
     if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+      return nixl_capi_status_from_nixl_status(ret);
     }
 
     // Allocate memory for the blob data
@@ -254,7 +254,7 @@ nixl_capi_load_remote_md(nixl_capi_agent_t agent, const void* data, size_t len, 
     // Load the metadata
     nixl_status_t ret = agent->inner->loadRemoteMD(blob, name);
     if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+      return nixl_capi_status_from_nixl_status(ret);
     }
 
     // Allocate and copy the agent name
@@ -1416,12 +1416,16 @@ nixl_capi_prep_xfer_dlist(nixl_capi_agent_t agent,
     }
 
     try {
-        *dlist_handle = new nixl_capi_xfer_dlist_handle_s;
+        auto handle = std::make_unique<nixl_capi_xfer_dlist_handle_s>();
         nixl_status_t ret = agent->inner->prepXferDlist(std::string(agent_name),
                                                         *descs->dlist,
-                                                        (*dlist_handle)->handle,
+                                                        handle->handle,
                                                         opt_args ? &opt_args->args : nullptr);
-        return nixl_capi_status_from_nixl_status(ret);
+        if (ret != NIXL_SUCCESS) {
+            return nixl_capi_status_from_nixl_status(ret);
+        }
+        *dlist_handle = handle.release();
+        return NIXL_CAPI_SUCCESS;
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;
@@ -1473,7 +1477,7 @@ nixl_capi_make_xfer_req(nixl_capi_agent_t agent,
 
         if (ret != NIXL_SUCCESS) {
             delete req;
-            return NIXL_CAPI_ERROR_BACKEND;
+            return nixl_capi_status_from_nixl_status(ret);
         }
 
         *req_hndl = req;
@@ -1641,7 +1645,7 @@ nixl_capi_get_notifs(nixl_capi_agent_t agent, nixl_capi_notif_map_t notif_map, n
   try {
     nixl_status_t ret = agent->inner->getNotifs(notif_map->notif_map, opt_args ? &opt_args->args : nullptr);
     if (ret != NIXL_SUCCESS) {
-      return NIXL_CAPI_ERROR_BACKEND;
+      return nixl_capi_status_from_nixl_status(ret);
     }
     return NIXL_CAPI_SUCCESS;
   }

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -221,7 +221,7 @@ nixl_capi_get_local_partial_md(nixl_capi_agent_t agent,
         nixl_opt_args_t *args = opt_args ? &opt_args->args : nullptr;
         nixl_status_t ret = agent->inner->getLocalPartialMD(*descs->dlist, blob, args);
         if (ret != NIXL_SUCCESS) {
-            return NIXL_CAPI_ERROR_BACKEND;
+            return nixl_capi_status_from_nixl_status(ret);
         }
         // Allocate memory for the blob data
         *data = malloc(blob.size());
@@ -1547,7 +1547,7 @@ nixl_capi_post_xfer_req(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl, 
   try {
     nixl_status_t ret = agent->inner->postXferReq(req_hndl->req, opt_args ? &opt_args->args : nullptr);
 
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1563,7 +1563,7 @@ nixl_capi_get_xfer_status(nixl_capi_agent_t agent, nixl_capi_xfer_req_t req_hndl
 
   try {
     nixl_status_t ret = agent->inner->getXferStatus(req_hndl->req);
-    return ret == NIXL_SUCCESS ? NIXL_CAPI_SUCCESS : ret == NIXL_IN_PROG ? NIXL_CAPI_IN_PROG : NIXL_CAPI_ERROR_BACKEND;
+    return nixl_capi_status_from_nixl_status(ret);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -1582,7 +1582,7 @@ nixl_capi_query_xfer_backend(nixl_capi_agent_t agent,
         nixl_status_t ret = agent->inner->queryXferBackend(req_hndl->req, backend_handle->backend);
         if (ret != NIXL_SUCCESS) {
             delete backend_handle;
-            return NIXL_CAPI_ERROR_BACKEND;
+            return nixl_capi_status_from_nixl_status(ret);
         }
         *backend = backend_handle;
         return nixl_capi_status_from_nixl_status(ret);
@@ -2040,9 +2040,18 @@ nixl_capi_status_from_nixl_status(nixl_status_t status) {
         return NIXL_CAPI_ERROR_INVALID_PARAM;
     case NIXL_ERR_NOT_FOUND:
         return NIXL_CAPI_ERROR_NOT_FOUND;
-    default:
+    case NIXL_ERR_NOT_POSTED:
+    case NIXL_ERR_BACKEND:
+    case NIXL_ERR_MISMATCH:
+    case NIXL_ERR_NOT_ALLOWED:
+    case NIXL_ERR_REPOST_ACTIVE:
+    case NIXL_ERR_UNKNOWN:
+    case NIXL_ERR_NOT_SUPPORTED:
+    case NIXL_ERR_REMOTE_DISCONNECT:
+    case NIXL_ERR_CANCELED:
         return NIXL_CAPI_ERROR_BACKEND;
     }
+    return NIXL_CAPI_ERROR_BACKEND;
 }
 
 nixl_capi_status_t

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -33,7 +33,7 @@ typedef enum {
     NIXL_CAPI_ERROR_EXCEPTION = -4,
     NIXL_CAPI_IN_PROG = 1,
     NIXL_CAPI_ERROR_NO_TELEMETRY = -5,
-    NIXL_CAPI_ERROR_NOT_FOUND = -6,
+    NIXL_CAPI_ERROR_NOT_FOUND = -6, ///< Agent metadata not loaded, or no backend serves the request
 } nixl_capi_status_t;
 
 // Memory types enum (matching nixl's memory types)

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -33,6 +33,7 @@ typedef enum {
     NIXL_CAPI_ERROR_EXCEPTION = -4,
     NIXL_CAPI_IN_PROG = 1,
     NIXL_CAPI_ERROR_NO_TELEMETRY = -5,
+    NIXL_CAPI_ERROR_NOT_FOUND = -6,
 } nixl_capi_status_t;
 
 // Memory types enum (matching nixl's memory types)


### PR DESCRIPTION
## What?

Makes the Rust bindings report the status NIXL actually returned, instead of
collapsing every non-success to `BACKEND`.

- adds `NIXL_CAPI_ERROR_NOT_FOUND` to the C API status enum
- teaches `nixl_capi_status_from_nixl_status` to map `NIXL_ERR_NOT_FOUND` and
  `NIXL_ERR_INVALID_PARAM`, which previously fell through to `BACKEND`
- routes through that mapper every wrapper whose status the bindings surface,
  replacing the hand-rolled `ret == NIXL_SUCCESS ? SUCCESS : BACKEND`
- adds `NixlError::NotFound` and the matching arms on the agent methods

## Why?

The mapper knew only `SUCCESS`, `IN_PROG` and `NO_TELEMETRY`, so a caller could
not tell "peer metadata not loaded yet", which is retryable, from a real fault,
which is fatal. `nixl_agent.cpp` returns `NIXL_ERR_NOT_FOUND` from roughly two
dozen sites, most of them on the connect path, and all of them reached Rust as
`BackendError`. The `InvalidParam` arms already written in the bindings were
unreachable for the same reason.

This matters for callers that retry: with only `BackendError` to go on, a
transport either retries everything, including genuine failures, or nothing.

## How?

**One behaviour change to be aware of.** An unknown remote agent now yields
`NotFound` where it used to yield `BackendError`. `getXferTelemetry` shares the
mapper and is affected the same way. This follows the C++ side rather than
changing it. `test_prep_xfer_dlist_invalid_agent` is updated to match — its
message already said `InvalidParam` while asserting `BackendError`.

**Some paths lost the status even after the wrapper was routed**, and are fixed
here too:

- `get_local_partial_md` and `query_xfer_backend` returned `BACKEND` from their
  `ret != NIXL_SUCCESS` guard, so the mapper call at the end only ever saw
  `NIXL_SUCCESS`
- `post_xfer_req` and `get_xfer_status` hand-rolled `SUCCESS`/`IN_PROG`/`BACKEND`;
  the mapper already maps `IN_PROG`
- `send_local_md`, `fetch_remote_md`, `invalidate_local_md`, `send_notification`
  and `get_xfer_telemetry` had no `NotFound` arm on the Rust side
- `invalidate_remote_md` and `invalidate_all_remotes` discarded the status and
  returned `Ok(())`, and dropped the remote from local tracking before the
  agent had invalidated it, so a failure lost it
- `get_local_md` checked `data.is_null()` before matching the status, so every
  error returned `InvalidDataPointer`
- `prep_xfer_dlist` leaked the handle it allocates when `prepXferDlist` fails

`check_remote_md` is deliberately unchanged: it returns `bool`, and `NOT_FOUND`
already means `false` there, which is what a presence probe should report.

`prep_mem_view_local` and `_remote`, merged in #2060, already call the mapper,
so they pick up a `NotFound` arm here. Their unknown-agent and all-null-agent
tests asserted only `is_err()` because `NOT_FOUND` had nowhere to map; both now
assert `NotFound`, which is what `nixl_agent.cpp` returns for a remote agent
whose metadata is not loaded and for a list with no addressable peer.

The repeated `InvalidParam`/`NotFound`/`_` arms this leaves behind are worth
folding into one helper. That is a pure refactor across files this PR does not
otherwise touch, so it follows separately.

## Testing

104 tests pass with `cargo test -- --test-threads=1` — 96 in `tests.rs`, 4 in
`mem_view.rs`, 4 in `test_sync_manager.rs` — on UCX 1.21 with a CUDA device,
against `libnixl` built from this branch's base. The two memory-view tests that
assert `NotFound` run by default; they need a GPU but no device-capable RDMA
lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for unavailable agents, metadata, backends, and telemetry.
  * Invalid parameters and missing resources now return specific, actionable errors instead of generic failures or false success.
  * Remote metadata invalidation now reports failures accurately and stops when an error occurs.
  * Transfer and memory operations provide more consistent status handling across the API.

* **Tests**
  * Updated coverage to verify precise “not found” and invalid-parameter error results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->