### PR TITLE
libfabric: Preserve remote disconnect CQ errors

### DIFF
--- a/src/utils/libfabric/libfabric_common.h
+++ b/src/utils/libfabric/libfabric_common.h
@@ -274,6 +274,11 @@ getAvailableNetworkDevices();
 // String utilities
 std::string
 hexdump(const void *data, size_t size);
+
+inline nixl_status_t
+cqErrorToNixlStatus(int error) {
+    return error == FI_ENOTCONN ? NIXL_ERR_REMOTE_DISCONNECT : NIXL_ERR_BACKEND;
+}
 } // namespace LibfabricUtils
 
 #endif // NIXL_SRC_UTILS_LIBFABRIC_LIBFABRIC_COMMON_H

--- a/src/utils/libfabric/libfabric_rail.cpp
+++ b/src/utils/libfabric/libfabric_rail.cpp
@@ -732,6 +732,11 @@ nixlLibfabricRail::progressCompletionQueue() const {
                 NIXL_ERROR << "CQ read failed on rail " << rail_id
                            << " with error: " << fi_strerror(err_entry.err)
                            << " prov_errno: " << err_entry.prov_errno << " len: " << err_entry.len;
+                nixl_status_t status = LibfabricUtils::cqErrorToNixlStatus(err_entry.err);
+                if (status == NIXL_ERR_REMOTE_DISCONNECT) {
+                    NIXL_WARN << "CQ read detected a disconnected remote endpoint on rail " << rail_id;
+                }
+                return status;
             } else {
                 NIXL_ERROR << "fi_cq_readerr failed with " << err_ret;
             }

--- a/src/utils/libfabric/libfabric_rail_manager.cpp
+++ b/src/utils/libfabric/libfabric_rail_manager.cpp
@@ -691,7 +691,7 @@ nixlLibfabricRailManager::progressAllControlRails() {
         } else if (status != NIXL_IN_PROG && status != NIXL_SUCCESS) {
             any_completions = true;
             NIXL_ERROR << "Failed to process completion on control rail " << rail_id;
-            return NIXL_ERR_BACKEND;
+            return status;
         }
     }
     return any_completions ? NIXL_SUCCESS : NIXL_IN_PROG;

--- a/test/unit/utils/libfabric/libfabric_error_status_test.cpp
+++ b/test/unit/utils/libfabric/libfabric_error_status_test.cpp
@@ -1,0 +1,15 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "libfabric/libfabric_common.h"
+
+#include <cassert>
+
+int
+main() {
+    assert(LibfabricUtils::cqErrorToNixlStatus(FI_ENOTCONN) == NIXL_ERR_REMOTE_DISCONNECT);
+    assert(LibfabricUtils::cqErrorToNixlStatus(FI_EIO) == NIXL_ERR_BACKEND);
+    return 0;
+}

--- a/test/unit/utils/libfabric/meson.build
+++ b/test/unit/utils/libfabric/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-FileCopyrightText: Copyright (c) 2025 Amazon.com, Inc. and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,5 +31,15 @@ if get_option('buildtype') != 'release'
                link_with: libfabric_utils_lib,
                cpp_args: libfabric_test_cpp_args,
                install: true)
+
+    libfabric_error_status_test_bin = executable('libfabric_error_status_test',
+               'libfabric_error_status_test.cpp',
+               dependencies: libfabric_utils_dep,
+               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               link_with: libfabric_utils_lib,
+               cpp_args: libfabric_test_cpp_args,
+               install: true)
+
+    test('libfabric_error_status_test', libfabric_error_status_test_bin)
 
 endif


### PR DESCRIPTION
## What?

Map libfabric CQ errors with FI_ENOTCONN to the existing NIXL_ERR_REMOTE_DISCONNECT status.

Preserve that status through control-rail polling. Add regression coverage.


## Why?

A remote peer loss currently becomes generic NIXL_ERR_BACKEND.
Callers cannot distinguish a disconnected peer from other backend failures.
This prevents targeted recovery by higher-level integrations.

## How?

Classify only fi_cq_readerr().err == FI_ENOTCONN.
Keep all other CQ errors as NIXL_ERR_BACKEND.
Return the typed status from control-rail polling.
Test both the typed disconnect and generic FI_EIO paths.
