### PR TITLE
ci: add combined crate-publish + compliance pipeline (release/1.4.1)

### DIFF
--- a/.github/workflows/nixl-compliance.yml
+++ b/.github/workflows/nixl-compliance.yml
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# nixl release pipeline: stage the Rust crate to Artifactory, then run the
+# centralized release-automation compliance pipeline — in a single tag-triggered DAG.
+#
+#   prep ─┐
+#         ├─ publish-crate ── compliance
+#         └───────────────────┘   (needs prep + publish-crate)
+#
+# On a v* tag:
+#   1. prep           derive rc_tag / wheel_version / sonar_branch / crate_version.
+#   2. publish-crate  cargo publish nixl-sys -> Artifactory sw-dynamo-nixl-cargo-local.
+#                     Runs on GitHub-hosted ubuntu-latest (a --no-verify publish needs no
+#                     builder; the self-hosted velonix runners reject tag/push events).
+#   3. compliance     trigger the release-automation GitLab pipeline (PROJECT=nixl:
+#                     wheel scan + SonarQube + nSpect register) and poll to completion.
+#                     GATED: only runs if publish-crate succeeded, so a broken crate
+#                     upload fails the run fast rather than after a long compliance scan.
+#
+# release-automation lives on GitLab (dl/ai-dynamo/release-automation), not GitHub, so
+# there is no reusable workflow to `uses:` — the trigger+poll logic is inlined here.
+# The crate is staged from GitHub (dynamo-parity split): GitLab only consumes it — the
+# GA crates.io publish happens later in the GitLab pipeline's promote:crates job.
+#
+# On a pull_request that touches the crate: run crate-validate only (cargo package,
+# no upload, no token, no GitLab) as a DRY RUN.
+#
+# PREREQUISITES (before the first real run):
+#   Runner: an internal runner with corp-net reach to gitlab-master.nvidia.com
+#           (the `gitlab_ci_runners` group — same one nixl's other GitLab triggers use).
+#   Secrets:
+#     ARTIFACTORY_URL          - e.g. https://artifactory.nvidia.com/artifactory  (crate)
+#     ARTIFACTORY_CARGO_TOKEN  - deploy token for the cargo repo                   (crate)
+#     GITLAB_TRIGGER_TOKEN     - release-automation pipeline trigger token   (compliance)
+#     GITLAB_API_TOKEN         - PAT with read_api scope, for polling        (compliance)
+#     (GITLAB_PROJECT_ID is hardcoded below to 191080 — no secret needed)
+#   release-automation projects/nixl.yml + configs/projects.yml onboard nixl as wheel+crate.
+name: NIXL release (crate + compliance)
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # PRs that touch the crate/workflow run crate-validate as a DRY RUN (validate; never publish).
+  pull_request:
+    branches:
+      - 'release/**'
+      - main
+    paths:
+      - '.github/workflows/nixl-compliance.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'src/bindings/rust/**'
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: "RC tag, e.g. v1.4.0-rc0 (defaults to the pushed tag)."
+        required: false
+        default: ""
+      wheel_version:
+        description: "Wheel version staged in sw-nbu-swx, e.g. 1.4.0 (default: base version from the tag, no rc suffix)."
+        required: false
+        default: ""
+      crate_version:
+        description: "nixl-sys crate version to stage (default: the tag version, e.g. v1.4.0-rc0 -> 1.4.0-rc0)."
+        required: false
+        default: ""
+      crate_dry_run:
+        description: "Crate: package only, do not upload (adds cargo publish --dry-run)."
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  # ── PR: validate the crate packages cleanly (no upload, no token, no GitLab) ──
+  crate-validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: cargo package (dry run)
+        run: |
+          set -e
+          if ! command -v cargo >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            . "$HOME/.cargo/env"
+          fi
+          echo "PR validation: cargo package (no upload)"
+          cargo package --manifest-path src/bindings/rust/Cargo.toml --no-verify --allow-dirty
+
+  # ── tag/manual: derive the versions used by publish-crate and compliance ──
+  prep:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      rc_tag: ${{ steps.v.outputs.rc_tag }}
+      wheel_version: ${{ steps.v.outputs.wheel_version }}
+      sonar_branch: ${{ steps.v.outputs.sonar_branch }}
+      crate_version: ${{ steps.v.outputs.crate_version }}
+    steps:
+      - id: v
+        run: |
+          set -e
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            RC_TAG="${GITHUB_REF_NAME}"
+          else
+            RC_TAG="${{ github.event.inputs.rc_tag }}"
+          fi
+          [ -n "$RC_TAG" ] || { echo "::error::rc_tag is required (push a v* tag or set the input)"; exit 1; }
+          T="${RC_TAG#v}"                          # 1.4.0-rc0
+          BASE="${T%%-rc*}"                        # 1.4.0
+          WV="${{ github.event.inputs.wheel_version }}"
+          # blossom stages the release wheels in sw-nbu-swx as the PLAIN base version
+          # (nixl_cu12/cu13 == 1.4.0), not rc-suffixed — so the scan/promote can find them.
+          [ -n "$WV" ] || WV="${BASE}"             # e.g. v1.4.0-rc0 -> 1.4.0
+          # Crate is staged at the full tag version (distinct per RC); overridable by input.
+          CV="${{ github.event.inputs.crate_version }}"
+          [ -n "$CV" ] || CV="${T}"                # e.g. v1.4.0-rc0 -> 1.4.0-rc0
+          echo "rc_tag=$RC_TAG" >> "$GITHUB_OUTPUT"
+          echo "wheel_version=$WV" >> "$GITHUB_OUTPUT"
+          echo "sonar_branch=release/${BASE}" >> "$GITHUB_OUTPUT"
+          echo "crate_version=$CV" >> "$GITHUB_OUTPUT"
+          echo "rc_tag=$RC_TAG  wheel_version=$WV  crate_version=$CV  sonar_branch=release/${BASE}"
+
+  # ── tag/manual: stage nixl-sys to Artifactory (dynamo-parity: GitHub pushes, GitLab consumes) ──
+  publish-crate:
+    if: github.event_name != 'pull_request'
+    needs: prep
+    # Always GitHub-hosted: a --no-verify cargo publish needs no builder image, and the
+    # self-hosted velonix runners reject tag/push events at admission anyway.
+    runs-on: ubuntu-latest
+    env:
+      ARTIFACTORY_URL: ${{ secrets.ARTIFACTORY_URL }}
+      ARTIFACTORY_CARGO_TOKEN: ${{ secrets.ARTIFACTORY_CARGO_TOKEN }}
+      CARGO_REPO: sw-dynamo-nixl-cargo-local
+      CRATE_VERSION: ${{ needs.prep.outputs.crate_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Guard secrets
+        run: |
+          echo "ARTIFACTORY_CARGO_TOKEN length: ${#ARTIFACTORY_CARGO_TOKEN}"
+          [ -n "$ARTIFACTORY_CARGO_TOKEN" ] || { echo "::error::ARTIFACTORY_CARGO_TOKEN secret is empty/unavailable for this ref."; exit 1; }
+          [ -n "$ARTIFACTORY_URL" ] || { echo "::error::ARTIFACTORY_URL secret is empty."; exit 1; }
+
+      - name: Set workspace version
+        run: |
+          set -e
+          # Bump the [workspace.package] version (nixl-sys uses version.workspace = true).
+          sed -i -E "s/^(version = \")([^\"]+)(\")/\1${CRATE_VERSION}\3/" Cargo.toml
+          grep -m1 '^version = ' Cargo.toml
+
+      - name: cargo publish -> Artifactory
+        run: |
+          set -e
+          # ubuntu-latest ships cargo; fall back to rustup just in case.
+          if ! command -v cargo >/dev/null 2>&1; then
+            echo "cargo not found; installing via rustup"
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            . "$HOME/.cargo/env"
+          fi
+          DRY=""
+          [ "${{ github.event.inputs.crate_dry_run }}" = "true" ] && DRY="--dry-run"
+          [ -n "$DRY" ] && echo "DRY RUN: packaging only, no upload"
+          # Token passed via env inside the arg; do not enable `set -x` around this line.
+          # --no-verify: source already built + tested by the wheel/CI path (nixl-sys' build.rs
+          # needs c++20 the packager lacks), so package + upload without a full build.
+          cargo publish --manifest-path src/bindings/rust/Cargo.toml \
+            --token "Bearer ${ARTIFACTORY_CARGO_TOKEN}" \
+            --index "sparse+${ARTIFACTORY_URL}/api/cargo/${CARGO_REPO}/index/" \
+            --no-verify --allow-dirty $DRY
+
+  # ── tag/manual: trigger + poll the release-automation compliance pipeline ──
+  compliance:
+    if: github.event_name != 'pull_request'
+    # GATED: run only if the crate staged successfully (and after prep).
+    needs: [prep, publish-crate]
+    # Internal runner with reach to gitlab-master (same group nixl's other triggers use).
+    runs-on:
+      group: gitlab_ci_runners
+    environment: automated-release
+    steps:
+      - name: Trigger release-automation compliance pipeline (PROJECT=nixl)
+        id: trigger
+        env:
+          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
+          GITLAB_PROJECT_ID: "191080"   # dl/ai-dynamo/release-automation (project id, not sensitive)
+          RC_TAG: ${{ needs.prep.outputs.rc_tag }}
+          WHEEL_VERSION: ${{ needs.prep.outputs.wheel_version }}
+          CRATE_VERSION: ${{ needs.prep.outputs.crate_version }}
+          SONAR_BRANCH: ${{ needs.prep.outputs.sonar_branch }}
+        run: |
+          set -euo pipefail
+          GITLAB_API="https://gitlab-master.nvidia.com/api/v4"
+          # Trigger token via @file so it never lands in process listings.
+          TF=$(mktemp); trap 'rm -f "$TF"' EXIT; chmod 600 "$TF"
+          printf '%s' "${GITLAB_TRIGGER_TOKEN}" > "$TF"
+          HTTP_CODE=$(curl -sS -o /tmp/gl_response.json -w "%{http_code}" -X POST \
+            "${GITLAB_API}/projects/${GITLAB_PROJECT_ID}/trigger/pipeline" \
+            --form "token=<${TF}" \
+            --form "ref=main" \
+            --form "variables[PIPELINE_TYPE]=rc" \
+            --form "variables[RELEASE_TYPE]=rc" \
+            --form "variables[PROJECT]=nixl" \
+            --form "variables[RC_TAG]=${RC_TAG}" \
+            --form "variables[WHEEL_VERSION]=${WHEEL_VERSION}" \
+            --form "variables[CRATE_VERSION]=${CRATE_VERSION}" \
+            --form "variables[ARTIFACTS]=wheel,crate" \
+            --form "variables[COMMIT_SHA]=${GITHUB_SHA}" \
+            --form "variables[ARTIFACTORY_PYPI_URL]=https://artifactory.nvidia.com/artifactory/api/pypi/sw-nbu-swx-nixl-pypi-local/simple" \
+            --form "variables[SONAR_BRANCH]=${SONAR_BRANCH}" \
+            --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}")
+          echo "GitLab API HTTP status: ${HTTP_CODE}"
+          jq . /tmp/gl_response.json 2>/dev/null || cat /tmp/gl_response.json
+          if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -ge 300 ]; then
+            echo "::error::Failed to trigger release-automation pipeline (HTTP ${HTTP_CODE})"; exit 1
+          fi
+          PIPELINE_ID=$(jq -r '.id' /tmp/gl_response.json)
+          PIPELINE_URL=$(jq -r '.web_url' /tmp/gl_response.json)
+          echo "pipeline_id=${PIPELINE_ID}" >> "$GITHUB_OUTPUT"
+          {
+            echo "## release-automation compliance (nixl)"
+            echo "Triggered: ${PIPELINE_URL}"
+            echo "Version: ${WHEEL_VERSION} (${RC_TAG}) · crate ${CRATE_VERSION}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Poll pipeline status
+        env:
+          GITLAB_API_TOKEN: ${{ secrets.GITLAB_API_TOKEN }}
+          GITLAB_PROJECT_ID: "191080"   # dl/ai-dynamo/release-automation (project id, not sensitive)
+        run: |
+          set -euo pipefail
+          PIPELINE_ID="${{ steps.trigger.outputs.pipeline_id }}"
+          GITLAB_API="https://gitlab-master.nvidia.com/api/v4"
+          MAX_WAIT=1800; INTERVAL=30; ELAPSED=0
+          while [ "${ELAPSED}" -lt "${MAX_WAIT}" ]; do
+            STATUS=$(curl -sS -H "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \
+              "${GITLAB_API}/projects/${GITLAB_PROJECT_ID}/pipelines/${PIPELINE_ID}" | jq -r '.status')
+            echo "[${ELAPSED}s] pipeline status: ${STATUS}"
+            case "${STATUS}" in
+              success)
+                echo "## release-automation compliance: PASSED" >> "$GITHUB_STEP_SUMMARY"; exit 0 ;;
+              failed|canceled|skipped)
+                echo "::error::compliance pipeline ${STATUS}"
+                echo "## release-automation compliance: FAILED (${STATUS})" >> "$GITHUB_STEP_SUMMARY"; exit 1 ;;
+              running|pending|waiting_for_resource|preparing|created) ;;
+              *) echo "::warning::unexpected status: ${STATUS}" ;;
+            esac
+            sleep "${INTERVAL}"; ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "::error::poll timed out after ${MAX_WAIT}s"; exit 1


### PR DESCRIPTION
Port the single-DAG release workflow to release/1.4.1: on a v* tag it runs prep -> publish-crate -> compliance (gated), staging the nixl-sys crate to Artifactory and then triggering the release-automation GitLab compliance pipeline (wheel scan + SonarQube + nSpect). PRs run crate-validate only.

Mirror of the release/1.4.0 crate pipeline (PR #2076).

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
