### PR TITLE
chore: update attributions for 1.4.1

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -9288,7 +9288,7 @@ NetworkX is distributed with the 3-clause BSD license.
   - `Source Code`: https://github.com/networkx/networkx
 
 
-## nixl (1.4.0)
+## nixl (1.4.1)
 
 ### Licenses
 License: `Apache-2.0`
@@ -9509,7 +9509,7 @@ License: `Apache-2.0`
 
 
 
-## nixl-cu12 (1.4.0)
+## nixl-cu12 (1.4.1)
 
 ### Licenses
 License: `Apache-2.0`
@@ -9730,7 +9730,7 @@ License: `Apache-2.0`
 
 
 
-## nixl-cu13 (1.4.0)
+## nixl-cu13 (1.4.1)
 
 ### Licenses
 License: `Apache-2.0`


### PR DESCRIPTION
Bump the nixl, nixl-cu12 and nixl-cu13 self-version entries from 1.4.0 to 1.4.1. No third-party dependency changes between 1.4.0 and 1.4.1: Rust crates verified 68/68 against Cargo.lock, all Meson wrap versions unchanged, and the wheel's torch/numpy deps are unchanged.

## What?
_Describe what this PR is doing._

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._
