### PR TITLE
fix(obj): reject duplicate devId registrations

### DIFF
--- a/src/plugins/obj/s3/engine_impl.cpp
+++ b/src/plugins/obj/s3/engine_impl.cpp
@@ -136,7 +136,12 @@ DefaultObjEngineImpl::registerMem(const nixlBlobDesc &mem,
     if (nixl_mem == OBJ_SEG) {
         std::unique_ptr<nixlObjMetadata> obj_md = std::make_unique<nixlObjMetadata>(
             nixl_mem, mem.devId, mem.metaInfo.empty() ? std::to_string(mem.devId) : mem.metaInfo);
-        devIdToObjKey_[mem.devId] = obj_md->objKey;
+        const bool inserted = devIdToObjKey_.emplace(mem.devId, obj_md->objKey).second;
+        if (!inserted) {
+            NIXL_ERROR << "OBJ requires a unique devId per object (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         out = obj_md.release();
     } else {
         out = nullptr;

--- a/src/plugins/obj/s3_accel/dell/engine_impl.cpp
+++ b/src/plugins/obj/s3_accel/dell/engine_impl.cpp
@@ -371,8 +371,8 @@ S3DellObsObjEngineImpl::S3DellObsObjEngineImpl(const nixlBackendInitParams *init
  * @param mem Memory blob descriptor containing address, length, device ID, and metadata
  * @param nixl_mem Memory type (OBJ_SEG, DRAM_SEG, or VRAM_SEG)
  * @param out Output backend metadata handle
- * @return NIXL_SUCCESS on success, NIXL_ERR_BACKEND on cuObject failure, NIXL_ERR_NOT_SUPPORTED for
- * unsupported memory types
+ * @return NIXL_SUCCESS on success, NIXL_ERR_INVALID_PARAM if the OBJ devId is already registered,
+ * NIXL_ERR_BACKEND on cuObject failure, or NIXL_ERR_NOT_SUPPORTED for unsupported memory types
  */
 nixl_status_t
 S3DellObsObjEngineImpl::registerMem(const nixlBlobDesc &mem,

--- a/src/plugins/obj/s3_accel/dell/engine_impl.cpp
+++ b/src/plugins/obj/s3_accel/dell/engine_impl.cpp
@@ -391,7 +391,12 @@ S3DellObsObjEngineImpl::registerMem(const nixlBlobDesc &mem,
     if (nixl_mem == OBJ_SEG) {
         std::unique_ptr<nixlObsObjMetadata> obj_md = std::make_unique<nixlObsObjMetadata>(
             nixl_mem, mem.devId, mem.metaInfo.empty() ? std::to_string(mem.devId) : mem.metaInfo);
-        devIdToObjKey_[mem.devId] = obj_md->objKey;
+        const bool inserted = devIdToObjKey_.emplace(mem.devId, obj_md->objKey).second;
+        if (!inserted) {
+            NIXL_ERROR << "OBJ requires a unique devId per object (devId=" << mem.devId
+                       << " already registered)";
+            return NIXL_ERR_INVALID_PARAM;
+        }
         out = obj_md.release();
     } else if ((nixl_mem == DRAM_SEG) || (nixl_mem == VRAM_SEG)) {
 

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -105,6 +105,50 @@ TEST_P(objParamTestFixture, RegisterMemoryObjSegWithoutKey) {
     EXPECT_EQ(status, NIXL_SUCCESS);
 }
 
+TEST_P(objParamTestFixture, RegisterMemoryDuplicateObjDevId) {
+    std::vector<char> test_buffer(64, 'x');
+
+    nixlBlobDesc local_desc(
+        reinterpret_cast<uintptr_t>(test_buffer.data()), test_buffer.size(), 1, "");
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    constexpr uint64_t dev_id = 42;
+    nixlBlobDesc registered_desc(0, 512, dev_id, "test-object-key-1");
+    nixlBlobDesc duplicate_desc(1024, 512, dev_id, "test-object-key-2");
+    nixlBackendMD *registered_metadata = nullptr;
+    nixlBackendMD *duplicate_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(registered_desc, OBJ_SEG, registered_metadata), NIXL_SUCCESS);
+    ASSERT_EQ(objEngine_->registerMem(duplicate_desc, OBJ_SEG, duplicate_metadata),
+              NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(duplicate_metadata, nullptr);
+
+    // A rejected duplicate must leave the original registration usable.
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+    local_descs.addDesc(nixlMetaDesc(local_desc.addr, local_desc.len, local_desc.devId));
+    remote_descs.addDesc(nixlMetaDesc(registered_desc.addr, test_buffer.size(), dev_id));
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(objEngine_->prepXfer(
+                  NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_SUCCESS);
+    ASSERT_EQ(objEngine_->postXfer(
+                  NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_IN_PROG);
+    mockS3Client_->execAsync();
+    EXPECT_EQ(objEngine_->checkXfer(handle), NIXL_SUCCESS);
+    EXPECT_EQ(objEngine_->releaseReqH(handle), NIXL_SUCCESS);
+
+    ASSERT_EQ(objEngine_->deregisterMem(registered_metadata), NIXL_SUCCESS);
+
+    // Deregistration makes the devId available for a new object registration.
+    EXPECT_EQ(objEngine_->registerMem(duplicate_desc, OBJ_SEG, duplicate_metadata), NIXL_SUCCESS);
+
+    EXPECT_EQ(objEngine_->deregisterMem(duplicate_metadata), NIXL_SUCCESS);
+    EXPECT_EQ(objEngine_->deregisterMem(local_metadata), NIXL_SUCCESS);
+}
+
 TEST_P(objParamTestFixture, RegisterMemoryDramSeg) {
     nixlBlobDesc mem_desc;
     mem_desc.devId = 123;


### PR DESCRIPTION
## What?
 Fixes https://github.com/ai-dynamo/nixl/issues/1794. Reject duplicate `devId` registrations in the default S3 and Dell OBJ backends.

## Why?
A duplicate `devId` could silently overwrite the existing object mapping and send data to the wrong object. 

  ## How?
Use `emplace()` to detect duplicates and return `NIXL_ERR_INVALID_PARAM`. Add tests to make sure the original mapping stays usable and the `devId` can be registered again after deregistration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate device IDs during object memory registration are now rejected with an invalid-parameter error instead of replacing the existing registration.
  * Existing registrations remain usable for transfers after a duplicate registration attempt.
  * Device IDs can be reused after the original registration is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->