### PR TITLE
ci: set UCX_RESOLVE_REMOTE_EP_ID=n for the CPP tests

### DIFF
--- a/.ci/jenkins/lib/test-dl-matrix.yaml
+++ b/.ci/jenkins/lib/test-dl-matrix.yaml
@@ -186,7 +186,8 @@ steps:
       credentialsId: "${SSH_CREDENTIALS_ID}"
       containerName: "nixl-ci-${BUILD_NUMBER}"
       slurmEnv: [
-        'UCX_IB_REG_METHODS=rcache'
+        'UCX_IB_REG_METHODS=rcache',
+        'UCX_RESOLVE_REMOTE_EP_ID=n'
       ]
 
   - name: Run DL Nixlbench tests

--- a/.ci/jenkins/lib/test-matrix.yaml
+++ b/.ci/jenkins/lib/test-matrix.yaml
@@ -156,6 +156,9 @@ steps:
       credentialsId: "${SCCTL_CREDENTIALS_ID}"
       containerName: "nixl-ci-${BUILD_NUMBER}"
       exportEnroot: "true"  # on failure, export the container to ${ENROOT_MOUNT_PATH} for crash debugging
+      slurmEnv: [
+        'UCX_RESOLVE_REMOTE_EP_ID=n'
+      ]
 
   - name: Run Python tests
     containerSelector: "{name: 'build_helper'}"


### PR DESCRIPTION
## What?

Set `UCX_RESOLVE_REMOTE_EP_ID=n` on the CPP test steps of the two jobs the nightly fans out to that run `.gitlab/test_cpp.sh`:

- `nixl-ci-gpu` — `Run CPP tests` (new `slurmEnv`)
- `nixl-ci-dl-gpu` — `Run DL CPP tests` (added alongside the existing `UCX_IB_REG_METHODS=rcache`)

## Why?

The CPP tests take a long time on the nightly UCX-master run. This measures whether disabling remote endpoint ID resolution improves the runtime.

## How?

Config only — no test or source changes. Two files, 5 added lines.

Note this applies to per-PR runs of those jobs as well, not just the nightly UCX-master leg, since the steps are shared. If the effect is worth keeping and should be scoped to UCX master only, the setting can be made conditional on `UCX_VER` in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of C++ and deep-learning test execution in Slurm environments.
  * Updated test configuration to prevent remote endpoint ID resolution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->