### PR TITLE
tracing: add internal trace context

### DIFF
--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -76,6 +76,7 @@ nixl_lib_sources = [
     'telemetry/buffer_exporter.cpp',
     'telemetry/buffer_plugin.cpp',
     'telemetry/nop_plugin.cpp',
+    'tracing/trace_context.cpp',
     'tracing/tracer.cpp',
 ]
 

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -14,21 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "trace_context.h"
-
 #include <algorithm>
 
 #include "common/uuid_v4.h"
+#include "trace_context.h"
 
+namespace {
 constexpr std::uint8_t supported_trace_flags = 0x03;
 
 template<std::size_t Size>
-[[nodiscard]] static bool
-allZero(const std::array<std::uint8_t, Size> &bytes) noexcept {
+[[nodiscard]] bool
+isAllZero(const std::array<std::uint8_t, Size> &bytes) noexcept {
     return std::all_of(bytes.begin(), bytes.end(), [](std::uint8_t byte) { return byte == 0; });
 }
 
-[[nodiscard]] static int
+[[nodiscard]] int
 hexValue(char value) noexcept {
     if (value >= '0' && value <= '9') {
         return value - '0';
@@ -39,7 +39,7 @@ hexValue(char value) noexcept {
     return -1;
 }
 
-[[nodiscard]] static bool
+[[nodiscard]] bool
 parseByte(std::string_view value, std::size_t offset, std::uint8_t &result) noexcept {
     const int high = hexValue(value[offset]);
     const int low = hexValue(value[offset + 1]);
@@ -51,7 +51,7 @@ parseByte(std::string_view value, std::size_t offset, std::uint8_t &result) noex
 }
 
 template<std::size_t Size>
-[[nodiscard]] static bool
+[[nodiscard]] bool
 parseBytes(std::string_view value,
            std::size_t offset,
            std::array<std::uint8_t, Size> &result) noexcept {
@@ -63,17 +63,18 @@ parseBytes(std::string_view value,
     return true;
 }
 
-static void
+void
 appendByte(std::string &result, std::uint8_t value) {
     constexpr std::array<char, 16> hex{
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
     result.push_back(hex[value >> 4]);
     result.push_back(hex[value & 0x0f]);
 }
+} // namespace
 
 bool
 nixl::trace::TraceContext::valid() const noexcept {
-    return !allZero(traceId) && !allZero(spanId);
+    return !isAllZero(traceId) && !isAllZero(spanId);
 }
 
 bool
@@ -132,12 +133,12 @@ nixl::trace::generateTraceContext() {
     nixl::trace::TraceContext context;
     do {
         context.traceId = nixl::UUIDv4{}.get_data();
-    } while (allZero(context.traceId));
+    } while (isAllZero(context.traceId));
     context.flags = 0x02;
 
     do {
         const auto span_source = nixl::UUIDv4{}.get_data();
         std::copy_n(span_source.begin(), context.spanId.size(), context.spanId.begin());
-    } while (allZero(context.spanId));
+    } while (isAllZero(context.spanId));
     return context;
 }

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -20,6 +20,8 @@
 
 #include "common/uuid_v4.h"
 
+constexpr std::uint8_t supported_trace_flags = 0x03;
+
 template<std::size_t Size>
 [[nodiscard]] static bool
 allZero(const std::array<std::uint8_t, Size> &bytes) noexcept {
@@ -33,9 +35,6 @@ hexValue(char value) noexcept {
     }
     if (value >= 'a' && value <= 'f') {
         return value - 'a' + 10;
-    }
-    if (value >= 'A' && value <= 'F') {
-        return value - 'A' + 10;
     }
     return -1;
 }
@@ -103,6 +102,7 @@ nixl::trace::parseTraceparent(std::string_view value) {
         !parseByte(value, 53, context.flags) || !context.valid()) {
         return std::nullopt;
     }
+    context.flags &= supported_trace_flags;
     return context;
 }
 
@@ -123,7 +123,7 @@ nixl::trace::formatTraceparent(const nixl::trace::TraceContext &context) {
         appendByte(result, byte);
     }
     result.push_back('-');
-    appendByte(result, context.flags);
+    appendByte(result, context.flags & supported_trace_flags);
     return result;
 }
 
@@ -133,6 +133,7 @@ nixl::trace::generateTraceContext() {
     do {
         context.traceId = nixl::UUIDv4{}.get_data();
     } while (allZero(context.traceId));
+    context.flags = 0x02;
 
     do {
         const auto span_source = nixl::UUIDv4{}.get_data();

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -1,0 +1,142 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "trace_context.h"
+
+#include <algorithm>
+
+#include "common/uuid_v4.h"
+
+template<std::size_t Size>
+[[nodiscard]] static bool
+allZero(const std::array<std::uint8_t, Size> &bytes) noexcept {
+    return std::all_of(bytes.begin(), bytes.end(), [](std::uint8_t byte) { return byte == 0; });
+}
+
+[[nodiscard]] static int
+hexValue(char value) noexcept {
+    if (value >= '0' && value <= '9') {
+        return value - '0';
+    }
+    if (value >= 'a' && value <= 'f') {
+        return value - 'a' + 10;
+    }
+    if (value >= 'A' && value <= 'F') {
+        return value - 'A' + 10;
+    }
+    return -1;
+}
+
+[[nodiscard]] static bool
+parseByte(std::string_view value, std::size_t offset, std::uint8_t &result) noexcept {
+    const int high = hexValue(value[offset]);
+    const int low = hexValue(value[offset + 1]);
+    if (high < 0 || low < 0) {
+        return false;
+    }
+    result = static_cast<std::uint8_t>((high << 4) | low);
+    return true;
+}
+
+template<std::size_t Size>
+[[nodiscard]] static bool
+parseBytes(std::string_view value,
+           std::size_t offset,
+           std::array<std::uint8_t, Size> &result) noexcept {
+    for (std::size_t index = 0; index < Size; ++index) {
+        if (!parseByte(value, offset + index * 2, result[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void
+appendByte(std::string &result, std::uint8_t value) {
+    constexpr std::array<char, 16> hex{
+        '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    result.push_back(hex[value >> 4]);
+    result.push_back(hex[value & 0x0f]);
+}
+
+bool
+nixl::trace::TraceContext::valid() const noexcept {
+    return !allZero(traceId) && !allZero(spanId);
+}
+
+bool
+nixl::trace::TraceContext::sampled() const noexcept {
+    return (flags & 0x01) != 0;
+}
+
+std::uint64_t
+nixl::trace::TraceContext::correlationId64() const noexcept {
+    std::uint64_t result = 0;
+    for (std::size_t index = 0; index < sizeof(result); ++index) {
+        result = (result << 8) | traceId[index];
+    }
+    return result;
+}
+
+std::optional<nixl::trace::TraceContext>
+nixl::trace::parseTraceparent(std::string_view value) {
+    if (value.size() != 55 || value[0] != '0' || value[1] != '0' || value[2] != '-' ||
+        value[35] != '-' || value[52] != '-') {
+        return std::nullopt;
+    }
+
+    nixl::trace::TraceContext context;
+    if (!parseBytes(value, 3, context.traceId) || !parseBytes(value, 36, context.spanId) ||
+        !parseByte(value, 53, context.flags) || !context.valid()) {
+        return std::nullopt;
+    }
+    return context;
+}
+
+std::string
+nixl::trace::formatTraceparent(const nixl::trace::TraceContext &context) {
+    if (!context.valid()) {
+        return {};
+    }
+
+    std::string result;
+    result.reserve(55);
+    result.append("00-");
+    for (const auto byte : context.traceId) {
+        appendByte(result, byte);
+    }
+    result.push_back('-');
+    for (const auto byte : context.spanId) {
+        appendByte(result, byte);
+    }
+    result.push_back('-');
+    appendByte(result, context.flags);
+    return result;
+}
+
+nixl::trace::TraceContext
+nixl::trace::generateTraceContext() {
+    nixl::trace::TraceContext context;
+    do {
+        context.traceId = nixl::UUIDv4{}.get_data();
+    } while (allZero(context.traceId));
+
+    do {
+        const auto span_source = nixl::UUIDv4{}.get_data();
+        std::copy_n(span_source.begin(), context.spanId.size(), context.spanId.begin());
+    } while (allZero(context.spanId));
+    return context;
+}

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -131,13 +131,12 @@ nixl::trace::TraceContext
 nixl::trace::generateTraceContext() {
     nixl::trace::TraceContext context;
     do {
-        context.traceId = nixl::UUIDv4{}.get_data();
+        nixl::generateRandomBytes(context.traceId.data(), context.traceId.size());
     } while (isAllZero(context.traceId));
     context.flags = 0x02;
 
     do {
-        const auto span_source = nixl::UUIDv4{}.get_data();
-        std::copy_n(span_source.begin(), context.spanId.size(), context.spanId.begin());
+        nixl::generateRandomBytes(context.spanId.data(), context.spanId.size());
     } while (isAllZero(context.spanId));
     return context;
 }

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -103,7 +103,6 @@ nixl::trace::parseTraceparent(std::string_view value) {
         !parseByte(value, 53, context.flags) || !context.valid()) {
         return std::nullopt;
     }
-    context.flags &= supported_trace_flags;
     return context;
 }
 

--- a/src/core/tracing/trace_context.h
+++ b/src/core/tracing/trace_context.h
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace nixl::trace {
+struct TraceContext;
+}
+
+struct nixl::trace::TraceContext {
+    std::array<std::uint8_t, 16> traceId{};
+    std::array<std::uint8_t, 8> spanId{};
+    std::uint8_t flags{};
+
+    [[nodiscard]] bool
+    valid() const noexcept;
+
+    [[nodiscard]] bool
+    sampled() const noexcept;
+
+    [[nodiscard]] std::uint64_t
+    correlationId64() const noexcept;
+};
+
+namespace nixl::trace {
+[[nodiscard]] std::optional<TraceContext>
+parseTraceparent(std::string_view value);
+}
+
+namespace nixl::trace {
+[[nodiscard]] std::string
+formatTraceparent(const TraceContext &context);
+}
+
+namespace nixl::trace {
+[[nodiscard]] TraceContext
+generateTraceContext();
+}

--- a/src/core/tracing/trace_context.h
+++ b/src/core/tracing/trace_context.h
@@ -14,7 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
+#ifndef NIXL_SRC_CORE_TRACING_TRACE_CONTEXT_H
+#define NIXL_SRC_CORE_TRACING_TRACE_CONTEXT_H
 
 #include <array>
 #include <cstdint>
@@ -55,3 +56,5 @@ namespace nixl::trace {
 [[nodiscard]] TraceContext
 generateTraceContext();
 }
+
+#endif

--- a/src/core/tracing/trace_context.h
+++ b/src/core/tracing/trace_context.h
@@ -24,10 +24,8 @@
 #include <string_view>
 
 namespace nixl::trace {
-struct TraceContext;
-}
 
-struct nixl::trace::TraceContext {
+struct TraceContext {
     std::array<std::uint8_t, 16> traceId{};
     std::array<std::uint8_t, 8> spanId{};
     std::uint8_t flags{};
@@ -42,19 +40,15 @@ struct nixl::trace::TraceContext {
     correlationId64() const noexcept;
 };
 
-namespace nixl::trace {
 [[nodiscard]] std::optional<TraceContext>
 parseTraceparent(std::string_view value);
-}
 
-namespace nixl::trace {
 [[nodiscard]] std::string
 formatTraceparent(const TraceContext &context);
-}
 
-namespace nixl::trace {
 [[nodiscard]] TraceContext
 generateTraceContext();
-}
+
+} // namespace nixl::trace
 
 #endif

--- a/src/utils/common/uuid_v4.cpp
+++ b/src/utils/common/uuid_v4.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/common/uuid_v4.cpp
+++ b/src/utils/common/uuid_v4.cpp
@@ -22,8 +22,19 @@
 
 namespace nixl {
 
+void
+generateRandomBytes(std::uint8_t *output, std::size_t size) {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    std::uniform_int_distribution<std::uint8_t> dis(0, 255);
+
+    for (std::size_t i = 0; i < size; ++i) {
+        output[i] = dis(gen);
+    }
+}
+
 UUIDv4::UUIDv4() {
-    generate_random_bytes(data.data(), data.size());
+    generateRandomBytes(data.data(), data.size());
     // Set version 4 bits (version 4 = 0100 in binary)
     data[6] = (data[6] & 0x0F) | 0x40;
     // Set variant bits (RFC 9562 variant = 10 in binary)
@@ -44,17 +55,6 @@ UUIDv4::to_string() const {
     }
 
     return oss.str();
-}
-
-void
-UUIDv4::generate_random_bytes(uint8_t *output, size_t size) {
-    std::random_device rd;
-    std::mt19937_64 gen(rd());
-    std::uniform_int_distribution<uint8_t> dis(0, 255);
-
-    for (size_t i = 0; i < size; ++i) {
-        output[i] = dis(gen);
-    }
 }
 
 } // namespace nixl

--- a/src/utils/common/uuid_v4.cpp
+++ b/src/utils/common/uuid_v4.cpp
@@ -26,10 +26,10 @@ void
 generateRandomBytes(std::uint8_t *output, std::size_t size) {
     std::random_device rd;
     std::mt19937_64 gen(rd());
-    std::uniform_int_distribution<std::uint8_t> dis(0, 255);
+    std::uniform_int_distribution<unsigned int> dis(0, 255);
 
     for (std::size_t i = 0; i < size; ++i) {
-        output[i] = dis(gen);
+        output[i] = static_cast<std::uint8_t>(dis(gen));
     }
 }
 

--- a/src/utils/common/uuid_v4.h
+++ b/src/utils/common/uuid_v4.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/utils/common/uuid_v4.h
+++ b/src/utils/common/uuid_v4.h
@@ -18,10 +18,19 @@
 #define UUID_V4_H
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <random>
 
 namespace nixl {
+
+/**
+ * @brief Generates pseudo-random bytes.
+ * @param output Pointer to the output buffer
+ * @param size Number of bytes to generate
+ */
+void
+generateRandomBytes(std::uint8_t *output, std::size_t size);
 
 /**
  * @brief A class that generates RFC 9562 UUID version 4 identifiers
@@ -59,15 +68,7 @@ public:
     }
 
 private:
-    std::array<uint8_t, 16> data;
-
-    /**
-     * @brief Generates cryptographically random bytes for UUID version 4
-     * @param output Pointer to the output buffer
-     * @param size Number of bytes to generate
-     */
-    static void
-    generate_random_bytes(uint8_t *output, size_t size);
+    std::array<std::uint8_t, 16> data;
 };
 
 } // namespace nixl

--- a/test/gtest/unit/tracing/meson.build
+++ b/test/gtest/unit/tracing/meson.build
@@ -15,6 +15,7 @@
 
 tracing_unit_test_dep = declare_dependency(
     sources: [
+        'trace_context_test.cpp',
         'tracing_test.cpp',
     ],
     include_directories: [nixl_inc_dirs, gtest_inc_dirs],

--- a/test/gtest/unit/tracing/trace_context_test.cpp
+++ b/test/gtest/unit/tracing/trace_context_test.cpp
@@ -93,7 +93,7 @@ TEST(TraceContext, RejectsZeroSpanId) {
             .has_value());
 }
 
-TEST(TraceContext, NormalizesFlagsAndReportsSampledBit) {
+TEST(TraceContext, PreservesFlagsAndNormalizesOutput) {
     const auto sampled =
         nixl::trace::parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ff");
     const auto unsampled =
@@ -101,9 +101,9 @@ TEST(TraceContext, NormalizesFlagsAndReportsSampledBit) {
 
     ASSERT_TRUE(sampled.has_value());
     ASSERT_TRUE(unsampled.has_value());
-    EXPECT_EQ(sampled->flags, 0x03);
+    EXPECT_EQ(sampled->flags, 0xff);
     EXPECT_TRUE(sampled->sampled());
-    EXPECT_EQ(unsampled->flags, 0x02);
+    EXPECT_EQ(unsampled->flags, 0xfe);
     EXPECT_FALSE(unsampled->sampled());
     EXPECT_EQ(nixl::trace::formatTraceparent(*sampled),
               "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03");

--- a/test/gtest/unit/tracing/trace_context_test.cpp
+++ b/test/gtest/unit/tracing/trace_context_test.cpp
@@ -31,13 +31,18 @@ TEST(TraceContext, ParsesAndFormatsCanonicalTraceparent) {
     EXPECT_EQ(nixl::trace::formatTraceparent(*context), kCanonicalTraceparent);
 }
 
-TEST(TraceContext, CanonicalizesMixedCaseInput) {
-    const auto context =
-        nixl::trace::parseTraceparent("00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-0A");
+TEST(TraceContext, RejectsUppercaseHex) {
+    std::string value = kCanonicalTraceparent;
+    value[4] = 'B';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
 
-    ASSERT_TRUE(context.has_value());
-    EXPECT_EQ(nixl::trace::formatTraceparent(*context),
-              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0a");
+    value = kCanonicalTraceparent;
+    value[38] = 'F';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+
+    value = kCanonicalTraceparent;
+    value[53] = 'A';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
 }
 
 TEST(TraceContext, RejectsInvalidLengths) {
@@ -88,7 +93,7 @@ TEST(TraceContext, RejectsZeroSpanId) {
             .has_value());
 }
 
-TEST(TraceContext, PreservesFlagsAndReportsSampledBit) {
+TEST(TraceContext, NormalizesFlagsAndReportsSampledBit) {
     const auto sampled =
         nixl::trace::parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ff");
     const auto unsampled =
@@ -96,10 +101,19 @@ TEST(TraceContext, PreservesFlagsAndReportsSampledBit) {
 
     ASSERT_TRUE(sampled.has_value());
     ASSERT_TRUE(unsampled.has_value());
-    EXPECT_EQ(sampled->flags, 0xff);
+    EXPECT_EQ(sampled->flags, 0x03);
     EXPECT_TRUE(sampled->sampled());
-    EXPECT_EQ(unsampled->flags, 0xfe);
+    EXPECT_EQ(unsampled->flags, 0x02);
     EXPECT_FALSE(unsampled->sampled());
+    EXPECT_EQ(nixl::trace::formatTraceparent(*sampled),
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03");
+    EXPECT_EQ(nixl::trace::formatTraceparent(*unsampled),
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02");
+
+    auto with_reserved_flags = *sampled;
+    with_reserved_flags.flags = 0xff;
+    EXPECT_EQ(nixl::trace::formatTraceparent(with_reserved_flags),
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-03");
 }
 
 TEST(TraceContext, RoundTripsFixedContextWithoutFieldDrift) {
@@ -120,7 +134,7 @@ TEST(TraceContext, RoundTripsFixedContextWithoutFieldDrift) {
                                               0x47,
                                               0x36},
                                              {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7},
-                                             0xa5};
+                                             0x03};
 
     const auto parsed = nixl::trace::parseTraceparent(nixl::trace::formatTraceparent(expected));
 
@@ -148,6 +162,7 @@ TEST(TraceContext, GeneratesDistinctValidContexts) {
     for (std::size_t index = 0; index < count; ++index) {
         const auto context = nixl::trace::generateTraceContext();
         EXPECT_TRUE(context.valid());
+        EXPECT_EQ(context.flags, 0x02);
         EXPECT_FALSE(context.sampled());
         generated.insert(nixl::trace::formatTraceparent(context));
     }

--- a/test/gtest/unit/tracing/trace_context_test.cpp
+++ b/test/gtest/unit/tracing/trace_context_test.cpp
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+
+#include "tracing/trace_context.h"
+
+constexpr char kCanonicalTraceparent[] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+TEST(TraceContext, ParsesAndFormatsCanonicalTraceparent) {
+    const auto context = nixl::trace::parseTraceparent(kCanonicalTraceparent);
+
+    ASSERT_TRUE(context.has_value());
+    EXPECT_TRUE(context->valid());
+    EXPECT_EQ(nixl::trace::formatTraceparent(*context), kCanonicalTraceparent);
+}
+
+TEST(TraceContext, CanonicalizesMixedCaseInput) {
+    const auto context =
+        nixl::trace::parseTraceparent("00-4BF92F3577B34DA6A3CE929D0E0E4736-00F067AA0BA902B7-0A");
+
+    ASSERT_TRUE(context.has_value());
+    EXPECT_EQ(nixl::trace::formatTraceparent(*context),
+              "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-0a");
+}
+
+TEST(TraceContext, RejectsInvalidLengths) {
+    const std::string canonical = kCanonicalTraceparent;
+
+    EXPECT_FALSE(nixl::trace::parseTraceparent(canonical.substr(1)).has_value());
+    EXPECT_FALSE(nixl::trace::parseTraceparent(canonical + "0").has_value());
+}
+
+TEST(TraceContext, RejectsInvalidSeparators) {
+    std::string value = kCanonicalTraceparent;
+    value[2] = ':';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+
+    value = kCanonicalTraceparent;
+    value[35] = ':';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+
+    value = kCanonicalTraceparent;
+    value[52] = ':';
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+}
+
+TEST(TraceContext, RejectsInvalidHex) {
+    for (const std::size_t offset : {3u, 36u, 53u}) {
+        std::string value = kCanonicalTraceparent;
+        value[offset] = 'g';
+        EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+    }
+}
+
+TEST(TraceContext, RejectsUnsupportedVersion) {
+    std::string value = kCanonicalTraceparent;
+    value[1] = '1';
+
+    EXPECT_FALSE(nixl::trace::parseTraceparent(value).has_value());
+}
+
+TEST(TraceContext, RejectsZeroTraceId) {
+    EXPECT_FALSE(
+        nixl::trace::parseTraceparent("00-00000000000000000000000000000000-00f067aa0ba902b7-01")
+            .has_value());
+}
+
+TEST(TraceContext, RejectsZeroSpanId) {
+    EXPECT_FALSE(
+        nixl::trace::parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01")
+            .has_value());
+}
+
+TEST(TraceContext, PreservesFlagsAndReportsSampledBit) {
+    const auto sampled =
+        nixl::trace::parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-ff");
+    const auto unsampled =
+        nixl::trace::parseTraceparent("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-fe");
+
+    ASSERT_TRUE(sampled.has_value());
+    ASSERT_TRUE(unsampled.has_value());
+    EXPECT_EQ(sampled->flags, 0xff);
+    EXPECT_TRUE(sampled->sampled());
+    EXPECT_EQ(unsampled->flags, 0xfe);
+    EXPECT_FALSE(unsampled->sampled());
+}
+
+TEST(TraceContext, RoundTripsFixedContextWithoutFieldDrift) {
+    const nixl::trace::TraceContext expected{{0x4b,
+                                              0xf9,
+                                              0x2f,
+                                              0x35,
+                                              0x77,
+                                              0xb3,
+                                              0x4d,
+                                              0xa6,
+                                              0xa3,
+                                              0xce,
+                                              0x92,
+                                              0x9d,
+                                              0x0e,
+                                              0x0e,
+                                              0x47,
+                                              0x36},
+                                             {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7},
+                                             0xa5};
+
+    const auto parsed = nixl::trace::parseTraceparent(nixl::trace::formatTraceparent(expected));
+
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->traceId, expected.traceId);
+    EXPECT_EQ(parsed->spanId, expected.spanId);
+    EXPECT_EQ(parsed->flags, expected.flags);
+}
+
+TEST(TraceContext, InvalidContextHasNoTextRepresentation) {
+    EXPECT_TRUE(nixl::trace::formatTraceparent({}).empty());
+}
+
+TEST(TraceContext, ProjectsTraceIdBigEndian) {
+    const auto context = nixl::trace::parseTraceparent(kCanonicalTraceparent);
+
+    ASSERT_TRUE(context.has_value());
+    EXPECT_EQ(context->correlationId64(), 0x4bf92f3577b34da6ULL);
+}
+
+TEST(TraceContext, GeneratesDistinctValidContexts) {
+    std::set<std::string> generated;
+    constexpr std::size_t count = 64;
+
+    for (std::size_t index = 0; index < count; ++index) {
+        const auto context = nixl::trace::generateTraceContext();
+        EXPECT_TRUE(context.valid());
+        EXPECT_FALSE(context.sampled());
+        generated.insert(nixl::trace::formatTraceparent(context));
+    }
+
+    EXPECT_EQ(generated.size(), count);
+}


### PR DESCRIPTION
## What?

Adds a self-contained internal `nixl::trace::TraceContext` under `src/core/tracing/`
(a 16-byte trace ID, an 8-byte span ID and one byte of flags) together with
validation, canonical W3C `traceparent` parsing/formatting, generation, and a
stable 64-bit projection of the trace ID for the existing NVTX unsigned-64
correlation payload. Generated bytes come from the existing RFC 9562 helper in
`src/utils/common/uuid_v4.{h,cpp}`; no new random generator or dependency is
introduced.

Nothing is activated or exposed by this PR: the type is not stored on any
request, no call site uses it, and there are no public header, `nixl_opt_args_t`,
Python, Rust, telemetry, plugin-API or NVTX changes. `nixl_trace_plugin_api_version::V1`
is untouched, and the new header is compiled into `libnixl` without being installed.

13 deterministic tests are added to the existing `unit` test executable as a new
module (`test/gtest/unit/tracing/trace_context_test.cpp`, alongside the existing
`tracing_test.cpp`), covering the canonical example, mixed-case canonicalization,
malformed lengths/separators/hex, an unsupported version, all-zero trace and span
IDs, flag preservation including the sampled bit, a fixed-context round trip, the
fixed big-endian projection, and distinctness of generated contexts.

## Why?

First groundwork PR for [NIX-1738](https://linear.app/nvidia/issue/NIX-1738),
a child of the [NIX-1537](https://linear.app/nvidia/issue/NIX-1537) distributed-tracing
umbrella.

Request-scoped distributed tracing needs one identity per request that can be
generated, validated, and later propagated. Landing that value type on its own
keeps it independently reviewable and keeps the follow-up PRs small: the next
child task stores one generated context on each transfer request and replaces the
request-pointer correlation key with `correlationId64()`. W3C Trace Context is
used because it is what OpenTelemetry propagates by default and the only format
observability vendors accept, so NIXL spans can later join an existing trace
instead of requiring a hand-rolled join.

<details>
<summary>Testing</summary>

`TraceContext.*:Tracing.*` runs 30 tests (13 new, plus the 17 pre-existing
`Tracing.*` cases, which are unchanged) in the existing `unit` binary. All pass
with no skips and no sanitizer diagnostics in four configurations: normal,
ASan+UBSan, UBSan alone, and TSan. Changed lines are clean under clang-format 19.

Note for local reproduction: these Meson build directories generate no
`CTestTestfile.cmake`, so `ctest` discovers zero tests and the registered `unit`
test was run through `meson test` instead. A local ASan run also needs the
Abseil/gRPC dependency stack built with matching `-fsanitize` flags, exactly as
`.gitlab/build.sh` documents via `DEPS_SANITIZE`; the CI sanitizer lanes already
use such an image.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracing context support with validation, sampling status, and correlation ID access.
  * Added parsing and formatting for W3C `traceparent` values, including validation of malformed or invalid contexts.
  * Added generation of unique trace and span contexts.
  * Added support for handling and normalizing trace flags.

* **Tests**
  * Added comprehensive coverage for parsing, formatting, validation, flag handling, round-tripping, and context generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->