### PR TITLE
EXAMPLES/DEVICE/EP: Added Stable Torch CUDA Streams API.

### DIFF
--- a/examples/device/ep/csrc/cuda_stream.cpp
+++ b/examples/device/ep/csrc/cuda_stream.cpp
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cuda_stream.hpp"
+
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/csrc/stable/c/shim.h>
+#include <torch/headeronly/util/shim_utils.h>
+#include <torch/version.h>
+
+#if TORCH_VERSION_MAJOR < 2 || (TORCH_VERSION_MAJOR == 2 && TORCH_VERSION_MINOR < 10)
+#error "nixl_ep requires PyTorch >=2.10 for torch_set_current_cuda_stream"
+#endif
+
+namespace nixl_ep::cuda_stream {
+cudaStream_t
+get_current() {
+    void *stream;
+    TORCH_ERROR_CODE_CHECK(aoti_torch_get_current_cuda_stream(-1, &stream));
+    return static_cast<cudaStream_t>(stream);
+}
+
+void
+set_current(cudaStream_t stream) {
+    const int32_t device_index = torch::stable::accelerator::getCurrentDeviceIndex();
+    TORCH_ERROR_CODE_CHECK(torch_set_current_cuda_stream(stream, device_index));
+}
+} // namespace nixl_ep::cuda_stream

--- a/examples/device/ep/csrc/cuda_stream.hpp
+++ b/examples/device/ep/csrc/cuda_stream.hpp
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace nixl_ep::cuda_stream {
+[[nodiscard]] cudaStream_t
+get_current();
+
+void
+set_current(cudaStream_t stream);
+} // namespace nixl_ep::cuda_stream

--- a/examples/device/ep/csrc/event_handle.hpp
+++ b/examples/device/ep/csrc/event_handle.hpp
@@ -23,10 +23,9 @@
 #pragma once
 
 #include "cuda_event.hpp"
+#include "cuda_stream.hpp"
 #include "cuda_warn.hpp"
 #include "kernels/exception.cuh"
-
-#include <ATen/cuda/CUDAContext.h>
 
 #include <memory>
 
@@ -35,10 +34,10 @@ namespace nixl_ep {
 class EventHandle {
 public:
     EventHandle() : event{std::make_shared<cuda::Event>()} {
-        event->record(at::cuda::getCurrentCUDAStream());
+        event->record(cuda_stream::get_current());
     }
 
-    explicit EventHandle(const at::cuda::CUDAStream &stream)
+    explicit EventHandle(cudaStream_t stream)
         : event{std::make_shared<cuda::Event>()} {
         event->record(stream);
     }
@@ -47,12 +46,12 @@ public:
 
     void
     current_stream_wait() const {
-        stream_wait(at::cuda::getCurrentCUDAStream());
+        stream_wait(cuda_stream::get_current());
     }
 
     void
-    stream_wait(const at::cuda::CUDAStream &stream) const {
-        CUDA_CHECK(cudaStreamWaitEvent(stream.stream(), event->get(), 0));
+    stream_wait(cudaStream_t stream) const {
+        CUDA_CHECK(cudaStreamWaitEvent(stream, event->get(), 0));
     }
 
 private:
@@ -60,8 +59,8 @@ private:
 };
 
 inline void
-stream_wait(const at::cuda::CUDAStream &stream_0, const at::cuda::CUDAStream &stream_1) {
-    EP_HOST_ASSERT(stream_0.id() != stream_1.id());
+stream_wait(cudaStream_t stream_0, cudaStream_t stream_1) {
+    EP_HOST_ASSERT(stream_0 != stream_1);
     cuda::Event event;
     event.record(stream_1);
     CUDA_CHECK(cudaStreamWaitEvent(stream_0, event.get(), 0));

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -367,8 +367,7 @@ void Buffer::destroy() {
 }
 
 void Buffer::barrier() {
-    auto compute_stream = at::cuda::getCurrentCUDAStream();
-    ep_kernels::barrier(gpu_ctx_ptr, mask_buffer_ptr, timeout_cycles, compute_stream);
+    ep_kernels::barrier(gpu_ctx_ptr, mask_buffer_ptr, timeout_cycles, cuda_stream::get_current());
 }
 
 void Buffer::_nixl_agents_connect(const std::vector<int>& ranks, const std::vector<nixl_blob_t>& remote_mds) {
@@ -560,7 +559,7 @@ Buffer::get_dispatch_layout(const torch::Tensor& topk_idx, int num_experts,
     auto compute_stream = at::cuda::getCurrentCUDAStream();
     if (allocate_on_comm_stream) {
         EP_HOST_ASSERT(previous_event.has_value() and async);
-        at::cuda::setCurrentCUDAStream(comm_stream);
+        cuda_stream::set_current(comm_stream);
     }
 
     // Wait previous tasks to be finished
@@ -607,7 +606,7 @@ Buffer::get_dispatch_layout(const torch::Tensor& topk_idx, int num_experts,
 
     // Switch back compute stream
     if (allocate_on_comm_stream)
-        at::cuda::setCurrentCUDAStream(compute_stream);
+        cuda_stream::set_current(compute_stream);
 
     return {num_tokens_per_rank, num_tokens_per_rdma_rank, num_tokens_per_expert, is_token_in_rank, event};
 }
@@ -716,7 +715,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
     auto compute_stream = at::cuda::getCurrentCUDAStream();
     if (allocate_on_comm_stream) {
         EP_HOST_ASSERT(previous_event.has_value() and async);
-        at::cuda::setCurrentCUDAStream(comm_stream);
+        cuda_stream::set_current(comm_stream);
     }
 
     // Wait previous tasks to be finished
@@ -887,7 +886,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
 
     // Switch back compute stream
     if (allocate_on_comm_stream)
-        at::cuda::setCurrentCUDAStream(compute_stream);
+        cuda_stream::set_current(compute_stream);
 
     // Return values
     return {recv_x, recv_x_scales, recv_topk_idx, recv_topk_weights, num_recv_tokens_per_expert_list,
@@ -936,7 +935,7 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
     auto compute_stream = at::cuda::getCurrentCUDAStream();
     if (allocate_on_comm_stream) {
         EP_HOST_ASSERT(previous_event.has_value() and async);
-        at::cuda::setCurrentCUDAStream(comm_stream);
+        cuda_stream::set_current(comm_stream);
     }
 
     // Wait previous tasks to be finished
@@ -1021,7 +1020,7 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
 
     // Switch back compute stream
     if (allocate_on_comm_stream)
-        at::cuda::setCurrentCUDAStream(compute_stream);
+        cuda_stream::set_current(compute_stream);
 
     // Return values
     return {combined_x, combined_topk_weights, event};
@@ -1070,8 +1069,8 @@ Buffer::dispatch(const torch::Tensor& x, const torch::Tensor& topk_idx,
 
     // Wait previous tasks to be finished
     // NOTES: the hook mode will always use the default stream
-    auto compute_stream = at::cuda::getCurrentCUDAStream();
-    auto launch_stream = return_recv_hook ? compute_stream : comm_stream;
+    cudaStream_t compute_stream = cuda_stream::get_current();
+    cudaStream_t launch_stream = return_recv_hook ? compute_stream : comm_stream.stream();
     EP_HOST_ASSERT(not (async and return_recv_hook));
     if (not return_recv_hook)
         stream_wait(launch_stream, compute_stream);
@@ -1190,8 +1189,8 @@ Buffer::combine(const torch::Tensor& x, const torch::Tensor& topk_idx, const tor
 
     // Wait previous tasks to be finished
     // NOTES: the hook mode will always use the default stream
-    auto compute_stream = at::cuda::getCurrentCUDAStream();
-    auto launch_stream = return_recv_hook ? compute_stream : comm_stream;
+    cudaStream_t compute_stream = cuda_stream::get_current();
+    cudaStream_t launch_stream = return_recv_hook ? compute_stream : comm_stream.stream();
     EP_HOST_ASSERT(not (async and return_recv_hook));
     if (not return_recv_hook)
         stream_wait(launch_stream, compute_stream);
@@ -1279,7 +1278,7 @@ void Buffer::update_mask_buffer(int rank_to_mask, bool mask) {
         EP_HOST_ASSERT(_is_rank_connected(rank_to_mask) && "cannot unmask an unconnected rank");
     active_ranks[rank_to_mask] = !mask;
     _refresh_active_rank_bound();
-    ep_kernels::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, at::cuda::getCurrentCUDAStream());
+    ep_kernels::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, cuda_stream::get_current());
 }
 
 void
@@ -1291,7 +1290,7 @@ Buffer::query_mask_buffer(const torch::Tensor &mask_status) const {
     ep_kernels::query_mask_buffer(mask_buffer_ptr,
                                   max_num_ranks,
                                   mask_status.data_ptr<int>(),
-                                  at::cuda::getCurrentCUDAStream());
+                                  cuda_stream::get_current());
 }
 
 void Buffer::clean_mask_buffer() {
@@ -1305,7 +1304,7 @@ void Buffer::clean_mask_buffer() {
     _refresh_active_rank_bound();
     CUDA_CHECK(cudaMemcpyAsync(mask_buffer_ptr, mask.data(),
                                max_num_ranks * sizeof(int), cudaMemcpyHostToDevice,
-                               at::cuda::getCurrentCUDAStream()));
+                               cuda_stream::get_current()));
 }
 
 std::string Buffer::get_local_metadata() const {

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -37,6 +37,7 @@
 
 #include <cuda_runtime.h>
 
+#include <ATen/cuda/CUDAContext.h>
 #include <torch/types.h>
 
 #include <pybind11/pytypes.h>

--- a/examples/device/ep/meson.build
+++ b/examples/device/ep/meson.build
@@ -62,6 +62,7 @@ endif
 
 
 nixl_ep_sources = [
+    'csrc/cuda_stream.cpp',
     'csrc/nixl_ep.cpp',
     'csrc/vmm.cpp',
     'csrc/kernels/nixl_ep_ll.cu',
@@ -96,6 +97,7 @@ nixl_ep_cpp_args = [
     '-Wno-sign-compare',
     '-Wno-reorder',
     '-Wno-attributes',
+    '-DUSE_CUDA',
 ]
 
 nixl_ep_cuda_args = [


### PR DESCRIPTION
## What?
Added Stable Torch CUDA Streams API.
Removed `at::cuda::setCurrentCUDAStream`, and partially removed `at::cuda::getCurrentCUDAStream`.

## Why?
To get rid of dependency on specific PyTorch version.

## How?
https://github.com/ai-dynamo/nixl/pull/1793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and updating the active CUDA stream.
  * Enabled CUDA stream handling for the endpoint extension.
* **Improvements**
  * Updated event handling and endpoint operations to use CUDA stream handles.
  * Improved stream selection across dispatch, synchronization, barrier, and communication operations.
  * Added error checking for CUDA stream access and updates.
* **Compatibility**
  * CUDA stream support now requires PyTorch 2.10 or newer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->