### PR TITLE
tracing: use request-scoped correlation context

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -64,11 +64,13 @@ nixlXferReqH::nixlXferReqH(const std::string &remote_agent,
                            const nixl_mem_t local_type,
                            const nixl_mem_t remote_type,
                            const size_t desc_count,
-                           const nixl_remote_section_weak_t &remote_section_ref)
+                           const nixl_remote_section_weak_t &remote_section_ref,
+                           nixl::trace::TraceContext trace_context)
     : initiatorDescs(local_type),
       targetDescs(remote_type),
       remoteAgent(remote_agent),
       remoteSection(remote_section_ref),
+      traceContext_(trace_context),
       backendOp(backend_op) {
     initiatorDescs.reserve(desc_count);
     targetDescs.reserve(desc_count);
@@ -814,12 +816,14 @@ nixlAgent::makeXferReq(nixl_xfer_op_t operation,
 
     // TODO [Perf]: Avoid heap allocation on the datapath, maybe use a mem pool
 
-    auto handle = std::make_unique<nixlXferReqH>(remote_side.remoteAgent,
-                                                 operation,
-                                                 local_descs.getType(),
-                                                 remote_descs.getType(),
-                                                 desc_count,
-                                                 remote_side.remoteSectionRef);
+    auto handle = std::make_unique<nixlXferReqH>(
+        remote_side.remoteAgent,
+        operation,
+        local_descs.getType(),
+        remote_descs.getType(),
+        desc_count,
+        remote_side.remoteSectionRef,
+        data->tracer_ ? nixl::trace::generateTraceContext() : nixl::trace::TraceContext{});
 
     size_t total_bytes = 0;
     const bool skip_desc_merge = extra_params && extra_params->skipDescMerge;
@@ -982,12 +986,14 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
     // TODO: merge descriptors back to back in memory (like makeXferReq).
     // TODO [Perf]: Avoid heap allocation on the datapath, maybe use a mem pool
 
-    auto handle = std::make_unique<nixlXferReqH>(remote_agent,
-                                                 operation,
-                                                 local_descs.getType(),
-                                                 remote_descs.getType(),
-                                                 local_descs.descCount(),
-                                                 rem_sec_it->second);
+    auto handle = std::make_unique<nixlXferReqH>(
+        remote_agent,
+        operation,
+        local_descs.getType(),
+        remote_descs.getType(),
+        local_descs.descCount(),
+        rem_sec_it->second,
+        data->tracer_ ? nixl::trace::generateTraceContext() : nixl::trace::TraceContext{});
 
     // Currently we loop through and find first local match. Can use a
     // preference list or more exhaustive search.
@@ -1110,9 +1116,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    // Request-handle address is a stable id shared with the completion below,
-    // so the two link even when posted and polled from different threads.
-    NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), reinterpret_cast<std::uint64_t>(req_hndl));
+    NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId());
     NIXL_TRACE_SCOPE(trace_span,
                      data->tracer_.get(),
                      req_hndl->backendOp == NIXL_WRITE ? "nixl::postXferReq.write" :
@@ -1244,8 +1248,7 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
             }
         }
         if (req_hndl->status == NIXL_SUCCESS) {
-            NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(),
-                                         reinterpret_cast<std::uint64_t>(req_hndl));
+            NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId());
             NIXL_TRACE_MARK(
                 data->tracer_.get(), "nixl::xfer.complete", nixl::trace::Kind::Metadata);
         }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -65,7 +65,7 @@ nixlXferReqH::nixlXferReqH(const std::string &remote_agent,
                            const nixl_mem_t remote_type,
                            const size_t desc_count,
                            const nixl_remote_section_weak_t &remote_section_ref,
-                           nixl::trace::TraceContext trace_context)
+                           const nixl::trace::TraceContext &trace_context)
     : initiatorDescs(local_type),
       targetDescs(remote_type),
       remoteAgent(remote_agent),
@@ -1116,7 +1116,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId());
+    NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId64());
     NIXL_TRACE_SCOPE(trace_span,
                      data->tracer_.get(),
                      req_hndl->backendOp == NIXL_WRITE ? "nixl::postXferReq.write" :
@@ -1248,7 +1248,7 @@ nixlAgent::getXferStatus (nixlXferReqH *req_hndl) const {
             }
         }
         if (req_hndl->status == NIXL_SUCCESS) {
-            NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId());
+            NIXL_TRACE_CORRELATION_SCOPE(data->tracer_.get(), req_hndl->traceCorrelationId64());
             NIXL_TRACE_MARK(
                 data->tracer_.get(), "nixl::xfer.complete", nixl::trace::Kind::Metadata);
         }

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -816,14 +816,13 @@ nixlAgent::makeXferReq(nixl_xfer_op_t operation,
 
     // TODO [Perf]: Avoid heap allocation on the datapath, maybe use a mem pool
 
-    auto handle = std::make_unique<nixlXferReqH>(
-        remote_side.remoteAgent,
-        operation,
-        local_descs.getType(),
-        remote_descs.getType(),
-        desc_count,
-        remote_side.remoteSectionRef,
-        data->tracer_ ? nixl::trace::generateTraceContext() : nixl::trace::TraceContext{});
+    auto handle = std::make_unique<nixlXferReqH>(remote_side.remoteAgent,
+                                                 operation,
+                                                 local_descs.getType(),
+                                                 remote_descs.getType(),
+                                                 desc_count,
+                                                 remote_side.remoteSectionRef,
+                                                 nixl::trace::TraceContext{data->tracer_.get()});
 
     size_t total_bytes = 0;
     const bool skip_desc_merge = extra_params && extra_params->skipDescMerge;
@@ -986,14 +985,13 @@ nixlAgent::createXferReq(const nixl_xfer_op_t &operation,
     // TODO: merge descriptors back to back in memory (like makeXferReq).
     // TODO [Perf]: Avoid heap allocation on the datapath, maybe use a mem pool
 
-    auto handle = std::make_unique<nixlXferReqH>(
-        remote_agent,
-        operation,
-        local_descs.getType(),
-        remote_descs.getType(),
-        local_descs.descCount(),
-        rem_sec_it->second,
-        data->tracer_ ? nixl::trace::generateTraceContext() : nixl::trace::TraceContext{});
+    auto handle = std::make_unique<nixlXferReqH>(remote_agent,
+                                                 operation,
+                                                 local_descs.getType(),
+                                                 remote_descs.getType(),
+                                                 local_descs.descCount(),
+                                                 rem_sec_it->second,
+                                                 nixl::trace::TraceContext{data->tracer_.get()});
 
     // Currently we loop through and find first local match. Can use a
     // preference list or more exhaustive search.

--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -64,6 +64,19 @@ parseBytes(std::string_view value,
 }
 
 void
+generateInto(nixl::trace::TraceContext &context) {
+    do {
+        nixl::generateRandomBytes(context.traceId.data(), context.traceId.size());
+    } while (isAllZero(context.traceId));
+
+    do {
+        nixl::generateRandomBytes(context.spanId.data(), context.spanId.size());
+    } while (isAllZero(context.spanId));
+
+    context.flags = 0x02;
+}
+
+void
 appendByte(std::string &result, std::uint8_t value) {
     constexpr std::array<char, 16> hex{
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
@@ -71,6 +84,12 @@ appendByte(std::string &result, std::uint8_t value) {
     result.push_back(hex[value & 0x0f]);
 }
 } // namespace
+
+nixl::trace::TraceContext::TraceContext(const nixl::trace::Tracer *tracer) {
+    if (tracer != nullptr) {
+        generateInto(*this);
+    }
+}
 
 bool
 nixl::trace::TraceContext::valid() const noexcept {
@@ -134,13 +153,6 @@ nixl::trace::formatTraceparent(const nixl::trace::TraceContext &context) {
 nixl::trace::TraceContext
 nixl::trace::generateTraceContext() {
     nixl::trace::TraceContext context;
-    do {
-        nixl::generateRandomBytes(context.traceId.data(), context.traceId.size());
-    } while (isAllZero(context.traceId));
-    context.flags = 0x02;
-
-    do {
-        nixl::generateRandomBytes(context.spanId.data(), context.spanId.size());
-    } while (isAllZero(context.spanId));
+    generateInto(context);
     return context;
 }

--- a/src/core/tracing/trace_context.h
+++ b/src/core/tracing/trace_context.h
@@ -25,7 +25,12 @@
 
 namespace nixl::trace {
 
+class Tracer;
+
 struct TraceContext {
+    TraceContext() = default;
+    explicit TraceContext(const Tracer *tracer);
+
     std::array<std::uint8_t, 16> traceId{};
     std::array<std::uint8_t, 8> spanId{};
     std::uint8_t flags{};

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -26,6 +26,7 @@
 #include "backend_engine.h"
 #include "telemetry.h"
 #include "common/nixl_duration.h"
+#include "tracing/trace_context.h"
 
 enum nixl_telemetry_stat_status_t {
     NIXL_TELEMETRY_POST = 0,
@@ -48,7 +49,8 @@ public:
                  const nixl_mem_t local_type,
                  const nixl_mem_t remote_type,
                  const size_t desc_count,
-                 const nixl_remote_section_weak_t &remote_section_ref);
+                 const nixl_remote_section_weak_t &remote_section_ref,
+                 nixl::trace::TraceContext trace_context);
 
     nixlXferReqH(nixlXferReqH &&) = delete;
     nixlXferReqH(const nixlXferReqH &) = delete;
@@ -67,6 +69,11 @@ public:
     void
     updateRequestStats(nixlTelemetry *telemetry, nixl_telemetry_stat_status_t stat_status);
 
+    [[nodiscard]] std::uint64_t
+    traceCorrelationId() const noexcept {
+        return traceContext_.correlationId64();
+    }
+
     friend class nixlAgent;
 
 private:
@@ -78,6 +85,7 @@ private:
 
     const std::string remoteAgent;
     const nixl_remote_section_weak_t remoteSection;
+    const nixl::trace::TraceContext traceContext_;
     nixl_blob_t notifMsg;
     bool hasNotif = false;
 

--- a/src/core/transfer_request.h
+++ b/src/core/transfer_request.h
@@ -50,7 +50,7 @@ public:
                  const nixl_mem_t remote_type,
                  const size_t desc_count,
                  const nixl_remote_section_weak_t &remote_section_ref,
-                 nixl::trace::TraceContext trace_context);
+                 const nixl::trace::TraceContext &trace_context);
 
     nixlXferReqH(nixlXferReqH &&) = delete;
     nixlXferReqH(const nixlXferReqH &) = delete;
@@ -70,7 +70,7 @@ public:
     updateRequestStats(nixlTelemetry *telemetry, nixl_telemetry_stat_status_t stat_status);
 
     [[nodiscard]] std::uint64_t
-    traceCorrelationId() const noexcept {
+    traceCorrelationId64() const noexcept {
         return traceContext_.correlationId64();
     }
 

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -62,5 +62,34 @@ for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write; do
     fi
 done
 
+SQLITE="${OUT}.sqlite"
+"${NSYS}" export --type sqlite --force-overwrite true --output "${SQLITE}" \
+    "${OUT}.nsys-rep" >/dev/null
+python3 - "${SQLITE}" <<'PY' || exit 1
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+rows = connection.execute(
+    """
+    SELECT COALESCE(events.text, strings.value), events.uint64Value
+    FROM NVTX_EVENTS AS events
+    LEFT JOIN StringIds AS strings ON events.textId = strings.id
+    WHERE COALESCE(events.text, strings.value) IN
+          ('nixl::postXferReq.write', 'nixl::xfer.complete')
+    """
+).fetchall()
+post_ids = [payload for name, payload in rows if name == "nixl::postXferReq.write"]
+complete_ids = [payload for name, payload in rows if name == "nixl::xfer.complete"]
+if not post_ids or not complete_ids:
+    raise SystemExit("tracing_nsys: missing correlated post or completion events")
+if any(payload is None for payload in post_ids + complete_ids):
+    raise SystemExit("tracing_nsys: correlation payload is not unsigned 64-bit")
+if set(post_ids) != set(complete_ids):
+    raise SystemExit("tracing_nsys: post and completion correlation payloads differ")
+if max(post_ids.count(payload) for payload in set(post_ids)) < 2:
+    raise SystemExit("tracing_nsys: no request correlation payload was reused")
+PY
+
 echo "tracing_nsys: wrote ${OUT}.nsys-rep"
 exit 0

--- a/test/gtest/run_nsys_tracing.sh
+++ b/test/gtest/run_nsys_tracing.sh
@@ -54,7 +54,7 @@ fi
 # Sanity-check expected NVTX ranges and the new metadata-exchange span.
 NVTX_RANGES="$(nsys stats --force-export=true --report nvtx_sum --format csv "${OUT}.nsys-rep" 2>/dev/null \
     | grep 'nixl::' | sed 's/.*,//' | sort -u)"
-for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write; do
+for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write nixl::postXferReq.read; do
     if ! echo "${NVTX_RANGES}" | grep -Fq -- "${expected}"; then
         echo "tracing_nsys: expected NVTX range '${expected}' missing from capture" >&2
         echo "${NVTX_RANGES}" | sed 's/^/  seen: /' >&2
@@ -63,8 +63,11 @@ for expected in nixl::loadRemoteMD nixl::registerMem nixl::postXferReq.write; do
 done
 
 SQLITE="${OUT}.sqlite"
-"${NSYS}" export --type sqlite --force-overwrite true --output "${SQLITE}" \
-    "${OUT}.nsys-rep" >/dev/null
+if ! "${NSYS}" export --type sqlite --force-overwrite true --output "${SQLITE}" \
+    "${OUT}.nsys-rep" >/dev/null; then
+    echo "tracing_nsys: failed to export ${OUT}.nsys-rep to SQLite" >&2
+    exit 1
+fi
 python3 - "${SQLITE}" <<'PY' || exit 1
 import sqlite3
 import sys
@@ -76,17 +79,17 @@ rows = connection.execute(
     FROM NVTX_EVENTS AS events
     LEFT JOIN StringIds AS strings ON events.textId = strings.id
     WHERE COALESCE(events.text, strings.value) IN
-          ('nixl::postXferReq.write', 'nixl::xfer.complete')
+          ('nixl::postXferReq.write', 'nixl::postXferReq.read', 'nixl::xfer.complete')
     """
 ).fetchall()
-post_ids = [payload for name, payload in rows if name == "nixl::postXferReq.write"]
+post_ids = [payload for name, payload in rows if name.startswith("nixl::postXferReq.")]
 complete_ids = [payload for name, payload in rows if name == "nixl::xfer.complete"]
 if not post_ids or not complete_ids:
     raise SystemExit("tracing_nsys: missing correlated post or completion events")
 if any(payload is None for payload in post_ids + complete_ids):
     raise SystemExit("tracing_nsys: correlation payload is not unsigned 64-bit")
-if set(post_ids) != set(complete_ids):
-    raise SystemExit("tracing_nsys: post and completion correlation payloads differ")
+if not set(complete_ids).issubset(set(post_ids)):
+    raise SystemExit("tracing_nsys: completion correlation payload was not posted")
 if max(post_ids.count(payload) for payload in set(post_ids)) < 2:
     raise SystemExit("tracing_nsys: no request correlation payload was reused")
 PY

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -22,6 +22,7 @@
 #include "nixl.h"
 #include "nixl_types.h"
 #include "plugin_manager.h"
+#include "transfer_request.h"
 
 #include <absl/strings/str_format.h>
 #include <absl/time/clock.h>
@@ -389,7 +390,8 @@ protected:
                nixl_mem_t dst_mem_type,
                std::vector<MemBuffer> dst_buffers,
                nixl_status_t expected_telem_status = NIXL_ERR_NO_TELEMETRY,
-               const std::string &notif_msg = NOTIF_MSG) {
+               const std::string &notif_msg = NOTIF_MSG,
+               bool expect_trace_context = false) {
         std::mutex logger_mutex;
         std::vector<std::thread> threads;
         nixl_notifs_t notif_map;
@@ -408,16 +410,22 @@ protected:
                                        &extra_params);
                 ASSERT_EQ(status, NIXL_SUCCESS);
                 EXPECT_NE(xfer_req, nullptr);
+                const auto trace_correlation_id = xfer_req->traceCorrelationId();
+                if (expect_trace_context) {
+                    EXPECT_NE(trace_correlation_id, 0u);
+                }
 
                 auto start_time = absl::Now();
 
                 for (size_t i = 0; i < repeat; i++) {
                     status = from.postXferReq(xfer_req);
                     ASSERT_TRUE((status == NIXL_SUCCESS) || (status == NIXL_IN_PROG));
+                    EXPECT_EQ(xfer_req->traceCorrelationId(), trace_correlation_id);
 
                     for (int i = 0; i < retry_count; i++) {
                         status = from.getXferStatus(xfer_req);
                         EXPECT_TRUE((status == NIXL_SUCCESS) || (status == NIXL_IN_PROG));
+                        EXPECT_EQ(xfer_req->traceCorrelationId(), trace_correlation_id);
                         if (status == NIXL_SUCCESS) {
                             break;
                         }
@@ -773,7 +781,10 @@ protected:
                    DRAM_SEG,
                    src_buffers,
                    DRAM_SEG,
-                   dst_buffers);
+                   dst_buffers,
+                   NIXL_ERR_NO_TELEMETRY,
+                   "notification",
+                   true);
         invalidateMD(0, 1);
         deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
         deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -769,22 +769,24 @@ protected:
         createRegisteredMem(getAgent(1), size, count, DRAM_SEG, dst_buffers);
 
         exchangeMD(0, 1);
-        doTransfer(getAgent(0),
-                   getAgentName(0),
-                   getAgent(1),
-                   getAgentName(1),
-                   NIXL_WRITE,
-                   size,
-                   count,
-                   repeat,
-                   num_threads,
-                   DRAM_SEG,
-                   src_buffers,
-                   DRAM_SEG,
-                   dst_buffers,
-                   NIXL_ERR_NO_TELEMETRY,
-                   "notification",
-                   true);
+        for (const auto op : {NIXL_WRITE, NIXL_READ}) {
+            doTransfer(getAgent(0),
+                       getAgentName(0),
+                       getAgent(1),
+                       getAgentName(1),
+                       op,
+                       size,
+                       count,
+                       repeat,
+                       num_threads,
+                       DRAM_SEG,
+                       src_buffers,
+                       DRAM_SEG,
+                       dst_buffers,
+                       NIXL_ERR_NO_TELEMETRY,
+                       "notification",
+                       true);
+        }
         invalidateMD(0, 1);
         deregisterMem(getAgent(0), src_buffers, DRAM_SEG);
         deregisterMem(getAgent(1), dst_buffers, DRAM_SEG);

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -410,7 +410,7 @@ protected:
                                        &extra_params);
                 ASSERT_EQ(status, NIXL_SUCCESS);
                 EXPECT_NE(xfer_req, nullptr);
-                const auto trace_correlation_id = xfer_req->traceCorrelationId();
+                const auto trace_correlation_id = xfer_req->traceCorrelationId64();
                 if (expect_trace_context) {
                     EXPECT_NE(trace_correlation_id, 0u);
                 }
@@ -420,12 +420,12 @@ protected:
                 for (size_t i = 0; i < repeat; i++) {
                     status = from.postXferReq(xfer_req);
                     ASSERT_TRUE((status == NIXL_SUCCESS) || (status == NIXL_IN_PROG));
-                    EXPECT_EQ(xfer_req->traceCorrelationId(), trace_correlation_id);
+                    EXPECT_EQ(xfer_req->traceCorrelationId64(), trace_correlation_id);
 
                     for (int i = 0; i < retry_count; i++) {
                         status = from.getXferStatus(xfer_req);
                         EXPECT_TRUE((status == NIXL_SUCCESS) || (status == NIXL_IN_PROG));
-                        EXPECT_EQ(xfer_req->traceCorrelationId(), trace_correlation_id);
+                        EXPECT_EQ(xfer_req->traceCorrelationId64(), trace_correlation_id);
                         if (status == NIXL_SUCCESS) {
                             break;
                         }

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -24,6 +24,7 @@
 #include "common.h"
 #include "nixl.h"
 #include "plugin_manager.h"
+#include "transfer_request.h"
 #include "mocks/gmock_engine.h"
 
 namespace gtest {
@@ -66,16 +67,17 @@ namespace agent {
 
     class agentHelper {
     protected:
+        ScopedEnv trace_env_;
         testing::NiceMock<mocks::GMockBackendEngine> gmock_engine_;
         std::unique_ptr<nixlAgent> agent_;
 
     public:
-        agentHelper(const std::string &name)
-            : agent_([&name]() {
-                  nixlAgentConfig cfg;
-                  cfg.useProgThread = true;
-                  return std::make_unique<nixlAgent>(name, cfg);
-              }()) {}
+        agentHelper(const std::string &name) {
+            trace_env_.addVar("NIXL_TRACE_BACKENDS", "");
+            nixlAgentConfig cfg;
+            cfg.useProgThread = true;
+            agent_ = std::make_unique<nixlAgent>(name, cfg);
+        }
 
         ~agentHelper() {
             /* We must release nixlAgent first (i.e. explicitly in the destructor), as it calls
@@ -421,8 +423,15 @@ namespace agent {
                                               xfer_req,
                                               &local_extra_params),
                   NIXL_SUCCESS);
+        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
         EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_SUCCESS);
         EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+
+        nixl_opt_args_t repost_params;
+        EXPECT_EQ(local_agent_->postXferReq(xfer_req, &repost_params), NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
 
         nixl_notifs_t notif_map;
         EXPECT_EQ(remote_agent_->getNotifs(notif_map), NIXL_SUCCESS);
@@ -499,9 +508,11 @@ namespace agent {
                                             xfer_req,
                                             &local_extra_params),
                   NIXL_SUCCESS);
+        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
         EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_SUCCESS);
 
         EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
 
         nixl_notifs_t notif_map;
         EXPECT_EQ(remote_agent_->getNotifs(notif_map), NIXL_SUCCESS);

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -423,15 +423,15 @@ namespace agent {
                                               xfer_req,
                                               &local_extra_params),
                   NIXL_SUCCESS);
-        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+        EXPECT_EQ(xfer_req->traceCorrelationId64(), 0u);
         EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_SUCCESS);
         EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
-        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+        EXPECT_EQ(xfer_req->traceCorrelationId64(), 0u);
 
         nixl_opt_args_t repost_params;
         EXPECT_EQ(local_agent_->postXferReq(xfer_req, &repost_params), NIXL_SUCCESS);
         EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
-        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+        EXPECT_EQ(xfer_req->traceCorrelationId64(), 0u);
 
         nixl_notifs_t notif_map;
         EXPECT_EQ(remote_agent_->getNotifs(notif_map), NIXL_SUCCESS);
@@ -508,11 +508,11 @@ namespace agent {
                                             xfer_req,
                                             &local_extra_params),
                   NIXL_SUCCESS);
-        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+        EXPECT_EQ(xfer_req->traceCorrelationId64(), 0u);
         EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_SUCCESS);
 
         EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
-        EXPECT_EQ(xfer_req->traceCorrelationId(), 0u);
+        EXPECT_EQ(xfer_req->traceCorrelationId64(), 0u);
 
         nixl_notifs_t notif_map;
         EXPECT_EQ(remote_agent_->getNotifs(notif_map), NIXL_SUCCESS);

--- a/test/gtest/unit/tracing/trace_context_test.cpp
+++ b/test/gtest/unit/tracing/trace_context_test.cpp
@@ -117,24 +117,25 @@ TEST(TraceContext, PreservesFlagsAndNormalizesOutput) {
 }
 
 TEST(TraceContext, RoundTripsFixedContextWithoutFieldDrift) {
-    const nixl::trace::TraceContext expected{{0x4b,
-                                              0xf9,
-                                              0x2f,
-                                              0x35,
-                                              0x77,
-                                              0xb3,
-                                              0x4d,
-                                              0xa6,
-                                              0xa3,
-                                              0xce,
-                                              0x92,
-                                              0x9d,
-                                              0x0e,
-                                              0x0e,
-                                              0x47,
-                                              0x36},
-                                             {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7},
-                                             0x03};
+    nixl::trace::TraceContext expected;
+    expected.traceId = {0x4b,
+                        0xf9,
+                        0x2f,
+                        0x35,
+                        0x77,
+                        0xb3,
+                        0x4d,
+                        0xa6,
+                        0xa3,
+                        0xce,
+                        0x92,
+                        0x9d,
+                        0x0e,
+                        0x0e,
+                        0x47,
+                        0x36};
+    expected.spanId = {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7};
+    expected.flags = 0x03;
 
     const auto parsed = nixl::trace::parseTraceparent(nixl::trace::formatTraceparent(expected));
 
@@ -162,6 +163,13 @@ TEST(TraceContext, InvalidContextsProjectZero) {
     no_span.traceId = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6};
     ASSERT_FALSE(no_span.valid());
     EXPECT_EQ(no_span.correlationId64(), 0ULL);
+}
+
+TEST(TraceContext, NullTracerYieldsInertContext) {
+    const nixl::trace::TraceContext context{nullptr};
+
+    EXPECT_FALSE(context.valid());
+    EXPECT_EQ(context.correlationId64(), 0ULL);
 }
 
 TEST(TraceContext, ValidSpanIdProjectsNonzero) {

--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "common.h"
+#include "transfer_request.h"
 #include "tracing/trace.h"
 
 namespace nixl::trace {
@@ -387,4 +388,48 @@ TEST(Tracing, CorrelationScopeNullTracerIsInert) {
     nixl::trace::Tracer *tracer = nullptr;
     { const nixl::trace::CorrelationScope scope(tracer, 0x1u); }
     SUCCEED();
+}
+
+TEST(Tracing, RequestStoresFixedCorrelationContext) {
+    nixl::trace::TraceContext context;
+    context.traceId = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6};
+    context.spanId = {1};
+
+    const nixlXferReqH request(
+        "remote", NIXL_WRITE, DRAM_SEG, DRAM_SEG, 0, nixl_remote_section_weak_t{}, context);
+
+    EXPECT_EQ(request.traceCorrelationId(), 0x4bf92f3577b34da6ULL);
+}
+
+TEST(Tracing, RequestContextsAreDistinctAndStable) {
+    const nixlXferReqH first("remote",
+                             NIXL_WRITE,
+                             DRAM_SEG,
+                             DRAM_SEG,
+                             0,
+                             nixl_remote_section_weak_t{},
+                             nixl::trace::generateTraceContext());
+    const nixlXferReqH second("remote",
+                              NIXL_WRITE,
+                              DRAM_SEG,
+                              DRAM_SEG,
+                              0,
+                              nixl_remote_section_weak_t{},
+                              nixl::trace::generateTraceContext());
+    const auto first_id = first.traceCorrelationId();
+
+    EXPECT_NE(first_id, second.traceCorrelationId());
+    EXPECT_EQ(first.traceCorrelationId(), first_id);
+}
+
+TEST(Tracing, RequestDefaultContextHasInertCorrelation) {
+    const nixlXferReqH request("remote",
+                               NIXL_WRITE,
+                               DRAM_SEG,
+                               DRAM_SEG,
+                               0,
+                               nixl_remote_section_weak_t{},
+                               nixl::trace::TraceContext{});
+
+    EXPECT_EQ(request.traceCorrelationId(), 0u);
 }

--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -393,12 +393,12 @@ TEST(Tracing, CorrelationScopeNullTracerIsInert) {
 TEST(Tracing, RequestStoresFixedCorrelationContext) {
     nixl::trace::TraceContext context;
     context.traceId = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6};
-    context.spanId = {1};
+    context.spanId = {0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7};
 
     const nixlXferReqH request(
         "remote", NIXL_WRITE, DRAM_SEG, DRAM_SEG, 0, nixl_remote_section_weak_t{}, context);
 
-    EXPECT_EQ(request.traceCorrelationId64(), 0x4bf92f3577b34da6ULL);
+    EXPECT_EQ(request.traceCorrelationId64(), 0x00f067aa0ba902b7ULL);
 }
 
 TEST(Tracing, RequestContextsAreDistinctAndStable) {

--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -398,7 +398,7 @@ TEST(Tracing, RequestStoresFixedCorrelationContext) {
     const nixlXferReqH request(
         "remote", NIXL_WRITE, DRAM_SEG, DRAM_SEG, 0, nixl_remote_section_weak_t{}, context);
 
-    EXPECT_EQ(request.traceCorrelationId(), 0x4bf92f3577b34da6ULL);
+    EXPECT_EQ(request.traceCorrelationId64(), 0x4bf92f3577b34da6ULL);
 }
 
 TEST(Tracing, RequestContextsAreDistinctAndStable) {
@@ -416,10 +416,10 @@ TEST(Tracing, RequestContextsAreDistinctAndStable) {
                               0,
                               nixl_remote_section_weak_t{},
                               nixl::trace::generateTraceContext());
-    const auto first_id = first.traceCorrelationId();
+    const auto first_id = first.traceCorrelationId64();
 
-    EXPECT_NE(first_id, second.traceCorrelationId());
-    EXPECT_EQ(first.traceCorrelationId(), first_id);
+    EXPECT_NE(first_id, second.traceCorrelationId64());
+    EXPECT_EQ(first.traceCorrelationId64(), first_id);
 }
 
 TEST(Tracing, RequestDefaultContextHasInertCorrelation) {
@@ -431,5 +431,5 @@ TEST(Tracing, RequestDefaultContextHasInertCorrelation) {
                                nixl_remote_section_weak_t{},
                                nixl::trace::TraceContext{});
 
-    EXPECT_EQ(request.traceCorrelationId(), 0u);
+    EXPECT_EQ(request.traceCorrelationId64(), 0u);
 }

--- a/test/gtest/unit/tracing/tracing_test.cpp
+++ b/test/gtest/unit/tracing/tracing_test.cpp
@@ -433,3 +433,15 @@ TEST(Tracing, RequestDefaultContextHasInertCorrelation) {
 
     EXPECT_EQ(request.traceCorrelationId64(), 0u);
 }
+
+TEST(Tracing, ActiveTracerConstructsGeneratedContext) {
+    CallLog a, b;
+    const auto tracer = makeMockTracer(a, b);
+
+    const nixl::trace::TraceContext first{tracer.get()};
+    const nixl::trace::TraceContext second{tracer.get()};
+
+    EXPECT_TRUE(first.valid());
+    EXPECT_TRUE(second.valid());
+    EXPECT_NE(first.correlationId64(), second.correlationId64());
+}


### PR DESCRIPTION
## What?

Give each traced transfer request one immutable internal `TraceContext` and use its stable 64-bit projection to correlate NVTX post and completion events. The context is generated once and reused across reposts.

## Why?

[NIX-1739](https://linear.app/nvidia/issue/NIX-1739), part of the [NIX-1537](https://linear.app/nvidia/issue/NIX-1537) distributed-tracing groundwork.

Request-handle addresses can be reused after release, which can merge unrelated transfers under one correlation ID. A request-owned context keeps the identity stable for the request's lifetime.

## How?

`makeXferReq` and `createXferReq` generate a context only when tracing is active. `nixlXferReqH` stores it as `const`, and `postXferReq` and successful asynchronous completion use `traceCorrelationId()`.

Unit, transfer, and Nsight Systems tests cover distinct and stable request identities, repost reuse, the tracing-disabled path, and matching post/completion correlation IDs. Normal and sanitizer CTest runs pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Transfer requests now retain stable trace correlation IDs throughout posting, status checks, and completion when tracing is enabled.
  - Transfer lifecycle events are correlated consistently without relying on request-handle memory addresses.

- **Bug Fixes**
  - Improved correlation of post-transfer and completion events across repeated requests.

- **Tests**
  - Added coverage for trace ID stability, tracing-disabled behavior, read and write operations, and event payload matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->