### PR TITLE
nixl_ep: Safely connect ranks during traffic

### DIFF
--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -1374,16 +1374,19 @@ void Buffer::_nixl_ep_memory_views_destroy(NixlMemoryViews& memory_views) {
 void Buffer::_nixl_ep_memory_views_commit(void) {
     if (!staged_memory_views.local)
         return;
+    // Wait for all kernels using the active memory views to finish.
     CUDA_CHECK(cudaDeviceSynchronize());
     std::swap(active_memory_views, staged_memory_views);
     gpu_ctx.local_mvh = active_memory_views.local;
     gpu_ctx.remote_mvh = active_memory_views.remote;
     gpu_ctx.barrier_mvh = active_memory_views.barrier;
     gpu_ctx.ht_barrier_mvh = active_memory_views.ht_barrier;
-    CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpyAsync(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx),
+                               cudaMemcpyHostToDevice, comm_stream));
     for (int remote_rank : remote_ranks)
         ep_kernels::cache_p2p_ptr(gpu_ctx_ptr, remote_rank, comm_stream);
-    CUDA_CHECK(cudaDeviceSynchronize());
+    // Wait for the new GPU context and cached P2P pointers to be ready.
+    CUDA_CHECK(cudaStreamSynchronize(comm_stream));
     _nixl_ep_memory_views_destroy(staged_memory_views);
 }
 

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -507,6 +507,7 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
     }
 
     if (!new_ranks.empty()) {
+        pybind11::gil_scoped_release release;
         _nixl_agents_connect(new_ranks, new_ranks_mds);
 
         _nixl_agents_peer_info_gather(new_ranks);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -511,14 +511,7 @@ void Buffer::connect_ranks(const std::vector<int>& remote_ranks_list, const std:
 
         _nixl_agents_peer_info_gather(new_ranks);
 
-        _nixl_ep_memory_views_destroy();
-
-        _nixl_ep_memory_views_create();
-
-        for (int remote_rank : new_ranks)
-            ep_kernels::cache_p2p_ptr(gpu_ctx_ptr, remote_rank, comm_stream);
-
-        CUDA_CHECK(cudaDeviceSynchronize());
+        _nixl_ep_memory_views_stage();
     }
 
     if (activate) {
@@ -546,8 +539,6 @@ void Buffer::disconnect_ranks(const std::vector<int>& remote_ranks_list) {
         CUDA_CHECK(cudaMemset(gpu_ctx.p2p_ptrs + removed_rank, 0, sizeof(void*)));
     }
 
-    _nixl_ep_memory_views_destroy();
-
     _nixl_agents_peer_info_cleanup(remote_ranks_list);
 
     _nixl_agents_disconnect(remote_ranks_list);
@@ -560,7 +551,9 @@ void Buffer::disconnect_ranks(const std::vector<int>& remote_ranks_list) {
         );
     }
 
-    _nixl_ep_memory_views_create();
+    _nixl_ep_memory_views_stage();
+
+    _nixl_ep_memory_views_commit();
 }
 
 std::tuple<torch::Tensor, std::optional<torch::Tensor>, torch::Tensor, torch::Tensor, std::optional<EventHandle>>
@@ -1292,6 +1285,7 @@ void Buffer::update_mask_buffer(int rank_to_mask, bool mask) {
     EP_HOST_ASSERT((rank_to_mask != rank or !mask) && "cannot mask the local rank");
     if (!mask)
         EP_HOST_ASSERT(_is_rank_connected(rank_to_mask) && "cannot unmask an unconnected rank");
+    _nixl_ep_memory_views_commit();
     active_ranks[rank_to_mask] = !mask;
     _refresh_active_rank_bound();
     ep_kernels::update_mask_buffer(mask_buffer_ptr, rank_to_mask, mask, at::cuda::getCurrentCUDAStream());
@@ -1311,6 +1305,7 @@ Buffer::query_mask_buffer(const torch::Tensor &mask_status) const {
 
 void Buffer::clean_mask_buffer() {
     EP_HOST_ASSERT(mask_buffer_ptr != nullptr and "Shrink mode must be enabled");
+    _nixl_ep_memory_views_commit();
     std::vector<int> mask(max_num_ranks, 1);
     for (int rank_id = 0; rank_id < max_num_ranks; ++rank_id) {
         const bool active = _is_rank_connected(rank_id);
@@ -1333,7 +1328,10 @@ std::string Buffer::get_local_metadata() const {
     return metadata_blob;
 }
 
-void Buffer::_nixl_ep_memory_views_create(void) {
+void Buffer::_nixl_ep_memory_views_stage(void) {
+    // TODO: Separate the local memory view so peer updates only rebuild remote views.
+    NixlMemoryViews& memory_views = staged_memory_views;
+    _nixl_ep_memory_views_destroy(memory_views);
     nixl_remote_dlist_t remote_descs(VRAM_SEG);
     nixl_remote_dlist_t barrier_descs(VRAM_SEG);
     nixl_local_dlist_t local_descs(VRAM_SEG);
@@ -1348,10 +1346,10 @@ void Buffer::_nixl_ep_memory_views_create(void) {
         barrier_descs.addDesc(nixlRemoteDesc((uintptr_t)nixl_peer_info[r].sync_buffer_ptr, max_num_ranks * sizeof(int), nixl_peer_info[r].device_id, remote_agent_name));
     }
 
-    EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(local_descs, gpu_ctx.local_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
+    EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(local_descs, memory_views.local, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
     if (!remote_ranks.empty()) {
-        EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(remote_descs, gpu_ctx.remote_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
-        EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(barrier_descs, gpu_ctx.barrier_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
+        EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(remote_descs, memory_views.remote, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
+        EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(barrier_descs, memory_views.barrier, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
 
         if (!low_latency_mode && max_num_ranks > NUM_MAX_NVL_PEERS) {
             nixl_remote_dlist_t ht_barrier_descs(VRAM_SEG);
@@ -1359,21 +1357,33 @@ void Buffer::_nixl_ep_memory_views_create(void) {
                 std::string remote_agent_name = remote_set.count(r) ? nixl_agent_info->remote_agent_names[r] : nixl_null_agent;
                 ht_barrier_descs.addDesc(nixlRemoteDesc((uintptr_t)nixl_peer_info[r].ht_barrier_ptr, sizeof(uint64_t), nixl_peer_info[r].device_id, remote_agent_name));
             }
-            EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(ht_barrier_descs, gpu_ctx.ht_barrier_mvh, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
+            EP_HOST_ASSERT(nixl_agent_info->agent->prepMemView(ht_barrier_descs, memory_views.ht_barrier, &nixl_agent_info->extra_params) == NIXL_SUCCESS);
         }
     }
-    CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
 }
 
-void Buffer::_nixl_ep_memory_views_destroy(void) {
-    if (gpu_ctx.local_mvh) nixl_agent_info->agent->releaseMemView(gpu_ctx.local_mvh);
-    if (gpu_ctx.remote_mvh) nixl_agent_info->agent->releaseMemView(gpu_ctx.remote_mvh);
-    if (gpu_ctx.barrier_mvh) nixl_agent_info->agent->releaseMemView(gpu_ctx.barrier_mvh);
-    if (gpu_ctx.ht_barrier_mvh) nixl_agent_info->agent->releaseMemView(gpu_ctx.ht_barrier_mvh);
-    gpu_ctx.local_mvh = nullptr;
-    gpu_ctx.remote_mvh = nullptr;
-    gpu_ctx.barrier_mvh = nullptr;
-    gpu_ctx.ht_barrier_mvh = nullptr;
+void Buffer::_nixl_ep_memory_views_destroy(NixlMemoryViews& memory_views) {
+    if (memory_views.local) nixl_agent_info->agent->releaseMemView(memory_views.local);
+    if (memory_views.remote) nixl_agent_info->agent->releaseMemView(memory_views.remote);
+    if (memory_views.barrier) nixl_agent_info->agent->releaseMemView(memory_views.barrier);
+    if (memory_views.ht_barrier) nixl_agent_info->agent->releaseMemView(memory_views.ht_barrier);
+    memory_views = {};
+}
+
+void Buffer::_nixl_ep_memory_views_commit(void) {
+    if (!staged_memory_views.local)
+        return;
+    CUDA_CHECK(cudaDeviceSynchronize());
+    std::swap(active_memory_views, staged_memory_views);
+    gpu_ctx.local_mvh = active_memory_views.local;
+    gpu_ctx.remote_mvh = active_memory_views.remote;
+    gpu_ctx.barrier_mvh = active_memory_views.barrier;
+    gpu_ctx.ht_barrier_mvh = active_memory_views.ht_barrier;
+    CUDA_CHECK(cudaMemcpy(gpu_ctx_ptr, &gpu_ctx, sizeof(gpu_ctx), cudaMemcpyHostToDevice));
+    for (int remote_rank : remote_ranks)
+        ep_kernels::cache_p2p_ptr(gpu_ctx_ptr, remote_rank, comm_stream);
+    CUDA_CHECK(cudaDeviceSynchronize());
+    _nixl_ep_memory_views_destroy(staged_memory_views);
 }
 
 void Buffer::_nixl_ep_init(void) {
@@ -1395,7 +1405,8 @@ void Buffer::_nixl_ep_init(void) {
 }
 
 void Buffer::_nixl_ep_destroy(void) {
-    _nixl_ep_memory_views_destroy();
+    _nixl_ep_memory_views_destroy(staged_memory_views);
+    _nixl_ep_memory_views_destroy(active_memory_views);
     if (gpu_ctx.p2p_ptrs != nullptr) {
         cudaFree(gpu_ctx.p2p_ptrs);
         gpu_ctx.p2p_ptrs = nullptr;

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -77,6 +77,13 @@ struct NixlAgentInfo
     std::vector<bool> wire_up_done; // [num_peers]
 };
 
+struct NixlMemoryViews {
+    nixlMemViewH local = nullptr;
+    nixlMemViewH remote = nullptr;
+    nixlMemViewH barrier = nullptr;
+    nixlMemViewH ht_barrier = nullptr;
+};
+
 struct Buffer {
     EP_STATIC_ASSERT(NUM_MAX_NVL_PEERS == 8, "The number of maximum NVLink peers must be 8");
 
@@ -157,6 +164,8 @@ private:
     std::vector<NixlPeerInfo> nixl_peer_info;
     NixlPeerInfo my_peer_info;
     nixl_ep::gpu_nixl_ctx gpu_ctx;
+    NixlMemoryViews active_memory_views;
+    NixlMemoryViews staged_memory_views;
     nixl_ep::gpu_nixl_ctx* gpu_ctx_ptr = nullptr;
     uint64_t* last_ht_barrier_counter = nullptr;
     uint64_t* local_ht_barrier_counter = nullptr;
@@ -169,8 +178,9 @@ private:
     void _nixl_agents_peer_info_cleanup(const std::vector<int>& ranks);
 
     void _nixl_ep_init(void);
-    void _nixl_ep_memory_views_create(void);
-    void _nixl_ep_memory_views_destroy(void);
+    void _nixl_ep_memory_views_destroy(NixlMemoryViews& memory_views);
+    void _nixl_ep_memory_views_stage(void);
+    void _nixl_ep_memory_views_commit(void);
     void _nixl_ep_destroy(void);
     bool _is_rank_connected(int rank_id) const;
     void set_active_rank_bound(int bound);

--- a/examples/device/ep/nixl_ep/buffer.py
+++ b/examples/device/ep/nixl_ep/buffer.py
@@ -846,7 +846,9 @@ class Buffer:
         Arguments:
             remote_ranks: List of remote rank IDs to establish connections with.
                          The current rank will be automatically filtered out.
-            activate: in low-latency mode, if False, keep newly connected ranks masked until update_mask_buffer(..., False).
+            activate: in low-latency mode, if False, keep newly connected ranks
+                masked until update_mask_buffer(..., False). Concurrent execution
+                is supported only with dispatch and combine.
         """
         if self.low_latency_mode:
             if self.tcp_store_group is not None:


### PR DESCRIPTION
connect_ranks(activate=False) previously destroyed and recreated active memory views while dispatch/combine kernels could still be using them. This made connecting new ranks during traffic unsafe.

Also, when the CUDA IPC cache is disabled, recreating memory views closes and reopens all IPC handles, which is slow.

Instead, during async connect_ranks, stage standby memory views while keeping the active views alive, then commit them when the new ranks are activated. This keeps inflight dispatch/combine kernels safe and avoids unnecessarily reopening existing IPC handles.

Also, release the Python GIL while connecting new ranks to avoid stalling request serving on the main inference engine thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved memory resource handling during device connections, disconnections, and configuration updates.
* Refreshed device context and peer-to-peer memory references more reliably when memory settings change.
* Ensured both active and pending memory resources are released during cleanup.
* Improved connection setup responsiveness by reducing unnecessary blocking during initialization.

## Documentation

* Clarified that connections can be established concurrently with dispatch and combine operations, but not during topology or lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->