### PR TITLE
ci: fix vllm-cu13 base image default to unsuffixed :latest tag

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -4,7 +4,7 @@
 # pre-built NIXL wheel set.
 #
 #   - vllm-cu12-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu129
-#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest-cu130
+#   - vllm-cu13-nixl-<ver>    : Dockerfile.vllm   + vllm/vllm-openai:latest
 #   - sglang-cu12-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu129-runtime
 #   - sglang-cu13-nixl-<ver>  : Dockerfile.sglang + lmsysorg/sglang:latest-cu130-runtime
 #
@@ -187,9 +187,9 @@ steps:
       IMAGE="${ARTIFACTORY_REGISTRY_URL}/vllm-cu13-nixl:${IMAGE_TAG}-${arch}"
       # Podman enforces short-name resolution, so always pass a fully-qualified
       # BASE_IMAGE. Falls back to the upstream docker.io image when no override.
-      # Use the CUDA-pinned latest tag: plain :latest carries no CUDA promise,
-      # while :latest-cu130 locks CUDA 13 yet still tracks the newest vLLM.
-      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:latest-cu130}"
+      # Since vLLM v0.20.0, CUDA 13 is the default and is published under the
+      # unsuffixed :latest tag; :latest-cu130 is no longer valid.
+      BASE="${BASE_IMAGE_VLLM_CU13:-docker.io/vllm/vllm-openai:latest}"
       podman build \
         --platform "${PLATFORM}" \
         --build-arg "BASE_IMAGE=${BASE}" \

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -716,7 +716,7 @@
           default: ""
           description: >
             Optional override for the vllm-cu13 base image build-arg.<br/>
-            Leave empty for <b>rc0</b> (uses the CUDA 13 default <code>docker.io/vllm/vllm-openai:latest-cu130</code>).<br/>
+            Leave empty for <b>rc0</b> (uses the CUDA 13 default <code>docker.io/vllm/vllm-openai:latest</code>).<br/>
             For <b>rcN, N&gt;0</b> set to the corresponding rc0 image, e.g.<br/>
             <code>artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/verification/llm/vllm-cu13-nixl:1.1.0-rc0</code>
       - string:


### PR DESCRIPTION
## Summary
The `nixl-ci-build-llm-container` pipeline's vLLM CU13 build defaulted to `docker.io/vllm/vllm-openai:latest-cu130`, which is no longer valid. Starting with vLLM v0.20.0, CUDA 13 became the default and current CUDA 13 images are published under the unsuffixed `vllm/vllm-openai:latest` tag.

- `.ci/jenkins/lib/build-llm-container-matrix.yaml`: default `BASE_IMAGE_VLLM_CU13` fallback changed to `docker.io/vllm/vllm-openai:latest`; updated surrounding comments
- `.ci/jenkins/pipeline/proj-jjb.yaml`: updated the `BASE_IMAGE_VLLM_CU13` job parameter description to match

CU12 (`latest-cu129`) remains unchanged, as it's still a valid CUDA 12.9 tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CUDA 13 vLLM base image reference to use the current `latest` tag.
  * Updated release-candidate build configuration to reference the corresponding vLLM image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->