### PR TITLE
ci: stop pushing failures to the triage agent

### DIFF
--- a/.ci/jenkins/pipeline/Jenkinsfile
+++ b/.ci/jenkins/pipeline/Jenkinsfile
@@ -50,22 +50,6 @@ try {
 } catch (Exception ex) {
     currentBuild.result = 'FAILURE'
     println ex
-    // On failure, kick off an automated CI triage investigation.
-    if (params.githubData) {
-        try {
-            // ciTriage (swx-jenkins-lib) POSTs to the agent on the flyweight executor.
-            withCredentials([string(credentialsId: 'ci-triage-nixl-url', variable: 'CI_TRIAGE_URL')]) {
-                ciTriage(
-                    url:       env.CI_TRIAGE_URL,
-                    commitSha: githubHelper.getMergedSHA(),
-                    prNumber:  githubHelper.getPRNumber(),
-                    insecure:  true,   // the ingress wildcard CA isn't in the controller trust store
-                )
-            }
-        } catch (Exception triageEx) {
-            echo "CI triage trigger failed (non-fatal): ${triageEx}"
-        }
-    }
     throw ex
 } finally {
     if (params.githubData) {


### PR DESCRIPTION
The CI triage agent now discovers failed builds itself by polling the repo's commit statuses, so the pipeline no longer needs to push them to it. With both in place every Jenkins failure would be reported twice on the PR.

Nothing is lost by dropping the push:

- The `finally` block already posts the build's commit status with its `pipeline-overview` URL, which is exactly what the agent discovers and reads the log from.
- Both the removed `ciTriage` call and the status post are gated on `githubData`, so the set of runs covered is unchanged.
- Removes the pipeline's only use of the `ci-triage-nixl-url` credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the automatic CI triage trigger from failed builds.
  * Failed builds no longer initiate separate triage error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->