### PR TITLE
descriptors: avoid overflow in range coverage checks

### DIFF
--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <vector>
 #include <string>
+#include <limits>
 #include <algorithm>
 #include "nixl_types.h"
 
@@ -105,6 +106,7 @@ public:
      */
     friend bool
     operator!=(const nixlBasicDesc &lhs, const nixlBasicDesc &rhs);
+
     /**
      * @brief Check if current object address range covers the input object's
      *
@@ -112,8 +114,26 @@ public:
      */
     bool
     covers(const nixlBasicDesc &query) const noexcept {
-        return (devId == query.devId) && (addr <= query.addr) &&
-            ((addr + len) >= (query.addr + query.len));
+        if (devId != query.devId || addr > query.addr) {
+            return false;
+        }
+
+        constexpr uintptr_t max_addr = std::numeric_limits<uintptr_t>::max();
+        if (query.len > max_addr - query.addr) {
+            return false;
+        }
+
+        // File-like section lists normalize len=0 to SIZE_MAX to represent an
+        // unbounded registration. Avoid adding that sentinel to a nonzero address.
+        if (len == SIZE_MAX) {
+            return true;
+        }
+        if (len > max_addr - addr) {
+            return false;
+        }
+
+        const size_t offset = query.addr - addr;
+        return offset <= len && query.len <= len - offset;
     }
 
     /**

--- a/src/api/cpp/nixl_descriptors.h
+++ b/src/api/cpp/nixl_descriptors.h
@@ -119,21 +119,16 @@ public:
         }
 
         constexpr uintptr_t max_addr = std::numeric_limits<uintptr_t>::max();
-        if (query.len > max_addr - query.addr) {
-            return false;
-        }
-
         // File-like section lists normalize len=0 to SIZE_MAX to represent an
         // unbounded registration. Avoid adding that sentinel to a nonzero address.
         if (len == SIZE_MAX) {
-            return true;
-        }
-        if (len > max_addr - addr) {
-            return false;
+            return query.len <= max_addr - query.addr;
         }
 
-        const size_t offset = query.addr - addr;
-        return offset <= len && query.len <= len - offset;
+        // If this finite range wraps, end is below addr and therefore below
+        // query.addr. The first comparison also keeps the subtraction safe.
+        const uintptr_t end = addr + len;
+        return query.addr <= end && query.len <= end - query.addr;
     }
 
     /**

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <map>
 #include <algorithm>
+#include <limits>
 #include <iostream>
 #include "nixl.h"
 #include "nixl_descriptors.h"
@@ -26,6 +27,31 @@
 #include "serdes/serdes.h"
 
 /*** Class nixlMemSection implementation ***/
+
+namespace {
+uintptr_t
+rangeEnd(const nixlBasicDesc &desc) noexcept {
+    const uintptr_t max_addr = std::numeric_limits<uintptr_t>::max();
+    return desc.len == SIZE_MAX ? max_addr : desc.addr + desc.len;
+}
+
+bool
+coversWithEnd(const nixlBasicDesc &covering,
+              const uintptr_t covering_end,
+              const nixlBasicDesc &query) noexcept {
+    const uintptr_t query_end = query.addr + query.len;
+    return covering.devId == query.devId && covering.addr <= query.addr &&
+        query_end >= query.addr && query_end <= covering_end;
+}
+
+bool
+coversFollowingWithEnd(const nixlBasicDesc &covering,
+                       const uintptr_t covering_end,
+                       const nixlBasicDesc &query) noexcept {
+    const uintptr_t query_end = query.addr + query.len;
+    return covering.devId == query.devId && query_end >= query.addr && query_end <= covering_end;
+}
+} // namespace
 
 nixlSecDescList &
 nixlMemSection::emplace(const nixl_mem_t nixl_mem, nixlBackendEngine *backend) {
@@ -78,7 +104,9 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
     if (s_index < 0) {
         return NIXL_ERR_UNKNOWN;
     }
-    resp.emplace(query[0].addr, query[0].len, query[0].devId, base[s_index].metadataP);
+    const nixlSectionDesc *covering = &base[s_index];
+    resp.emplace(query[0].addr, query[0].len, query[0].devId, covering->metadataP);
+    uintptr_t covering_end = rangeEnd(*covering);
 
     // Walk forward for non-decreasing elements; logN search on temporal disorder
     for (int i = 1; i < query.descCount(); ++i) {
@@ -89,16 +117,27 @@ nixl_status_t nixlMemSection::populate (const nixl_xfer_dlist_t &query,
                 resp.clear();
                 return NIXL_ERR_UNKNOWN;
             }
+            covering = &base[s_index];
+            covering_end = rangeEnd(*covering);
         } else {
-            while (s_index < size && !base[s_index].covers(query[i]))
-                ++s_index;
+            // The current section covered the previous query. For an ordered
+            // query on the same device, its start cannot precede the section.
+            if (!coversFollowingWithEnd(*covering, covering_end, query[i])) {
+                do {
+                    ++s_index;
+                    if (s_index < size) {
+                        covering = &base[s_index];
+                        covering_end = rangeEnd(*covering);
+                    }
+                } while (s_index < size && !coversWithEnd(*covering, covering_end, query[i]));
+            }
             if (s_index == size) [[unlikely]] {
                 resp.clear();
                 return NIXL_ERR_UNKNOWN;
             }
         }
 
-        resp.emplace(query[i].addr, query[i].len, query[i].devId, base[s_index].metadataP);
+        resp.emplace(query[i].addr, query[i].len, query[i].devId, covering->metadataP);
     }
     return NIXL_SUCCESS;
 }
@@ -131,21 +170,26 @@ nixlMemSection::populate(const nixl_xfer_dlist_t &query,
 
     nixlStrideDesc current(
         query[0].addr, query[0].len, query[0].devId, base[s_index].metadataP, query[0].len, 1);
+    uintptr_t covering_end = rangeEnd(base[s_index]);
     uintptr_t prev_addr = query[0].addr;
 
     for (int i = 1; i < n; ++i) {
         const nixlBasicDesc &it = query[i];
 
-        if (!base[s_index].covers(it)) [[unlikely]] {
+        if (!coversWithEnd(base[s_index], covering_end, it)) [[unlikely]] {
             if (it < query[i - 1]) {
                 s_index = base.getCoveringIndex(it);
                 if (s_index < 0) {
                     resp.clear();
                     return NIXL_ERR_UNKNOWN;
                 }
+                covering_end = rangeEnd(base[s_index]);
             } else {
-                while (s_index < size && !base[s_index].covers(it)) {
+                while (s_index < size && !coversWithEnd(base[s_index], covering_end, it)) {
                     ++s_index;
+                    if (s_index < size) {
+                        covering_end = rangeEnd(base[s_index]);
+                    }
                 }
                 if (s_index == size) {
                     resp.clear();

--- a/test/gtest/unit/descriptors/sec_desc_list.cpp
+++ b/test/gtest/unit/descriptors/sec_desc_list.cpp
@@ -241,6 +241,28 @@ TEST_F(secDescListTest, ZeroLenObjSegQuery) {
     EXPECT_EQ(list.getIndex(query), 0);
 }
 
+TEST_F(secDescListTest, UnboundedFileSegCoversFiniteRangeFromNonzeroOffset) {
+    nixlSecDescList list(FILE_SEG);
+    list.addDesc(nixlSectionDesc(4096, 0, 0));
+
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(4096, 64, 0)), 0);
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(8192, 64, 0)), 0);
+}
+
+TEST_F(secDescListTest, UnboundedFileSegDoesNotCoverEarlierRange) {
+    nixlSecDescList list(FILE_SEG);
+    list.addDesc(nixlSectionDesc(4096, 0, 0));
+
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(0, 64, 0)), -1);
+}
+
+TEST_F(secDescListTest, FiniteFileSegDoesNotCoverOverflowingRange) {
+    nixlSecDescList list(FILE_SEG);
+    list.addDesc(nixlSectionDesc(4096, 4096, 0));
+
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(4160, SIZE_MAX, 0)), -1);
+}
+
 TEST_F(secDescListTest, ZeroLenQueryNotFound) {
     nixlSecDescList list(FILE_SEG);
     nixlSectionDesc desc(0, SIZE_MAX, 0);

--- a/test/gtest/unit/descriptors/sec_desc_list.cpp
+++ b/test/gtest/unit/descriptors/sec_desc_list.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <limits>
 #include <random>
 #include <vector>
 
@@ -80,6 +81,15 @@ protected:
             EXPECT_EQ(list[i].devId, expected[i].second) << "devId mismatch at index " << i;
             EXPECT_EQ(list[i].len, defaultLen) << "len mismatch at index " << i;
         }
+    }
+};
+
+class testMemSection : public nixlMemSection {
+public:
+    void
+    addDescs(nixlSecDescList descs) {
+        nixlSecDescList &target = emplace(descs.getType(), nullptr);
+        target.addDescs(std::move(descs));
     }
 };
 
@@ -261,6 +271,69 @@ TEST_F(secDescListTest, FiniteFileSegDoesNotCoverOverflowingRange) {
     list.addDesc(nixlSectionDesc(4096, 4096, 0));
 
     EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(4160, SIZE_MAX, 0)), -1);
+}
+
+TEST_F(secDescListTest, UnboundedFileSegDoesNotCoverOverflowingRange) {
+    nixlSecDescList list(FILE_SEG);
+    list.addDesc(nixlSectionDesc(4096, 0, 0));
+
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(4160, SIZE_MAX, 0)), -1);
+}
+
+TEST_F(secDescListTest, OverflowingFiniteFileSegDoesNotCoverRange) {
+    constexpr uintptr_t max_addr = std::numeric_limits<uintptr_t>::max();
+    nixlSecDescList list(FILE_SEG);
+    list.addDesc(nixlSectionDesc(max_addr - 64, 128, 0));
+
+    EXPECT_EQ(list.getCoveringIndex(nixlBasicDesc(max_addr - 32, 16, 0)), -1);
+}
+
+TEST_F(secDescListTest, PopulateWalksOrderedSectionsAndDevices) {
+    nixlBackendMD metadata1(false);
+    nixlBackendMD metadata2(false);
+    nixlBackendMD metadata3(false);
+
+    nixlSecDescList registrations(DRAM_SEG);
+    registrations.addDesc(nixlSectionDesc(100, 64, 1, &metadata1));
+    registrations.addDesc(nixlSectionDesc(200, 64, 1, &metadata2));
+    registrations.addDesc(nixlSectionDesc(100, 64, 2, &metadata3));
+
+    testMemSection section;
+    section.addDescs(std::move(registrations));
+
+    nixl_xfer_dlist_t query(DRAM_SEG);
+    query.addDesc(nixlBasicDesc(112, 16, 1));
+    query.addDesc(nixlBasicDesc(208, 16, 1));
+    query.addDesc(nixlBasicDesc(112, 16, 2));
+
+    nixl_meta_dlist_t response(DRAM_SEG);
+    ASSERT_EQ(section.populate(query, nullptr, response), NIXL_SUCCESS);
+    ASSERT_EQ(response.descCount(), 3);
+    EXPECT_EQ(response[0].metadataP, &metadata1);
+    EXPECT_EQ(response[1].metadataP, &metadata2);
+    EXPECT_EQ(response[2].metadataP, &metadata3);
+}
+
+TEST_F(secDescListTest, PopulateFallsBackForDisorderedQueries) {
+    nixlBackendMD metadata1(false);
+    nixlBackendMD metadata2(false);
+
+    nixlSecDescList registrations(DRAM_SEG);
+    registrations.addDesc(nixlSectionDesc(100, 64, 1, &metadata1));
+    registrations.addDesc(nixlSectionDesc(200, 64, 1, &metadata2));
+
+    testMemSection section;
+    section.addDescs(std::move(registrations));
+
+    nixl_xfer_dlist_t query(DRAM_SEG);
+    query.addDesc(nixlBasicDesc(208, 16, 1));
+    query.addDesc(nixlBasicDesc(112, 16, 1));
+
+    nixl_meta_dlist_t response(DRAM_SEG);
+    ASSERT_EQ(section.populate(query, nullptr, response), NIXL_SUCCESS);
+    ASSERT_EQ(response.descCount(), 2);
+    EXPECT_EQ(response[0].metadataP, &metadata2);
+    EXPECT_EQ(response[1].metadataP, &metadata1);
 }
 
 TEST_F(secDescListTest, ZeroLenQueryNotFound) {


### PR DESCRIPTION
## What?

Make `nixlBasicDesc::covers()` compare descriptor ranges without overflowing their
end addresses, and add regression coverage for unbounded file registrations and
overflowing transfer ranges.

## Why?

File-like section lists normalize a zero-length registration to `SIZE_MAX` as an
unbounded-range sentinel. The existing `addr + len` comparison wraps whenever
that registration starts at a nonzero offset, so `getCoveringIndex()` rejects
valid transfer descriptors inside the registration. Conversely, a transfer
descriptor whose end address wraps can be accepted by a finite registration.

A standalone probe against the parent commit reproduced both cases:

```text
unbounded_covers_finite=0
finite_covers_wrapping=1
```

With this change:

```text
unbounded_covers_finite=1
finite_covers_wrapping=0
```

## How?

- Reject transfer ranges whose end address is not representable.
- Preserve the existing `SIZE_MAX` unbounded-registration convention without
  adding the sentinel to a nonzero address.
- Validate finite ranges with subtraction after checking their endpoints.

This does not change the public API or the zero-length normalization contract.

## Validation

Base: `8770b655a6b17b5cdf7d2b56b6e0be5392496df5`

```text
secDescListTest.*: 29/29 passed
full unit executable: 90/90 passed
git diff --check: passed
changed-lines clang-format check: passed
```

The unit build enabled the POSIX plugin, used the local mock backend for memory
registration tests, and did not require RDMA or storage-specific hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved descriptor range validation and coverage handling.
  * Prevented invalid matches caused by device mismatches, out-of-range addresses, and address arithmetic overflow.
  * Added support for unbounded ranges and more accurate offset-based containment checks.
  * Improved metadata handling for ordered and disordered range queries.

* **Tests**
  * Added coverage for unbounded segments, earlier offsets, overflowing queries, and address-overflow cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->