### PR TITLE
gds_mt: decode cuFile errors correctly in IO failure logs

### DIFF
--- a/src/plugins/gds_mt/gds_mt_backend.cpp
+++ b/src/plugins/gds_mt/gds_mt_backend.cpp
@@ -116,20 +116,33 @@ getThreadCount(const nixlBackendInitParams *init_params) {
     return (count > 0) ? count : default_thread_count;
 }
 
+// cuFileRead/cuFileWrite return -1 with errno set for filesystem errors, and
+// a negative CUfileOpError enum value for all other errors, where errno is
+// not meaningful.
+void
+logCuFileIOError(const char *api, ssize_t nbytes) {
+    if (nbytes == -1) {
+        NIXL_ERROR << "GDS_MT: " << api << " failed: " << strerror(errno);
+    } else {
+        NIXL_ERROR << "GDS_MT: " << api << " failed: " << CUFILE_ERRSTR(nbytes)
+                   << " (err=" << -nbytes << ")";
+    }
+}
+
 void
 runCuFileOp (GdsMtTransferRequestH *req, std::atomic<nixl_status_t> *overall_status) {
     ssize_t nbytes = 0;
     if (req->op == CUFILE_READ) {
         nbytes = cuFileRead (req->fh, req->addr, req->size, req->file_offset, 0);
         if (nbytes < 0) {
-            NIXL_ERROR << "GDS_MT: cuFileRead failed: " << strerror (errno);
+            logCuFileIOError("cuFileRead", nbytes);
             overall_status->store (NIXL_ERR_BACKEND);
             return;
         }
     } else if (req->op == CUFILE_WRITE) {
         nbytes = cuFileWrite (req->fh, req->addr, req->size, req->file_offset, 0);
         if (nbytes < 0) {
-            NIXL_ERROR << "GDS_MT: cuFileWrite failed: " << strerror (errno);
+            logCuFileIOError("cuFileWrite", nbytes);
             overall_status->store (NIXL_ERR_BACKEND);
             return;
         }

--- a/src/plugins/gds_mt/gds_mt_backend.cpp
+++ b/src/plugins/gds_mt/gds_mt_backend.cpp
@@ -116,16 +116,18 @@ getThreadCount(const nixlBackendInitParams *init_params) {
     return (count > 0) ? count : default_thread_count;
 }
 
-// cuFileRead/cuFileWrite return -1 with errno set for filesystem errors, and
-// a negative CUfileOpError enum value for all other errors, where errno is
-// not meaningful.
+// cuFileRead/cuFileWrite report filesystem errors as -1 with errno set, and
+// cuFile-level errors either as a negative CUfileOpError return value (as
+// documented) or, as observed in practice, as -1 with the CUfileOpError code
+// stored in errno. strerror is only meaningful for the first case.
 void
 logCuFileIOError(const char *api, ssize_t nbytes) {
-    if (nbytes == -1) {
+    if (nbytes == -1 && !IS_CUFILE_ERR(errno)) {
         NIXL_ERROR << "GDS_MT: " << api << " failed: " << strerror(errno);
     } else {
-        NIXL_ERROR << "GDS_MT: " << api << " failed: " << CUFILE_ERRSTR(nbytes)
-                   << " (err=" << -nbytes << ")";
+        const int err = (nbytes == -1) ? errno : (int)-nbytes;
+        NIXL_ERROR << "GDS_MT: " << api << " failed: " << CUFILE_ERRSTR(err) << " (err=" << err
+                   << ")";
     }
 }
 


### PR DESCRIPTION
## What?

Fix error decoding in `runCuFileOp`: use `strerror(errno)` only for plain filesystem errors, and decode cuFile-level errors via `CUFILE_ERRSTR` with the numeric code included. Follow-up to #2069, which did the equivalent for the cuda_gds plugin, using the same message format.

## Why?

cuFileRead/cuFileWrite report filesystem errors as -1 with errno set, and cuFile-level errors either as a negative `CUfileOpError` return value (as documented in cufile.h) or, as observed in practice, as -1 with the `CUfileOpError` code stored in errno. The current code prints `strerror(errno)` for every failure, which produces garbage for cuFile-level errors. Reproduced on a B200 system by forcing a cuFile-level read failure:

    before: GDS_MT: cuFileRead failed: Unknown error 5027
    after:  GDS_MT: cuFileRead failed: file descriptor is not registered (err=5027)

## How?

Added a small file-local helper that branches using the `IS_CUFILE_ERR` macro from cufile.h, used by both the read and write paths, following the helper pattern suggested in the #2069 review. Plain filesystem error messages are unchanged. Verified the changed lines pass clang-format-19 and the plugin builds cleanly.
