### PR TITLE
cuda_gds: remove unused needs_prep flag

### DIFF
--- a/src/plugins/cuda_gds/gds_backend.cpp
+++ b/src/plugins/cuda_gds/gds_backend.cpp
@@ -251,7 +251,6 @@ nixl_status_t nixlGdsEngine::prepXfer (const nixl_xfer_op_t &operation,
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    gds_handle->needs_prep = false;  // Just prepared, no need for prep
     handle = gds_handle;
     return NIXL_SUCCESS;
 }
@@ -356,7 +355,6 @@ nixl_status_t nixlGdsEngine::checkXfer(nixlBackendReqH* handle) const
     nixlGdsBackendReqH *gds_handle = (nixlGdsBackendReqH *)handle;
 
     if (gds_handle->batch_io_list.empty()) {
-        gds_handle->needs_prep = true;
         return NIXL_SUCCESS;
     }
 
@@ -375,7 +373,6 @@ nixl_status_t nixlGdsEngine::checkXfer(nixlBackendReqH* handle) const
     }
 
     gds_handle->batch_io_list.clear();
-    gds_handle->needs_prep = true;
     return status;
 }
 

--- a/src/plugins/cuda_gds/gds_backend.h
+++ b/src/plugins/cuda_gds/gds_backend.h
@@ -75,11 +75,7 @@ class nixlGdsBackendReqH : public nixlBackendReqH {
     public:
         std::vector<GdsTransferRequestH> request_list;
         std::vector<nixlGdsIOBatch*> batch_io_list;
-        bool needs_prep;
 
-        nixlGdsBackendReqH() {
-            needs_prep = true;
-        }
         ~nixlGdsBackendReqH() {
             for (auto* batch : batch_io_list) {
                 delete batch;


### PR DESCRIPTION
## What?

Remove the `needs_prep` member of `nixlGdsBackendReqH`, which is assigned but never read, along with its constructor initialization and the three assignments to it. Cleanup only, no behavior change.

## Why?

The flag is assigned in three places (set to false in prepXfer after building the request list, and set to true in checkXfer when a transfer completes) but nothing in the repository ever reads it, so its value has no effect on any code path. It has been this way since it was introduced with the reposting support in #145, where the consuming side was apparently never implemented.

Looking at how reposting actually works today, the flag is not needed: prepXfer builds `request_list` once per handle and that list stays valid for the lifetime of the handle, postXfer rebuilds cuFile batches from it unconditionally on every post, and reposting an in-flight request is already rejected at the agent level with `NIXL_ERR_REPOST_ACTIVE`. So both concerns the flag could have guarded (re-preparation and premature repost) are covered elsewhere.

Removing it also avoids confusion for readers of checkXfer, who otherwise have to trace the flag through the repository to find out it does nothing.

## How?

Deleted the member and its assignments in gds_backend.h and gds_backend.cpp. Verified with a repository-wide search that nothing references the symbol, confirmed the changed lines pass clang-format-19, and built the plugin cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA GDS transfer request handling by removing unnecessary preparation-state tracking.
  * Transfer preparation and status checks now avoid modifying obsolete request state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->