### PR TITLE
test: add Python TCPStore metadata integration

### DIFF
--- a/.gitlab/test_python.sh
+++ b/.gitlab/test_python.sh
@@ -67,6 +67,9 @@ $pip3 install --break-system-packages zmq
 
 start_etcd_server "/nixl/python_ci"
 
+NIXL_TCPSTORE_PORT=$(get_next_tcp_port)
+export NIXL_TCPSTORE_PORT
+
 echo "==== Running python tests ===="
 pytest -s test/python
 

--- a/src/bindings/python/nixl-meta/nixl/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl/__init__.py
@@ -47,7 +47,7 @@ def _load_cuda_backend() -> str:
 
 _pkg = sys.modules[_load_cuda_backend()]
 
-submodules = ["_api", "_bindings", "_utils", "logging"]
+submodules = ["_bindings", "_utils", "logging", "_api"]
 for sub_name in submodules:
     # Import submodule from actual wheel
     module = importlib.import_module(f"{_pkg.__name__}.{sub_name}")

--- a/test/python/test_tcpstore_metadata.py
+++ b/test/python/test_tcpstore_metadata.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import time
 import uuid
 from datetime import timedelta
@@ -15,9 +16,11 @@ from nixl import nixl_agent, nixl_agent_config, nixl_thread_sync_t
 @pytest.mark.timeout(20)
 def test_tcpstore_metadata_exchange(monkeypatch):
     """Publish and fetch agent metadata through a real PyTorch TCPStore."""
+    # CI assigns the port from the range this executor owns, see
+    # .gitlab/test_python.sh; a local run lets the kernel pick one.
     tcp_store = dist.TCPStore(
         host_name="127.0.0.1",
-        port=0,
+        port=int(os.environ.get("NIXL_TCPSTORE_PORT", "0")),
         world_size=None,
         is_master=True,
         timeout=timedelta(seconds=5),

--- a/test/python/test_tcpstore_metadata.py
+++ b/test/python/test_tcpstore_metadata.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+import uuid
+from datetime import timedelta
+
+import pytest
+import torch.distributed as dist
+
+import nixl._utils as utils
+from nixl import nixl_agent, nixl_agent_config, nixl_thread_sync_t
+
+
+@pytest.mark.timeout(20)
+def test_tcpstore_metadata_exchange(monkeypatch):
+    """Publish and fetch agent metadata through a real PyTorch TCPStore."""
+    tcp_store = dist.TCPStore(
+        host_name="127.0.0.1",
+        port=0,
+        world_size=None,
+        is_master=True,
+        timeout=timedelta(seconds=5),
+        wait_for_workers=False,
+    )
+
+    # CI normally exports NIXL_ETCD_ENDPOINTS for the rest of the Python suite.
+    # The metadata manager permits exactly one name-addressed backend per agent.
+    monkeypatch.delenv("NIXL_ETCD_ENDPOINTS", raising=False)
+    monkeypatch.setenv("NIXL_TCPSTORE_ENDPOINT", f"127.0.0.1:{tcp_store.port}")
+
+    config = nixl_agent_config(
+        enable_prog_thread=False,
+        enable_listen_thread=False,
+        backends=["UCX"],
+        sync_mode=nixl_thread_sync_t.NIXL_THREAD_SYNC_STRICT,
+    )
+    suffix = uuid.uuid4().hex
+    source = nixl_agent(f"tcpstore_source_{suffix}", config)
+    target = nixl_agent(f"tcpstore_target_{suffix}", config)
+
+    source_addr = utils.malloc_passthru(1024)
+    target_addr = utils.malloc_passthru(1024)
+    source_reg = source.get_reg_descs(
+        [(source_addr, 1024, 0, "tcpstore-source")], mem_type="DRAM"
+    )
+    target_reg = target.get_reg_descs(
+        [(target_addr, 1024, 0, "tcpstore-target")], mem_type="DRAM"
+    )
+
+    try:
+        assert source.register_memory(source_reg) is not None
+        assert target.register_memory(target_reg) is not None
+
+        source.send_local_metadata()
+        target.fetch_remote_metadata(source.name)
+
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            if target.check_remote_metadata(source.name):
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("TCPStore metadata was not fetched within 10 seconds")
+
+        # TCPStore does not notify peers when a key is deleted, so clean up both
+        # the published key and the target's cached metadata explicitly.
+        source.invalidate_local_metadata()
+        target.remove_remote_agent(source.name)
+    finally:
+        source.deregister_memory(source_reg)
+        target.deregister_memory(target_reg)
+        # Stop the agents' TCPStore workers while the in-process store is alive.
+        del target
+        del source
+        utils.free_passthru(source_addr)
+        utils.free_passthru(target_addr)


### PR DESCRIPTION
## What?

Adds a Python integration test for the TCPStore metadata backend. The test verifies metadata publish and fetch between two NIXL agents through a real PyTorch TCPStore server.

## Why?

The existing C++ tests cover the TCPStore backend but require an externally configured server. This adds self-contained end-to-end coverage through the public Python API and runs automatically as part of the existing Python CI suite.

## How?

The test:

- Starts an in-process `torch.distributed.TCPStore` server.
- Temporarily selects TCPStore instead of the CI-configured ETCD backend.
- Creates two NIXL agents and registers DRAM buffers.
- Publishes metadata from one agent and fetches it from the other.
- Polls until the remote metadata is available and performs cleanup afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for TCPStore-backed metadata exchange, synchronization, polling, removal, and invalidation.
  * Verifies complete cleanup of published metadata, registered memory, agents, and allocated resources.
  * Improved test execution by automatically selecting an available TCPStore port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->