### PR TITLE
EP: Hold HT tensors instead of record_stream under CUDA-graph capture

### DIFF
--- a/examples/device/ep/README.md
+++ b/examples/device/ep/README.md
@@ -43,6 +43,10 @@ buffer.disconnect_ranks(ranks)
 - `connect_ranks(remote_ranks, activate=True)`: Establish NIXL connections to new peers (can be called multiple times); in low-latency mode, use `activate=False` to keep new peers masked until explicitly unmasked.
 - `disconnect_ranks(remote_ranks)`: Clean up connections to departing peers
 
+## Environment Variables
+
+- `NIXL_EP_HT_AVOID_RECORD_STREAM`: Set to `1` to make `ht_dispatch`/`ht_combine` keep their tensors alive by reference in the returned event handle instead of calling `record_stream()` on the communication stream. Use it when capturing dispatch/combine into a CUDA graph: under capture `record_stream()` never lets the caching allocator reclaim a block, so a graph holding one dispatch/combine pair per MoE layer pins one set of output buffers per layer. The references are dropped when the caller releases the handle, so the allocator can recycle the block normally, including inside a capture. The variable is read once per `Buffer`, at construction, so set it before creating the `Buffer`; two `Buffer`s may differ. It cannot be combined with `allocate_on_comm_stream`, where holding a reference cannot substitute for `record_stream(compute_stream)`. Unset or not `1` leaves `record_stream()` behavior unchanged.
+
 ## Testing
 
 The elastic test suite in `tests/elastic/` validates dynamic scaling capabilities:

--- a/examples/device/ep/csrc/event.hpp
+++ b/examples/device/ep/csrc/event.hpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2025 DeepSeek
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This file incorporates material from the DeepSeek project, licensed under the MIT License.
  * The modifications made by NVIDIA are licensed under the Apache License, Version 2.0.
@@ -29,6 +29,9 @@ namespace nixl_ep {
 
 struct EventHandle {
     std::shared_ptr<torch::Event> event;
+
+    // Held instead of record_stream(), which a captured graph never reclaims; freed with the handle
+    std::vector<torch::Tensor> extra_tensors;
 
     EventHandle() {
         event = std::make_shared<torch::Event>(torch::kCUDA);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -85,7 +85,10 @@ Buffer::Buffer(int rank, bool explicitly_destroy, bool low_latency_mode, int tim
         }()),
         rank(rank),
         explicitly_destroy(explicitly_destroy),
-        comm_stream(at::cuda::getStreamFromPool(true)) {}
+        comm_stream(at::cuda::getStreamFromPool(true)) {
+    const char* env = std::getenv("NIXL_EP_HT_AVOID_RECORD_STREAM");
+    ht_avoid_record_stream = env != nullptr and env[0] == '1';
+}
 
 bool Buffer::_is_rank_connected(int rank_id) const {
     return rank_id == rank or std::find(remote_ranks.begin(), remote_ranks.end(), rank_id) != remote_ranks.end();
@@ -731,6 +734,7 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
     auto compute_stream = at::cuda::getCurrentCUDAStream();
     if (allocate_on_comm_stream) {
         EP_HOST_ASSERT(previous_event.has_value() and async);
+        EP_HOST_ASSERT(not ht_avoid_record_stream and "NIXL_EP_HT_AVOID_RECORD_STREAM does not support allocate_on_comm_stream");
         at::cuda::setCurrentCUDAStream(comm_stream);
     }
 
@@ -880,6 +884,10 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
     if (async) {
         event = EventHandle(comm_stream);
         auto keep = [&](const torch::Tensor& t) {
+            if (ht_avoid_record_stream) {
+                event->extra_tensors.push_back(t);
+                return;
+            }
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
@@ -951,6 +959,7 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
     auto compute_stream = at::cuda::getCurrentCUDAStream();
     if (allocate_on_comm_stream) {
         EP_HOST_ASSERT(previous_event.has_value() and async);
+        EP_HOST_ASSERT(not ht_avoid_record_stream and "NIXL_EP_HT_AVOID_RECORD_STREAM does not support allocate_on_comm_stream");
         at::cuda::setCurrentCUDAStream(comm_stream);
     }
 
@@ -1019,6 +1028,10 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
     if (async) {
         event = EventHandle(comm_stream);
         auto keep = [&](const torch::Tensor& t) {
+            if (ht_avoid_record_stream) {
+                event->extra_tensors.push_back(t);
+                return;
+            }
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);

--- a/examples/device/ep/csrc/nixl_ep.cpp
+++ b/examples/device/ep/csrc/nixl_ep.cpp
@@ -879,23 +879,23 @@ Buffer::ht_dispatch(const torch::Tensor& x, const std::optional<torch::Tensor>& 
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t: {x, is_token_in_rank, recv_x,
-                       rdma_channel_prefix_matrix, recv_rdma_rank_prefix_sum, gbl_channel_prefix_matrix, recv_gbl_rank_prefix_sum}) {
+        auto keep = [&](const torch::Tensor& t) {
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
-        }
+        };
+        for (auto& t: {x, is_token_in_rank, recv_x,
+                       rdma_channel_prefix_matrix, recv_rdma_rank_prefix_sum, gbl_channel_prefix_matrix, recv_gbl_rank_prefix_sum})
+            keep(t);
         for (auto& to: {x_scales, topk_idx, topk_weights,
                         num_tokens_per_rank, num_tokens_per_rdma_rank, num_tokens_per_expert,
                         cached_rdma_channel_prefix_matrix, cached_recv_rdma_rank_prefix_sum,
                         cached_gbl_channel_prefix_matrix, cached_recv_gbl_rank_prefix_sum,
                         recv_topk_idx, recv_topk_weights, recv_x_scales,
                         recv_rdma_channel_prefix_matrix, recv_gbl_channel_prefix_matrix, send_rdma_head, send_nvl_head,
-                        recv_src_meta}) {
-            to.has_value() ? to->record_stream(comm_stream) : void();
-            if (allocate_on_comm_stream)
-                to.has_value() ? to->record_stream(compute_stream) : void();
-        }
+                        recv_src_meta})
+            if (to.has_value())
+                keep(to.value());
     } else {
         stream_wait(compute_stream, comm_stream);
     }
@@ -1018,18 +1018,18 @@ Buffer::ht_combine(const torch::Tensor& x, const std::optional<torch::Tensor>& t
     std::optional<EventHandle> event;
     if (async) {
         event = EventHandle(comm_stream);
-        for (auto& t: {x, src_meta,
-                       is_combined_token_in_rank, rdma_channel_prefix_matrix, rdma_rank_prefix_sum, gbl_channel_prefix_matrix,
-                       combined_x, combined_rdma_head, combined_nvl_head}) {
+        auto keep = [&](const torch::Tensor& t) {
             t.record_stream(comm_stream);
             if (allocate_on_comm_stream)
                 t.record_stream(compute_stream);
-        }
-        for (auto& to: {topk_weights, combined_topk_weights, bias_0, bias_1}) {
-            to.has_value() ? to->record_stream(comm_stream) : void();
-            if (allocate_on_comm_stream)
-                to.has_value() ? to->record_stream(compute_stream) : void();
-        }
+        };
+        for (auto& t: {x, src_meta,
+                       is_combined_token_in_rank, rdma_channel_prefix_matrix, rdma_rank_prefix_sum, gbl_channel_prefix_matrix,
+                       combined_x, combined_rdma_head, combined_nvl_head})
+            keep(t);
+        for (auto& to: {topk_weights, combined_topk_weights, bias_0, bias_1})
+            if (to.has_value())
+                keep(to.value());
     } else {
         stream_wait(compute_stream, comm_stream);
     }

--- a/examples/device/ep/csrc/nixl_ep.hpp
+++ b/examples/device/ep/csrc/nixl_ep.hpp
@@ -126,6 +126,9 @@ private:
     // Stream for communication
     at::cuda::CUDAStream comm_stream;
 
+    // Hold HT tensors in the EventHandle instead of record_stream(), for CUDA-graph capture
+    bool ht_avoid_record_stream = false;
+
     // After synchronization, this flag will be true
     bool available = false;
 


### PR DESCRIPTION
## What?

Add an opt-in mode, `NIXL_EP_HT_AVOID_RECORD_STREAM=1`, in which `ht_dispatch` and
`ht_combine` keep their output tensors alive by reference in the returned
`EventHandle` instead of calling `record_stream()` on the communication stream. The
change is in two commits, with the explanation included in the commit message: (1) a
no-functional-change refactor pulling the per-tensor stream recording into a local
helper; (2) the opt-in itself, which is a small diff against it.
No API, signature or default-behaviour change.

## Why?

Under CUDA-graph capture, `record_stream()` defers reclaiming a block until the
allocator observes an event on the recording stream complete. Capture only records
comm-stream work and never executes it, so that event never completes and no block is
reclaimed. A graph holding one dispatch/combine pair per MoE layer therefore retains
one set of output buffers per layer, for the lifetime of the graph. On B200 with 16
ranks over 2 hosts at 4096 tokens, a captured graph grows 424 MiB per layer by
default and stays flat at one layer's worth with the variable set, while
dispatch/combine latency moves 0.20% or less.

The memory is not lost, since the graph returns it on destruction, but until then
the reserved footprint of a captured step scales with layer count.

Scope: the gate is the environment variable, read once per `Buffer` at construction,
so the mode is fixed for a Buffer's lifetime and two Buffers may differ. Unset or not
`1` leaves `record_stream()` behaviour exactly as before, so nothing changes for
callers who do not capture. It is rejected together with `allocate_on_comm_stream`,
where holding a reference cannot substitute for `record_stream(compute_stream)`; both
HT entry points assert rather than silently doing the wrong thing. This is the C++
counterpart of `EventOverlap.extra_tensors`, which the low-latency paths already use
unconditionally for the same reason.

<details>

<summary>Reserved memory held by the captured graph, B200, 2 x 8 ranks, 4096 tokens, hidden 7168</summary>

| Layers in graph | default    | `NIXL_EP_HT_AVOID_RECORD_STREAM=1` |
| --------------: | ---------: | ---------------------------------: |
| 2               | 848.0 MiB  | 424.0 MiB                          |
| 10              | 4240.0 MiB | 424.0 MiB                          |
| **per layer**   | **424.0 MiB** | **0.0 MiB**                     |

Enabled, the graph reuses one set of output buffers across every layer.

</details>

<details>

<summary>Dispatch/combine latency, best tuning result from tests/test_ht.py</summary>

| Operation     | default   | `NIXL_EP_HT_AVOID_RECORD_STREAM=1` | delta      |
| ------------- | --------: | ---------------------------------: | ---------: |
| Dispatch BF16 | 1386.0 us | 1385.0 us                          | **-0.07%** |
| Dispatch FP8  | 819.0 us  | 819.9 us                           | **+0.11%** |
| Combine       | 1515.0 us | 1511.0 us                          | **-0.26%** |

Dispatch+combine over 50 iterations: 3474.8 us against 3481.9 us
(**0.20%**), and 3480.3 us against 3479.6 us (**0.02%**) on the second node.

</details>

## Testing

The HT paths need more than 8 ranks, so `test_ht.py` was run on 2 x 8 B200 ranks and
passes with the variable both unset and set to 1. It validates dispatched and
combined tensors and asserts on mismatch. Every run was grepped for both
receive-timeout warnings, since a timeout masks a source rank and lets a run exit
clean; none were present in either mode.

That the opt-in path was actually taken was measured rather than assumed: the same
harness reports 424 MiB per captured layer unset and 0.0 set, and both HT entry
points were driven with `allocate_on_comm_stream` to confirm they reject the
combination.

The `nixl_ep` elastic suite passes on both branches of the completion path: NVLink by
default, and the `--disable-ll-nvlink` RDMA plans, which `test_ep.sh` skips on this
cluster because it gates on `mlx5_0..mlx5_3` while these hosts expose
`mlx5_4/7/8/9/10/13`. `test_cpp.sh`, `test_python.sh`, `test_rust.sh` and
`test_nixlbench.sh` pass at the tip.


## Summary by CodeRabbit

* **New Features**
  * Added the `NIXL_EP_HT_AVOID_RECORD_STREAM` environment variable to support CUDA graph capture without recording tensors on CUDA streams.
  * Documented initialization timing, default behavior, and compatibility considerations.
* **Bug Fixes**
  * Improved asynchronous tensor lifetime handling when stream recording is disabled.
  * Added validation to reject incompatible communication-stream allocation settings in high-throughput operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->