### PR TITLE
CI: enhance nightly wheel build (spcx/Infinia plugins, ci_refspec, PUBLISH_DIR)

### DIFF
--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -190,9 +190,9 @@ their own nightly/manual trigger. They split into two groups:
 - **Automatic on every PR:** No — standalone/nightly + manual only.
 
 ### `nixl-ci-build-wheel-nightly` (standalone)
-- **Trigger:** Nightly cron (two runs, CUDA 13 and CUDA 12 base images, from `main`), or manual run from any branch/tag/PR ref/SHA.
-- **What it does:** Reuses the per-PR wheel build path (`contrib/build-container.sh` + `Dockerfile.manylinux`), adds UCX wiring, and publishes verification wheels to Artifactory.
-- **Automatic on every PR:** No — standalone/nightly + manual only.
+- **Trigger:** Nightly cron (two runs, CUDA 13 and CUDA 12 `BASE_TAG`), or manual run. The pipeline and matrix config run from `ci_refspec` (default `main`; pass `refs/pull/<n>/head` to test CI changes end to end before merge); the NIXL source is cloned inside the build from the `NIXL_VERSION` parameter (branch/tag/PR ref/sha), so any ref is buildable without CI files on it.
+- **What it does:** Reuses the per-PR wheel build path (`contrib/build-container.sh` + `Dockerfile.manylinux`), adds UCX wiring, and publishes wheels to `sw-nbu-swx-nixl-pypi-local` under `<PUBLISH_DIR|verification>/<nixl-sha8>/`. With `PUBLISH_DIR` empty (the default, and what the nightly cron uses) wheels land under `verification/`; manual release runs can pass `release/<ver>`. `BUILD_UCX_SPCX_PLUGIN` and `BUILD_INFINIA` bundle the UCX spcx / Infinia DDN plugins and default to on; each needs a source ref whose `contrib/build-container.sh` carries the flag and pins the plugin version, so turn them off to build a ref that predates them.
+- **Automatic on every PR:** No — standalone nightly + manual only.
 
 ### `nixl-ci-build-llm-container` (standalone)
 - **Trigger:** Manual only (no cron, no webhook).

--- a/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
@@ -79,18 +79,14 @@ steps:
   - name: Checkout Source
     parallel: false
     run: |
-      # Clone the built source (contrib scripts + Dockerfile come from this ref;
-      # CI config stays on main). Public github clone - no plugin creds here;
-      # the gitlab/spcx creds bind only on Build Wheel. Split from the build so
-      # a checkout failure is triaged separately from a build failure.
+      # Clone the built source (contrib scripts + Dockerfile come from this
+      # ref; CI config stays on main). Split from Build Wheel so a checkout
+      # failure is triaged separately from a build failure.
       set -x
-      # The Jenkins checkout is owned by a different uid; trust only it
-      # (nixl-src is cloned by this step's own user and needs no exemption).
+      # The Jenkins checkout is owned by a different uid; trust only it.
       git config --global --add safe.directory "${PWD}"
-      # Full clone: build-container.sh derives a version label from git
-      # (describe --tags against main), so it needs the main ref + tags, not
-      # just the built tree. NIXL history is small (~16MB); if it ever grows
-      # heavy, use --filter=blob:none (git describe still works), not --depth.
+      # Full clone: build-container.sh derives a version label via
+      # `git describe --tags`, which needs history + tags, not just the tree.
       rm -rf nixl-src
       git clone "${NIXL_REPO_URL}" nixl-src
       # fetch covers branch/tag/PR refs; the fallback covers raw shas. Fail
@@ -101,9 +97,8 @@ steps:
         git -C nixl-src checkout --detach "${NIXL_VERSION}" \
           || { echo "ERROR: cannot resolve NIXL_VERSION=${NIXL_VERSION}"; exit 1; }
       fi
-      # Exact first 8 hex for the publish folder key. rev-parse --short=8 is a
-      # minimum and extends on ambiguity, which would make the folder key
-      # inconsistent across builds of the same commit.
+      # Exact first 8 hex for the publish folder key (--short=8 is a minimum
+      # and can extend on ambiguity).
       NIXL_SHA="$(git -C nixl-src rev-parse HEAD | cut -c1-8)"
       # Build against the exact UCX commit; ^{} (last line) peels annotated tags.
       if [[ "${UCX_VERSION}" =~ ^[a-f0-9]{8,40}$ ]]; then
@@ -125,9 +120,8 @@ steps:
       # image so Publish extracts dist/. Plugin creds bind only here.
       set -x
       . ./wheel_build_ids.env   # UCX_SHA (+ NIXL_SHA) from Checkout Source
-      # Each plugin is opt-in; the enable flag is passed only when its param is
-      # set. The plugin version ships with the built source ref - its
-      # build-container.sh must carry the flag and pins the plugin ref/image.
+      # Each plugin is opt-in; the built source ref's build-container.sh must
+      # carry the flag and pins the plugin ref/image.
       SPCX_FLAGS=""
       [ "${BUILD_UCX_SPCX_PLUGIN}" = "true" ] && SPCX_FLAGS="--build-ucx-spcx-plugin"
       INFINIA_FLAGS=""

--- a/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
@@ -1,13 +1,13 @@
-# Nightly NIXL wheel verification build.
-# Reuses the per-PR wheel build path (build-container.sh + Dockerfile.manylinux)
-# and adds UCX wiring + a publish step. Driven by the nixl-ci-build-wheel-nightly
-# JJB job, which supplies NIXL_VERSION / UCX_VERSION and the nightly trigger.
+# Nightly NIXL wheel verification build. Pipeline and this config run from
+# main; the source ref (NIXL_VERSION) is cloned into nixl-src, so built refs
+# carry no CI config. Wheels publish to
+# WHEEL_REPO_URL/<PUBLISH_DIR or verification>/<nixl-sha>.
 
 ---
 job: nixl-ci-build-wheel-nightly
 
 failFast: false
-timeout_minutes: 240
+timeout_minutes: 180
 
 registry_host: artifactory.nvidia.com
 
@@ -15,6 +15,13 @@ credentials:
   - credentialsId: 'svc-nixl-new-artifactory-token'
     usernameVariable: 'ARTIFACTORY_USER'
     passwordVariable: 'ARTIFACTORY_TOKEN'
+  - credentialsId: 'svc-nixl-gitlab-token'
+    usernameVariable: 'NIXL_GITLAB_USER'
+    passwordVariable: 'NIXL_GITLAB_TOKEN'
+  # Paired with NIXL_GITLAB_TOKEN; only read on the spcx path.
+  - credentialsId: 'ucx-plugin-gitlab-url'
+    type: 'string'
+    variable: 'NIXL_SPCX_PLUGIN_REPO_URL'
 
 kubernetes:
   cloud: il-ipp-blossom-prod
@@ -54,6 +61,8 @@ env:
   WHEEL_IMAGE_TAG: "nixl-wheel:build"   # constant: each matrix cell is its own pod
   # SWX team's NIXL pypi repo (publish target).
   WHEEL_REPO_URL: "https://artifactory.nvidia.com/artifactory/sw-nbu-swx-nixl-pypi-local"
+  # Source repo cloned in Build Wheel.
+  NIXL_REPO_URL: "https://github.com/ai-dynamo/nixl.git"
   MAIL_FROM: "jenkins@nvidia.com"
 
 steps:
@@ -67,36 +76,78 @@ steps:
       ln -sfT $(type -p podman) /usr/bin/docker
       echo "$ARTIFACTORY_TOKEN" | docker login "https://${registry_host}" -u "$ARTIFACTORY_USER" --password-stdin
 
-  - name: Build Wheel
+  - name: Checkout Source
     parallel: false
     run: |
-      # Resolve NIXL+UCX to shas (build against the exact UCX commit; reused by
-      # Publish for the per-source path). --tag pins the image so Publish extracts dist/.
+      # Clone the built source (contrib scripts + Dockerfile come from this ref;
+      # CI config stays on main). Public github clone - no plugin creds here;
+      # the gitlab/spcx creds bind only on Build Wheel. Split from the build so
+      # a checkout failure is triaged separately from a build failure.
       set -x
-      git config --global --add safe.directory '*'
-      NIXL_SHA="$(git rev-parse --short=8 HEAD)"
+      # The Jenkins checkout is owned by a different uid; trust only it
+      # (nixl-src is cloned by this step's own user and needs no exemption).
+      git config --global --add safe.directory "${PWD}"
+      # Full clone: build-container.sh derives a version label from git
+      # (describe --tags against main), so it needs the main ref + tags, not
+      # just the built tree. NIXL history is small (~16MB); if it ever grows
+      # heavy, use --filter=blob:none (git describe still works), not --depth.
+      rm -rf nixl-src
+      git clone "${NIXL_REPO_URL}" nixl-src
+      # fetch covers branch/tag/PR refs; the fallback covers raw shas. Fail
+      # loud if neither resolves, so we never silently build the clone default.
+      if git -C nixl-src fetch origin "${NIXL_VERSION}" 2>/dev/null; then
+        git -C nixl-src checkout --detach FETCH_HEAD
+      else
+        git -C nixl-src checkout --detach "${NIXL_VERSION}" \
+          || { echo "ERROR: cannot resolve NIXL_VERSION=${NIXL_VERSION}"; exit 1; }
+      fi
+      # Exact first 8 hex for the publish folder key. rev-parse --short=8 is a
+      # minimum and extends on ambiguity, which would make the folder key
+      # inconsistent across builds of the same commit.
+      NIXL_SHA="$(git -C nixl-src rev-parse HEAD | cut -c1-8)"
+      # Build against the exact UCX commit; ^{} (last line) peels annotated tags.
       if [[ "${UCX_VERSION}" =~ ^[a-f0-9]{8,40}$ ]]; then
         UCX_SHA="${UCX_VERSION:0:8}"
       else
-        # Resolve the ref to a commit; the ^{} peel (last line) handles annotated tags.
-        UCX_SHA="$(git ls-remote https://github.com/openucx/ucx.git "${UCX_VERSION}" "${UCX_VERSION}^{}" | tail -n1 | cut -c1-8)"
+        UCX_SHA="$(timeout 30 git ls-remote https://github.com/openucx/ucx.git "${UCX_VERSION}" "${UCX_VERSION}^{}" | tail -n1 | cut -c1-8)"
       fi
       [ -n "${UCX_SHA}" ] || { echo "ERROR: cannot resolve UCX_VERSION=${UCX_VERSION}"; exit 1; }
+      # Shas carried to Build Wheel (--ucx-ref) and Publish (folder key).
       printf 'NIXL_SHA=%s\nUCX_SHA=%s\n' "${NIXL_SHA}" "${UCX_SHA}" > wheel_build_ids.env
-      # Derive CUDA major from BASE_TAG for torch version selection.
-      # BASE_TAG format: <major>.<minor>.<patch>-devel-ubi8; CUDA_VERSION is
-      # derived automatically inside build-container.sh.
-      CUDA_MAJOR="$(echo "${BASE_TAG}" | cut -d. -f1)"
+
+  - name: Build Wheel
+    credentialsId:
+      - 'svc-nixl-gitlab-token'
+      - 'ucx-plugin-gitlab-url'
+    parallel: false
+    run: |
+      # Build the wheel image from the checked-out nixl-src. --tag pins the
+      # image so Publish extracts dist/. Plugin creds bind only here.
+      set -x
+      . ./wheel_build_ids.env   # UCX_SHA (+ NIXL_SHA) from Checkout Source
+      # Each plugin is opt-in; the enable flag is passed only when its param is
+      # set. The plugin version ships with the built source ref - its
+      # build-container.sh must carry the flag and pins the plugin ref/image.
+      SPCX_FLAGS=""
+      [ "${BUILD_UCX_SPCX_PLUGIN}" = "true" ] && SPCX_FLAGS="--build-ucx-spcx-plugin"
+      INFINIA_FLAGS=""
+      [ "${BUILD_INFINIA}" = "true" ] && INFINIA_FLAGS="--build-infinia"
+      # CUDA MAJOR.MINOR from BASE_TAG (12.9.1-devel-ubi8 -> 12.9): drives the
+      # torch cuXXX index and the cu12/cu13 wheel split.
+      CUDA_VERSION="$(echo "${BASE_TAG}" | grep -oE '^[0-9]+\.[0-9]+')"
+      [ -n "${CUDA_VERSION}" ] || { echo "ERROR: cannot derive CUDA version from BASE_TAG=${BASE_TAG}"; exit 1; }
       # The two CUDA majors have different torch coverage: 2.11 is not available
       # on the cu13 index, and 2.14 is not available on the cu12 one.
       # Auto-select unless overridden.
       if [ -z "${TORCH_VERSIONS:-}" ]; then
-        if [ "${CUDA_MAJOR}" = "12" ]; then TORCH_VERSIONS="2.11,2.12,2.13"
+        if [ "${CUDA_VERSION%%.*}" = "12" ]; then TORCH_VERSIONS="2.11,2.12,2.13"
         else TORCH_VERSIONS="2.12,2.13,2.14"; fi
       fi
+      cd nixl-src
       ./contrib/build-container.sh \
         --base-image "${BASE_IMAGE}" \
         --base-image-tag "${BASE_TAG}" \
+        --cuda-version "${CUDA_VERSION}" \
         --manylinux-image "${MANYLINUX_IMAGE}" \
         --manylinux-image-tag "${MANYLINUX_IMAGE_TAG}" \
         --wheel-base "manylinux_${manylinux}" \
@@ -105,7 +156,9 @@ steps:
         --ucx-ref "${UCX_SHA}" \
         --torch-versions "${TORCH_VERSIONS}" \
         --tag "${WHEEL_IMAGE_TAG}" \
-        --dockerfile contrib/Dockerfile.manylinux
+        --dockerfile contrib/Dockerfile.manylinux \
+        ${SPCX_FLAGS} \
+        ${INFINIA_FLAGS}
 
   - name: Publish
     credentialsId: 'svc-nixl-new-artifactory-token'
@@ -119,10 +172,17 @@ steps:
       docker rm -f "${cid}" || true
       ls -l dist/
 
-      # Per-source path (NIXL+UCX shas): same-source cu12/cu13 builds co-locate, so
+      # Nightly runs leave PUBLISH_DIR empty and publish to verification/;
+      # manual release runs can pass release/<ver>. Allowlist it - the URL is
+      # PUT with the service token, and a path like ../<other-repo> would
+      # normalize into a different Artifactory repo.
+      PUBLISH_DIR="${PUBLISH_DIR:-verification}"
+      [[ "${PUBLISH_DIR}" =~ ^(verification|release/[A-Za-z0-9][A-Za-z0-9._-]*)$ ]] \
+        || { echo "ERROR: invalid PUBLISH_DIR '${PUBLISH_DIR}'"; exit 1; }
+      # Per-commit folder: cu12/cu13 builds of the same commit co-locate, so
       # `pip install --find-links <path> "nixl[cuXX]"` resolves a matched set.
       . ./wheel_build_ids.env
-      DEST="${WHEEL_REPO_URL}/verification/g${NIXL_SHA}.ucx${UCX_SHA}"
+      DEST="${WHEEL_REPO_URL}/${PUBLISH_DIR}/${NIXL_SHA}"
 
       # curl-PUT (no python on the runner for twine); Artifactory indexes it as a
       # pip repo. rc fails the step on any upload error; set +x hides the token.
@@ -136,16 +196,26 @@ steps:
 
 taskName: '${name}_${manylinux}/${arch}/python_${python_version}'
 
-# Email build result (success/failure) when MAIL_TO is set - notification for the
-# unattended nightly, mirroring nixl-ci-build-container.
+# Display name distinguishes builds in the history list:
+# #N-<source>-cuXX[+spcx][+infinia], mirroring nixl-ci-build-container.
+pipeline_start:
+  shell: action
+  module: groovy
+  containerSelector: "{name: 'manylinux'}"
+  run: |
+    def src = params.NIXL_VERSION ==~ /[0-9a-f]{40}/ ? params.NIXL_VERSION.take(8) : params.NIXL_VERSION
+    def cu = "cu${params.BASE_TAG.tokenize('.')[0]}"
+    def plugins = (params.BUILD_UCX_SPCX_PLUGIN ? '+spcx' : '') + (params.BUILD_INFINIA ? '+infinia' : '')
+    currentBuild.displayName += "-${src}-${cu}${plugins}"
+
+# Mail the unattended nightly only when it fails; a green night stays quiet.
 pipeline_stop:
   shell: action
   module: groovy
   containerSelector: "{name: 'manylinux'}"
   run: |
-    if (params.MAIL_TO) {
-        def jobStatus = currentBuild.result ?: 'SUCCESS'
-        def statusColor = jobStatus == 'SUCCESS' ? 'green' : 'red'
+    def jobStatus = currentBuild.result ?: 'SUCCESS'
+    if (jobStatus != 'SUCCESS' && params.MAIL_TO) {
         def userName = currentBuild.rawBuild.getCause(hudson.model.Cause.UserIdCause)?.userName ?: 'schedule'
         mail(
             from: env.MAIL_FROM,
@@ -154,7 +224,7 @@ pipeline_stop:
             mimeType: 'text/html',
             body: """
                 <p>Started by: <b>${userName}</b></p>
-                <p>Status: <span style="color: ${statusColor};"><b>${jobStatus}</b></span></p>
+                <p>Status: <span style="color: red;"><b>${jobStatus}</b></span></p>
                 <p>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a></p>
                 <p>Build: <a href='${env.BUILD_URL}'>#${env.BUILD_NUMBER}</a></p>
                 <p>Console Output: <a href='${env.BUILD_URL}console'>Full Log</a></p>

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -923,16 +923,17 @@
     triggers:
       - parameterized-timer:
           cron: |
-            # Build NIXL wheels nightly ~10 AM for CUDA 13 and CUDA 12 (the cu12
-            # run also produces the nixl meta wheel). Both publish to the repo.
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=13.2.1-devel-ubi8
-            H 10 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=12.9.1-devel-ubi8
+            # Build NIXL wheels nightly around midnight for CUDA 13 and CUDA 12
+            # (the cu12 run also produces the nixl meta wheel). Both publish to
+            # the repo.
+            H 0 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=13.2.1-devel-ubi8
+            H 0 * * * %NIXL_VERSION=main;UCX_VERSION=v1.22.x;BASE_IMAGE=nvcr.io/nvidia/cuda;BASE_TAG=12.9.1-devel-ubi8
     # Manual build parameters
     parameters:
       - string:
           name: "NIXL_VERSION"
           default: "{jjb_branch}"
-          description: "NIXL version to build wheels from (tag like 1.2.0, branch name, PR ref, or commit hash)"
+          description: "NIXL source ref to build wheels from (tag like 1.2.0, branch name, PR ref, or commit hash) - cloned inside the build, not the pipeline checkout ref"
       - string:
           name: "UCX_VERSION"
           default: "v1.22.x"
@@ -950,22 +951,42 @@
           default: ""
           description: "Comma-separated PyTorch versions to build EP extensions for. Leave empty to auto-derive from CUDA major version."
       - string:
+          name: "PUBLISH_DIR"
+          default: ""
+          description: "Artifactory publish subdir; empty = verification (nightly default). Manual release runs can pass release/&lt;ver&gt;."
+      - bool:
+          name: "BUILD_UCX_SPCX_PLUGIN"
+          default: true
+          description: "Build and bundle the UCX spcx external plugin (the built source ref pins the plugin version in contrib/build-container.sh)"
+      - bool:
+          name: "BUILD_INFINIA"
+          default: true
+          description: "Build and bundle the Infinia DDN plugin (the built source ref pins the plugin version in contrib/build-container.sh; harbor.mellanox.com must be reachable)"
+      - string:
           name: "DEBUG"
           default: 0
           description: "Enable debug prints and traces, valid values are 0-9"
       - string:
           name: "MAIL_TO"
-          default: "25f58ae0.NVIDIA.onmicrosoft.com@amer.teams.ms"
-          description: "Email address to send build results to (optional)"
-    # SCM configuration - resolves branch/tag/PR/SHA from NIXL_VERSION
+          default: "nixl-ci-alerts@exchange.nvidia.com"
+          description: "Recipient(s) for the failure report. Mail is sent only when the build fails."
+      - string:
+          name: "ci_refspec"
+          default: "{jjb_branch}"
+          description: >
+            Git ref to check out the pipeline + matrix config from (separate from
+            NIXL_VERSION, the source being built). Default main; pass e.g.
+            <code>refs/pull/1234/head</code> to test CI changes end to end before merge.
+    # SCM = ci_refspec (default main): supplies the pipeline + matrix config
+    # only; the build clones the source from NIXL_VERSION itself
     pipeline-scm:
       scm:
         - git:
             url: "{jjb_git}"
-            branches: ['$NIXL_VERSION']
+            branches: ['${{ci_refspec}}']
             shallow-clone: false
             do-not-fetch-tags: false
-            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/remotes/origin/tags/* +$NIXL_VERSION:refs/remotes/origin/$NIXL_VERSION"
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +refs/pull/*/head:refs/pull/*/head"
             browser: githubweb
             browser-url: "{jjb_git}"
             submodule:


### PR DESCRIPTION
## Summary

Pulls in the `build-wheel-nightly` and `proj-jjb` portions of #1912 (release wheel poller), without the poller itself. Prepared as a standalone follow-up so the nightly wheel improvements can land independently.

- Nightly build now clones the source ref (`NIXL_VERSION`) separately from the pipeline/matrix config (`ci_refspec`), so any ref is buildable without CI files on it.
- Adds opt-in `BUILD_UCX_SPCX_PLUGIN` and `BUILD_INFINIA` flags to bundle the UCX spcx and Infinia DDN plugins in nightly wheels.
- Adds `PUBLISH_DIR` param so manual runs can publish outside `verification/` (e.g. for a release).
- Splits the "Build Wheel" step into "Checkout Source" + "Build Wheel" so checkout failures triage separately from build failures.
- Mails on failure only (previously mailed on every run); nightly cron moved to midnight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Nightly wheel builds can use selected NIXL branches, tags, pull requests, or commits.
  - Added optional UCX SPCX and Infinia plugin packaging.
  - Build outputs support configurable, commit-specific publication locations.
  - Build labels now show source, CUDA, and plugin details.

- **Improvements**
  - Nightly builds now run at midnight.
  - Failed unattended runs provide improved email notifications.
  - Documentation explains the expanded configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->