### PR TITLE
bindings/rust: bind the optional-args custom parameter

### DIFF
--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -56,6 +56,7 @@ use bindings::{
     nixl_capi_opt_args_get_has_notif, nixl_capi_opt_args_get_notif_msg,
     nixl_capi_opt_args_get_skip_desc_merge, nixl_capi_opt_args_set_has_notif,
     nixl_capi_opt_args_set_notif_msg, nixl_capi_opt_args_set_skip_desc_merge,
+    nixl_capi_opt_args_set_custom_param, nixl_capi_opt_args_get_custom_param,
     nixl_capi_params_create_iterator, nixl_capi_params_destroy_iterator, nixl_capi_params_is_empty,
     nixl_capi_params_iterator_next, nixl_capi_post_xfer_req, nixl_capi_reg_dlist_add_desc,
     nixl_capi_reg_dlist_clear, nixl_capi_register_mem, nixl_capi_string_list_get,
@@ -333,6 +334,49 @@ impl OptArgs {
         };
         match status {
             NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Sets the backend custom parameter, which `prep_mem_view_local` and
+    /// `_remote` forward to the backend. UCX reads `worker_id=<n>` from it to
+    /// pick the worker a memory view is bound to.
+    pub fn set_custom_param(&mut self, param: &[u8]) -> Result<(), NixlError> {
+        let status = unsafe {
+            nixl_capi_opt_args_set_custom_param(
+                self.inner.as_ptr(),
+                param.as_ptr() as *const _,
+                param.len(),
+            )
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => Ok(()),
+            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+            _ => Err(NixlError::BackendError),
+        }
+    }
+
+    /// Gets the backend custom parameter
+    pub fn get_custom_param(&self) -> Result<Vec<u8>, NixlError> {
+        let mut data = ptr::null_mut();
+        let mut len = 0;
+        let status = unsafe {
+            nixl_capi_opt_args_get_custom_param(self.inner.as_ptr(), &mut data, &mut len)
+        };
+        match status {
+            NIXL_CAPI_SUCCESS => {
+                if data.is_null() {
+                    return Ok(Vec::new());
+                }
+                // SAFETY: the C API allocated len bytes at data, which we own
+                let bytes = unsafe {
+                    let vec = std::slice::from_raw_parts(data as *const u8, len).to_vec();
+                    libc::free(data);
+                    vec
+                };
+                Ok(bytes)
+            }
             NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
             _ => Err(NixlError::BackendError),
         }

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -53,10 +53,10 @@ use bindings::{
     nixl_capi_mem_type_t, nixl_capi_mem_type_to_string, nixl_capi_notif_map_clear,
     nixl_capi_notif_map_get_agent_at, nixl_capi_notif_map_get_notif,
     nixl_capi_notif_map_get_notifs_size, nixl_capi_notif_map_size, nixl_capi_opt_args_add_backend,
-    nixl_capi_opt_args_get_has_notif, nixl_capi_opt_args_get_notif_msg,
-    nixl_capi_opt_args_get_skip_desc_merge, nixl_capi_opt_args_set_has_notif,
+    nixl_capi_opt_args_get_custom_param, nixl_capi_opt_args_get_has_notif,
+    nixl_capi_opt_args_get_notif_msg, nixl_capi_opt_args_get_skip_desc_merge,
+    nixl_capi_opt_args_set_custom_param, nixl_capi_opt_args_set_has_notif,
     nixl_capi_opt_args_set_notif_msg, nixl_capi_opt_args_set_skip_desc_merge,
-    nixl_capi_opt_args_set_custom_param, nixl_capi_opt_args_get_custom_param,
     nixl_capi_params_create_iterator, nixl_capi_params_destroy_iterator, nixl_capi_params_is_empty,
     nixl_capi_params_iterator_next, nixl_capi_post_xfer_req, nixl_capi_reg_dlist_add_desc,
     nixl_capi_reg_dlist_clear, nixl_capi_register_mem, nixl_capi_string_list_get,
@@ -361,7 +361,17 @@ impl OptArgs {
         }
     }
 
-    /// UCX reads `worker_id=<n>` from this to pick the worker a memory view binds to.
+    /// Get the notification message
+    pub fn get_notification_message(&self) -> Result<Vec<u8>, NixlError> {
+        let mut data = ptr::null_mut();
+        let mut len = 0;
+        let status =
+            unsafe { nixl_capi_opt_args_get_notif_msg(self.inner.as_ptr(), &mut data, &mut len) };
+
+        take_capi_blob(status, data, len)
+    }
+
+    /// Opaque blob forwarded to the backend; its contents are backend-defined.
     pub fn set_custom_param(&mut self, param: &[u8]) -> Result<(), NixlError> {
         let status = unsafe {
             nixl_capi_opt_args_set_custom_param(
@@ -383,16 +393,6 @@ impl OptArgs {
         let status = unsafe {
             nixl_capi_opt_args_get_custom_param(self.inner.as_ptr(), &mut data, &mut len)
         };
-        take_capi_blob(status, data, len)
-    }
-
-    /// Get the notification message
-    pub fn get_notification_message(&self) -> Result<Vec<u8>, NixlError> {
-        let mut data = ptr::null_mut();
-        let mut len = 0;
-        let status =
-            unsafe { nixl_capi_opt_args_get_notif_msg(self.inner.as_ptr(), &mut data, &mut len) };
-
         take_capi_blob(status, data, len)
     }
 

--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -294,6 +294,28 @@ pub struct OptArgs {
     inner: NonNull<bindings::nixl_capi_opt_args_s>,
 }
 
+/// Copies out a blob the C API malloc'd, and frees it.
+fn take_capi_blob(
+    status: bindings::nixl_capi_status_t,
+    data: *mut std::ffi::c_void,
+    len: usize,
+) -> Result<Vec<u8>, NixlError> {
+    match status {
+        NIXL_CAPI_SUCCESS if data.is_null() => Ok(Vec::new()),
+        NIXL_CAPI_SUCCESS => {
+            // SAFETY: on success the C API left len bytes at data for us to own
+            let bytes = unsafe {
+                let vec = std::slice::from_raw_parts(data as *const u8, len).to_vec();
+                libc::free(data);
+                vec
+            };
+            Ok(bytes)
+        }
+        NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
+        _ => Err(NixlError::BackendError),
+    }
+}
+
 impl OptArgs {
     /// Creates a new empty optional arguments struct
     pub fn new() -> Result<Self, NixlError> {
@@ -339,9 +361,7 @@ impl OptArgs {
         }
     }
 
-    /// Sets the backend custom parameter, which `prep_mem_view_local` and
-    /// `_remote` forward to the backend. UCX reads `worker_id=<n>` from it to
-    /// pick the worker a memory view is bound to.
+    /// UCX reads `worker_id=<n>` from this to pick the worker a memory view binds to.
     pub fn set_custom_param(&mut self, param: &[u8]) -> Result<(), NixlError> {
         let status = unsafe {
             nixl_capi_opt_args_set_custom_param(
@@ -357,29 +377,13 @@ impl OptArgs {
         }
     }
 
-    /// Gets the backend custom parameter
     pub fn get_custom_param(&self) -> Result<Vec<u8>, NixlError> {
         let mut data = ptr::null_mut();
         let mut len = 0;
         let status = unsafe {
             nixl_capi_opt_args_get_custom_param(self.inner.as_ptr(), &mut data, &mut len)
         };
-        match status {
-            NIXL_CAPI_SUCCESS => {
-                if data.is_null() {
-                    return Ok(Vec::new());
-                }
-                // SAFETY: the C API allocated len bytes at data, which we own
-                let bytes = unsafe {
-                    let vec = std::slice::from_raw_parts(data as *const u8, len).to_vec();
-                    libc::free(data);
-                    vec
-                };
-                Ok(bytes)
-            }
-            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
-            _ => Err(NixlError::BackendError),
-        }
+        take_capi_blob(status, data, len)
     }
 
     /// Get the notification message
@@ -389,24 +393,7 @@ impl OptArgs {
         let status =
             unsafe { nixl_capi_opt_args_get_notif_msg(self.inner.as_ptr(), &mut data, &mut len) };
 
-        match status {
-            NIXL_CAPI_SUCCESS => {
-                if data.is_null() {
-                    Ok(Vec::new())
-                } else {
-                    // SAFETY: If status is 0 and data is not null, it points to valid memory of size len
-                    let message = unsafe {
-                        let slice = std::slice::from_raw_parts(data as *const u8, len);
-                        let vec = slice.to_vec();
-                        libc::free(data as *mut _);
-                        vec
-                    };
-                    Ok(message)
-                }
-            }
-            NIXL_CAPI_ERROR_INVALID_PARAM => Err(NixlError::InvalidParam),
-            _ => Err(NixlError::BackendError),
-        }
+        take_capi_blob(status, data, len)
     }
 
     /// Set whether notification is enabled

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -390,6 +390,20 @@ nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void *data, si
 }
 
 nixl_capi_status_t
+nixl_capi_opt_args_set_custom_param(nixl_capi_opt_args_t args, const void *data, size_t len) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, const void *, size_t);
+    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_set_custom_param");
+    return real(args, data, len);
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size_t *len) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, void **, size_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_custom_param");
+    return real(args, data, len);
+}
+
+nixl_capi_status_t
 nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void **data, size_t *len) {
     using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, void **, size_t *);
     static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_notif_msg");

--- a/src/bindings/rust/stubs.cpp
+++ b/src/bindings/rust/stubs.cpp
@@ -390,6 +390,13 @@ nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void *data, si
 }
 
 nixl_capi_status_t
+nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void **data, size_t *len) {
+    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, void **, size_t *);
+    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_notif_msg");
+    return real(args, data, len);
+}
+
+nixl_capi_status_t
 nixl_capi_opt_args_set_custom_param(nixl_capi_opt_args_t args, const void *data, size_t len) {
     using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, const void *, size_t);
     static fn_t real = (fn_t)resolve("nixl_capi_opt_args_set_custom_param");
@@ -400,13 +407,6 @@ nixl_capi_status_t
 nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size_t *len) {
     using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, void **, size_t *);
     static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_custom_param");
-    return real(args, data, len);
-}
-
-nixl_capi_status_t
-nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void **data, size_t *len) {
-    using fn_t = nixl_capi_status_t (*)(nixl_capi_opt_args_t, void **, size_t *);
-    static fn_t real = (fn_t)resolve("nixl_capi_opt_args_get_notif_msg");
     return real(args, data, len);
 }
 

--- a/src/bindings/rust/tests/mem_view.rs
+++ b/src/bindings/rust/tests/mem_view.rs
@@ -146,8 +146,8 @@ fn test_prep_mem_view_local() {
     assert!(!view.as_ptr().is_null());
 }
 
-/// The custom parameter is how a caller picks the UCX worker a view binds to,
-/// mirroring `extra_params.customParam` in test/gtest/device_api/single_write_test.cu.
+/// The custom parameter is forwarded to the backend, mirroring
+/// `extra_params.customParam` in test/gtest/device_api/single_write_test.cu.
 #[test]
 fn test_prep_mem_view_local_with_custom_param() {
     if !has_cuda_gpu() {

--- a/src/bindings/rust/tests/mem_view.rs
+++ b/src/bindings/rust/tests/mem_view.rs
@@ -146,6 +146,33 @@ fn test_prep_mem_view_local() {
     assert!(!view.as_ptr().is_null());
 }
 
+/// The custom parameter is how a caller picks the UCX worker a view binds to,
+/// mirroring `extra_params.customParam` in test/gtest/device_api/single_write_test.cu.
+#[test]
+fn test_prep_mem_view_local_with_custom_param() {
+    if !has_cuda_gpu() {
+        eprintln!("skipping test_prep_mem_view_local_with_custom_param: no CUDA-capable GPU");
+        return;
+    }
+    select_gpu();
+
+    let (agent, mut opt_args) = create_agent_with_backend("mem_view_custom_param").expect("Failed to create agent");
+    let (storage, _handle) = vram_buffer(&agent, &opt_args).expect("Failed to allocate VRAM");
+
+    opt_args
+        .set_custom_param(b"worker_id=0")
+        .expect("Failed to set custom param");
+    assert_eq!(
+        opt_args.get_custom_param().expect("Failed to get custom param"),
+        b"worker_id=0"
+    );
+
+    // SAFETY: storage outlives the view
+    let view = unsafe { agent.prep_mem_view_local(&vram_dlist(&storage), Some(&opt_args)) }
+        .expect("prep_mem_view_local failed");
+    assert!(!view.as_ptr().is_null());
+}
+
 /// A remote memory view has no device lane until the endpoint is wired up.
 /// Mirrors `DeviceApiTestBase::completeWireup`.
 fn complete_wireup(from: &Agent, to: &Agent, to_name: &str) {

--- a/src/bindings/rust/tests/mem_view.rs
+++ b/src/bindings/rust/tests/mem_view.rs
@@ -146,8 +146,6 @@ fn test_prep_mem_view_local() {
     assert!(!view.as_ptr().is_null());
 }
 
-/// The custom parameter is forwarded to the backend, mirroring
-/// `extra_params.customParam` in test/gtest/device_api/single_write_test.cu.
 #[test]
 fn test_prep_mem_view_local_with_custom_param() {
     if !has_cuda_gpu() {

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -493,8 +493,7 @@ fn test_make_connection_success() {
     );
 }
 
-/// The custom parameter is a blob, not a C string: the gpunetio backend stores
-/// a raw cudaStream_t in it, so embedded zero bytes must survive.
+/// The payload is a blob, not a C string, so embedded zero bytes must survive.
 #[test]
 fn test_opt_args_custom_param_round_trip() {
     let mut opt_args = OptArgs::new().expect("Failed to create opt args");

--- a/src/bindings/rust/tests/tests.rs
+++ b/src/bindings/rust/tests/tests.rs
@@ -493,6 +493,21 @@ fn test_make_connection_success() {
     );
 }
 
+/// The custom parameter is a blob, not a C string: the gpunetio backend stores
+/// a raw cudaStream_t in it, so embedded zero bytes must survive.
+#[test]
+fn test_opt_args_custom_param_round_trip() {
+    let mut opt_args = OptArgs::new().expect("Failed to create opt args");
+    assert!(opt_args.get_custom_param().expect("Failed to get custom param").is_empty());
+
+    let param = [0x01u8, 0x00, 0x02, 0x00, 0x03];
+    opt_args.set_custom_param(&param).expect("Failed to set custom param");
+    assert_eq!(
+        opt_args.get_custom_param().expect("Failed to get custom param"),
+        param
+    );
+}
+
 #[test]
 fn test_make_connection_invalid_param() {
     let agent = Agent::new("test_agent").expect("Failed to create agent");

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -656,6 +656,50 @@ nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t*
 }
 
 nixl_capi_status_t
+nixl_capi_opt_args_set_custom_param(nixl_capi_opt_args_t args, const void *data, size_t len) {
+    if (!args || (!data && len > 0)) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        args->args.customParam.assign((const char *)data, len);
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
+nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size_t *len) {
+    if (!args || !data || !len) {
+        return NIXL_CAPI_ERROR_INVALID_PARAM;
+    }
+
+    try {
+        const nixl_blob_t &param = args->args.customParam;
+        if (param.empty()) {
+            *data = nullptr;
+            *len = 0;
+            return NIXL_CAPI_SUCCESS;
+        }
+
+        void *param_data = malloc(param.size());
+        if (!param_data) {
+            return NIXL_CAPI_ERROR_BACKEND;
+        }
+
+        memcpy(param_data, param.data(), param.size());
+        *data = param_data;
+        *len = param.size();
+        return NIXL_CAPI_SUCCESS;
+    }
+    catch (...) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+}
+
+nixl_capi_status_t
 nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif)
 {
   if (!args) {

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -650,8 +650,9 @@ nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t*
   }
 
   try {
-      return nixl_capi_blob_to_buffer(
-          args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg, data, len);
+        const nixl_blob_t &msg =
+            args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
+        return nixl_capi_blob_to_buffer(msg, data, len);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -604,6 +604,25 @@ nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nixl_capi_backend_t ba
   }
 }
 
+static nixl_capi_status_t
+nixl_capi_blob_to_buffer(const nixl_blob_t &blob, void **data, size_t *len) {
+    if (blob.empty()) {
+        *data = nullptr;
+        *len = 0;
+        return NIXL_CAPI_SUCCESS;
+    }
+
+    void *buf = malloc(blob.size());
+    if (!buf) {
+        return NIXL_CAPI_ERROR_BACKEND;
+    }
+
+    memcpy(buf, blob.data(), blob.size());
+    *data = buf;
+    *len = blob.size();
+    return NIXL_CAPI_SUCCESS;
+}
+
 nixl_capi_status_t
 nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void* data, size_t len)
 {
@@ -631,24 +650,8 @@ nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t*
   }
 
   try {
-      const nixl_blob_t &msg =
-          args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
-      size_t msg_size = msg.size();
-      if (msg_size == 0) {
-          *data = nullptr;
-          *len = 0;
-          return NIXL_CAPI_SUCCESS;
-      }
-
-      void *msg_data = malloc(msg_size);
-      if (!msg_data) {
-          return NIXL_CAPI_ERROR_BACKEND;
-      }
-
-      memcpy(msg_data, msg.data(), msg_size);
-      *data = msg_data;
-      *len = msg_size;
-      return NIXL_CAPI_SUCCESS;
+      return nixl_capi_blob_to_buffer(
+          args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg, data, len);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;
@@ -677,22 +680,7 @@ nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size
     }
 
     try {
-        const nixl_blob_t &param = args->args.customParam;
-        if (param.empty()) {
-            *data = nullptr;
-            *len = 0;
-            return NIXL_CAPI_SUCCESS;
-        }
-
-        void *param_data = malloc(param.size());
-        if (!param_data) {
-            return NIXL_CAPI_ERROR_BACKEND;
-        }
-
-        memcpy(param_data, param.data(), param.size());
-        *data = param_data;
-        *len = param.size();
-        return NIXL_CAPI_SUCCESS;
+        return nixl_capi_blob_to_buffer(args->args.customParam, data, len);
     }
     catch (...) {
         return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.cpp
+++ b/src/bindings/rust/wrapper.cpp
@@ -650,9 +650,9 @@ nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t*
   }
 
   try {
-        const nixl_blob_t &msg =
-            args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
-        return nixl_capi_blob_to_buffer(msg, data, len);
+      const nixl_blob_t &msg =
+          args->args.notif.has_value() ? args->args.notif.value() : args->args.notifMsg;
+      return nixl_capi_blob_to_buffer(msg, data, len);
   }
   catch (...) {
     return NIXL_CAPI_ERROR_BACKEND;

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -191,10 +191,35 @@ nixl_capi_status_t nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nix
 // OptArgs notification and merge control
 nixl_capi_status_t nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void* data, size_t len);
 nixl_capi_status_t nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t* len);
+
+/**
+ * @brief Set the backend custom parameter, a blob whose contents are backend-defined.
+ *
+ * Copies @a len bytes out of @a data, which may be freed once this returns. @a data
+ * may be NULL only when @a len is 0.
+ *
+ * @param  args  [in]  Optional arguments
+ * @param  data  [in]  Parameter bytes
+ * @param  len   [in]  Byte count
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
 nixl_capi_status_t
 nixl_capi_opt_args_set_custom_param(nixl_capi_opt_args_t args, const void *data, size_t len);
+
+/**
+ * @brief Get the backend custom parameter.
+ *
+ * On success the caller owns @a data and must release it with free(). An unset
+ * parameter yields NULL and a length of 0.
+ *
+ * @param  args  [in]  Optional arguments
+ * @param  data  [out] Newly allocated copy of the parameter bytes
+ * @param  len   [out] Byte count
+ * @return nixl_capi_status_t Error code if call was not successful
+ */
 nixl_capi_status_t
 nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size_t *len);
+
 nixl_capi_status_t nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif);
 nixl_capi_status_t nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif);
 nixl_capi_status_t nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);

--- a/src/bindings/rust/wrapper.h
+++ b/src/bindings/rust/wrapper.h
@@ -191,6 +191,10 @@ nixl_capi_status_t nixl_capi_opt_args_add_backend(nixl_capi_opt_args_t args, nix
 // OptArgs notification and merge control
 nixl_capi_status_t nixl_capi_opt_args_set_notif_msg(nixl_capi_opt_args_t args, const void* data, size_t len);
 nixl_capi_status_t nixl_capi_opt_args_get_notif_msg(nixl_capi_opt_args_t args, void** data, size_t* len);
+nixl_capi_status_t
+nixl_capi_opt_args_set_custom_param(nixl_capi_opt_args_t args, const void *data, size_t len);
+nixl_capi_status_t
+nixl_capi_opt_args_get_custom_param(nixl_capi_opt_args_t args, void **data, size_t *len);
 nixl_capi_status_t nixl_capi_opt_args_set_has_notif(nixl_capi_opt_args_t args, bool has_notif);
 nixl_capi_status_t nixl_capi_opt_args_get_has_notif(nixl_capi_opt_args_t args, bool* has_notif);
 nixl_capi_status_t nixl_capi_opt_args_set_skip_desc_merge(nixl_capi_opt_args_t args, bool skip_merge);


### PR DESCRIPTION
## What?

Binds the optional-args custom parameter into the Rust C API layer and
`nixl-sys`.

- C API: `nixl_capi_opt_args_set_custom_param` / `_get_custom_param`, with
  matching `stubs.cpp` forwarders
- nixl-sys: `OptArgs::set_custom_param` / `get_custom_param`
- a memory view test that sets `worker_id=0` and prepares a view with it

## Why?

`prepMemView` is the reason. `nixlAgent::prepMemView` copies
`extra_params->customParam` into the backend args in both overloads
(`nixl_agent.cpp:1921`, `:1994`), and the UCX backend parses `worker_id=<n>`
out of it to choose which shared worker the view binds to
(`ucx_backend.cpp:1036-1060`). The device API test sets it the same way:

```cpp
extra_params.customParam = "worker_id=" + std::to_string(worker_id);
// test/gtest/device_api/single_write_test.cu:455
```

Without a binding a Rust caller cannot select the worker, so the memory views
added in #2060 are reachable but not fully controllable. It is the only field
of `nixl_opt_args_t` that `prepMemView` reads, and it was the one field the
bindings did not expose.

## How?

The setter is byte-oriented (`const void *`, `size_t`), mirroring
`nixl_capi_opt_args_set_notif_msg` rather than the `const char *` of
`set_ip_addr`. The blob is not always text: the gpunetio backend stores a raw
`cudaStream_t` in it (`gpunetio_backend.cpp:1141`), which a C-string API would
truncate at the first zero byte.

## Testing

106 tests pass with `cargo test -- --test-threads=1` — 97 in `tests.rs`, 5 in
`mem_view.rs`, 4 in `test_sync_manager.rs` — on UCX 1.21 with a CUDA device.
The new test runs by default; it needs a GPU but no device-capable RDMA lane.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for setting and retrieving custom binary parameters through optional arguments.
  * Custom parameters preserve arbitrary byte content, including embedded zero bytes.
  * Added support for using custom parameters when preparing local GPU memory views.

* **Bug Fixes**
  * Improved handling of returned binary data, including empty values and notification messages.

* **Tests**
  * Added coverage for parameter round-tripping and CUDA-based memory view preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->