### PR TITLE
PLUGINS/UCX: Support for control features

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -441,6 +441,22 @@ if ucx_dep.found()
     endif
 endif
 
+# UCX control features detection. UCP_PARAM_FIELD_CTRL_FEATURES is an enumerator
+# rather than a macro, so it cannot be probed with #ifdef.
+if ucx_dep.found()
+    have_ucx_ctrl_features = cpp.has_header_symbol('ucp/api/ucp.h',
+        'UCP_PARAM_FIELD_CTRL_FEATURES',
+        dependencies: ucx_dep)
+
+    if have_ucx_ctrl_features
+        add_project_arguments('-DHAVE_UCP_CTRL_FEATURES', language: 'cpp')
+    endif
+
+    summary({
+        'UCX control features' : have_ucx_ctrl_features,
+    }, section: 'UCX', bool_yn: true)
+endif
+
 if get_option('disable_gds_backend')
     add_project_arguments('-DDISABLE_GDS_BACKEND', language: 'cpp')
 endif

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -454,7 +454,16 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
 
     ucp_params_t ucp_params;
     ucp_params.field_mask = UCP_PARAM_FIELD_FEATURES | UCP_PARAM_FIELD_MT_WORKERS_SHARED;
-    ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64 | UCP_FEATURE_AM;
+    ucp_params.features = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64;
+
+#ifdef HAVE_UCP_CTRL_FEATURES
+    ucp_params.field_mask |= UCP_PARAM_FIELD_CTRL_FEATURES;
+    ucp_params.ctrl_features = UCP_FEATURE_AM;
+    NIXL_DEBUG << "UCX control features supported, requesting AM as a control feature";
+#else
+    ucp_params.features |= UCP_FEATURE_AM;
+    NIXL_DEBUG << "UCX control features not supported, requesting AM as a data feature";
+#endif
 
     if (!name_.empty()) {
         ucp_params.field_mask |= UCP_PARAM_FIELD_NAME;


### PR DESCRIPTION
## What?
Detects UCX support for control features (https://github.com/openucx/ucx/pull/11480)
Set's AM as a control feature, if UCX supports it

## Why?
Currently UCX_TLS is a source of confusion, because it defines transports for both NIXL's DATA and CTRL channels. People sets this option expecting that it affects only the DATA path, and they shouldn't really care about NIXL internal control path (active messages).
Starting from this point, **UCX_TLS setting for NIXL means transport for DATA payload only**.
Transport for control path (AM) is chosen automatically by UCX from **all** available transports.

## How?
Set AM as a control feature, which basically tells UCX to use all available transports for AM, independent of UCX_TLS setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved UCX capability detection during configuration.
  * UCX context initialization now requests communication features more precisely when supported.

* **Bug Fixes**
  * Improved compatibility with UCX versions that support control features, while preserving behavior for older versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->