### PR TITLE
posix: roll back queued entries when postXfer fails partway

### DIFF
--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -323,8 +323,13 @@ class nixlAgent {
                           nixlBackendH* &backend) const;
 
         /**
-         * @brief  Release the transfer request `req_hndl`. If the transfer is active,
-         *         it will be canceled, or return an error if the transfer cannot be aborted.
+         * @brief  Release the transfer request `req_hndl`. If the transfer is active, the
+         *         backend will try to cancel it. Backends that cannot cancel in-flight
+         *         operations either defer the release, returning NIXL_SUCCESS and freeing
+         *         the request internally once its outstanding operations complete, or
+         *         refuse it with an error; on error `req_hndl` stays valid and pollable,
+         *         so the caller can drive it to completion via getXferStatus() and then
+         *         retry the release.
          *
          * @param  req_hndl      Transfer request handle to be released
          * @return nixl_status_t Error code if call was not successful

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1294,13 +1294,13 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
         if(req_hndl->status == NIXL_IN_PROG) {
 
-            req_hndl->status = req_hndl->engine->releaseReqH(
-                                         req_hndl->backendHandle);
+            const nixl_status_t rel_status = req_hndl->engine->releaseReqH(req_hndl->backendHandle);
 
-            if (req_hndl->status < 0) {
+            if (rel_status < 0) {
                 NIXL_ERROR_FUNC << "backend '" << req_hndl->engine->getType()
                                 << "' could not release transfer request and returned error status "
-                                << req_hndl->status;
+                                << rel_status;
+                // Keep the request pollable so the user can drive it to completion and retry.
                 return NIXL_ERR_REPOST_ACTIVE; // Might need renaming
             }
             // just in case the backend doesn't set to NULL on success

--- a/src/plugins/posix/io_queue.h
+++ b/src/plugins/posix/io_queue.h
@@ -60,6 +60,21 @@ public:
         return 0;
     }
 
+    /**
+     * @brief Discard queued-but-unsubmitted entries whose completion context is @a ctx.
+     *
+     * Returns every entry that is still awaiting submission and stores @a ctx as its
+     * completion callback context to the free pool, so no later post() or poll() can
+     * submit it. Entries already submitted to the kernel are not affected. Unlike
+     * cancel(), no completion callbacks are invoked; the caller unwinds its own
+     * accounting. Used to roll back a request whose enqueue() sequence failed partway,
+     * keeping submission all-or-nothing per request.
+     *
+     * @param ctx The completion callback context identifying the request to roll back.
+     */
+    virtual void
+    discardQueued(void *ctx) = 0;
+
     static std::unique_ptr<nixlPosixIOQueue>
     instantiate(std::string_view io_queue_type, uint32_t ios_pool_size, uint32_t kernel_queue_size);
     static std::string_view
@@ -93,6 +108,18 @@ public:
           ios_(ios_pool_size_) {
         for (uint32_t i = 0; i < ios_pool_size_; i++) {
             free_ios_.push_back(&ios_[i]);
+        }
+    }
+
+    void
+    discardQueued(void *ctx) override {
+        for (auto it = ios_to_submit_.begin(); it != ios_to_submit_.end();) {
+            if ((*it)->ctx_ == ctx) {
+                free_ios_.push_back(*it);
+                it = ios_to_submit_.erase(it);
+            } else {
+                ++it;
+            }
         }
     }
 

--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -57,6 +57,11 @@ protected:
 };
 
 nixlPosixIOQueueAIO::~nixlPosixIOQueueAIO() {
+    // Cancellation is only a hint; do not delay teardown waiting for stragglers.
+    if (!ios_in_flight_.empty()) {
+        NIXL_ERROR << "POSIX AIO queue destroyed with " << ios_in_flight_.size()
+                   << " operations still in flight";
+    }
     for (auto &io : ios_) {
         if (io.aio_.aio_fildes != 0) {
             aio_cancel(io.aio_.aio_fildes, &io.aio_);

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -229,8 +229,18 @@ nixlPosixBackendReqH::postXfer() {
                                                   this);
 
         if (status != NIXL_SUCCESS) {
-            // Currently we do not support partial submissions, so it's all or nothing
+            // Submission is all or nothing per request: return the entries already
+            // queued for this request to the free pool. Left in the shared submission
+            // list, a later post or poll, possibly driven by another request, would
+            // submit them after the caller was told this post failed, performing I/O
+            // the caller no longer expects with this request as the entries' completion
+            // callback context (issue #1957).
             NIXL_ERROR << absl::StrFormat("Error preparing I/O operation: %d", status);
+            io_queue_->discardQueued(this);
+            // Nothing from this batch is queued or in flight anymore and the cancel
+            // counters are still at their reset values, so restore the pre-post
+            // invariant: the request is complete and immediately releasable.
+            num_confirmed_ios_ = queue_depth_;
             return status;
         }
     }

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -265,6 +265,17 @@ nixlPosixEngine::nixlPosixEngine(const nixlBackendInitParams *init_params)
                                  io_queue_type_);
 }
 
+// Free requests still parked at teardown; nothing can poll the queue anymore.
+nixlPosixEngine::~nixlPosixEngine() {
+    if (!released_reqs_.empty()) {
+        NIXL_ERROR << "POSIX engine destroyed with " << released_reqs_.size()
+                   << " released requests still awaiting completions";
+    }
+    for (auto *req : released_reqs_) {
+        delete req;
+    }
+}
+
 nixl_status_t
 nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
                              const nixl_mem_t &nixl_mem,
@@ -369,7 +380,9 @@ nixlPosixEngine::checkXfer(nixlBackendReqH *handle) const {
     try {
         auto &posix_handle = castPosixHandle(handle);
         NIXL_LOCK_GUARD(io_queue_lock_);
-        return posix_handle.checkXfer();
+        nixl_status_t status = posix_handle.checkXfer();
+        reapReleasedReqs();
+        return status;
     }
     catch (const nixlPosixBackendReqH::exception &e) {
         NIXL_ERROR << e.what();
@@ -378,10 +391,37 @@ nixlPosixEngine::checkXfer(nixlBackendReqH *handle) const {
     return NIXL_ERR_BACKEND;
 }
 
+// Free parked requests that have since completed; must be called with io_queue_lock_ held.
+void
+nixlPosixEngine::reapReleasedReqs() const {
+    auto it = released_reqs_.begin();
+    while (it != released_reqs_.end()) {
+        if ((*it)->isComplete()) {
+            delete *it;
+            it = released_reqs_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+// An incomplete request is parked instead of freed: queue entries reference it as their
+// completion callback context until reaped, and no queue can abort submitted operations.
 nixl_status_t
 nixlPosixEngine::releaseReqH(nixlBackendReqH *handle) const {
-    NIXL_ASSERT(handle != nullptr);
-    delete handle;
+    if (!handle) {
+        NIXL_ERROR << "releaseReqH called with a null handle";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto &posix_handle = static_cast<nixlPosixBackendReqH &>(*handle);
+    NIXL_LOCK_GUARD(io_queue_lock_);
+    if (posix_handle.isComplete()) {
+        delete handle;
+    } else {
+        NIXL_DEBUG << "POSIX request released while in progress; deferring free until its "
+                      "outstanding completions drain";
+        released_reqs_.push_back(&posix_handle);
+    }
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -47,6 +47,16 @@ public:
     nixl_status_t
     checkXfer();
 
+    /**
+     * @brief Whether every completion (confirmed I/Os and expected cancellations) has been
+     *        reaped; queue entries reference this request until then, so only a complete
+     *        request may be freed.
+     */
+    bool
+    isComplete() const {
+        return num_confirmed_ios_ == queue_depth_ && cancels_expected_ == cancels_seen_;
+    }
+
     // Exception classes
     class exception : public std::exception {
     private:
@@ -62,11 +72,6 @@ public:
     };
 
 private:
-    bool
-    isComplete() const {
-        return num_confirmed_ios_ == queue_depth_ && cancels_expected_ == cancels_seen_;
-    }
-
     unsigned
     requestCancellation();
     void
@@ -98,10 +103,15 @@ private:
     mutable std::unique_ptr<nixlPosixIOQueue> io_queue_;
     mutable nixlLock io_queue_lock_;
     nixl::PathModeDevIdRegistry path_mode_devids_;
+    // Requests released while incomplete, freed by reapReleasedReqs(); guarded by io_queue_lock_.
+    mutable std::vector<nixlPosixBackendReqH *> released_reqs_;
+
+    void
+    reapReleasedReqs() const;
 
 public:
     nixlPosixEngine(const nixlBackendInitParams *init_params);
-    virtual ~nixlPosixEngine() = default;
+    virtual ~nixlPosixEngine();
 
     bool
     supportsRemote() const override {

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -812,6 +812,322 @@ test_posix_repost (std::string test_files_dir_path_abs_path, bool use_uring) {
     return 0;
 }
 
+// Buffers/files for the release tests; declared before the agent so in-flight I/O at
+// teardown still targets live memory.
+struct releaseTestBuffers {
+    std::vector<std::unique_ptr<void, PosixMemalignDeleter>> dram_addr;
+    std::vector<tempFile> fd;
+    std::unique_ptr<nixlBlobDesc[]> dram_buf;
+    std::unique_ptr<nixlBlobDesc[]> ftrans;
+    nixl_reg_dlist_t dram_for_posix;
+    nixl_reg_dlist_t file_for_posix;
+    nixl_xfer_dlist_t dram_for_posix_xfer;
+    nixl_xfer_dlist_t file_for_posix_xfer;
+
+    releaseTestBuffers()
+        : dram_for_posix(DRAM_SEG),
+          file_for_posix(FILE_SEG),
+          dram_for_posix_xfer(DRAM_SEG),
+          file_for_posix_xfer(FILE_SEG) {}
+};
+
+static int
+setup_release_test_buffers(const std::string &test_files_dir_path_abs_path,
+                           const std::string &file_infix,
+                           int num_transfers,
+                           size_t transfer_size,
+                           releaseTestBuffers &bufs) {
+    bufs.dram_addr.reserve(num_transfers);
+    bufs.fd.reserve(num_transfers);
+    bufs.dram_buf.reset(new nixlBlobDesc[num_transfers]);
+    bufs.ftrans.reset(new nixlBlobDesc[num_transfers]);
+
+    int file_open_flags = O_RDWR | O_CREAT;
+    mode_t file_mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH; // rw-r--r--
+    for (int i = 0; i < num_transfers; ++i) {
+        void *ptr;
+        if (posix_memalign(&ptr, page_size, transfer_size) != 0) {
+            std::cerr << "DRAM allocation failed" << std::endl;
+            return 1;
+        }
+        bufs.dram_addr.emplace_back(ptr);
+        fill_test_pattern(ptr, read_write_test_phrase, transfer_size);
+
+        std::string file_name = generate_timestamped_filename(test_file_name);
+        std::string file_path =
+            test_files_dir_path_abs_path + "/" + file_name + file_infix + std::to_string(i);
+        try {
+            bufs.fd.emplace_back(file_path, file_open_flags, file_mode);
+        }
+        catch (const std::exception &e) {
+            std::cerr << "Failed to open file: " << file_path << " - " << e.what() << std::endl;
+            return 1;
+        }
+
+        bufs.dram_buf[i].addr = (uintptr_t)(ptr);
+        bufs.dram_buf[i].len = transfer_size;
+        bufs.dram_buf[i].devId = 0;
+        bufs.dram_for_posix.addDesc(bufs.dram_buf[i]);
+        bufs.dram_for_posix_xfer.addDesc(bufs.dram_buf[i]);
+
+        bufs.ftrans[i].addr = 0;
+        bufs.ftrans[i].len = transfer_size;
+        bufs.ftrans[i].devId = bufs.fd[i].fd;
+        bufs.file_for_posix.addDesc(bufs.ftrans[i]);
+        bufs.file_for_posix_xfer.addDesc(bufs.ftrans[i]);
+    }
+
+    return 0;
+}
+
+// Regression test for issue #1955: releasing a NIXL_IN_PROG transfer must not free the
+// request while queue entries still hold it as their completion callback context.
+// Determinism: no progress thread, and 256 descriptors against the 64-entry poll cap keep
+// the transfer active across the release.
+int
+test_posix_release_active(const std::string &test_files_dir_path_abs_path, bool use_uring) {
+    constexpr int num_transfers = 256;
+    constexpr size_t transfer_size = 128 * 1024; // 128KB
+
+    nixl_b_params_t params;
+    if (use_uring) {
+        params["use_uring"] = "true";
+        params["use_aio"] = "false";
+    } else {
+        params["use_uring"] = "false";
+    }
+
+    print_segment_title("NIXL STORAGE RELEASE-ACTIVE TEST STARTING (POSIX PLUGIN)");
+
+    print_segment_title(phase_title("Allocating and registering buffers"));
+
+    releaseTestBuffers bufs;
+    if (setup_release_test_buffers(
+            test_files_dir_path_abs_path, "_ra_", num_transfers, transfer_size, bufs) != 0) {
+        return 1;
+    }
+
+    // No progress thread: completions are reaped only by explicit polls.
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXReleaseActiveTester", cfg);
+    nixlBackendH *posix = nullptr;
+    if (agent.createBackend("POSIX", params, posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to create POSIX backend" << std::endl;
+        return 1;
+    }
+
+    if (agent.registerMem(bufs.dram_for_posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to register DRAM memory with NIXL" << std::endl;
+        return 1;
+    }
+    if (agent.registerMem(bufs.file_for_posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to register file memory with NIXL" << std::endl;
+        return 1;
+    }
+
+    print_segment_title(phase_title("Releasing an in-progress write transfer"));
+
+    nixlXferReqH *treq = nullptr;
+    nixl_status_t status = agent.createXferReq(NIXL_WRITE,
+                                               bufs.dram_for_posix_xfer,
+                                               bufs.file_for_posix_xfer,
+                                               "POSIXReleaseActiveTester",
+                                               treq);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create write transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq);
+    if (status != NIXL_IN_PROG) {
+        std::cerr << "Expected posted transfer to be NIXL_IN_PROG, got: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq);
+        return 1;
+    }
+
+    // The backend accepts the release and defers the free; treq is invalid from here on.
+    status = agent.releaseXferReq(treq);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Expected release of an active transfer to succeed, got: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+    std::cout << "Release of active transfer accepted, free deferred" << std::endl;
+
+    print_segment_title(phase_title("Draining the released transfer with a second write"));
+
+    // A second write polls the shared queue, draining the released transfer (ASAN catches
+    // the old delete-on-release here, LSAN a request never freed). Both writes carry
+    // identical bytes, so the final file contents are deterministic.
+    nixlXferReqH *treq_drain = nullptr;
+    status = agent.createXferReq(NIXL_WRITE,
+                                 bufs.dram_for_posix_xfer,
+                                 bufs.file_for_posix_xfer,
+                                 "POSIXReleaseActiveTester",
+                                 treq_drain);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create drain transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_drain);
+    if (status < 0) {
+        std::cerr << "Failed to post drain transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_drain);
+        return 1;
+    }
+
+    do {
+        status = agent.getXferStatus(treq_drain);
+        if (status < 0) {
+            std::cerr << "Error during drain transfer - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq_drain);
+            return 1;
+        }
+    } while (status == NIXL_IN_PROG);
+
+    status = agent.releaseXferReq(treq_drain);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to release completed drain request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+    std::cout << "Second write completed; orphaned completions reaped" << std::endl;
+
+    print_segment_title(phase_title("Read-back validation"));
+
+    for (int i = 0; i < num_transfers; ++i) {
+        clear_buffer(bufs.dram_addr[i].get(), transfer_size);
+    }
+
+    nixlXferReqH *treq_read = nullptr;
+    status = agent.createXferReq(NIXL_READ,
+                                 bufs.dram_for_posix_xfer,
+                                 bufs.file_for_posix_xfer,
+                                 "POSIXReleaseActiveTester",
+                                 treq_read);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create read transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_read);
+    if (status < 0) {
+        std::cerr << "Failed to post read transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_read);
+        return 1;
+    }
+
+    do {
+        status = agent.getXferStatus(treq_read);
+        if (status < 0) {
+            std::cerr << "Error during read transfer - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq_read);
+            return 1;
+        }
+    } while (status == NIXL_IN_PROG);
+    agent.releaseXferReq(treq_read);
+
+    std::unique_ptr<char[]> expected_buffer = std::make_unique<char[]>(transfer_size);
+    fill_test_pattern(expected_buffer.get(), read_write_test_phrase, transfer_size);
+    for (int i = 0; i < num_transfers; ++i) {
+        if (memcmp(bufs.dram_addr[i].get(), expected_buffer.get(), transfer_size) != 0) {
+            std::cerr << "DRAM buffer " << i << " validation failed" << std::endl;
+            return 1;
+        }
+    }
+    std::cout << "Read-back and validation: OK" << std::endl;
+
+    agent.deregisterMem(bufs.file_for_posix);
+    agent.deregisterMem(bufs.dram_for_posix);
+
+    return 0;
+}
+
+// Companion to test_posix_release_active covering the destructor path: nothing drains the
+// released request, so the engine destructor must free it (verified by LSAN at exit).
+int
+test_posix_release_teardown(const std::string &test_files_dir_path_abs_path, bool use_uring) {
+    constexpr int num_transfers = 256;
+    constexpr size_t transfer_size = 128 * 1024; // 128KB
+
+    nixl_b_params_t params;
+    if (use_uring) {
+        params["use_uring"] = "true";
+        params["use_aio"] = "false";
+    } else {
+        params["use_uring"] = "false";
+    }
+
+    print_segment_title("NIXL STORAGE RELEASE-TEARDOWN TEST STARTING (POSIX PLUGIN)");
+
+    releaseTestBuffers bufs;
+    if (setup_release_test_buffers(
+            test_files_dir_path_abs_path, "_rt_", num_transfers, transfer_size, bufs) != 0) {
+        return 1;
+    }
+
+    {
+        nixlAgentConfig cfg;
+        nixlAgent agent("POSIXReleaseTeardownTester", cfg);
+        nixlBackendH *posix = nullptr;
+        if (agent.createBackend("POSIX", params, posix) != NIXL_SUCCESS) {
+            std::cerr << "Failed to create POSIX backend" << std::endl;
+            return 1;
+        }
+
+        if (agent.registerMem(bufs.dram_for_posix) != NIXL_SUCCESS) {
+            std::cerr << "Failed to register DRAM memory with NIXL" << std::endl;
+            return 1;
+        }
+        if (agent.registerMem(bufs.file_for_posix) != NIXL_SUCCESS) {
+            std::cerr << "Failed to register file memory with NIXL" << std::endl;
+            return 1;
+        }
+
+        nixlXferReqH *treq = nullptr;
+        nixl_status_t status = agent.createXferReq(NIXL_WRITE,
+                                                   bufs.dram_for_posix_xfer,
+                                                   bufs.file_for_posix_xfer,
+                                                   "POSIXReleaseTeardownTester",
+                                                   treq);
+        if (status != NIXL_SUCCESS) {
+            std::cerr << "Failed to create write transfer request - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            return 1;
+        }
+
+        status = agent.postXferReq(treq);
+        if (status != NIXL_IN_PROG) {
+            std::cerr << "Expected posted transfer to be NIXL_IN_PROG, got: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq);
+            return 1;
+        }
+
+        status = agent.releaseXferReq(treq);
+        if (status != NIXL_SUCCESS) {
+            std::cerr << "Expected release of an active transfer to succeed, got: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            return 1;
+        }
+        std::cout << "Release of active transfer accepted, free deferred" << std::endl;
+
+        // The agent goes out of scope with the released transfer still in flight.
+    }
+    std::cout << "Teardown with in-flight released transfer: OK" << std::endl;
+
+    return 0;
+}
+
 // Path-mode parser unit checks (POSIX-only since it owns parsePathMeta tests).
 static void
 checkPathModeParser() {
@@ -1132,6 +1448,24 @@ main (int argc, char *argv[]) {
     ret = test_posix_repost (test_files_dir_path_abs_path, use_uring);
     if (ret != 0) {
         std::cerr << "Repost Test failed" << std::endl;
+        return 1;
+    }
+
+    // Reset phase number for release-active test
+    phase_num = 1;
+
+    ret = test_posix_release_active(test_files_dir_path_abs_path, use_uring);
+    if (ret != 0) {
+        std::cerr << "Release-Active Test failed" << std::endl;
+        return 1;
+    }
+
+    // Reset phase number for release-teardown test
+    phase_num = 1;
+
+    ret = test_posix_release_teardown(test_files_dir_path_abs_path, use_uring);
+    if (ret != 0) {
+        std::cerr << "Release-Teardown Test failed" << std::endl;
         return 1;
     }
 

--- a/test/unit/plugins/posix/nixl_posix_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_test.cpp
@@ -1128,6 +1128,253 @@ test_posix_release_teardown(const std::string &test_files_dir_path_abs_path, boo
     return 0;
 }
 
+// Regression test for issue #1957: a post that fails partway through enqueueing must not
+// leave its already-queued entries in the shared submission list. Left there, a later
+// poll driven by an unrelated request submits them, performing I/O the caller was told
+// had failed, with a request handle the caller has since released as their completion
+// callback context.
+//
+// Determinism: the I/O pool is capped at its 64-entry minimum and the agent runs without
+// a progress thread, so nothing is reaped between explicit calls. A first write occupying
+// 63 entries stays in flight, so the second write's first descriptor takes the last free
+// entry and its second descriptor deterministically fails the enqueue. After the first
+// write is driven to completion, whose polls would submit anything left in the
+// submission list, the failed write's files must still be empty: any byte in them means
+// the entry that should have been rolled back was submitted anyway.
+int
+test_posix_partial_enqueue(const std::string &test_files_dir_path_abs_path, bool use_uring) {
+    constexpr int pool_size = 64; // MIN_IOS_POOL_SIZE, the smallest pool the queues allow
+    constexpr int num_blocker_transfers = pool_size - 1;
+    constexpr int num_failed_transfers = 2;
+    constexpr size_t transfer_size = 128 * 1024; // 128KB
+
+    nixl_b_params_t params;
+    params["ios_pool_size"] = std::to_string(pool_size);
+    if (use_uring) {
+        params["use_uring"] = "true";
+        params["use_aio"] = "false";
+    } else {
+        params["use_uring"] = "false";
+    }
+
+    print_segment_title("NIXL STORAGE PARTIAL-ENQUEUE TEST STARTING (POSIX PLUGIN)");
+
+    print_segment_title(phase_title("Allocating and registering buffers"));
+
+    releaseTestBuffers blocker_bufs; // Occupies all but one pool entry
+    releaseTestBuffers failed_bufs; // Two descriptors; only one pool entry left
+    if (setup_release_test_buffers(test_files_dir_path_abs_path,
+                                   "_pe_blk_",
+                                   num_blocker_transfers,
+                                   transfer_size,
+                                   blocker_bufs) != 0) {
+        return 1;
+    }
+    if (setup_release_test_buffers(test_files_dir_path_abs_path,
+                                   "_pe_fail_",
+                                   num_failed_transfers,
+                                   transfer_size,
+                                   failed_bufs) != 0) {
+        return 1;
+    }
+
+    // No progress thread: queue entries are only submitted/reaped by explicit polls.
+    nixlAgentConfig cfg;
+    nixlAgent agent("POSIXPartialEnqueueTester", cfg);
+    nixlBackendH *posix = nullptr;
+    if (agent.createBackend("POSIX", params, posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to create POSIX backend" << std::endl;
+        return 1;
+    }
+
+    if (agent.registerMem(blocker_bufs.dram_for_posix) != NIXL_SUCCESS ||
+        agent.registerMem(blocker_bufs.file_for_posix) != NIXL_SUCCESS ||
+        agent.registerMem(failed_bufs.dram_for_posix) != NIXL_SUCCESS ||
+        agent.registerMem(failed_bufs.file_for_posix) != NIXL_SUCCESS) {
+        std::cerr << "Failed to register memory with NIXL" << std::endl;
+        return 1;
+    }
+
+    print_segment_title(phase_title("Posting a write that fills all but one pool entry"));
+
+    nixlXferReqH *treq_blocker = nullptr;
+    nixl_status_t status = agent.createXferReq(NIXL_WRITE,
+                                               blocker_bufs.dram_for_posix_xfer,
+                                               blocker_bufs.file_for_posix_xfer,
+                                               "POSIXPartialEnqueueTester",
+                                               treq_blocker);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create blocker transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_blocker);
+    if (status != NIXL_IN_PROG) {
+        std::cerr << "Expected blocker transfer to be NIXL_IN_PROG, got: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_blocker);
+        return 1;
+    }
+
+    print_segment_title(phase_title("Failing a write partway through enqueue"));
+
+    nixlXferReqH *treq_failed = nullptr;
+    status = agent.createXferReq(NIXL_WRITE,
+                                 failed_bufs.dram_for_posix_xfer,
+                                 failed_bufs.file_for_posix_xfer,
+                                 "POSIXPartialEnqueueTester",
+                                 treq_failed);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create partial-enqueue transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_blocker);
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_failed);
+    if (status >= 0) {
+        std::cerr << "Expected partial-enqueue post to fail, got: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_failed);
+        agent.releaseXferReq(treq_blocker);
+        return 1;
+    }
+    std::cout << "Post failed as expected with: " << nixlEnumStrings::statusStr(status)
+              << std::endl;
+
+    // The failed post rolled its queued entries back, so the request has nothing
+    // outstanding and the release frees it on the spot.
+    status = agent.releaseXferReq(treq_failed);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to release the failed request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_blocker);
+        return 1;
+    }
+
+    print_segment_title(phase_title("Draining the blocker write"));
+
+    do {
+        status = agent.getXferStatus(treq_blocker);
+        if (status < 0) {
+            std::cerr << "Error during blocker transfer - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq_blocker);
+            return 1;
+        }
+    } while (status == NIXL_IN_PROG);
+
+    status = agent.releaseXferReq(treq_blocker);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to release completed blocker request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    print_segment_title(phase_title("Verifying the failed request did no I/O"));
+
+    for (int i = 0; i < num_failed_transfers; ++i) {
+        struct stat st;
+        if (fstat(failed_bufs.fd[i].fd, &st) != 0) {
+            std::cerr << "fstat failed for failed-request file " << i << std::endl;
+            return 1;
+        }
+        if (st.st_size != 0) {
+            std::cerr << "Failed-request file " << i << " has " << st.st_size
+                      << " bytes; a rolled-back entry was submitted anyway" << std::endl;
+            return 1;
+        }
+    }
+    std::cout << "Files of the failed request are still empty" << std::endl;
+
+    print_segment_title(phase_title("Reposting on the freed pool entries"));
+
+    // The rolled-back entries must be reusable: the same descriptors now post cleanly.
+    nixlXferReqH *treq_retry = nullptr;
+    status = agent.createXferReq(NIXL_WRITE,
+                                 failed_bufs.dram_for_posix_xfer,
+                                 failed_bufs.file_for_posix_xfer,
+                                 "POSIXPartialEnqueueTester",
+                                 treq_retry);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create retry transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_retry);
+    if (status < 0) {
+        std::cerr << "Failed to post retry transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_retry);
+        return 1;
+    }
+
+    do {
+        status = agent.getXferStatus(treq_retry);
+        if (status < 0) {
+            std::cerr << "Error during retry transfer - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq_retry);
+            return 1;
+        }
+    } while (status == NIXL_IN_PROG);
+    agent.releaseXferReq(treq_retry);
+
+    for (int i = 0; i < num_failed_transfers; ++i) {
+        clear_buffer(failed_bufs.dram_addr[i].get(), transfer_size);
+    }
+
+    nixlXferReqH *treq_read = nullptr;
+    status = agent.createXferReq(NIXL_READ,
+                                 failed_bufs.dram_for_posix_xfer,
+                                 failed_bufs.file_for_posix_xfer,
+                                 "POSIXPartialEnqueueTester",
+                                 treq_read);
+    if (status != NIXL_SUCCESS) {
+        std::cerr << "Failed to create read transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        return 1;
+    }
+
+    status = agent.postXferReq(treq_read);
+    if (status < 0) {
+        std::cerr << "Failed to post read transfer request - status: "
+                  << nixlEnumStrings::statusStr(status) << std::endl;
+        agent.releaseXferReq(treq_read);
+        return 1;
+    }
+
+    do {
+        status = agent.getXferStatus(treq_read);
+        if (status < 0) {
+            std::cerr << "Error during read transfer - status: "
+                      << nixlEnumStrings::statusStr(status) << std::endl;
+            agent.releaseXferReq(treq_read);
+            return 1;
+        }
+    } while (status == NIXL_IN_PROG);
+    agent.releaseXferReq(treq_read);
+
+    std::unique_ptr<char[]> expected_buffer = std::make_unique<char[]>(transfer_size);
+    fill_test_pattern(expected_buffer.get(), read_write_test_phrase, transfer_size);
+    for (int i = 0; i < num_failed_transfers; ++i) {
+        if (memcmp(failed_bufs.dram_addr[i].get(), expected_buffer.get(), transfer_size) != 0) {
+            std::cerr << "Retry read-back validation failed for buffer " << i << std::endl;
+            return 1;
+        }
+    }
+    std::cout << "Retry on the rolled-back entries completed and validated" << std::endl;
+
+    agent.deregisterMem(failed_bufs.file_for_posix);
+    agent.deregisterMem(failed_bufs.dram_for_posix);
+    agent.deregisterMem(blocker_bufs.file_for_posix);
+    agent.deregisterMem(blocker_bufs.dram_for_posix);
+
+    return 0;
+}
+
 // Path-mode parser unit checks (POSIX-only since it owns parsePathMeta tests).
 static void
 checkPathModeParser() {
@@ -1468,6 +1715,16 @@ main (int argc, char *argv[]) {
         std::cerr << "Release-Teardown Test failed" << std::endl;
         return 1;
     }
+
+    // Reset phase number for partial-enqueue test
+    phase_num = 1;
+
+    ret = test_posix_partial_enqueue(test_files_dir_path_abs_path, use_uring);
+    if (ret != 0) {
+        std::cerr << "Partial-Enqueue Test failed" << std::endl;
+        return 1;
+    }
+
 
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes #1957. When `nixlPosixBackendReqH::postXfer()` fails partway through its `enqueue()` loop, the entries it already queued now get rolled back into the free pool instead of staying in the shared submission list, where a later poll, typically driven by an unrelated request, would submit them anyway.

Stacked on #2077 (branched from its head, so its commits appear in the diff until it merges; the change of this PR is the last commit). Builds on the direction AlterHoodie proposed in #1957: preflight or rollback under `io_queue_lock_`. Rollback was chosen because it covers any enqueue failure cause, not just pool exhaustion, and needs no capacity accessor on the queue interface.

## Root cause

All three POSIX I/O queues share one submission list (`ios_to_submit_`) and free pool across requests. `enqueue()` moves an entry from the pool to the submission list and stores the request handle as the entry's completion callback context. On a mid-loop `enqueue()` failure (pool exhausted, `NIXL_ERR_NOT_ALLOWED`), `postXfer()` returned the error without removing the entries it had already queued. Every queue's `poll()` calls `post()` first, so the next poll for any request submitted the leftover entries: I/O the caller was told had failed executed against its buffers and files, with a handle the caller had likely released as callback context. On main before #2077 that is a use-after-free once the handle is released; on top of #2077's deferred free the handle survives but is parked until engine teardown, and the spurious I/O still executes.

At the failure point none of the failing batch has been submitted: `postXfer()` calls `post()` only after the loop, and every prep, post, and poll site holds `io_queue_lock_`, so no concurrent poll can submit the batch mid-loop. A pure rollback is therefore exact. Entries already submitted to the kernel (partial `post()`/submit failures) are a separate concern and belong to the cancellation machinery from #1942 and its follow-ups.

## Changes

- `io_queue.h`: new `nixlPosixIOQueue::discardQueued(void *ctx)`, implemented once in `nixlPosixIOQueueImpl` for the AIO, io_uring, and POSIX AIO queues: walk `ios_to_submit_`, return every entry whose `ctx_` matches to `free_ios_`.
- `posix_backend.cpp`: the `enqueue()` error path in `postXfer()` calls `discardQueued(this)` and restores `num_confirmed_ios_ = queue_depth_`, the pre-post invariant, so the request is immediately releasable; with #2077 in place `releaseReqH()` then frees it on the spot instead of parking it until teardown.
- `nixl_posix_test.cpp`: `test_posix_partial_enqueue`, run for both the AIO and io_uring modes. Caps the pool at its 64-entry minimum, posts a 63-descriptor write that stays in flight (no progress thread), then a 2-descriptor write whose second `enqueue()` deterministically fails. Asserts the failed post returns an error, its release succeeds, the blocker drains to completion, the failed request's files are still empty afterwards (any byte in them means a leftover entry was submitted; the drain's polls are exactly the submission path that used to pick it up), and a retry on the same descriptors posts, completes, and validates, proving the rolled-back entries returned to the pool usable.

## Validation

Not buildable on this machine (macOS, no meson toolchain, and the AIO/io_uring queues need Linux), so plugin build and the new test run are deferred to CI.

What was run locally:

- A standalone harness compiling `io_queue.h` (clang, `-std=c++17 -Wall -Wextra`) with a minimal entry type, exercising `discardQueued()` on interleaved entries of two contexts: discarding one context removes exactly its three entries and leaves the other's two, discarding the second empties the list, the pool count returns to 64, and a discard with nothing queued is a no-op. Compile and run both exit 0.
- `git clang-format --diff <branch point>` over the change: `clang-format did not modify any files`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of active transfer cancellation and deferred cleanup.
  * Failed releases remain pollable and can be retried after completion.
  * Prevented unintended I/O and safely rolled back queued operations after submission failures.
  * Improved cleanup of in-progress operations during shutdown.
  * Ensured completed transfers and queued operations are released safely.

* **Tests**
  * Added regression coverage for active-transfer release, shutdown with outstanding transfers, and partial submission failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->