### PR TITLE
fix(posix): defer deletion of active request handles

### DIFF
--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -136,6 +136,25 @@ nixlPosixBackendReqH::nixlPosixBackendReqH(const nixl_xfer_op_t &op,
 }
 
 void
+nixlPosixBackendReqH::release() {
+    if (isComplete()) {
+        delete this;
+        return;
+    }
+
+    NIXL_ERROR << "DANGER: A pending POSIX transfer handle was released while outstanding I/O may "
+                  "still access user buffers";
+    released_ = true;
+}
+
+void
+nixlPosixBackendReqH::deleteIfReleasedAndComplete() {
+    if (released_ && isComplete()) {
+        delete this;
+    }
+}
+
+void
 nixlPosixBackendReqH::ioDone(uint32_t data_size, int error) {
     num_confirmed_ios_++;
     if (error && !transfer_failed_) {
@@ -143,6 +162,7 @@ nixlPosixBackendReqH::ioDone(uint32_t data_size, int error) {
         transfer_failed_ = true;
     }
     logOnPercentStep(num_confirmed_ios_, queue_depth_);
+    deleteIfReleasedAndComplete();
 }
 
 void
@@ -154,6 +174,7 @@ nixlPosixBackendReqH::ioDoneClb(void *ctx, uint32_t data_size, int error) {
 void
 nixlPosixBackendReqH::cancelDone() {
     cancels_seen_++;
+    deleteIfReleasedAndComplete();
 }
 
 void
@@ -381,7 +402,9 @@ nixlPosixEngine::checkXfer(nixlBackendReqH *handle) const {
 nixl_status_t
 nixlPosixEngine::releaseReqH(nixlBackendReqH *handle) const {
     NIXL_ASSERT(handle != nullptr);
-    delete handle;
+    auto &posix_handle = castPosixHandle(handle);
+    NIXL_LOCK_GUARD(io_queue_lock_);
+    posix_handle.release();
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -40,6 +40,8 @@ public:
                          std::unique_ptr<nixlPosixIOQueue> &io_queue);
     ~nixlPosixBackendReqH() {};
 
+    void
+    release();
     nixl_status_t
     postXfer();
     nixl_status_t
@@ -70,6 +72,8 @@ private:
     unsigned
     requestCancellation();
     void
+    deleteIfReleasedAndComplete();
+    void
     ioDone(uint32_t data_size, int error);
     static void
     ioDoneClb(void *ctx, uint32_t data_size, int error);
@@ -89,6 +93,7 @@ private:
     bool cancellation_requested_ = false; // Set when cancellation begins for this transfer
     unsigned cancels_expected_ = 0; // Cancellations expected for this request
     unsigned cancels_seen_ = 0; // Cancellations completed for this request
+    bool released_ = false; // The owning transfer handle was released while I/O was pending
     std::unique_ptr<nixlPosixIOQueue> &io_queue_; // Async I/O queue instance
 };
 


### PR DESCRIPTION
## What?
Free POSIX request handles only if no remaining requests are present. If IOs are outstanding, free only after they complete. 

* It *is* possible that requests without handles still complete. Multiple requests share a backend (aio or one single `io_uring`), thus, polls on other requests can trigger their completion. 
* `io_queue_lock_` is necessary to synchronize access the new `released_` flag and the completed/cancelled counts.
* Clients that use the API correctly (poll to completion) should never run into the case where the backend handle has outstanding IOs. We have observed some production issues where this free causes a segfault (see #2067). I think the root causes is *not* this issue, but the fact that this caused a panic hides relevant python exception information. So in the spirit of defensive coding I think this fix here is correct.

Fixes #1955, related to #2067

## Why?

Use-after-free is bad.

## How?

Do not unconditionally free the handle: If no outstanding IOs, free right away (common case). If ios are outstanding: Complain, then mark request as released, wait for IOs to complete and lazy free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of completed and cancelled asynchronous I/O requests.
  * Prevented premature request destruction while operations are still pending.
  * Ensured released requests are automatically cleaned up once I/O finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->