### PR TITLE
TEST/GTEST: Add SGL variants of the UCX transfer gtests

### DIFF
--- a/test/gtest/common.h
+++ b/test/gtest/common.h
@@ -177,6 +177,7 @@ struct nixlTestParam {
     unsigned numWorkers;
     unsigned numThreads;
     std::string engineConfig;
+    bool sglEnabled = false;
 };
 
 using nixl_test_t = testing::TestWithParam<nixlTestParam>;
@@ -195,5 +196,22 @@ using nixl_test_t = testing::TestWithParam<nixlTestParam>;
         _test_case,                                     \
         testing::ValuesIn(std::vector<nixlTestParam>(   \
             {{_backend, _progress_thread_enabled, _num_workers, _num_threads, _engine_config}})));
+
+#define NIXL_INSTANTIATE_TEST_SGL(_test_name,                                    \
+                                  _test_case,                                    \
+                                  _backend,                                      \
+                                  _progress_thread_enabled,                      \
+                                  _num_workers,                                  \
+                                  _num_threads,                                  \
+                                  _engine_config)                                \
+    INSTANTIATE_TEST_SUITE_P(                                                    \
+        _test_name,                                                              \
+        _test_case,                                                              \
+        testing::ValuesIn(std::vector<nixlTestParam>({{_backend,                 \
+                                                       _progress_thread_enabled, \
+                                                       _num_workers,             \
+                                                       _num_threads,             \
+                                                       _engine_config,           \
+                                                       true}})));
 
 #endif /* TEST_GTEST_COMMON_H */

--- a/test/gtest/test_transfer.cpp
+++ b/test/gtest/test_transfer.cpp
@@ -155,6 +155,10 @@ protected:
         // Disabling Telemetry until the corresponding test
         env.addVar("NIXL_TELEMETRY_ENABLE", "n");
 
+        if (isSglEnabled()) {
+            env.addVar("NIXL_UCX_SGL_ENABLE", "y");
+        }
+
         // Create two agents
         for (size_t i = 0; i < 2; i++) {
             addAgent(i);
@@ -184,6 +188,11 @@ protected:
     size_t
     getNumThreads() const {
         return GetParam().numThreads;
+    }
+
+    bool
+    isSglEnabled() const {
+        return GetParam().sglEnabled;
     }
 
     nixl_opt_args_t
@@ -691,6 +700,14 @@ NIXL_INSTANTIATE_TEST(ucx, TestTransfer, "UCX", true, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_no_pt, TestTransfer, "UCX", false, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_threadpool, TestTransfer, "UCX", true, 6, 4, "");
 NIXL_INSTANTIATE_TEST(ucx_threadpool_no_pt, TestTransfer, "UCX", false, 6, 4, "");
+
+#ifdef HAVE_UCX_SGL_API
+
+NIXL_INSTANTIATE_TEST_SGL(ucx_sgl, TestTransfer, "UCX", true, 2, 0, "");
+NIXL_INSTANTIATE_TEST_SGL(ucx_sgl_no_pt, TestTransfer, "UCX", false, 2, 0, "");
+NIXL_INSTANTIATE_TEST_SGL(ucx_sgl_threadpool, TestTransfer, "UCX", true, 6, 4, "");
+NIXL_INSTANTIATE_TEST_SGL(ucx_sgl_threadpool_no_pt, TestTransfer, "UCX", false, 6, 4, "");
+#endif
 
 NIXL_INSTANTIATE_TEST(ucx_telemetry, TestTransferTelemetry, "UCX", true, 2, 0, "");
 NIXL_INSTANTIATE_TEST(ucx_telemetry_no_pt, TestTransferTelemetry, "UCX", false, 2, 0, "");


### PR DESCRIPTION
Pending https://github.com/openucx/ucx/pull/11841.

## What?
Runs the existing UCX `TestTransfer` gtests as additional variants with `NIXL_UCX_SGL_ENABLE=y`.

## Why?
The UCX plugin's SGL path had no gtest coverage.

## How?
Adds an `sglEnabled` flag to `nixlTestParam` and a `NIXL_INSTANTIATE_TEST_SGL` macro that sets it, with the four new instantiations gated on `HAVE_UCX_SGL_API`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage for scatter-gather list (SGL) transfers in UCX environments.
  - Expanded validation across progress-thread and thread-pool configurations.
  - SGL test coverage is enabled only when the required UCX API is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->