### PR TITLE
test: show registerMem collapses southbound errors to NIXL_ERR_BACKEND

### DIFF
--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -88,6 +88,12 @@ namespace agent {
             return agent_.get();
         }
 
+        /** @brief Return the GMock engine so tests can set `EXPECT_CALL` on it. */
+        mocks::GMockBackendEngine &
+        getGMockEngine() {
+            return gmock_engine_;
+        }
+
         const mocks::GMockBackendEngine &
         getGMockEngine() const {
             return gmock_engine_;
@@ -196,6 +202,10 @@ namespace agent {
         }
     };
 
+    /** @brief Parameterized fixture that injects a southbound `registerMem` error. */
+    class registerMemErrorMappingFixture : public singleAgentSessionFixture,
+                                           public testing::WithParamInterface<nixl_status_t> {};
+
     TEST_F(singleAgentSessionFixture, GetNonExistingPluginTest) {
         nixl_mem_list_t mem;
         nixl_b_params_t params;
@@ -269,6 +279,37 @@ namespace agent {
                   NIXL_SUCCESS);
         EXPECT_EQ(agent_->deregisterMem(reg_dlist, &extra_params), NIXL_SUCCESS);
     }
+
+    /** Distinct plugin `registerMem` errors surface as one northbound `NIXL_ERR_BACKEND`. */
+    TEST_P(registerMemErrorMappingFixture, CollapsesSouthboundErrorToBackendError) {
+        nixl_b_params_t params;
+        nixlBackendH *backend = nullptr;
+        ASSERT_EQ(agent_helper_->createBackendWithGMock(params, backend), NIXL_SUCCESS);
+
+        EXPECT_CALL(agent_helper_->getGMockEngine(),
+                    registerMem(testing::_, testing::_, testing::_))
+            .WillOnce(testing::Return(GetParam()));
+
+        blob test_blob;
+        nixl_opt_args_t extra_params;
+        nixl_reg_dlist_t reg_dlist(DRAM_SEG);
+        const nixl_status_t status =
+            agent_helper_->initAndRegisterMemory(test_blob, reg_dlist, extra_params, backend);
+
+        EXPECT_EQ(status, NIXL_ERR_BACKEND)
+            << "injected southbound status: " << nixlEnumStrings::statusStr(GetParam());
+    }
+
+    INSTANTIATE_TEST_SUITE_P(RepresentativeSouthboundErrors,
+                             registerMemErrorMappingFixture,
+                             testing::Values(NIXL_ERR_INVALID_PARAM,
+                                             NIXL_ERR_NOT_FOUND,
+                                             NIXL_ERR_MISMATCH,
+                                             NIXL_ERR_NOT_SUPPORTED,
+                                             NIXL_ERR_CANCELED),
+                             [](const testing::TestParamInfo<nixl_status_t> &info) {
+                                 return nixlEnumStrings::statusStr(info.param);
+                             });
 
     TEST_F(singleAgentSessionFixture, RegisterDeregisterMemRepeatedTest) {
         constexpr int kWarmupIters = 3;


### PR DESCRIPTION
Parameterize MOCK_BACKEND registerMem failures so distinct plugin statuses are asserted to surface as one northbound backend error.

What?
Adds a parameterized registerMem unit test that injects distinct southbound plugin errors via MOCK_BACKEND and asserts the agent always returns NIXL_ERR_BACKEND.

Why?
Northbound nixlAgent::registerMem is best-effort: if no backend succeeds, it drops the original southbound status and surfaces a single backend error. Callers and Python bindings cannot tell INVALID_PARAM from NOT_FOUND (and similar). This test locks that mapping so the API behavior is formalized in a test.

How?
registerMemErrorMappingFixture stubs GMockBackendEngine::registerMem to return one of NIXL_ERR_INVALID_PARAM, NIXL_ERR_NOT_FOUND, NIXL_ERR_MISMATCH, NIXL_ERR_NOT_SUPPORTED, or NIXL_ERR_CANCELED, then checks the agent result is NIXL_ERR_BACKEND. No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of southbound registration errors by mapping representative backend failures to a consistent registration error.
  * Registration failures now provide more predictable error behavior across supported backend scenarios.

* **Tests**
  * Added coverage for registration-memory error mapping scenarios.
  * Added parameterized validation for representative backend registration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->