### PR TITLE
gpunetio: fix OOB read on malformed remote metadata and metadata leaks on error paths

### DIFF
--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1008,6 +1008,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
 
     if (it == gdevs.end()) {
         NIXL_ERROR << "Can't register memory for unknown device " << mem.devId;
+        delete priv;
         return NIXL_ERR_INVALID_PARAM;
     }
 
@@ -1017,6 +1018,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        delete priv;
         return NIXL_ERR_BACKEND;
     }
 
@@ -1060,6 +1062,7 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
 
     if (search == remoteConnMap.end()) {
         NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
+        delete md;
         return NIXL_ERR_NOT_FOUND;
     }
 
@@ -1072,6 +1075,13 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     while (std::getline(ss, token, info_delimiter))
         tokens.push_back(token);
 
+    if (tokens.size() < 3) {
+        NIXL_ERROR << "err: malformed remote metadata (expected 3 fields) for agent "
+                   << remote_agent;
+        delete md;
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
     uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
     uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
     size_t tot_size = static_cast<size_t>(atol(tokens[2].c_str()));
@@ -1082,6 +1092,7 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        delete md;
         return NIXL_ERR_BACKEND;
     }
 


### PR DESCRIPTION
## Problem

Three defects in `src/plugins/gpunetio/gpunetio_backend.cpp`, all on error paths:

1. **Out-of-bounds read.** `loadRemoteMD` splits the remote metadata blob into `tokens`, then indexes `tokens[0]`, `tokens[1]`, `tokens[2]` with no count check:

   ```cpp
   while (std::getline(ss, token, info_delimiter)) tokens.push_back(token);
   uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
   uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
   size_t tot_size = static_cast<size_t>(atol(tokens[2].c_str()));
   ```
   A remote agent whose `metaInfo` has fewer than three `info_delimiter`-separated fields causes an out-of-bounds `std::vector` read.

2. **Leak.** `loadRemoteMD` `new`s `md` (`nixlDocaPublicMetadata`) up front but returns `NIXL_ERR_NOT_FOUND` (unknown remote agent) and `NIXL_ERR_BACKEND` (mr construction throws) without freeing it.

3. **Leak.** `registerMem` `new`s `priv` (`nixlDocaPrivateMetadata`) up front but returns `NIXL_ERR_INVALID_PARAM` (unknown device) and `NIXL_ERR_BACKEND` (mr construction throws) without freeing it.

## Fix

Reject a `tokens.size() < 3` blob before indexing, and free `md` / `priv` on the error-return paths. The success paths transfer ownership via `output` / `out`, so there is no double free.

## Testing

Static change confined to error-path cleanup. This backend requires the DOCA + GPUNetIO libraries, which I don't have on my dev box, so I have not built the plugin here; the edits are localized to the failure paths and mirror the ownership already established on the success path. Brace balance verified.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory cleanup when device registration, remote connection lookup, or remote memory setup fails.
  * Added validation for incomplete remote metadata to prevent invalid processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->