### PR TITLE
[GPUNetIO] Support peer-GPU multi-rank writes

### DIFF
--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -512,6 +512,7 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 ```
 --gpunetio_device_list LIST # Comma-separated GPU CUDA device id for GPUNETIO
 --gpunetio_oob_list IFACE  # OOB interface; set explicitly for bonded network devices
+--gpunetio_oob_port PORT   # OOB TCP port; use a distinct port per colocated backend
 --gpunetio_gid_index N     # RoCE GID table index (default: 0)
 ```
 

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -511,6 +511,8 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 **GPUNETIO Backend:**
 ```
 --gpunetio_device_list LIST # Comma-separated GPU CUDA device id for GPUNETIO
+--gpunetio_oob_list IFACE  # OOB interface; set explicitly for bonded network devices
+--gpunetio_gid_index N     # RoCE GID table index (default: 0)
 ```
 
 **OBJ (S3) Backend:**

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,10 +175,9 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
-NB_ARG_STRING(
-    gpunetio_gid_index,
-    "",
-    "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
+NB_ARG_STRING(gpunetio_gid_index,
+              "",
+              "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,6 +175,10 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
+NB_ARG_STRING(
+    gpunetio_gid_index,
+    "",
+    "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");
@@ -292,6 +296,7 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
+std::string xferBenchConfig::gpunetio_gid_index = "";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
@@ -479,6 +484,7 @@ xferBenchConfig::loadParams(void) {
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             gpunetio_device_list = NB_ARG(gpunetio_device_list);
             gpunetio_oob_list = NB_ARG(gpunetio_oob_list);
+            gpunetio_gid_index = NB_ARG(gpunetio_gid_index);
         }
 
         // Load HD3FS-specific configurations if backend is HD3FS
@@ -897,6 +903,7 @@ xferBenchConfig::printConfig() {
                         gpunetio_device_list);
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
+            printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -178,6 +178,9 @@ NB_ARG_STRING(
 NB_ARG_STRING(gpunetio_gid_index,
               "0",
               "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
+NB_ARG_STRING(gpunetio_oob_port,
+              "",
+              "OOB TCP port for GPUNetIO (only used with nixl worker; default: 6544)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");
@@ -296,6 +299,7 @@ int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
 std::string xferBenchConfig::gpunetio_gid_index = "0";
+std::string xferBenchConfig::gpunetio_oob_port = "";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
@@ -484,6 +488,7 @@ xferBenchConfig::loadParams(void) {
             gpunetio_device_list = NB_ARG(gpunetio_device_list);
             gpunetio_oob_list = NB_ARG(gpunetio_oob_list);
             gpunetio_gid_index = NB_ARG(gpunetio_gid_index);
+            gpunetio_oob_port = NB_ARG(gpunetio_oob_port);
         }
 
         // Load HD3FS-specific configurations if backend is HD3FS
@@ -903,6 +908,7 @@ xferBenchConfig::printConfig() {
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
             printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
+            printOption("OOB TCP port (--gpunetio_oob_port=N)", gpunetio_oob_port);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -176,7 +176,7 @@ NB_ARG_STRING(
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
 NB_ARG_STRING(gpunetio_gid_index,
-              "",
+              "0",
               "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
@@ -295,7 +295,7 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
-std::string xferBenchConfig::gpunetio_gid_index = "";
+std::string xferBenchConfig::gpunetio_gid_index = "0";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -202,6 +202,7 @@ public:
     static int gds_mt_num_threads;
     static std::string gpunetio_device_list;
     static std::string gpunetio_oob_list;
+    static std::string gpunetio_gid_index;
     static long page_size;
     static std::string obj_access_key;
     static std::string obj_secret_key;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -203,6 +203,7 @@ public:
     static std::string gpunetio_device_list;
     static std::string gpunetio_oob_list;
     static std::string gpunetio_gid_index;
+    static std::string gpunetio_oob_port;
     static long page_size;
     static std::string obj_access_key;
     static std::string obj_secret_key;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -227,10 +227,12 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GPUNETIO)) {
         std::cout << "GPUNETIO backend, network device " << devices[0] << " GPU device "
                   << xferBenchConfig::gpunetio_device_list << " OOB interface "
-                  << xferBenchConfig::gpunetio_oob_list << std::endl;
+                  << xferBenchConfig::gpunetio_oob_list << " GID index "
+                  << xferBenchConfig::gpunetio_gid_index << std::endl;
         backend_params["network_devices"] = devices[0];
         backend_params["gpu_devices"] = xferBenchConfig::gpunetio_device_list;
         backend_params["oob_interface"] = xferBenchConfig::gpunetio_oob_list;
+        backend_params["gid_index"] = xferBenchConfig::gpunetio_gid_index;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE)) {
         std::cout << "Mooncake backend" << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_HF3FS)) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -228,11 +228,16 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
         std::cout << "GPUNETIO backend, network device " << devices[0] << " GPU device "
                   << xferBenchConfig::gpunetio_device_list << " OOB interface "
                   << xferBenchConfig::gpunetio_oob_list << " GID index "
-                  << xferBenchConfig::gpunetio_gid_index << std::endl;
+                  << xferBenchConfig::gpunetio_gid_index << " OOB port "
+                  << (xferBenchConfig::gpunetio_oob_port.empty() ?
+                          "6544" :
+                          xferBenchConfig::gpunetio_oob_port)
+                  << std::endl;
         backend_params["network_devices"] = devices[0];
         backend_params["gpu_devices"] = xferBenchConfig::gpunetio_device_list;
         backend_params["oob_interface"] = xferBenchConfig::gpunetio_oob_list;
         backend_params["gid_index"] = xferBenchConfig::gpunetio_gid_index;
+        backend_params["oob_port"] = xferBenchConfig::gpunetio_oob_port;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE)) {
         std::cout << "Mooncake backend" << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_HF3FS)) {

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -34,11 +34,12 @@ Stream pool mode instead is when applications mostly wants to process data on th
 
 ## Input parameters
 
-DOCA GPUNetIO backend takes 3 input parameters:
+DOCA GPUNetIO backend takes 5 input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
-- oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
+- oob_interface: network interface to be used when exchanging control info during initiator/target connection. Set this explicitly for bonded network devices whose IPv4 address cannot be obtained from DOCA.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
+- gid_index: RoCE GID table index. Defaults to 0; use the GID corresponding to the selected RoCE path.
 
 ## Example
 

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -34,9 +34,10 @@ Stream pool mode instead is when applications mostly wants to process data on th
 
 ## Input parameters
 
-DOCA GPUNetIO backend takes 5 input parameters:
+DOCA GPUNetIO backend takes these input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
 - oob_interface: network interface to be used when exchanging control info during initiator/target connection. Set this explicitly for bonded network devices whose IPv4 address cannot be obtained from DOCA.
+- oob_port: TCP port used to listen for OOB connection setup. Defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
 - gid_index: RoCE GID table index. Defaults to 0; use the GID corresponding to the selected RoCE path.

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1217,9 +1217,12 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     uint32_t desc_offset = 0;
     do {
-        auto &request = xferReqRingCpu[pos];
-        while (desc_offset < lcnt && request.num < DOCA_XFER_REQ_SIZE) {
-            const uint32_t idx = request.num;
+        // Build in cacheable CPU memory, then publish the request with one
+        // sequential copy to the GPU-mapped ring.
+        docaXferReqGpu staged_req{};
+        staged_req.has_notif_msg_idx = DOCA_NOTIF_NULL;
+        while (desc_offset < lcnt && staged_req.num < DOCA_XFER_REQ_SIZE) {
+            const uint32_t idx = staged_req.num;
             const uint32_t desc_idx = desc_offset;
             const size_t lsize = local[desc_idx].len;
             const size_t rsize = remote[desc_idx].len;
@@ -1228,13 +1231,13 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
             lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
 
-            request.lbuf[idx] = local[desc_idx].addr;
-            request.lkey[idx] = lmd->mr->get_lkey();
-            request.rbuf[idx] = remote[desc_idx].addr;
-            request.rkey[idx] = rmd->mr->get_rkey();
-            request.size[idx] = lsize;
-            request.num_sge[idx] = 1;
-            request.num++;
+            staged_req.lbuf[idx] = local[desc_idx].addr;
+            staged_req.lkey[idx] = lmd->mr->get_lkey();
+            staged_req.rbuf[idx] = remote[desc_idx].addr;
+            staged_req.rkey[idx] = rmd->mr->get_rkey();
+            staged_req.size[idx] = lsize;
+            staged_req.num_sge[idx] = 1;
+            staged_req.num++;
 
             // Keep sparse local rows direct: adjacent remote ranges can share
             // one two-SGE RDMA WRITE WQE without a gather buffer. Preserve the
@@ -1251,21 +1254,22 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                 const bool contiguous_remote =
                     next_remote >= current_remote && next_remote - current_remote == rsize;
                 if (next_lsize == next_rsize && contiguous_remote &&
-                    next_rmd->mr->get_rkey() == request.rkey[idx]) {
-                    request.lbuf2[idx] = local[desc_idx + 1].addr;
-                    request.lkey2[idx] = next_lmd->mr->get_lkey();
-                    request.size2[idx] = next_lsize;
-                    request.num_sge[idx] = 2;
+                    next_rmd->mr->get_rkey() == staged_req.rkey[idx]) {
+                    staged_req.lbuf2[idx] = local[desc_idx + 1].addr;
+                    staged_req.lkey2[idx] = next_lmd->mr->get_lkey();
+                    staged_req.size2[idx] = next_lsize;
+                    staged_req.num_sge[idx] = 2;
                     ++desc_offset;
                 }
             }
             ++desc_offset;
         }
 
-        request.last_rsvd = last_rsvd_flags;
-        request.last_posted = last_posted_flags;
-        request.qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
-        request.qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
+        staged_req.last_rsvd = last_rsvd_flags;
+        staged_req.last_posted = last_posted_flags;
+        staged_req.qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
+        staged_req.qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
+        memcpy(&xferReqRingCpu[pos], &staged_req, sizeof(staged_req));
 
         if (desc_offset < lcnt) {
             pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "gpunetio_backend.h"
-#include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
 #include <iterator>
@@ -147,6 +146,8 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     gid_index = parseGidIndex((*custom_params)["gid_index"]);
     NIXL_INFO << "RoCE GID index: " << gid_index;
 
+    local_port = parseGpunetioOobPort((*custom_params)["oob_port"]);
+    NIXL_INFO << "OOB listen port: " << local_port;
     /* Open DOCA device */
     verbs_context = open_ib_device((char *)(ndevs[0].c_str()));
     if (verbs_context == nullptr) {
@@ -566,21 +567,21 @@ nixlDocaEngine::progressThreadStart() {
     if (oobdev.size() > 0 && oobdev[0] != "") {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         /* Bind to the set port and IP: */
-        addr_in->sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        addr_in->sin_port = htons(local_port);
         if (bind(oob_sock_server, (struct sockaddr *)addr_in, sizeof(struct sockaddr_in)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
     } else {
         /* Set port and IP: */
         server_addr.sin_family = AF_INET;
-        server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        server_addr.sin_port = htons(local_port);
         server_addr.sin_addr.s_addr = INADDR_ANY; /* listen on any interface */
 
         /* Bind to the set port and IP: */
         if (bind(oob_sock_server, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
@@ -620,7 +621,7 @@ nixlDocaEngine::progressThreadStop() {
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd);
+    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
     close(oob_sock_server);
@@ -1004,7 +1005,7 @@ nixlDocaEngine::getConnInfo(std::string &str) const {
     std::stringstream ss;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
-    str = ss.str();
+    str = formatGpunetioOobEndpoint(ss.str(), local_port);
     return NIXL_SUCCESS;
 }
 
@@ -1029,17 +1030,20 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     // TODO: Connect part should be moved into connect() method
     nixlDocaConnection conn;
-    size_t size = remote_conn_info.size();
-    // TODO: eventually std::byte?
-    char *addr = new char[size];
-
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    GpunetioOobEndpoint endpoint;
+    try {
+        endpoint = parseGpunetioOobEndpoint(remote_conn_info);
+    }
+    catch (const std::invalid_argument &error) {
+        NIXL_ERROR << error.what();
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(endpoint.ipv4.c_str(), &oob_sock_client, endpoint.port);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
@@ -1062,8 +1066,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -18,6 +18,7 @@
 #include "gpunetio_backend.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <cerrno>
 #include <iterator>
 #include <stdexcept>
 #include <unistd.h>
@@ -68,6 +69,40 @@ parseGidIndex(const std::string &value) {
     }
 
     return parsed_value;
+}
+
+bool
+sendAll(int fd, const void *buffer, size_t size) {
+    const auto *cursor = static_cast<const uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t sent = send(fd, cursor, size, 0);
+        if (sent < 0 && errno == EINTR) {
+            continue;
+        }
+        if (sent <= 0) {
+            return false;
+        }
+        cursor += sent;
+        size -= static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+bool
+recvAll(int fd, void *buffer, size_t size) {
+    auto *cursor = static_cast<uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t received = recv(fd, cursor, size, 0);
+        if (received < 0 && errno == EINTR) {
+            continue;
+        }
+        if (received <= 0) {
+            return false;
+        }
+        cursor += received;
+        size -= static_cast<size_t>(received);
+    }
+    return true;
 }
 } // namespace
 
@@ -344,7 +379,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         }
     }
 
-    ((volatile uint8_t *)wait_exit_cpu)[0] = 0;
+    *reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) = 0;
 
     result = doca_gpu_mem_alloc(gdevs[0].second,
                                 sizeof(struct docaNotif),
@@ -414,7 +449,7 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before progressThreadStop ";
     progressThreadStop();
 
-    ((volatile uint8_t *)wait_exit_cpu)[0] = 1;
+    *reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) = 1;
     NIXL_DEBUG << "Before cudaStreamSynchronize ";
     nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
     nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
@@ -701,26 +736,26 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     NIXL_DEBUG << "connectClientRdmaQp: Send to server data qp connection details";
     // Data QP
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     // Notif QP
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send LID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -728,7 +763,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -736,19 +771,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -793,7 +828,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 sync:
     connectLock.unlock();
     NIXL_DEBUG << "Client recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -807,7 +842,7 @@ sync:
     }
 
     NIXL_DEBUG << "Client sending rack" << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -823,7 +858,7 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
     size_t msg_size;
 
     // Msg
-    if (recv(oob_sock_client, &msg_size, sizeof(size_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &msg_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to recv msg details";
         close(oob_sock_client);
         return NIXL_ERR_BACKEND;
@@ -837,7 +872,7 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
 
     remote_agent.resize(msg_size);
 
-    if (recv(oob_sock_client, remote_agent.data(), msg_size, 0) < 0) {
+    if (!recvAll(oob_sock_client, remote_agent.data(), msg_size)) {
         NIXL_ERROR << "Failed to recv msg details";
         close(oob_sock_client);
         return NIXL_ERR_BACKEND;
@@ -850,12 +885,12 @@ nixl_status_t
 nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
     size_t agent_size = localAgent.size();
 
-    if (send(oob_sock_client, &agent_size, sizeof(size_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &agent_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, localAgent.c_str(), localAgent.size(), 0) < 0) {
+    if (!sendAll(oob_sock_client, localAgent.c_str(), localAgent.size())) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
@@ -875,7 +910,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -883,19 +918,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -903,7 +938,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -911,20 +946,20 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server Send remote notif qp connection details 4";
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send local GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -973,14 +1008,14 @@ sync:
     connectLock.unlock();
 
     NIXL_DEBUG << "Server send rack " << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -1386,6 +1421,9 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
 nixl_status_t
 nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
+    if (*reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) != 0) {
+        return NIXL_ERR_BACKEND;
+    }
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
@@ -1416,6 +1454,9 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
+    if (*reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) != 0) {
+        return NIXL_ERR_BACKEND;
+    }
     uint32_t recv_idx;
     std::string msg_src;
     char *addr;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -75,7 +75,7 @@ bool
 sendAll(int fd, const void *buffer, size_t size) {
     const auto *cursor = static_cast<const uint8_t *>(buffer);
     while (size > 0) {
-        const ssize_t sent = send(fd, cursor, size, 0);
+        const ssize_t sent = send(fd, cursor, size, MSG_NOSIGNAL);
         if (sent < 0 && errno == EINTR) {
             continue;
         }
@@ -438,7 +438,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     lastPostedReq = 0;
     xferRingPos = 0;
 
-    progressThreadStart();
+    if (progressThreadStart() != NIXL_SUCCESS) {
+        throw std::runtime_error("Failed to start GPUNETIO connection thread");
+    }
 }
 
 nixl_mem_list_t
@@ -479,6 +481,9 @@ nixlDocaEngine::~nixlDocaEngine() {
 
     NIXL_DEBUG << "Before qpMap.clear ";
 
+    for (auto &entry : qpMap) {
+        delete entry.second;
+    }
     qpMap.clear();
 
     result = doca_dev_close(ddev);
@@ -499,7 +504,6 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
-    struct nixlDocaNotif *notif;
     ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     std::lock_guard<std::mutex> lock(notifLock);
@@ -509,7 +513,7 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         return NIXL_SUCCESS;
     }
 
-    notif = new struct nixlDocaNotif;
+    auto notif = std::make_unique<nixlDocaNotif>();
 
     notif->elems_num = DOCA_MAX_NOTIF_INFLIGHT;
     notif->elems_size = DOCA_MAX_NOTIF_MESSAGE_SIZE;
@@ -526,12 +530,15 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
 
     notif->recv_addr = (uint8_t *)calloc(notif->elems_size * notif->elems_num, sizeof(uint8_t));
     if (notif->recv_addr == nullptr) {
         NIXL_ERROR << "Can't alloc memory for send notif";
+        notif->send_mr.reset();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
     memset(notif->recv_addr, 0, notif->elems_size * notif->elems_num);
@@ -542,6 +549,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        notif->send_mr.reset();
+        free(notif->send_addr);
+        free(notif->recv_addr);
         return NIXL_ERR_BACKEND;
     }
 
@@ -549,13 +559,23 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->recv_pi = 0;
 
     // Ensure notif list is not added twice for the same peer
-    notifMap[remote_agent] = notif;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
+    auto *notif_ptr = notif.get();
+    notifMap[remote_agent] = notif.release();
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
+    {
+        std::lock_guard<std::mutex> qp_lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            nixlDocaDestroyNotif(gpu, notifMap.extract(remote_agent).mapped());
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+    }
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif_ptr->recv_addr;
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif_ptr->recv_mr->get_lkey();
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif_ptr->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
-        qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
         ;
 
@@ -566,6 +586,10 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
 
 nixl_status_t
 nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif) {
+    notif->send_mr.reset();
+    notif->recv_mr.reset();
+    free(notif->send_addr);
+    free(notif->recv_addr);
     delete notif;
 
     return NIXL_SUCCESS;
@@ -590,12 +614,6 @@ nixlDocaEngine::progressThreadStart() {
         return NIXL_ERR_NOT_SUPPORTED;
     }
     NIXL_INFO << "DOCA Server socket created successfully";
-
-    if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable))) {
-        NIXL_ERROR << "Error setting socket options";
-        close(oob_sock_server);
-        return NIXL_ERR_NOT_SUPPORTED;
-    }
 
     if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable))) {
         NIXL_ERROR << "Error setting socket options";
@@ -629,7 +647,7 @@ nixlDocaEngine::progressThreadStart() {
     NIXL_INFO << "Done with binding";
 
     /* Listen for clients: */
-    if (listen(oob_sock_server, 1) < 0) {
+    if (listen(oob_sock_server, SOMAXCONN) < 0) {
         NIXL_ERROR << "Error while listening";
         close(oob_sock_server);
         return NIXL_ERR_NOT_SUPPORTED;
@@ -645,6 +663,9 @@ nixlDocaEngine::progressThreadStart() {
     result = pthread_create(&server_thread_id, nullptr, threadProgressFunc, (void *)this);
     if (result != 0) {
         NIXL_ERROR << "Failed to create threadProgressFunc thread";
+        close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_BACKEND;
     }
 
@@ -653,18 +674,24 @@ nixlDocaEngine::progressThreadStart() {
 
 void
 nixlDocaEngine::progressThreadStop() {
-    int fake_sock_fd;
+    int fake_sock_fd = -1;
     std::stringstream ss;
 
     ACCESS_ONCE(*pthrStop) = 1;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
+    if (oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port) < 0) {
+        shutdown(oob_sock_server, SHUT_RDWR);
+    }
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
     close(oob_sock_server);
-    close(fake_sock_fd);
+    if (fake_sock_fd >= 0) {
+        close(fake_sock_fd);
+    }
+    free((void *)pthrStop);
+    pthrStop = nullptr;
 }
 
 uint32_t
@@ -674,7 +701,6 @@ nixlDocaEngine::getGpuCudaId() {
 
 nixl_status_t
 nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
-    struct nixlDocaRdmaQp *rdma_qp;
     ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     std::lock_guard<std::mutex> lock(qpLock);
@@ -688,7 +714,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
 
-    rdma_qp = new struct nixlDocaRdmaQp;
+    auto rdma_qp = std::make_unique<nixlDocaRdmaQp>();
 
     try {
         rdma_qp->qp_data =
@@ -725,7 +751,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     rdma_qp->qpn_notif = doca_verbs_qp_get_qpn(rdma_qp->qp_notif->get_qp());
 
-    qpMap[remote_agent] = rdma_qp;
+    qpMap[remote_agent] = rdma_qp.release();
 
     NIXL_DEBUG << "DOCA addRdmaQp new QP added for " << remote_agent;
 
@@ -735,8 +761,22 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 nixl_status_t
 nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent];
+    struct nixlDocaRdmaQp *rdma_qp;
+    uint32_t remote_qpn_data;
+    uint32_t remote_qpn_notif;
+    doca_verbs_gid remote_gid{};
+    uint32_t remote_lid;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            NIXL_ERROR << "Can't find QP for remote agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "connectClientRdmaQp: Send to server data qp connection details";
     // Data QP
@@ -767,7 +807,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -775,19 +815,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -803,13 +843,15 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -818,11 +860,8 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -830,6 +869,10 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     }
 
 sync:
+    // Record the QP transition before the final control ACK. If that ACK fails,
+    // a retry must reuse the RTS QP rather than trying to transition it again.
+    // remoteConnMap is published only after the ACK succeeds.
+    connMap[remote_agent] = 1;
     connectLock.unlock();
     NIXL_DEBUG << "Client recv lack";
     if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
@@ -852,8 +895,6 @@ sync:
         return NIXL_ERR_BACKEND;
     }
 
-    connMap[remote_agent] = 1;
-
     return NIXL_SUCCESS;
 }
 
@@ -864,13 +905,11 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
     // Msg
     if (!recvAll(oob_sock_client, &msg_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
     if (msg_size == 0) {
         NIXL_ERROR << "recvRemoteAgentName received msg size 0";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
@@ -878,7 +917,6 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
 
     if (!recvAll(oob_sock_client, remote_agent.data(), msg_size)) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
@@ -907,14 +945,28 @@ nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
 nixl_status_t
 nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent]; // validate
+    struct nixlDocaRdmaQp *rdma_qp;
+    uint32_t remote_qpn_data;
+    uint32_t remote_qpn_notif;
+    doca_verbs_gid remote_gid{};
+    uint32_t remote_lid;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            NIXL_ERROR << "Can't find QP for remote agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "DOCA connectServerRdmaQp for agent " << remote_agent.c_str();
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -922,19 +974,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -979,13 +1031,15 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -994,11 +1048,8 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -1069,8 +1120,11 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     // TODO: Connect part should be moved into connect() method
     nixlDocaConnection conn;
-    if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
 
     GpunetioOobEndpoint endpoint;
@@ -1089,17 +1143,36 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
+    status = addRdmaQp(remote_agent);
+    if (status != NIXL_SUCCESS && status != NIXL_IN_PROG) {
+        close(oob_sock_client);
+        return status;
+    }
+    status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
+    status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
 
     conn.remoteAgent = remote_agent;
     conn.connected = true;
     // if client or server already created this QP, no need to re-create
-    if (remoteConnMap.find(remote_agent) == remoteConnMap.end()) {
-        remoteConnMap[remote_agent] = conn;
-        NIXL_INFO << "remoteConnMap extended with remote agent " << remote_agent << std::endl;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        if (remoteConnMap.find(remote_agent) == remoteConnMap.end()) {
+            remoteConnMap[remote_agent] = conn;
+            NIXL_INFO << "remoteConnMap extended with remote agent " << remote_agent << std::endl;
+        }
     }
 
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
@@ -1116,7 +1189,7 @@ nixl_status_t
 nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
                             const nixl_mem_t &nixl_mem,
                             nixlBackendMD *&out) {
-    nixlDocaPrivateMetadata *priv = new nixlDocaPrivateMetadata;
+    auto priv = std::make_unique<nixlDocaPrivateMetadata>();
     std::stringstream ss;
 
     auto it = std::find_if(gdevs.begin(), gdevs.end(), [&mem](std::pair<uint32_t, doca_gpu *> &x) {
@@ -1152,7 +1225,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
        << info_delimiter << ((size_t)priv->mr->get_tot_size());
     priv->remoteMrStr = ss.str();
 
-    out = (nixlBackendMD *)priv;
+    out = priv.release();
 
     return NIXL_SUCCESS;
 }
@@ -1182,15 +1255,16 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     nixlDocaConnection conn;
     std::vector<std::string> tokens;
     std::string token;
-    nixlDocaPublicMetadata *md = new nixlDocaPublicMetadata;
-    auto search = remoteConnMap.find(remote_agent);
-
-    if (search == remoteConnMap.end()) {
-        NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
-        return NIXL_ERR_NOT_FOUND;
+    auto md = std::make_unique<nixlDocaPublicMetadata>();
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        auto search = remoteConnMap.find(remote_agent);
+        if (search == remoteConnMap.end()) {
+            NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
+            return NIXL_ERR_NOT_FOUND;
+        }
+        conn = search->second;
     }
-
-    conn = (nixlDocaConnection)search->second;
 
     // directly copy underlying conn struct
     md->conn = conn;
@@ -1199,9 +1273,32 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     while (std::getline(ss, token, info_delimiter))
         tokens.push_back(token);
 
-    uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
-    uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
-    size_t tot_size = static_cast<size_t>(atol(tokens[2].c_str()));
+    if (tokens.size() != 3) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    uint32_t rkey;
+    uintptr_t addr;
+    size_t tot_size;
+    try {
+        size_t parsed = 0;
+        const auto parsed_rkey = std::stoull(tokens[0], &parsed);
+        if (parsed != tokens[0].size() || parsed_rkey > UINT32_MAX) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rkey = static_cast<uint32_t>(parsed_rkey);
+        addr = static_cast<uintptr_t>(std::stoull(tokens[1], &parsed));
+        if (parsed != tokens[1].size()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        tot_size = static_cast<size_t>(std::stoull(tokens[2], &parsed));
+        if (parsed != tokens[2].size()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+    catch (const std::exception &) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     // Empty mmap, filled with imported data
     try {
@@ -1212,13 +1309,14 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
         return NIXL_ERR_BACKEND;
     }
 
-    output = (nixlBackendMD *)md;
+    output = md.release();
 
     return NIXL_SUCCESS;
 }
 
 nixl_status_t
 nixlDocaEngine::unloadMD(nixlBackendMD *input) {
+    delete static_cast<nixlDocaPublicMetadata *>(input);
     return NIXL_SUCCESS;
 }
 
@@ -1266,13 +1364,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         return NIXL_ERR_NOT_SUPPORTED;
     }
 
-    auto search = qpMap.find(remote_agent);
-    if (search == qpMap.end()) {
-        NIXL_ERROR << "Can't find remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto search = qpMap.find(remote_agent);
+        if (search == qpMap.end()) {
+            NIXL_ERROR << "Can't find remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = search->second;
     }
-
-    rdma_qp = search->second;
 
     treq = new nixlDocaBckndReq;
     auto abandon_request = [&]() {
@@ -1373,14 +1473,16 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
 
-        auto search = notifMap.find(remote_agent);
-        if (search == notifMap.end()) {
-            NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
-            abandon_request();
-            return NIXL_ERR_INVALID_PARAM;
+        {
+            std::lock_guard<std::mutex> lock(notifLock);
+            auto search = notifMap.find(remote_agent);
+            if (search == notifMap.end()) {
+                NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+                abandon_request();
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            notif = search->second;
         }
-
-        notif = search->second;
 
         // Check notifMsg size
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
@@ -1425,19 +1527,26 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
     ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     for (uint32_t idx : treq->positions) {
+        doca_error_t result;
         xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
         completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
         completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
 
         switch (operation) {
         case NIXL_READ:
-            doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
+            result =
+                doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
             break;
         case NIXL_WRITE:
-            doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
+            result =
+                doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
             break;
         default:
             return NIXL_ERR_INVALID_PARAM;
+        }
+        if (result != DOCA_SUCCESS) {
+            *reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) = 1;
+            return NIXL_ERR_BACKEND;
         }
     }
 
@@ -1555,7 +1664,15 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
         progress->msg_num = 0;
         notifProgressPeer = notif.first;
         notifProgressCursor = (peer_index + 1) % peer_count;
-        progress->qp_gpu = qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
+        {
+            std::lock_guard<std::mutex> qp_lock(qpLock);
+            auto qp = qpMap.find(notif.first);
+            if (qp == qpMap.end()) {
+                notifProgressPeer.clear();
+                return NIXL_ERR_BACKEND;
+            }
+            progress->qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+        }
         std::atomic_thread_fence(std::memory_order_seq_cst);
         break;
     }
@@ -1566,13 +1683,19 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
 nixl_status_t
 nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg) const {
     struct nixlDocaNotif *notif;
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
     uint32_t buf_idx;
     uintptr_t msg_buf;
 
-    auto searchNotif = notifMap.find(remote_agent);
-    if (searchNotif == notifMap.end()) {
-        NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent << std::endl;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(notifLock);
+        auto searchNotif = notifMap.find(remote_agent);
+        if (searchNotif == notifMap.end()) {
+            NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent
+                       << std::endl;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif = searchNotif->second;
     }
 
     // 16B is uint16_t msg size
@@ -1583,12 +1706,14 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    notif = searchNotif->second;
-
-    auto searchQp = qpMap.find(remote_agent);
-    if (searchQp == qpMap.end()) {
-        NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto searchQp = qpMap.find(remote_agent);
+        if (searchQp == qpMap.end()) {
+            NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = searchQp->second->qp_notif->get_qp_gpu_dev();
     }
 
     std::string newMsg = msg_tag_start + std::to_string((int)msg.size()) + msg_tag_end + msg;
@@ -1604,8 +1729,7 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     ((volatile struct docaNotif *)notif_send_cpu)->msg_lkey = notif->send_mr->get_lkey();
     ((volatile struct docaNotif *)notif_send_cpu)->msg_size = newMsg.size();
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu =
-        searchQp->second->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr)
         ;
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -118,6 +118,10 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     int ret;
     union ibv_gid rgid;
 
+    for (auto &reserved : xferReqReserved) {
+        reserved.store(false, std::memory_order_relaxed);
+    }
+
     result = doca_log_backend_create_standard();
     if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
 
@@ -1229,7 +1233,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    nixlDocaBckndReq *treq;
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
     uint32_t lcnt = (uint32_t)local.descCount();
@@ -1238,6 +1242,20 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     struct nixlDocaRdmaQp *rdma_qp;
     uintptr_t notif_addr;
     bool peer_memory = false;
+
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (lcnt != rcnt || lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    for (uint32_t idx = 0; idx < lcnt; ++idx) {
+        if (local[idx].len != remote[idx].len) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
 
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
@@ -1256,9 +1274,13 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
-
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
+    treq = new nixlDocaBckndReq;
+    auto abandon_request = [&]() {
+        for (uint32_t reserved_pos : treq->positions) {
+            xferReqReserved[reserved_pos].store(false, std::memory_order_release);
+        }
+        delete treq;
+    };
 
     if (opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
@@ -1269,7 +1291,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     auto reserve_position = [&]() -> bool {
         pos = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
-        if (xferReqRingCpu[pos].in_use != 0) {
+        bool expected = false;
+        if (!xferReqReserved[pos].compare_exchange_strong(
+                expected, true, std::memory_order_acq_rel)) {
             NIXL_ERROR << "GPUNETIO transfer ring exhausted at position " << pos;
             return false;
         }
@@ -1278,6 +1302,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     };
     treq->positions.reserve((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE);
     if (!reserve_position()) {
+        abandon_request();
         return NIXL_ERR_BACKEND;
     }
 
@@ -1292,8 +1317,6 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
             const uint32_t desc_idx = desc_offset;
             const size_t lsize = local[desc_idx].len;
             const size_t rsize = remote[desc_idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
-
             lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
 
@@ -1339,6 +1362,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
         if (desc_offset < lcnt) {
             if (!reserve_position()) {
+                abandon_request();
                 return NIXL_ERR_BACKEND;
             }
         }
@@ -1352,6 +1376,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         auto search = notifMap.find(remote_agent);
         if (search == notifMap.end()) {
             NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+            abandon_request();
             return NIXL_ERR_INVALID_PARAM;
         }
 
@@ -1448,7 +1473,11 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
     if (status == NIXL_IN_PROG) {
         return status;
     }
-    delete static_cast<nixlDocaBckndReq *>(handle);
+    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    for (uint32_t idx : treq->positions) {
+        xferReqReserved[idx].store(false, std::memory_order_release);
+    }
+    delete treq;
     return status;
 }
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -27,6 +27,27 @@
 const char info_delimiter = '-';
 
 namespace {
+class ScopedCudaDevice {
+public:
+    explicit ScopedCudaDevice(int device) : previousDevice(0), restore(false) {
+        nixlDocaEngineCheckCudaError(cudaGetDevice(&previousDevice), "Failed to get CUDA device");
+        if (previousDevice != device) {
+            nixlDocaEngineCheckCudaError(cudaSetDevice(device), "Failed to set CUDA device");
+            restore = true;
+        }
+    }
+
+    ~ScopedCudaDevice() {
+        if (restore && cudaSetDevice(previousDevice) != cudaSuccess) {
+            NIXL_ERROR << "Failed to restore CUDA device";
+        }
+    }
+
+private:
+    int previousDevice;
+    bool restore;
+};
+
 int
 parseGidIndex(const std::string &value) {
     if (value.empty()) {
@@ -192,6 +213,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         if (result != DOCA_SUCCESS)
             NIXL_ERROR << "Failed to create DOCA GPU device " << doca_error_get_descr(result);
     }
+
+    // The first configured GPU owns the QPs, streams, and progress kernels.
+    nixlDocaEngineCheckCudaError(cudaSetDevice(gdevs[0].first), "Failed to set QP owner device");
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
         if (netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask) != 0) {
@@ -383,6 +407,7 @@ nixlDocaEngine::getSupportedMems() const {
 
 nixlDocaEngine::~nixlDocaEngine() {
     doca_error_t result;
+    ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     NIXL_DEBUG << "Before progressThreadStop ";
     progressThreadStop();
@@ -419,9 +444,12 @@ nixlDocaEngine::~nixlDocaEngine() {
     if (result != DOCA_SUCCESS)
         NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
 
-    result = doca_gpu_destroy(gdevs[0].second);
-    if (result != DOCA_SUCCESS)
-        NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
+    for (auto &item : gdevs) {
+        result = doca_gpu_destroy(item.second);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
+        }
+    }
 }
 
 /****************************************
@@ -431,6 +459,7 @@ nixlDocaEngine::~nixlDocaEngine() {
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
     struct nixlDocaNotif *notif;
+    ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
@@ -605,6 +634,7 @@ nixlDocaEngine::getGpuCudaId() {
 nixl_status_t
 nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     struct nixlDocaRdmaQp *rdma_qp;
+    ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     std::lock_guard<std::mutex> lock(qpLock);
 
@@ -1038,15 +1068,19 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
     auto it = std::find_if(gdevs.begin(), gdevs.end(), [&mem](std::pair<uint32_t, doca_gpu *> &x) {
         return x.first == mem.devId;
     });
-
     if (it == gdevs.end()) {
-        NIXL_ERROR << "Can't register memory for unknown device " << mem.devId;
-        return NIXL_ERR_INVALID_PARAM;
+        int device_count = 0;
+        if (nixl_mem != VRAM_SEG || cudaGetDeviceCount(&device_count) != cudaSuccess ||
+            mem.devId >= static_cast<uint64_t>(device_count)) {
+            NIXL_ERROR << "Can't register memory for unknown device " << mem.devId;
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
+    doca_gpu *memory_gpu = it == gdevs.end() ? nullptr : it->second;
 
     try {
         priv->mr = std::make_unique<nixl::doca::verbs::mr>(
-            it->second, (void *)mem.addr, 1, (size_t)mem.len, pd);
+            memory_gpu, (void *)mem.addr, 1, (size_t)mem.len, pd);
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
@@ -1147,12 +1181,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     uint32_t stream_id;
     struct nixlDocaRdmaQp *rdma_qp;
     uintptr_t notif_addr;
+    bool peer_memory = false;
 
-    // TODO: check device id from local dlist mr that should be all the same and same of
-    // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-        if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
+        peer_memory |= lmd->devId != gdevs[0].first;
+    }
+    if (peer_memory && opt_args && !opt_args->customParam.empty()) {
+        NIXL_ERROR << "Attached CUDA streams are not supported for peer-GPU payload memory";
+        return NIXL_ERR_NOT_SUPPORTED;
     }
 
     auto search = qpMap.find(remote_agent);
@@ -1262,6 +1299,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
+    ScopedCudaDevice deviceGuard(gdevs[0].first);
 
     for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
         xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -29,19 +29,22 @@ const char info_delimiter = '-';
 namespace {
 int
 parse_gid_index(const std::string &value) {
-    if (value.empty())
+    if (value.empty()) {
         return 0;
+    }
 
     size_t parsed_chars = 0;
     int parsed_value = 0;
     try {
         parsed_value = std::stoi(value, &parsed_chars);
-    } catch (const std::exception &) {
+    }
+    catch (const std::exception &) {
         throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
     }
 
-    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255)
+    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255) {
         throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+    }
 
     return parsed_value;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1289,20 +1289,18 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
 
+        auto &final_request = xferReqRingCpu[treq->end_pos - 1];
+        final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
-            (uintptr_t)(notif->send_addr +
-                        (xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx * notif->elems_size));
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx =
-            (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
-        xferReqRingCpu[treq->end_pos - 1].msg_sz = newMsg.size();
-        xferReqRingCpu[treq->end_pos - 1].lbuf_notif = notif_addr;
-        xferReqRingCpu[treq->end_pos - 1].lkey_notif = notif->send_mr->get_lkey();
+            (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
+        final_request.msg_sz = newMsg.size();
+        final_request.lbuf_notif = notif_addr;
+        final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
-                  << xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx << " msg " << newMsg
-                  << " to " << remote_agent;
+                  << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
 
     } else {
         xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx = DOCA_NOTIF_NULL;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1214,36 +1214,62 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     treq->start_pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
     pos = treq->start_pos;
 
+    uint32_t desc_offset = 0;
     do {
-        for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
-            size_t lsize = local[idx].len;
-            size_t rsize = remote[idx].len;
+        auto &request = xferReqRingCpu[pos];
+        while (desc_offset < lcnt && request.num < DOCA_XFER_REQ_SIZE) {
+            const uint32_t idx = request.num;
+            const uint32_t desc_idx = desc_offset;
+            const size_t lsize = local[desc_idx].len;
+            const size_t rsize = remote[desc_idx].len;
             if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
 
-            lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-            rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
+            lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
+            rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
 
-            xferReqRingCpu[pos].lbuf[idx] = (uintptr_t)lmd->mr->get_addr();
-            xferReqRingCpu[pos].lkey[idx] = (uintptr_t)lmd->mr->get_lkey();
-            xferReqRingCpu[pos].rbuf[idx] = (uintptr_t)rmd->mr->get_addr();
-            xferReqRingCpu[pos].rkey[idx] = (uintptr_t)rmd->mr->get_rkey();
-            xferReqRingCpu[pos].size[idx] = lsize;
-            xferReqRingCpu[pos].num++;
+            request.lbuf[idx] = local[desc_idx].addr;
+            request.lkey[idx] = lmd->mr->get_lkey();
+            request.rbuf[idx] = remote[desc_idx].addr;
+            request.rkey[idx] = rmd->mr->get_rkey();
+            request.size[idx] = lsize;
+            request.num_sge[idx] = 1;
+            request.num++;
+
+            // Keep sparse local rows direct: adjacent remote ranges can share
+            // one two-SGE RDMA WRITE WQE without a gather buffer. Preserve the
+            // final descriptor as the protocol ordering boundary.
+            if (operation == NIXL_WRITE && desc_idx + 1 < lcnt - 1) {
+                auto *next_lmd =
+                    static_cast<nixlDocaPrivateMetadata *>(local[desc_idx + 1].metadataP);
+                auto *next_rmd =
+                    static_cast<nixlDocaPublicMetadata *>(remote[desc_idx + 1].metadataP);
+                const size_t next_lsize = local[desc_idx + 1].len;
+                const size_t next_rsize = remote[desc_idx + 1].len;
+                const uintptr_t current_remote = remote[desc_idx].addr;
+                const uintptr_t next_remote = remote[desc_idx + 1].addr;
+                const bool contiguous_remote =
+                    next_remote >= current_remote && next_remote - current_remote == rsize;
+                if (next_lsize == next_rsize && contiguous_remote &&
+                    next_rmd->mr->get_rkey() == request.rkey[idx]) {
+                    request.lbuf2[idx] = local[desc_idx + 1].addr;
+                    request.lkey2[idx] = next_lmd->mr->get_lkey();
+                    request.size2[idx] = next_lsize;
+                    request.num_sge[idx] = 2;
+                    ++desc_offset;
+                }
+            }
+            ++desc_offset;
         }
 
-        xferReqRingCpu[pos].last_rsvd = last_rsvd_flags;
-        xferReqRingCpu[pos].last_posted = last_posted_flags;
+        request.last_rsvd = last_rsvd_flags;
+        request.last_posted = last_posted_flags;
+        request.qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
+        request.qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
 
-        xferReqRingCpu[pos].qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
-        xferReqRingCpu[pos].qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
-
-        if (lcnt > DOCA_XFER_REQ_SIZE) {
-            lcnt -= DOCA_XFER_REQ_SIZE;
+        if (desc_offset < lcnt) {
             pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-        } else {
-            lcnt = 0;
         }
-    } while (lcnt > 0);
+    } while (desc_offset < lcnt);
 
     treq->end_pos = xferRingPos;
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -741,13 +741,13 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -765,8 +765,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -775,8 +778,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -882,13 +888,13 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -935,8 +941,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -945,8 +954,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -1080,8 +1092,14 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
     doca_gpu *memory_gpu = it == gdevs.end() ? nullptr : it->second;
 
     try {
-        priv->mr = std::make_unique<nixl::doca::verbs::mr>(
-            memory_gpu, (void *)mem.addr, 1, (size_t)mem.len, pd);
+        if (nixl_mem == VRAM_SEG) {
+            ScopedCudaDevice deviceGuard(static_cast<int>(mem.devId));
+            priv->mr = std::make_unique<nixl::doca::verbs::mr>(
+                memory_gpu, (void *)mem.addr, 1, (size_t)mem.len, pd);
+        } else {
+            priv->mr = std::make_unique<nixl::doca::verbs::mr>(
+                memory_gpu, (void *)mem.addr, 1, (size_t)mem.len, pd);
+        }
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -19,6 +19,7 @@
 #include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <iterator>
 #include <stdexcept>
 #include <unistd.h>
 #include "common/nixl_log.h"
@@ -1380,58 +1381,76 @@ nixl_status_t
 nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
     uint32_t recv_idx;
     std::string msg_src;
-    uint32_t num_msg = 0;
     char *addr;
     size_t position;
 
     // Lock required to prevent inconsistency if another notifyQp (new peer) is added
     // while getNotifs is running
     std::lock_guard<std::mutex> lock(notifLock);
-    for (auto &notif : notifMap) {
-        ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu =
-            qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
-        std::atomic_thread_fence(std::memory_order_seq_cst);
-        while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr)
-            ;
-        num_msg = ((volatile struct docaNotif *)notif_progress_cpu)->msg_num;
-        while (num_msg > 0) {
-            recv_idx = notif.second->recv_pi.load() & (DOCA_MAX_NOTIF_INFLIGHT - 1);
-            addr = (char *)(notif.second->recv_addr + (recv_idx * notif.second->elems_size));
-            msg_src = addr;
+    auto *progress = (volatile struct docaNotif *)notif_progress_cpu;
+    if (progress->qp_gpu != nullptr) {
+        return NIXL_SUCCESS;
+    }
 
-            NIXL_DEBUG << "CPU num_msg " << num_msg << " at " << recv_idx << " addr "
-                       << (void *)addr << " msg " << msg_src << std::endl;
-
+    if (!notifProgressPeer.empty()) {
+        auto notif = notifMap.find(notifProgressPeer);
+        if (notif != notifMap.end() && progress->msg_num > 0) {
+            recv_idx = notif->second->recv_pi.load() & (DOCA_MAX_NOTIF_INFLIGHT - 1);
+            addr = (char *)(notif->second->recv_addr + (recv_idx * notif->second->elems_size));
+            msg_src.assign(addr, notif->second->elems_size);
             position = msg_src.find(msg_tag_start);
-
-            NIXL_DEBUG << "getNotifs idx " << recv_idx << " addr "
-                       << (void *)((notif.second->recv_addr +
-                                    (recv_idx * notif.second->elems_size)))
-                       << " msg " << msg_src << " position " << (int)position << std::endl;
-
-            if (position != std::string::npos && position == 0) {
-                unsigned last = msg_src.find(msg_tag_end);
+            size_t last = msg_src.find(msg_tag_end, msg_tag_start.size());
+            size_t parsed = 0;
+            unsigned long long msg_size = 0;
+            bool valid = position == 0 && last != std::string::npos;
+            if (valid) {
                 std::string msg_sz =
-                    msg_src.substr(position + msg_tag_start.size(), last - position);
-                int sz = std::stoi(msg_sz);
-
-                std::string msg(addr + last + msg_tag_end.size(),
-                                addr + last + msg_tag_end.size() + sz);
-
-                NIXL_DEBUG << "getNotifs propagating notif from " << notif.first << " msg " << msg
-                           << " size " << sz << " num " << num_msg << std::endl;
-
-                notif_list.push_back(std::pair(notif.first, msg));
-                // Tag cleanup
-                memset(addr, 0, msg_tag_start.size());
-                recv_idx = notif.second->recv_pi.fetch_add(1);
-                num_msg--;
-            } else {
-                NIXL_ERROR << "getNotifs error message at " << num_msg << " size " << msg_src.size()
-                           << " msg " << msg_src;
-                break;
+                    msg_src.substr(msg_tag_start.size(), last - msg_tag_start.size());
+                try {
+                    msg_size = std::stoull(msg_sz, &parsed);
+                }
+                catch (const std::exception &) {
+                    valid = false;
+                }
+                size_t payload_offset = last + msg_tag_end.size();
+                valid = valid && parsed == msg_sz.size() && payload_offset <= msg_src.size() &&
+                    msg_size <= msg_src.size() - payload_offset;
+                if (valid) {
+                    notif_list.emplace_back(
+                        notif->first,
+                        std::string(addr + payload_offset, addr + payload_offset + msg_size));
+                }
             }
+            memset(addr, 0, msg_tag_start.size());
+            notif->second->recv_pi.fetch_add(1);
+            notifProgressPeer.clear();
+            if (!valid) {
+                NIXL_ERROR << "getNotifs received malformed notification from " << notif->first;
+                return NIXL_ERR_BACKEND;
+            }
+            return NIXL_SUCCESS;
         }
+        notifProgressPeer.clear();
+        return NIXL_SUCCESS;
+    }
+
+    const size_t peer_count = notifMap.size();
+    for (size_t offset = 0; offset < peer_count; ++offset) {
+        const size_t peer_index = (notifProgressCursor + offset) % peer_count;
+        auto notif_iter = notifMap.begin();
+        std::advance(notif_iter, peer_index);
+        auto &notif = *notif_iter;
+        recv_idx = notif.second->recv_pi.load() & (DOCA_MAX_NOTIF_INFLIGHT - 1);
+        addr = (char *)(notif.second->recv_addr + (recv_idx * notif.second->elems_size));
+        if (memcmp(addr, msg_tag_start.data(), msg_tag_start.size()) != 0) {
+            continue;
+        }
+        progress->msg_num = 0;
+        notifProgressPeer = notif.first;
+        notifProgressCursor = (peer_index + 1) % peer_count;
+        progress->qp_gpu = qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        break;
     }
 
     return NIXL_SUCCESS;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1212,8 +1212,19 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         treq->stream = (cudaStream_t) * ((uintptr_t *)opt_args->customParam.data());
     }
 
-    treq->start_pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-    pos = treq->start_pos;
+    auto reserve_position = [&]() -> bool {
+        pos = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
+        if (xferReqRingCpu[pos].in_use != 0) {
+            NIXL_ERROR << "GPUNETIO transfer ring exhausted at position " << pos;
+            return false;
+        }
+        treq->positions.push_back(pos);
+        return true;
+    };
+    treq->positions.reserve((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE);
+    if (!reserve_position()) {
+        return NIXL_ERR_BACKEND;
+    }
 
     uint32_t desc_offset = 0;
     do {
@@ -1272,11 +1283,13 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         memcpy(&xferReqRingCpu[pos], &staged_req, sizeof(staged_req));
 
         if (desc_offset < lcnt) {
-            pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
+            if (!reserve_position()) {
+                return NIXL_ERR_BACKEND;
+            }
         }
     } while (desc_offset < lcnt);
 
-    treq->end_pos = xferRingPos;
+    const uint32_t final_pos = treq->positions.back();
 
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
@@ -1293,7 +1306,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
 
-        auto &final_request = xferReqRingCpu[treq->end_pos - 1];
+        auto &final_request = xferReqRingCpu[final_pos];
         final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
             (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
@@ -1307,11 +1320,12 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
 
     } else {
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx = DOCA_NOTIF_NULL;
+        xferReqRingCpu[final_pos].has_notif_msg_idx = DOCA_NOTIF_NULL;
     }
 
-    NIXL_INFO << "DOCA REQUEST from " << treq->start_pos << " to " << treq->end_pos - 1
-              << " stream " << stream_id << std::endl;
+    NIXL_INFO << "DOCA REQUEST with " << treq->positions.size() << " ring positions, first "
+              << treq->positions.front() << ", last " << final_pos << ", stream " << stream_id
+              << std::endl;
 
     treq->backendHandleGpu = 0;
 
@@ -1330,7 +1344,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     ScopedCudaDevice deviceGuard(gdevs[0].first);
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
         completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
         completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
@@ -1355,16 +1369,16 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
 
-        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed == 1) {
-            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-            NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
-                      << " COMPLETED!\n";
-            return NIXL_SUCCESS;
-        } else
+        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed != 1) {
             return NIXL_IN_PROG;
+        }
+    }
+    for (uint32_t idx : treq->positions) {
+        *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+        NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!\n";
     }
 
     return NIXL_SUCCESS;
@@ -1372,11 +1386,12 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
-    uint32_t tmp = xferRingPos.load() & (DOCA_XFER_REQ_MAX - 1);
-    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0)
-        return NIXL_SUCCESS;
-    else
-        return NIXL_IN_PROG;
+    nixl_status_t status = checkXfer(handle);
+    if (status == NIXL_IN_PROG) {
+        return status;
+    }
+    delete static_cast<nixlDocaBckndReq *>(handle);
+    return status;
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -26,6 +26,27 @@
 
 const char info_delimiter = '-';
 
+namespace {
+int
+parse_gid_index(const std::string &value) {
+    if (value.empty())
+        return 0;
+
+    size_t parsed_chars = 0;
+    int parsed_value = 0;
+    try {
+        parsed_value = std::stoi(value, &parsed_chars);
+    } catch (const std::exception &) {
+        throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+    }
+
+    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255)
+        throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+
+    return parsed_value;
+}
+} // namespace
+
 /****************************************
  * Constructor/Destructor
  *****************************************/
@@ -98,6 +119,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
+    gid_index = parse_gid_index((*custom_params)["gid_index"]);
+    NIXL_INFO << "RoCE GID index: " << gid_index;
+
     /* Open DOCA device */
     verbs_context = open_ib_device((char *)(ndevs[0].c_str()));
     if (verbs_context == nullptr) {
@@ -124,8 +148,6 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (ret) {
         throw std::invalid_argument("Failed to query ibv port attributes");
     }
-
-    gid_index = 0;
 
     ret = ibv_query_gid(pd->context, 1, gid_index, &rgid);
     if (ret) {
@@ -169,7 +191,10 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
-        netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask);
+        if (netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask) != 0) {
+            throw std::invalid_argument("Failed to get IPv4 address for GPUNETIO OOB interface '" +
+                                        oobdev[0] + "'");
+        }
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         memcpy(ipv4_addr, (uint8_t *)&(addr_in->sin_addr.s_addr), 4);
         NIXL_DEBUG << "Eth IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
@@ -177,8 +202,13 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
                    << static_cast<unsigned>(ipv4_addr[2]) << " "
                    << static_cast<unsigned>(ipv4_addr[3]) << " " << "ifface " << oobdev[0].c_str();
     } else {
-        doca_devinfo_get_ipv4_addr(
+        result = doca_devinfo_get_ipv4_addr(
             doca_dev_as_devinfo(ddev), (uint8_t *)ipv4_addr, DOCA_DEVINFO_IPV4_ADDR_SIZE);
+        if (result != DOCA_SUCCESS) {
+            throw std::invalid_argument(
+                "Failed to determine the GPUNETIO IPv4 address; set oob_interface explicitly "
+                "when using a bonded network device");
+        }
         NIXL_DEBUG << "DOCA IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
                    << static_cast<unsigned>(ipv4_addr[1]) << " "
                    << static_cast<unsigned>(ipv4_addr[2]) << " "

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -28,7 +28,7 @@ const char info_delimiter = '-';
 
 namespace {
 int
-parse_gid_index(const std::string &value) {
+parseGidIndex(const std::string &value) {
     if (value.empty()) {
         return 0;
     }
@@ -122,7 +122,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
-    gid_index = parse_gid_index((*custom_params)["gid_index"]);
+    gid_index = parseGidIndex((*custom_params)["gid_index"]);
     NIXL_INFO << "RoCE GID index: " << gid_index;
 
     /* Open DOCA device */

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -166,6 +166,7 @@ private:
     struct docaXferReqGpu *xferReqRingGpu;
     struct docaXferReqGpu *xferReqRingCpu;
     mutable std::atomic<uint32_t> xferRingPos;
+    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved;
 
     struct docaXferCompletion *completion_list_gpu;
     struct docaXferCompletion *completion_list_cpu;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -150,7 +150,7 @@ private:
     std::vector<struct nixlDocaRdmaQp> rdma_qp_v;
     int nstreams;
 
-    uint32_t local_port;
+    uint16_t local_port;
     int noSyncIters;
     uint8_t ipv4_addr[4];
     struct sockaddr oob_saddr;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -194,8 +194,7 @@ private:
     public:
         cudaStream_t stream;
         uint32_t devId;
-        uint32_t start_pos;
-        uint32_t end_pos;
+        std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -24,9 +24,10 @@ class nixlDocaEngine : public nixlBackendEngine {
 public:
     CUcontext main_cuda_ctx;
     int oob_sock_server;
-    std::mutex notifLock;
-    std::mutex qpLock;
+    mutable std::mutex notifLock;
+    mutable std::mutex qpLock;
     std::mutex connectLock;
+    mutable std::mutex remoteConnLock;
     std::vector<std::pair<uint32_t, doca_gpu *>> gdevs; /* List of DOCA GPUNetIO device handlers */
     doca_dev *ddev; /* DOCA device handler associated to queues */
     doca_verbs_context *verbs_context; /* DOCA Verbs Context */

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -184,6 +184,8 @@ private:
     std::unordered_map<std::string, struct nixlDocaRdmaQp *> qpMap;
     std::unordered_map<std::string, int> connMap;
     std::unordered_map<std::string, struct nixlDocaNotif *> notifMap;
+    std::string notifProgressPeer;
+    size_t notifProgressCursor = 0;
 
     pthread_t server_thread_id;
 

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -53,17 +53,23 @@
 // Local includes
 #include "common/nixl_time.h"
 
-constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT = 128;
+constexpr uint32_t DOCA_EIGHT_RANK_MAX_INFLIGHT = 7 * 36 + 7;
+constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT = 512;
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT_MASK = (DOCA_MAX_COMPLETION_INFLIGHT - 1);
 constexpr uint32_t RDMA_SEND_QUEUE_SIZE = 2048;
 constexpr uint32_t RDMA_RECV_QUEUE_SIZE = (RDMA_SEND_QUEUE_SIZE * 2);
 constexpr uint32_t DOCA_POST_STREAM_NUM = 4;
 constexpr uint32_t DOCA_XFER_REQ_SIZE = 512;
-constexpr uint32_t DOCA_XFER_REQ_MAX = 32;
+constexpr uint32_t DOCA_XFER_REQ_MAX = 512;
 constexpr uint32_t DOCA_XFER_REQ_MASK = (DOCA_XFER_REQ_MAX - 1);
 constexpr uint32_t DOCA_ENG_MAX_CONN = 20;
 constexpr uint32_t DOCA_RDMA_CM_LOCAL_PORT_SERVER = 6544;
 constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
+
+static_assert((DOCA_MAX_COMPLETION_INFLIGHT & DOCA_MAX_COMPLETION_INFLIGHT_MASK) == 0);
+static_assert((DOCA_XFER_REQ_MAX & DOCA_XFER_REQ_MASK) == 0);
+static_assert(DOCA_MAX_COMPLETION_INFLIGHT >= DOCA_EIGHT_RANK_MAX_INFLIGHT);
+static_assert(DOCA_XFER_REQ_MAX >= DOCA_EIGHT_RANK_MAX_INFLIGHT);
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define DOCA_RDMA_SERVER_ADDR_LEN \

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -80,10 +80,14 @@ constexpr uint32_t DOCA_NOTIF_NULL = 0xFFFFFFFF;
 struct docaXferReqGpu {
     uint32_t id;
     uintptr_t lbuf[DOCA_XFER_REQ_SIZE];
+    uintptr_t lbuf2[DOCA_XFER_REQ_SIZE];
     uintptr_t rbuf[DOCA_XFER_REQ_SIZE];
     size_t size[DOCA_XFER_REQ_SIZE];
+    size_t size2[DOCA_XFER_REQ_SIZE];
     uint32_t lkey[DOCA_XFER_REQ_SIZE];
+    uint32_t lkey2[DOCA_XFER_REQ_SIZE];
     uint32_t rkey[DOCA_XFER_REQ_SIZE];
+    uint8_t num_sge[DOCA_XFER_REQ_SIZE];
     uint16_t num;
     uint8_t in_use;
     uint32_t conn_idx;

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -52,6 +52,7 @@
 
 // Local includes
 #include "common/nixl_time.h"
+#include "gpunetio_oob_endpoint.h"
 
 constexpr uint32_t DOCA_EIGHT_RANK_MAX_INFLIGHT = 7 * 36 + 7;
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT = 512;
@@ -63,7 +64,6 @@ constexpr uint32_t DOCA_XFER_REQ_SIZE = 512;
 constexpr uint32_t DOCA_XFER_REQ_MAX = 512;
 constexpr uint32_t DOCA_XFER_REQ_MASK = (DOCA_XFER_REQ_MAX - 1);
 constexpr uint32_t DOCA_ENG_MAX_CONN = 20;
-constexpr uint32_t DOCA_RDMA_CM_LOCAL_PORT_SERVER = 6544;
 constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
 
 static_assert((DOCA_MAX_COMPLETION_INFLIGHT & DOCA_MAX_COMPLETION_INFLIGHT_MASK) == 0);
@@ -194,7 +194,9 @@ nixlDocaEngineCheckCudaError(cudaError_t result, const char *message);
 void
 nixlDocaEngineCheckCuError(CUresult result, const char *message);
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd);
+oob_connection_client_setup(const char *server_ip,
+                            int *oob_sock_fd,
+                            uint16_t server_port = GPUNETIO_DEFAULT_OOB_PORT);
 void
 oob_connection_client_close(int oob_sock_fd);
 void

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -179,12 +179,12 @@ struct nixlDocaRdmaQp {
     std::unique_ptr<nixl::doca::verbs::qp> qp_data;
     uint32_t qpn_data;
     uint32_t rqpn_data;
-    uint32_t remote_gid_data;
 
     std::unique_ptr<nixl::doca::verbs::qp> qp_notif;
     uint32_t qpn_notif;
     uint32_t rqpn_notif;
-    uint32_t remote_gid_notif;
+    doca_verbs_gid remote_gid{};
+    uint32_t remote_lid = 0;
 };
 
 struct nixlDocaEngine;
@@ -207,7 +207,11 @@ create_verbs_ah_attr(doca_verbs_context *verbs_context,
                      enum doca_verbs_addr_type addr_type,
                      doca_verbs_ah_attr **verbs_ah_attr);
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid);
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid);
 void *
 threadProgressFunc(void *arg);
 int

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -18,6 +18,7 @@
 #ifndef GPUNETIO_BACKEND_AUX_H
 #define GPUNETIO_BACKEND_AUX_H
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -23,7 +23,7 @@
 
 #include "gpunetio_backend.h"
 
-#if DOCA_VERSION_MINOR >= 2
+#if DOCA_VERSION_MAJOR == 3 && DOCA_VERSION_MINOR >= 2
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_mcst)
 #else
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_dump)

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -334,7 +334,7 @@ kernel_progress(struct docaXferCompletion *completion_list,
                     nixl_gpunetio_dev_poll_one_cq_at<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
                                                      DOCA_GPUNETIO_VERBS_QP_RQ>(
                         doca_gpu_dev_verbs_qp_get_cq_rq(notif_progress->qp_gpu), msg_last);
-                if (ret != EBUSY) {
+                if (ret == 0) {
 #if ENABLE_DEBUG == 1
                     printf("kernel received notification at %d ret %d\n", msg_last, ret);
 #endif
@@ -362,6 +362,7 @@ kernel_progress(struct docaXferCompletion *completion_list,
                     printf("kernel received notification EBUSY at %d ret %d\n", msg_last, ret);
 #endif
                     DOCA_GPUNETIO_VOLATILE(notif_progress->msg_num) = 0;
+                    if (ret < 0) DOCA_GPUNETIO_VOLATILE(*exit_flag) = 1;
                     doca_gpu_dev_verbs_fence_release<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS>();
                     DOCA_GPUNETIO_VOLATILE(notif_progress->qp_gpu) = nullptr;
                 }

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,17 @@
 
 #include <doca_gpunetio_dev_verbs_onesided.cuh>
 #include <doca_gpunetio_dev_verbs_twosided.cuh>
+#include <doca_version.h>
 #include <cuda.h>
 #include <cuda/atomic>
 
 #include "gpunetio_backend.h"
+
+#if DOCA_VERSION_MINOR >= 2
+#define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_mcst)
+#else
+#define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_dump)
+#endif
 
 #define ENABLE_DEBUG 0
 
@@ -107,10 +114,11 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
     tot_wqe = xferReqRing[pos].num;
 
     if (threadIdx.x == 0) {
-        if (qp->need_mcst == true)
+        if (NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) == true) {
             base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots(qp, tot_wqe + 1);
-        else
+        } else {
             base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots(qp, tot_wqe);
+        }
     }
     __syncthreads();
 
@@ -131,7 +139,7 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
     __syncthreads();
 
     if ((idx - blockDim.x) == (tot_wqe - 1)) {
-        if (qp->need_mcst == true) {
+        if (NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) == true) {
             wqe_idx++;
             wqe_ptr = doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
 
@@ -162,6 +170,8 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
                base_wqe_idx);
 #endif
 }
+
+#undef NIXL_GPUNETIO_QP_NEEDS_DUMP
 
 __global__ void
 kernel_write(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint32_t pos) {

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -201,17 +201,34 @@ kernel_write(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint
                xferReqRing[pos].lkey[idx],
                (uint64_t)xferReqRing[pos].size[idx]);
 #endif
-        doca_gpu_dev_verbs_wqe_prepare_write(qp,
-                                             wqe_ptr,
-                                             wqe_idx,
-                                             MLX5_OPCODE_RDMA_WRITE,
-                                             cflag,
-                                             0,
-                                             (uint64_t)(xferReqRing[pos].rbuf[idx]),
-                                             xferReqRing[pos].rkey[idx],
-                                             (uint64_t)(xferReqRing[pos].lbuf[idx]),
-                                             xferReqRing[pos].lkey[idx],
-                                             xferReqRing[pos].size[idx]);
+        if (xferReqRing[pos].num_sge[idx] == 2) {
+            doca_gpu_dev_verbs_wqe_prepare_write(qp,
+                                                 wqe_ptr,
+                                                 wqe_idx,
+                                                 MLX5_OPCODE_RDMA_WRITE,
+                                                 cflag,
+                                                 0,
+                                                 (uint64_t)(xferReqRing[pos].rbuf[idx]),
+                                                 xferReqRing[pos].rkey[idx],
+                                                 (uint64_t)(xferReqRing[pos].lbuf[idx]),
+                                                 xferReqRing[pos].lkey[idx],
+                                                 xferReqRing[pos].size[idx],
+                                                 (uint64_t)(xferReqRing[pos].lbuf2[idx]),
+                                                 xferReqRing[pos].lkey2[idx],
+                                                 xferReqRing[pos].size2[idx]);
+        } else {
+            doca_gpu_dev_verbs_wqe_prepare_write(qp,
+                                                 wqe_ptr,
+                                                 wqe_idx,
+                                                 MLX5_OPCODE_RDMA_WRITE,
+                                                 cflag,
+                                                 0,
+                                                 (uint64_t)(xferReqRing[pos].rbuf[idx]),
+                                                 xferReqRing[pos].rkey[idx],
+                                                 (uint64_t)(xferReqRing[pos].lbuf[idx]),
+                                                 xferReqRing[pos].lkey[idx],
+                                                 xferReqRing[pos].size[idx]);
+        }
     }
     __syncthreads();
 

--- a/src/plugins/gpunetio/gpunetio_oob_endpoint.h
+++ b/src/plugins/gpunetio/gpunetio_oob_endpoint.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GPUNETIO_OOB_ENDPOINT_H
+#define GPUNETIO_OOB_ENDPOINT_H
+
+#include <arpa/inet.h>
+
+#include <charconv>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+constexpr uint16_t GPUNETIO_DEFAULT_OOB_PORT = 6544;
+
+struct GpunetioOobEndpoint {
+    std::string ipv4;
+    uint16_t port;
+};
+
+inline uint16_t
+parseGpunetioOobPort(std::string_view value) {
+    if (value.empty()) {
+        return GPUNETIO_DEFAULT_OOB_PORT;
+    }
+
+    uint32_t port = 0;
+    const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), port);
+    if (error != std::errc() || end != value.data() + value.size() || port == 0 || port > 65535) {
+        throw std::invalid_argument("oob_port must be an integer in the range [1, 65535]");
+    }
+    return static_cast<uint16_t>(port);
+}
+
+inline GpunetioOobEndpoint
+parseGpunetioOobEndpoint(std::string_view metadata) {
+    if (metadata.empty() || metadata.find('\0') != std::string_view::npos) {
+        throw std::invalid_argument("GPUNETIO connection metadata is empty or malformed");
+    }
+
+    const size_t separator = metadata.find(':');
+    if (separator != std::string_view::npos &&
+        (separator == 0 || separator + 1 == metadata.size() ||
+         metadata.find(':', separator + 1) != std::string_view::npos)) {
+        throw std::invalid_argument("GPUNETIO connection metadata must be IPv4 or IPv4:port");
+    }
+
+    const std::string ipv4(metadata.substr(0, separator));
+    in_addr address{};
+    if (inet_pton(AF_INET, ipv4.c_str(), &address) != 1) {
+        throw std::invalid_argument(
+            "GPUNETIO connection metadata contains an invalid IPv4 address");
+    }
+
+    const uint16_t port = separator == std::string_view::npos ?
+        GPUNETIO_DEFAULT_OOB_PORT :
+        parseGpunetioOobPort(metadata.substr(separator + 1));
+    return {ipv4, port};
+}
+
+inline std::string
+formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
+    if (port == GPUNETIO_DEFAULT_OOB_PORT) {
+        return std::string(ipv4);
+    }
+    return std::string(ipv4) + ":" + std::to_string(port);
+}
+
+#endif

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -57,6 +57,7 @@ get_backend_options() {
     params["oob_interface"] = "";
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
+    params["gid_index"] = "";
     return params;
 }
 

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -55,6 +55,7 @@ get_backend_options() {
     nixl_b_params_t params;
     params["network_devices"] = "";
     params["oob_interface"] = "";
+    params["oob_port"] = "";
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
     params["gid_index"] = "";

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -181,11 +181,15 @@ destroy_verbs_ah:
 }
 
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid) {
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid) {
     doca_error_t status = DOCA_SUCCESS, tmp_status = DOCA_SUCCESS;
     doca_verbs_qp_attr *verbs_qp_attr = NULL;
 
-    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, eng->remote_gid);
+    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, remote_gid);
     if (status != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to set remote gid " << doca_error_get_descr(status);
         return status;
@@ -193,7 +197,7 @@ connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t
 
     // IB
     if (eng->port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
-        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, eng->dlid);
+        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, remote_lid);
         if (status != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to set dlid";
             return status;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -48,7 +48,7 @@ nixlDocaEngineCheckCuError(CUresult result, const char *message) {
 }
 
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
+oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t server_port) {
     struct sockaddr_in server_addr = {0};
     int oob_sock_fd_;
 
@@ -62,13 +62,17 @@ oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
 
     /* Set port and IP the same as server-side: */
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
-    server_addr.sin_addr.s_addr = inet_addr(server_ip);
+    server_addr.sin_port = htons(server_port);
+    if (inet_pton(AF_INET, server_ip, &server_addr.sin_addr) != 1) {
+        close(oob_sock_fd_);
+        NIXL_ERROR << "Invalid server IPv4 address " << server_ip;
+        return -1;
+    }
 
     /* Send connection request to server: */
     if (connect(oob_sock_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         close(oob_sock_fd_);
-        NIXL_ERROR << "Unable to connect to server at " << server_ip;
+        NIXL_ERROR << "Unable to connect to server at " << server_ip << ":" << server_port;
         return -1;
     }
     NIXL_INFO << "Connected with server successfully";

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -428,7 +428,7 @@ netif_get_addr(const char *if_name,
                sa_family_t af,
                struct sockaddr *saddr,
                struct sockaddr *netmask) {
-    int status = 0;
+    int status = -1;
     struct ifaddrs *ifa;
     struct ifaddrs *ifaddrs;
     const struct sockaddr_in6 *saddr6;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -386,6 +386,7 @@ threadProgressFunc(void *arg) {
 
         if (ACCESS_ONCE(*eng->pthrStop) == 1) {
             NIXL_DEBUG << "Stopping thread " << oob_sock_client;
+            close(oob_sock_client);
             return nullptr;
         }
 
@@ -394,11 +395,23 @@ threadProgressFunc(void *arg) {
 
         // cuCtxSetCurrent(eng->main_cuda_ctx);
 
-        eng->recvRemoteAgentName(oob_sock_client, remote_agent);
-
-        eng->addRdmaQp(remote_agent);
-        eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
-        eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        remote_agent.clear();
+        nixl_status_t status = eng->recvRemoteAgentName(oob_sock_client, remote_agent);
+        if (status == NIXL_SUCCESS) {
+            status = eng->addRdmaQp(remote_agent);
+        }
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        }
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
+        }
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -478,8 +478,12 @@ mr::mr(void *addr_, size_t tot_size_, uint32_t rkey_)
 }
 
 mr::~mr() {
-    int ret = ibv_dereg_mr(ibmr);
-    if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+    if (ibmr != nullptr) {
+        int ret = ibv_dereg_mr(ibmr);
+        if (ret != 0) {
+            NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+        }
+    }
 }
 
 } // namespace nixl::doca::verbs

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -20,7 +20,7 @@
 #include "verbs.h"
 #include "gpunetio_backend_aux.h"
 
-#define VERBS_TEST_MAX_SEND_SEGS (1)
+#define VERBS_TEST_MAX_SEND_SEGS (2)
 #define VERBS_TEST_MAX_RECEIVE_SEGS (1)
 #define VERBS_TEST_DBR_SIZE (8)
 #define ROUND_UP(unaligned_mapping_size, align_val) \

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -415,8 +415,9 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
       elem_num(elem_num_),
       elem_size(elem_size_),
       pd(pd_) {
-    if (gpu_dev == nullptr || addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr)
+    if (addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr) {
         throw std::invalid_argument("Invalid mr input values");
+    }
 
     doca_error_t status;
     static size_t host_page_size = sysconf(_SC_PAGESIZE);
@@ -434,7 +435,7 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
     /* Try to map GPU memory with dmabuf.
      * Input size and address should be aliegned to host page size.
      */
-    if ((tot_size % host_page_size) == 0 &&
+    if (gpu_dev != nullptr && (tot_size % host_page_size) == 0 &&
         ((reinterpret_cast<uintptr_t>(addr) % host_page_size) == 0)) {
         status = doca_gpu_dmabuf_fd(gpu_dev, addr, tot_size, &dmabuf_fd);
         if (status == DOCA_SUCCESS) {
@@ -455,6 +456,7 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
      * Fallback mechanism using legacy mode with nvidia-peermem module and ibv_reg_mr.
      */
     if (ibmr == nullptr) {
+        NIXL_INFO << "Registering memory through legacy ibv_reg_mr";
         ibmr = ibv_reg_mr(pd,
                           addr,
                           tot_size,

--- a/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
+++ b/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_oob_endpoint.h"
+
+#include <cassert>
+#include <stdexcept>
+
+template<typename Fn>
+void
+assertInvalid(Fn &&fn) {
+    bool rejected = false;
+    try {
+        fn();
+    }
+    catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+int
+main() {
+    assert(parseGpunetioOobPort("") == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(parseGpunetioOobPort("1") == 1);
+    assert(parseGpunetioOobPort("65535") == 65535);
+
+    const auto legacy = parseGpunetioOobEndpoint("192.0.2.1");
+    assert(legacy.ipv4 == "192.0.2.1");
+    assert(legacy.port == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(formatGpunetioOobEndpoint(legacy.ipv4, legacy.port) == "192.0.2.1");
+
+    const auto configured = parseGpunetioOobEndpoint("198.51.100.2:16544");
+    assert(configured.ipv4 == "198.51.100.2");
+    assert(configured.port == 16544);
+    assert(formatGpunetioOobEndpoint(configured.ipv4, configured.port) == "198.51.100.2:16544");
+
+    for (const auto *value : {"0", "-1", "+1", "65536", "12x", " 6544", "6544 "}) {
+        assertInvalid([=] { parseGpunetioOobPort(value); });
+    }
+
+    for (const auto *value : {"",
+                              "192.0.2",
+                              "256.0.0.1",
+                              "192.0.2.1:",
+                              "192.0.2.1:0",
+                              "192.0.2.1:65536",
+                              "192.0.2.1:12x",
+                              "192.0.2.1:6544:1",
+                              "[::1]:6544"}) {
+        assertInvalid([=] { parseGpunetioOobEndpoint(value); });
+    }
+    assertInvalid([] { parseGpunetioOobEndpoint(std::string("192.0.2.1\0:6544", 16)); });
+
+    return 0;
+}

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -15,6 +15,13 @@
 
 compile_flags = []
 
+gpunetio_oob_endpoint_test = executable(
+        'gpunetio_oob_endpoint_test',
+        'gpunetio_oob_endpoint_test.cpp',
+        include_directories: include_directories('../../../../src/plugins/gpunetio'),
+        install: false)
+test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
+
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]
         compile_flags += '-DHAVE_CUDA'


### PR DESCRIPTION
## What?

Enable the GPUNETIO Verbs backend to move peer-owned GPU memory correctly in a multi-rank process and reduce sparse WRITE overhead without a gather buffer.

Review split:

- connection/OOB correctness is isolated in #2174;
- multi-chunk request construction and completion correctness is isolated in #2175;
- NIXLBench GID/OOB parameter forwarding is isolated in #2173;
- notification-slot ordering and CQE/error propagation are isolated in #2177;
- metadata/MR/QP lifecycle cleanup is isolated in #2178;
- this draft remains the peer-memory/write2 performance and integration follow-up, carrying the dependency stack until those PRs land.

This change:

- registers each VRAM range under its owning CUDA device context;
- stores the remote GID and LID per QP instead of in engine-global connection state;
- makes the OOB port configurable and exposes it through `nixlbench`, so colocated ranks do not share one `SO_REUSEPORT` listener;
- combines adjacent remote WRITE ranges into one two-SGE WQE while preserving the final ordering marker;
- moves request publication to one mapped-ring copy and tracks every ring position used by a logical request;
- reserves ring positions on the host until the request handle is released;
- makes notification CQ progress asynchronous and propagates CQE failures to the NIXL request API;
- handles short or interrupted TCP control messages as full-read/full-write operations.

The standalone peer/staging CUDA experiments used during development are intentionally excluded from this PR.

## Why?

In a P/D DCP deployment, the GPUNETIO QP can be owned by one GPU while source or destination memory belongs to another GPU. The previous implementation registered that memory under the QP owner's current CUDA context and reused engine-global route state while several ranks connected concurrently.

The misleading final diagnostic was:

```text
syndrome=0x5, vendor_err_synd=0xf9, wqe_counter=511
```

`0x5` is a downstream WR flush. Instrumenting the first error CQE exposed two independent initiating failures:

1. `0x13/0x88` remote access error, fixed by selecting the memory owner's CUDA device during MR creation.
2. `0x15/0x81` transport retry error, fixed by keeping route state per QP and assigning a rank-local OOB port so QPNs cannot be cross-wired between colocated listeners.

Related: #952, #1954, and #2052.

## How?

The data path still posts directly from the original GPU rows. Adjacent descriptors with contiguous remote addresses and a common rkey use two local SGEs in one RDMA WRITE WQE; non-pairable WRITE descriptors and all READ descriptors retain the existing one-SGE path.

Connection metadata remains backward compatible: the default endpoint serializes as the legacy IPv4-only form, while a non-default port serializes as `IPv4:port`.

This branch is based on current `upstream/main` `226e76d7`. Its first three commits are the current-main equivalent of the open #2052 prerequisite; the new peer/write2 series starts at `0e89a239` and ends at `d30df40d`.

## Validation

Build and static checks:

- full configured Ninja build on H20 with DOCA 3.1 and CUDA: PASS;
- OOB endpoint parser unit with `-Wall -Wextra -Werror`: PASS;
- `git diff --check`: PASS;
- DCO sign-off on all 15 commits from current upstream: PASS.



<!-- validated-gpunetio-ucx-component:start -->
### Matched GPUNETIO vs UCX sender-component result

The provenance-bearing phase run on the fixed H20 P/D workload isolated the sender data path:

| Sender phase | UCX | GPUNETIO | GPUNETIO reduction |
|---|---:|---:|---:|
| KV issue | 15.377 ms | 4.029 ms | 73.8% / 11.349 ms |
| Worker total | 16.217 ms | 5.307 ms | 67.3% / 10.910 ms |

These are phase-local component medians from the matched diagnostic run, not serving TTFT measurements. They show that the retained GPUNETIO direct-row/write2 sender path is materially faster than the UCX pack-and-bulk sender path under this workload.
<!-- validated-gpunetio-ucx-component:end -->

Current-head cross-node DCP4 smoke:

```text
source:  lj-2qd302321, GPUNETIO QP on GPU0, peer source on GPU2
target:  lj-21d305044, TP4/DCP4 plus one communication GPU
plugin:  5808d075128067ac760a131c28fabc8738951bf9c26ef2bdeca1d4036eddd29e
result:  PASS, 8/8 ready epochs, identical 32-token output
errors:  zero CQE, transfer, readiness, or transport errors
TTFT:    83.081 ms (correctness smoke, not the A/B performance row)
```

The matched five-pair serving A/B used the same current NIXL core/plugin implementation before the final control-path hardening commits:

```text
workload: DeepSeek-V2-Lite, 256 prompt tokens, 32 output tokens,
          prefill TP1, decode TP4/DCP4, FP8 KV, page size 64

UCX TTFT mean/median:       87.227 / 86.191 ms
GPUNETIO mean/median:       80.843 / 80.651 ms
paired TTFT deltas:         -5.389, -14.536, -4.764, -3.983, -3.251 ms
paired median improvement: 4.764 ms
correctness:               10/10 PASS, GPUNETIO won 5/5 pairs
```

The final TCP, CQE-propagation, and host-reservation commits were rebuilt and then passed the current-head DCP4 smoke above. The A/B row is not presented as a rerun of those non-performance control-path changes.

cc @e-ago @ovidiusm @brminich
