### PR TITLE
[NIXLBench] Expose GPUNETIO GID index and OOB port

### DIFF
--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -511,6 +511,9 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 **GPUNETIO Backend:**
 ```
 --gpunetio_device_list LIST # Comma-separated GPU CUDA device id for GPUNETIO
+--gpunetio_oob_list IFACE   # OOB interface name for the control path
+--gpunetio_gid_index N      # RoCE GID table index (default: 0)
+--gpunetio_oob_port PORT    # OOB TCP port (default: 6544)
 ```
 
 **OBJ (S3) Backend:**

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -908,7 +908,8 @@ xferBenchConfig::printConfig() {
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
             printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
-            printOption("OOB TCP port (--gpunetio_oob_port=N)", gpunetio_oob_port);
+            printOption("OOB TCP port (--gpunetio_oob_port=N)",
+                        gpunetio_oob_port.empty() ? "6544" : gpunetio_oob_port);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -905,7 +905,7 @@ xferBenchConfig::printConfig() {
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             printOption("GPU CUDA Device id list (--device_list=dev1,dev2,...)",
                         gpunetio_device_list);
-            printOption("OOB network interface name for control path (--oob_list=ifface)",
+            printOption("OOB network interface name for control path (--gpunetio_oob_list=IFACE)",
                         gpunetio_oob_list);
             printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
             printOption("OOB TCP port (--gpunetio_oob_port=N)",

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,6 +175,12 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
+NB_ARG_STRING(gpunetio_gid_index,
+              "0",
+              "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
+NB_ARG_STRING(gpunetio_oob_port,
+              "",
+              "OOB TCP port for GPUNetIO (only used with nixl worker; default: 6544)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");
@@ -292,6 +298,8 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
+std::string xferBenchConfig::gpunetio_gid_index = "0";
+std::string xferBenchConfig::gpunetio_oob_port = "";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
@@ -479,6 +487,8 @@ xferBenchConfig::loadParams(void) {
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             gpunetio_device_list = NB_ARG(gpunetio_device_list);
             gpunetio_oob_list = NB_ARG(gpunetio_oob_list);
+            gpunetio_gid_index = NB_ARG(gpunetio_gid_index);
+            gpunetio_oob_port = NB_ARG(gpunetio_oob_port);
         }
 
         // Load HD3FS-specific configurations if backend is HD3FS
@@ -897,6 +907,8 @@ xferBenchConfig::printConfig() {
                         gpunetio_device_list);
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
+            printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
+            printOption("OOB TCP port (--gpunetio_oob_port=N)", gpunetio_oob_port);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -202,6 +202,8 @@ public:
     static int gds_mt_num_threads;
     static std::string gpunetio_device_list;
     static std::string gpunetio_oob_list;
+    static std::string gpunetio_gid_index;
+    static std::string gpunetio_oob_port;
     static long page_size;
     static std::string obj_access_key;
     static std::string obj_secret_key;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -227,10 +227,17 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GPUNETIO)) {
         std::cout << "GPUNETIO backend, network device " << devices[0] << " GPU device "
                   << xferBenchConfig::gpunetio_device_list << " OOB interface "
-                  << xferBenchConfig::gpunetio_oob_list << std::endl;
+                  << xferBenchConfig::gpunetio_oob_list << " GID index "
+                  << xferBenchConfig::gpunetio_gid_index << " OOB port "
+                  << (xferBenchConfig::gpunetio_oob_port.empty() ?
+                          "6544" :
+                          xferBenchConfig::gpunetio_oob_port)
+                  << std::endl;
         backend_params["network_devices"] = devices[0];
         backend_params["gpu_devices"] = xferBenchConfig::gpunetio_device_list;
         backend_params["oob_interface"] = xferBenchConfig::gpunetio_oob_list;
+        backend_params["gid_index"] = xferBenchConfig::gpunetio_gid_index;
+        backend_params["oob_port"] = xferBenchConfig::gpunetio_oob_port;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE)) {
         std::cout << "Mooncake backend" << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_HF3FS)) {


### PR DESCRIPTION
## Dependency

This focused wiring PR should merge after #2052 and #2174. Those PRs implement the GPUNETIO backend consumers for `gid_index` and `oob_port`; this PR only exposes and forwards them from NIXLBench.

## What

Expose GPUNETIO RoCE GID selection and OOB TCP port configuration through NIXLBench:

- `--gpunetio_gid_index`, default `0`;
- `--gpunetio_oob_port`, with an empty stored value preserving backend default `6544`;
- CLI/TOML loading through `xferBenchConfig`;
- forwarding as backend parameters `gid_index` and `oob_port`;
- effective-value reporting and README documentation.

## Data path

```text
CLI or TOML
  -> xferBenchConfig
  -> xferBenchNixlWorker
  -> backend_params["gid_index" / "oob_port"]
  -> nixlAgent::createBackend()
```

Validation and range checking remain owned by the GPUNETIO plugin.

## Validation

Current stack:

```text
base:   fd2299e9
commit: f7ee515a
```

- fresh standalone NIXLBench Meson configuration: PASS
- full NIXLBench build with warnings as errors: PASS
- `nixlbench --help` exposes both options: PASS
- omitted OOB port reports effective value `6544`: covered by the current reporting path
- diff, formatting, SPDX, and DCO checks: PASS; CI is rerunning after the review follow-up

Public reproduction from `benchmark/nixlbench`:

```bash
meson setup build -Dwerror=true
ninja -C build
./build/nixlbench --help | grep -E 'gpunetio_(gid_index|oob_port)'
```

## Scope

This PR changes NIXLBench configuration only. It does not duplicate backend parsing or OOB implementation and makes no transport-performance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPUNetIO options for the RoCE GID index and out-of-band TCP port.
  * Supported configuring these options through command-line arguments and configuration files.
  * Displayed the active GPUNetIO settings during benchmark initialization.
  * Used port 6544 when no out-of-band TCP port is specified.
  * Updated command-line documentation with the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
