### PR TITLE
[GPUNetIO]: isolate OOB endpoints and QP route state

### DIFF
--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -34,9 +34,10 @@ Stream pool mode instead is when applications mostly wants to process data on th
 
 ## Input parameters
 
-DOCA GPUNetIO backend takes 3 input parameters:
+DOCA GPUNetIO backend takes these input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
 - oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
+- oob_port: TCP port used to listen for OOB connection setup. Defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
 

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -37,7 +37,7 @@ Stream pool mode instead is when applications mostly wants to process data on th
 DOCA GPUNetIO backend takes these input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
 - oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
-- oob_port: TCP port used to listen for OOB connection setup. Defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
+- oob_port: TCP port used to listen for OOB connection setup. It must be an integer in the inclusive range [1, 65535] and defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "gpunetio_backend.h"
-#include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
 #include <stdexcept>
@@ -98,6 +97,8 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
+    local_port = parseGpunetioOobPort((*custom_params)["oob_port"]);
+    NIXL_INFO << "OOB listen port: " << local_port;
     /* Open DOCA device */
     verbs_context = open_ib_device((char *)(ndevs[0].c_str()));
     if (verbs_context == nullptr) {
@@ -503,21 +504,21 @@ nixlDocaEngine::progressThreadStart() {
     if (oobdev.size() > 0 && oobdev[0] != "") {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         /* Bind to the set port and IP: */
-        addr_in->sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        addr_in->sin_port = htons(local_port);
         if (bind(oob_sock_server, (struct sockaddr *)addr_in, sizeof(struct sockaddr_in)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
     } else {
         /* Set port and IP: */
         server_addr.sin_family = AF_INET;
-        server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        server_addr.sin_port = htons(local_port);
         server_addr.sin_addr.s_addr = INADDR_ANY; /* listen on any interface */
 
         /* Bind to the set port and IP: */
         if (bind(oob_sock_server, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
@@ -557,7 +558,7 @@ nixlDocaEngine::progressThreadStop() {
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd);
+    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
     close(oob_sock_server);
@@ -928,7 +929,7 @@ nixlDocaEngine::getConnInfo(std::string &str) const {
     std::stringstream ss;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
-    str = ss.str();
+    str = formatGpunetioOobEndpoint(ss.str(), local_port);
     return NIXL_SUCCESS;
 }
 
@@ -953,17 +954,20 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     // TODO: Connect part should be moved into connect() method
     nixlDocaConnection conn;
-    size_t size = remote_conn_info.size();
-    // TODO: eventually std::byte?
-    char *addr = new char[size];
-
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    GpunetioOobEndpoint endpoint;
+    try {
+        endpoint = parseGpunetioOobEndpoint(remote_conn_info);
+    }
+    catch (const std::invalid_argument &error) {
+        NIXL_ERROR << error.what();
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(endpoint.ipv4.c_str(), &oob_sock_client, endpoint.port);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
@@ -986,8 +990,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -769,7 +769,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     NIXL_DEBUG << "connectClientRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
     std::unique_lock<std::mutex> lock(connectLock);
-    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+    if (rdma_qp->dataProgrammed || rdma_qp->notifProgrammed) {
         if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
             rdma_qp->remote_lid != remote_lid ||
             memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
@@ -789,26 +789,26 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    if (!rdma_qp->data_programmed) {
+    if (!rdma_qp->dataProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->data_programmed = true;
+        rdma_qp->dataProgrammed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    if (!rdma_qp->notif_programmed) {
+    if (!rdma_qp->notifProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->notif_programmed = true;
+        rdma_qp->notifProgrammed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -970,7 +970,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     NIXL_DEBUG << "connectServerRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
     std::unique_lock<std::mutex> lock(connectLock);
-    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+    if (rdma_qp->dataProgrammed || rdma_qp->notifProgrammed) {
         if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
             rdma_qp->remote_lid != remote_lid ||
             memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
@@ -990,26 +990,26 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    if (!rdma_qp->data_programmed) {
+    if (!rdma_qp->dataProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->data_programmed = true;
+        rdma_qp->dataProgrammed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    if (!rdma_qp->notif_programmed) {
+    if (!rdma_qp->notifProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->notif_programmed = true;
+        rdma_qp->notifProgrammed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -678,13 +678,13 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -702,8 +702,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -712,8 +715,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -819,13 +825,13 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -872,8 +878,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -882,8 +891,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -18,6 +18,7 @@
 #include "gpunetio_backend.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <cstring>
 #include <cerrno>
 #include <stdexcept>
 #include <unistd.h>
@@ -767,36 +768,47 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     // Avoid duplicating RDMA connection to the same QP by client/server threads
     NIXL_DEBUG << "connectClientRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
-    connectLock.lock();
+    std::unique_lock<std::mutex> lock(connectLock);
+    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+        if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
+            rdma_qp->remote_lid != remote_lid ||
+            memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
+            NIXL_ERROR << "Remote QP route changed during retry";
+            return NIXL_ERR_BACKEND;
+        }
+    } else {
+        rdma_qp->rqpn_data = remote_qpn_data;
+        rdma_qp->rqpn_notif = remote_qpn_notif;
+        rdma_qp->remote_gid = remote_gid;
+        rdma_qp->remote_lid = remote_lid;
+    }
     if (connMap.find(remote_agent) != connMap.end()) {
         NIXL_INFO << "QP for " << remote_agent << " already connected" << std::endl;
         goto sync;
-        // return NIXL_SUCCESS;
     }
-
-    rdma_qp->rqpn_data = remote_qpn_data;
-    rdma_qp->rqpn_notif = remote_qpn_notif;
-    rdma_qp->remote_gid = remote_gid;
-    rdma_qp->remote_lid = remote_lid;
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result =
-        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->data_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->data_programmed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->notif_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->notif_programmed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -804,7 +816,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     connMap[remote_agent] = 1;
 
 sync:
-    connectLock.unlock();
+    lock.unlock();
     NIXL_DEBUG << "Client recv lack";
     if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
@@ -957,36 +969,47 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     // Avoid duplicating RDMA connection to the same QP by client/server threads
     NIXL_DEBUG << "connectServerRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
-    connectLock.lock();
+    std::unique_lock<std::mutex> lock(connectLock);
+    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+        if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
+            rdma_qp->remote_lid != remote_lid ||
+            memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
+            NIXL_ERROR << "Remote QP route changed during retry";
+            return NIXL_ERR_BACKEND;
+        }
+    } else {
+        rdma_qp->rqpn_data = remote_qpn_data;
+        rdma_qp->rqpn_notif = remote_qpn_notif;
+        rdma_qp->remote_gid = remote_gid;
+        rdma_qp->remote_lid = remote_lid;
+    }
     if (connMap.find(remote_agent) != connMap.end()) {
         NIXL_DEBUG << "QP for " << remote_agent << " already connected";
         goto sync;
-        // return NIXL_SUCCESS;
     }
-
-    rdma_qp->rqpn_data = remote_qpn_data;
-    rdma_qp->rqpn_notif = remote_qpn_notif;
-    rdma_qp->remote_gid = remote_gid;
-    rdma_qp->remote_lid = remote_lid;
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result =
-        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->data_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->data_programmed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->notif_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->notif_programmed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -994,8 +1017,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     connMap[remote_agent] = 1;
 
 sync:
-
-    connectLock.unlock();
+    lock.unlock();
 
     NIXL_DEBUG << "Server send rack " << rack;
     if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -18,12 +18,49 @@
 #include "gpunetio_backend.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <cerrno>
 #include <stdexcept>
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <absl/strings/str_split.h>
 
 const char info_delimiter = '-';
+
+namespace {
+bool
+sendAll(int fd, const void *buffer, size_t size) {
+    const auto *cursor = static_cast<const uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t sent = send(fd, cursor, size, MSG_NOSIGNAL);
+        if (sent < 0 && errno == EINTR) {
+            continue;
+        }
+        if (sent <= 0) {
+            return false;
+        }
+        cursor += sent;
+        size -= static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+bool
+recvAll(int fd, void *buffer, size_t size) {
+    auto *cursor = static_cast<uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t received = recv(fd, cursor, size, 0);
+        if (received < 0 && errno == EINTR) {
+            continue;
+        }
+        if (received <= 0) {
+            return false;
+        }
+        cursor += received;
+        size -= static_cast<size_t>(received);
+    }
+    return true;
+}
+} // namespace
 
 /****************************************
  * Constructor/Destructor
@@ -341,7 +378,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     lastPostedReq = 0;
     xferRingPos = 0;
 
-    progressThreadStart();
+    if (progressThreadStart() != NIXL_SUCCESS) {
+        throw std::runtime_error("Failed to start GPUNETIO connection thread");
+    }
 }
 
 nixl_mem_list_t
@@ -446,14 +485,22 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->send_pi = 0;
     notif->recv_pi = 0;
 
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
+    {
+        std::lock_guard<std::mutex> qp_lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+    }
     // Ensure notif list is not added twice for the same peer
     notifMap[remote_agent] = notif;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
-        qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
         ;
 
@@ -485,19 +532,17 @@ nixlDocaEngine::progressThreadStart() {
     oob_sock_server = socket(AF_INET, SOCK_STREAM, 0);
     if (oob_sock_server < 0) {
         NIXL_ERROR << "Error while creating socket " << oob_sock_server;
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
     NIXL_INFO << "DOCA Server socket created successfully";
 
-    if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable))) {
-        NIXL_ERROR << "Error setting socket options";
-        close(oob_sock_server);
-        return NIXL_ERR_NOT_SUPPORTED;
-    }
-
     if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable))) {
         NIXL_ERROR << "Error setting socket options";
         close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
 
@@ -508,6 +553,8 @@ nixlDocaEngine::progressThreadStart() {
         if (bind(oob_sock_server, (struct sockaddr *)addr_in, sizeof(struct sockaddr_in)) < 0) {
             NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
+            free((void *)pthrStop);
+            pthrStop = nullptr;
             return NIXL_ERR_NOT_SUPPORTED;
         }
     } else {
@@ -520,6 +567,8 @@ nixlDocaEngine::progressThreadStart() {
         if (bind(oob_sock_server, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
             NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
+            free((void *)pthrStop);
+            pthrStop = nullptr;
             return NIXL_ERR_NOT_SUPPORTED;
         }
     }
@@ -527,9 +576,11 @@ nixlDocaEngine::progressThreadStart() {
     NIXL_INFO << "Done with binding";
 
     /* Listen for clients: */
-    if (listen(oob_sock_server, 1) < 0) {
+    if (listen(oob_sock_server, SOMAXCONN) < 0) {
         NIXL_ERROR << "Error while listening";
         close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
     NIXL_INFO << "Listening for incoming connections";
@@ -543,26 +594,41 @@ nixlDocaEngine::progressThreadStart() {
     result = pthread_create(&server_thread_id, nullptr, threadProgressFunc, (void *)this);
     if (result != 0) {
         NIXL_ERROR << "Failed to create threadProgressFunc thread";
+        close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_BACKEND;
     }
+    serverThreadStarted = true;
 
     return NIXL_SUCCESS;
 }
 
 void
 nixlDocaEngine::progressThreadStop() {
-    int fake_sock_fd;
+    if (!serverThreadStarted) {
+        return;
+    }
+
+    int fake_sock_fd = -1;
     std::stringstream ss;
 
     ACCESS_ONCE(*pthrStop) = 1;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
+    if (oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port) < 0) {
+        shutdown(oob_sock_server, SHUT_RDWR);
+    }
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
+    serverThreadStarted = false;
     close(oob_sock_server);
-    close(fake_sock_fd);
+    if (fake_sock_fd >= 0) {
+        close(fake_sock_fd);
+    }
+    free((void *)pthrStop);
+    pthrStop = nullptr;
 }
 
 uint32_t
@@ -632,31 +698,40 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 nixl_status_t
 nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent];
+    struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "connectClientRdmaQp: Send to server data qp connection details";
     // Data QP
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     // Notif QP
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send LID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -664,7 +739,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -672,19 +747,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -729,7 +804,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 sync:
     connectLock.unlock();
     NIXL_DEBUG << "Client recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -743,7 +818,7 @@ sync:
     }
 
     NIXL_DEBUG << "Client sending rack" << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -759,23 +834,20 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
     size_t msg_size;
 
     // Msg
-    if (recv(oob_sock_client, &msg_size, sizeof(size_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &msg_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
     if (msg_size == 0) {
         NIXL_ERROR << "recvRemoteAgentName received msg size 0";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
     remote_agent.resize(msg_size);
 
-    if (recv(oob_sock_client, remote_agent.data(), msg_size, 0) < 0) {
+    if (!recvAll(oob_sock_client, remote_agent.data(), msg_size)) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
@@ -786,12 +858,12 @@ nixl_status_t
 nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
     size_t agent_size = localAgent.size();
 
-    if (send(oob_sock_client, &agent_size, sizeof(size_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &agent_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, localAgent.c_str(), localAgent.size(), 0) < 0) {
+    if (!sendAll(oob_sock_client, localAgent.c_str(), localAgent.size())) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
@@ -804,14 +876,23 @@ nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
 nixl_status_t
 nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent]; // validate
+    struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "DOCA connectServerRdmaQp for agent " << remote_agent.c_str();
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -819,19 +900,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -839,7 +920,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -847,20 +928,20 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server Send remote notif qp connection details 4";
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send local GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -909,14 +990,14 @@ sync:
     connectLock.unlock();
 
     NIXL_DEBUG << "Server send rack " << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -964,12 +1045,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     int oob_sock_client;
 
-    // TODO: Connect part should be moved into connect() method
-    nixlDocaConnection conn;
-    if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
-        return NIXL_ERR_INVALID_PARAM;
-    }
-
     GpunetioOobEndpoint endpoint;
     try {
         endpoint = parseGpunetioOobEndpoint(remote_conn_info);
@@ -979,24 +1054,56 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
         return NIXL_ERR_INVALID_PARAM;
     }
 
+    // TODO: Connect part should be moved into connect() method
+    nixlDocaConnection conn;
+    conn.remoteAgent = remote_agent;
+    conn.connected = false;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        if (!remoteConnMap.emplace(remote_agent, conn).second) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+    auto clear_pending = [&]() {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        auto pending = remoteConnMap.find(remote_agent);
+        if (pending != remoteConnMap.end() && !pending->second.connected) {
+            remoteConnMap.erase(pending);
+        }
+    };
+
     int ret = oob_connection_client_setup(endpoint.ipv4.c_str(), &oob_sock_client, endpoint.port);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
+        clear_pending();
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status == NIXL_SUCCESS) {
+        status = addRdmaQp(remote_agent);
+    }
+    if (status == NIXL_IN_PROG) {
+        status = NIXL_SUCCESS;
+    }
+    if (status == NIXL_SUCCESS) {
+        status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    }
+    if (status == NIXL_SUCCESS) {
+        status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    }
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        clear_pending();
+        return status;
+    }
 
-    conn.remoteAgent = remote_agent;
     conn.connected = true;
-    // if client or server already created this QP, no need to re-create
-    if (remoteConnMap.find(remote_agent) == remoteConnMap.end()) {
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
         remoteConnMap[remote_agent] = conn;
-        NIXL_INFO << "remoteConnMap extended with remote agent " << remote_agent << std::endl;
+        NIXL_INFO << "remoteConnMap connected remote agent " << remote_agent << std::endl;
     }
 
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
@@ -1070,14 +1177,16 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     std::vector<std::string> tokens;
     std::string token;
     nixlDocaPublicMetadata *md = new nixlDocaPublicMetadata;
-    auto search = remoteConnMap.find(remote_agent);
-
-    if (search == remoteConnMap.end()) {
-        NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
-        return NIXL_ERR_NOT_FOUND;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        auto search = remoteConnMap.find(remote_agent);
+        if (search == remoteConnMap.end() || !search->second.connected) {
+            NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
+            delete md;
+            return NIXL_ERR_NOT_FOUND;
+        }
+        conn = search->second;
     }
-
-    conn = (nixlDocaConnection)search->second;
 
     // directly copy underlying conn struct
     md->conn = conn;
@@ -1136,13 +1245,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
     }
 
-    auto search = qpMap.find(remote_agent);
-    if (search == qpMap.end()) {
-        NIXL_ERROR << "Can't find remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto search = qpMap.find(remote_agent);
+        if (search == qpMap.end()) {
+            NIXL_ERROR << "Can't find remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = search->second;
     }
-
-    rdma_qp = search->second;
 
     if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
 
@@ -1194,13 +1305,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
 
-        auto search = notifMap.find(remote_agent);
-        if (search == notifMap.end()) {
-            NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
-            return NIXL_ERR_INVALID_PARAM;
+        {
+            std::lock_guard<std::mutex> lock(notifLock);
+            auto search = notifMap.find(remote_agent);
+            if (search == notifMap.end()) {
+                NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            notif = search->second;
         }
-
-        notif = search->second;
 
         // Check notifMsg size
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
@@ -1305,8 +1418,16 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
     // while getNotifs is running
     std::lock_guard<std::mutex> lock(notifLock);
     for (auto &notif : notifMap) {
-        ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu =
-            qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
+        doca_gpu_dev_verbs_qp *notif_qp_gpu;
+        {
+            std::lock_guard<std::mutex> qp_lock(qpLock);
+            auto qp = qpMap.find(notif.first);
+            if (qp == qpMap.end()) {
+                return NIXL_ERR_BACKEND;
+            }
+            notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+        }
+        ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu = notif_qp_gpu;
         std::atomic_thread_fence(std::memory_order_seq_cst);
         while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr)
             ;
@@ -1360,10 +1481,15 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     uint32_t buf_idx;
     uintptr_t msg_buf;
 
-    auto searchNotif = notifMap.find(remote_agent);
-    if (searchNotif == notifMap.end()) {
-        NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent << std::endl;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(notifLock);
+        auto searchNotif = notifMap.find(remote_agent);
+        if (searchNotif == notifMap.end()) {
+            NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent
+                       << std::endl;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif = searchNotif->second;
     }
 
     // 16B is uint16_t msg size
@@ -1374,12 +1500,15 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    notif = searchNotif->second;
-
-    auto searchQp = qpMap.find(remote_agent);
-    if (searchQp == qpMap.end()) {
-        NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto searchQp = qpMap.find(remote_agent);
+        if (searchQp == qpMap.end()) {
+            NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = searchQp->second->qp_notif->get_qp_gpu_dev();
     }
 
     std::string newMsg = msg_tag_start + std::to_string((int)msg.size()) + msg_tag_end + msg;
@@ -1395,8 +1524,7 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     ((volatile struct docaNotif *)notif_send_cpu)->msg_lkey = notif->send_mr->get_lkey();
     ((volatile struct docaNotif *)notif_send_cpu)->msg_size = newMsg.size();
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu =
-        searchQp->second->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr)
         ;
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -437,8 +437,6 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
-    struct nixlDocaNotif *notif;
-
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -446,7 +444,7 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         return NIXL_SUCCESS;
     }
 
-    notif = new struct nixlDocaNotif;
+    auto notif = std::make_unique<nixlDocaNotif>();
 
     notif->elems_num = DOCA_MAX_NOTIF_INFLIGHT;
     notif->elems_size = DOCA_MAX_NOTIF_MESSAGE_SIZE;
@@ -495,7 +493,6 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
     }
     // Ensure notif list is not added twice for the same peer
-    notifMap[remote_agent] = notif;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
@@ -503,6 +500,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
         ;
+
+    const bool inserted = notifMap.emplace(remote_agent, notif.get()).second;
+    if (!inserted) {
+        return NIXL_ERR_BACKEND;
+    }
+    notif.release();
 
     NIXL_INFO << "nixlDocaInitNotif added new qp for " << remote_agent << std::endl;
 
@@ -610,23 +613,17 @@ nixlDocaEngine::progressThreadStop() {
         return;
     }
 
-    int fake_sock_fd = -1;
-    std::stringstream ss;
-
     ACCESS_ONCE(*pthrStop) = 1;
-    ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
-       << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    if (oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port) < 0) {
-        shutdown(oob_sock_server, SHUT_RDWR);
+
+    const int active_socket = activeOobSocket.exchange(-1);
+    if (active_socket >= 0) {
+        shutdown(active_socket, SHUT_RDWR);
     }
-    // pthr.join();
+    shutdown(oob_sock_server, SHUT_RDWR);
     pthread_join(server_thread_id, nullptr);
     serverThreadStarted = false;
     close(oob_sock_server);
-    if (fake_sock_fd >= 0) {
-        close(fake_sock_fd);
-    }
     free((void *)pthrStop);
     pthrStop = nullptr;
 }
@@ -700,6 +697,8 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     doca_error_t result;
     struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+    uint32_t remote_qpn_data = 0, remote_qpn_notif = 0, remote_lid = 0;
+    doca_verbs_gid remote_gid{};
 
     {
         std::lock_guard<std::mutex> lock(qpLock);
@@ -739,7 +738,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -747,19 +746,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -775,13 +774,15 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -790,16 +791,17 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
         return NIXL_ERR_BACKEND;
     }
+
+    // QP programming is complete even if the final ACK exchange later fails.
+    // A retry must skip another QP state transition and repeat only the handshake.
+    connMap[remote_agent] = 1;
 
 sync:
     connectLock.unlock();
@@ -824,8 +826,6 @@ sync:
         return NIXL_ERR_BACKEND;
     }
 
-    connMap[remote_agent] = 1;
-
     return NIXL_SUCCESS;
 }
 
@@ -839,8 +839,8 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
         return NIXL_ERR_BACKEND;
     }
 
-    if (msg_size == 0) {
-        NIXL_ERROR << "recvRemoteAgentName received msg size 0";
+    if (!isValidGpunetioAgentNameSize(msg_size)) {
+        NIXL_ERROR << "recvRemoteAgentName received invalid msg size " << msg_size;
         return NIXL_ERR_BACKEND;
     }
 
@@ -857,6 +857,11 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
 nixl_status_t
 nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
     size_t agent_size = localAgent.size();
+
+    if (!isValidGpunetioAgentNameSize(agent_size)) {
+        NIXL_ERROR << "sendLocalAgentName has invalid msg size " << agent_size;
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     if (!sendAll(oob_sock_client, &agent_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to send connection details";
@@ -878,6 +883,8 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     doca_error_t result;
     struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+    uint32_t remote_qpn_data = 0, remote_qpn_notif = 0, remote_lid = 0;
+    doca_verbs_gid remote_gid{};
 
     {
         std::lock_guard<std::mutex> lock(qpLock);
@@ -892,7 +899,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -900,19 +907,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -957,13 +964,15 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -972,17 +981,16 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
         return NIXL_ERR_BACKEND;
     }
 
+    // QP programming is complete even if the final ACK exchange later fails.
+    // A retry must skip another QP state transition and repeat only the handshake.
     connMap[remote_agent] = 1;
 
 sync:
@@ -1229,7 +1237,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    auto treq = std::make_unique<nixlDocaBckndReq>();
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
     uint32_t lcnt = (uint32_t)local.descCount();
@@ -1343,7 +1351,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     treq->backendHandleGpu = 0;
 
-    handle = treq;
+    handle = treq.release();
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -24,6 +24,7 @@ class nixlDocaEngine : public nixlBackendEngine {
 public:
     CUcontext main_cuda_ctx;
     int oob_sock_server;
+    std::atomic<int> activeOobSocket{-1};
     mutable std::mutex notifLock;
     mutable std::mutex qpLock;
     std::mutex connectLock;
@@ -36,7 +37,7 @@ public:
     struct ibv_pd *pd; /* local protection domain */
     doca_verbs_gid gid; /* local gid address */
     doca_verbs_gid remote_gid; /* remote gid address */
-    int lid; /* IB: local ID */
+    int lid = 0; /* IB: local ID */
     int dlid; /* IB: destination ID */
     int gid_index;
     struct ibv_port_attr port_attr;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -150,7 +150,7 @@ private:
     std::vector<struct nixlDocaRdmaQp> rdma_qp_v;
     int nstreams;
 
-    uint32_t local_port;
+    uint16_t local_port;
     int noSyncIters;
     uint8_t ipv4_addr[4];
     struct sockaddr oob_saddr;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -24,9 +24,10 @@ class nixlDocaEngine : public nixlBackendEngine {
 public:
     CUcontext main_cuda_ctx;
     int oob_sock_server;
-    std::mutex notifLock;
-    std::mutex qpLock;
+    mutable std::mutex notifLock;
+    mutable std::mutex qpLock;
     std::mutex connectLock;
+    mutable std::mutex remoteConnLock;
     std::vector<std::pair<uint32_t, doca_gpu *>> gdevs; /* List of DOCA GPUNetIO device handlers */
     doca_dev *ddev; /* DOCA device handler associated to queues */
     doca_verbs_context *verbs_context; /* DOCA Verbs Context */
@@ -186,6 +187,7 @@ private:
     std::unordered_map<std::string, struct nixlDocaNotif *> notifMap;
 
     pthread_t server_thread_id;
+    bool serverThreadStarted = false;
 
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -184,8 +184,8 @@ struct nixlDocaRdmaQp {
     uint32_t rqpn_notif;
     doca_verbs_gid remote_gid{};
     uint32_t remote_lid = 0;
-    bool data_programmed = false;
-    bool notif_programmed = false;
+    bool dataProgrammed = false;
+    bool notifProgrammed = false;
 };
 
 struct nixlDocaEngine;

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -19,6 +19,7 @@
 #define GPUNETIO_BACKEND_AUX_H
 
 #include <atomic>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <mutex>
@@ -71,6 +72,7 @@ constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
 // Pre-fill the whole recv queue with notif once
 constexpr uint32_t DOCA_MAX_NOTIF_INFLIGHT = RDMA_RECV_QUEUE_SIZE;
 constexpr uint32_t DOCA_MAX_NOTIF_MESSAGE_SIZE = 8192;
+constexpr time_t DOCA_OOB_SOCKET_TIMEOUT_SEC = 10;
 constexpr uint32_t DOCA_NOTIF_NULL = 0xFFFFFFFF;
 
 #ifndef ACCESS_ONCE
@@ -100,14 +102,21 @@ struct docaXferReqGpu {
 };
 
 struct nixlDocaNotif {
-    uint32_t elems_num;
-    uint32_t elems_size;
-    uint8_t *send_addr;
-    std::atomic<uint32_t> send_pi;
+    uint32_t elems_num = 0;
+    uint32_t elems_size = 0;
+    uint8_t *send_addr = nullptr;
+    std::atomic<uint32_t> send_pi{0};
     std::unique_ptr<nixl::doca::verbs::mr> send_mr;
-    uint8_t *recv_addr;
-    std::atomic<uint32_t> recv_pi;
+    uint8_t *recv_addr = nullptr;
+    std::atomic<uint32_t> recv_pi{0};
     std::unique_ptr<nixl::doca::verbs::mr> recv_mr;
+
+    ~nixlDocaNotif() {
+        send_mr.reset();
+        recv_mr.reset();
+        free(send_addr);
+        free(recv_addr);
+    }
 };
 
 struct docaXferCompletion {
@@ -187,6 +196,8 @@ int
 oob_connection_client_setup(const char *server_ip,
                             int *oob_sock_fd,
                             uint16_t server_port = GPUNETIO_DEFAULT_OOB_PORT);
+int
+setOobSocketTimeouts(int oob_sock_fd);
 void
 oob_connection_client_close(int oob_sock_fd);
 void

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -169,12 +169,12 @@ struct nixlDocaRdmaQp {
     std::unique_ptr<nixl::doca::verbs::qp> qp_data;
     uint32_t qpn_data;
     uint32_t rqpn_data;
-    uint32_t remote_gid_data;
 
     std::unique_ptr<nixl::doca::verbs::qp> qp_notif;
     uint32_t qpn_notif;
     uint32_t rqpn_notif;
-    uint32_t remote_gid_notif;
+    doca_verbs_gid remote_gid{};
+    uint32_t remote_lid = 0;
 };
 
 struct nixlDocaEngine;
@@ -199,7 +199,11 @@ create_verbs_ah_attr(doca_verbs_context *verbs_context,
                      enum doca_verbs_addr_type addr_type,
                      doca_verbs_ah_attr **verbs_ah_attr);
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid);
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid);
 void *
 threadProgressFunc(void *arg);
 int

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -52,6 +52,7 @@
 
 // Local includes
 #include "common/nixl_time.h"
+#include "gpunetio_oob_endpoint.h"
 
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT = 128;
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT_MASK = (DOCA_MAX_COMPLETION_INFLIGHT - 1);
@@ -62,7 +63,6 @@ constexpr uint32_t DOCA_XFER_REQ_SIZE = 512;
 constexpr uint32_t DOCA_XFER_REQ_MAX = 32;
 constexpr uint32_t DOCA_XFER_REQ_MASK = (DOCA_XFER_REQ_MAX - 1);
 constexpr uint32_t DOCA_ENG_MAX_CONN = 20;
-constexpr uint32_t DOCA_RDMA_CM_LOCAL_PORT_SERVER = 6544;
 constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
@@ -184,7 +184,9 @@ nixlDocaEngineCheckCudaError(cudaError_t result, const char *message);
 void
 nixlDocaEngineCheckCuError(CUresult result, const char *message);
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd);
+oob_connection_client_setup(const char *server_ip,
+                            int *oob_sock_fd,
+                            uint16_t server_port = GPUNETIO_DEFAULT_OOB_PORT);
 void
 oob_connection_client_close(int oob_sock_fd);
 void

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -184,6 +184,8 @@ struct nixlDocaRdmaQp {
     uint32_t rqpn_notif;
     doca_verbs_gid remote_gid{};
     uint32_t remote_lid = 0;
+    bool data_programmed = false;
+    bool notif_programmed = false;
 };
 
 struct nixlDocaEngine;

--- a/src/plugins/gpunetio/gpunetio_oob_endpoint.h
+++ b/src/plugins/gpunetio/gpunetio_oob_endpoint.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GPUNETIO_OOB_ENDPOINT_H
+#define GPUNETIO_OOB_ENDPOINT_H
+
+#include <arpa/inet.h>
+
+#include <charconv>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+constexpr uint16_t GPUNETIO_DEFAULT_OOB_PORT = 6544;
+
+struct GpunetioOobEndpoint {
+    std::string ipv4;
+    uint16_t port;
+};
+
+inline uint16_t
+parseGpunetioOobPort(std::string_view value) {
+    if (value.empty()) {
+        return GPUNETIO_DEFAULT_OOB_PORT;
+    }
+
+    uint32_t port = 0;
+    const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), port);
+    if (error != std::errc() || end != value.data() + value.size() || port == 0 || port > 65535) {
+        throw std::invalid_argument("oob_port must be an integer in the range [1, 65535]");
+    }
+    return static_cast<uint16_t>(port);
+}
+
+inline GpunetioOobEndpoint
+parseGpunetioOobEndpoint(std::string_view metadata) {
+    if (metadata.empty() || metadata.find('\0') != std::string_view::npos) {
+        throw std::invalid_argument("GPUNETIO connection metadata is empty or malformed");
+    }
+
+    const size_t separator = metadata.find(':');
+    if (separator != std::string_view::npos &&
+        (separator == 0 || separator + 1 == metadata.size() ||
+         metadata.find(':', separator + 1) != std::string_view::npos)) {
+        throw std::invalid_argument("GPUNETIO connection metadata must be IPv4 or IPv4:port");
+    }
+
+    const std::string ipv4(metadata.substr(0, separator));
+    in_addr address{};
+    if (inet_pton(AF_INET, ipv4.c_str(), &address) != 1) {
+        throw std::invalid_argument(
+            "GPUNETIO connection metadata contains an invalid IPv4 address");
+    }
+
+    const uint16_t port = separator == std::string_view::npos ?
+        GPUNETIO_DEFAULT_OOB_PORT :
+        parseGpunetioOobPort(metadata.substr(separator + 1));
+    return {ipv4, port};
+}
+
+inline std::string
+formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
+    if (port == GPUNETIO_DEFAULT_OOB_PORT) {
+        return std::string(ipv4);
+    }
+    return std::string(ipv4) + ":" + std::to_string(port);
+}
+
+#endif

--- a/src/plugins/gpunetio/gpunetio_oob_endpoint.h
+++ b/src/plugins/gpunetio/gpunetio_oob_endpoint.h
@@ -3,24 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef GPUNETIO_OOB_ENDPOINT_H
-#define GPUNETIO_OOB_ENDPOINT_H
+#ifndef NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H
+#define NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H
 
 #include <arpa/inet.h>
 
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 
 constexpr uint16_t GPUNETIO_DEFAULT_OOB_PORT = 6544;
+constexpr std::size_t GPUNETIO_MAX_AGENT_NAME_SIZE = 4096;
 
+/** Return whether an OOB agent-name payload length is safe to allocate. */
+inline bool
+isValidGpunetioAgentNameSize(std::size_t size) noexcept {
+    return size > 0 && size <= GPUNETIO_MAX_AGENT_NAME_SIZE;
+}
+
+/** Parsed GPUNETIO IPv4 endpoint and TCP port. */
 struct GpunetioOobEndpoint {
     std::string ipv4;
     uint16_t port;
 };
 
+/**
+ * Parse a decimal TCP port in [1, 65535]. An empty value selects the default port.
+ *
+ * @throws std::invalid_argument if the value is not a valid TCP port.
+ */
 inline uint16_t
 parseGpunetioOobPort(std::string_view value) {
     if (value.empty()) {
@@ -35,6 +49,12 @@ parseGpunetioOobPort(std::string_view value) {
     return static_cast<uint16_t>(port);
 }
 
+/**
+ * Parse connection metadata encoded as IPv4 or IPv4:port.
+ *
+ * IPv4-only metadata selects the default port for backward compatibility.
+ * @throws std::invalid_argument if the metadata or port is malformed.
+ */
 inline GpunetioOobEndpoint
 parseGpunetioOobEndpoint(std::string_view metadata) {
     if (metadata.empty() || metadata.find('\0') != std::string_view::npos) {
@@ -61,6 +81,7 @@ parseGpunetioOobEndpoint(std::string_view metadata) {
     return {ipv4, port};
 }
 
+/** Format an IPv4 endpoint, omitting the port when it is the default. */
 inline std::string
 formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
     if (port == GPUNETIO_DEFAULT_OOB_PORT) {
@@ -69,4 +90,4 @@ formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
     return std::string(ipv4) + ":" + std::to_string(port);
 }
 
-#endif
+#endif // NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -55,6 +55,7 @@ get_backend_options() {
     nixl_b_params_t params;
     params["network_devices"] = "";
     params["oob_interface"] = "";
+    params["oob_port"] = "";
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
     return params;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -48,7 +48,7 @@ nixlDocaEngineCheckCuError(CUresult result, const char *message) {
 }
 
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
+oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t server_port) {
     struct sockaddr_in server_addr = {0};
     int oob_sock_fd_;
 
@@ -62,13 +62,17 @@ oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
 
     /* Set port and IP the same as server-side: */
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
-    server_addr.sin_addr.s_addr = inet_addr(server_ip);
+    server_addr.sin_port = htons(server_port);
+    if (inet_pton(AF_INET, server_ip, &server_addr.sin_addr) != 1) {
+        close(oob_sock_fd_);
+        NIXL_ERROR << "Invalid server IPv4 address " << server_ip;
+        return -1;
+    }
 
     /* Send connection request to server: */
     if (connect(oob_sock_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         close(oob_sock_fd_);
-        NIXL_ERROR << "Unable to connect to server at " << server_ip;
+        NIXL_ERROR << "Unable to connect to server at " << server_ip << ":" << server_port;
         return -1;
     }
     NIXL_INFO << "Connected with server successfully";

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -19,6 +19,7 @@
 #include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <stdexcept>
+#include <sys/time.h>
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <chrono>
@@ -48,6 +49,17 @@ nixlDocaEngineCheckCuError(CUresult result, const char *message) {
 }
 
 int
+setOobSocketTimeouts(int oob_sock_fd) {
+    const timeval timeout{DOCA_OOB_SOCKET_TIMEOUT_SEC, 0};
+    if (setsockopt(oob_sock_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0 ||
+        setsockopt(oob_sock_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+        NIXL_ERROR << "Unable to set OOB socket timeout";
+        return -1;
+    }
+    return 0;
+}
+
+int
 oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t server_port) {
     struct sockaddr_in server_addr = {0};
     int oob_sock_fd_;
@@ -59,6 +71,11 @@ oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t se
         return -1;
     }
     NIXL_INFO << "Socket created successfully";
+
+    if (setOobSocketTimeouts(oob_sock_fd_) != 0) {
+        close(oob_sock_fd_);
+        return -1;
+    }
 
     /* Set port and IP the same as server-side: */
     server_addr.sin_family = AF_INET;
@@ -384,10 +401,19 @@ threadProgressFunc(void *arg) {
             return nullptr;
         }
 
+        eng->activeOobSocket.store(oob_sock_client);
+
         if (ACCESS_ONCE(*eng->pthrStop) == 1) {
             NIXL_DEBUG << "Stopping thread " << oob_sock_client;
+            eng->activeOobSocket.store(-1);
             close(oob_sock_client);
             return nullptr;
+        }
+
+        if (setOobSocketTimeouts(oob_sock_client) != 0) {
+            eng->activeOobSocket.store(-1);
+            close(oob_sock_client);
+            continue;
         }
 
         NIXL_INFO << "Server: client connected at IP: " << inet_ntoa(client_addr.sin_addr)
@@ -412,6 +438,7 @@ threadProgressFunc(void *arg) {
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
         }
+        eng->activeOobSocket.store(-1);
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -185,11 +185,15 @@ destroy_verbs_ah:
 }
 
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid) {
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid) {
     doca_error_t status = DOCA_SUCCESS, tmp_status = DOCA_SUCCESS;
     doca_verbs_qp_attr *verbs_qp_attr = NULL;
 
-    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, eng->remote_gid);
+    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, remote_gid);
     if (status != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to set remote gid " << doca_error_get_descr(status);
         return status;
@@ -197,7 +201,7 @@ connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t
 
     // IB
     if (eng->port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
-        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, eng->dlid);
+        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, remote_lid);
         if (status != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to set dlid";
             return status;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -386,6 +386,7 @@ threadProgressFunc(void *arg) {
 
         if (ACCESS_ONCE(*eng->pthrStop) == 1) {
             NIXL_DEBUG << "Stopping thread " << oob_sock_client;
+            close(oob_sock_client);
             return nullptr;
         }
 
@@ -394,11 +395,23 @@ threadProgressFunc(void *arg) {
 
         // cuCtxSetCurrent(eng->main_cuda_ctx);
 
-        eng->recvRemoteAgentName(oob_sock_client, remote_agent);
-
-        eng->addRdmaQp(remote_agent);
-        eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
-        eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        remote_agent.clear();
+        nixl_status_t status = eng->recvRemoteAgentName(oob_sock_client, remote_agent);
+        if (status == NIXL_SUCCESS) {
+            status = eng->addRdmaQp(remote_agent);
+        }
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        }
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
+        }
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <chrono>
+#include <thread>
 
 // constexpr auto connection_delay = 500ms;
 constexpr std::chrono::microseconds connection_delay(500000);
@@ -394,11 +395,12 @@ threadProgressFunc(void *arg) {
         oob_sock_client =
             accept(eng->oob_sock_server, (struct sockaddr *)&client_addr, &client_size);
         if (oob_sock_client < 0) {
+            if (ACCESS_ONCE(*eng->pthrStop) != 0) {
+                return nullptr;
+            }
             NIXL_ERROR << "Can't accept new socket connection " << oob_sock_client;
-            if (ACCESS_ONCE(*eng->pthrStop) == 0)
-                NIXL_ERROR << "Can't accept new socket connection " << oob_sock_client;
-            // close(eng->oob_sock_server);
-            return nullptr;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
         }
 
         eng->activeOobSocket.store(oob_sock_client);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
@@ -6,6 +6,7 @@
 #include "gpunetio_oob_endpoint.h"
 
 #include <cassert>
+#include <limits>
 #include <stdexcept>
 
 template<typename Fn>
@@ -23,6 +24,12 @@ assertInvalid(Fn &&fn) {
 
 int
 main() {
+    assert(!isValidGpunetioAgentNameSize(0));
+    assert(isValidGpunetioAgentNameSize(1));
+    assert(isValidGpunetioAgentNameSize(GPUNETIO_MAX_AGENT_NAME_SIZE));
+    assert(!isValidGpunetioAgentNameSize(GPUNETIO_MAX_AGENT_NAME_SIZE + 1));
+    assert(!isValidGpunetioAgentNameSize(std::numeric_limits<std::size_t>::max()));
+
     assert(parseGpunetioOobPort("") == GPUNETIO_DEFAULT_OOB_PORT);
     assert(parseGpunetioOobPort("1") == 1);
     assert(parseGpunetioOobPort("65535") == 65535);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -20,10 +20,8 @@ main() {
     timeval send_timeout{};
     socklen_t recv_size = sizeof(recv_timeout);
     socklen_t send_size = sizeof(send_timeout);
-    assert(getsockopt(
-               sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
-    assert(getsockopt(
-               sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
+    assert(getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
+    assert(getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
     assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
     assert(recv_timeout.tv_usec == 0);
     assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -5,7 +5,7 @@
 
 #include "gpunetio_backend_aux.h"
 
-#include <cassert>
+#include <iostream>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -13,19 +13,39 @@
 int
 main() {
     int sockets[2] = {-1, -1};
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
-    assert(setOobSocketTimeouts(sockets[0]) == 0);
+    auto fail = [&](const char *message) {
+        std::cerr << message << std::endl;
+        if (sockets[0] >= 0) {
+            close(sockets[0]);
+        }
+        if (sockets[1] >= 0) {
+            close(sockets[1]);
+        }
+        return 1;
+    };
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+        return fail("socketpair failed");
+    }
+    if (setOobSocketTimeouts(sockets[0]) != 0) {
+        return fail("setting socket timeouts failed");
+    }
 
     timeval recv_timeout{};
     timeval send_timeout{};
     socklen_t recv_size = sizeof(recv_timeout);
     socklen_t send_size = sizeof(send_timeout);
-    assert(getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
-    assert(getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
-    assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
-    assert(recv_timeout.tv_usec == 0);
-    assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
-    assert(send_timeout.tv_usec == 0);
+    if (getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) != 0) {
+        return fail("reading receive timeout failed");
+    }
+    if (getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) != 0) {
+        return fail("reading send timeout failed");
+    }
+    if (recv_timeout.tv_sec != DOCA_OOB_SOCKET_TIMEOUT_SEC || recv_timeout.tv_usec != 0) {
+        return fail("receive timeout mismatch");
+    }
+    if (send_timeout.tv_sec != DOCA_OOB_SOCKET_TIMEOUT_SEC || send_timeout.tv_usec != 0) {
+        return fail("send timeout mismatch");
+    }
 
     close(sockets[0]);
     close(sockets[1]);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_backend_aux.h"
+
+#include <cassert>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+main() {
+    int sockets[2] = {-1, -1};
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(setOobSocketTimeouts(sockets[0]) == 0);
+
+    timeval recv_timeout{};
+    timeval send_timeout{};
+    socklen_t recv_size = sizeof(recv_timeout);
+    socklen_t send_size = sizeof(send_timeout);
+    assert(getsockopt(
+               sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
+    assert(getsockopt(
+               sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
+    assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
+    assert(recv_timeout.tv_usec == 0);
+    assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
+    assert(send_timeout.tv_usec == 0);
+
+    close(sockets[0]);
+    close(sockets[1]);
+    return 0;
+}

--- a/test/gtest/plugins/gpunetio/meson.build
+++ b/test/gtest/plugins/gpunetio/meson.build
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+gpunetio_oob_endpoint_test = executable(
+    'gpunetio_oob_endpoint_test',
+    'gpunetio_oob_endpoint_test.cpp',
+    include_directories: include_directories('../../../../src/plugins/gpunetio'),
+    install: true,
+)
+test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
+
+gpunetio_oob_socket_test = executable(
+    'gpunetio_oob_socket_test',
+    'gpunetio_oob_socket_test.cpp',
+    include_directories: [
+        nixl_inc_dirs,
+        utils_inc_dirs,
+        include_directories('../../../../src/plugins/gpunetio'),
+    ],
+    dependencies: [gpunetio_backend_interface, cuda_dep, absl_log_dep] + plugin_gpunetio_deps,
+    install: true,
+)
+test('gpunetio_oob_socket', gpunetio_oob_socket_test)

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -21,6 +21,10 @@ if enabled_plugins.get('AZURE_BLOB')
     subdir('azure_blob')
 endif
 
+if enabled_plugins.get('GPUNETIO')
+    subdir('gpunetio')
+endif
+
 if not enabled_plugins.get('OBJ')
     message('OBJ plugin not enabled, skipping plugins_gtest build')
     subdir_done()

--- a/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
+++ b/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_oob_endpoint.h"
+
+#include <cassert>
+#include <stdexcept>
+
+template<typename Fn>
+void
+assertInvalid(Fn &&fn) {
+    bool rejected = false;
+    try {
+        fn();
+    }
+    catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+int
+main() {
+    assert(parseGpunetioOobPort("") == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(parseGpunetioOobPort("1") == 1);
+    assert(parseGpunetioOobPort("65535") == 65535);
+
+    const auto legacy = parseGpunetioOobEndpoint("192.0.2.1");
+    assert(legacy.ipv4 == "192.0.2.1");
+    assert(legacy.port == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(formatGpunetioOobEndpoint(legacy.ipv4, legacy.port) == "192.0.2.1");
+
+    const auto configured = parseGpunetioOobEndpoint("198.51.100.2:16544");
+    assert(configured.ipv4 == "198.51.100.2");
+    assert(configured.port == 16544);
+    assert(formatGpunetioOobEndpoint(configured.ipv4, configured.port) == "198.51.100.2:16544");
+
+    for (const auto *value : {"0", "-1", "+1", "65536", "12x", " 6544", "6544 "}) {
+        assertInvalid([=] { parseGpunetioOobPort(value); });
+    }
+
+    for (const auto *value : {"",
+                              "192.0.2",
+                              "256.0.0.1",
+                              "192.0.2.1:",
+                              "192.0.2.1:0",
+                              "192.0.2.1:65536",
+                              "192.0.2.1:12x",
+                              "192.0.2.1:6544:1",
+                              "[::1]:6544"}) {
+        assertInvalid([=] { parseGpunetioOobEndpoint(value); });
+    }
+    assertInvalid([] { parseGpunetioOobEndpoint(std::string("192.0.2.1\0:6544", 16)); });
+
+    return 0;
+}

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +14,6 @@
 # limitations under the License.
 
 compile_flags = []
-
-gpunetio_oob_endpoint_test = executable(
-        'gpunetio_oob_endpoint_test',
-        'gpunetio_oob_endpoint_test.cpp',
-        include_directories: include_directories('../../../../src/plugins/gpunetio'),
-        install: false)
-test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
 
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -15,6 +15,13 @@
 
 compile_flags = []
 
+gpunetio_oob_endpoint_test = executable(
+        'gpunetio_oob_endpoint_test',
+        'gpunetio_oob_endpoint_test.cpp',
+        include_directories: include_directories('../../../../src/plugins/gpunetio'),
+        install: false)
+test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
+
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]
         compile_flags += '-DHAVE_CUDA'


### PR DESCRIPTION
## What?

Make GPUNETIO connection setup unambiguous when several peers or backend instances initialize concurrently.

This change:

- stores the remote GID and LID on each RDMA QP instead of in engine-global mutable fields;
- passes that per-QP route state explicitly into the Verbs QP transition;
- adds an optional GPUNETIO `oob_port` backend parameter;
- preserves the legacy IPv4-only connection metadata when the default port 6544 is used and serializes non-default endpoints as `IPv4:port`;
- removes `SO_REUSEPORT`, so two backends accidentally using the same address and port fail during setup instead of sharing a listener;
- raises the TCP listen backlog from 1 to `SOMAXCONN`;
- validates OOB endpoint parsing, including malformed IPv4 and port values.

## Why?

The GPUNETIO engine previously reused one remote GID/LID pair while multiple peer connections populated and transitioned different QPs. A connection could therefore consume route state written by another connection. On a shared host network namespace, `SO_REUSEPORT` also allowed multiple backend listeners on the default port, making the receiving rank ambiguous.

The result can be a QP connected to the wrong peer and later CQ failures. Connection identity and route state must be fixed before data transfer begins.

## How?

Connection metadata remains backward compatible:

```text
default port:      192.0.2.1
non-default port:  192.0.2.1:16544
```

Each backend binds one explicit endpoint. Each `nixlDocaRdmaQp` owns its received remote GID and LID, and `connect_verbs_qp()` consumes those values directly.

## Scope

This PR does not change peer-memory registration, WRITE coalescing, notification polling, request-ring sizing/publication, or NIXLBench CLI wiring. NIXLBench forwarding is proposed separately in #2173.

The H20 DOCA 3.1 environment also requires the compatibility and bonded-RoCE work in #2052; that is an environment dependency for the live validation, not a source dependency of the endpoint/route-state design.

## Validation

- OOB endpoint parser test compiled with C++20, `-Wall -Wextra -Werror`: PASS.
- Legacy/default endpoint formatting and explicit-port round trips: PASS.
- Invalid IPv4, zero/out-of-range ports, signs, whitespace, and embedded NUL input are rejected: PASS.
- `git diff --check`: PASS.
- GPUNETIO plugin build with `werror=true` on H20/DOCA 3.1 plus the #2052 compatibility patch: PASS.

Integration evidence with #2052 and the later GPUNETIO data-path stack:

```text
H20 cross-node TP4/DCP4: PASS
ready epochs:            8/8
output:                  identical 32-token sequence
CQE/transport errors:    zero
```

That H20 row validates the combined stack. It is not presented as an isolated performance result for this correctness-only diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable GPUNetIO out-of-band communication ports, defaulting to 6544.
  * Added support for IPv4 endpoint metadata in `address` or `address:port` format.
  * Added validation for ports, IPv4 addresses, endpoint formats, and agent-name sizes.

* **Bug Fixes**
  * Improved reliability during interrupted transfers, connection timeouts, shutdowns, and failed setup attempts.
  * Improved validation and cleanup for remote connections, notifications, and transfer resources.

* **Tests**
  * Added coverage for endpoint parsing, validation, formatting, and socket timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->