### PR TITLE
[GPUNetIO] Surface completion failures

### DIFF
--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -400,6 +400,11 @@ nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
     struct nixlDocaNotif *notif;
 
+    const nixl_status_t completion_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+    if (completion_status != NIXL_SUCCESS) {
+        return completion_status;
+    }
+
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -454,8 +459,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
         qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
-    while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
-        ;
+    while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr) {
+        const nixl_status_t wait_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+        if (wait_status != NIXL_SUCCESS) {
+            return wait_status;
+        }
+    }
 
     NIXL_INFO << "nixlDocaInitNotif added new qp for " << remote_agent << std::endl;
 
@@ -1234,6 +1243,10 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const std::string &remote_agent,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
+    const nixl_status_t completion_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+    if (completion_status != NIXL_SUCCESS) {
+        return completion_status;
+    }
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
     for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
@@ -1272,7 +1285,7 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
             *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
             NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
                       << " COMPLETED!\n";
-            return NIXL_SUCCESS;
+            return nixl::gpunetio::completionStatus(wait_exit_cpu);
         } else
             return NIXL_IN_PROG;
     }
@@ -1305,11 +1318,23 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
     // while getNotifs is running
     std::lock_guard<std::mutex> lock(notifLock);
     for (auto &notif : notifMap) {
+        const nixl_status_t preflight_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+        if (preflight_status != NIXL_SUCCESS) {
+            return preflight_status;
+        }
         ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu =
             qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
         std::atomic_thread_fence(std::memory_order_seq_cst);
-        while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr)
-            ;
+        while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr) {
+            const nixl_status_t wait_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+            if (wait_status != NIXL_SUCCESS) {
+                return wait_status;
+            }
+        }
+        const nixl_status_t progress_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+        if (progress_status != NIXL_SUCCESS) {
+            return progress_status;
+        }
         num_msg = ((volatile struct docaNotif *)notif_progress_cpu)->msg_num;
         while (num_msg > 0) {
             recv_idx = notif.second->recv_pi.load() & (DOCA_MAX_NOTIF_INFLIGHT - 1);
@@ -1360,6 +1385,11 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     uint32_t buf_idx;
     uintptr_t msg_buf;
 
+    const nixl_status_t completion_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+    if (completion_status != NIXL_SUCCESS) {
+        return completion_status;
+    }
+
     auto searchNotif = notifMap.find(remote_agent);
     if (searchNotif == notifMap.end()) {
         NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent << std::endl;
@@ -1397,8 +1427,12 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu =
         searchQp->second->qp_notif->get_qp_gpu_dev();
-    while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr)
-        ;
+    while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr) {
+        const nixl_status_t wait_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+        if (wait_status != NIXL_SUCCESS) {
+            return wait_status;
+        }
+    }
 
-    return NIXL_SUCCESS;
+    return nixl::gpunetio::completionStatus(wait_exit_cpu);
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1107,18 +1107,27 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    nixlDocaBckndReq *treq;
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
     uint32_t lcnt = (uint32_t)local.descCount();
     uint32_t rcnt = (uint32_t)remote.descCount();
     uint32_t stream_id;
     struct nixlDocaRdmaQp *rdma_qp;
+    struct nixlDocaNotif *notif = nullptr;
+    std::string newMsg;
     uintptr_t notif_addr;
+
+    if (lcnt != rcnt || lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     // TODO: check device id from local dlist mr that should be all the same and same of
     // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
+        if (local[idx].len != remote[idx].len) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
         if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
     }
@@ -1131,10 +1140,21 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
+    if (opt_args && opt_args->hasNotif) {
+        auto notif_search = notifMap.find(remote_agent);
+        if (notif_search == notifMap.end()) {
+            NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif = notif_search->second;
+        newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) + msg_tag_end +
+            opt_args->notifMsg;
+        if (newMsg.size() + 1 > notif->elems_size) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
 
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
-
+    treq = new nixlDocaBckndReq;
     if (opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
         treq->stream = post_stream[stream_id];
@@ -1148,8 +1168,6 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     do {
         for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
             size_t lsize = local[idx].len;
-            size_t rsize = remote[idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
 
             lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
@@ -1179,20 +1197,6 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     treq->end_pos = xferRingPos;
 
     if (opt_args && opt_args->hasNotif) {
-        struct nixlDocaNotif *notif;
-
-        auto search = notifMap.find(remote_agent);
-        if (search == notifMap.end()) {
-            NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
-            return NIXL_ERR_INVALID_PARAM;
-        }
-
-        notif = search->second;
-
-        // Check notifMsg size
-        std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
-            msg_tag_end + opt_args->notifMsg;
-
         auto &final_request = xferReqRingCpu[treq->end_pos - 1];
         notif_addr =
             (uintptr_t)nixl::gpunetio::reserveNotificationSlot(notif->send_pi,
@@ -1200,11 +1204,11 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                                                                notif->send_addr,
                                                                notif->elems_size,
                                                                final_request.has_notif_msg_idx);
-        final_request.msg_sz = newMsg.size();
+        final_request.msg_sz = newMsg.size() + 1;
         final_request.lbuf_notif = notif_addr;
         final_request.lkey_notif = notif->send_mr->get_lkey();
 
-        memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
+        memcpy((void *)notif_addr, newMsg.c_str(), final_request.msg_sz);
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -965,25 +965,38 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     nixlDocaConnection conn;
     size_t size = remote_conn_info.size();
     // TODO: eventually std::byte?
-    char *addr = new char[size];
+    auto addr = std::make_unique<char[]>(size);
 
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    nixlSerDes::_stringToBytes((void *)addr.get(), remote_conn_info, size);
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(addr.get(), &oob_sock_client);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status == NIXL_SUCCESS) {
+        status = addRdmaQp(remote_agent);
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+    }
+    if (status == NIXL_SUCCESS) {
+        status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    }
+    if (status == NIXL_SUCCESS) {
+        status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    }
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
 
     conn.remoteAgent = remote_agent;
     conn.connected = true;
@@ -996,8 +1009,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gpunetio_backend.h"
+#include "gpunetio_completion_status.h"
 #include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
@@ -285,7 +286,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         }
     }
 
-    ((volatile uint8_t *)wait_exit_cpu)[0] = 0;
+    *reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) = 0;
 
     result = doca_gpu_mem_alloc(gdevs[0].second,
                                 sizeof(struct docaNotif),
@@ -354,7 +355,7 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before progressThreadStop ";
     progressThreadStop();
 
-    ((volatile uint8_t *)wait_exit_cpu)[0] = 1;
+    *reinterpret_cast<volatile uint32_t *>(wait_exit_cpu) = 1;
     NIXL_DEBUG << "Before cudaStreamSynchronize ";
     nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
     nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
@@ -1192,20 +1193,21 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
 
+        auto &final_request = xferReqRingCpu[treq->end_pos - 1];
         notif_addr =
-            (uintptr_t)(notif->send_addr +
-                        (xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx * notif->elems_size));
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx =
-            (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
-        xferReqRingCpu[treq->end_pos - 1].msg_sz = newMsg.size();
-        xferReqRingCpu[treq->end_pos - 1].lbuf_notif = notif_addr;
-        xferReqRingCpu[treq->end_pos - 1].lkey_notif = notif->send_mr->get_lkey();
+            (uintptr_t)nixl::gpunetio::reserveNotificationSlot(notif->send_pi,
+                                                               notif->elems_num,
+                                                               notif->send_addr,
+                                                               notif->elems_size,
+                                                               final_request.has_notif_msg_idx);
+        final_request.msg_sz = newMsg.size();
+        final_request.lbuf_notif = notif_addr;
+        final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
-                  << xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx << " msg " << newMsg
-                  << " to " << remote_agent;
+                  << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
 
     } else {
         xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx = DOCA_NOTIF_NULL;
@@ -1252,6 +1254,10 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
 nixl_status_t
 nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
+    const nixl_status_t completion_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+    if (completion_status != NIXL_SUCCESS) {
+        return completion_status;
+    }
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
@@ -1281,6 +1287,10 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
+    const nixl_status_t completion_status = nixl::gpunetio::completionStatus(wait_exit_cpu);
+    if (completion_status != NIXL_SUCCESS) {
+        return completion_status;
+    }
     uint32_t recv_idx;
     std::string msg_src;
     uint32_t num_msg = 0;

--- a/src/plugins/gpunetio/gpunetio_completion_status.h
+++ b/src/plugins/gpunetio/gpunetio_completion_status.h
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GPUNETIO_COMPLETION_STATUS_H
+#define GPUNETIO_COMPLETION_STATUS_H
+
+#include "nixl_types.h"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace nixl::gpunetio {
+
+inline nixl_status_t
+completionStatus(const volatile uint32_t *error_flag) {
+    return *error_flag == 0 ? NIXL_SUCCESS : NIXL_ERR_BACKEND;
+}
+
+inline uint8_t *
+reserveNotificationSlot(std::atomic<uint32_t> &send_pi,
+                        uint32_t elems_num,
+                        uint8_t *send_addr,
+                        size_t elems_size,
+                        uint32_t &notification_slot) {
+    notification_slot = send_pi.fetch_add(1) & (elems_num - 1);
+    return send_addr + (notification_slot * elems_size);
+}
+
+} // namespace nixl::gpunetio
+
+#endif /* GPUNETIO_COMPLETION_STATUS_H */

--- a/src/plugins/gpunetio/gpunetio_completion_status.h
+++ b/src/plugins/gpunetio/gpunetio_completion_status.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef GPUNETIO_COMPLETION_STATUS_H
-#define GPUNETIO_COMPLETION_STATUS_H
+#ifndef NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COMPLETION_STATUS_H
+#define NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COMPLETION_STATUS_H
 
 #include "nixl_types.h"
 
@@ -26,11 +26,27 @@
 
 namespace nixl::gpunetio {
 
+/**
+ * @brief Convert the shared GPU error latch to a NIXL completion status.
+ *
+ * @param error_flag Error latch written by the GPU progress kernel.
+ * @return NIXL_SUCCESS when the latch is clear, otherwise NIXL_ERR_BACKEND.
+ */
 inline nixl_status_t
 completionStatus(const volatile uint32_t *error_flag) {
     return *error_flag == 0 ? NIXL_SUCCESS : NIXL_ERR_BACKEND;
 }
 
+/**
+ * @brief Reserve the next notification slot in a power-of-two ring.
+ *
+ * @param send_pi Producer index advanced by this call.
+ * @param elems_num Number of ring slots; must be a power of two.
+ * @param send_addr Address of the first slot.
+ * @param elems_size Size of each slot in bytes.
+ * @param notification_slot Receives the reserved slot index.
+ * @return Address of the reserved slot.
+ */
 inline uint8_t *
 reserveNotificationSlot(std::atomic<uint32_t> &send_pi,
                         uint32_t elems_num,
@@ -43,4 +59,4 @@ reserveNotificationSlot(std::atomic<uint32_t> &send_pi,
 
 } // namespace nixl::gpunetio
 
-#endif /* GPUNETIO_COMPLETION_STATUS_H */
+#endif /* NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COMPLETION_STATUS_H */

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -332,7 +332,11 @@ kernel_progress(struct docaXferCompletion *completion_list,
                     DOCA_GPUNETIO_VOLATILE(notif_progress->qp_gpu) = nullptr;
                 } else {
 #if ENABLE_DEBUG == 1
-                    printf("kernel received notification EBUSY at %d ret %d\n", msg_last, ret);
+                    if (ret == EBUSY) {
+                        printf("kernel received notification EBUSY at %d ret %d\n", msg_last, ret);
+                    } else {
+                        printf("kernel notification CQ poll failed at %d ret %d\n", msg_last, ret);
+                    }
 #endif
                     DOCA_GPUNETIO_VOLATILE(notif_progress->msg_num) = 0;
                     if (ret < 0) {

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -281,9 +281,23 @@ kernel_progress(struct docaXferCompletion *completion_list,
                                     .key = completion_list[index].xferReqRingGpu->lkey_notif},
                                 completion_list[index].xferReqRingGpu->msg_sz,
                                 &out_ticket);
-
-                            doca_gpu_dev_verbs_wait(completion_list[index].xferReqRingGpu->qp_notif,
-                                                    &out_ticket);
+                            int notif_status;
+                            do {
+                                notif_status = nixl_gpunetio_dev_poll_one_cq_at<
+                                    DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                                    DOCA_GPUNETIO_VERBS_QP_SQ>(
+                                    doca_gpu_dev_verbs_qp_get_cq_sq(
+                                        completion_list[index].xferReqRingGpu->qp_notif),
+                                    out_ticket);
+                            } while (notif_status == EBUSY &&
+                                     DOCA_GPUNETIO_VOLATILE(*exit_flag) == 0);
+                            if (notif_status != 0) {
+                                DOCA_GPUNETIO_VOLATILE(*exit_flag) = 1;
+                                printf("kernel_progress: notification CQ error %d wqe %ld\n",
+                                       notif_status,
+                                       out_ticket);
+                                continue;
+                            }
 #if ENABLE_DEBUG == 1
                             printf("Notif correctly sent %ld\n", out_ticket);
 #endif
@@ -380,15 +394,28 @@ kernel_progress(struct docaXferCompletion *completion_list,
                                             .key = notif_send_gpu->msg_lkey},
                     notif_send_gpu->msg_size,
                     &out_ticket);
-
-                doca_gpu_dev_verbs_wait(notif_send_gpu->qp_gpu, &out_ticket);
+                int notif_status;
+                do {
+                    notif_status = nixl_gpunetio_dev_poll_one_cq_at<
+                        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                        DOCA_GPUNETIO_VERBS_QP_SQ>(
+                        doca_gpu_dev_verbs_qp_get_cq_sq(notif_send_gpu->qp_gpu), out_ticket);
+                } while (notif_status == EBUSY && DOCA_GPUNETIO_VOLATILE(*exit_flag) == 0);
+                if (notif_status != 0) {
+                    DOCA_GPUNETIO_VOLATILE(*exit_flag) = 1;
+                    printf("kernel_progress: standalone notification CQ error %d wqe %ld\n",
+                           notif_status,
+                           out_ticket);
+                }
 #if ENABLE_DEBUG == 1
-                printf("Notif correctly sent %ld addr %lx msg_lkey %x qp %p size %d\n",
-                       out_ticket,
-                       notif_send_gpu->msg_buf,
-                       notif_send_gpu->msg_lkey,
-                       (void *)notif_send_gpu->qp_gpu,
-                       (int)notif_send_gpu->msg_size);
+                if (notif_status == 0) {
+                    printf("Notif correctly sent %ld addr %lx msg_lkey %x qp %p size %d\n",
+                           out_ticket,
+                           notif_send_gpu->msg_buf,
+                           notif_send_gpu->msg_lkey,
+                           (void *)notif_send_gpu->qp_gpu,
+                           (int)notif_send_gpu->msg_size);
+                }
 #endif
                 DOCA_GPUNETIO_VOLATILE(notif_send_gpu->qp_gpu) = nullptr;
             }

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -307,7 +307,7 @@ kernel_progress(struct docaXferCompletion *completion_list,
                     nixl_gpunetio_dev_poll_one_cq_at<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
                                                      DOCA_GPUNETIO_VERBS_QP_RQ>(
                         doca_gpu_dev_verbs_qp_get_cq_rq(notif_progress->qp_gpu), msg_last);
-                if (ret != EBUSY) {
+                if (ret == 0) {
 #if ENABLE_DEBUG == 1
                     printf("kernel received notification at %d ret %d\n", msg_last, ret);
 #endif
@@ -335,6 +335,9 @@ kernel_progress(struct docaXferCompletion *completion_list,
                     printf("kernel received notification EBUSY at %d ret %d\n", msg_last, ret);
 #endif
                     DOCA_GPUNETIO_VOLATILE(notif_progress->msg_num) = 0;
+                    if (ret < 0) {
+                        DOCA_GPUNETIO_VOLATILE(*exit_flag) = 1;
+                    }
                     doca_gpu_dev_verbs_fence_release<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS>();
                     DOCA_GPUNETIO_VOLATILE(notif_progress->qp_gpu) = nullptr;
                 }

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -386,11 +386,22 @@ threadProgressFunc(void *arg) {
 
         // cuCtxSetCurrent(eng->main_cuda_ctx);
 
-        eng->recvRemoteAgentName(oob_sock_client, remote_agent);
-
-        eng->addRdmaQp(remote_agent);
-        eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
-        eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        nixl_status_t status = eng->recvRemoteAgentName(oob_sock_client, remote_agent);
+        if (status == NIXL_SUCCESS) {
+            status = eng->addRdmaQp(remote_agent);
+            if (status == NIXL_IN_PROG) {
+                status = NIXL_SUCCESS;
+            }
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        }
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
+        }
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/meson.build
+++ b/src/plugins/gpunetio/meson.build
@@ -20,7 +20,7 @@ compile_flags = ['-D DOCA_ALLOW_EXPERIMENTAL_API']
 
 if 'GPUNETIO' in static_plugins
     gpunetio_backend_lib = static_library('GPUNETIO',
-               'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
+               'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_completion_status.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
                dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,
@@ -30,7 +30,7 @@ if 'GPUNETIO' in static_plugins
                install_dir: plugin_install_dir)  # Custom prefix for plugin libraries
 else
     gpunetio_backend_lib = shared_library('GPUNETIO',
-               'verbs/verbs.cpp', 'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
+               'verbs/verbs.cpp', 'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_completion_status.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
                dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
                include_directories: [nixl_inc_dirs, utils_inc_dirs],
                install: true,

--- a/test/gtest/unit/gpunetio/gpunetio_completion_status_test.cpp
+++ b/test/gtest/unit/gpunetio/gpunetio_completion_status_test.cpp
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+
+#include "gpunetio_completion_status.h"
+
+namespace {
+
+TEST(GpuNetioCompletionStatus, MapsLatchedGpuErrorToBackendFailure) {
+    uint32_t error_flag = 0;
+    EXPECT_EQ(nixl::gpunetio::completionStatus(&error_flag), NIXL_SUCCESS);
+
+    error_flag = 1;
+    EXPECT_EQ(nixl::gpunetio::completionStatus(&error_flag), NIXL_ERR_BACKEND);
+}
+
+TEST(GpuNetioCompletionStatus, ReservesNotificationSlotAndMatchingAddress) {
+    std::atomic<uint32_t> send_pi = 3;
+    uint32_t notification_slot = 0;
+    uint8_t buffer[64] = {};
+    constexpr uint32_t elems_num = 8;
+    constexpr size_t slot_size = 8;
+
+    uint8_t *notification_addr = nixl::gpunetio::reserveNotificationSlot(
+        send_pi, elems_num, buffer, slot_size, notification_slot);
+
+    EXPECT_EQ(notification_slot, 3);
+    EXPECT_EQ(notification_addr, buffer + 24);
+    EXPECT_EQ(send_pi.load(), 4);
+}
+
+} // namespace

--- a/test/gtest/unit/gpunetio/meson.build
+++ b/test/gtest/unit/gpunetio/meson.build
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+gpunetio_completion_status_unit_test_dep = declare_dependency(
+    sources: [
+        'gpunetio_completion_status_test.cpp',
+    ],
+    include_directories: [
+        nixl_inc_dirs,
+        gtest_inc_dirs,
+        include_directories('../../../../src/plugins/gpunetio'),
+    ],
+)

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -32,6 +32,9 @@ unit_test_deps += [descriptors_unit_test_dep]
 subdir('util')
 unit_test_deps += [util_unit_test_dep]
 
+subdir('gpunetio')
+unit_test_deps += [gpunetio_completion_status_unit_test_dep]
+
 subdir('tracing')
 unit_test_deps += [tracing_unit_test_dep]
 


### PR DESCRIPTION
## Summary

- Assign the notification slot before deriving its buffer address, so request metadata and payload use the same slot.
- Validate tagged notification size before request allocation or ring-position consumption.
- Send the terminating NUL byte so reused receiver slots cannot expose a stale suffix.
- Treat negative notification CQ polls as transport failures and surface the shared GPU error latch through request and notification polling.
- Initialize and stop the shared error latch with full-width `uint32_t` stores.
- Add a hardware-independent unit boundary for the error latch and notification-slot address calculation.

## Validation

Current head: `2adb27c2`

- GPUNETIO warning-as-error build against CUDA 12.8 / DOCA 3.1: PASS
- focused helper tests: 2/2 PASS
- diff, SPDX, formatting, DCO, and repository checks: PASS before this review follow-up; CI is rerunning on the current head

The focused tests can be reproduced from a debug test build with:

```bash
ninja -C build test/gtest/unit/unit
./build/test/gtest/unit/unit \
  --gtest_filter='GpuNetioCompletionStatus.*'
```

The DOCA compatibility change pending in #2052 was used only as an identical build overlay and is not part of this branch.

## Scope

This PR is limited to notification-slot ordering, notification capacity/wire termination, and completion-error propagation. It does not change transfer WQE construction, polling policy, request-ring capacity, peer memory, or performance behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GPUNetIO transfers now report asynchronous GPU completion errors instead of incorrectly indicating success.
  - Notification handling validates message details, detects failed completion events, and terminates progress when required.
  - Completion polling now handles transient busy states more reliably.
  - Wait-exit signaling is now more reliable across supported environments.
  - GPUNetIO connection setup now reports initialization failures and handles in-progress connections correctly.

- **Tests**
  - Added coverage for completion errors, successful operations, notification-slot handling, and notification validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


