### PR TITLE
[GPUNetIO] Clean up lifecycle ownership

### DIFF
--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -39,18 +39,25 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     union ibv_gid rgid;
 
     result = doca_log_backend_create_standard();
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_create_with_file_sdk(stderr, &sdk_log);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_set_sdk_level(sdk_log, DOCA_LOG_LEVEL_ERROR);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     NIXL_INFO << "DOCA network devices ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("network_devices") > 1)
+    if (custom_params->count("network_devices") > 1) {
         throw std::invalid_argument("Only 1 network device is allowed");
+    }
 
     if (custom_params->count("network_devices") == 0 || (*custom_params)["network_devices"] == "" ||
         (*custom_params)["network_devices"] == "all") {
@@ -65,8 +72,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (custom_params->count("oob_interface") > 0) {
         NIXL_INFO << "DOCA network devices ";
         // Temporary: will extend to more GPUs in a dedicated PR
-        if (custom_params->count("oob_interface") > 1)
+        if (custom_params->count("oob_interface") > 1) {
             throw std::invalid_argument("Only 1 oob interface is allowed");
+        }
 
         oobdev = absl::StrSplit((*custom_params)["oob_interface"], " ");
         NIXL_INFO << "Using oob interface" << oobdev[0];
@@ -75,8 +83,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "DOCA GPU devices: ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("gpu_devices") > 1)
+    if (custom_params->count("gpu_devices") > 1) {
         throw std::invalid_argument("Only 1 GPU device is allowed");
+    }
 
     if (custom_params->count("gpu_devices") == 0 || (*custom_params)["gpu_devices"] == "" ||
         (*custom_params)["gpu_devices"] == "all") {
@@ -92,9 +101,12 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     NIXL_INFO << std::endl;
 
     nstreams = 0;
-    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "")
+    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "") {
         nstreams = std::stoi((*custom_params)["cuda_streams"]);
-    if (nstreams == 0) nstreams = DOCA_POST_STREAM_NUM;
+    }
+    if (nstreams == 0) {
+        nstreams = DOCA_POST_STREAM_NUM;
+    }
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
@@ -112,7 +124,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     pd = doca_verbs_bridge_verbs_pd_get_ibv_pd(verbs_pd);
-    if (pd == NULL) throw std::invalid_argument("Failed to get ibv_pd");
+    if (pd == NULL) {
+        throw std::invalid_argument("Failed to get ibv_pd");
+    }
 
     result = doca_rdma_bridge_open_dev_from_pd(pd, &ddev);
     if (result != DOCA_SUCCESS) {
@@ -137,8 +151,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
         result = create_verbs_ah_attr(
             verbs_context, gid_index, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH, &verbs_ah_attr);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             throw std::invalid_argument("Failed to create doca verbs ah attributes");
+        }
 
         lid = port_attr.lid;
     } else {
@@ -164,8 +179,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         cudaFree(0);
 
         result = doca_gpu_create(pciBusId, &item.second);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to create DOCA GPU device " << doca_error_get_descr(result);
+        }
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
@@ -241,10 +257,11 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     nixlDocaEngineCheckCudaError(cudaStreamCreateWithFlags(&wait_stream, cudaStreamNonBlocking),
                                  "Failed to create CUDA stream");
-    for (int i = 0; i < nstreams; i++)
+    for (int i = 0; i < nstreams; i++) {
         nixlDocaEngineCheckCudaError(
             cudaStreamCreateWithFlags(&post_stream[i], cudaStreamNonBlocking),
             "Failed to create CUDA stream");
+    }
     xferStream = 0;
 
     result = doca_gpu_mem_alloc(gdevs[0].second,
@@ -370,8 +387,9 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
-    for (auto notif : notifMap)
+    for (auto notif : notifMap) {
         nixlDocaDestroyNotif(gdevs[0].second, notif.second);
+    }
     notifMap.clear();
 
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
@@ -381,17 +399,20 @@ nixlDocaEngine::~nixlDocaEngine() {
 
     NIXL_DEBUG << "Before qpMap.clear ";
 
-    for (auto &qp : qpMap)
+    for (auto &qp : qpMap) {
         delete qp.second;
+    }
     qpMap.clear();
 
     result = doca_dev_close(ddev);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
+    }
 
     result = doca_gpu_destroy(gdevs[0].second);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
+    }
 }
 
 /****************************************
@@ -471,7 +492,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
 
 nixl_status_t
 nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif) {
-    if (notif == nullptr) return NIXL_SUCCESS;
+    if (notif == nullptr) {
+        return NIXL_SUCCESS;
+    }
 
     notif->send_mr.reset();
     notif->recv_mr.reset();
@@ -1081,8 +1104,9 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     md->conn = conn;
 
     std::stringstream ss(input.metaInfo.data());
-    while (std::getline(ss, token, info_delimiter))
+    while (std::getline(ss, token, info_delimiter)) {
         tokens.push_back(token);
+    }
 
     uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
     uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
@@ -1132,7 +1156,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-        if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
+        if (lmd->devId != gdevs[0].first) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
 
     auto search = qpMap.find(remote_agent);
@@ -1143,9 +1169,13 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
+    if (lcnt != rcnt) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
+    if (lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     if (opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
@@ -1161,7 +1191,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
             size_t lsize = local[idx].len;
             size_t rsize = remote[idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
+            if (lsize != rsize) {
+                return NIXL_ERR_INVALID_PARAM;
+            }
 
             lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
@@ -1276,8 +1308,9 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
             NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
                       << " COMPLETED!\n";
             return NIXL_SUCCESS;
-        } else
+        } else {
             return NIXL_IN_PROG;
+        }
     }
 
     return NIXL_SUCCESS;
@@ -1286,10 +1319,11 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
     uint32_t tmp = xferRingPos.load() & (DOCA_XFER_REQ_MAX - 1);
-    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0)
+    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0) {
         return NIXL_SUCCESS;
-    else
+    } else {
         return NIXL_IN_PROG;
+    }
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -372,6 +372,7 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap)
         nixlDocaDestroyNotif(gdevs[0].second, notif.second);
+    notifMap.clear();
 
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
@@ -380,6 +381,8 @@ nixlDocaEngine::~nixlDocaEngine() {
 
     NIXL_DEBUG << "Before qpMap.clear ";
 
+    for (auto &qp : qpMap)
+        delete qp.second;
     qpMap.clear();
 
     result = doca_dev_close(ddev);
@@ -397,8 +400,6 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
-    struct nixlDocaNotif *notif;
-
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -406,7 +407,7 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         return NIXL_SUCCESS;
     }
 
-    notif = new struct nixlDocaNotif;
+    auto notif = std::make_unique<nixlDocaNotif>();
 
     notif->elems_num = DOCA_MAX_NOTIF_INFLIGHT;
     notif->elems_size = DOCA_MAX_NOTIF_MESSAGE_SIZE;
@@ -423,12 +424,15 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
 
     notif->recv_addr = (uint8_t *)calloc(notif->elems_size * notif->elems_num, sizeof(uint8_t));
     if (notif->recv_addr == nullptr) {
         NIXL_ERROR << "Can't alloc memory for send notif";
+        notif->send_mr.reset();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
     memset(notif->recv_addr, 0, notif->elems_size * notif->elems_num);
@@ -439,6 +443,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        notif->send_mr.reset();
+        free(notif->send_addr);
+        free(notif->recv_addr);
         return NIXL_ERR_BACKEND;
     }
 
@@ -446,10 +453,11 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->recv_pi = 0;
 
     // Ensure notif list is not added twice for the same peer
-    notifMap[remote_agent] = notif;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
+    auto *notif_ptr = notif.get();
+    notifMap[remote_agent] = notif.release();
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif_ptr->recv_addr;
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif_ptr->recv_mr->get_lkey();
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif_ptr->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
         qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
@@ -463,6 +471,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
 
 nixl_status_t
 nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif) {
+    if (notif == nullptr) return NIXL_SUCCESS;
+
+    notif->send_mr.reset();
+    notif->recv_mr.reset();
+    free(notif->send_addr);
+    free(notif->recv_addr);
     delete notif;
 
     return NIXL_SUCCESS;
@@ -571,8 +585,6 @@ nixlDocaEngine::getGpuCudaId() {
 
 nixl_status_t
 nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
-    struct nixlDocaRdmaQp *rdma_qp;
-
     std::lock_guard<std::mutex> lock(qpLock);
 
     NIXL_DEBUG << "addRdmaQp for " << remote_agent << std::endl;
@@ -584,7 +596,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
 
-    rdma_qp = new struct nixlDocaRdmaQp;
+    auto rdma_qp = std::make_unique<nixlDocaRdmaQp>();
 
     try {
         rdma_qp->qp_data =
@@ -621,7 +633,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     rdma_qp->qpn_notif = doca_verbs_qp_get_qpn(rdma_qp->qp_notif->get_qp());
 
-    qpMap[remote_agent] = rdma_qp;
+    qpMap[remote_agent] = rdma_qp.release();
 
     NIXL_DEBUG << "DOCA addRdmaQp new QP added for " << remote_agent;
 
@@ -999,7 +1011,7 @@ nixl_status_t
 nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
                             const nixl_mem_t &nixl_mem,
                             nixlBackendMD *&out) {
-    nixlDocaPrivateMetadata *priv = new nixlDocaPrivateMetadata;
+    auto priv = std::make_unique<nixlDocaPrivateMetadata>();
     std::stringstream ss;
 
     auto it = std::find_if(gdevs.begin(), gdevs.end(), [&mem](std::pair<uint32_t, doca_gpu *> &x) {
@@ -1025,7 +1037,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
        << info_delimiter << ((size_t)priv->mr->get_tot_size());
     priv->remoteMrStr = ss.str();
 
-    out = (nixlBackendMD *)priv;
+    out = priv.release();
 
     return NIXL_SUCCESS;
 }
@@ -1055,7 +1067,7 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     nixlDocaConnection conn;
     std::vector<std::string> tokens;
     std::string token;
-    nixlDocaPublicMetadata *md = new nixlDocaPublicMetadata;
+    auto md = std::make_unique<nixlDocaPublicMetadata>();
     auto search = remoteConnMap.find(remote_agent);
 
     if (search == remoteConnMap.end()) {
@@ -1085,13 +1097,14 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
         return NIXL_ERR_BACKEND;
     }
 
-    output = (nixlBackendMD *)md;
+    output = md.release();
 
     return NIXL_SUCCESS;
 }
 
 nixl_status_t
 nixlDocaEngine::unloadMD(nixlBackendMD *input) {
+    delete static_cast<nixlDocaPublicMetadata *>(input);
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -383,13 +383,24 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
 
     bool qps_closed = true;
+    bool retained_closed = true;
     for (auto &qp : qpMap) {
         const bool data_closed = qp.second->qp_data->close();
         const bool notif_closed = qp.second->qp_notif->close();
         qps_closed = data_closed && notif_closed && qps_closed;
     }
+    if (retainedQp_ != nullptr) {
+        const bool data_closed = retainedQp_->qp_data == nullptr || retainedQp_->qp_data->close();
+        const bool notif_closed =
+            retainedQp_->qp_notif == nullptr || retainedQp_->qp_notif->close();
+        retained_closed = data_closed && notif_closed;
+        qps_closed = retained_closed && qps_closed;
+    }
     if (!qps_closed) {
         NIXL_ERROR << "GPUNETIO QP unexport failed; retaining dependent resources";
+        if (!retained_closed) {
+            retainedQp_.release();
+        }
         return;
     }
 
@@ -397,6 +408,7 @@ nixlDocaEngine::~nixlDocaEngine() {
         delete qp.second;
     }
     qpMap.clear();
+    retainedQp_.reset();
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -650,6 +662,9 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     if (qpMap.find(remote_agent) != qpMap.end()) {
         return NIXL_IN_PROG;
     }
+    if (retainedQp_ != nullptr) {
+        return NIXL_ERR_BACKEND;
+    }
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
 
@@ -685,6 +700,9 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        if (!rdma_qp->qp_data->close()) {
+            retainedQp_ = std::move(rdma_qp);
+        }
         return NIXL_ERR_BACKEND;
     }
 
@@ -1028,25 +1046,38 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     nixlDocaConnection conn;
     size_t size = remote_conn_info.size();
     // TODO: eventually std::byte?
-    char *addr = new char[size];
+    auto addr = std::make_unique<char[]>(size);
 
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    nixlSerDes::_stringToBytes((void *)addr.get(), remote_conn_info, size);
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(addr.get(), &oob_sock_client);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status == NIXL_SUCCESS) {
+        status = addRdmaQp(remote_agent);
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+    }
+    if (status == NIXL_SUCCESS) {
+        status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    }
+    if (status == NIXL_SUCCESS) {
+        status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    }
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
 
     conn.remoteAgent = remote_agent;
     conn.connected = true;
@@ -1059,8 +1090,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -382,10 +382,21 @@ nixlDocaEngine::~nixlDocaEngine() {
         nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
     }
 
-    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
-    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
-    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
-    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
+    bool qps_closed = true;
+    for (auto &qp : qpMap) {
+        const bool data_closed = qp.second->qp_data->close();
+        const bool notif_closed = qp.second->qp_notif->close();
+        qps_closed = data_closed && notif_closed && qps_closed;
+    }
+    if (!qps_closed) {
+        NIXL_ERROR << "GPUNETIO QP unexport failed; retaining dependent resources";
+        return;
+    }
+
+    for (auto &qp : qpMap) {
+        delete qp.second;
+    }
+    qpMap.clear();
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -393,17 +404,14 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
     notifMap.clear();
 
+    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
+    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
+    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
+    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_send_gpu);
     doca_gpu_mem_free(gdevs[0].second, completion_list_gpu);
-
-    NIXL_DEBUG << "Before qpMap.clear ";
-
-    for (auto &qp : qpMap) {
-        delete qp.second;
-    }
-    qpMap.clear();
 
     result = doca_gpu_destroy(gdevs[0].second);
     if (result != DOCA_SUCCESS) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -375,16 +375,17 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before cudaStreamSynchronize ";
     nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
     nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
-    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
-    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
-    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
-    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
 
     for (int i = 0; i < nstreams; i++) {
         NIXL_DEBUG << "Before cudaStreamSynchronize post_stream " << i;
         nixlDocaEngineCheckCudaError(cudaStreamSynchronize(post_stream[i]), "stream synchronize");
         nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
     }
+
+    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
+    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
+    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
+    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -404,15 +405,36 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
     qpMap.clear();
 
-    result = doca_dev_close(ddev);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
-    }
-
     result = doca_gpu_destroy(gdevs[0].second);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
     }
+    gdevs[0].second = nullptr;
+
+    result = doca_verbs_ah_attr_destroy(verbs_ah_attr);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs AH " << doca_error_get_descr(result);
+    }
+    verbs_ah_attr = nullptr;
+
+    result = doca_dev_close(ddev);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
+    }
+    ddev = nullptr;
+
+    result = doca_verbs_pd_destroy(verbs_pd);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs PD " << doca_error_get_descr(result);
+    }
+    verbs_pd = nullptr;
+    pd = nullptr;
+
+    result = doca_verbs_context_destroy(verbs_context);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs context " << doca_error_get_descr(result);
+    }
+    verbs_context = nullptr;
 }
 
 /****************************************
@@ -474,8 +496,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->recv_pi = 0;
 
     // Ensure notif list is not added twice for the same peer
-    auto *notif_ptr = notif.get();
-    notifMap[remote_agent] = notif.release();
+    const auto [notif_it, inserted] = notifMap.emplace(remote_agent, notif.get());
+    if (!inserted) {
+        return NIXL_SUCCESS;
+    }
+    notif.release();
+    auto *notif_ptr = notif_it->second;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif_ptr->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif_ptr->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif_ptr->elems_size;
@@ -656,7 +682,11 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     rdma_qp->qpn_notif = doca_verbs_qp_get_qpn(rdma_qp->qp_notif->get_qp());
 
-    qpMap[remote_agent] = rdma_qp.release();
+    const auto [qp_it, inserted] = qpMap.emplace(remote_agent, rdma_qp.get());
+    if (!inserted) {
+        return NIXL_IN_PROG;
+    }
+    rdma_qp.release();
 
     NIXL_DEBUG << "DOCA addRdmaQp new QP added for " << remote_agent;
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -28,11 +28,11 @@ public:
     std::mutex qpLock;
     std::mutex connectLock;
     std::vector<std::pair<uint32_t, doca_gpu *>> gdevs; /* List of DOCA GPUNetIO device handlers */
-    doca_dev *ddev; /* DOCA device handler associated to queues */
-    doca_verbs_context *verbs_context; /* DOCA Verbs Context */
-    doca_verbs_pd *verbs_pd; /* DOCA Verbs Protection Domain */
-    doca_verbs_ah_attr *verbs_ah_attr; /* DOCA Verbs address handle */
-    struct ibv_pd *pd; /* local protection domain */
+    doca_dev *ddev = nullptr; /* DOCA device handler associated to queues */
+    doca_verbs_context *verbs_context = nullptr; /* DOCA Verbs Context */
+    doca_verbs_pd *verbs_pd = nullptr; /* DOCA Verbs Protection Domain */
+    doca_verbs_ah_attr *verbs_ah_attr = nullptr; /* DOCA Verbs address handle */
+    struct ibv_pd *pd = nullptr; /* local protection domain */
     doca_verbs_gid gid; /* local gid address */
     doca_verbs_gid remote_gid; /* remote gid address */
     int lid; /* IB: local ID */
@@ -158,7 +158,7 @@ private:
     std::thread pthr;
     uint64_t *last_rsvd_flags;
     uint64_t *last_posted_flags;
-    cudaStream_t post_stream[DOCA_POST_STREAM_NUM];
+    cudaStream_t post_stream[DOCA_POST_STREAM_NUM]{};
     cudaStream_t wait_stream;
     mutable std::atomic<uint32_t> xferStream;
     mutable std::atomic<uint32_t> lastPostedReq;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -182,6 +182,7 @@ private:
     // Map of agent name to saved nixlDocaConnection info
     std::unordered_map<std::string, nixlDocaConnection> remoteConnMap;
     std::unordered_map<std::string, struct nixlDocaRdmaQp *> qpMap;
+    std::unique_ptr<nixlDocaRdmaQp> retainedQp_;
     std::unordered_map<std::string, int> connMap;
     std::unordered_map<std::string, struct nixlDocaNotif *> notifMap;
 

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -102,10 +102,10 @@ struct docaXferReqGpu {
 struct nixlDocaNotif {
     uint32_t elems_num;
     uint32_t elems_size;
-    uint8_t *send_addr;
+    uint8_t *send_addr = nullptr;
     std::atomic<uint32_t> send_pi;
     std::unique_ptr<nixl::doca::verbs::mr> send_mr;
-    uint8_t *recv_addr;
+    uint8_t *recv_addr = nullptr;
     std::atomic<uint32_t> recv_pi;
     std::unique_ptr<nixl::doca::verbs::mr> recv_mr;
 };

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -68,6 +68,26 @@ mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
             (MLX5_CQE_INVALID << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT) | MLX5_CQE_OWNER_MASK;
 }
 
+class CqAttrGuard {
+public:
+    doca_verbs_cq_attr *value = nullptr;
+
+    ~CqAttrGuard() {
+        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
+    }
+};
+
+class QpAttrGuard {
+public:
+    doca_verbs_qp_init_attr *value = nullptr;
+
+    ~QpAttrGuard() {
+        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
+    }
+};
+
 namespace nixl::doca::verbs {
 
 cq::cq(doca_gpu *gpu_dev_,
@@ -91,27 +111,22 @@ doca_verbs_cq *
 cq::createCq() {
     doca_error_t status = DOCA_SUCCESS;
     cudaError_t status_cuda = cudaSuccess;
-    doca_verbs_cq_attr *verbs_cq_attr = nullptr;
+    CqAttrGuard verbs_cq_attr;
     doca_verbs_cq *new_cq = nullptr;
     struct mlx5_cqe64 *cq_ring_haddr = nullptr;
     uint32_t external_umem_size = 0;
     external_uar = nullptr;
 
-    status = doca_verbs_cq_attr_create(&verbs_cq_attr);
+    status = doca_verbs_cq_attr_create(&verbs_cq_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to create doca verbs cq attributes");
 
-    status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr, 1);
+    status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
-        doca_verbs_cq_attr_destroy(verbs_cq_attr);
         throw std::runtime_error("Failed to set doca verbs cq external datapath en");
     }
 
     external_umem_size = calc_cq_external_umem_size(ncqe);
-    if (status != DOCA_SUCCESS) {
-        doca_verbs_cq_attr_destroy(verbs_cq_attr);
-        throw std::runtime_error("Failed to calc external umem size");
-    }
 
     status = doca_gpu_mem_alloc(gpu_dev,
                                 external_umem_size,
@@ -136,6 +151,8 @@ cq::createCq() {
     status_cuda =
         cudaMemcpy(cq_umem_gpu_ptr, (void *)(cq_ring_haddr), external_umem_size, cudaMemcpyDefault);
     if (status_cuda != cudaSuccess) {
+        free(cq_ring_haddr);
+        cq_ring_haddr = nullptr;
         destroyCq();
         throw std::runtime_error("Failed to cudaMempy gpu cq cq ring buffer");
     }
@@ -155,19 +172,19 @@ cq::createCq() {
         throw std::runtime_error("Failed to create gpu umem");
     }
 
-    status = doca_verbs_cq_attr_set_external_umem(verbs_cq_attr, cq_umem, 0);
+    status = doca_verbs_cq_attr_set_external_umem(verbs_cq_attr.value, cq_umem, 0);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq external umem");
     }
 
-    status = doca_verbs_cq_attr_set_cq_size(verbs_cq_attr, ncqe);
+    status = doca_verbs_cq_attr_set_cq_size(verbs_cq_attr.value, ncqe);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq size");
     }
 
-    status = doca_verbs_cq_attr_set_cq_overrun(verbs_cq_attr, 1);
+    status = doca_verbs_cq_attr_set_cq_overrun(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq size");
@@ -179,23 +196,25 @@ cq::createCq() {
         throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
     }
 
-    status = doca_verbs_cq_attr_set_external_uar(verbs_cq_attr, external_uar);
+    status = doca_verbs_cq_attr_set_external_uar(verbs_cq_attr.value, external_uar);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq external uar");
     }
 
-    status = doca_verbs_cq_create(verbs_ctx, verbs_cq_attr, &new_cq);
+    status = doca_verbs_cq_create(verbs_ctx, verbs_cq_attr.value, &new_cq);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to create doca verbs cq");
     }
+    cq_verbs = new_cq;
 
-    status = doca_verbs_cq_attr_destroy(verbs_cq_attr);
+    status = doca_verbs_cq_attr_destroy(verbs_cq_attr.value);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to destroy doca verbs cq attributes");
     }
+    verbs_cq_attr.value = nullptr;
 
     return new_cq;
 }
@@ -204,32 +223,40 @@ void
 cq::destroyCq() {
     doca_error_t status;
 
-    status = doca_verbs_cq_destroy(cq_verbs);
-    if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+    if (cq_verbs != nullptr) {
+        status = doca_verbs_cq_destroy(cq_verbs);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        cq_verbs = nullptr;
+    }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        external_uar = nullptr;
     }
 
     if (cq_umem != nullptr) {
         status = doca_umem_destroy(cq_umem);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        cq_umem = nullptr;
     }
 
-    if (cq_umem_gpu_ptr != 0) {
+    if (cq_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        cq_umem_gpu_ptr = nullptr;
     }
 
     if (cq_umem_dbr != nullptr) {
         status = doca_umem_destroy(cq_umem_dbr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        cq_umem_dbr = nullptr;
     }
 
-    if (cq_umem_dbr_gpu_ptr != 0) {
+    if (cq_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_dbr_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        cq_umem_dbr_gpu_ptr = nullptr;
     }
 }
 
@@ -249,30 +276,43 @@ qp::qp(doca_gpu *gpu_dev_,
       nic_handler(nic_handler_) {
     doca_error_t status;
 
-    cq_rq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, rq_nwqe);
-    cq_sq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, sq_nwqe);
-    qp_verbs = createQp();
+    try {
+        cq_rq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, rq_nwqe);
+        cq_sq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, sq_nwqe);
+        qp_verbs = createQp();
 
-    status = doca_gpu_verbs_export_qp(gpu_dev,
-                                      dev,
-                                      qp_verbs,
-                                      nic_handler,
-                                      qp_umem_gpu_ptr,
-                                      cq_sq->get_cq(),
-                                      cq_rq->get_cq(),
-                                      &qp_gverbs);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        status = doca_gpu_verbs_export_qp(gpu_dev,
+                                          dev,
+                                          qp_verbs,
+                                          nic_handler,
+                                          qp_umem_gpu_ptr,
+                                          cq_sq->get_cq(),
+                                          cq_rq->get_cq(),
+                                          &qp_gverbs);
+        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
 
-    status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
+        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+    }
+    catch (...) {
+        if (qp_gverbs != nullptr) {
+            doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            qp_gverbs = nullptr;
+        }
+        destroyQp();
+        throw;
+    }
 }
 
 qp::~qp() {
     doca_error_t status;
 
-    status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
-    if (status != DOCA_SUCCESS)
-        NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+    if (qp_gverbs != nullptr) {
+        status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+        if (status != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+        qp_gverbs = nullptr;
+    }
 
     destroyQp();
 }
@@ -280,23 +320,23 @@ qp::~qp() {
 doca_verbs_qp *
 qp::createQp() {
     doca_error_t status = DOCA_SUCCESS;
-    doca_verbs_qp_init_attr *verbs_qp_init_attr = nullptr;
+    QpAttrGuard verbs_qp_init_attr;
     doca_verbs_qp *new_qp = nullptr;
     uint32_t external_umem_size = 0;
     size_t dbr_umem_align_sz = ROUND_UP(VERBS_TEST_DBR_SIZE, get_page_size());
 
-    status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr);
+    status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to create doca verbs qp attributes");
 
-    status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr, 1);
+    status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr.value, 1);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs external datapath en");
 
     status = doca_uar_create(dev, DOCA_UAR_ALLOCATION_TYPE_NONCACHE_DEDICATED, &external_uar);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
 
-    status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr, external_uar);
+    status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr.value, external_uar);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set external_uar");
 
     external_umem_size = calc_qp_external_umem_size(rq_nwqe, sq_nwqe);
@@ -319,7 +359,7 @@ qp::createQp() {
                                   &qp_umem);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
 
-    status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr, qp_umem, 0);
+    status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr.value, qp_umem, 0);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs qp external umem");
 
@@ -341,71 +381,86 @@ qp::createQp() {
                                   &qp_umem_dbr);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
 
-    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr, qp_umem_dbr, 0);
+    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
 
-    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr, verbs_pd);
+    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs PD");
 
-    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr, sq_nwqe);
+    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set SQ size");
 
-    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr, rq_nwqe);
+    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set RQ size");
 
-    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr, DOCA_VERBS_QP_TYPE_RC);
+    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set QP type");
 
-    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr, cq_sq->get_cq());
+    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
 
     status =
-        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr, VERBS_TEST_MAX_SEND_SEGS);
+        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value, VERBS_TEST_MAX_SEND_SEGS);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set send_max_sges");
 
-    status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr,
+    status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr.value,
                                                           VERBS_TEST_MAX_RECEIVE_SEGS);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set receive_max_sges");
 
-    status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr, cq_rq->get_cq());
+    status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr.value, cq_rq->get_cq());
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
 
-    status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr, &new_qp);
+    status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr.value, &new_qp);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create doca verbs QP");
+    qp_verbs = new_qp;
 
-    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr);
+    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
+    verbs_qp_init_attr.value = nullptr;
 
-    return new_qp;
+    return qp_verbs;
 }
 
 void
 qp::destroyQp() {
     doca_error_t status;
 
-    status = doca_verbs_qp_destroy(qp_verbs);
-    if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+    if (qp_verbs != nullptr) {
+        status = doca_verbs_qp_destroy(qp_verbs);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+        qp_verbs = nullptr;
+    }
+
+    if (external_uar != nullptr) {
+        status = doca_uar_destroy(external_uar);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        external_uar = nullptr;
+    }
 
     if (qp_umem != nullptr) {
         status = doca_umem_destroy(qp_umem);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem";
+        qp_umem = nullptr;
     }
 
-    if (qp_umem_gpu_ptr != 0) {
+    if (qp_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        qp_umem_gpu_ptr = nullptr;
     }
 
     if (qp_umem_dbr != nullptr) {
         status = doca_umem_destroy(qp_umem_dbr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        qp_umem_dbr = nullptr;
     }
 
-    if (qp_umem_dbr_gpu_ptr != 0) {
+    if (qp_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_dbr_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        qp_umem_dbr_gpu_ptr = nullptr;
     }
 }
 
@@ -476,8 +531,10 @@ mr::mr(void *addr_, size_t tot_size_, uint32_t rkey_)
 }
 
 mr::~mr() {
-    int ret = ibv_dereg_mr(ibmr);
-    if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+    if (ibmr != nullptr) {
+        int ret = ibv_dereg_mr(ibmr);
+        if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+    }
 }
 
 } // namespace nixl::doca::verbs

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,14 +29,18 @@
 static uint32_t
 align_up_uint32(uint32_t value, uint32_t alignment) {
     uint64_t remainder = (value % alignment);
-    if (remainder == 0) return value;
+    if (remainder == 0) {
+        return value;
+    }
     return (uint32_t)(value + (alignment - remainder));
 }
 
 static size_t
 get_page_size(void) {
     long ret = sysconf(_SC_PAGESIZE);
-    if (ret == -1) return 4096; // 4KB, default Linux page size
+    if (ret == -1) {
+        return 4096; // 4KB, default Linux page size
+    }
 
     return (size_t)ret;
 }
@@ -46,8 +50,12 @@ calc_qp_external_umem_size(uint32_t rq_nwqes, uint32_t sq_nwqes) {
     uint32_t rq_ring_size = 0;
     uint32_t sq_ring_size = 0;
 
-    if (rq_nwqes != 0) rq_ring_size = (uint32_t)(rq_nwqes * sizeof(struct mlx5_wqe_data_seg));
-    if (sq_nwqes != 0) sq_ring_size = (uint32_t)(sq_nwqes * sizeof(doca_gpu_dev_verbs_wqe));
+    if (rq_nwqes != 0) {
+        rq_ring_size = (uint32_t)(rq_nwqes * sizeof(struct mlx5_wqe_data_seg));
+    }
+    if (sq_nwqes != 0) {
+        sq_ring_size = (uint32_t)(sq_nwqes * sizeof(doca_gpu_dev_verbs_wqe));
+    }
 
     return align_up_uint32(rq_ring_size + sq_ring_size, get_page_size());
 }
@@ -56,16 +64,19 @@ static uint32_t
 calc_cq_external_umem_size(uint32_t queue_size) {
     uint32_t cqe_buf_size = 0;
 
-    if (queue_size != 0) cqe_buf_size = (uint32_t)(queue_size * sizeof(struct mlx5_cqe64));
+    if (queue_size != 0) {
+        cqe_buf_size = (uint32_t)(queue_size * sizeof(struct mlx5_cqe64));
+    }
 
     return align_up_uint32(cqe_buf_size + VERBS_TEST_DBR_SIZE, get_page_size());
 }
 
 static void
 mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
-    for (uint32_t cqe_idx = 0; cqe_idx < nb_cqes; cqe_idx++)
+    for (uint32_t cqe_idx = 0; cqe_idx < nb_cqes; cqe_idx++) {
         cqes[cqe_idx].op_own =
             (MLX5_CQE_INVALID << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT) | MLX5_CQE_OWNER_MASK;
+    }
 }
 
 class CqAttrGuard {
@@ -73,8 +84,9 @@ public:
     doca_verbs_cq_attr *value = nullptr;
 
     ~CqAttrGuard() {
-        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS)
+        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
+        }
     }
 };
 
@@ -83,8 +95,9 @@ public:
     doca_verbs_qp_init_attr *value = nullptr;
 
     ~QpAttrGuard() {
-        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS)
+        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
+        }
     }
 };
 
@@ -118,8 +131,9 @@ cq::createCq() {
     external_uar = nullptr;
 
     status = doca_verbs_cq_attr_create(&verbs_cq_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to create doca verbs cq attributes");
+    }
 
     status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
@@ -225,37 +239,49 @@ cq::destroyCq() {
 
     if (cq_verbs != nullptr) {
         status = doca_verbs_cq_destroy(cq_verbs);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        }
         cq_verbs = nullptr;
     }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu external_uar";
+        }
         external_uar = nullptr;
     }
 
     if (cq_umem != nullptr) {
         status = doca_umem_destroy(cq_umem);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        }
         cq_umem = nullptr;
     }
 
     if (cq_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        }
         cq_umem_gpu_ptr = nullptr;
     }
 
     if (cq_umem_dbr != nullptr) {
         status = doca_umem_destroy(cq_umem_dbr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        }
         cq_umem_dbr = nullptr;
     }
 
     if (cq_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_dbr_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        }
         cq_umem_dbr_gpu_ptr = nullptr;
     }
 }
@@ -289,10 +315,14 @@ qp::qp(doca_gpu *gpu_dev_,
                                           cq_sq->get_cq(),
                                           cq_rq->get_cq(),
                                           &qp_gverbs);
-        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        if (status != DOCA_SUCCESS) {
+            throw std::runtime_error("Failed to create GPU verbs QP");
+        }
 
         status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
-        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        if (status != DOCA_SUCCESS) {
+            throw std::runtime_error("Failed to create GPU verbs QP");
+        }
     }
     catch (...) {
         if (qp_gverbs != nullptr) {
@@ -309,8 +339,9 @@ qp::~qp() {
 
     if (qp_gverbs != nullptr) {
         status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
-        if (status != DOCA_SUCCESS)
+        if (status != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+        }
         qp_gverbs = nullptr;
     }
 
@@ -326,18 +357,24 @@ qp::createQp() {
     size_t dbr_umem_align_sz = ROUND_UP(VERBS_TEST_DBR_SIZE, get_page_size());
 
     status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to create doca verbs qp attributes");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr.value, 1);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to set doca verbs external datapath en");
+    }
 
     status = doca_uar_create(dev, DOCA_UAR_ALLOCATION_TYPE_NONCACHE_DEDICATED, &external_uar);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr.value, external_uar);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set external_uar");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set external_uar");
+    }
 
     external_umem_size = calc_qp_external_umem_size(rq_nwqe, sq_nwqe);
 
@@ -347,8 +384,9 @@ qp::createQp() {
                                 DOCA_GPU_MEM_TYPE_GPU,
                                 (void **)&qp_umem_gpu_ptr,
                                 nullptr);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to alloc gpu memory for external umem qp");
+    }
 
     status = doca_umem_gpu_create(gpu_dev,
                                   dev,
@@ -357,11 +395,14 @@ qp::createQp() {
                                   DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
                                       DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
                                   &qp_umem);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create gpu umem");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr.value, qp_umem, 0);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to set doca verbs qp external umem");
+    }
 
     status = doca_gpu_mem_alloc(gpu_dev,
                                 dbr_umem_align_sz,
@@ -369,8 +410,9 @@ qp::createQp() {
                                 DOCA_GPU_MEM_TYPE_GPU,
                                 (void **)&qp_umem_dbr_gpu_ptr,
                                 nullptr);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to alloc gpu memory for external umem qp");
+    }
 
     status = doca_umem_gpu_create(gpu_dev,
                                   dev,
@@ -379,45 +421,68 @@ qp::createQp() {
                                   DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
                                       DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
                                   &qp_umem_dbr);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
-
-    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
-    if (status != DOCA_SUCCESS)
-        throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
-
-    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs PD");
-
-    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set SQ size");
-
-    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set RQ size");
-
-    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set QP type");
-
-    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create gpu umem");
+    }
 
     status =
-        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value, VERBS_TEST_MAX_SEND_SEGS);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set send_max_sges");
+        doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
+    }
+
+    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs PD");
+    }
+
+    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set SQ size");
+    }
+
+    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set RQ size");
+    }
+
+    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set QP type");
+    }
+
+    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs CQ");
+    }
+
+    status = doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value,
+                                                       VERBS_TEST_MAX_SEND_SEGS);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set send_max_sges");
+    }
 
     status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr.value,
                                                           VERBS_TEST_MAX_RECEIVE_SEGS);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set receive_max_sges");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set receive_max_sges");
+    }
 
     status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr.value, cq_rq->get_cq());
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs CQ");
+    }
 
     status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr.value, &new_qp);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create doca verbs QP");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create doca verbs QP");
+    }
     qp_verbs = new_qp;
 
     status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
+    }
     verbs_qp_init_attr.value = nullptr;
 
     return qp_verbs;
@@ -429,37 +494,49 @@ qp::destroyQp() {
 
     if (qp_verbs != nullptr) {
         status = doca_verbs_qp_destroy(qp_verbs);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy doca verbs QP";
+        }
         qp_verbs = nullptr;
     }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu external_uar";
+        }
         external_uar = nullptr;
     }
 
     if (qp_umem != nullptr) {
         status = doca_umem_destroy(qp_umem);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu qp umem";
+        }
         qp_umem = nullptr;
     }
 
     if (qp_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        }
         qp_umem_gpu_ptr = nullptr;
     }
 
     if (qp_umem_dbr != nullptr) {
         status = doca_umem_destroy(qp_umem_dbr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        }
         qp_umem_dbr = nullptr;
     }
 
     if (qp_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_dbr_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        }
         qp_umem_dbr_gpu_ptr = nullptr;
     }
 }
@@ -470,8 +547,9 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
       elem_num(elem_num_),
       elem_size(elem_size_),
       pd(pd_) {
-    if (gpu_dev == nullptr || addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr)
+    if (gpu_dev == nullptr || addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr) {
         throw std::invalid_argument("Invalid mr input values");
+    }
 
     doca_error_t status;
     static size_t host_page_size = sysconf(_SC_PAGESIZE);
@@ -515,7 +593,9 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
                           tot_size,
                           IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                               IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
-        if (ibmr == nullptr) throw std::invalid_argument("Failed to create mr");
+        if (ibmr == nullptr) {
+            throw std::invalid_argument("Failed to create mr");
+        }
     }
 
     lkey = htobe32(ibmr->lkey);
@@ -533,7 +613,9 @@ mr::mr(void *addr_, size_t tot_size_, uint32_t rkey_)
 mr::~mr() {
     if (ibmr != nullptr) {
         int ret = ibv_dereg_mr(ibmr);
-        if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+        if (ret != 0) {
+            NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+        }
     }
 }
 

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -347,17 +347,29 @@ qp::qp(doca_gpu *gpu_dev_,
 }
 
 qp::~qp() {
-    doca_error_t status;
+    if (!close()) {
+        // Keep CQ dependencies alive when DOCA still owns the exported QP.
+        cq_rq.release();
+        cq_sq.release();
+    }
+}
 
+bool
+qp::close() noexcept {
     if (qp_gverbs != nullptr) {
-        status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+        const doca_error_t status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
         if (status != DOCA_SUCCESS) {
-            NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+            NIXL_ERROR << "Failed to unexport DOCA GPU verbs QP";
+            return false;
         }
         qp_gverbs = nullptr;
+        qp_gdev_verbs = nullptr;
     }
 
     destroyQp();
+    cq_rq.reset();
+    cq_sq.reset();
+    return true;
 }
 
 doca_verbs_qp *

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -79,8 +79,15 @@ mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
     }
 }
 
+namespace {
+
 class CqAttrGuard {
 public:
+    CqAttrGuard() = default;
+    CqAttrGuard(const CqAttrGuard &) = delete;
+    CqAttrGuard &
+    operator=(const CqAttrGuard &) = delete;
+
     doca_verbs_cq_attr *value = nullptr;
 
     doca_error_t
@@ -99,6 +106,11 @@ public:
 
 class QpAttrGuard {
 public:
+    QpAttrGuard() = default;
+    QpAttrGuard(const QpAttrGuard &) = delete;
+    QpAttrGuard &
+    operator=(const QpAttrGuard &) = delete;
+
     doca_verbs_qp_init_attr *value = nullptr;
 
     doca_error_t
@@ -114,6 +126,8 @@ public:
         }
     }
 };
+
+} // namespace
 
 namespace nixl::doca::verbs {
 
@@ -338,8 +352,16 @@ qp::qp(doca_gpu *gpu_dev_,
     }
     catch (...) {
         if (qp_gverbs != nullptr) {
-            doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            const doca_error_t unexport_status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            if (unexport_status != DOCA_SUCCESS) {
+                NIXL_ERROR << "Failed to unexport DOCA GPU verbs QP during rollback; retaining "
+                              "dependent resources";
+                cq_rq.release();
+                cq_sq.release();
+                throw;
+            }
             qp_gverbs = nullptr;
+            qp_gdev_verbs = nullptr;
         }
         destroyQp();
         throw;

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -83,8 +83,15 @@ class CqAttrGuard {
 public:
     doca_verbs_cq_attr *value = nullptr;
 
+    doca_error_t
+    destroy() noexcept {
+        auto *attr = value;
+        value = nullptr;
+        return attr == nullptr ? DOCA_SUCCESS : doca_verbs_cq_attr_destroy(attr);
+    }
+
     ~CqAttrGuard() {
-        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS) {
+        if (destroy() != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
         }
     }
@@ -94,8 +101,15 @@ class QpAttrGuard {
 public:
     doca_verbs_qp_init_attr *value = nullptr;
 
+    doca_error_t
+    destroy() noexcept {
+        auto *attr = value;
+        value = nullptr;
+        return attr == nullptr ? DOCA_SUCCESS : doca_verbs_qp_init_attr_destroy(attr);
+    }
+
     ~QpAttrGuard() {
-        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS) {
+        if (destroy() != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
         }
     }
@@ -223,13 +237,11 @@ cq::createCq() {
     }
     cq_verbs = new_cq;
 
-    status = doca_verbs_cq_attr_destroy(verbs_cq_attr.value);
+    status = verbs_cq_attr.destroy();
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to destroy doca verbs cq attributes");
     }
-    verbs_cq_attr.value = nullptr;
-
     return new_cq;
 }
 
@@ -479,12 +491,10 @@ qp::createQp() {
     }
     qp_verbs = new_qp;
 
-    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
+    status = verbs_qp_init_attr.destroy();
     if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
     }
-    verbs_qp_init_attr.value = nullptr;
-
     return qp_verbs;
 }
 

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -94,6 +94,13 @@ public:
 
     ~qp();
 
+    /**
+     * @brief Unexport the GPU QP and release its backing resources.
+     * @return true when teardown completed; false when the exported QP must remain alive.
+     */
+    bool
+    close() noexcept;
+
     [[nodiscard]] doca_verbs_qp *
     get_qp() const {
         return qp_verbs;

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -72,14 +72,14 @@ private:
     doca_dev *dev;
     doca_verbs_context *verbs_ctx;
     doca_verbs_pd *verbs_pd;
-    doca_uar *external_uar;
+    doca_uar *external_uar = nullptr;
     uint16_t ncqe;
 
-    doca_verbs_cq *cq_verbs;
-    void *cq_umem_gpu_ptr;
-    doca_umem *cq_umem;
-    void *cq_umem_dbr_gpu_ptr;
-    doca_umem *cq_umem_dbr;
+    doca_verbs_cq *cq_verbs = nullptr;
+    void *cq_umem_gpu_ptr = nullptr;
+    doca_umem *cq_umem = nullptr;
+    void *cq_umem_dbr_gpu_ptr = nullptr;
+    doca_umem *cq_umem_dbr = nullptr;
 };
 
 class qp {
@@ -124,14 +124,14 @@ private:
     uint16_t rq_nwqe;
     doca_gpu_dev_verbs_nic_handler nic_handler;
 
-    doca_verbs_qp *qp_verbs;
-    void *qp_umem_gpu_ptr;
-    doca_umem *qp_umem;
-    void *qp_umem_dbr_gpu_ptr;
-    doca_umem *qp_umem_dbr;
-    doca_uar *external_uar;
-    doca_gpu_verbs_qp *qp_gverbs;
-    doca_gpu_dev_verbs_qp *qp_gdev_verbs;
+    doca_verbs_qp *qp_verbs = nullptr;
+    void *qp_umem_gpu_ptr = nullptr;
+    doca_umem *qp_umem = nullptr;
+    void *qp_umem_dbr_gpu_ptr = nullptr;
+    doca_umem *qp_umem_dbr = nullptr;
+    doca_uar *external_uar = nullptr;
+    doca_gpu_verbs_qp *qp_gverbs = nullptr;
+    doca_gpu_dev_verbs_qp *qp_gdev_verbs = nullptr;
 
     std::unique_ptr<nixl::doca::verbs::cq> cq_rq;
     std::unique_ptr<nixl::doca::verbs::cq> cq_sq;


### PR DESCRIPTION
## Summary

- Fix GPUNETIO ownership leaks across remote metadata, notifications, QPs, and throwing helper initialization paths.
- Synchronize posting streams before freeing shared GPU state.
- Quiesce data and notification QPs before releasing notification MRs or buffers.
- Fail closed and retain dependent resources if DOCA refuses to unexport a QP.
- Destroy QPs, GPU state, AH, DOCA device, verbs PD, and verbs context in dependency order.
- Preserve local ownership until map insertion succeeds.

## Validation

Current stack:

```text
base:   e0db240a2a7f78e8e9b347a6fd4509c6944f7954
commit: 14868661
```

- CUDA 12.8 / DOCA 3.1 GPUNETIO warning-as-error build: PASS
- focused lifecycle smoke covering engine creation, connection/metadata setup, unload, deregistration, and engine destruction: PASS twice in fresh processes on the original lifecycle patch
- final teardown-order and fail-closed follow-ups: exact warning-as-error plugin link PASS
- SPDX and whitespace checks: PASS

A public build reproduction is:

```bash
meson setup build \
  -Denable_plugins=GPUNETIO \
  -Dnixl_cuda_arch_list=90 \
  -Dbuildtype=release \
  -Dwerror=true
ninja -C build src/plugins/gpunetio/libplugin_GPUNETIO.so
```

The pending DOCA 3.1 compatibility change from #2052 was applied only to the test tree's kernel compatibility boundary and is not part of this PR.

## Scope

This PR changes ownership and teardown only. It does not change peer memory, WQE construction, request-ring behavior, completion polling, OOB/control behavior, or performance policy. It makes no performance claim.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of networking and GPU communication resources during shutdown.
  * Prevented crashes and invalid resource access when setup or teardown encounters errors.
  * Added safer handling for partially initialized connections and failed resource creation.
  * Improved cleanup of notification buffers, memory registrations, queues, and communication resources.

* **Reliability**
  * Improved rollback when communication resources cannot be created successfully.
  * Preserved dependent resources when cleanup operations do not complete.
  * Improved handling of failed transfers, registrations, and resource closures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

