### PR TITLE
CI: add nixl-ci-gpu-vr pipeline on the Vera Rubin partition

### DIFF
--- a/.ci/cidemo-init.sh
+++ b/.ci/cidemo-init.sh
@@ -21,6 +21,7 @@ YAML_FILES=(
     ".ci/jenkins/lib/build-matrix.yaml"
     ".ci/jenkins/lib/test-matrix.yaml"
     ".ci/jenkins/lib/test-dl-matrix.yaml"
+    ".ci/jenkins/lib/test-vr-matrix.yaml"
     ".ci/jenkins/lib/test-dl-ep-matrix.yaml"
     ".ci/jenkins/lib/test-sanitizer-matrix.yaml"
     ".ci/jenkins/lib/build-wheel-matrix.yaml"

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -20,7 +20,7 @@ runs on-demand (`workflow_dispatch`, a PR comment, or a cron schedule).
 | [Claude Code Review](#claude-code-review-claude-reviewyml) | GitHub Actions | `pull_request` (opened/synchronize/reopened) | Yes |
 | [External Contributor](#external-contributor-external_contributoryaml) | GitHub Actions | `pull_request_target` (opened, fork only) | Yes (fork PRs only) |
 | [Blossom-CI](#blossom-ci-blossom-ciyml) | GitHub Actions | `/build` PR comment, or `workflow_dispatch` | No — manual |
-| `nixl-ci-dispatcher` → `non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`, `test-sanitizers`, `build-container-pr` | Jenkins (dispatcher-triggered) | Fan-out from Blossom-CI `Job-trigger` | No — only after `/build`, but these 7 are the *only* Jenkins jobs in the PR CI path |
+| `nixl-ci-dispatcher` → `non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `gpu-vr`, `build-wheel`, `test-sanitizers`, `build-container-pr` | Jenkins (dispatcher-triggered) | Fan-out from Blossom-CI `Job-trigger` | No — only after `/build`, but these 8 are the *only* Jenkins jobs in the PR CI path |
 | `nixl-ci-build-container` | Jenkins (standalone) | Nightly cron + manual | No — never runs as part of PR CI |
 | `nixl-ci-build-wheel-nightly` | Jenkins (standalone) | Nightly cron, triggered by `build-wheel-release-poller`, or manual | No — never runs as part of PR CI |
 | `nixl-build-wheel-release-poller` | Jenkins (standalone) | 4-hourly cron + manual | No — never runs as part of PR CI |
@@ -102,7 +102,7 @@ sequenceDiagram
     participant Scan as Vulnerability-scan (Black Duck)
     participant Trigger as Job-trigger
     participant Jenkins as nixl-ci-dispatcher
-    participant Children as Child jobs<br/>(non-gpu, gpu, dl-gpu,<br/>dl-gpu-ep, build-wheel,<br/>test-sanitizers, build-container-pr)
+    participant Children as Child jobs<br/>(non-gpu, gpu, dl-gpu,<br/>dl-gpu-ep, gpu-vr, build-wheel,<br/>test-sanitizers, build-container-pr)
 
     User->>GH: comment "/build"
     GH->>Blossom: issue_comment event
@@ -132,8 +132,8 @@ Step by step, matching the jobs in `blossom-ci.yml`:
    Duck-based vulnerability scan via the `NVIDIA/blossom-action`.
 5. **Job-trigger** calls `blossom-ci` with `OPERATION: START-CI-JOB`, which
    triggers the Jenkins `nixl-ci-dispatcher` job.
-6. `nixl-ci-dispatcher` fans out in parallel to its seven child jobs
-   (`non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`,
+6. `nixl-ci-dispatcher` fans out in parallel to its eight child jobs
+   (`non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `gpu-vr`, `build-wheel`,
    `test-sanitizers`, `build-container-pr` — see [Jenkins jobs](#jenkins-jobs) below).
 7. Each child job reports its own status back as an individual GitHub PR
    check, so the PR shows per-job pass/fail rather than one aggregate check.
@@ -162,15 +162,16 @@ their own nightly/manual trigger. They split into two groups:
 ### `nixl-ci-dispatcher` (dispatcher-triggered)
 
 - **Trigger:** GitHub webhook payload forwarded by Blossom-CI's `Job-trigger` step (`OPERATION: START-CI-JOB`). Not a raw GitHub Actions event.
-- **What it does:** Fans out in parallel to seven downstream Jenkins jobs, waiting on all of them:
+- **What it does:** Fans out in parallel to eight downstream Jenkins jobs, waiting on all of them:
   - `nixl-ci-non-gpu` — `.ci/jenkins/lib/build-matrix.yaml`
   - `nixl-ci-gpu` — `.ci/jenkins/lib/test-matrix.yaml`
   - `nixl-ci-dl-gpu` — `.ci/jenkins/lib/test-dl-matrix.yaml` (dlcluster.nvidia.com)
   - `nixl-ci-dl-gpu-ep` — `.ci/jenkins/lib/test-dl-ep-matrix.yaml` (NIXL EP tests on dlcluster.nvidia.com)
+  - `nixl-ci-gpu-vr` — `.ci/jenkins/lib/test-vr-matrix.yaml` (same tests as `nixl-ci-dl-gpu`, on the Vera Rubin `vrnvl72` partition / `rubin` account)
   - `nixl-ci-build-wheel` — `.ci/jenkins/lib/build-wheel-matrix.yaml`
   - `nixl-ci-test-sanitizers` — `.ci/jenkins/lib/test-sanitizer-matrix.yaml` (ASan/UBSan + TSan)
   - `nixl-ci-build-container-pr` — `.ci/jenkins/lib/build-container-pr-matrix.yaml`
-- **UCX version:** The three GPU test jobs (`nixl-ci-gpu`, `nixl-ci-dl-gpu`, `nixl-ci-dl-gpu-ep`) build and test against a single UCX version per run — the `UCX_VER` parameter, which defaults to empty and falls back to the `Dockerfile` `ARG UCX_VERSION` default (`v1.23.x`). UCX `master` is validated nightly, not per PR: the standalone `nixl-ci-nightly` job (see below) fans out to all three with `UCX_VER=master` and emails one consolidated report, so UCX regressions surface outside the PR path instead of blocking PRs.
+- **UCX version:** The four GPU test jobs (`nixl-ci-gpu`, `nixl-ci-dl-gpu`, `nixl-ci-dl-gpu-ep`, `nixl-ci-gpu-vr`) build and test against a single UCX version per run — the `UCX_VER` parameter, which defaults to empty and falls back to the `Dockerfile` `ARG UCX_VERSION` default (`v1.23.x`). UCX `master` is validated nightly, not per PR: the standalone `nixl-ci-nightly` job (see below) fans out to all four with `UCX_VER=master` and emails one consolidated report, so UCX regressions surface outside the PR path instead of blocking PRs.
 - **Automatic on every PR:** No — only runs after a `/build` comment triggers Blossom-CI. The dispatcher also aborts any stale in-flight dispatcher run for the same PR (and the leaf builds it started) before starting.
 
 ### `nixl-ci-build-container-pr` (dispatcher-triggered)
@@ -222,7 +223,7 @@ their own nightly/manual trigger. They split into two groups:
 ### `nixl-ci-nightly` (standalone)
 
 - **Trigger:** Nightly cron (`H 0 * * *`), or manual run (`UCX_REF`, `MAIL_TO` parameters).
-- **What it does:** Fans out to `nixl-ci-gpu`, `nixl-ci-dl-gpu`, `nixl-ci-dl-gpu-ep` with `UCX_VER=${UCX_REF}` (default `master`), waits for all three, and emails one consolidated report to `MAIL_TO` (default `nixl-ci-alerts@exchange.nvidia.com`) **only when a leg fails** — a green night is silent. This is the single place nightly UCX-`master` results are collected and sent from; per-PR runs of the GPU jobs cover only the release UCX version.
+- **What it does:** Fans out to `nixl-ci-gpu`, `nixl-ci-dl-gpu`, `nixl-ci-dl-gpu-ep`, `nixl-ci-gpu-vr` with `UCX_VER=${UCX_REF}` (default `master`), waits for all four, and emails one consolidated report to `MAIL_TO` (default `nixl-ci-alerts@exchange.nvidia.com`) **only when a leg fails** — a green night is silent. This is the single place nightly UCX-`master` results are collected and sent from; per-PR runs of the GPU jobs cover only the release UCX version.
 - **Matrix:** `.ci/jenkins/lib/nightly-matrix.yaml` — a lightweight ci-demo orchestrator (one groovy step: fan out, wait, mail), no GPU of its own.
 - **Automatic on every PR:** No — standalone/scheduled + manual only.
 
@@ -235,6 +236,7 @@ Jobs submitted via the `slurmCI` module are named `${JOB_BASE_NAME}-${BUILD_NUMB
 | `nixl-ci-gpu` | `nixl-ci-gpu-<build>` |
 | `nixl-ci-dl-gpu` | `nixl-ci-dl-gpu-<build>` |
 | `nixl-ci-dl-gpu-ep` | `nixl-ci-dl-gpu-ep-<build>` |
+| `nixl-ci-gpu-vr` | `nixl-ci-gpu-vr-<build>` |
 | `nixl-ci-build-wheel` | `nixl-ci-build-wheel-<fw>-<build>` (`fw`: `vllm` or `sglang`) |
 | `nixl-ci-test-llm-container` | `nixl-ci-test-llm-container-<build>` |
 

--- a/.ci/jenkins/lib/nightly-matrix.yaml
+++ b/.ci/jenkins/lib/nightly-matrix.yaml
@@ -1,7 +1,8 @@
 # NIXL nightly UCX-master validation orchestrator.
 #
-# Fans out to the three GPU test jobs (nixl-ci-gpu, nixl-ci-dl-gpu,
-# nixl-ci-dl-gpu-ep) with UCX_VER=master, waits for all of them, and emails one
+# Fans out to the four GPU test jobs (nixl-ci-gpu, nixl-ci-dl-gpu,
+# nixl-ci-dl-gpu-ep, nixl-ci-gpu-vr) with UCX_VER=master, waits for all of
+# them, and emails one
 # consolidated report when any leg fails. This is the single place nightly
 # UCX-master results are collected and sent from; per-PR runs of the GPU jobs
 # cover only the release UCX version.
@@ -46,6 +47,7 @@ steps:
           'gpu':       'nixl-ci-gpu',
           'dl-gpu':    'nixl-ci-dl-gpu',
           'dl-gpu-ep': 'nixl-ci-dl-gpu-ep',
+          'gpu-vr':    'nixl-ci-gpu-vr',
       ]
       def ucxRef = params.UCX_REF ?: 'master'
       def results = [:]

--- a/.ci/jenkins/lib/test-vr-matrix.yaml
+++ b/.ci/jenkins/lib/test-vr-matrix.yaml
@@ -1,0 +1,229 @@
+---
+#
+# Vera Rubin GPU Test Matrix Configuration
+#
+# Same test flow as nixl-ci-dl-gpu, run on the Vera Rubin Slurm partition
+# (vrnvl72 / account rubin) instead of gb200nvl72_ci. The base and build_helper
+# images are shared with nixl-ci-dl-gpu (identical build args), so only the
+# per-build PR image and Slurm container names are namespaced with -vr.
+#
+# Per-test timeouts mirror test-matrix.yaml, which runs the same four scripts;
+# SLURM_JOB_TIMEOUT is kept above their sum so the allocation outlives the tests.
+#
+# Key Components:
+# - Job Configuration: Defines timeout, failure behavior, and server resources
+# - Docker Images: Specifies the container images used for different build stages
+# - Matrix Axes: Defines build variations (multi-node, multi-GPU)
+# - Run Steps: Sequential steps for running the GPU tests
+#
+# When Modified:
+# - Adding/removing Docker images: Affects available test environments
+# - Modifying matrix axes: Changes test variations (e.g., adding architectures)
+# - Adjusting resource limits: Impacts test performance and resource allocation
+# - Adding/removing steps: Changes the test pipeline sequence
+#
+# Note: Changes to this file are tested as part of the PR CI flow no need to test them manually.
+
+
+job: nixl-ci-gpu-vr
+
+# Fail job if one of the steps fails or continue
+failFast: false
+
+timeout_minutes: 240
+
+registry_host: artifactory.nvidia.com
+registry_auth: svc-nixl-new-artifactory-token
+registry_path: /sw-nbu-swx-nixl-docker-local/ci
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  imagePullSecrets: "['artifactory-pull-secret']"
+  limits: "{memory: 16Gi, cpu: 16000m}"
+  requests: "{memory: 8Gi, cpu: 8000m}"
+  privileged: true
+
+credentials:
+  - {credentialsId: 'svc-nixl-new-artifactory-token', usernameVariable: 'REPO_USER', passwordVariable: 'REPO_PASS'}
+
+env:
+  ARTIFACTORY_PATH: /sw-nbu-swx-nixl-docker-local/ci
+  NIXL_INSTALL_DIR: /opt/nixl
+  NIXL_BUILD_DIR: nixl_build
+  SLURM_NODES: 1
+  SLURM_PARTITION: vrnvl72
+  SLURM_HEAD_NODE: dlcluster.nvidia.com
+  SLURM_HEAD_USER: svc-nixl
+  SLURM_ACCOUNT: 'rubin'
+  SLURM_JOB_TIMEOUT: '02:20:00'
+  SLURM_IMMEDIATE_TIMEOUT: 3600
+  SSH_CREDENTIALS_ID: 'svc-nixl-ssh_key'
+  JOB_ID_FILE_ROOT: "/mnt/pvc/${JOB_BASE_NAME}"
+  STORAGE_DRIVER: overlay
+  # Auto-derived and patched by cidemo-init.sh at CI time from the CI source files;
+  # the "CI_MANAGED" placeholder must not be hand-edited.
+  CI_IMAGE_TAG: "CI_MANAGED"
+
+empty_volumes:
+  - {mountPath: /var/lib/containers/storage, memory: false}
+
+pvc_volumes:
+  - {claimName: nbu-swx-nixl-pvc, mountPath: /mnt/pvc, readOnly: false}
+
+# Docker images for DL testing
+runs_on_dockers:
+  - {
+     file: '.ci/dockerfiles/Dockerfile.base',
+     name: 'nixl-ci-dl-gpu-base',
+     tag: "${CI_IMAGE_TAG}",
+     arch: "aarch64",
+     build_args: '--build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} --build-arg PRE_INSTALLED_UCX_ENV=true --build-arg PRE_INSTALLED_NIXL_ENV=true --build-arg ARCH=${arch} --pull --no-cache'
+    }
+
+  - {
+     file: '.ci/dockerfiles/Dockerfile.build_helper',
+     name: 'build_helper_dl',
+     arch: "aarch64",
+     tag: "${CI_IMAGE_TAG}",
+     build_args: '--build-arg ARCH=${arch}'
+    }
+
+matrix:
+  axes:
+    arch:
+      - aarch64
+
+taskName: "${name}/${arch}/${axis_index}"
+
+steps:
+  - name: Compiling NIXL Docker Image
+    containerSelector: "{name: 'build_helper_dl'}"
+    credentialsId: "svc-nixl-new-artifactory-token"
+    parallel: false
+    run: |
+      set -x
+      # Pass UCX_VERSION only when UCX_VER is set (e.g. nightly master);
+      # empty falls back to the Dockerfile ARG UCX_VERSION default so the
+      # per-branch default lives in one place.
+      UCX_ARG=""
+      if [ -n "${UCX_VER}" ]; then UCX_ARG="--build-arg UCX_VERSION=${UCX_VER}"; fi
+      export PR_IMAGE=${registry_host}${registry_path}/pr/${arch}/nixl-ci-gpu-vr-test:${BUILD_NUMBER}
+      rm -rf /etc/containers/storage.conf && rm -f /usr/share/containers/storage.conf
+      set +x -v
+      podman build --network host --creds ${REPO_USER}:${REPO_PASS} \
+      ${UCX_ARG} \
+      --build-arg PRE_INSTALLED_ENV="true" \
+      --build-arg NIXL_INSTALL_DIR=${NIXL_INSTALL_DIR} \
+      --build-arg NIXL_BUILD_DIR=${NIXL_BUILD_DIR} \
+      --build-arg HAS_GPU=true \
+      --build-arg BASE_IMAGE=${registry_host}${registry_path}/${arch}/nixl-ci-dl-gpu-base:${CI_IMAGE_TAG} \
+      --tag ${PR_IMAGE} \
+      -f .ci/dockerfiles/Dockerfile.gpu-test .
+      for i in {1..6}; do
+          podman push --creds ${REPO_USER}:${REPO_PASS} ${PR_IMAGE} && break
+          [ "$i" = 6 ] && exit 1
+          sleep $((2 ** (i - 1)))
+      done
+
+  - name: Allocate Environment
+    containerSelector: "{name: 'build_helper_dl'}"
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: allocation
+    args:
+      partition: "${SLURM_PARTITION}"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      nodes: "${SLURM_NODES}"
+      jobTimeout: "${SLURM_JOB_TIMEOUT}"
+      immediateTimeout: "${SLURM_IMMEDIATE_TIMEOUT}"
+      jobName: "${JOB_BASE_NAME}-${BUILD_NUMBER}"
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      extraArgs: [
+        "--account=${SLURM_ACCOUNT}"
+      ]
+
+  - name: Run Python tests
+    containerSelector: "{name: 'build_helper_dl'}"
+    timeout: 20
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: ".gitlab/test_python.sh ${NIXL_INSTALL_DIR}"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-vr-test:${BUILD_NUMBER}"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      containerName: "nixl-ci-vr-${BUILD_NUMBER}"
+
+  - name: Run Rust tests
+    containerSelector: "{name: 'build_helper_dl'}"
+    timeout: 15
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: ".gitlab/test_rust.sh ${NIXL_INSTALL_DIR}"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-vr-test:${BUILD_NUMBER}"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      containerName: "nixl-ci-vr-${BUILD_NUMBER}"
+
+  - name: Run CPP tests
+    containerSelector: "{name: 'build_helper_dl'}"
+    timeout: 60
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: ".gitlab/test_cpp.sh ${NIXL_INSTALL_DIR} run_uring"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-vr-test:${BUILD_NUMBER}"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      containerName: "nixl-ci-vr-${BUILD_NUMBER}"
+      slurmEnv: [
+        'UCX_IB_REG_METHODS=rcache'
+      ]
+
+  - name: Run Nixlbench tests
+    containerSelector: "{name: 'build_helper_dl'}"
+    timeout: 25
+    parallel: false
+    shell: action
+    module: slurmCI
+    run: run
+    args:
+      jobIdFile: "${JOB_ID_FILE_ROOT}/job_id_${BUILD_NUMBER}.txt"
+      testScript: ".gitlab/test_nixlbench.sh ${NIXL_INSTALL_DIR}"
+      headNode: "${SLURM_HEAD_NODE}"
+      headUser: "${SLURM_HEAD_USER}"
+      dockerImage: "${registry_host}#${ARTIFACTORY_PATH}/pr/${arch}/nixl-ci-gpu-vr-test:${BUILD_NUMBER}"
+      credentialsId: "${SSH_CREDENTIALS_ID}"
+      containerName: "nixl-ci-vr-${BUILD_NUMBER}"
+      slurmEnv: [
+        'HAS_GPU=false'
+      ]
+
+pipeline_stop:
+  containerSelector: "{name: 'build_helper_dl'}"
+  parallel: false
+  shell: action
+  module: slurmCI
+  run: stopAllForBuild
+  args:
+    credentialsId: "${SSH_CREDENTIALS_ID}"
+    headNode: "${SLURM_HEAD_NODE}"
+    headUser: "${SLURM_HEAD_USER}"
+    jobIdDir: "${JOB_ID_FILE_ROOT}"

--- a/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
+++ b/.ci/jenkins/pipeline/Jenkinsfile.dispatcher
@@ -91,6 +91,7 @@ def leafJobs = [
     'gpu':             'nixl-ci-gpu',
     'dl-gpu':          'nixl-ci-dl-gpu',
     'dl-gpu-ep':       'nixl-ci-dl-gpu-ep',
+    'gpu-vr':          'nixl-ci-gpu-vr',
     'wheel':           'nixl-ci-build-wheel',
     'sanitizers':      'nixl-ci-test-sanitizers',
     'build-container': 'nixl-ci-build-container-pr',

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -450,6 +450,71 @@
                     parent-credentials: true
         script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
 
+# Template for the Vera Rubin GPU test job
+- job-template:
+    name: "{jjb_proj}-gpu-vr"      # Will be expanded to 'nixl-ci-gpu-vr'
+    project-type: pipeline
+    disabled: false
+    properties:
+        # Similar properties as dispatcher job
+        - github:
+            url: "{jjb_gh_url}"
+        - build-discarder:
+            days-to-keep: 14
+            num-to-keep: 1000
+        - inject:
+            keep-system-variables: true
+            properties-content: |
+              jjb_proj={jjb_proj}-gpu-vr
+    description: Do NOT edit this job through the Web GUI !
+    concurrent: true
+    sandbox: true
+    # Test job parameters
+    parameters:
+        - string:
+            name: "sha1"
+            default: "{jjb_branch}"    # Default to 'main' branch
+            description: "Commit to be checked, usually set by PR"
+        - string:
+            name: "githubData"
+            default: ""
+            description: "Variables from post"
+        - string:
+            name: "conf_file"
+            default: ".ci/jenkins/lib/test-vr-matrix.yaml"  # Vera Rubin test matrix configuration
+            description: "Job config file"
+        - string:
+            name: "UCX_VER"
+            default: ""
+            description: "UCX ref (branch/tag/commit) to build against. Empty uses the Dockerfile ARG UCX_VERSION default (kept per branch in one place); the nixl-ci-nightly job sets it to master."
+        - bool:
+            name: "build_dockers"
+            default: false
+            description: "Force rebuild docker containers"
+        - string:
+            name: "DEBUG"
+            default: 0
+            description: "Enable debug prints and traces, valid values are 0-9"
+    # SCM configuration for the build job
+    pipeline-scm:
+        scm:
+            - git:
+                url: "{jjb_git}"
+                branches: ['$sha1']
+                shallow-clone: false
+                do-not-fetch-tags: false
+                # Configure refspec to handle branches, PRs, and tags
+                refspec: "{jjb_gh_refspec}"
+                browser: githubweb
+                browser-url: "{jjb_git}"
+                # Handle git submodules
+                submodule:
+                    disable: false
+                    recursive: true
+                    tracking: true
+                    parent-credentials: true
+        script-path: "{jjb_jenkinsfile}"  # Path to Jenkinsfile that defines the build steps
+
 # Template for NIXL build container job
 # Builds and pushes NIXL and NIXLBench container images for x86_64 and aarch64
 # Supports nightly automatic builds and manual builds via parameters
@@ -1114,8 +1179,9 @@
             conf_file=.ci/jenkins/lib/nightly-matrix.yaml
     description: >
       <b>NIXL nightly UCX-master validation</b><br/>
-      Runs <code>nixl-ci-gpu</code>, <code>nixl-ci-dl-gpu</code> and
-      <code>nixl-ci-dl-gpu-ep</code> against UCX <code>master</code> nightly and
+      Runs <code>nixl-ci-gpu</code>, <code>nixl-ci-dl-gpu</code>,
+      <code>nixl-ci-dl-gpu-ep</code> and <code>nixl-ci-gpu-vr</code> against
+      UCX <code>master</code> nightly and
       emails one consolidated pass/fail report.<br/>
       <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
     concurrent: false
@@ -1171,6 +1237,7 @@
         - "{jjb_proj}-gpu"        # Create gpu job
         - "{jjb_proj}-dl-gpu"   # Create dl-gpu job for dlcluster.nvidia.com
         - "{jjb_proj}-dl-gpu-ep"  # Create dl-gpu-ep job for NIXL EP on dlcluster.nvidia.com
+        - "{jjb_proj}-gpu-vr"  # Create gpu-vr job for the Vera Rubin partition
         - "{jjb_proj}-build-wheel"  # Create build wheel job
         - "{jjb_proj}-build-wheel-nightly"  # Create nightly wheel verification job
         - "nixl-build-wheel-release-poller"  # Create release wheel poller job


### PR DESCRIPTION
Adds a new Jenkins pipeline, `nixl-ci-gpu-vr`, that runs the same GPU test flow as `nixl-ci-dl-gpu` (python, rust, cpp, nixlbench) on the Vera Rubin Slurm partition `vrnvl72` under the `rubin` account, so NIXL is validated on Vera Rubin hardware.

The job runs per PR from the dispatcher fan-out and as a fourth leg of the nightly UCX-`master` validation, matching how `nixl-ci-dl-gpu` and `nixl-ci-dl-gpu-ep` are wired.

The new job shares the base and `build_helper` images with `nixl-ci-dl-gpu` since their build args are identical, so no extra aarch64 base image build is introduced. Only the per-build PR image and the Slurm container name are namespaced with `-vr` to avoid collisions between the two jobs' independent build numbers.

Per-test timeouts follow `test-matrix.yaml`, which runs the same four scripts (cpp 60, python 20, rust 15, nixlbench 25), and `SLURM_JOB_TIMEOUT` is `02:20:00` so the Slurm allocation outlives their sum.

Changes:

- New `.ci/jenkins/lib/test-vr-matrix.yaml` — same flow as `test-dl-matrix.yaml`, differing in `job`, `SLURM_PARTITION`, `SLURM_ACCOUNT`, timeouts, PR image name and container name.
- `.ci/jenkins/pipeline/proj-jjb.yaml` — new `{jjb_proj}-gpu-vr` job template, its entry in the project `jobs:` list, and the nightly job description.
- `.ci/jenkins/pipeline/Jenkinsfile.dispatcher` — added to `leafJobs` so it runs as part of the PR fan-out.
- `.ci/jenkins/lib/nightly-matrix.yaml` — added as a fourth leg of the nightly UCX-`master` fan-out.
- `.ci/cidemo-init.sh` — added to `YAML_FILES` so the `CI_MANAGED` image-tag placeholder is patched at CI time.
- `.ci/docs/ci-overview.md` — updated child-job count and lists, the nightly fan-out, the Slurm job-name table and the UCX-version note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Vera Rubin GPU validation to pull request testing.
  - Expanded automated CI coverage with the `gpu-vr` test job.
  - Increased pull request test fan-out from seven to eight parallel jobs.
  - Added Vera Rubin GPU validation to nightly UCX-master testing with consolidated result reporting.
  - Configured validation on the `vrnvl72` partition using the `rubin` account.
  - Added automated setup, execution, retry handling, and cleanup for Vera Rubin GPU tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->