### PR TITLE
obj: add Everpure accelerated S3 engine for Pure Storage FlashBlade

### DIFF
--- a/src/plugins/obj/README.md
+++ b/src/plugins/obj/README.md
@@ -72,7 +72,7 @@ Backend parameters are passed as a key-value map (`nixl_b_params_t`) when creati
 | `crtMinLimit` | Minimum object size (bytes) to use S3 CRT client for high-performance transfers | Disabled**** | No |
 | `throughput_target_gbps` | Target throughput for the S3 CRT client in **whole Gbps** (integer); sizes its parallel connection count | `10` | No |
 | `accelerated` | Enable S3 Accelerated engine (`true`/`false`) | `false` | No |
-| `type` | Accelerated engine type (`dell`, etc.) | - | No |
+| `type` | Accelerated engine type (`dell`, `everpure`, etc.) | - | No |
 
 \* If `access_key` and `secret_key` are not provided, the AWS SDK will attempt to use default credential providers (IAM roles, environment variables, credential files, etc.)
 

--- a/src/plugins/obj/meson.build
+++ b/src/plugins/obj/meson.build
@@ -51,6 +51,10 @@ if cuobj_dep.found()
         's3_accel/dell/client.h',
         's3_accel/dell/engine_impl.cpp',
         's3_accel/dell/engine_impl.h',
+        's3_accel/everpure/client.cpp',
+        's3_accel/everpure/client.h',
+        's3_accel/everpure/engine_impl.cpp',
+        's3_accel/everpure/engine_impl.h',
     ]
     plugin_deps += [ cuobj_dep ]
 else

--- a/src/plugins/obj/s3/client.cpp
+++ b/src/plugins/obj/s3/client.cpp
@@ -86,6 +86,13 @@ awsS3Client::putObjectAsync(std::string_view key,
             const Aws::S3::Model::PutObjectRequest &,
             const Aws::S3::Model::PutObjectOutcome &outcome,
             const std::shared_ptr<const Aws::Client::AsyncCallerContext> &) {
+            if (!outcome.IsSuccess()) {
+                const auto &error = outcome.GetError();
+                NIXL_ERROR << absl::StrFormat("putObjectAsync: failed - %s: %s (HTTP %d)",
+                                              error.GetExceptionName().c_str(),
+                                              error.GetMessage().c_str(),
+                                              static_cast<int>(error.GetResponseCode()));
+            }
             callback(outcome.IsSuccess());
         },
         nullptr);
@@ -116,6 +123,13 @@ awsS3Client::getObjectAsync(std::string_view key,
                                    const Aws::S3::Model::GetObjectRequest &,
                                    const Aws::S3::Model::GetObjectOutcome &outcome,
                                    const std::shared_ptr<const Aws::Client::AsyncCallerContext> &) {
+            if (!outcome.IsSuccess()) {
+                const auto &error = outcome.GetError();
+                NIXL_ERROR << absl::StrFormat("getObjectAsync: failed - %s: %s (HTTP %d)",
+                                              error.GetExceptionName().c_str(),
+                                              error.GetMessage().c_str(),
+                                              static_cast<int>(error.GetResponseCode()));
+            }
             callback(outcome.IsSuccess());
         },
         nullptr);

--- a/src/plugins/obj/s3_accel/everpure/README.md
+++ b/src/plugins/obj/s3_accel/everpure/README.md
@@ -1,0 +1,235 @@
+<!--
+Copyright 2026 Everpure, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# NIXL Everpure accelerated S3 engine
+
+`everpure` is the accelerated OBJ engine for S3-over-RDMA using the CUDA
+Toolkit's cuObject client library (`cuobjclient`, `<cuobjclient.h>`), driven
+through the same AWS S3 SDK plumbing as the rest of the OBJ backend. It
+targets any S3-compatible endpoint that speaks the cuObject RDMA descriptor
+protocol described below - `type: everpure` selects this engine regardless
+of which such endpoint you're talking to. Its defaults are tuned for
+FlashBlade, the reference implementation it was built against, but every
+protocol-specific detail (header names, the confirmation check, the
+checksum value) is overridable via [Backend
+parameters](#backend-parameters)/[Environment
+variables](#environment-variables) so another cuObject-compatible endpoint
+can reuse this client without a fork.
+
+If a FlashBlade data VIP is reachable but its RDMA feature flag isn't turned
+on, use the plain `s3` engine (`accelerated` unset or `false`) instead - a
+non-RDMA client works against the same endpoint.
+
+## Wire protocol
+
+This engine's default headers and general protocol follow the [S3-over-RDMA
+protocol
+spec](https://github.com/KiranModukuri/aws-c-s3/blob/nvidia_rdma/RDMA_PROTOCOL_SPEC.md).
+It expects its RDMA endpoint to speak the following contract on top of
+ordinary S3:
+
+- The RDMA descriptor travels in a request header (`rdma_token_header`,
+  default `x-amz-rdma-token`) as the **bare** cuObject descriptor string
+  produced by `cuMemObjGetRDMAToken`, with nothing appended to it.
+- The request body is empty (`Content-Length: 0`) since the payload moves
+  over RDMA rather than the HTTP connection. RDMA PUT always writes the
+  whole object from byte zero, so a non-zero write offset is rejected
+  before a request is ever built.
+- The request-body-checksum header (`x-amz-content-sha256`) carries a fixed
+  value (`content_sha256_value`, default `UNSIGNED-PAYLOAD`) rather than a
+  real checksum: the AWS SDK computes request checksums from the literal
+  body bytes it's about to send, so a checksum computed over the (empty)
+  HTTP body would never match the real payload moved over RDMA.
+- A successful response carries a confirmation header (`rdma_reply_header`,
+  default `x-amz-rdma-reply`). Its absence despite an HTTP-level success
+  means the endpoint fell back to ordinary S3 semantics instead of actually
+  moving data over RDMA, and this client treats that as a failure.
+
+This engine's client (`client.cpp`) enforces the client-side half of this
+contract before ever building a request: it will not send a token derived
+from an empty descriptor, will not accept a nonzero PUT offset, and applies
+the header/value defaults above unless overridden.
+
+### FlashBlade specifics
+
+FlashBlade implements the spec's default protocol described above.
+Beyond that baseline, its implementation adds the following specifics:
+
+- FlashBlade splits the RDMA token header value on `:` and requires
+  **exactly 7 fields**; anything extra (for example a `:start_addr:size`
+  suffix tacked on by a caller) is rejected with `InvalidRDMAToken`. Fields
+  0 and 1 are the hex-encoded RDMA buffer start address and size, parsed
+  directly by the array; the remaining fields are opaque to the client.
+- A successful GET carries `x-amz-rdma-reply: 200` (or `206` for a ranged
+  read) plus `x-amz-rdma-bytes-transferred`; a `501` reply means the array
+  declined RDMA for that request.
+- RDMA requests must be plain HTTP, not HTTPS, and the client must connect
+  over IPv4 - FlashBlade rejects RDMA over HTTPS or IPv6.
+- RDMA is gated behind a feature flag on the array; if it isn't enabled,
+  every RDMA request is rejected up front.
+
+## Dependencies
+
+This engine requires aws-sdk-cpp. This dependency and steps to install it
+are provided in the OBJ backend documentation.
+
+This engine requires the CUDA Toolkit (which provides `cuobjclient`) version
+13.1.1 or later. See the [CUDA GDS Install and Setup
+guide](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html).
+
+## Backend parameters
+
+In addition to the parameters documented for the OBJ backend generally, set
+these to select the Everpure engine:
+
+| Parameter | Description | Default | Required |
+|-----------|-------------|---------|----------|
+| `accelerated` | Enable an accelerated engine | `false` | Yes (`true`) |
+| `type` | Vendor engine to use | - | Yes (`everpure`) |
+| `resp_checksum` | AWS SDK response checksum validation (`required`/`supported`) | `required` | No |
+| `req_checksum` | AWS SDK request checksum policy (`required`/`supported`) | `required` | No |
+| `content_sha256_value` | Value sent for the `x-amz-content-sha256` header; set to an empty string to omit the header | `UNSIGNED-PAYLOAD` | No |
+
+See [Environment variables](#environment-variables) below for the RDMA
+token/confirmation header names and connection pool/timeout tuning.
+
+`resp_checksum` defaults to `required` (`ResponseChecksumValidation::WHEN_REQUIRED`)
+because RDMA GET responses arrive with an empty body and no checksum
+headers to validate against - matching FlashBlade's own restriction that RDMA
+responses never carry checksum headers. Pass it explicitly to override.
+
+`req_checksum` defaults to `required` (`RequestChecksumCalculation::WHEN_REQUIRED`)
+because RDMA PUT requests also carry an empty body - the real payload moves
+over RDMA - so a checksum computed over that body would never match the
+object FlashBlade actually receives. `WHEN_REQUIRED` is the more
+conservative of the two supported settings, since `WHEN_SUPPORTED` would
+have the SDK attach one proactively. Pass it explicitly to override.
+
+```cpp
+nixl_b_params_t params = {
+    {"access_key", "..."},
+    {"secret_key", "..."},
+    {"bucket", "my-bucket"},
+    {"endpoint_override", "http://<rdma-capable-s3-endpoint>"},
+    {"scheme", "http"},
+    {"use_virtual_addressing", "false"},
+    {"accelerated", "true"},
+    {"type", "everpure"},
+};
+agent.createBackend("OBJ", params);
+```
+
+The endpoint's data VIP must be reachable over the RDMA fabric (RoCEv2)
+from the host running NIXL, and RDMA support must be enabled on that
+endpoint (see [FlashBlade specifics](#flashblade-specifics) above for the
+exact requirement there).
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NIXL_EVERPURE_RDMA_TOKEN_HEADER` | Request header carrying the RDMA descriptor | `x-amz-rdma-token` |
+| `NIXL_EVERPURE_RDMA_REPLY_HEADER` | Response header confirming the request was actually served over RDMA | `x-amz-rdma-reply` |
+| `NIXL_EVERPURE_MAX_CONNECTIONS` | Size of this engine's HTTP connection pool | AWS SDK default (25) |
+| `NIXL_EVERPURE_CONNECT_TIMEOUT_MS` | TCP connect timeout, in milliseconds | AWS SDK default (1000) |
+| `NIXL_EVERPURE_REQUEST_TIMEOUT_MS` | Stall timeout: aborts a transfer once it has moved under 1 byte/sec for this long, in milliseconds | AWS SDK default (3000) |
+
+Leaving `NIXL_EVERPURE_RDMA_TOKEN_HEADER`/`NIXL_EVERPURE_RDMA_REPLY_HEADER`
+unset picks the FlashBlade-protocol default above; setting either to an
+empty string is rejected with an error rather than treated as meaningful,
+since an empty header name doesn't map to any well-defined behavior. This
+engine talks to any S3 endpoint that accepts a cuObject RDMA descriptor in
+a request header, so a different endpoint speaking that same protocol with
+different header names can reuse it by setting these instead of relying on
+the defaults above.
+
+`NIXL_EVERPURE_RDMA_REPLY_HEADER` guards against a request succeeding at the
+HTTP level without actually moving data over RDMA - for example if the
+endpoint didn't recognize the token header and fell back to ordinary S3
+semantics. A response missing this header is treated as a failure even
+though the underlying HTTP request succeeded.
+
+`NIXL_EVERPURE_MAX_CONNECTIONS`, `NIXL_EVERPURE_CONNECT_TIMEOUT_MS`, and
+`NIXL_EVERPURE_REQUEST_TIMEOUT_MS` apply only to this engine, not the
+default S3 engine, and tune this engine's connection pool size and
+timeouts independently of the AWS SDK's own defaults (25 connections, a 1s
+connect timeout, a 3s stall timeout). Raise these for high-concurrency
+workloads.
+
+Each of these can also be set via a NIXL TOML config file instead of the
+process environment - see the OBJ backend documentation's configuration
+section for the file's resolution order (`NIXL_CONFIG_FILE`, then
+`~/.nixl.cfg`, then `/etc/nixl.cfg`). A set environment variable always
+takes priority over the same key in the TOML file. Example:
+
+```toml
+NIXL_EVERPURE_RDMA_TOKEN_HEADER = "x-amz-rdma-token"
+NIXL_EVERPURE_RDMA_REPLY_HEADER = "x-amz-rdma-reply"
+NIXL_EVERPURE_MAX_CONNECTIONS = 64
+NIXL_EVERPURE_CONNECT_TIMEOUT_MS = 3000
+NIXL_EVERPURE_REQUEST_TIMEOUT_MS = 10000
+```
+
+## cuObject client configuration
+
+`cuobjclient` needs to know which local RDMA-capable NICs to use. Point it
+at a JSON config listing the client IP addresses on the RDMA fabric:
+
+```json
+{
+    "execution": {
+        "parallel_io": false
+    },
+    "properties": {
+        "allow_compat_mode": true,
+        "use_pci_p2pdma": true,
+        "rdma_peer_type": "dmabuf",
+        "rdma_dev_addr_list": ["10.0.1.2", "10.0.2.2"]
+    }
+}
+```
+
+```bash
+export CUFILE_ENV_PATH_JSON=/path/to/cufile.json
+```
+
+## Supported memory types
+
+- `OBJ_SEG` - S3 object
+- `DRAM_SEG` - host memory
+- `VRAM_SEG` - GPU memory (data moves directly between the RDMA fabric and
+  GPU memory; it never transits host RAM)
+
+## Transfer semantics
+
+- **Object key mapping**: registering an `OBJ_SEG` blob records a mapping
+  from its `devId` to an object key - `metaInfo` if provided, otherwise the
+  stringified `devId`. `prepXfer` looks this mapping up per descriptor, so an
+  `OBJ_SEG` must be registered before it appears as a transfer target.
+- **Reads**: the remote descriptor's `addr` is the byte offset into the
+  object; `len` is how much to read. The engine issues a ranged GET
+  (`Range: bytes=<offset>-<offset+len-1>`) with the RDMA token attached, and
+  the endpoint writes the result directly into the registered local buffer.
+- **Writes**: RDMA PUT always writes the object in full from byte zero - a
+  non-zero write offset is rejected before a request is ever built.
+- **Completion**: `postXfer` fires all transfer units for the request
+  concurrently and returns `NIXL_IN_PROG` immediately; each unit's AWS SDK
+  callback updates the request handle's completion state as it lands, so
+  `checkXfer` is a cheap, lock-free poll rather than a blocking wait.
+  `releaseReqH` releases each unit's RDMA token via `cuMemObjPutRDMAToken`
+  and frees the request handle once `checkXfer` reports the transfer is
+  done.

--- a/src/plugins/obj/s3_accel/everpure/client.cpp
+++ b/src/plugins/obj/s3_accel/everpure/client.cpp
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026 Everpure, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "client.h"
+#include "object/s3/utils.h"
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/core/AmazonWebServiceRequest.h>
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <absl/strings/str_format.h>
+#include <atomic>
+#include "common/backend.h"
+#include "common/configuration.h"
+#include "common/exception.h"
+#include "common/nixl_log.h"
+
+namespace {
+
+// Header carrying the bare cuObject descriptor - nothing appended. Default
+// below; override via environment variable (see client.h) for other
+// cuObject-compatible endpoints.
+constexpr char kDefaultRdmaTokenHeader[] = "x-amz-rdma-token";
+
+// Standard AWS SigV4 checksum header - fixed name. The RDMA body is always
+// empty, so the value defaults to UNSIGNED-PAYLOAD rather than checksumming
+// nothing.
+constexpr char kContentSha256Header[] = "x-amz-content-sha256";
+constexpr char kDefaultContentSha256Value[] = "UNSIGNED-PAYLOAD";
+
+// A successful RDMA response carries this header; its absence means the
+// request fell back to ordinary S3 semantics instead of moving data over
+// RDMA.
+constexpr char kDefaultRdmaReplyHeader[] = "x-amz-rdma-reply";
+
+// RDMA moves the payload out-of-band, so the HTTP body carries no bytes.
+constexpr size_t kRdmaBodyLength = 0;
+
+// An explicitly empty header name is ambiguous (disable a check? clear a
+// default?), so it's rejected rather than given a meaning. Leaving the
+// variable unset is how a caller gets the default.
+std::string
+requireNonEmptyIfSet(const std::string &env, const std::string &fallback) {
+    const auto opt = nixl::config::getValueOptional<std::string>(env);
+    if (!opt) {
+        return fallback;
+    }
+    if (opt->empty()) {
+        nixl::throwRuntimeError("Config parameter '", env, "' must not be set to an empty value");
+    }
+    return *opt;
+}
+
+std::string
+describeDescriptor(std::string_view rdma_desc) {
+    return rdma_desc.empty() ? "<empty>" : std::string(rdma_desc);
+}
+
+// Rejects a request up front if the descriptor is missing or there's nothing
+// to move; both PUT and GET share this baseline check.
+bool
+rejectIfNoPayload(std::string_view rdma_desc, size_t data_len, const char *op) {
+    if (rdma_desc.empty()) {
+        NIXL_ERROR << op << ": rdma_desc is empty, refusing to build request";
+        return true;
+    }
+    if (data_len == 0) {
+        NIXL_ERROR << op << ": data_len is 0, refusing to build request";
+        return true;
+    }
+    return false;
+}
+
+template <typename OutcomeT>
+bool
+logOutcome(const char *op, const OutcomeT &outcome) {
+    if (outcome.IsSuccess()) {
+        NIXL_DEBUG << op << ": completed successfully";
+        return true;
+    }
+    const auto &error = outcome.GetError();
+    NIXL_ERROR << absl::StrFormat("%s: failed - %s: %s (HTTP %d)",
+                                  op,
+                                  error.GetExceptionName().c_str(),
+                                  error.GetMessage().c_str(),
+                                  static_cast<int>(error.GetResponseCode()));
+    return false;
+}
+
+// Watches for `reply_header` in the response and reports it via the
+// returned flag. Needed because PutObjectResult/GetObjectResult drop any
+// header the S3 API model doesn't know about, so by the time the async
+// callback runs, the confirmation header is already gone.
+std::shared_ptr<std::atomic<bool>>
+armRdmaConfirmation(Aws::AmazonWebServiceRequest &request, const std::string &reply_header) {
+    auto confirmed = std::make_shared<std::atomic<bool>>(false);
+    request.SetHeadersReceivedEventHandler(
+        [confirmed, reply_header](const Aws::Http::HttpRequest *, Aws::Http::HttpResponse *response) {
+            if (response && response->HasHeader(reply_header.c_str())) {
+                confirmed->store(true, std::memory_order_relaxed);
+            }
+        });
+    return confirmed;
+}
+
+// Succeeds only if both the transport call and the RDMA confirmation check
+// pass.
+template <typename OutcomeT>
+bool
+checkRdmaOutcome(const char *op, const OutcomeT &outcome, const std::atomic<bool> &confirmed) {
+    if (!logOutcome(op, outcome)) {
+        return false;
+    }
+    if (!confirmed.load(std::memory_order_relaxed)) {
+        NIXL_ERROR << op
+                   << ": succeeded over HTTP but the RDMA confirmation header was absent - "
+                      "the request likely fell back to non-RDMA S3 semantics (check "
+                      "NIXL_EVERPURE_RDMA_TOKEN_HEADER/NIXL_EVERPURE_RDMA_REPLY_HEADER against "
+                      "the endpoint's protocol)";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+awsS3EverpureClient::awsS3EverpureClient(nixl_b_params_t *custom_params,
+                                         std::shared_ptr<Aws::Utils::Threading::Executor> executor)
+    : awsS3AccelClient(custom_params, executor),
+      rdmaTokenHeader_(
+          requireNonEmptyIfSet("NIXL_EVERPURE_RDMA_TOKEN_HEADER", kDefaultRdmaTokenHeader)),
+      contentSha256Value_(nixl::getBackendParamDefaulted(
+          custom_params, "content_sha256_value", std::string(kDefaultContentSha256Value))),
+      rdmaReplyHeader_(
+          requireNonEmptyIfSet("NIXL_EVERPURE_RDMA_REPLY_HEADER", kDefaultRdmaReplyHeader)) {
+    // Own connection pool/timeout budget, separate from the default S3
+    // engine's - override via environment variable, else the AWS SDK
+    // defaults apply.
+    Aws::Client::ClientConfiguration config;
+    nixl_s3_utils::configureClientCommon(config, custom_params);
+    if (executor) config.executor = executor;
+
+    // The RDMA body is empty, so a checksum over it would never match the
+    // real payload; WHEN_REQUIRED stops the SDK computing one by default.
+    if (!nixl::getBackendParamOptional<std::string>(custom_params, "req_checksum")) {
+        config.checksumConfig.requestChecksumCalculation =
+            Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+    }
+    if (!nixl::getBackendParamOptional<std::string>(custom_params, "resp_checksum")) {
+        config.checksumConfig.responseChecksumValidation =
+            Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
+    }
+
+    if (const auto opt =
+            nixl::config::getValueOptional<size_t>("NIXL_EVERPURE_MAX_CONNECTIONS")) {
+        config.maxConnections = *opt;
+    }
+    if (const auto opt =
+            nixl::config::getValueOptional<long>("NIXL_EVERPURE_CONNECT_TIMEOUT_MS")) {
+        config.connectTimeoutMs = *opt;
+    }
+    if (const auto opt =
+            nixl::config::getValueOptional<long>("NIXL_EVERPURE_REQUEST_TIMEOUT_MS")) {
+        config.requestTimeoutMs = *opt;
+    }
+
+    auto credentials_opt = nixl_s3_utils::createAWSCredentials(custom_params);
+    bool use_virtual_addressing = nixl_s3_utils::getUseVirtualAddressing(custom_params);
+    s3Client_ = credentials_opt.has_value() ?
+        std::make_unique<Aws::S3::S3Client>(
+            *credentials_opt,
+            config,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
+            use_virtual_addressing) :
+        std::make_unique<Aws::S3::S3Client>(
+            config,
+            Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::RequestDependent,
+            use_virtual_addressing);
+
+    const char *req_checksum_str =
+        config.checksumConfig.requestChecksumCalculation ==
+                Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED ?
+            "required" :
+            "supported";
+    const char *resp_checksum_str =
+        config.checksumConfig.responseChecksumValidation ==
+                Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED ?
+            "required" :
+            "supported";
+    NIXL_DEBUG << absl::StrFormat(
+        "awsS3EverpureClient ready for S3-RDMA (rdma_token_header=%s, "
+        "rdma_reply_header=%s, content_sha256_value=%s, req_checksum=%s, "
+        "resp_checksum=%s, max_connections=%u, connect_timeout_ms=%ld, "
+        "request_timeout_ms=%ld)",
+        rdmaTokenHeader_,
+        rdmaReplyHeader_,
+        contentSha256Value_,
+        req_checksum_str,
+        resp_checksum_str,
+        config.maxConnections,
+        config.connectTimeoutMs,
+        config.requestTimeoutMs);
+}
+
+void
+awsS3EverpureClient::putObjectRdmaAsync(std::string_view key,
+                                       uintptr_t data_ptr,
+                                       size_t data_len,
+                                       size_t offset,
+                                       std::string_view rdma_desc,
+                                       put_object_callback_t callback) {
+    NIXL_DEBUG << absl::StrFormat("putObjectRdmaAsync: key=%s ptr=%p len=%zu offset=%zu desc=%s",
+                                  std::string(key).c_str(),
+                                  reinterpret_cast<void *>(data_ptr),
+                                  data_len,
+                                  offset,
+                                  describeDescriptor(rdma_desc).c_str());
+
+    // RDMA PUT always writes from byte zero - no partial/append path
+    // exists, so a nonzero offset is rejected before touching the wire.
+    if (offset != 0) {
+        NIXL_ERROR << "putObjectRdmaAsync: RDMA PUT requires offset 0, got " << offset;
+        callback(false);
+        return;
+    }
+
+    if (rejectIfNoPayload(rdma_desc, data_len, "putObjectRdmaAsync")) {
+        callback(false);
+        return;
+    }
+
+    Aws::S3::Model::PutObjectRequest request;
+    request.WithBucket(bucketName_).WithKey(Aws::String(key));
+    request.SetAdditionalCustomHeaderValue(rdmaTokenHeader_, std::string(rdma_desc));
+    if (!contentSha256Value_.empty()) {
+        request.SetAdditionalCustomHeaderValue(kContentSha256Header, contentSha256Value_);
+    }
+    request.SetContentLength(kRdmaBodyLength);
+
+    auto rdma_confirmed = armRdmaConfirmation(request, rdmaReplyHeader_);
+
+    s3Client_->PutObjectAsync(
+        request,
+        [callback, rdma_confirmed](const Aws::S3::S3Client *,
+                   const Aws::S3::Model::PutObjectRequest &,
+                   const Aws::S3::Model::PutObjectOutcome &outcome,
+                   const std::shared_ptr<const Aws::Client::AsyncCallerContext> &) {
+            // Missing confirmation header despite HTTP success means the
+            // payload never moved - the endpoint wrote an empty object at
+            // this key instead.
+            // TODO: DeleteObjectAsync to clean up that stale object; not
+            // implemented.
+            callback(checkRdmaOutcome("putObjectRdmaAsync", outcome, *rdma_confirmed));
+        },
+        nullptr);
+}
+
+void
+awsS3EverpureClient::getObjectRdmaAsync(std::string_view key,
+                                       uintptr_t data_ptr,
+                                       size_t data_len,
+                                       size_t offset,
+                                       std::string_view rdma_desc,
+                                       get_object_callback_t callback) {
+    NIXL_DEBUG << absl::StrFormat("getObjectRdmaAsync: key=%s ptr=%p len=%zu offset=%zu desc=%s",
+                                  std::string(key).c_str(),
+                                  reinterpret_cast<void *>(data_ptr),
+                                  data_len,
+                                  offset,
+                                  describeDescriptor(rdma_desc).c_str());
+
+    if (rejectIfNoPayload(rdma_desc, data_len, "getObjectRdmaAsync")) {
+        callback(false);
+        return;
+    }
+
+    const size_t last_byte = offset + (data_len - 1);
+    if (last_byte < offset) {
+        NIXL_ERROR << "getObjectRdmaAsync: offset " << offset << " + len " << data_len
+                   << " overflows, refusing to build request";
+        callback(false);
+        return;
+    }
+
+    Aws::S3::Model::GetObjectRequest request;
+    request.WithBucket(bucketName_)
+        .WithKey(Aws::String(key))
+        .WithRange(absl::StrFormat("bytes=%zu-%zu", offset, last_byte));
+    request.SetAdditionalCustomHeaderValue(rdmaTokenHeader_, std::string(rdma_desc));
+    if (!contentSha256Value_.empty()) {
+        request.SetAdditionalCustomHeaderValue(kContentSha256Header, contentSha256Value_);
+    }
+
+    auto rdma_confirmed = armRdmaConfirmation(request, rdmaReplyHeader_);
+
+    s3Client_->GetObjectAsync(
+        request,
+        [callback, rdma_confirmed](const Aws::S3::S3Client *,
+                   const Aws::S3::Model::GetObjectRequest &,
+                   const Aws::S3::Model::GetObjectOutcome &outcome,
+                   const std::shared_ptr<const Aws::Client::AsyncCallerContext> &) {
+            // A fallback here returns the real object in the HTTP body
+            // instead of RDMA, but that body is never read - the caller's
+            // buffer stays untouched rather than wrong. Nothing to clean
+            // up server-side; GET doesn't modify the object.
+            callback(checkRdmaOutcome("getObjectRdmaAsync", outcome, *rdma_confirmed));
+        },
+        nullptr);
+}

--- a/src/plugins/obj/s3_accel/everpure/client.h
+++ b/src/plugins/obj/s3_accel/everpure/client.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Everpure, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_OBJ_PLUGIN_S3_EVERPURE_CLIENT_H
+#define NIXL_OBJ_PLUGIN_S3_EVERPURE_CLIENT_H
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <cstdint>
+#include <aws/s3/S3Client.h>
+#include <aws/core/utils/memory/stl/AWSString.h>
+#include "s3_accel/client.h"
+#include "rdma_interface.h"
+#include "nixl_types.h"
+
+/**
+ * S3 Accelerated Object Client for cuObject-compatible RDMA endpoints -
+ * inherits from Accelerated S3 Client, presenting Put/GetObject over RDMA
+ * via the cuObject API (cuobjclient / libcuobjclient). Defaults are tuned
+ * for FlashBlade, but every protocol detail is overridable so another
+ * cuObject-compatible endpoint can reuse it under the same `everpure` type.
+ *
+ * The RDMA descriptor travels as a bare request header (`x-amz-rdma-token`
+ * by default) -- see client.cpp. Header names and this client's connection
+ * pool/timeout budget (separate from the default S3 engine's) override via
+ * environment variable (`NIXL_EVERPURE_RDMA_TOKEN_HEADER`,
+ * `NIXL_EVERPURE_RDMA_REPLY_HEADER`, `NIXL_EVERPURE_MAX_CONNECTIONS`,
+ * `NIXL_EVERPURE_CONNECT_TIMEOUT_MS`, `NIXL_EVERPURE_REQUEST_TIMEOUT_MS`).
+ * The `x-amz-content-sha256` header's value overrides via custom_params
+ * instead (`content_sha256_value`).
+ */
+class awsS3EverpureClient : public awsS3AccelClient, public iEverpureS3RdmaClient {
+public:
+    /**
+     * Constructor that creates an AWS S3 client for RDMA-accelerated
+     * transfers from custom parameters.
+     * @param custom_params Custom parameters containing S3 configuration
+     * @param executor Optional executor for async operations
+     */
+    awsS3EverpureClient(nixl_b_params_t *custom_params,
+                        std::shared_ptr<Aws::Utils::Threading::Executor> executor = nullptr);
+
+    virtual ~awsS3EverpureClient() = default;
+
+    /**
+     * Asynchronously puts an object to the S3 endpoint using RDMA
+     * acceleration.
+     *
+     * @param key The object key to store
+     * @param data_ptr Pointer to the data buffer
+     * @param data_len Length of the data to transfer
+     * @param offset Offset within the object (must be 0; whole-object writes only)
+     * @param rdma_desc RDMA descriptor for acceleration
+     * @param callback Callback function invoked on completion
+     */
+    void
+    putObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       put_object_callback_t callback);
+
+    /**
+     * Asynchronously gets an object from the S3 endpoint using RDMA
+     * acceleration.
+     *
+     * @param key The object key to retrieve
+     * @param data_ptr Pointer to the buffer to fill
+     * @param data_len Length of the data to transfer
+     * @param offset Offset within the object
+     * @param rdma_desc RDMA descriptor for acceleration
+     * @param callback Callback function invoked on completion
+     */
+    void
+    getObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       get_object_callback_t callback);
+
+private:
+    std::string rdmaTokenHeader_;
+    std::string contentSha256Value_;
+    std::string rdmaReplyHeader_;
+};
+
+#endif // NIXL_OBJ_PLUGIN_S3_EVERPURE_CLIENT_H

--- a/src/plugins/obj/s3_accel/everpure/engine_impl.cpp
+++ b/src/plugins/obj/s3_accel/everpure/engine_impl.cpp
@@ -1,0 +1,395 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "engine_impl.h"
+#include "client.h"
+#include "rdma_interface.h"
+#include "common/nixl_log.h"
+#include <absl/strings/str_format.h>
+#include <atomic>
+#include <memory>
+#include <vector>
+#include <algorithm>
+
+#include "obj_engine_registry.h"
+
+#if defined(HAVE_CUOBJ_CLIENT)
+
+namespace {
+
+objAccelEngineRegistrar reg_everpure(
+    "everpure",
+    [](const nixlBackendInitParams *p) { return std::make_unique<S3EverpureObjEngineImpl>(p); },
+    [](const nixlBackendInitParams *p, std::shared_ptr<iS3Client> s3, std::shared_ptr<iS3Client>) {
+        return std::make_unique<S3EverpureObjEngineImpl>(p, std::move(s3));
+    });
+
+// RDMA GET responses arrive with an empty HTTP body and no checksum
+// headers, so the SDK's response-checksum validation has nothing to check
+// against. Default resp_checksum to required, unless the caller already set it.
+//
+// RDMA PUT requests also carry an empty HTTP body, so a request checksum
+// computed over it would never match the real object. Default req_checksum
+// to its more conservative setting (WHEN_REQUIRED), unless already set.
+void
+applyEverpureDefaults(const nixlBackendInitParams *init_params,
+                      nixl_b_params_t *&params_to_use,
+                      nixl_b_params_t &owned_fallback) {
+    if (init_params->customParams) {
+        init_params->customParams->emplace("resp_checksum", "required");
+        init_params->customParams->emplace("req_checksum", "required");
+        params_to_use = init_params->customParams;
+        return;
+    }
+    owned_fallback["resp_checksum"] = "required";
+    owned_fallback["req_checksum"] = "required";
+    params_to_use = &owned_fallback;
+}
+
+bool
+isValidPrepXferParams(const nixl_xfer_op_t &operation,
+                      const nixl_meta_dlist_t &local,
+                      const nixl_meta_dlist_t &remote,
+                      const std::string &remote_agent,
+                      const std::string &local_agent) {
+    if (operation != NIXL_WRITE && operation != NIXL_READ) {
+        NIXL_ERROR << absl::StrFormat("Invalid operation type: %d", operation);
+        return false;
+    }
+    if (remote_agent != local_agent) {
+        NIXL_WARN << absl::StrFormat("Remote agent (%s) does not match requesting agent (%s)",
+                                     remote_agent,
+                                     local_agent);
+    }
+    if ((local.getType() != DRAM_SEG) && (local.getType() != VRAM_SEG)) {
+        NIXL_ERROR << absl::StrFormat("Local memory must be DRAM_SEG or VRAM_SEG, got %d",
+                                      local.getType());
+        return false;
+    }
+    if (remote.getType() != OBJ_SEG) {
+        NIXL_ERROR << absl::StrFormat("Remote memory must be OBJ_SEG, got %d", remote.getType());
+        return false;
+    }
+    if (local.descCount() != remote.descCount()) {
+        NIXL_ERROR << absl::StrFormat("Descriptor count mismatch: %d local vs %d remote",
+                                      local.descCount(),
+                                      remote.descCount());
+        return false;
+    }
+    return true;
+}
+
+/// Backend metadata for a registered object key (OBJ_SEG side).
+class nixlEverpureObjKeyMD : public nixlBackendMD {
+public:
+    explicit nixlEverpureObjKeyMD(std::string obj_key)
+        : nixlBackendMD(true), objKey(std::move(obj_key)) {}
+
+    std::string objKey;
+};
+
+/// Backend metadata for a registered local memory region (DRAM_SEG/VRAM_SEG side).
+class nixlEverpureMemRegMD : public nixlBackendMD {
+public:
+    explicit nixlEverpureMemRegMD(uintptr_t addr) : nixlBackendMD(true), addr(addr) {}
+
+    uintptr_t addr;
+};
+
+/// Everything one RDMA transfer needs to hand off to the S3 client, plus the
+/// token to release via cuMemObjPutRDMAToken once the handle is released.
+struct everpureTransferUnit {
+    uintptr_t addr;
+    size_t size;
+    size_t offset;
+    std::string objKey;
+    std::string rdmaDesc;
+    char *rdmaToken = nullptr;
+
+    everpureTransferUnit(uintptr_t addr_, size_t size_, size_t offset_, std::string obj_key)
+        : addr(addr_),
+          size(size_),
+          offset(offset_),
+          objKey(std::move(obj_key)) {}
+};
+
+/**
+ * Request handle for a batch of RDMA transfers.
+ *
+ * Completion is tracked with a single outstanding-count and a sticky
+ * failure flag, both updated directly from the S3 client's async
+ * callbacks, so checkXfer() is a plain load rather than a walk over
+ * per-unit state.
+ */
+class nixlEverpureObjBackendReqH : public nixlBackendReqH {
+public:
+    std::vector<everpureTransferUnit> units;
+    std::atomic<size_t> outstanding{0};
+    std::atomic<bool> anyFailed{false};
+
+    void
+    armCompletionTracking() {
+        outstanding.store(units.size(), std::memory_order_release);
+    }
+
+    void
+    onUnitDone(bool success) {
+        if (!success) {
+            anyFailed.store(true, std::memory_order_relaxed);
+        }
+        outstanding.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    nixl_status_t
+    poll() const {
+        if (outstanding.load(std::memory_order_acquire) != 0) {
+            return NIXL_IN_PROG;
+        }
+        return anyFailed.load(std::memory_order_relaxed) ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
+    }
+};
+
+// cuObjClient's constructor requires an IO callback table; every transfer
+// resolves its descriptor via cuMemObjGetRDMAToken instead, so these never run.
+ssize_t
+unusedGetCallback(const void *, char *, size_t, loff_t, const cufileRDMAInfo_t *) {
+    return -EINVAL;
+}
+
+ssize_t
+unusedPutCallback(const void *, const char *, size_t, loff_t, const cufileRDMAInfo_t *) {
+    return -EINVAL;
+}
+
+// Dynamically Connected verbs transport for the cuObject client.
+CUObjIOOps everpureIoOps = {.get = unusedGetCallback, .put = unusedPutCallback};
+
+} // namespace
+
+S3EverpureObjEngineImpl::S3EverpureObjEngineImpl(const nixlBackendInitParams *init_params)
+    : S3AccelObjEngineImpl(init_params) {
+    nixl_b_params_t *params_to_use = nullptr;
+    nixl_b_params_t owned_fallback;
+    applyEverpureDefaults(init_params, params_to_use, owned_fallback);
+
+    s3Client_ = std::make_shared<awsS3EverpureClient>(params_to_use, executor_);
+    cuClient_ = std::make_shared<cuObjClient>(everpureIoOps, CUOBJ_PROTO_RDMA_DC_V1);
+    if (!cuClient_->isConnected()) {
+        NIXL_ERROR << "S3EverpureObjEngineImpl: cuObjClient failed to connect";
+        return;
+    }
+    NIXL_INFO << "S3EverpureObjEngineImpl: ready (S3-RDMA)";
+}
+
+S3EverpureObjEngineImpl::S3EverpureObjEngineImpl(const nixlBackendInitParams *init_params,
+                                                 std::shared_ptr<iS3Client> s3_client)
+    : S3AccelObjEngineImpl(init_params, s3_client) {
+    if (s3_client) {
+        s3Client_ = std::move(s3_client);
+    } else {
+        nixl_b_params_t *params_to_use = nullptr;
+        nixl_b_params_t owned_fallback;
+        applyEverpureDefaults(init_params, params_to_use, owned_fallback);
+        s3Client_ = std::make_shared<awsS3EverpureClient>(params_to_use, executor_);
+    }
+
+    cuClient_ = std::make_shared<cuObjClient>(everpureIoOps, CUOBJ_PROTO_RDMA_DC_V1);
+    if (!cuClient_->isConnected()) {
+        NIXL_ERROR << "S3EverpureObjEngineImpl: cuObjClient failed to connect";
+        return;
+    }
+    NIXL_INFO << "S3EverpureObjEngineImpl: ready (S3-RDMA, injected S3 client)";
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::requireCuObjReady() const {
+    if (!cuClient_ || !cuClient_->isConnected()) {
+        NIXL_ERROR << "S3EverpureObjEngineImpl: cuObjClient is not connected";
+        return NIXL_ERR_BACKEND;
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::registerMem(const nixlBlobDesc &mem,
+                                     const nixl_mem_t &nixl_mem,
+                                     nixlBackendMD *&out) {
+    if (auto status = requireCuObjReady(); status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    switch (nixl_mem) {
+    case OBJ_SEG: {
+        std::string obj_key = mem.metaInfo.empty() ? std::to_string(mem.devId) : mem.metaInfo;
+        out = new nixlEverpureObjKeyMD(std::move(obj_key));
+        return NIXL_SUCCESS;
+    }
+    case DRAM_SEG:
+    case VRAM_SEG: {
+        if (mem.len > CUOBJ_MAX_MEMORY_REG_SIZE) {
+            NIXL_ERROR << "registerMem: region of " << mem.len
+                       << " bytes exceeds CUOBJ_MAX_MEMORY_REG_SIZE";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+        cuObjErr_t status = cuClient_->cuMemObjGetDescriptor(
+            reinterpret_cast<void *>(mem.addr), mem.len);
+        if (status != CU_OBJ_SUCCESS) {
+            NIXL_ERROR << "registerMem: cuMemObjGetDescriptor failed, status=" << status;
+            return NIXL_ERR_BACKEND;
+        }
+        out = new nixlEverpureMemRegMD(mem.addr);
+        return NIXL_SUCCESS;
+    }
+    default:
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::deregisterMem(nixlBackendMD *meta) {
+    if (auto *obj_md = dynamic_cast<nixlEverpureObjKeyMD *>(meta)) {
+        delete obj_md;
+        return NIXL_SUCCESS;
+    }
+
+    if (auto *mem_md = dynamic_cast<nixlEverpureMemRegMD *>(meta)) {
+        cuObjErr_t status = cuClient_->cuMemObjPutDescriptor(reinterpret_cast<void *>(mem_md->addr));
+        if (status != CU_OBJ_SUCCESS) {
+            NIXL_ERROR << "deregisterMem: cuMemObjPutDescriptor failed, status=" << status;
+            // Leave *mem_md alive so the caller can retry the deregistration.
+            return NIXL_ERR_BACKEND;
+        }
+        delete mem_md;
+        return NIXL_SUCCESS;
+    }
+
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::prepXfer(const nixl_xfer_op_t &operation,
+                                  const nixl_meta_dlist_t &local,
+                                  const nixl_meta_dlist_t &remote,
+                                  const std::string &remote_agent,
+                                  const std::string &local_agent,
+                                  nixlBackendReqH *&handle,
+                                  const nixl_opt_b_args_t *opt_args) const {
+    if (auto status = requireCuObjReady(); status != NIXL_SUCCESS) {
+        return status;
+    }
+    if (!isValidPrepXferParams(operation, local, remote, remote_agent, local_agent)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto req_h = std::make_unique<nixlEverpureObjBackendReqH>();
+    req_h->units.reserve(local.descCount());
+
+    const cuObjOpType_t cu_op = (operation == NIXL_WRITE) ? CUOBJ_PUT : CUOBJ_GET;
+
+    for (int i = 0; i < local.descCount(); ++i) {
+        auto *obj_md = dynamic_cast<nixlEverpureObjKeyMD *>(remote[i].metadataP);
+        if (!obj_md) {
+            NIXL_ERROR << "prepXfer: object segment devId " << remote[i].devId
+                       << " was never registered";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        auto *mem_md = dynamic_cast<nixlEverpureMemRegMD *>(local[i].metadataP);
+        if (!mem_md) {
+            NIXL_ERROR << "prepXfer: local segment devId " << local[i].devId
+                       << " was never registered";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+
+        everpureTransferUnit unit(local[i].addr, local[i].len, remote[i].addr, obj_md->objKey);
+
+        // cuMemObjGetRDMAToken requires the exact base pointer that was passed
+        // to cuMemObjGetDescriptor at registration time (the whole scratch
+        // pool), plus the byte offset of this transfer's region within it --
+        // it does not accept an already-offset pointer with buffer_offset=0.
+        char *desc_str = nullptr;
+        const size_t buffer_offset = static_cast<size_t>(unit.addr - mem_md->addr);
+        cuObjErr_t status = cuClient_->cuMemObjGetRDMAToken(
+            reinterpret_cast<void *>(mem_md->addr), unit.size, buffer_offset, cu_op, &desc_str);
+        if (status != CU_OBJ_SUCCESS || desc_str == nullptr) {
+            NIXL_ERROR << "prepXfer: cuMemObjGetRDMAToken failed, status=" << status;
+            for (const auto &acquired : req_h->units) {
+                cuClient_->cuMemObjPutRDMAToken(acquired.rdmaToken);
+            }
+            return NIXL_ERR_BACKEND;
+        }
+        unit.rdmaDesc = desc_str;
+        unit.rdmaToken = desc_str;
+
+        req_h->units.push_back(std::move(unit));
+    }
+
+    handle = req_h.release();
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::postXfer(const nixl_xfer_op_t &operation,
+                                  const nixl_meta_dlist_t &local,
+                                  const nixl_meta_dlist_t &remote,
+                                  const std::string &remote_agent,
+                                  nixlBackendReqH *&handle,
+                                  const nixl_opt_b_args_t *opt_args) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "postXfer: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto *req_h = static_cast<nixlEverpureObjBackendReqH *>(handle);
+
+    auto *rdma_client = dynamic_cast<iEverpureS3RdmaClient *>(s3Client_.get());
+    if (!rdma_client) {
+        NIXL_ERROR << "postXfer: S3 client does not implement iEverpureS3RdmaClient";
+        return NIXL_ERR_BACKEND;
+    }
+
+    req_h->armCompletionTracking();
+    for (const auto &unit : req_h->units) {
+        auto on_done = [req_h](bool success) { req_h->onUnitDone(success); };
+        if (operation == NIXL_WRITE) {
+            rdma_client->putObjectRdmaAsync(
+                unit.objKey, unit.addr, unit.size, unit.offset, unit.rdmaDesc, on_done);
+        } else {
+            rdma_client->getObjectRdmaAsync(
+                unit.objKey, unit.addr, unit.size, unit.offset, unit.rdmaDesc, on_done);
+        }
+    }
+
+    return NIXL_IN_PROG;
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::checkXfer(nixlBackendReqH *handle) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "checkXfer: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return static_cast<nixlEverpureObjBackendReqH *>(handle)->poll();
+}
+
+nixl_status_t
+S3EverpureObjEngineImpl::releaseReqH(nixlBackendReqH *handle) const {
+    if (handle == nullptr) {
+        NIXL_ERROR << "releaseReqH: transfer request handle is null";
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto *req_h = static_cast<nixlEverpureObjBackendReqH *>(handle);
+    for (const auto &unit : req_h->units) {
+        cuClient_->cuMemObjPutRDMAToken(unit.rdmaToken);
+    }
+    delete req_h;
+    return NIXL_SUCCESS;
+}
+
+iS3Client *
+S3EverpureObjEngineImpl::getClient() const {
+    return s3Client_.get();
+}
+
+#endif // HAVE_CUOBJ_CLIENT

--- a/src/plugins/obj/s3_accel/everpure/engine_impl.h
+++ b/src/plugins/obj/s3_accel/everpure/engine_impl.h
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_OBJ_PLUGIN_S3_EVERPURE_ENGINE_IMPL_H
+#define NIXL_OBJ_PLUGIN_S3_EVERPURE_ENGINE_IMPL_H
+
+#if defined(HAVE_CUOBJ_CLIENT)
+
+#include "s3_accel/engine_impl.h"
+#include "s3_accel/everpure/client.h"
+#include <cuobjclient.h>
+
+/**
+ * RDMA-accelerated S3 object engine for cuObject-compatible endpoints,
+ * registered under `type: everpure` -- see client.h.
+ *
+ * Talks to the cuObject client library directly (cuobjclient /
+ * libcuobjclient, via <cuobjclient.h>).
+ */
+class S3EverpureObjEngineImpl : public S3AccelObjEngineImpl {
+public:
+    explicit S3EverpureObjEngineImpl(const nixlBackendInitParams *init_params);
+    S3EverpureObjEngineImpl(const nixlBackendInitParams *init_params,
+                            std::shared_ptr<iS3Client> s3_client);
+
+    nixl_status_t
+    registerMem(const nixlBlobDesc &mem, const nixl_mem_t &nixl_mem, nixlBackendMD *&out) override;
+
+    nixl_status_t
+    deregisterMem(nixlBackendMD *meta) override;
+
+    nixl_status_t
+    prepXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             const std::string &local_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args) const override;
+
+    nixl_status_t
+    postXfer(const nixl_xfer_op_t &operation,
+             const nixl_meta_dlist_t &local,
+             const nixl_meta_dlist_t &remote,
+             const std::string &remote_agent,
+             nixlBackendReqH *&handle,
+             const nixl_opt_b_args_t *opt_args = nullptr) const override;
+
+    nixl_status_t
+    checkXfer(nixlBackendReqH *handle) const override;
+
+    nixl_status_t
+    releaseReqH(nixlBackendReqH *handle) const override;
+
+    // The cuObject path moves data straight out of GPU memory, so VRAM_SEG
+    // is added on top of the DRAM_SEG/OBJ_SEG pair the base engine already
+    // advertises.
+    nixl_mem_list_t
+    getSupportedMems() const override {
+        return {OBJ_SEG, DRAM_SEG, VRAM_SEG};
+    }
+
+protected:
+    iS3Client *
+    getClient() const override;
+
+private:
+    /// Fails fast with NIXL_ERR_BACKEND when the cuObject client dropped its
+    /// connection; shared by every entry point that touches cuClient_.
+    nixl_status_t
+    requireCuObjReady() const;
+
+    std::shared_ptr<iS3Client> s3Client_;
+    std::shared_ptr<cuObjClient> cuClient_;
+};
+
+#endif // HAVE_CUOBJ_CLIENT
+
+#endif // NIXL_OBJ_PLUGIN_S3_EVERPURE_ENGINE_IMPL_H

--- a/src/plugins/obj/s3_accel/everpure/rdma_interface.h
+++ b/src/plugins/obj/s3_accel/everpure/rdma_interface.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_OBJ_PLUGIN_S3_EVERPURE_RDMA_INTERFACE_H
+#define NIXL_OBJ_PLUGIN_S3_EVERPURE_RDMA_INTERFACE_H
+
+#include <string_view>
+#include <cstdint>
+#include <functional>
+#include "nixl_types.h"
+
+/**
+ * Interface for S3 clients that support RDMA operations against a
+ * cuObject-compatible endpoint. Only Everpure-specific clients implement
+ * this interface.
+ */
+class iEverpureS3RdmaClient {
+public:
+    virtual ~iEverpureS3RdmaClient() = default;
+
+    /**
+     * Asynchronously put an object to S3 using RDMA.
+     * @param key The object key
+     * @param data_ptr Pointer to the data to upload
+     * @param data_len Length of the data in bytes
+     * @param offset Offset within the object
+     * @param rdma_desc RDMA descriptor for the transfer
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    putObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       put_object_callback_t callback) = 0;
+
+    /**
+     * Asynchronously get an object from S3 using RDMA.
+     * @param key The object key
+     * @param data_ptr Pointer to the buffer to store the downloaded data
+     * @param data_len Maximum length of data to read
+     * @param offset Offset within the object to start reading from
+     * @param rdma_desc RDMA descriptor for the transfer
+     * @param callback Callback function to handle the result
+     */
+    virtual void
+    getObjectRdmaAsync(std::string_view key,
+                       uintptr_t data_ptr,
+                       size_t data_len,
+                       size_t offset,
+                       std::string_view rdma_desc,
+                       get_object_callback_t callback) = 0;
+};
+
+#endif // NIXL_OBJ_PLUGIN_S3_EVERPURE_RDMA_INTERFACE_H

--- a/test/gtest/unit/obj/meson.build
+++ b/test/gtest/unit/obj/meson.build
@@ -16,7 +16,12 @@
 obj_test_sources = ['obj.cpp']
 
 if cuobj_dep.found()
-    obj_test_sources += ['mock_dell_s3_client.cpp', 'obj_cuobj.cpp']
+    obj_test_sources += [
+        'mock_dell_s3_client.cpp',
+        'obj_cuobj.cpp',
+        'mock_everpure_s3_client.cpp',
+        'obj_everpure.cpp',
+    ]
 endif
 
 obj_unit_test_dep = declare_dependency(

--- a/test/gtest/unit/obj/mock_everpure_s3_client.cpp
+++ b/test/gtest/unit/obj/mock_everpure_s3_client.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Everpure, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "obj_test_base.h"
+#include "mock_client_registry.h"
+#include "s3_accel/everpure/rdma_interface.h"
+
+namespace gtest::obj {
+namespace {
+
+    class mockEverpureS3Client : public mockS3Client, public iEverpureS3RdmaClient {
+    public:
+        mockEverpureS3Client() = default;
+
+        mockEverpureS3Client([[maybe_unused]] nixl_b_params_t *custom_params,
+                             std::shared_ptr<Aws::Utils::Threading::Executor> executor = nullptr)
+            : mockS3Client(custom_params, executor) {}
+
+        void
+        putObjectRdmaAsync([[maybe_unused]] std::string_view key,
+                           [[maybe_unused]] uintptr_t data_ptr,
+                           [[maybe_unused]] size_t data_len,
+                           [[maybe_unused]] size_t offset,
+                           std::string_view rdma_desc,
+                           put_object_callback_t callback) override {
+            if (rdma_desc.empty()) {
+                getPendingCallbacks().push_back([callback]() { callback(false); });
+            } else {
+                getPendingCallbacks().push_back(
+                    [callback, this]() { callback(getSimulateSuccess()); });
+            }
+        }
+
+        void
+        getObjectRdmaAsync([[maybe_unused]] std::string_view key,
+                           uintptr_t data_ptr,
+                           size_t data_len,
+                           size_t offset,
+                           std::string_view rdma_desc,
+                           get_object_callback_t callback) override {
+            if (rdma_desc.empty()) {
+                getPendingCallbacks().push_back([callback]() { callback(false); });
+            } else {
+                getPendingCallbacks().push_back([callback, data_ptr, data_len, offset, this]() {
+                    if (getSimulateSuccess() && data_ptr && data_len > 0) {
+                        char *buffer = reinterpret_cast<char *>(data_ptr);
+                        for (size_t i = 0; i < data_len; ++i) {
+                            buffer[i] = static_cast<char>('A' + ((i + offset) % 26));
+                        }
+                    }
+                    callback(getSimulateSuccess());
+                });
+            }
+        }
+    };
+
+    mockClientRegistrar reg_everpure("everpure",
+                                     []() { return std::make_shared<mockEverpureS3Client>(); });
+
+} // anonymous namespace
+} // namespace gtest::obj

--- a/test/gtest/unit/obj/obj.cpp
+++ b/test/gtest/unit/obj/obj.cpp
@@ -40,6 +40,10 @@ static const ObjTestConfig dellConfig = {"Dell",
                                          {{"accelerated", "true"}, {"type", "dell"}},
                                          "test-dell-agent",
                                          true};
+static const ObjTestConfig everpureConfig = {"Everpure",
+                                             {{"accelerated", "true"}, {"type", "everpure"}},
+                                             "test-everpure-agent",
+                                             true};
 #endif
 
 // Parameterized tests - run for all client types
@@ -302,12 +306,11 @@ TEST_P(objParamTestFixture, CheckObjectExistsAsyncRequestError) {
 
 // Instantiate parameterized tests for all client configurations
 #if defined HAVE_CUOBJ_CLIENT
-INSTANTIATE_TEST_SUITE_P(ObjClientTests,
-                         objParamTestFixture,
-                         testing::Values(standardConfig, crtConfig, accelConfig, dellConfig),
-                         [](const testing::TestParamInfo<ObjTestConfig> &info) {
-                             return info.param.name;
-                         });
+INSTANTIATE_TEST_SUITE_P(
+    ObjClientTests,
+    objParamTestFixture,
+    testing::Values(standardConfig, crtConfig, accelConfig, dellConfig, everpureConfig),
+    [](const testing::TestParamInfo<ObjTestConfig> &info) { return info.param.name; });
 #else
 INSTANTIATE_TEST_SUITE_P(ObjClientTests,
                          objParamTestFixture,

--- a/test/gtest/unit/obj/obj_everpure.cpp
+++ b/test/gtest/unit/obj/obj_everpure.cpp
@@ -1,0 +1,692 @@
+/*
+ * Copyright 2026 Everpure, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Unit tests for the Everpure accelerated S3 engine.
+ *
+ * This file is only built when the cuobjclient library is available.
+ * It exercises the Everpure S3-over-RDMA code path.
+ */
+#include "obj_test_base.h"
+
+namespace gtest::obj {
+
+/**
+ * Everpure accelerated engine test fixture.
+ *
+ * Exercises the Everpure S3-over-RDMA code path by configuring the OBJ
+ * engine with accelerated=true and type=everpure. Uses mockEverpureS3Client
+ * to simulate RDMA put/get operations via the iEverpureS3RdmaClient
+ * interface without requiring real cuobjclient or RDMA fabric.
+ */
+class objEverpureTestFixture : public objTestBase, public testing::Test {
+protected:
+    void
+    SetUp() override {
+        setupEngine("test-everpure-agent", {{"accelerated", "true"}, {"type", "everpure"}});
+    }
+};
+
+/** End-to-end RDMA write through the Everpure accelerated engine. */
+TEST_F(objEverpureTestFixture, EverpureRdmaWriteWithDescriptor) {
+    testTransferWithSize(NIXL_WRITE, 1024, "-everpure-rdma");
+}
+
+/** RDMA read at a non-zero object offset; verifies data correctness. */
+TEST_F(objEverpureTestFixture, EverpureRdmaReadWithOffset) {
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(256);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "everpure-rdma-read-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    const size_t offset = 512;
+    const size_t length = 256;
+    nixlMetaDesc local_meta_desc(local_desc.addr, length, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(offset, length, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(objEngine_->prepXfer(
+                  NIXL_READ, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_SUCCESS);
+
+    nixl_status_t status = objEngine_->postXfer(
+        NIXL_READ, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    mockS3Client_->execAsync();
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_EQ(test_buffer[0], 'A' + (offset % 26));
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** Everpure engine advertises VRAM_SEG support and can register VRAM memory. */
+TEST_F(objEverpureTestFixture, EverpureVramMemorySupport) {
+    auto supported_mems = objEngine_->getSupportedMems();
+    EXPECT_TRUE(std::find(supported_mems.begin(), supported_mems.end(), VRAM_SEG) !=
+                supported_mems.end());
+
+    std::vector<char> test_buffer1(512);
+    std::fill(test_buffer1.begin(), test_buffer1.end(), 'A');
+    nixlBlobDesc vram_desc;
+
+    vram_desc.addr = reinterpret_cast<uintptr_t>(test_buffer1.data());
+    vram_desc.len = test_buffer1.size();
+    vram_desc.devId = 3;
+    nixlBackendMD *vram_metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(vram_desc, VRAM_SEG, vram_metadata);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(vram_metadata, nullptr);
+
+    objEngine_->deregisterMem(vram_metadata);
+}
+
+/** Multi-descriptor RDMA write with two different buffer sizes. */
+TEST_F(objEverpureTestFixture, EverpureMultiDescriptorRdmaOperations) {
+    testMultiDescriptorWithSizes(NIXL_WRITE, 512, 1024, "-everpure-multi");
+}
+
+/** prepXfer rejects an invalid (out-of-range) transfer operation enum. */
+TEST_F(objEverpureTestFixture, EverpureEngineInvalidOperationType) {
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "invalid-op-test";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+
+    // Test invalid operation type (using a cast to simulate invalid enum)
+    nixl_xfer_op_t invalid_op = static_cast<nixl_xfer_op_t>(999);
+    nixl_status_t status = objEngine_->prepXfer(
+        invalid_op, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail due to invalid operation
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer rejects OBJ_SEG as the local descriptor segment type. */
+TEST_F(objEverpureTestFixture, EverpureEngineInvalidLocalMemoryType) {
+    // Test that the engine rejects invalid local memory type in prepXfer
+    nixlBlobDesc local_desc, remote_desc;
+    nixlBackendMD *local_metadata = nullptr, *remote_metadata = nullptr;
+
+    // Register both as OBJ_SEG
+    local_desc.devId = 1;
+    local_desc.metaInfo = "local-obj-key";
+    ASSERT_EQ(objEngine_->registerMem(local_desc, OBJ_SEG, local_metadata), NIXL_SUCCESS);
+
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "remote-obj-key";
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(OBJ_SEG); // Invalid - should be DRAM/VRAM
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    char dummy[1024];
+    nixlMetaDesc local_meta_desc(reinterpret_cast<uintptr_t>(dummy), 1024, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail due to invalid local memory type
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer rejects a non-OBJ_SEG remote descriptor segment type. */
+TEST_F(objEverpureTestFixture, EverpureEngineInvalidRemoteMemoryType) {
+    // Test that the engine rejects non-OBJ_SEG remote memory type in prepXfer
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(DRAM_SEG); // Invalid - should be OBJ_SEG
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, 2);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+}
+
+/** prepXfer rejects mismatched local/remote descriptor list sizes. */
+TEST_F(objEverpureTestFixture, EverpureEngineMismatchedDescriptorCounts) {
+    // Test that the engine rejects mismatched local/remote descriptor counts
+    std::vector<char> test_buffer1(512);
+    std::vector<char> test_buffer2(512);
+
+    nixlBlobDesc local_desc1, local_desc2;
+    local_desc1.addr = reinterpret_cast<uintptr_t>(test_buffer1.data());
+    local_desc1.len = test_buffer1.size();
+    local_desc1.devId = 1;
+    local_desc2.addr = reinterpret_cast<uintptr_t>(test_buffer2.data());
+    local_desc2.len = test_buffer2.size();
+    local_desc2.devId = 2;
+    nixlBackendMD *local_metadata1 = nullptr, *local_metadata2 = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc1, DRAM_SEG, local_metadata1), NIXL_SUCCESS);
+    ASSERT_EQ(objEngine_->registerMem(local_desc2, DRAM_SEG, local_metadata2), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 3;
+    remote_desc.metaInfo = "mismatch-test-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Add 2 local descriptors but only 1 remote descriptor
+    nixlMetaDesc local_meta_desc1(local_desc1.addr, local_desc1.len, local_desc1.devId);
+    nixlMetaDesc local_meta_desc2(local_desc2.addr, local_desc2.len, local_desc2.devId);
+    nixlMetaDesc remote_meta_desc(0, 512, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc1);
+    local_descs.addDesc(local_meta_desc2);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata1);
+    objEngine_->deregisterMem(local_metadata2);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer fails when the remote devId has no registered OBJ_SEG mapping. */
+TEST_F(objEverpureTestFixture, EverpureUnregisteredRemoteDevId) {
+    // Test that the engine rejects transfers when remote devId is not registered
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    // Register an OBJ_SEG with devId=2, but use devId=999 in the descriptor
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "registered-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    // Use devId=999 which was never registered
+    nixlMetaDesc remote_meta_desc(0, 1024, 999);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** registerMem rejects unsupported segment types (BLK_SEG, FILE_SEG). */
+TEST_F(objEverpureTestFixture, EverpureRegisterMemUnsupportedType) {
+    // Test that the engine rejects unsupported memory types
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, BLK_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Also test FILE_SEG
+    status = objEngine_->registerMem(mem_desc, FILE_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** registerMem rejects DRAM/VRAM buffers exceeding CUOBJ_MAX_MEMORY_REG_SIZE (4 GiB). */
+TEST_F(objEverpureTestFixture, EverpureRegisterMemExceedsMaxSize) {
+    // Test that registerMem rejects DRAM/VRAM buffers larger than CUOBJ_MAX_MEMORY_REG_SIZE (4
+    // GiB). This constant is defined in cuobjclient.h; keep in sync if it changes.
+    constexpr size_t kMaxMemRegSize = 4ULL * 1024 * 1024 * 1024;
+    std::vector<char> dummy(1);
+
+    nixlBlobDesc mem_desc;
+    mem_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    mem_desc.len = kMaxMemRegSize + 1;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, DRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Same check for VRAM_SEG
+    metadata = nullptr;
+    status = objEngine_->registerMem(mem_desc, VRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_NOT_SUPPORTED);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** prepXfer handles zero-length descriptors without crashing. */
+TEST_F(objEverpureTestFixture, EverpureEngineZeroSizePrep) {
+    // Test that prepXfer accepts zero-size descriptors without crashing.
+    // Note: both putObjectRdmaAsync and getObjectRdmaAsync in client.cpp
+    // reject data_len==0, so a zero-size transfer would fail at postXfer
+    // in production. This test only verifies prepXfer handles the edge case.
+    mockS3Client_->setSimulateSuccess(true);
+
+    nixlBlobDesc local_desc;
+    std::vector<char> dummy(1);
+    local_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    local_desc.len = 1;
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    // registerMem calls into cuMemObjGetDescriptor which requires a non-zero length buffer
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "zero-size-test";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Create meta descriptions with zero size
+    nixlMetaDesc local_meta_desc(local_desc.addr, 0, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 0, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should handle zero size gracefully
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    if (handle) {
+        objEngine_->releaseReqH(handle);
+    }
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** Simulated RDMA write failure propagates error status through checkXfer. */
+TEST_F(objEverpureTestFixture, EverpureWriteTransferFailure) {
+    testTransferFailure(NIXL_WRITE, 1024, "-everpure-fail-write");
+}
+
+/** Simulated RDMA read failure propagates error status through checkXfer. */
+TEST_F(objEverpureTestFixture, EverpureReadTransferFailure) {
+    testTransferFailure(NIXL_READ, 1024, "-everpure-fail-read");
+}
+
+/** Multi-descriptor RDMA read with data-content verification. */
+TEST_F(objEverpureTestFixture, EverpureMultiDescriptorReadVerifyData) {
+    testMultiDescriptorWithSizes(NIXL_READ, 512, 256, "-everpure-multi-read");
+}
+
+/** Agent name mismatch between prepXfer and engine logs a warning but succeeds. */
+TEST_F(objEverpureTestFixture, EverpureAgentMismatchWarning) {
+    // Test that agent mismatch produces a warning but does not fail
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "agent-mismatch-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    // Pass a different remote_agent than the engine's localAgent
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, "different-agent", handle, nullptr);
+
+    // Should succeed (mismatch is only a warning, not an error)
+    EXPECT_EQ(status, NIXL_SUCCESS);
+    EXPECT_NE(handle, nullptr);
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** OBJ_SEG registration with empty metaInfo auto-generates a key from devId. */
+TEST_F(objEverpureTestFixture, EverpureObjSegAutoKeyGeneration) {
+    // Test that OBJ_SEG with empty metaInfo auto-generates key from devId
+    nixlBlobDesc mem_desc;
+    mem_desc.devId = 42;
+    mem_desc.metaInfo = ""; // Empty key - engine will generate from devId
+
+    nixlBackendMD *metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(mem_desc, OBJ_SEG, metadata), NIXL_SUCCESS);
+    ASSERT_NE(metadata, nullptr);
+
+    // Verify the key is used by attempting a transfer
+    std::vector<char> test_buffer(256);
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), mem_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    // The auto-generated key should be "42" (from devId)
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    if (handle) {
+        objEngine_->releaseReqH(handle);
+    }
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(metadata);
+}
+
+/** Deregistering an OBJ_SEG removes its devId-to-key mapping; subsequent transfers fail. */
+TEST_F(objEverpureTestFixture, EverpureDeregisterObjSegCleansMapping) {
+    // Test that deregistering OBJ_SEG cleans up the devId-to-key mapping
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 10;
+    remote_desc.metaInfo = "deregister-cleanup-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    // Deregister the OBJ_SEG
+    ASSERT_EQ(objEngine_->deregisterMem(remote_metadata), NIXL_SUCCESS);
+
+    // Now try to use the devId in a transfer - should fail because mapping was cleaned
+    std::vector<char> test_buffer(256);
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 256, 10); // devId=10, no longer registered
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    // Should fail because devId 10 mapping was removed
+    EXPECT_EQ(status, NIXL_ERR_INVALID_PARAM);
+
+    objEngine_->deregisterMem(local_metadata);
+}
+
+/** checkXfer returns NIXL_IN_PROG before mock callbacks are executed. */
+TEST_F(objEverpureTestFixture, EverpureCheckXferBeforeExecAsync) {
+    // Test checkXfer returns NIXL_IN_PROG before callbacks are executed
+    mockS3Client_->setSimulateSuccess(true);
+
+    std::vector<char> test_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(test_buffer.data());
+    local_desc.len = test_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "check-before-exec-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    nixlMetaDesc local_meta_desc(local_desc.addr, local_desc.len, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, test_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    ASSERT_EQ(objEngine_->prepXfer(
+                  NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr),
+              NIXL_SUCCESS);
+
+    nixl_status_t status = objEngine_->postXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Check before executing async callbacks - should still be in progress
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_IN_PROG);
+
+    // Now execute and verify completion
+    mockS3Client_->execAsync();
+    status = objEngine_->checkXfer(handle);
+    EXPECT_EQ(status, NIXL_SUCCESS);
+
+    objEngine_->releaseReqH(handle);
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** registerMem rejects zero-length DRAM/VRAM buffers with NIXL_ERR_BACKEND. */
+TEST_F(objEverpureTestFixture, EverpureRegisterMemZeroLengthBuffer) {
+    // Test that cuMemObjGetDescriptor fails when given a zero-length buffer
+    std::vector<char> dummy(1);
+
+    nixlBlobDesc mem_desc;
+    mem_desc.addr = reinterpret_cast<uintptr_t>(dummy.data());
+    mem_desc.len = 0;
+    mem_desc.devId = 1;
+
+    nixlBackendMD *metadata = nullptr;
+    nixl_status_t status = objEngine_->registerMem(mem_desc, DRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(metadata, nullptr);
+
+    // Same check for VRAM_SEG
+    metadata = nullptr;
+    status = objEngine_->registerMem(mem_desc, VRAM_SEG, metadata);
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(metadata, nullptr);
+}
+
+/** prepXfer fails when the local buffer address was never registered with cuObj. */
+TEST_F(objEverpureTestFixture, EverpurePrepXferUnregisteredAddress) {
+    // Test that cuMemObjGetRDMAToken fails when the local address was never registered with cuObj
+    std::vector<char> registered_buffer(1024);
+    std::vector<char> unregistered_buffer(1024);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(registered_buffer.data());
+    local_desc.len = registered_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "unregistered-addr-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Use unregistered_buffer's address - not registered with cuMemObjGetDescriptor
+    nixlMetaDesc local_meta_desc(reinterpret_cast<uintptr_t>(unregistered_buffer.data()),
+                                 unregistered_buffer.size(),
+                                 local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, unregistered_buffer.size(), remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+/** prepXfer fails when the local address exceeds the 16 MiB RDMA descriptor coverage limit. */
+TEST_F(objEverpureTestFixture, EverpurePrepXferLargeMemoryOffset) {
+    // Test that cuMemObjGetRDMAToken fails when the local address is more than 16 MB from
+    // the base address of the registered memory region.
+    // This is a cuObject library constraint on RDMA descriptor coverage.
+    constexpr size_t k16MiB = 16ULL * 1024 * 1024;
+    constexpr size_t kBufSize = k16MiB + 4096;
+    std::vector<char> large_buffer(kBufSize);
+
+    nixlBlobDesc local_desc;
+    local_desc.addr = reinterpret_cast<uintptr_t>(large_buffer.data());
+    local_desc.len = large_buffer.size();
+    local_desc.devId = 1;
+    nixlBackendMD *local_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(local_desc, DRAM_SEG, local_metadata), NIXL_SUCCESS);
+
+    nixlBlobDesc remote_desc;
+    remote_desc.devId = 2;
+    remote_desc.metaInfo = "large-offset-key";
+    nixlBackendMD *remote_metadata = nullptr;
+    ASSERT_EQ(objEngine_->registerMem(remote_desc, OBJ_SEG, remote_metadata), NIXL_SUCCESS);
+
+    nixl_meta_dlist_t local_descs(DRAM_SEG);
+    nixl_meta_dlist_t remote_descs(OBJ_SEG);
+
+    // Use an address > 16 MiB from the registered base
+    uintptr_t offset_addr = reinterpret_cast<uintptr_t>(large_buffer.data()) + k16MiB + 1;
+    nixlMetaDesc local_meta_desc(offset_addr, 1024, local_desc.devId);
+    nixlMetaDesc remote_meta_desc(0, 1024, remote_desc.devId);
+    local_descs.addDesc(local_meta_desc);
+    remote_descs.addDesc(remote_meta_desc);
+
+    nixlBackendReqH *handle = nullptr;
+    nixl_status_t status = objEngine_->prepXfer(
+        NIXL_WRITE, local_descs, remote_descs, initParams_.localAgent, handle, nullptr);
+
+    EXPECT_EQ(status, NIXL_ERR_BACKEND);
+    EXPECT_EQ(handle, nullptr);
+
+    objEngine_->deregisterMem(local_metadata);
+    objEngine_->deregisterMem(remote_metadata);
+}
+
+} // namespace gtest::obj

--- a/test/unit/plugins/object/nixl_object_test.cpp
+++ b/test/unit/plugins/object/nixl_object_test.cpp
@@ -105,6 +105,12 @@ print_usage(const char *program_name) {
               << "  -T, --type TYPE         Vendor type for accelerated engine (e.g., dell)\n"
               << "  -v, --vram              Use VRAM (GPU memory) instead of DRAM\n"
               << "                          (requires --accelerated and CUDA/GPU support)\n"
+              << "  --max-connections N     Sets NIXL_EVERPURE_MAX_CONNECTIONS (AWS SDK "
+                 "default: 25)\n"
+              << "  --connect-timeout-ms N  Sets NIXL_EVERPURE_CONNECT_TIMEOUT_MS (AWS SDK "
+                 "default: 1000)\n"
+              << "  --request-timeout-ms N  Sets NIXL_EVERPURE_REQUEST_TIMEOUT_MS (AWS SDK "
+                 "default: 3000)\n"
               << "  -h, --help              Show this help message\n"
               << "\nExamples:\n"
               << "  " << program_name << " -n 100 -s 16M -t 5\n"
@@ -274,6 +280,9 @@ main(int argc, char *argv[]) {
     bool use_accelerated = false;
     std::string accel_type;
     bool use_vram = false;
+    std::string max_connections;
+    std::string connect_timeout_ms;
+    std::string request_timeout_ms;
     int ret_code = 0;
     nixlXferReqH *write_req = nullptr;
     nixlXferReqH *read_req = nullptr;
@@ -293,6 +302,9 @@ main(int argc, char *argv[]) {
                                            {"accelerated", no_argument, 0, 'a'},
                                            {"type", required_argument, 0, 'T'},
                                            {"vram", no_argument, 0, 'v'},
+                                           {"max-connections", required_argument, 0, 256},
+                                           {"connect-timeout-ms", required_argument, 0, 257},
+                                           {"request-timeout-ms", required_argument, 0, 258},
                                            {"help", no_argument, 0, 'h'},
                                            {0, 0, 0, 0}};
 
@@ -335,6 +347,15 @@ main(int argc, char *argv[]) {
             break;
         case 'v':
             use_vram = true;
+            break;
+        case 256:
+            max_connections = optarg;
+            break;
+        case 257:
+            connect_timeout_ms = optarg;
+            break;
+        case 258:
+            request_timeout_ms = optarg;
             break;
         case 'h':
             print_usage(argv[0]);
@@ -428,6 +449,12 @@ main(int argc, char *argv[]) {
             params["type"] = accel_type;
         }
     }
+
+    if (!max_connections.empty()) setenv("NIXL_EVERPURE_MAX_CONNECTIONS", max_connections.c_str(), 1);
+    if (!connect_timeout_ms.empty())
+        setenv("NIXL_EVERPURE_CONNECT_TIMEOUT_MS", connect_timeout_ms.c_str(), 1);
+    if (!request_timeout_ms.empty())
+        setenv("NIXL_EVERPURE_REQUEST_TIMEOUT_MS", request_timeout_ms.c_str(), 1);
 
     // Pre-allocate host-side buffers: pattern buffer for writes and validation,
     // and a staging buffer for GPU readback during validation.


### PR DESCRIPTION
RDMA-accelerated OBJ engine for FlashBlade's S3-over-RDMA data path, linking cuobjclient directly. Includes unit tests and CLI flags for connection tuning.

## What?
Adds `everpure`, a new accelerated engine for the OBJ backend (`src/plugins/obj/s3_accel/everpure/`) that moves S3 PUT/GET payloads directly over RDMA using NVIDIA's `cuobjclient` library instead of streaming them through HTTP. The AWS S3 SDK is used only for a lightweight control-plane request/response — the RDMA descriptor rides in a request header, and the object bytes move over the RDMA fabric. Selected via `type: everpure` on the existing `accelerated` OBJ engine registry. Supports `DRAM_SEG`, `VRAM_SEG`, and `OBJ_SEG` memory types, and adds unit test coverage via a mock RDMA-capable S3 client, plus `--max-connections`/`--connect-timeout-ms`/`--request-timeout-ms` flags on the object-plugin test CLI.

## Why?
FlashBlade exposes an S3-over-RDMA data path that bypasses HTTP body transfer entirely, giving substantially better throughput than the default HTTP-based S3 engine for large object transfers. The existing OBJ backend had no engine that spoke this protocol. Protocol details (header names, checksum handling, connection tuning) are configurable rather than hardcoded, so any other cuObject-compatible endpoint can reuse this engine without a separate plugin impl.

## How?
The engine links `cuobjclient` directly and uses its manual-token-management API (`cuMemObjGetDescriptor`/`cuMemObjPutDescriptor` at registration time, `cuMemObjGetRDMAToken`/`cuMemObjPutRDMAToken` per transfer) rather than the synchronous callback API, to stay compatible with NIXL's async post/poll transfer model. The RDMA descriptor is sent as a bare token in a request header (`NIXL_EVERPURE_RDMA_TOKEN_HEADER`, default `x-amz-rdma-token`), and a response header (`NIXL_EVERPURE_RDMA_REPLY_HEADER`) confirms the request was actually served over RDMA rather than falling back to plain S3. See `src/plugins/obj/s3_accel/everpure/README.md` for the full wire-protocol and configuration details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Everpure accelerated S3-over-RDMA backend.
  * Added support for object transfers using DRAM and VRAM memory.
  * Added configurable connection limits and connection/request timeouts.
  * Added detailed setup, configuration, and transfer documentation.

* **Bug Fixes**
  * Improved asynchronous S3 failure reporting with AWS error details.

* **Tests**
  * Added comprehensive coverage for Everpure transfers, validation, memory registration, offsets, failures, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->