### PR TITLE
PLUGINS/UCX: Disable AH handle cache in UCX v1.23

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -497,6 +497,10 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
         config.modify("RNDV_PIPELINE_ERROR_HANDLING", "y");
     }
 
+    if (ucpVersion_ >= UCP_VERSION(1, 23)) {
+        config.modify("IB_AH_CACHE_TTL", "0");
+    }
+
     const auto &hw_info = nixl::hwInfo::instance();
     if (hw_info.numEfaDevices != 0) {
         config.modify("ADDRESS_VERSION", "v2");


### PR DESCRIPTION
## What?
Disable AH cache in UCX to avoid L2 stale entries. It should only be merged after https://github.com/openucx/ucx/pull/11856.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UCX compatibility for versions 1.23 and newer by disabling the InfiniBand address-handle cache during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->