### PR TITLE
[GPUNetIO] Coalesce contiguous READ runs across chunks

### DIFF
--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1299,15 +1299,16 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
         if(req_hndl->status == NIXL_IN_PROG) {
 
-            req_hndl->status = req_hndl->engine->releaseReqH(
-                                         req_hndl->backendHandle);
+            const nixl_status_t release_status =
+                req_hndl->engine->releaseReqH(req_hndl->backendHandle);
 
-            if (req_hndl->status < 0) {
+            if (release_status < 0) {
                 NIXL_ERROR_FUNC << "backend '" << req_hndl->engine->getType()
                                 << "' could not release transfer request and returned error status "
-                                << req_hndl->status;
+                                << release_status;
                 return NIXL_ERR_REPOST_ACTIVE; // Might need renaming
             }
+            req_hndl->status = release_status;
             // just in case the backend doesn't set to NULL on success
             // this will prevent calling releaseReqH again in destructor
             req_hndl->backendHandle = nullptr;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gpunetio_backend.h"
+#include "gpunetio_coalescing.h"
 #include "serdes/serdes.h"
 #include <algorithm>
 #include <arpa/inet.h>
@@ -27,6 +28,14 @@
 #include <absl/strings/str_split.h>
 
 const char info_delimiter = '-';
+
+#ifndef NIXL_GPUNETIO_MAX_READ_WQE_SIZE
+#define NIXL_GPUNETIO_MAX_READ_WQE_SIZE (8ULL * 1024 * 1024)
+#endif
+
+constexpr size_t MAX_READ_WQE_SIZE = NIXL_GPUNETIO_MAX_READ_WQE_SIZE;
+static_assert(MAX_READ_WQE_SIZE <= DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE);
+static_assert(MAX_READ_WQE_SIZE <= std::numeric_limits<uint32_t>::max());
 
 /****************************************
  * Constructor/Destructor
@@ -1200,31 +1209,40 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         staged_req.has_notif_msg_idx = DOCA_NOTIF_NULL;
 
         uint32_t chunk_desc_count = 0;
-        while (desc_offset < lcnt && chunk_desc_count < DOCA_XFER_REQ_SIZE) {
-            const uint32_t desc_idx = desc_offset++;
-            ++chunk_desc_count;
+        while (desc_offset < lcnt && staged_req.num < DOCA_XFER_REQ_SIZE &&
+               (operation == NIXL_READ || chunk_desc_count < DOCA_XFER_REQ_SIZE)) {
+            const uint32_t desc_idx = desc_offset;
 
             lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
 
+            bool mergeable = false;
             if (operation == NIXL_READ && staged_req.num > 0) {
                 const uint32_t prev = staged_req.num - 1;
-                constexpr size_t max_read_size = std::min<size_t>(
-                    std::numeric_limits<uint32_t>::max(), DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE);
-                const bool size_fits = staged_req.size[prev] <= max_read_size &&
-                    local[desc_idx].len <= max_read_size - staged_req.size[prev];
-                const bool local_adjacent = staged_req.lbuf[prev] <=
-                        std::numeric_limits<uintptr_t>::max() - staged_req.size[prev] &&
-                    staged_req.lbuf[prev] + staged_req.size[prev] == local[desc_idx].addr;
-                const bool remote_adjacent = staged_req.rbuf[prev] <=
-                        std::numeric_limits<uintptr_t>::max() - staged_req.size[prev] &&
-                    staged_req.rbuf[prev] + staged_req.size[prev] == remote[desc_idx].addr;
-                if (size_fits && local_adjacent && remote_adjacent &&
-                    staged_req.lkey[prev] == lmd->mr->get_lkey() &&
-                    staged_req.rkey[prev] == rmd->mr->get_rkey()) {
+                mergeable = nixl::gpunetio::canCoalesceRead({staged_req.lbuf[prev],
+                                                             staged_req.rbuf[prev],
+                                                             staged_req.size[prev],
+                                                             staged_req.lkey[prev],
+                                                             staged_req.rkey[prev]},
+                                                            {local[desc_idx].addr,
+                                                             remote[desc_idx].addr,
+                                                             local[desc_idx].len,
+                                                             lmd->mr->get_lkey(),
+                                                             rmd->mr->get_rkey()},
+                                                            MAX_READ_WQE_SIZE);
+                if (mergeable) {
                     staged_req.size[prev] += local[desc_idx].len;
-                    continue;
                 }
+            }
+
+            if (chunk_desc_count >= DOCA_XFER_REQ_SIZE && !mergeable) {
+                break;
+            }
+
+            ++desc_offset;
+            ++chunk_desc_count;
+            if (mergeable) {
+                continue;
             }
 
             const uint32_t idx = staged_req.num;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1292,7 +1292,8 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
-    treq->completed = false;
+    treq->completionState.store(nixlDocaBckndReq::CompletionState::IN_PROGRESS,
+                                std::memory_order_release);
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
         const uint32_t completion_index =
@@ -1321,7 +1322,12 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    if (treq->completed) {
+    auto state = treq->completionState.load(std::memory_order_acquire);
+    if (state == nixlDocaBckndReq::CompletionState::COMPLETE) {
+        return treq->postStatus;
+    }
+    if (state == nixlDocaBckndReq::CompletionState::COMPLETING) {
+        treq->completionState.wait(state, std::memory_order_acquire);
         return treq->postStatus;
     }
 
@@ -1334,13 +1340,23 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    for (size_t i = 0; i < treq->postedCount; ++i) {
-        const uint32_t idx = treq->positions[i];
-        *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-        NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
+    auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
+    if (treq->completionState.compare_exchange_strong(
+            expected,
+            nixlDocaBckndReq::CompletionState::COMPLETING,
+            std::memory_order_acq_rel)) {
+        for (size_t i = 0; i < treq->postedCount; ++i) {
+            const uint32_t idx = treq->positions[i];
+            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+            NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
+        }
+        treq->completionState.store(nixlDocaBckndReq::CompletionState::COMPLETE,
+                                    std::memory_order_release);
+        treq->completionState.notify_all();
+    } else if (expected == nixlDocaBckndReq::CompletionState::COMPLETING) {
+        treq->completionState.wait(expected, std::memory_order_acquire);
     }
 
-    treq->completed = true;
     return treq->postStatus;
 }
 
@@ -1355,7 +1371,8 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
         return NIXL_SUCCESS;
     }
 
-    if (!treq->completed) {
+    if (treq->completionState.load(std::memory_order_acquire) !=
+        nixlDocaBckndReq::CompletionState::COMPLETE) {
         nixl_status_t status = checkXfer(handle);
         if (status == NIXL_IN_PROG) {
             return NIXL_ERR_BACKEND;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1286,6 +1286,9 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
     if (operation != NIXL_READ && operation != NIXL_WRITE) {
         return NIXL_ERR_INVALID_PARAM;
     }
+    if (treq->postStatus != NIXL_SUCCESS) {
+        return treq->postStatus;
+    }
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1289,6 +1289,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
+    treq->completed = false;
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
         const uint32_t completion_index =
@@ -1317,6 +1318,10 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
+    if (treq->completed) {
+        return treq->postStatus;
+    }
+
     for (size_t i = 0; i < treq->postedCount; ++i) {
         const uint32_t idx = treq->positions[i];
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
@@ -1332,6 +1337,7 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
+    treq->completed = true;
     return treq->postStatus;
 }
 
@@ -1346,9 +1352,11 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
         return NIXL_SUCCESS;
     }
 
-    nixl_status_t status = checkXfer(handle);
-    if (status == NIXL_IN_PROG) {
-        return NIXL_ERR_BACKEND;
+    if (!treq->completed) {
+        nixl_status_t status = checkXfer(handle);
+        if (status == NIXL_IN_PROG) {
+            return NIXL_ERR_BACKEND;
+        }
     }
 
     for (uint32_t idx : treq->positions) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1250,12 +1250,11 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
             (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
-        final_request.msg_sz = newMsg.size();
+        final_request.msg_sz = newMsg.size() + 1;
         final_request.lbuf_notif = notif_addr;
         final_request.lkey_notif = notif->send_mr->get_lkey();
 
-        memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
-        reinterpret_cast<char *>(notif_addr)[newMsg.size()] = '\0';
+        memcpy((void *)notif_addr, newMsg.c_str(), final_request.msg_sz);
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1342,9 +1342,7 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 
     auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
     if (treq->completionState.compare_exchange_strong(
-            expected,
-            nixlDocaBckndReq::CompletionState::COMPLETING,
-            std::memory_order_acq_rel)) {
+            expected, nixlDocaBckndReq::CompletionState::COMPLETING, std::memory_order_acq_rel)) {
         for (size_t i = 0; i < treq->postedCount; ++i) {
             const uint32_t idx = treq->positions[i];
             *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1210,8 +1210,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
             if (operation == NIXL_READ && staged_req.num > 0) {
                 const uint32_t prev = staged_req.num - 1;
                 constexpr size_t max_read_size = std::min<size_t>(
-                    std::numeric_limits<uint32_t>::max(),
-                    DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE);
+                    std::numeric_limits<uint32_t>::max(), DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE);
                 const bool size_fits = staged_req.size[prev] <= max_read_size &&
                     local[desc_idx].len <= max_read_size - staged_req.size[prev];
                 const bool local_adjacent = staged_req.lbuf[prev] <=

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -38,7 +38,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     int ret;
     union ibv_gid rgid;
 
-    for (auto &reserved : xferReqReserved) {
+    for (auto &reserved : xferReqReserved_) {
         reserved.store(false, std::memory_order_relaxed);
     }
 
@@ -1155,7 +1155,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     treq = new nixlDocaBckndReq;
     auto abandon_request = [&]() {
         for (uint32_t reserved_pos : treq->positions) {
-            xferReqReserved[reserved_pos].store(false, std::memory_order_release);
+            xferReqReserved_[reserved_pos].store(false, std::memory_order_release);
         }
         delete treq;
     };
@@ -1164,14 +1164,18 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
         treq->stream = post_stream[stream_id];
     } else {
-        treq->stream = (cudaStream_t) * ((uintptr_t *)opt_args->customParam.data());
+        if (opt_args->customParam.size() != sizeof(cudaStream_t)) {
+            abandon_request();
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        std::memcpy(&treq->stream, opt_args->customParam.data(), sizeof(treq->stream));
     }
 
     auto reserve_position = [&]() -> bool {
         for (uint32_t attempt = 0; attempt < DOCA_XFER_REQ_MAX; ++attempt) {
             const uint32_t candidate = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
             bool expected = false;
-            if (xferReqReserved[candidate].compare_exchange_strong(
+            if (xferReqReserved_[candidate].compare_exchange_strong(
                     expected, true, std::memory_order_acq_rel)) {
                 pos = candidate;
                 treq->positions.push_back(candidate);
@@ -1237,6 +1241,10 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         // Check notifMsg size
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
+        if (newMsg.size() >= notif->elems_size) {
+            abandon_request();
+            return NIXL_ERR_INVALID_PARAM;
+        }
 
         auto &final_request = xferReqRingCpu[final_pos];
         final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
@@ -1247,6 +1255,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
+        reinterpret_cast<char *>(notif_addr)[newMsg.size()] = '\0';
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
@@ -1275,24 +1284,33 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const nixl_opt_b_args_t *opt_args) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
-    for (uint32_t idx : treq->positions) {
-        xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
-        completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
-        completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
-
-        switch (operation) {
-        case NIXL_READ:
-            doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
-            break;
-        case NIXL_WRITE:
-            doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
-            break;
-        default:
-            return NIXL_ERR_INVALID_PARAM;
-        }
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
     }
 
-    return NIXL_IN_PROG;
+    treq->postedCount = 0;
+    treq->postStatus = NIXL_SUCCESS;
+    for (uint32_t idx : treq->positions) {
+        std::lock_guard<std::mutex> lock(postLock_);
+        const uint32_t completion_index =
+            lastPostedReq.load(std::memory_order_relaxed) & DOCA_MAX_COMPLETION_INFLIGHT_MASK;
+        xferReqRingCpu[idx].id = completion_index;
+        completion_list_cpu[completion_index].xferReqRingGpu = nullptr;
+        completion_list_cpu[completion_index].completed = 0;
+
+        const doca_error_t result = operation == NIXL_READ ?
+            doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx) :
+            doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
+        if (result != DOCA_SUCCESS) {
+            treq->postStatus = NIXL_ERR_BACKEND;
+            break;
+        }
+        completion_list_cpu[completion_index].xferReqRingGpu = xferReqRingGpu + idx;
+        lastPostedReq.fetch_add(1, std::memory_order_relaxed);
+        ++treq->postedCount;
+    }
+
+    return treq->postedCount == 0 ? treq->postStatus : NIXL_IN_PROG;
 }
 
 nixl_status_t
@@ -1300,7 +1318,8 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    for (uint32_t idx : treq->positions) {
+    for (size_t i = 0; i < treq->postedCount; ++i) {
+        const uint32_t idx = treq->positions[i];
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
 
         if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed != 1) {
@@ -1308,27 +1327,36 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    for (uint32_t idx : treq->positions) {
+    for (size_t i = 0; i < treq->postedCount; ++i) {
+        const uint32_t idx = treq->positions[i];
         *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
         NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
-    return NIXL_SUCCESS;
+    return treq->postStatus;
 }
 
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
-    nixl_status_t status = checkXfer(handle);
-    if (status == NIXL_IN_PROG) {
-        return status;
+    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    if (treq->postedCount == 0) {
+        for (uint32_t idx : treq->positions) {
+            xferReqReserved_[idx].store(false, std::memory_order_release);
+        }
+        delete treq;
+        return NIXL_SUCCESS;
     }
 
-    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    nixl_status_t status = checkXfer(handle);
+    if (status == NIXL_IN_PROG) {
+        return NIXL_ERR_BACKEND;
+    }
+
     for (uint32_t idx : treq->positions) {
-        xferReqReserved[idx].store(false, std::memory_order_release);
+        xferReqReserved_[idx].store(false, std::memory_order_release);
     }
     delete treq;
-    return status;
+    return NIXL_SUCCESS;
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -17,6 +17,7 @@
 
 #include "gpunetio_backend.h"
 #include "serdes/serdes.h"
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cassert>
 #include <limits>
@@ -1208,7 +1209,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
             if (operation == NIXL_READ && staged_req.num > 0) {
                 const uint32_t prev = staged_req.num - 1;
-                constexpr size_t max_read_size = std::numeric_limits<uint32_t>::max();
+                constexpr size_t max_read_size = std::min<size_t>(
+                    std::numeric_limits<uint32_t>::max(),
+                    DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE);
                 const bool size_fits = staged_req.size[prev] <= max_read_size &&
                     local[desc_idx].len <= max_read_size - staged_req.size[prev];
                 const bool local_adjacent = staged_req.lbuf[prev] <=

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1292,7 +1292,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
-    treq->completionState.store(nixlDocaBckndReq::CompletionState::IN_PROGRESS,
+    treq->completionState.store(nixlDocaBckndReq::completion_state::IN_PROGRESS,
                                 std::memory_order_release);
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
@@ -1323,10 +1323,10 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     uint32_t completion_index;
 
     auto state = treq->completionState.load(std::memory_order_acquire);
-    if (state == nixlDocaBckndReq::CompletionState::COMPLETE) {
+    if (state == nixlDocaBckndReq::completion_state::COMPLETE) {
         return treq->postStatus;
     }
-    if (state == nixlDocaBckndReq::CompletionState::COMPLETING) {
+    if (state == nixlDocaBckndReq::completion_state::COMPLETING) {
         treq->completionState.wait(state, std::memory_order_acquire);
         return treq->postStatus;
     }
@@ -1340,22 +1340,35 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
-    if (treq->completionState.compare_exchange_strong(
-            expected, nixlDocaBckndReq::CompletionState::COMPLETING, std::memory_order_acq_rel)) {
-        for (size_t i = 0; i < treq->postedCount; ++i) {
-            const uint32_t idx = treq->positions[i];
-            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-            NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
-        }
-        treq->completionState.store(nixlDocaBckndReq::CompletionState::COMPLETE,
-                                    std::memory_order_release);
-        treq->completionState.notify_all();
-    } else if (expected == nixlDocaBckndReq::CompletionState::COMPLETING) {
-        treq->completionState.wait(expected, std::memory_order_acquire);
+    retireRequest(treq);
+    return treq->postStatus;
+}
+
+void
+nixlDocaEngine::retireRequest(nixlDocaBckndReq *request) const {
+    auto state = request->completionState.load(std::memory_order_acquire);
+    if (state == nixlDocaBckndReq::completion_state::COMPLETE) {
+        return;
+    }
+    if (state == nixlDocaBckndReq::completion_state::COMPLETING) {
+        request->completionState.wait(state, std::memory_order_acquire);
+        return;
     }
 
-    return treq->postStatus;
+    auto expected = nixlDocaBckndReq::completion_state::IN_PROGRESS;
+    if (request->completionState.compare_exchange_strong(
+            expected, nixlDocaBckndReq::completion_state::COMPLETING, std::memory_order_acq_rel)) {
+        for (size_t i = 0; i < request->postedCount; ++i) {
+            const uint32_t idx = request->positions[i];
+            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+            NIXL_INFO << "DOCA retireRequest pos " << idx << " COMPLETED!";
+        }
+        request->completionState.store(nixlDocaBckndReq::completion_state::COMPLETE,
+                                       std::memory_order_release);
+        request->completionState.notify_all();
+    } else if (expected == nixlDocaBckndReq::completion_state::COMPLETING) {
+        request->completionState.wait(expected, std::memory_order_acquire);
+    }
 }
 
 nixl_status_t
@@ -1370,7 +1383,7 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
     }
 
     if (treq->completionState.load(std::memory_order_acquire) !=
-        nixlDocaBckndReq::CompletionState::COMPLETE) {
+        nixlDocaBckndReq::completion_state::COMPLETE) {
         nixl_status_t status = checkXfer(handle);
         if (status == NIXL_IN_PROG) {
             return NIXL_ERR_BACKEND;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -19,6 +19,7 @@
 #include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <limits>
 #include <stdexcept>
 #include <unistd.h>
 #include "common/nixl_log.h"
@@ -1197,13 +1198,34 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         docaXferReqGpu staged_req{};
         staged_req.has_notif_msg_idx = DOCA_NOTIF_NULL;
 
-        while (desc_offset < lcnt && staged_req.num < DOCA_XFER_REQ_SIZE) {
-            const uint32_t idx = staged_req.num;
+        uint32_t chunk_desc_count = 0;
+        while (desc_offset < lcnt && chunk_desc_count < DOCA_XFER_REQ_SIZE) {
             const uint32_t desc_idx = desc_offset++;
+            ++chunk_desc_count;
 
             lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
 
+            if (operation == NIXL_READ && staged_req.num > 0) {
+                const uint32_t prev = staged_req.num - 1;
+                constexpr size_t max_read_size = std::numeric_limits<uint32_t>::max();
+                const bool size_fits = staged_req.size[prev] <= max_read_size &&
+                    local[desc_idx].len <= max_read_size - staged_req.size[prev];
+                const bool local_adjacent = staged_req.lbuf[prev] <=
+                        std::numeric_limits<uintptr_t>::max() - staged_req.size[prev] &&
+                    staged_req.lbuf[prev] + staged_req.size[prev] == local[desc_idx].addr;
+                const bool remote_adjacent = staged_req.rbuf[prev] <=
+                        std::numeric_limits<uintptr_t>::max() - staged_req.size[prev] &&
+                    staged_req.rbuf[prev] + staged_req.size[prev] == remote[desc_idx].addr;
+                if (size_fits && local_adjacent && remote_adjacent &&
+                    staged_req.lkey[prev] == lmd->mr->get_lkey() &&
+                    staged_req.rkey[prev] == rmd->mr->get_rkey()) {
+                    staged_req.size[prev] += local[desc_idx].len;
+                    continue;
+                }
+            }
+
+            const uint32_t idx = staged_req.num;
             staged_req.lbuf[idx] = local[desc_idx].addr;
             staged_req.lkey[idx] = lmd->mr->get_lkey();
             staged_req.rbuf[idx] = remote[desc_idx].addr;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -38,6 +38,10 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     int ret;
     union ibv_gid rgid;
 
+    for (auto &reserved : xferReqReserved) {
+        reserved.store(false, std::memory_order_relaxed);
+    }
+
     result = doca_log_backend_create_standard();
     if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
 
@@ -1106,20 +1110,38 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    nixlDocaBckndReq *treq;
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
-    uint32_t lcnt = (uint32_t)local.descCount();
-    uint32_t rcnt = (uint32_t)remote.descCount();
-    uint32_t stream_id;
+    const uint32_t lcnt = (uint32_t)local.descCount();
+    const uint32_t rcnt = (uint32_t)remote.descCount();
+    uint32_t stream_id = DOCA_POST_STREAM_NUM;
     struct nixlDocaRdmaQp *rdma_qp;
     uintptr_t notif_addr;
+
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (lcnt != rcnt || lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if ((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE > DOCA_XFER_REQ_MAX) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    for (uint32_t idx = 0; idx < lcnt; idx++) {
+        if (local[idx].len != remote[idx].len) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
 
     // TODO: check device id from local dlist mr that should be all the same and same of
     // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-        if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
+        if (lmd->devId != gdevs[0].first) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
 
     auto search = qpMap.find(remote_agent);
@@ -1130,52 +1152,75 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
+    treq = new nixlDocaBckndReq;
+    auto abandon_request = [&]() {
+        for (uint32_t reserved_pos : treq->positions) {
+            xferReqReserved[reserved_pos].store(false, std::memory_order_release);
+        }
+        delete treq;
+    };
 
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
-
-    if (opt_args->customParam.empty()) {
+    if (opt_args == nullptr || opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
         treq->stream = post_stream[stream_id];
     } else {
         treq->stream = (cudaStream_t) * ((uintptr_t *)opt_args->customParam.data());
     }
 
-    treq->start_pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-    pos = treq->start_pos;
+    auto reserve_position = [&]() -> bool {
+        for (uint32_t attempt = 0; attempt < DOCA_XFER_REQ_MAX; ++attempt) {
+            const uint32_t candidate = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
+            bool expected = false;
+            if (xferReqReserved[candidate].compare_exchange_strong(
+                    expected, true, std::memory_order_acq_rel)) {
+                pos = candidate;
+                treq->positions.push_back(candidate);
+                return true;
+            }
+        }
+        NIXL_ERROR << "GPUNETIO transfer ring exhausted";
+        return false;
+    };
 
+    treq->positions.reserve((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE);
+    if (!reserve_position()) {
+        abandon_request();
+        return NIXL_ERR_BACKEND;
+    }
+
+    uint32_t desc_offset = 0;
     do {
-        for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
-            size_t lsize = local[idx].len;
-            size_t rsize = remote[idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
+        docaXferReqGpu staged_req{};
+        staged_req.has_notif_msg_idx = DOCA_NOTIF_NULL;
 
-            lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-            rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
+        while (desc_offset < lcnt && staged_req.num < DOCA_XFER_REQ_SIZE) {
+            const uint32_t idx = staged_req.num;
+            const uint32_t desc_idx = desc_offset++;
 
-            xferReqRingCpu[pos].lbuf[idx] = (uintptr_t)lmd->mr->get_addr();
-            xferReqRingCpu[pos].lkey[idx] = (uintptr_t)lmd->mr->get_lkey();
-            xferReqRingCpu[pos].rbuf[idx] = (uintptr_t)rmd->mr->get_addr();
-            xferReqRingCpu[pos].rkey[idx] = (uintptr_t)rmd->mr->get_rkey();
-            xferReqRingCpu[pos].size[idx] = lsize;
-            xferReqRingCpu[pos].num++;
+            lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
+            rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
+
+            staged_req.lbuf[idx] = local[desc_idx].addr;
+            staged_req.lkey[idx] = lmd->mr->get_lkey();
+            staged_req.rbuf[idx] = remote[desc_idx].addr;
+            staged_req.rkey[idx] = rmd->mr->get_rkey();
+            staged_req.size[idx] = local[desc_idx].len;
+            staged_req.num++;
         }
 
-        xferReqRingCpu[pos].last_rsvd = last_rsvd_flags;
-        xferReqRingCpu[pos].last_posted = last_posted_flags;
+        staged_req.last_rsvd = last_rsvd_flags;
+        staged_req.last_posted = last_posted_flags;
+        staged_req.qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
+        staged_req.qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
+        memcpy(&xferReqRingCpu[pos], &staged_req, sizeof(staged_req));
 
-        xferReqRingCpu[pos].qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
-        xferReqRingCpu[pos].qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
-
-        if (lcnt > DOCA_XFER_REQ_SIZE) {
-            lcnt -= DOCA_XFER_REQ_SIZE;
-            pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-        } else {
-            lcnt = 0;
+        if (desc_offset < lcnt && !reserve_position()) {
+            abandon_request();
+            return NIXL_ERR_BACKEND;
         }
-    } while (lcnt > 0);
+    } while (desc_offset < lcnt);
 
-    treq->end_pos = xferRingPos;
+    const uint32_t final_pos = treq->positions.back();
 
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
@@ -1183,6 +1228,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         auto search = notifMap.find(remote_agent);
         if (search == notifMap.end()) {
             NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+            abandon_request();
             return NIXL_ERR_INVALID_PARAM;
         }
 
@@ -1192,27 +1238,26 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
 
+        auto &final_request = xferReqRingCpu[final_pos];
+        final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
-            (uintptr_t)(notif->send_addr +
-                        (xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx * notif->elems_size));
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx =
-            (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
-        xferReqRingCpu[treq->end_pos - 1].msg_sz = newMsg.size();
-        xferReqRingCpu[treq->end_pos - 1].lbuf_notif = notif_addr;
-        xferReqRingCpu[treq->end_pos - 1].lkey_notif = notif->send_mr->get_lkey();
+            (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
+        final_request.msg_sz = newMsg.size();
+        final_request.lbuf_notif = notif_addr;
+        final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
-                  << xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx << " msg " << newMsg
-                  << " to " << remote_agent;
+                  << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
 
     } else {
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx = DOCA_NOTIF_NULL;
+        xferReqRingCpu[final_pos].has_notif_msg_idx = DOCA_NOTIF_NULL;
     }
 
-    NIXL_INFO << "DOCA REQUEST from " << treq->start_pos << " to " << treq->end_pos - 1
-              << " stream " << stream_id << std::endl;
+    NIXL_INFO << "DOCA REQUEST with " << treq->positions.size() << " ring positions, first "
+              << treq->positions.front() << ", last " << final_pos << ", stream " << stream_id
+              << std::endl;
 
     treq->backendHandleGpu = 0;
 
@@ -1230,7 +1275,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const nixl_opt_b_args_t *opt_args) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
         completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
         completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
@@ -1255,16 +1300,17 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
 
-        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed == 1) {
-            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-            NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
-                      << " COMPLETED!\n";
-            return NIXL_SUCCESS;
-        } else
+        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed != 1) {
             return NIXL_IN_PROG;
+        }
+    }
+
+    for (uint32_t idx : treq->positions) {
+        *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+        NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
     return NIXL_SUCCESS;
@@ -1272,11 +1318,17 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
-    uint32_t tmp = xferRingPos.load() & (DOCA_XFER_REQ_MAX - 1);
-    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0)
-        return NIXL_SUCCESS;
-    else
-        return NIXL_IN_PROG;
+    nixl_status_t status = checkXfer(handle);
+    if (status == NIXL_IN_PROG) {
+        return status;
+    }
+
+    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    for (uint32_t idx : treq->positions) {
+        xferReqReserved[idx].store(false, std::memory_order_release);
+    }
+    delete treq;
+    return status;
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -192,13 +192,15 @@ private:
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:
     public:
+        enum class CompletionState : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
+
         cudaStream_t stream;
         uint32_t devId;
         std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
-        bool completed = false;
+        std::atomic<CompletionState> completionState{CompletionState::IN_PROGRESS};
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -198,6 +198,7 @@ private:
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
+        bool completed = false;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,6 +166,7 @@ private:
     struct docaXferReqGpu *xferReqRingGpu;
     struct docaXferReqGpu *xferReqRingCpu;
     mutable std::atomic<uint32_t> xferRingPos;
+    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved;
 
     struct docaXferCompletion *completion_list_gpu;
     struct docaXferCompletion *completion_list_cpu;
@@ -192,8 +193,7 @@ private:
     public:
         cudaStream_t stream;
         uint32_t devId;
-        uint32_t start_pos;
-        uint32_t end_pos;
+        std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -192,7 +192,7 @@ private:
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:
     public:
-        enum class CompletionState : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
+        enum class completion_state : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
 
         cudaStream_t stream;
         uint32_t devId;
@@ -200,12 +200,15 @@ private:
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
-        std::atomic<CompletionState> completionState{CompletionState::IN_PROGRESS};
+        std::atomic<completion_state> completionState{completion_state::IN_PROGRESS};
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 
         ~nixlDocaBckndReq() {}
     };
+
+    void
+    retireRequest(nixlDocaBckndReq *request) const;
 
     nixl_status_t
     progressThreadStart();

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -162,11 +162,12 @@ private:
     cudaStream_t wait_stream;
     mutable std::atomic<uint32_t> xferStream;
     mutable std::atomic<uint32_t> lastPostedReq;
+    mutable std::mutex postLock_;
 
     struct docaXferReqGpu *xferReqRingGpu;
     struct docaXferReqGpu *xferReqRingCpu;
     mutable std::atomic<uint32_t> xferRingPos;
-    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved;
+    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved_;
 
     struct docaXferCompletion *completion_list_gpu;
     struct docaXferCompletion *completion_list_cpu;
@@ -195,6 +196,8 @@ private:
         uint32_t devId;
         std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
+        size_t postedCount = 0;
+        nixl_status_t postStatus = NIXL_SUCCESS;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -18,6 +18,7 @@
 #ifndef GPUNETIO_BACKEND_AUX_H
 #define GPUNETIO_BACKEND_AUX_H
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/gpunetio/gpunetio_coalescing.h
+++ b/src/plugins/gpunetio/gpunetio_coalescing.h
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GPUNETIO_COALESCING_H
+#define GPUNETIO_COALESCING_H
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace nixl::gpunetio {
+
+struct ReadSegment {
+    uintptr_t local_addr;
+    uintptr_t remote_addr;
+    size_t size;
+    uint32_t local_key;
+    uint32_t remote_key;
+};
+
+inline bool
+canCoalesceRead(const ReadSegment &current, const ReadSegment &next, size_t max_size) {
+    if (current.size > max_size || next.size > max_size - current.size) {
+        return false;
+    }
+    if (current.local_addr > std::numeric_limits<uintptr_t>::max() - current.size) {
+        return false;
+    }
+    if (current.remote_addr > std::numeric_limits<uintptr_t>::max() - current.size) {
+        return false;
+    }
+
+    return current.local_addr + current.size == next.local_addr &&
+        current.remote_addr + current.size == next.remote_addr &&
+        current.local_key == next.local_key && current.remote_key == next.remote_key;
+}
+
+} // namespace nixl::gpunetio
+
+#endif /* GPUNETIO_COALESCING_H */

--- a/src/plugins/gpunetio/gpunetio_coalescing.h
+++ b/src/plugins/gpunetio/gpunetio_coalescing.h
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef GPUNETIO_COALESCING_H
-#define GPUNETIO_COALESCING_H
+#ifndef NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COALESCING_H
+#define NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COALESCING_H
 
 #include <cstddef>
 #include <cstdint>
@@ -12,6 +12,7 @@
 
 namespace nixl::gpunetio {
 
+/** @brief Address, length, and keys for one prepared READ segment. */
 struct ReadSegment {
     uintptr_t local_addr;
     uintptr_t remote_addr;
@@ -20,6 +21,13 @@ struct ReadSegment {
     uint32_t remote_key;
 };
 
+/**
+ * @brief Test whether two READ segments form one safe contiguous WQE.
+ * @param current Existing prepared segment.
+ * @param next Input segment considered for merging.
+ * @param max_size Maximum merged byte count.
+ * @return true only when ranges and keys match without size or address overflow.
+ */
 inline bool
 canCoalesceRead(const ReadSegment &current, const ReadSegment &next, size_t max_size) {
     if (current.size > max_size || next.size > max_size - current.size) {
@@ -39,4 +47,4 @@ canCoalesceRead(const ReadSegment &current, const ReadSegment &next, size_t max_
 
 } // namespace nixl::gpunetio
 
-#endif /* GPUNETIO_COALESCING_H */
+#endif /* NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_COALESCING_H */

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -433,6 +433,45 @@ namespace agent {
         EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
     }
 
+    TEST_F(dualAgentBridgeFixture, FailedActiveReleaseKeepsRequestPollable) {
+        DualAgentSetup s(DRAM_SEG);
+        setupDualAgent(s);
+
+        nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG), remote_xfer_dlist(DRAM_SEG);
+        local_xfer_dlist.addDesc(s.local_blob.getDesc());
+        remote_xfer_dlist.addDesc(s.remote_blob.getDesc());
+
+        nixlBackendReqH backend_request;
+        auto &engine = local_agent_helper_->getGMockEngine();
+        EXPECT_CALL(engine, prepXfer)
+            .WillOnce([&](const auto &,
+                          const auto &,
+                          const auto &,
+                          const auto &,
+                          nixlBackendReqH *&request,
+                          const auto *) {
+                request = &backend_request;
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(engine, postXfer).WillOnce(testing::Return(NIXL_IN_PROG));
+        EXPECT_CALL(engine, checkXfer)
+            .WillOnce(testing::Return(NIXL_IN_PROG))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+        EXPECT_CALL(engine, releaseReqH)
+            .WillOnce(testing::Return(NIXL_ERR_BACKEND))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+
+        nixlXferReqH *xfer_req;
+        EXPECT_EQ(
+            local_agent_->createXferReq(
+                NIXL_WRITE, local_xfer_dlist, remote_xfer_dlist, s.remote_agent_name, xfer_req),
+            NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_IN_PROG);
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_ERR_REPOST_ACTIVE);
+        EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
+    }
+
     TEST_F(dualAgentBridgeFixture, PrepMemViewRemoteDRAM) {
         DualAgentSetup s(DRAM_SEG);
         setupDualAgent(s, /*register_local=*/false);

--- a/test/unit/plugins/gpunetio/gpunetio_coalescing_test.cpp
+++ b/test/unit/plugins/gpunetio/gpunetio_coalescing_test.cpp
@@ -5,7 +5,9 @@
 
 #include "gpunetio_coalescing.h"
 
+#include <cstdint>
 #include <iostream>
+#include <limits>
 
 using nixl::gpunetio::ReadSegment;
 using nixl::gpunetio::canCoalesceRead;

--- a/test/unit/plugins/gpunetio/gpunetio_coalescing_test.cpp
+++ b/test/unit/plugins/gpunetio/gpunetio_coalescing_test.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_coalescing.h"
+
+#include <iostream>
+
+using nixl::gpunetio::ReadSegment;
+using nixl::gpunetio::canCoalesceRead;
+
+int
+main() {
+    constexpr size_t page = 4096;
+    const ReadSegment current{0x10000, 0x20000, page, 11, 22};
+    const ReadSegment adjacent{0x11000, 0x21000, page, 11, 22};
+
+    auto require = [](bool condition, const char *message) {
+        if (!condition) {
+            std::cerr << message << std::endl;
+        }
+        return condition;
+    };
+
+    bool passed = true;
+    passed &= require(canCoalesceRead(current, adjacent, 2 * page), "adjacent run rejected");
+    passed &=
+        require(!canCoalesceRead(current, ReadSegment{0x12000, 0x21000, page, 11, 22}, 2 * page),
+                "local gap accepted");
+    passed &=
+        require(!canCoalesceRead(current, ReadSegment{0x11000, 0x22000, page, 11, 22}, 2 * page),
+                "remote gap accepted");
+    passed &=
+        require(!canCoalesceRead(current, ReadSegment{0x11000, 0x21000, page, 12, 22}, 2 * page),
+                "local key boundary accepted");
+    passed &=
+        require(!canCoalesceRead(current, ReadSegment{0x11000, 0x21000, page, 11, 23}, 2 * page),
+                "remote key boundary accepted");
+    passed &= require(!canCoalesceRead(current, adjacent, 2 * page - 1), "length limit exceeded");
+    passed &= require(
+        !canCoalesceRead(
+            ReadSegment{std::numeric_limits<uintptr_t>::max() - 1024, 0x20000, page, 11, 22},
+            adjacent,
+            2 * page),
+        "address overflow accepted");
+
+    return passed ? 0 : 1;
+}

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,12 @@
 # limitations under the License.
 
 compile_flags = []
+
+coalescing_test = executable(
+    'gpunetio_coalescing_test',
+    'gpunetio_coalescing_test.cpp',
+    include_directories: include_directories('../../../../src/plugins/gpunetio'))
+test('gpunetio_coalescing_test', coalescing_test)
 
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -18,7 +18,8 @@ compile_flags = []
 coalescing_test = executable(
     'gpunetio_coalescing_test',
     'gpunetio_coalescing_test.cpp',
-    include_directories: include_directories('../../../../src/plugins/gpunetio'))
+    include_directories: include_directories('../../../../src/plugins/gpunetio'),
+    install: true)
 test('gpunetio_coalescing_test', coalescing_test)
 
 if cuda_dep.found()


### PR DESCRIPTION
## Dependency and claim boundary

Depends on #2176. This is a READ-only component optimization; it makes no serving or end-to-end claim.

The H20 reproduction applied #2052 compatibility and #2173 NIXLBench option wiring identically to the #2176 baseline and #2188 candidate. Those test dependencies are not part of this diff.

## What

Allow one mergeable GPUNETIO READ run to continue across the existing 512-input-descriptor staging boundary. Segments merge only when:

- local and remote ranges are adjacent;
- local and remote keys match;
- address arithmetic is safe; and
- merged length stays within the selected 8 MiB cap.

At the first nonmergeable segment after a boundary, the current ring entry closes without consuming that segment. The next entry therefore preserves fragmented fallback. WRITE retains its original 512-input boundary. Kernels, CQ policy, completion tracking, and notifications are unchanged.

## Why

#2176 reduces the public contiguous 4,096 × 4 KiB shape from 4,096 WQEs to eight 2 MiB WQEs, but the input staging boundary still forces eight ring entries and completions. This patch represents the same contiguous run as two 8 MiB WQEs/ring entries.

The 8 MiB cap is an empirical knee below the DOCA transfer-size and 32-bit byte-count limits; it is not presented as an API maximum.

## Current stack

```text
base:      c7f554c3 (#2176)
candidate: 82566db1
code:      2c1d5052
```

The cross-chunk code patch is byte-identical to the measured candidate. The final parent restack adds #2175 atomic completion-retirement serialization; measured runs had no concurrent status polling.

## Current-head revalidation

Configuration:

- pairwise VRAM-to-VRAM READ;
- 4,096 descriptors × 4,096 bytes;
- 64 MiB buffer, one QP;
- nonrandom contiguous offsets;
- 20 warmups + 100 measured operations;
- consistency checking enabled;
- two fresh process pairs for the candidate.

| Arm | Run | Throughput (GB/s) | Transfer p99 (us) |
|---|---:|---:|---:|
| #2176 baseline | prior two-run median | 18.505619 | 893 |
| #2188 candidate | R1 | 21.949077 | 761 |
| #2188 candidate | R2 | 22.008390 | 761 |
| #2188 candidate | median | 21.978733 | 761 |

Results:

- throughput: **18.505619 → 21.978733 GB/s**, **+18.768%**;
- transfer p99: **893 → 761 us**, **−14.782%**;
- normalized max-min throughput noise: #2176 **0.780%**, #2188 **0.270%**;
- effect / maximum noise: **24.07×**.

Both candidate runs completed 100 measured operations with consistency enabled and no CQE, retry, timeout, corruption, or segmentation error. Installs on both endpoints matched byte-for-byte.

The actual 513/1,024/4,096 unique-pattern, guard-region, repeated-request, fragmented-boundary, key-boundary, and ring-position tests passed on the unchanged code patch before restacking. Current-head validation reran the public 4,096 shape; the helper predicate test also passes with warnings as errors.

## Reproduce performance

Build the public heads above, applying #2052 compatibility and #2173 NIXLBench wiring identically when explicit GID/OOB selection is required. Run this block on two endpoints with endpoint-local device variables and one shared unique `BENCHMARK_GROUP`; repeat twice.

```bash
export NIXL_REPO='<PUBLIC_NIXL_CHECKOUT>'
export NIXLBENCH="$NIXL_REPO/build/benchmark/nixlbench/nixlbench"
export NIXL_PREFIX='<NIXL_INSTALL_PREFIX>'
export ETCD_ENDPOINT='<ETCD_ENDPOINT>'
export BENCHMARK_GROUP='<UNIQUE_GROUP_SHARED_BY_BOTH_ENDPOINTS>'
export GPUNETIO_DEVICE='<ROCE_DEVICE_VISIBLE_TO_THIS_ENDPOINT>'
export OOB_INTERFACE='<OOB_INTERFACE_VISIBLE_TO_THIS_ENDPOINT>'
export OOB_PORT='<OOB_PORT>'
export GID_INDEX='<ROCE_GID_INDEX>'

export LD_LIBRARY_PATH="$NIXL_PREFIX/lib/x86_64-linux-gnu:/opt/mellanox/doca/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
export NIXL_PLUGIN_DIR="$NIXL_PREFIX/lib/x86_64-linux-gnu/plugins"
export NIXL_LOG_LEVEL=WARN

git -C "$NIXL_REPO" rev-parse HEAD

"$NIXLBENCH" \
  --benchmark_group="$BENCHMARK_GROUP" \
  --runtime_type=ETCD \
  --etcd_endpoints="$ETCD_ENDPOINT" \
  --worker_type=nixl \
  --backend=GPUNETIO \
  --device_list="$GPUNETIO_DEVICE" \
  --gpunetio_oob_list="$OOB_INTERFACE" \
  --gpunetio_oob_port="$OOB_PORT" \
  --gpunetio_gid_index="$GID_INDEX" \
  --gpunetio_device_list=0 \
  --initiator_seg_type=VRAM \
  --target_seg_type=VRAM \
  --op_type=READ \
  --scheme=pairwise \
  --mode=SG \
  --num_threads=1 \
  --num_initiator_dev=1 \
  --num_target_dev=1 \
  --total_buffer_size=67108864 \
  --start_block_size=4096 \
  --max_block_size=4096 \
  --start_batch_size=4096 \
  --max_batch_size=4096 \
  --pipeline_depth=1 \
  --num_iter=100 \
  --warmup_iter=20 \
  --large_blk_iter_ftr=1 \
  --check_consistency=true 2>&1 | tee "gpunetio-read-${BENCHMARK_GROUP}.log"
```

Public NIXLBench constructs this nonrandomized descriptor list at `j * block_size` in `benchmark/nixlbench/src/main.cpp`. Its output reports the effective configuration, operation count, throughput, transfer p99, and consistency/runtime errors.

## Scope and risks

- Gain applies to long contiguous same-key READ runs; fragmented or multi-key inputs use the existing fallback.
- The 8 MiB cap is specific to this measured shape and can be revisited independently.
- Fewer ring entries couple WQE and completion-count reduction under the unchanged completion policy.
- WRITE, multi-QP, CQ policy, completion scheduling, and application integration are out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable GPUNetIO read sizing and improved support for coalesced transfers.
  - Added handling for multiple transfer reservations, partial completions, and enhanced notifications.
  - Added validation for transfer operations, descriptors, device IDs, request capacity, and notification sizes.

- **Bug Fixes**
  - Improved cleanup and status reporting when transfers or releases fail.
  - Active requests remain available for status checks after a failed release attempt.

- **Tests**
  - Added coverage for release recovery and GPUNetIO read coalescing validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



