### PR TITLE
CONTRIB: pin spcx-plugin to v0.3.x branch

### DIFF
--- a/.ci/docs/build-wheel-matrix-ci.md
+++ b/.ci/docs/build-wheel-matrix-ci.md
@@ -134,7 +134,7 @@ The nightly job (`nixl-ci-build-wheel-nightly`) omits `--wheel-base-image`, so i
 | `NIXL_SPCX_PLUGIN_REPO_URL` | Git URL of the plugin repo | `ucx-plugin-gitlab-url` | Secret text |
 | `NIXL_GITLAB_TOKEN` | GitLab token (`read_repository` scope) used via a git credential helper so it never appears in URLs, argv, or git error output | `svc-nixl-gitlab-token` | Username/Password (token in password field) |
 
-The plugin ref defaults to `v0.2.x` and is selectable with `--ucx-spcx-plugin-ref`. The plugin build flag, `--build-ucx-spcx-plugin`, is not enabled in the PR CI pipeline — `nixl-ci-build-container-pr` never passes it, so the `ARG` default of `false` applies. It is enabled by default in the standalone `nixl-ci-build-container` verification job (`BUILD_UCX_SPCX_PLUGIN`, uncheck to disable) and in the QA/release invocations of `build-container.sh`, all of which bind both credentials into the environment.
+The plugin ref defaults to `v0.3.x` and is selectable with `--ucx-spcx-plugin-ref`. The plugin build flag, `--build-ucx-spcx-plugin`, is not enabled in the PR CI pipeline - `nixl-ci-build-container-pr` never passes it, so the `ARG` default of `false` applies. It is enabled by default in the standalone `nixl-ci-build-container` verification job (`BUILD_UCX_SPCX_PLUGIN`, uncheck to disable) and in the QA/release invocations of `build-container.sh`, all of which bind both credentials into the environment.
 
 ### Key Dependencies Installed
 

--- a/contrib/build-container.sh
+++ b/contrib/build-container.sh
@@ -58,7 +58,7 @@ BUILD_INFINIA="false"
 INFINIA_LIBS_IMAGE="harbor.mellanox.com/nixl/infinia-libs:v2.4.0-beta.1"
 APT_MIRROR=""
 BUILD_UCX_SPCX_PLUGIN="false"
-UCX_SPCX_PLUGIN_REF="v0.2.x"
+UCX_SPCX_PLUGIN_REF="v0.3.x"
 BUILD_OPTIONS_FILE=""
 
 get_options() {


### PR DESCRIPTION
## Summary

Pin the default UCX Spectrum-X plugin source ref to v0.3.x.
Keep the CI documentation aligned with the new default.

## Rationale

NIXL container workflows that opt into the plugin should use the v0.3.x maintenance line rather than v0.2.x.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the documented default UCX SPCX external plugin reference from `v0.2.x` to `v0.3.x`.

- **Chores**
  - Updated container build configuration to use the UCX SPCX plugin version `v0.3.x` by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->