### PR TITLE
bindings/python: add nixl_rocm to meta-wheel backend dispatcher

### DIFF
--- a/src/bindings/python/nixl-meta/nixl/__init__.py
+++ b/src/bindings/python/nixl-meta/nixl/__init__.py
@@ -34,7 +34,7 @@ def _load_cuda_backend() -> str:
                 f"detected CUDA {cuda_major} but {pip_name} is not installed"
             ) from e
     # No CUDA stack detected — use whatever backend is installed.
-    for mod_name in ("nixl_cu13", "nixl_cu12"):
+    for mod_name in ("nixl_cu13", "nixl_cu12", "nixl_rocm"):
         try:
             return importlib.import_module(mod_name).__name__
         except ModuleNotFoundError as e:
@@ -42,7 +42,7 @@ def _load_cuda_backend() -> str:
                 # Re-raise if the error is not about the module we're trying to import
                 raise
             continue
-    raise ImportError("No NIXL CUDA backend found")
+    raise ImportError("No NIXL backend found (tried nixl_cu13, nixl_cu12, nixl_rocm)")
 
 
 _pkg = sys.modules[_load_cuda_backend()]

--- a/src/bindings/python/nixl-meta/nixl/_api.py
+++ b/src/bindings/python/nixl-meta/nixl/_api.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 # This file is a type stub for static analysis tools (pyright, mypy, IDEs).
-# At runtime it is shadowed by the actual nixl_cu12._api or nixl_cu13._api
-# module, which __init__.py injects into sys.modules["nixl._api"].
+# At runtime it is shadowed by the actual nixl_cu12._api, nixl_cu13._api, or
+# nixl_rocm._api module, which __init__.py injects into sys.modules["nixl._api"].
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -30,12 +30,23 @@ if TYPE_CHECKING:
             nixl_xfer_handle,
         )
     except ImportError:
-        from nixl_cu12._api import (  # type: ignore[import]  # noqa: F401
-            DEFAULT_COMM_PORT,
-            nixl_agent,
-            nixl_agent_config,
-            nixl_backend_handle,
-            nixl_prepped_dlist_handle,
-            nixl_thread_sync_t,
-            nixl_xfer_handle,
-        )
+        try:
+            from nixl_cu12._api import (  # type: ignore[import]  # noqa: F401
+                DEFAULT_COMM_PORT,
+                nixl_agent,
+                nixl_agent_config,
+                nixl_backend_handle,
+                nixl_prepped_dlist_handle,
+                nixl_thread_sync_t,
+                nixl_xfer_handle,
+            )
+        except ImportError:
+            from nixl_rocm._api import (  # type: ignore[import]  # noqa: F401
+                DEFAULT_COMM_PORT,
+                nixl_agent,
+                nixl_agent_config,
+                nixl_backend_handle,
+                nixl_prepped_dlist_handle,
+                nixl_thread_sync_t,
+                nixl_xfer_handle,
+            )


### PR DESCRIPTION
## What?
The meta-wheel dispatcher in nixl/__init__.py only tried nixl_cu13 and nixl_cu12 as fallback backends when no CUDA stack was detected, making `import nixl` silently broken on ROCm systems even with nixl_rocm installed.

Add nixl_rocm to the fallback list and update the type stub in _api.py to match.

Note: this only enables using `import nixl` for ROCm devices for local compilations, it does not fix that `pip install nixl` does not pull a rocm wheel variant. That change will require further work.

## Why?
primary justification is to make the python test work for the ROCm CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added automatic ROCm backend discovery when CUDA backends are unavailable.
  - Improved fallback error messages to accurately list all supported backend attempts.
  - Preserved reporting of unrelated import errors.
- **Documentation**
  - Updated runtime and type-checking documentation to include ROCm support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->