### PR TITLE
Forward memtype to UCX

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -641,6 +641,43 @@ nixlUcxWorker::connect(void *addr) {
  * Memory management
  * =========================================== */
 
+namespace {
+
+[[nodiscard]] ucs_memory_type_t
+toUcsMemoryType(ucp_context_h ctx, nixl_mem_t nixl_mem_type) noexcept {
+    switch (nixl_mem_type) {
+    case DRAM_SEG:
+        return UCS_MEMORY_TYPE_HOST;
+
+    case VRAM_SEG: {
+        ucp_context_attr_t attr = {
+            .field_mask = UCP_ATTR_FIELD_MEMORY_TYPES,
+        };
+
+        if (ucp_context_query(ctx, &attr) != UCS_OK) {
+            return UCS_MEMORY_TYPE_UNKNOWN;
+        }
+
+        const bool has_cuda = UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_CUDA);
+        const bool has_rocm = UCS_BIT_GET(attr.memory_types, UCS_MEMORY_TYPE_ROCM);
+
+        if (has_cuda != has_rocm) {
+            return has_cuda ? UCS_MEMORY_TYPE_CUDA : UCS_MEMORY_TYPE_ROCM;
+        }
+
+        return UCS_MEMORY_TYPE_UNKNOWN;
+    }
+
+    case BLK_SEG:
+    case OBJ_SEG:
+    case FILE_SEG:
+        return UCS_MEMORY_TYPE_UNKNOWN;
+    }
+
+    return UCS_MEMORY_TYPE_UNKNOWN;
+}
+
+} // namespace
 
 int
 nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl_mem_type) {
@@ -649,9 +686,10 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
 
     ucp_mem_map_params_t mem_params = {
         .field_mask = UCP_MEM_MAP_PARAM_FIELD_FLAGS | UCP_MEM_MAP_PARAM_FIELD_LENGTH |
-            UCP_MEM_MAP_PARAM_FIELD_ADDRESS,
+            UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE,
         .address = mem.base,
         .length = mem.size,
+        .memory_type = toUcsMemoryType(ctx, nixl_mem_type),
     };
 
     ucs_status_t status = ucp_mem_map(ctx.get(), &mem_params, &mem.memh);

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -689,7 +689,7 @@ nixlUcxContext::memReg(void *addr, size_t size, nixlUcxMem &mem, nixl_mem_t nixl
             UCP_MEM_MAP_PARAM_FIELD_ADDRESS | UCP_MEM_MAP_PARAM_FIELD_MEMORY_TYPE,
         .address = mem.base,
         .length = mem.size,
-        .memory_type = toUcsMemoryType(ctx, nixl_mem_type),
+        .memory_type = toUcsMemoryType(ctx.get(), nixl_mem_type),
     };
 
     ucs_status_t status = ucp_mem_map(ctx.get(), &mem_params, &mem.memh);


### PR DESCRIPTION
## What?
NIXL's UCX backend doesn't forward the memtype paramter it gets from the user: `nixl_mem_type` to UCX's ucp_mem_map.

## Why?
Hit the UCX fast path
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory registration compatibility for DRAM and supported CUDA or ROCm VRAM.
  * Added safer fallback handling when memory types are unsupported or hardware capability checks fail.
  * Improved interoperability across environments with different accelerator capabilities.
  * Memory registration now more reliably identifies supported memory types and avoids failures when capabilities cannot be determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->