### PR TITLE
bugfix: test: make the device API tests actually run

### DIFF
--- a/test/gtest/common.h
+++ b/test/gtest/common.h
@@ -34,7 +34,11 @@
 #include "absl/log/log_sink.h"
 #include "absl/log/log_entry.h"
 
-#ifdef HAVE_CUDA
+#if defined(HAVE_CUDA) || defined(__CUDACC__)
+#define NIXL_TEST_HAVE_CUDA 1
+#endif
+
+#ifdef NIXL_TEST_HAVE_CUDA
 #include <cuda_runtime.h>
 #endif
 
@@ -42,7 +46,7 @@ namespace gtest {
 
 inline bool
 hasCudaGpu() {
-#ifdef HAVE_CUDA
+#ifdef NIXL_TEST_HAVE_CUDA
     int count = 0;
     auto err = cudaGetDeviceCount(&count);
     return (err == cudaSuccess && count > 0);

--- a/test/gtest/device_api/single_write_test.cu
+++ b/test/gtest/device_api/single_write_test.cu
@@ -533,9 +533,12 @@ TEST_P(SingleWriteTest, SingleWorkerPutGap) {
     status = dispatchLaunchPutKernel(GetParam(), put_params, num_iters, &gpu_timer);
     ASSERT_EQ(status, NIXL_SUCCESS);
 
-    void *ptr;
-    getPtrKernel<<<1, 1>>>(dst_mvh, 0, &ptr);
-    ASSERT_NE(ptr, nullptr);
+    gpuVar<void *> ptr;
+    getPtrKernel<<<1, 1>>>(dst_mvh, 0, ptr.get());
+    ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+    EXPECT_NE(*ptr, nullptr) << "nixlGetPtr is null unless the remote is locally mapped "
+                                "(cuda_ipc / NVLink)";
 
     logResultsPublic(size, count, num_iters, *gpu_timer.start_, *gpu_timer.end_);
 


### PR DESCRIPTION
## What?

Two standalone fixes make the CUDA device API tests run and repair `SingleWorkerPutGap` without removing its `nixlGetPtr` coverage:

1. Store the `getPtrKernel` result in device-accessible memory and check launch and execution errors in the correct order.
2. Teach the shared GPU probe to recognize CUDA translation units through `__CUDACC__`.

## Why?

`SingleWorkerPutGap` passed the address of a host stack variable to device code. The resulting invalid access poisoned the CUDA context, after which timer and destination copies returned unusable data. The test now uses its existing `gpuVar` helper, checks the immediate launch result, synchronizes for execution errors, and retains the local-pointer expectation.

Separately, the device API tests are `.cu` files compiled by nvcc, but `HAVE_CUDA` is passed only through `cpp_args`. As a result, `gtest::hasCudaGpu()` compiled to `return false` and all nine tests skipped themselves even on GPU systems. Detecting `__CUDACC__` enables the suite without forwarding `HAVE_CUDA` to nvcc.

## Commit breakdown

1. `test: store device pointer results in device memory`
   - Keeps `getPtrKernel` and the non-null pointer expectation.
   - Replaces the invalid host-stack output address with `gpuVar<void *>`.
   - Checks `cudaGetLastError()` immediately after launch, then `cudaDeviceSynchronize()` for execution errors.

2. `test: detect CUDA translation units in GPU probe`
   - Recognizes `__CUDACC__` in `test/gtest/common.h`.
   - Enables the device API suite without temporary Meson flags or add-then-revert history.

Each commit is self-contained; the pointer-storage bug is fixed before the second commit enables the suite.

## Validation

- Built `test/gtest/gtest` with CUDA 12.8 for `sm_89` and UCX device API support.
- Passed `SingleWorkerPutGap` in BLOCK, WARP, and THREAD modes with `UCX_TLS=all`.
- Passed `SingleWorkerPutGap` in BLOCK, WARP, and THREAD modes with `UCX_TLS=^rc_gda`.
- Passed all 9 `ucxDeviceApi/*` tests with `UCX_TLS=all` on an NVIDIA L40S.
