### PR TITLE
BUGFIX: PLUGIN/UCX: do not force-close a failed endpoint under err-mode none

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -134,8 +134,17 @@ nixlUcxEp::closeImpl() {
         NIXL_ASSERT(eph == nullptr);
         return NIXL_SUCCESS;
     case nixl::ucx::ep_state_t::FAILED: {
-        ucs_status_ptr_t request = ucpEpClose(eph, UCP_EP_CLOSE_FLAG_FORCE);
-        if (UCS_PTR_IS_PTR(request)) {
+        // Forcing a close is only legal when error handling is enabled: under
+        // err-mode none UCP rejects the flag outright and hands back an error
+        // pointer, which used to be discarded here and leak the ucp_ep. A
+        // failed endpoint has already had its lanes discarded, so a graceful
+        // close of one completes immediately anyway.
+        ucs_status_ptr_t request =
+            ucpEpClose(eph, errorHandlingEnabled() ? UCP_EP_CLOSE_FLAG_FORCE : 0u);
+        if (UCS_PTR_IS_ERR(request)) {
+            NIXL_ERROR << "Failed to close failed ep " << eph << ": "
+                       << ucs_status_string(UCS_PTR_STATUS(request));
+        } else if (UCS_PTR_IS_PTR(request)) {
             ucp_request_free(request);
         }
         eph = nullptr;
@@ -162,7 +171,8 @@ nixlUcxEp::closeImpl() {
     std::terminate();
 }
 
-nixlUcxEp::nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t err_handling_mode) {
+nixlUcxEp::nixlUcxEp(ucp_worker_h worker, void *addr, ucp_err_handling_mode_t err_handling_mode)
+    : errHandlingMode_{err_handling_mode} {
     ucp_ep_params_t ep_params;
     nixl_status_t status;
 

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -46,6 +46,19 @@ class nixlUcxEp {
 private:
     ucp_ep_h eph{nullptr};
     std::atomic<nixl::ucx::ep_state_t> state_{nixl::ucx::ep_state_t::UNINITIALIZED};
+    /** Remembered because it decides which close flavours UCP will accept. */
+    const ucp_err_handling_mode_t errHandlingMode_;
+
+    /**
+     * UCP only accepts UCP_EP_CLOSE_FLAG_FORCE, and only guarantees request
+     * completion on failure, when error handling is enabled for the endpoint
+     * (ucp_ep.inl, ucp_ep_config_err_handling_enabled).
+     */
+    [[nodiscard]] bool
+    errorHandlingEnabled() const noexcept {
+        return errHandlingMode_ == UCP_ERR_HANDLING_MODE_PEER ||
+            errHandlingMode_ == UCP_ERR_HANDLING_MODE_FAILOVER;
+    }
 
     void
     setState(nixl::ucx::ep_state_t new_state);


### PR DESCRIPTION
## What?
`nixlUcxEp::closeImpl()` stops passing `UCP_EP_CLOSE_FLAG_FORCE` when the endpoint's error-handling mode is `none`, and reports a close that fails for any other reason instead of discarding it. The endpoint remembers its mode.

## Why?
`ucp_ep_close_nbx` rejects `UCP_EP_CLOSE_FLAG_FORCE` unless error handling is enabled for the endpoint.
With `ucx_error_handling_mode=none` the FAILED branch got back an error pointer and dropped it silently:
`UCS_PTR_IS_PTR` is false for an error pointer, and nulled `eph`.
The `ucp_ep` was never closed and leaked until worker destroy.

Currently a bug for any `err-mode=none` user today.
It is also a prerequisite for the CPU proxy stack, which requires that mode because every UCP AMO protocol is disqualified under `peer` and `failover`:

#### Context from UCX:

[`src/ucp/proto/proto_common.c:43-56` - `ucp_proto_common_init_check_err_handling()`](https://github.com/openucx/ucx/blob/master/src/ucp/proto/proto_common.c#L43-L56)
```c++
switch (init_params->super.ep_config_key->err_mode) {
case UCP_ERR_HANDLING_MODE_NONE:
    return 1;
case UCP_ERR_HANDLING_MODE_PEER:
    return !!(init_params->flags & UCP_PROTO_COMMON_INIT_FLAG_ERR_HANDLING);
case UCP_ERR_HANDLING_MODE_FAILOVER:
    return !!(init_params->flags & UCP_PROTO_COMMON_INIT_FLAG_FAILOVER);
``` 

Both AMO protocols probe through ucp_proto_single_probe and set neither flag — I checked the actual flag lists:

- [`rma/amo_offload.c:176-178`](https://github.com/openucx/ucx/blob/9cba81decb8249c2ea44e3913ac28ba889eef0af/src/ucp/rma/amo_offload.c#L176-L178) → `REMOTE_ACCESS | RECV_ZCOPY | SINGLE_FRAG`
- [`rma/amo_sw.c:431-432`](https://github.com/openucx/ucx/blob/9cba81decb8249c2ea44e3913ac28ba889eef0af/src/ucp/rma/amo_sw.c#L431-L432) → `flags | SINGLE_FRAG | CAP_SEG_SIZE`, and its only two callers pass `0` (post, :469) and `RESPONSE` (fetch, :498)

## How?
An endpoint only reaches FAILED after UCX has discarded its lanes, so a graceful close of one completes immediately; that is what it now uses.

Sits textually where `closeFlags_` was, removed by #2090.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed connections by selecting graceful or forced closure based on the configured error-handling mode.
  * Added logging for connection-close errors, improving visibility into shutdown issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->