### PR TITLE
utils: add a device memory allocator with owning handles

### DIFF
--- a/src/utils/device/device_allocator.cpp
+++ b/src/utils/device/device_allocator.cpp
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "device/device_allocator.h"
+
+#include <dlfcn.h>
+
+#include <filesystem>
+
+namespace {
+
+constexpr const char *kCudaAllocatorLibrary = "libnixl_device_allocator_cuda.so";
+constexpr const char *kCudaAllocatorFactory = "nixlCreateCudaDeviceAllocatorV1";
+
+class nixlUnsupportedDeviceAllocator final : public nixlDeviceAllocator {
+public:
+    nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t) noexcept override {
+        if (ptr != nullptr) {
+            *ptr = nullptr;
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    void
+    doFreeDeviceMem(void *) noexcept override {}
+
+    nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t) noexcept override {
+        if (host_ptr != nullptr) {
+            *host_ptr = nullptr;
+        }
+        if (dev_ptr != nullptr) {
+            *dev_ptr = nullptr;
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    void
+    doFreeMappedHostMem(void *) noexcept override {}
+
+    nixl_status_t
+    copyHostToDevice(void *, const void *, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    copyDeviceToHost(void *, const void *, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    memsetDeviceMem(void *, int, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    synchronize() noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    getActiveDevice(int &) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    setActiveDevice(int) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+};
+
+using CudaAllocatorFactory = nixlDeviceAllocator *(*)() noexcept;
+
+nixlDeviceAllocator *
+loadCudaAllocator() noexcept {
+    Dl_info info{};
+    if (dladdr(reinterpret_cast<void *>(&nixlGetDeviceAllocator), &info) == 0 ||
+        info.dli_fname == nullptr) {
+        return nullptr;
+    }
+
+    // The frontend and optional CUDA implementation are installed side by side.
+    const auto library_path =
+        std::filesystem::path(info.dli_fname).parent_path() / kCudaAllocatorLibrary;
+    void *handle = dlopen(library_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+        return nullptr;
+    }
+
+    auto factory = reinterpret_cast<CudaAllocatorFactory>(dlsym(handle, kCudaAllocatorFactory));
+    if (factory == nullptr) {
+        dlclose(handle);
+        return nullptr;
+    }
+
+    nixlDeviceAllocator *allocator = factory();
+    if (allocator == nullptr) {
+        dlclose(handle);
+    }
+    // Keep the library loaded on success because the allocator and its vtable live in it.
+    return allocator;
+}
+
+} // namespace
+
+nixlDeviceAllocator &
+nixlGetDeviceAllocator() noexcept {
+    static nixlUnsupportedDeviceAllocator unsupported;
+    static nixlDeviceAllocator *allocator = []() noexcept {
+        nixlDeviceAllocator *cuda_allocator = loadCudaAllocator();
+        return cuda_allocator == nullptr ? &unsupported : cuda_allocator;
+    }();
+    return *allocator;
+}

--- a/src/utils/device/device_allocator.h
+++ b/src/utils/device/device_allocator.h
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H
+#define NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H
+
+#include <cstddef>
+#include <utility>
+
+#include <nixl_types.h>
+
+class nixlDeviceMem;
+class nixlMappedHostMem;
+
+/**
+ * Device memory-ops interface. All host-side interaction with the GPU memory
+ * runtime goes through this class so that no other host code needs a
+ * cuda_runtime.h include. CUDA is the current platform implementation; HIP
+ * can provide another. Allocations are returned as owning RAII handles, while
+ * raw alloc/free remain protected implementation hooks. The class is not
+ * internally synchronized. Transfers are issued on the default stream and are
+ * ordered there, but not all are complete on return; synchronize() is the
+ * barrier. Active device state is thread-local: copies, memset, and
+ * synchronize use the caller's current device; freeing works from any.
+ */
+class nixlDeviceAllocator {
+public:
+    virtual ~nixlDeviceAllocator() = default;
+
+    [[nodiscard]] nixl_status_t
+    allocDeviceMem(size_t size, nixlDeviceMem &out) noexcept;
+
+    /**
+     * Allocate pinned host memory that is mapped into the device address
+     * space; the handle exposes both the host pointer and its
+     * device-visible alias.
+     */
+    [[nodiscard]] nixl_status_t
+    allocMappedHostMem(size_t size, nixlMappedHostMem &out) noexcept;
+
+    /**
+     * Free device memory. Used for pointers whose ownership left RAII scope
+     * via nixlDeviceMem::release() (for example, nixlMemViewH handles crossing
+     * the public API boundary). The pointer must be one allocDeviceMem
+     * produced; it is not validated. Prefer the RAII handles everywhere else.
+     */
+    void
+    freeDeviceMem(void *ptr) noexcept {
+        doFreeDeviceMem(ptr);
+    }
+
+    /** src is reusable on return; the device-side write may still be pending. */
+    [[nodiscard]] virtual nixl_status_t
+    copyHostToDevice(void *dst, const void *src, size_t size) noexcept = 0;
+
+    /** Blocking: dst holds the data on return. */
+    [[nodiscard]] virtual nixl_status_t
+    copyDeviceToHost(void *dst, const void *src, size_t size) noexcept = 0;
+
+    /** Enqueued, not complete on return; ordered against later default-stream work. */
+    [[nodiscard]] virtual nixl_status_t
+    memsetDeviceMem(void *ptr, int value, size_t size) noexcept = 0;
+
+    /** Block until all outstanding work on the active device completes. */
+    [[nodiscard]] virtual nixl_status_t
+    synchronize() noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    getActiveDevice(int &device_id) noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    setActiveDevice(int device_id) noexcept = 0;
+
+protected:
+    [[nodiscard]] virtual nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t size) noexcept = 0;
+
+    virtual void
+    doFreeDeviceMem(void *ptr) noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t size) noexcept = 0;
+
+    virtual void
+    doFreeMappedHostMem(void *host_ptr) noexcept = 0;
+
+private:
+    friend class nixlDeviceMem;
+    friend class nixlMappedHostMem;
+};
+
+/**
+ * Owning, move-only handle to device (HBM) memory. The handle stores only the
+ * allocator, the pointer, and the size; the owning device is recovered by
+ * the platform free, so the destroying thread may be on any device.
+ */
+class nixlDeviceMem {
+public:
+    nixlDeviceMem() = default;
+
+    ~nixlDeviceMem() {
+        reset();
+    }
+
+    nixlDeviceMem(nixlDeviceMem &&other) noexcept {
+        *this = std::move(other);
+    }
+
+    nixlDeviceMem &
+    operator=(nixlDeviceMem &&other) noexcept {
+        if (this != &other) {
+            reset();
+            allocator_ = std::exchange(other.allocator_, nullptr);
+            ptr_ = std::exchange(other.ptr_, nullptr);
+            size_ = std::exchange(other.size_, 0);
+        }
+        return *this;
+    }
+
+    nixlDeviceMem(const nixlDeviceMem &) = delete;
+    nixlDeviceMem &
+    operator=(const nixlDeviceMem &) = delete;
+
+    [[nodiscard]] void *
+    get() const noexcept {
+        return ptr_;
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    as() const noexcept {
+        return static_cast<T *>(ptr_);
+    }
+
+    [[nodiscard]] size_t
+    size() const noexcept {
+        return size_;
+    }
+
+    explicit
+    operator bool() const noexcept {
+        return ptr_ != nullptr;
+    }
+
+    void
+    reset() noexcept {
+        if (ptr_ == nullptr) {
+            return;
+        }
+        allocator_->doFreeDeviceMem(ptr_);
+        allocator_ = nullptr;
+        ptr_ = nullptr;
+        size_ = 0;
+    }
+
+    /** Give up ownership; the pointer must later go to freeDeviceMem(). */
+    [[nodiscard]] void *
+    release() noexcept {
+        allocator_ = nullptr;
+        size_ = 0;
+        return std::exchange(ptr_, nullptr);
+    }
+
+private:
+    friend class nixlDeviceAllocator;
+
+    nixlDeviceMem(nixlDeviceAllocator *allocator, void *ptr, size_t size) noexcept
+        : allocator_(allocator),
+          ptr_(ptr),
+          size_(size) {}
+
+    nixlDeviceAllocator *allocator_ = nullptr;
+    void *ptr_ = nullptr;
+    size_t size_ = 0;
+};
+
+/**
+ * Owning, move-only handle to pinned host memory mapped into the device
+ * address space. Exposes the host pointer and its device-visible alias.
+ */
+class nixlMappedHostMem {
+public:
+    nixlMappedHostMem() = default;
+
+    ~nixlMappedHostMem() {
+        reset();
+    }
+
+    nixlMappedHostMem(nixlMappedHostMem &&other) noexcept {
+        *this = std::move(other);
+    }
+
+    nixlMappedHostMem &
+    operator=(nixlMappedHostMem &&other) noexcept {
+        if (this != &other) {
+            reset();
+            allocator_ = std::exchange(other.allocator_, nullptr);
+            host_ptr_ = std::exchange(other.host_ptr_, nullptr);
+            dev_ptr_ = std::exchange(other.dev_ptr_, nullptr);
+            size_ = std::exchange(other.size_, 0);
+        }
+        return *this;
+    }
+
+    nixlMappedHostMem(const nixlMappedHostMem &) = delete;
+    nixlMappedHostMem &
+    operator=(const nixlMappedHostMem &) = delete;
+
+    [[nodiscard]] void *
+    hostPtr() const noexcept {
+        return host_ptr_;
+    }
+
+    [[nodiscard]] void *
+    devPtr() const noexcept {
+        return dev_ptr_;
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    asHost() const noexcept {
+        return static_cast<T *>(host_ptr_);
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    asDev() const noexcept {
+        return static_cast<T *>(dev_ptr_);
+    }
+
+    [[nodiscard]] size_t
+    size() const noexcept {
+        return size_;
+    }
+
+    explicit
+    operator bool() const noexcept {
+        return host_ptr_ != nullptr;
+    }
+
+    void
+    reset() noexcept {
+        if (host_ptr_ == nullptr) {
+            return;
+        }
+        allocator_->doFreeMappedHostMem(host_ptr_);
+        allocator_ = nullptr;
+        host_ptr_ = nullptr;
+        dev_ptr_ = nullptr;
+        size_ = 0;
+    }
+
+private:
+    friend class nixlDeviceAllocator;
+
+    nixlMappedHostMem(nixlDeviceAllocator *allocator,
+                      void *host_ptr,
+                      void *dev_ptr,
+                      size_t size) noexcept
+        : allocator_(allocator),
+          host_ptr_(host_ptr),
+          dev_ptr_(dev_ptr),
+          size_(size) {}
+
+    nixlDeviceAllocator *allocator_ = nullptr;
+    void *host_ptr_ = nullptr;
+    void *dev_ptr_ = nullptr;
+    size_t size_ = 0;
+};
+
+inline nixl_status_t
+nixlDeviceAllocator::allocDeviceMem(size_t size, nixlDeviceMem &out) noexcept {
+    // `out` is only touched on success; a failed allocation leaves the
+    // caller's existing buffer intact.
+    void *ptr = nullptr;
+    const nixl_status_t status = doAllocDeviceMem(&ptr, size);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+    out = nixlDeviceMem(this, ptr, size);
+    return NIXL_SUCCESS;
+}
+
+inline nixl_status_t
+nixlDeviceAllocator::allocMappedHostMem(size_t size, nixlMappedHostMem &out) noexcept {
+    // `out` is only touched on success; a failed allocation leaves the
+    // caller's existing buffer intact.
+    void *host_ptr = nullptr;
+    void *dev_ptr = nullptr;
+    const nixl_status_t status = doAllocMappedHostMem(&host_ptr, &dev_ptr, size);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+    out = nixlMappedHostMem(this, host_ptr, dev_ptr, size);
+    return NIXL_SUCCESS;
+}
+
+/** Process-wide allocator for the device runtime available to this process. */
+[[nodiscard]] nixlDeviceAllocator &
+nixlGetDeviceAllocator() noexcept;
+
+#endif // NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H

--- a/src/utils/device/device_allocator_cuda.cpp
+++ b/src/utils/device/device_allocator_cuda.cpp
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "device/device_allocator.h"
+
+#include <cuda_runtime.h>
+
+#include "common/nixl_log.h"
+
+namespace {
+
+void
+logCudaFailure(const char *operation, cudaError_t error) {
+    NIXL_ERROR << operation << " failed: " << cudaGetErrorString(error);
+}
+
+class nixlCudaDeviceAllocator final : public nixlDeviceAllocator {
+public:
+    nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t size) noexcept override {
+        if (ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        *ptr = nullptr;
+        const cudaError_t error = cudaMalloc(ptr, size);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMalloc", error);
+            *ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    void
+    doFreeDeviceMem(void *ptr) noexcept override {
+        // cudaFree is a no-op on nullptr and resolves the allocation's owning
+        // device from the pointer itself, so neither a null guard nor a device
+        // switch belongs here. The caller must pass a pointer that
+        // allocDeviceMem produced.
+        const cudaError_t error = cudaFree(ptr);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaFree", error);
+        }
+    }
+
+    nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t size) noexcept override {
+        if (host_ptr == nullptr || dev_ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        *host_ptr = nullptr;
+        *dev_ptr = nullptr;
+        // Mapped guarantees cudaHostGetDevicePointer; portable permits use from other GPUs.
+        cudaError_t error =
+            cudaHostAlloc(host_ptr, size, cudaHostAllocMapped | cudaHostAllocPortable);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaHostAlloc", error);
+            *host_ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        error = cudaHostGetDevicePointer(dev_ptr, *host_ptr, 0);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaHostGetDevicePointer", error);
+            const cudaError_t free_error = cudaFreeHost(*host_ptr);
+            if (free_error != cudaSuccess) {
+                logCudaFailure("cudaFreeHost after cudaHostGetDevicePointer", free_error);
+            }
+            *host_ptr = nullptr;
+            *dev_ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    void
+    doFreeMappedHostMem(void *host_ptr) noexcept override {
+        if (host_ptr == nullptr) {
+            return;
+        }
+        const cudaError_t error = cudaFreeHost(host_ptr);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaFreeHost", error);
+        }
+    }
+
+    nixl_status_t
+    copyHostToDevice(void *dst, const void *src, size_t size) noexcept override {
+        if (dst == nullptr || src == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemcpy host to device", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    copyDeviceToHost(void *dst, const void *src, size_t size) noexcept override {
+        if (dst == nullptr || src == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemcpy device to host", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    memsetDeviceMem(void *ptr, int value, size_t size) noexcept override {
+        if (ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemset(ptr, value, size);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemset", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    synchronize() noexcept override {
+        const cudaError_t error = cudaDeviceSynchronize();
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaDeviceSynchronize", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    getActiveDevice(int &device_id) noexcept override {
+        const cudaError_t error = cudaGetDevice(&device_id);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaGetDevice", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    setActiveDevice(int device_id) noexcept override {
+        const cudaError_t error = cudaSetDevice(device_id);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaSetDevice", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+};
+
+} // namespace
+
+extern "C" __attribute__((visibility("default"))) nixlDeviceAllocator *
+nixlCreateCudaDeviceAllocatorV1() noexcept {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        return nullptr;
+    }
+
+    static nixlCudaDeviceAllocator allocator;
+    return &allocator;
+}

--- a/src/utils/device/meson.build
+++ b/src/utils/device/meson.build
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+device_allocator_lib = shared_library('nixl_device_allocator',
+           ['device_allocator.cpp', 'device_allocator.h'],
+           include_directories: [nixl_inc_dirs, utils_inc_dirs],
+           dependencies: [dl_dep],
+           install: true)
+
+device_allocator_interface = declare_dependency(link_with: device_allocator_lib)
+
+if cuda_dep.found()
+    shared_library('nixl_device_allocator_cuda',
+               'device_allocator_cuda.cpp',
+               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               dependencies: [cuda_dep, nixl_common_dep],
+               install: true)
+endif

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -18,6 +18,7 @@ subdir('serdes')
 subdir('stream')
 subdir('file')
 subdir('object')
+subdir('device')
 
 if enabled_plugins.get('LIBFABRIC') and libfabric_dep.found()
     subdir('libfabric')

--- a/test/gtest/unit/device_allocator/device_allocator.cpp
+++ b/test/gtest/unit/device_allocator/device_allocator.cpp
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "device/device_allocator.h"
+
+namespace gtest {
+namespace device_allocator {
+
+    constexpr size_t kSize = 4096;
+
+    class deviceAllocatorTest : public testing::Test {
+    protected:
+        nixlDeviceAllocator *allocator_ = nullptr;
+
+        void
+        SetUp() override {
+            int count = 0;
+            if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+                GTEST_SKIP() << "No CUDA-capable GPU is available.";
+            }
+            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+            allocator_ = &nixlGetDeviceAllocator();
+        }
+    };
+
+    TEST_F(deviceAllocatorTest, AllocCopyFree) {
+        nixlDeviceAllocator &allocator = *allocator_;
+
+        nixlDeviceMem mem;
+        ASSERT_EQ(allocator.allocDeviceMem(kSize, mem), NIXL_SUCCESS);
+
+        std::vector<unsigned char> src(kSize, 0xA5);
+        std::vector<unsigned char> dst(kSize, 0);
+        ASSERT_EQ(allocator.copyHostToDevice(mem.get(), src.data(), kSize), NIXL_SUCCESS);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mem.get(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, src);
+
+        ASSERT_EQ(allocator.memsetDeviceMem(mem.get(), 0, kSize), NIXL_SUCCESS);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mem.get(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, std::vector<unsigned char>(kSize, 0));
+
+        allocator.freeDeviceMem(mem.release());
+
+        nixlMappedHostMem mapped;
+        ASSERT_EQ(allocator.allocMappedHostMem(kSize, mapped), NIXL_SUCCESS);
+        std::fill_n(mapped.asHost<unsigned char>(), kSize, 0x5A);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mapped.devPtr(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, std::vector<unsigned char>(kSize, 0x5A));
+    }
+
+} // namespace device_allocator
+} // namespace gtest

--- a/test/gtest/unit/device_allocator/meson.build
+++ b/test/gtest/unit/device_allocator/meson.build
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+device_allocator_unit_test_dep = declare_dependency()
+
+if cuda_dep.found() and is_variable('device_allocator_interface')
+    device_allocator_unit_test_dep = declare_dependency(
+        sources: ['device_allocator.cpp'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, gtest_inc_dirs],
+        dependencies: [nixl_common_dep, cuda_dep, device_allocator_interface],
+    )
+endif

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -29,6 +29,9 @@ unit_test_deps += [agent_unit_test_dep]
 subdir('descriptors')
 unit_test_deps += [descriptors_unit_test_dep]
 
+subdir('device_allocator')
+unit_test_deps += [device_allocator_unit_test_dep]
+
 subdir('util')
 unit_test_deps += [util_unit_test_dep]
 


### PR DESCRIPTION
## What?

  Introduce `nixlDeviceAllocator`, a centralized interface for host-side device
  memory operations, together with two move-only RAII handles:

  - `nixlDeviceMem` owns device memory.
  - `nixlMappedHostMem` owns pinned host memory and its device-visible alias.
  - `libnixl_device_allocator.so` is always built and has no CUDA dependency.
  - `libnixl_device_allocator_cuda.so` contains the optional CUDA implementation.
  - A focused integration test exercises the real CUDA allocator when a GPU is
    available.

  ## Why?

  Callers currently include CUDA headers and pair allocations and frees manually.
  The allocator provides one ownership and memory-operation boundary for code that
  otherwise has no reason to depend directly on CUDA.

  This is also required by the CPU proxy work. UCX must be able to use the
  allocator without placing `libcudart` on the UCX plugin's load path. Otherwise,
  a CUDA-built package can lose the entire UCX backend on a system where CUDA is
  unavailable, even when only DRAM transfers are requested.

  ## How?

  `nixlGetDeviceAllocator()` lives in the always-built CUDA-free frontend. On
  first use, it locates the sibling `libnixl_device_allocator_cuda.so` with
  `dladdr()`, loads it with `dlopen()`, and resolves a versioned factory symbol.

  If the CUDA library, factory, driver, or device is unavailable, the accessor
  returns an implementation whose operations report `NIXL_ERR_NOT_SUPPORTED`.
  Failed loads are closed; a successful load remains open because the allocator
  and its vtable reside in the CUDA library.

  The CUDA implementation remains the only source that includes
  `cuda_runtime.h`. No plugin registry or plugin discovery mechanism is involved.

  ## Test status

  - CUDA frontend and implementation build successfully.
  - A CUDA-free configuration builds the frontend successfully.
  - `libnixl_device_allocator.so` has no CUDA `DT_NEEDED` entries.
  - The unavailable-CUDA path returns `NIXL_ERR_NOT_SUPPORTED`.
  - The unit test suite passes.
  - The real-GPU integration test skips cleanly when no GPU is present.
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUDA device-memory allocation and management.
  * Added mapped host-memory support for efficient host/device access.
  * Added memory transfers, device memory initialization, synchronization, and active-device selection.
  * Added automatic cleanup and ownership transfer for allocated memory.
  * Added validation and error handling for invalid inputs and allocation failures.

* **Tests**
  * Added coverage for memory lifecycle, transfers, cleanup, error handling, and multi-device behavior.
  * Added GPU integration tests that run when CUDA hardware is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->