### PR TITLE
feat(ucx): add GPU-visible read completion signal

### DIFF
--- a/src/api/cpp/backend/backend_aux.h
+++ b/src/api/cpp/backend/backend_aux.h
@@ -17,6 +17,7 @@
 #ifndef __BACKEND_AUX_H_
 #define __BACKEND_AUX_H_
 
+#include <atomic>
 #include <mutex>
 #include <string>
 #include "common/nixl_log.h"
@@ -34,6 +35,7 @@ struct nixlBackendOptionalArgs {
     nixl_blob_t notifMsg;
     bool        hasNotif = false;
     nixl_blob_t customParam;
+    std::atomic<uint64_t> *completionSignal = nullptr;
 };
 
 using nixl_opt_b_args_t = nixlBackendOptionalArgs;

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -111,6 +111,12 @@ class nixlBackendEngine {
         // pure virtual, and return errors, as parent shouldn't call if supportsNotif is false.
         virtual bool supportsNotif() const = 0;
 
+        // Determines if a backend supports a host-mapped GPU completion signal.
+        virtual bool
+        supportsCompletionSignal() const {
+            return false;
+        }
+
         virtual nixl_mem_list_t getSupportedMems() const = 0;  // TODO: Return by const-reference and mark noexcept?
 
 

--- a/src/api/cpp/nixl.h
+++ b/src/api/cpp/nixl.h
@@ -336,6 +336,10 @@ class nixlAgent {
          *         will be NIXL_SUCCESS. Otherwise, the output status will be NIXL_IN_PROG until
          *         completion. Notification  message  can be preovided through the extra_params,
          *         and can be updated per re-post.
+         *         The UCX backend also accepts @ref nixlAgentOptionalArgs::completionSignal for
+         *         NIXL_READ. It increments the host-mapped signal after successful transfer
+         *         completion. With the UCX progress thread enabled, a GPU stream can wait without
+         *         host status polling.
          *
          * @param  req_hndl      Transfer request handle obtained from makeXferReq/createXferReq
          * @param  extra_params  Optional extra parameters used in posting a transfer request

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -16,6 +16,7 @@
  */
 #ifndef _NIXL_TYPES_H
 #define _NIXL_TYPES_H
+#include <atomic>
 #include <vector>
 #include <string>
 #include <unordered_map>
@@ -231,6 +232,21 @@ struct nixlAgentOptionalArgs {
      * @var Backend custom parameter
      */
     nixl_blob_t customParam;
+
+    /**
+     * @var completionSignal Optional host-side completion signal for NIXL_READ.
+     *
+     * When supported by the selected backend, the signal is incremented with
+     * release ordering after the transfer completes successfully. The signal
+     * must be lock-free, CUDA host-mapped memory and remain valid until the
+     * request completes or is released. A GPU stream can wait on the device
+     * alias with cuStreamWaitValue64() and CU_STREAM_WAIT_VALUE_FLUSH so remote
+     * writes to the destination are visible to subsequent GPU work.
+     *
+     * This option is consumed by postXferReq() and is currently implemented by
+     * the UCX backend for NIXL_READ.
+     */
+    std::atomic<uint64_t> *completionSignal = nullptr;
 };
 /**
  * @brief A typedef for a nixlAgentOptionalArgs

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1162,6 +1162,7 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
 
     // Updating the notification based on opt_args
     if (extra_params) {
+        opt_args.completionSignal = extra_params->completionSignal;
         if (extra_params->notif) {
             req_hndl->notifMsg = *extra_params->notif;
             opt_args.notifMsg = *extra_params->notif;
@@ -1183,6 +1184,13 @@ nixlAgent::postXferReq(nixlXferReqH *req_hndl,
                         << "' does not support notifications";
         data->addErrorTelemetry(NIXL_ERR_BACKEND);
         return NIXL_ERR_BACKEND;
+    }
+
+    if (opt_args.completionSignal && !req_hndl->engine->supportsCompletionSignal()) {
+        NIXL_ERROR_FUNC << "the selected backend '" << req_hndl->engine->getType()
+                        << "' does not support completion signals";
+        data->addErrorTelemetry(NIXL_ERR_NOT_SUPPORTED);
+        return NIXL_ERR_NOT_SUPPORTED;
     }
 
     // If status is not NIXL_IN_PROG we can repost,

--- a/src/plugins/ucx/ucx_backend.cpp
+++ b/src/plugins/ucx/ucx_backend.cpp
@@ -62,6 +62,7 @@ private:
     ucx_connection_ptr_t conn_;
     std::vector<nixlUcxReq> requests_;
     nixlUcxWorker *worker_ = nullptr;
+    std::atomic<uint64_t> *completionSignal_ = nullptr;
 
     [[nodiscard]] nixl_status_t
     checkConnection(const nixl_status_t status = NIXL_SUCCESS) const {
@@ -102,6 +103,16 @@ public:
     reserve(size_t size) {
         requests_.reserve(size);
         NIXL_ASSERT(conn_ == nullptr);
+    }
+
+    void
+    setCompletionSignal(std::atomic<uint64_t> *completion_signal) {
+        completionSignal_ = completion_signal;
+    }
+
+    [[nodiscard]] std::atomic<uint64_t> *
+    getCompletionSignal() const {
+        return completionSignal_;
     }
 
     [[nodiscard]] nixl_status_t
@@ -1246,7 +1257,7 @@ nixlUcxEngine::sendXferRange(const nixl_xfer_op_t &operation,
      * completed, which can happen after local requests completion.
      */
     nixlUcxReq flush_req;
-    const nixl_status_t flush_ret = ep->flushEp(flush_req);
+    const nixl_status_t flush_ret = ep->flushEp(flush_req, int_handle->getCompletionSignal());
     if (int_handle->append(flush_ret, flush_req, conn) != NIXL_SUCCESS) {
         return flush_ret;
     }
@@ -1271,6 +1282,19 @@ nixlUcxEngine::postXfer(const nixl_xfer_op_t &operation,
                    << ") descriptor lists differ in size";
         return NIXL_ERR_INVALID_PARAM;
     }
+
+    std::atomic<uint64_t> *completion_signal = opt_args ? opt_args->completionSignal : nullptr;
+    if (completion_signal) {
+        if (operation != NIXL_READ) {
+            NIXL_ERROR << "Completion signals are only supported for NIXL_READ";
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+        if (!completion_signal->is_lock_free()) {
+            NIXL_ERROR << "Completion signal must be lock-free";
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+    int_handle->setCompletionSignal(completion_signal);
 
     // TODO: assert that handle is empty/completed, as we can't post request before completion
 

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -115,6 +115,11 @@ public:
         return true;
     }
 
+    bool
+    supportsCompletionSignal() const override {
+        return true;
+    }
+
     nixl_mem_list_t
     getSupportedMems() const override;
 

--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -346,11 +346,21 @@ nixlUcxEp::estimateCost(size_t size,
 }
 
 nixl_status_t
-nixlUcxEp::flushEp(nixlUcxReq &req) {
-    ucp_request_param_t param;
+nixlUcxEp::flushEp(nixlUcxReq &req, std::atomic<uint64_t> *completion_signal) {
+    ucp_request_param_t param = {};
     ucs_status_ptr_t request;
 
-    param.op_attr_mask = 0;
+    if (completion_signal) {
+        param.op_attr_mask = UCP_OP_ATTR_FIELD_CALLBACK | UCP_OP_ATTR_FIELD_USER_DATA;
+        param.cb.send = [](void *, ucs_status_t status, void *user_data) {
+            if (status == UCS_OK) {
+                static_cast<std::atomic<uint64_t> *>(user_data)->fetch_add(
+                    1, std::memory_order_release);
+            }
+        };
+        param.user_data = completion_signal;
+    }
+
     request = ucp_ep_flush_nbx(eph, &param);
 
     if (UCS_PTR_IS_PTR(request)) {
@@ -358,7 +368,11 @@ nixlUcxEp::flushEp(nixlUcxReq &req) {
         return NIXL_IN_PROG;
     }
 
-    return nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
+    const nixl_status_t status = nixl::ucx::ucsToNixlStatus(UCS_PTR_STATUS(request));
+    if ((status == NIXL_SUCCESS) && completion_signal) {
+        completion_signal->fetch_add(1, std::memory_order_release);
+    }
+    return status;
 }
 
 #ifdef HAVE_UCX_SGL_API

--- a/src/plugins/ucx/ucx_utils.h
+++ b/src/plugins/ucx/ucx_utils.h
@@ -108,7 +108,7 @@ public:
                  std::chrono::microseconds &err_margin,
                  nixl_cost_t &method);
     nixl_status_t
-    flushEp(nixlUcxReq &req);
+    flushEp(nixlUcxReq &req, std::atomic<uint64_t> *completion_signal = nullptr);
 
 #ifdef HAVE_UCX_SGL_API
     /* Scatter-gather list (SGL) operations */

--- a/test/unit/plugins/ucx/ucx_backend_test.cpp
+++ b/test/unit/plugins/ucx/ucx_backend_test.cpp
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <atomic>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -317,6 +318,10 @@ performTransfer(nixlUcxEngine *ucx1,
     nixl_opt_b_args_t opt_args;
     opt_args.notifMsg = test_str;
     opt_args.hasNotif = use_notif;
+    std::atomic<uint64_t> completion_signal{0};
+    if (op == NIXL_READ) {
+        opt_args.completionSignal = &completion_signal;
+    }
 
 
     // Posting a request, to be updated to return an async handler,
@@ -376,6 +381,11 @@ performTransfer(nixlUcxEngine *ucx1,
                              "Incorrect front notif message");
 
         cout << "OK" << endl;
+    }
+
+    if (op == NIXL_READ) {
+        nixl_exit_on_failure(completion_signal.load(std::memory_order_acquire) == 1,
+                             "Read completion signal was not incremented exactly once");
     }
 
     cout << "\t\tData verification: " << flush;


### PR DESCRIPTION
## What?

Add an opt-in host-mapped generation counter for UCX `NIXL_READ` completion. The UCX endpoint flush callback increments the counter only after the complete READ succeeds, so a CUDA stream can wait on the counter without application status polling when the UCX progress thread is enabled.

Closes #2198.

## Why?

NIXL's GPU device API currently exposes GPU-initiated PUT plus GPU CQ polling, but UCX has no corresponding device GET primitive. Host-posted `ucp_get_nbx()` therefore has no GPU-visible completion object. This provides the practical host-GET bridge without claiming to implement GPU-initiated RDMA READ.

## How?

- Add `nixlAgentOptionalArgs::completionSignal`, a caller-owned lock-free atomic allocated in CUDA host-mapped memory.
- Reject the option on unsupported backends and non-READ UCX operations.
- Attach the signal to the endpoint flush that already defines transfer completion.
- Increment with release ordering on successful immediate or asynchronous completion.
- Require GPU consumers to wait on the device alias using `CU_STREAM_WAIT_VALUE_FLUSH`; a CUDA event alone is not sufficient for GPUDirect RDMA visibility.

```mermaid
sequenceDiagram
    participant GPU
    participant NIXL
    participant UCX
    participant NIC
    GPU->>GPU: enqueue cuStreamWaitValue64(EQ|FLUSH)
    NIXL->>UCX: ucp_get_nbx(destination VRAM)
    UCX->>NIC: post RDMA READ
    NIC-->>UCX: CQE / endpoint flush complete
    UCX-->>NIXL: flush callback
    NIXL->>GPU: host release-increment mapped generation
    GPU->>GPU: wait flushes remote writes, then continues
```

This is deliberately not a true GPU-initiated GET. That requires a UCX/UCT device GET operation, READ WQE construction and local keys, plus GPU CQ completion/error handling. NIXL's GPUNetIO backend already demonstrates that larger design separately.

## Reviewer Ask

**Manual repro:** Configure with `meson setup build -Ducx_path=<UCX> -Denable_plugins=UCX -Dbuild_examples=false -Dbuild_tests=true`, build, and run `build/test/unit/plugins/ucx/ucx_backend_test`; READ cases should increment the generation exactly once and preserve data verification.

**Review focus:** Please review the public option shape, signal lifetime contract, and whether endpoint flush is the desired UCX completion boundary.

**Not asking for:** Review or validation of true GPU-initiated GET support; this PR does not add it.

## Testing

- `git diff --check` passes.
- UCX callback signature was syntax-checked against `/opt/ucx/include`.
- Full local build is currently blocked before compilation by an old system Abseil package (`absl_base` present but `absl_log` missing). The PR remains draft pending CI/design feedback.
- Added UCX backend coverage asserting exactly one completion increment for READ transfers.

## Perf Evidence

- [x] Not a performance-claiming change. The optional path adds one host atomic only at transfer completion.
- CPU overhead: no work is added when `completionSignal == nullptr` beyond a null branch while preparing the flush parameters.
- GPU fence/stall: NIXL adds no CUDA launch or fence; the caller explicitly chooses `cuStreamWaitValue64(..., CU_STREAM_WAIT_VALUE_FLUSH)`.

## Checklist

- [x] Self-reviewed the complete diff
- [x] Minimal implementation; no device GET capability is invented
- [x] Added regression coverage
- [x] Documented memory lifetime and remote-write ordering requirements
- [x] DCO sign-off included
- [x] No secrets or credentials

Made with [Cursor](https://cursor.com)