### PR TITLE
refactor(posix): Resolve file devIds in I/O queues

### DIFF
--- a/src/plugins/posix/io_queue.cpp
+++ b/src/plugins/posix/io_queue.cpp
@@ -19,6 +19,8 @@
 #include "common/nixl_log.h"
 #include <absl/strings/str_format.h>
 
+#include <limits>
+
 #ifdef HAVE_POSIXAIO
 std::unique_ptr<nixlPosixIOQueue>
 nixlPosixIOQueueAIOCreate(uint32_t ios_pool_size, uint32_t kernel_queue_size);
@@ -46,6 +48,52 @@ static const struct {
     {"AIO", nixlPosixIOQueueLinuxAIOCreate},
 #endif
 };
+
+nixl_status_t
+nixlPosixIOQueue::registerFile(uint64_t dev_id, const std::string &meta_info) {
+    const bool path_mode = nixl::parsePathMeta(meta_info).has_value();
+    if (!path_mode && dev_id > static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto file = files_.find(dev_id);
+    if (file != files_.end()) {
+        if (path_mode || file->second.pathMode) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        file->second.registrations++;
+        return NIXL_SUCCESS;
+    }
+
+    files_.try_emplace(dev_id, dev_id, meta_info, path_mode);
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlPosixIOQueue::deregisterFile(uint64_t dev_id) {
+    auto file = files_.find(dev_id);
+    if (file == files_.end()) {
+        return NIXL_SUCCESS;
+    }
+    if (--file->second.registrations == 0) {
+        files_.erase(file);
+    }
+    return NIXL_SUCCESS;
+}
+
+nixl_status_t
+nixlPosixIOQueue::enqueue(uint64_t dev_id,
+                          void *buf,
+                          size_t len,
+                          off_t offset,
+                          bool read,
+                          nixlPosixIOQueueDoneCb clb,
+                          void *ctx) {
+    auto file = files_.find(dev_id);
+    if (file == files_.end()) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    return enqueueFd(file->second.fileFd.fd(), buf, len, offset, read, std::move(clb), ctx);
+}
 
 std::unique_ptr<nixlPosixIOQueue>
 nixlPosixIOQueue::instantiate(std::string_view io_queue_type,

--- a/src/plugins/posix/io_queue.h
+++ b/src/plugins/posix/io_queue.h
@@ -21,9 +21,12 @@
 #include <stdint.h>
 #include <list>
 #include <memory>
+#include <string>
+#include <unordered_map>
 #include <vector>
 #include <functional>
 #include "backend_aux.h"
+#include "file/file_path_mode.h"
 
 using nixlPosixIOQueueDoneCb = std::function<void(void *ctx, uint32_t data_size, int error)>;
 using nixlPosixIOQueueCancelDoneCb = std::function<void(void *ctx)>;
@@ -40,14 +43,31 @@ public:
 
     virtual ~nixlPosixIOQueue() {}
 
+    /**
+     * @brief Register a file identifier for subsequent I/O.
+     * @param dev_id Identifier used by enqueue().
+     * @param meta_info File registration metadata.
+     * @return NIXL_SUCCESS on success, or an error status otherwise.
+     */
     virtual nixl_status_t
-    enqueue(int fd,
+    registerFile(uint64_t dev_id, const std::string &meta_info);
+
+    /**
+     * @brief Deregister a file identifier.
+     * @param dev_id Identifier previously passed to registerFile().
+     * @return NIXL_SUCCESS on success, or an error status otherwise.
+     */
+    virtual nixl_status_t
+    deregisterFile(uint64_t dev_id);
+
+    virtual nixl_status_t
+    enqueue(uint64_t dev_id,
             void *buf,
             size_t len,
             off_t offset,
             bool read,
             nixlPosixIOQueueDoneCb clb,
-            void *ctx) = 0;
+            void *ctx);
     virtual nixl_status_t
     post(void) = 0;
     virtual nixl_status_t
@@ -73,6 +93,25 @@ public:
     static constexpr uint32_t DEF_KERNEL_QUEUE_SIZE = 256;
 
 protected:
+    struct registeredFile {
+        registeredFile(uint64_t dev_id, const std::string &meta_info, bool is_path_mode)
+            : fileFd(is_path_mode ? -1 : static_cast<int>(dev_id), meta_info),
+              pathMode(is_path_mode) {}
+
+        nixl::FileFd fileFd;
+        size_t registrations = 1;
+        bool pathMode;
+    };
+
+    virtual nixl_status_t
+    enqueueFd(int fd,
+              void *buf,
+              size_t len,
+              off_t offset,
+              bool read,
+              nixlPosixIOQueueDoneCb clb,
+              void *ctx) = 0;
+
     static uint32_t
     normalizedIOSPoolSize(uint32_t ios_pool_size) {
         return std::clamp(ios_pool_size, MIN_IOS_POOL_SIZE, MAX_IOS_POOL_SIZE);
@@ -85,6 +124,7 @@ protected:
 
     uint32_t ios_pool_size_;
     uint32_t kernel_queue_size_;
+    std::unordered_map<uint64_t, registeredFile> files_;
 };
 
 template<typename Entry> class nixlPosixIOQueueImpl : public nixlPosixIOQueue {

--- a/src/plugins/posix/io_uring_io_queue.cpp
+++ b/src/plugins/posix/io_uring_io_queue.cpp
@@ -63,13 +63,13 @@ public:
     virtual nixl_status_t
     post(void) override;
     virtual nixl_status_t
-    enqueue(int fd,
-            void *buf,
-            size_t len,
-            off_t offset,
-            bool read,
-            nixlPosixIOQueueDoneCb clb,
-            void *ctx) override;
+    enqueueFd(int fd,
+              void *buf,
+              size_t len,
+              off_t offset,
+              bool read,
+              nixlPosixIOQueueDoneCb clb,
+              void *ctx) override;
     virtual nixl_status_t
     poll(void) override;
     virtual unsigned
@@ -244,13 +244,13 @@ nixlPosixIOQueueUring::doCheckCompleted(void) {
 }
 
 nixl_status_t
-nixlPosixIOQueueUring::enqueue(int fd,
-                               void *buf,
-                               size_t len,
-                               off_t offset,
-                               bool read,
-                               nixlPosixIOQueueDoneCb clb,
-                               void *ctx) {
+nixlPosixIOQueueUring::enqueueFd(int fd,
+                                 void *buf,
+                                 size_t len,
+                                 off_t offset,
+                                 bool read,
+                                 nixlPosixIOQueueDoneCb clb,
+                                 void *ctx) {
     if (free_ios_.empty()) {
         NIXL_ERROR << "No more free blocks available";
         return NIXL_ERR_NOT_ALLOWED;

--- a/src/plugins/posix/linux_aio_io_queue.cpp
+++ b/src/plugins/posix/linux_aio_io_queue.cpp
@@ -41,13 +41,13 @@ public:
     virtual nixl_status_t
     post(void) override;
     virtual nixl_status_t
-    enqueue(int fd,
-            void *buf,
-            size_t len,
-            off_t offset,
-            bool read,
-            nixlPosixIOQueueDoneCb clb,
-            void *ctx) override;
+    enqueueFd(int fd,
+              void *buf,
+              size_t len,
+              off_t offset,
+              bool read,
+              nixlPosixIOQueueDoneCb clb,
+              void *ctx) override;
     virtual nixl_status_t
     poll(void) override;
     virtual unsigned
@@ -89,13 +89,13 @@ nixlPosixIOQueueLinuxAIO::nixlPosixIOQueueLinuxAIO(uint32_t ios_pool_size,
 }
 
 nixl_status_t
-nixlPosixIOQueueLinuxAIO::enqueue(int fd,
-                                  void *buf,
-                                  size_t len,
-                                  off_t offset,
-                                  bool read,
-                                  nixlPosixIOQueueDoneCb clb,
-                                  void *ctx) {
+nixlPosixIOQueueLinuxAIO::enqueueFd(int fd,
+                                    void *buf,
+                                    size_t len,
+                                    off_t offset,
+                                    bool read,
+                                    nixlPosixIOQueueDoneCb clb,
+                                    void *ctx) {
     if (terminal_error_) {
         return NIXL_ERR_BACKEND;
     }

--- a/src/plugins/posix/posix_aio_io_queue.cpp
+++ b/src/plugins/posix/posix_aio_io_queue.cpp
@@ -38,13 +38,13 @@ public:
     virtual nixl_status_t
     post(void) override;
     virtual nixl_status_t
-    enqueue(int fd,
-            void *buf,
-            size_t len,
-            off_t offset,
-            bool read,
-            nixlPosixIOQueueDoneCb clb,
-            void *ctx) override;
+    enqueueFd(int fd,
+              void *buf,
+              size_t len,
+              off_t offset,
+              bool read,
+              nixlPosixIOQueueDoneCb clb,
+              void *ctx) override;
     virtual nixl_status_t
     poll(void) override;
     virtual ~nixlPosixIOQueueAIO() override;
@@ -65,13 +65,13 @@ nixlPosixIOQueueAIO::~nixlPosixIOQueueAIO() {
 }
 
 nixl_status_t
-nixlPosixIOQueueAIO::enqueue(int fd,
-                             void *buf,
-                             size_t len,
-                             off_t offset,
-                             bool read,
-                             nixlPosixIOQueueDoneCb clb,
-                             void *ctx) {
+nixlPosixIOQueueAIO::enqueueFd(int fd,
+                               void *buf,
+                               size_t len,
+                               off_t offset,
+                               bool read,
+                               nixlPosixIOQueueDoneCb clb,
+                               void *ctx) {
     if (free_ios_.empty()) {
         NIXL_ERROR << "No more free blocks available";
         return NIXL_ERR_NOT_ALLOWED;

--- a/src/plugins/posix/posix_backend.cpp
+++ b/src/plugins/posix/posix_backend.cpp
@@ -223,8 +223,8 @@ nixlPosixBackendReqH::postXfer() {
     for (auto [local_it, remote_it] = std::make_pair(local.begin(), remote.begin());
          local_it != local.end() && remote_it != remote.end();
          ++local_it, ++remote_it) {
-        int fd = static_cast<nixlPosixFileMD *>(remote_it->metadataP)->file_fd.fd();
-        nixl_status_t status = io_queue_->enqueue(fd,
+        uint64_t dev_id = static_cast<nixlPosixFileMD *>(remote_it->metadataP)->devId;
+        nixl_status_t status = io_queue_->enqueue(dev_id,
                                                   reinterpret_cast<void *>(local_it->addr),
                                                   remote_it->len,
                                                   remote_it->addr,
@@ -301,7 +301,16 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
                 return NIXL_ERR_INVALID_PARAM;
             }
             try {
-                out = new nixlPosixFileMD(mem.devId, mem.metaInfo);
+                auto file_md = std::make_unique<nixlPosixFileMD>(mem.devId);
+                nixl_status_t status;
+                {
+                    NIXL_LOCK_GUARD(io_queue_lock_);
+                    status = io_queue_->registerFile(mem.devId, mem.metaInfo);
+                }
+                if (status != NIXL_SUCCESS) {
+                    return status;
+                }
+                out = file_md.release();
             }
             catch (const std::system_error &e) {
                 NIXL_ERROR << "POSIX path-mode open failed: " << e.what();
@@ -317,13 +326,17 @@ nixlPosixEngine::registerMem(const nixlBlobDesc &mem,
 
 nixl_status_t
 nixlPosixEngine::deregisterMem(nixlBackendMD *meta) {
-    // non-null meta is always a file MD. Release the path-mode reservation (path() empty in
-    // fd-mode)
     if (meta) {
         auto *file_md = static_cast<nixlPosixFileMD *>(meta);
-        if (!file_md->file_fd.path().empty()) {
-            path_mode_devids_.release(file_md->devId);
+        nixl_status_t status;
+        {
+            NIXL_LOCK_GUARD(io_queue_lock_);
+            status = io_queue_->deregisterFile(file_md->devId);
         }
+        if (status != NIXL_SUCCESS) {
+            return status;
+        }
+        path_mode_devids_.release(file_md->devId);
     }
     delete meta;
     return NIXL_SUCCESS;

--- a/src/plugins/posix/posix_backend.h
+++ b/src/plugins/posix/posix_backend.h
@@ -29,8 +29,12 @@
 #include "io_queue.h"
 #include "sync.h"
 
-// POSIX reuses the shared owned-fd base (path-mode devId stored for dereg).
-using nixlPosixFileMD = nixlFilePathMD;
+class nixlPosixFileMD : public nixlBackendMD {
+public:
+    explicit nixlPosixFileMD(uint64_t dev_id) : nixlBackendMD(true /*isPrivate*/), devId(dev_id) {}
+
+    uint64_t devId;
+};
 
 class nixlPosixBackendReqH : public nixlBackendReqH {
 public:
@@ -38,7 +42,7 @@ public:
                          const nixl_meta_dlist_t &local,
                          const nixl_meta_dlist_t &remote,
                          std::unique_ptr<nixlPosixIOQueue> &io_queue);
-    ~nixlPosixBackendReqH() {};
+    ~nixlPosixBackendReqH() override = default;
 
     nixl_status_t
     postXfer();

--- a/test/unit/plugins/posix/nixl_posix_aio_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_aio_test.cpp
@@ -82,12 +82,17 @@ struct aioTest {
             throw std::runtime_error("mkstemp failed");
         }
         unlink(path);
+        if (queue->registerFile(fd, "") != NIXL_SUCCESS) {
+            close(fd);
+            throw std::runtime_error("file registration failed");
+        }
         for (size_t i = 0; i < buffers.size(); i++) {
             std::memset(buffers[i].data(), static_cast<int>(i + 1), buffers[i].size());
         }
     }
 
     ~aioTest() {
+        queue->deregisterFile(fd);
         queue.reset();
         close(fd);
     }
@@ -288,7 +293,7 @@ main() {
     {
         setSubmitMode(submitMode::PARTIAL_THEN_ERROR);
         aioTest test(request_count + 1);
-        nixlPosixFileMD file_md(test.fd, "");
+        nixlPosixFileMD file_md(test.fd);
         aioRequest failed(test, file_md, 0, request_count);
         aioRequest unrelated(test, file_md, request_count, 1);
 
@@ -312,7 +317,7 @@ main() {
         constexpr int completion_error_request_count = 65;
         setSubmitMode(submitMode::COMPLETION_ERROR);
         aioTest test(completion_error_request_count);
-        nixlPosixFileMD file_md(test.fd, "");
+        nixlPosixFileMD file_md(test.fd);
         aioRequest failed(test, file_md, 0, completion_error_request_count);
 
         nixl_status_t status = failed.request.postXfer();

--- a/test/unit/plugins/posix/nixl_posix_uring_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_uring_test.cpp
@@ -63,12 +63,17 @@ struct uringTest {
             throw std::runtime_error("mkstemp failed");
         }
         unlink(path);
+        if (queue->registerFile(fd, "") != NIXL_SUCCESS) {
+            close(fd);
+            throw std::runtime_error("file registration failed");
+        }
         for (size_t i = 0; i < buffers.size(); i++) {
             std::memset(buffers[i].data(), static_cast<int>(i + 1), buffers[i].size());
         }
     }
 
     ~uringTest() {
+        queue->deregisterFile(fd);
         queue.reset();
         close(fd);
     }
@@ -189,7 +194,7 @@ main() {
     }
     {
         uringTest test(submit_mode_t::PASS_THROUGH);
-        nixlPosixFileMD file_md(test.fd, "");
+        nixlPosixFileMD file_md(test.fd);
         uringRequest cancelled(test, file_md, 0), unrelated(test, file_md, 1);
         nixl_status_t cancelled_status = cancelled.request.postXfer();
         URING_CHECK(cancelled_status >= NIXL_IN_PROG);


### PR DESCRIPTION
## What?
First PR in series for #2202 . This PR moves the devId->fd/state map to the io engine. 

## Why?
In the next PRs we will introduce asynchronous opens. This makes it awkward to keep track of the FD (which might simply not exist yet) in the common posix backend. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added file registration and deregistration for POSIX I/O operations.
  - POSIX transfers now use registered device identifiers, including path metadata support.
  - Duplicate registrations and invalid device identifiers are validated.
  - I/O requests now verify that files are registered before being queued.

- **Bug Fixes**
  - File references are released and registrations removed when no longer in use.

- **Tests**
  - Updated asynchronous I/O tests to cover file registration and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->