### PR TITLE
ci: support mis-versioned wheel sets

### DIFF
--- a/.ci/jenkins/lib/build-llm-container-matrix.yaml
+++ b/.ci/jenkins/lib/build-llm-container-matrix.yaml
@@ -157,11 +157,30 @@ steps:
       rm -rf "${DEST}"
       mkdir -p "${DEST}"
 
-      BASE="${WHEELS_ARTIFACTORY_URL}/release/${NIXL_VERSION}/${WHEEL_BUILD_ID}"
+      # Normally wheel filenames use NIXL_VERSION. For a release directory
+      # containing mis-versioned wheels, WHEEL_BUILD_ID may be supplied as
+      # "<build-id>@<wheel-version>" (for example, "59bfaa77@1.4.0").
+      case "${WHEEL_BUILD_ID}" in
+        *@*@*|@*|*@)
+          echo "ERROR: invalid WHEEL_BUILD_ID '${WHEEL_BUILD_ID}'"
+          exit 1
+          ;;
+        *@*)
+          BUILD_ID="${WHEEL_BUILD_ID%%@*}"
+          WHEEL_VERSION="${WHEEL_BUILD_ID#*@}"
+          ;;
+        *)
+          BUILD_ID="${WHEEL_BUILD_ID}"
+          WHEEL_VERSION="${NIXL_VERSION}"
+          ;;
+      esac
+
+      BASE="${WHEELS_ARTIFACTORY_URL}/release/${NIXL_VERSION}/${BUILD_ID}"
+      echo "Downloading wheel version ${WHEEL_VERSION} from ${BASE}"
       WHEELS=(
-        "nixl-${NIXL_VERSION}-py3-none-any.whl"
-        "nixl_cu12-${NIXL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
-        "nixl_cu13-${NIXL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
+        "nixl-${WHEEL_VERSION}-py3-none-any.whl"
+        "nixl_cu12-${WHEEL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
+        "nixl_cu13-${WHEEL_VERSION}-${PYTHON_TAG}-${PYTHON_TAG}-manylinux_${MANYLINUX_TAG}_${arch}.whl"
       )
       for whl in "${WHEELS[@]}"; do
         curl -fL --retry 3 --retry-delay 2 \

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -693,8 +693,10 @@
           description: >
             First 8 chars of the NIXL commit sha the wheels were built from, which
             is the folder name the release wheel pipeline publishes under
-            (e.g. <code>51a42f86</code>).<br/>
-            Full wheel URL: <code>sw-nbu-swx-nixl-pypi-local/release/${{NIXL_VERSION}}/${{WHEEL_BUILD_ID}}/nixl*.whl</code>
+            (e.g. <code>51a42f86</code>). For a directory containing wheels whose
+            package version differs from NIXL_VERSION, append that version after
+            <code>@</code> (e.g. <code>59bfaa77@1.4.0</code>).<br/>
+            Wheel directory: <code>sw-nbu-swx-nixl-pypi-local/release/${{NIXL_VERSION}}/&lt;build-id&gt;/</code>
       - string:
           name: "PYTHON_TAG"
           default: "cp312"


### PR DESCRIPTION
## What

Allow the LLM container build job to consume a release wheel directory whose wheel package version differs from `NIXL_VERSION`.

`WHEEL_BUILD_ID` now accepts an optional `<build-id>@<wheel-version>` form. Plain build IDs retain the existing behavior.

Example:

```text
NIXL_VERSION=1.5.0
WHEEL_BUILD_ID=59bfaa77@1.4.0
```

This reads wheels from `release/1.5.0/59bfaa77/` while requesting filenames containing version `1.4.0`.

## Why

The `release/1.5.0/59bfaa77/` directory was published with `1.4.0` embedded in the wheel filenames and metadata. The artifacts cannot be modified, and the existing job uses `NIXL_VERSION` for both the release directory and filenames.

## Validation

- Executed the real `Download Wheels` shell block with a stubbed curl and verified the mismatched-version case.
- Verified the unchanged plain-build-ID case.
- Verified malformed override syntax is rejected.
- Ran repository pre-commit hooks for both changed YAML files.
- Parsed both YAML files and ran ShellCheck on the modified shell block.
