### PR TITLE
PLUGINS/UCX: Enable GET over CUDA IPC on GPU without NVLINK

### DIFF
--- a/src/plugins/ucx/ucx_utils.cpp
+++ b/src/plugins/ucx/ucx_utils.cpp
@@ -483,6 +483,7 @@ nixlUcxContext::nixlUcxContext(const std::vector<std::string> &devs,
     config.modify("RNDV_THRESH", "inf");
     config.modify("MAX_RMA_RAILS", "2");
     config.modify("IB_PCI_RELAXED_ORDERING", "try");
+    config.modify("CUDA_IPC_ENABLE_GET_ZCOPY", "on");
 
     // NIXL only needs AMs to be visible after previous PUTs which RC already
     // provides without the need of strict order key.


### PR DESCRIPTION
## What?
Enable CUDA IPC on systems that do not have NVLINK.

## Why?
On node without HCA, lack of CUDA IPC Get can result in sending data over TCP.
Related: https://github.com/vllm-project/vllm/issues/52607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled CUDA IPC zero-copy transfers for improved GPU data movement performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->