### PR TITLE
tracing: use span id for correlation

### DIFF
--- a/src/core/tracing/trace_context.cpp
+++ b/src/core/tracing/trace_context.cpp
@@ -84,9 +84,13 @@ nixl::trace::TraceContext::sampled() const noexcept {
 
 std::uint64_t
 nixl::trace::TraceContext::correlationId64() const noexcept {
+    if (!valid()) {
+        return 0;
+    }
+
     std::uint64_t result = 0;
-    for (std::size_t index = 0; index < sizeof(result); ++index) {
-        result = (result << 8) | traceId[index];
+    for (const auto byte : spanId) {
+        result = (result << 8) | byte;
     }
     return result;
 }

--- a/test/gtest/unit/tracing/trace_context_test.cpp
+++ b/test/gtest/unit/tracing/trace_context_test.cpp
@@ -148,11 +148,46 @@ TEST(TraceContext, InvalidContextHasNoTextRepresentation) {
     EXPECT_TRUE(nixl::trace::formatTraceparent({}).empty());
 }
 
-TEST(TraceContext, ProjectsTraceIdBigEndian) {
+TEST(TraceContext, ProjectsSpanIdBigEndian) {
     const auto context = nixl::trace::parseTraceparent(kCanonicalTraceparent);
 
     ASSERT_TRUE(context.has_value());
-    EXPECT_EQ(context->correlationId64(), 0x4bf92f3577b34da6ULL);
+    EXPECT_EQ(context->correlationId64(), 0x00f067aa0ba902b7ULL);
+}
+
+TEST(TraceContext, InvalidContextsProjectZero) {
+    EXPECT_EQ(nixl::trace::TraceContext{}.correlationId64(), 0ULL);
+
+    nixl::trace::TraceContext no_span;
+    no_span.traceId = {0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6};
+    ASSERT_FALSE(no_span.valid());
+    EXPECT_EQ(no_span.correlationId64(), 0ULL);
+}
+
+TEST(TraceContext, ValidSpanIdProjectsNonzero) {
+    nixl::trace::TraceContext context;
+    context.traceId[15] = 0x01;
+    context.spanId[7] = 0x01;
+
+    ASSERT_TRUE(context.valid());
+    EXPECT_EQ(context.correlationId64(), 0x01ULL);
+}
+
+TEST(TraceContext, ProjectionFollowsSpanIdAndIsStable) {
+    auto context = nixl::trace::parseTraceparent(kCanonicalTraceparent);
+    ASSERT_TRUE(context.has_value());
+    const auto baseline = context->correlationId64();
+
+    EXPECT_EQ(context->correlationId64(), baseline);
+
+    auto trace_changed = *context;
+    trace_changed.traceId[0] ^= 0xFF;
+    trace_changed.traceId[15] ^= 0xFF;
+    EXPECT_EQ(trace_changed.correlationId64(), baseline);
+
+    auto span_changed = *context;
+    span_changed.spanId[7] ^= 0xFF;
+    EXPECT_NE(span_changed.correlationId64(), baseline);
 }
 
 TEST(TraceContext, GeneratesDistinctValidContexts) {


### PR DESCRIPTION
## What?

Project `TraceContext::spanId` into the internal 64-bit NVTX correlation ID. Invalid contexts now return zero.

## Why?

A trace ID may be shared by concurrent requests, while each request has its own span ID. Using the span ID preserves request-level correlation before context propagation lands in [NIX-1744](https://linear.app/nvidia/issue/NIX-1744). Tracked by [NIX-1778](https://linear.app/nvidia/issue/NIX-1778).

## How?

Interpret the eight span-ID bytes in big-endian order. Focused and full unit CTest runs pass in normal, ASan/UBSan, UBSan, and TSan builds.