### PR TITLE
Revert NIXL EP optimization from #2112

### DIFF
--- a/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
+++ b/examples/device/ep/csrc/kernels/nixl_ep_ll.cu
@@ -32,8 +32,6 @@ namespace cg = cooperative_groups;
 
 namespace nixl_ep {
 
-constexpr int kNumMaxWarpGroups = 32;
-
 __device__ inline void* p2p_ptr_get(gpu_nixl_ctx& ctx, uint64_t dst_ptr, int dst_rank) {
     if (dst_rank == ctx.rank) return (void*) dst_ptr;
 
@@ -85,7 +83,6 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
          int num_tokens, int num_max_dispatch_tokens_per_rank,
          int num_topk, int active_rank_bound, int num_local_experts, int rank,
          int num_warp_groups, int num_warps_per_group,
-         uint64_t* recv_pub, int recv_slices,
          bool round_scale, uint64_t timeout_cycles, int phases, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
     const auto sm_id = static_cast<int>(blockIdx.x);
@@ -117,6 +114,7 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     EP_DEVICE_ASSERT(num_bytes_per_msg % sizeof(int4) == 0);
 
     // Expert counts
+    constexpr int kNumMaxWarpGroups = 32;
     __shared__ int shared_num_tokens_sent_per_expert[kNumMaxWarpGroups];
 
     // Sending phase
@@ -235,11 +233,10 @@ dispatch(void* packed_recv_x, void* packed_recv_x_scales,
         int expert_count[kNumMaxWarpGroups] = {0};
         const auto expert_begin_idx = sm_id * num_warp_groups;
         const auto expert_end_idx = min(expert_begin_idx + num_warp_groups, active_expert_bound);
-        const auto scan_len = expert_begin_idx < active_expert_bound ? num_tokens * num_topk : 0;
 
         // Per lane count
         #pragma unroll 8
-        for (int i = lane_id; i < scan_len; i += 32) {
+        for (int i = lane_id; i < num_tokens * num_topk; i += 32) {
             auto idx = static_cast<int>(__ldg(topk_idx + i));
             if (idx >= expert_begin_idx and idx < expert_end_idx)
                 expert_count[idx - expert_begin_idx]++;
@@ -296,21 +293,9 @@ DISPATCH_RECV:
         cg::this_grid().sync();
 
     // Receiving and packing
-    // Split each (source rank, local expert) copy across `recv_slices` blocks
-    int recv_expert_idx, recv_slice;
-    if (recv_slices > 1) {
-        recv_expert_idx = sm_id % active_expert_bound;
-        recv_slice = sm_id / active_expert_bound;
-        // No grid sync below, so an early return is safe
-        if (recv_slice >= recv_slices)
-            return;
-    } else {
-        recv_expert_idx = responsible_expert_idx;
-        recv_slice = 0;
-    }
-    if (recv_expert_idx < active_expert_bound) {
-        const auto src_rank = recv_expert_idx / num_local_experts;
-        const auto local_expert_idx = recv_expert_idx % num_local_experts;
+    if (responsible_expert_idx < active_expert_bound) {
+        const auto src_rank = responsible_expert_idx / num_local_experts;
+        const auto local_expert_idx = responsible_expert_idx % num_local_experts;
         const auto rdma_recv_x_uint8 = static_cast<uint8_t*>(rdma_recv_x) +
                 local_expert_idx * active_rank_bound * num_max_dispatch_tokens_per_rank * num_bytes_per_msg +
                 src_rank * num_max_dispatch_tokens_per_rank * num_bytes_per_msg;
@@ -327,17 +312,8 @@ DISPATCH_RECV:
         // Wait tokens to arrive
         // NOTES: using sub-warp 1 to overlap with sub-warp 0
         int num_recv_tokens = 0, recv_token_begin_idx;
-        EP_DEVICE_ASSERT(num_warps_per_group > 1 and num_warp_groups < 15 and recv_slices > 0);
-        if (sub_warp_id == 1 and lane_id == 0 and recv_slice > 0) {
-            // Helper slices take slice 0's reservation. Slice 0 publishes on every path,
-            // including timeout and masked, so no timeout is needed here
-            uint64_t published;
-            while ((published = ld_acquire_sys_global(recv_pub + recv_expert_idx)) == ~0ull)
-                ;
-            unpack2(published, num_recv_tokens, recv_token_begin_idx);
-            shared_num_recv_tokens[warp_group_id] = num_recv_tokens;
-            shared_recv_token_begin_idx[warp_group_id] = recv_token_begin_idx;
-        } else if (sub_warp_id == 1 and lane_id == 0) {
+        EP_DEVICE_ASSERT(num_warps_per_group > 1 and num_warp_groups < 15);
+        if (sub_warp_id == 1 and lane_id == 0) {
             auto start_time = clock64();
             uint64_t wait_recv_cost = 0;
             if (not is_rank_masked(mask_buffer_ptr, src_rank)) {
@@ -365,10 +341,7 @@ DISPATCH_RECV:
             recv_token_begin_idx = atomicAdd(packed_recv_count + local_expert_idx, num_recv_tokens);
             shared_num_recv_tokens[warp_group_id] = num_recv_tokens;
             shared_recv_token_begin_idx[warp_group_id] = recv_token_begin_idx;
-            const auto packed_range = pack2<int, int64_t>(num_recv_tokens, recv_token_begin_idx);
-            recv_range[src_rank] = packed_range;
-            if (recv_slices > 1)
-                st_release_sys_global(recv_pub + recv_expert_idx, static_cast<uint64_t>(packed_range));
+            recv_range[src_rank] = pack2<int, int64_t>(num_recv_tokens, recv_token_begin_idx);
 
             // Add stats for diagnosis
             if (cumulative_local_expert_recv_stats != nullptr)
@@ -382,9 +355,7 @@ DISPATCH_RECV:
 
         // Copy tokens
         EP_DEVICE_ASSERT(num_scales <= 64);
-        const int worker_id = recv_slice * num_warps_per_group + sub_warp_id;
-        const int num_workers = recv_slices * num_warps_per_group;
-        for (int i = worker_id; i < num_recv_tokens; i += num_workers) {
+        for (int i = sub_warp_id; i < num_recv_tokens; i += num_warps_per_group) {
             // Copy source info
             const auto src_src_idx = reinterpret_cast<int*>(rdma_recv_x_uint8 + i * num_bytes_per_msg);
             if (lane_id == 0)
@@ -446,32 +417,13 @@ void dispatch(void* packed_recv_x, void* packed_recv_x_scales,
     EP_HOST_ASSERT(kNumMaxTopK + 1 <= num_warp_groups * num_warps_per_group);
 
     const auto num_warps = num_warp_groups * num_warps_per_group;
-    // Size the grid by tokens or experts. Cap at `num_device_sms`
-    const int num_send_per_sm = max(1, ceil_div(num_tokens, num_device_sms));
-    const auto num_sms = max(ceil_div(active_expert_bound, num_warp_groups),
-                             ceil_div(num_tokens, num_send_per_sm));
+    const auto num_sms = ceil_div(active_expert_bound, num_warp_groups);
     EP_HOST_ASSERT(num_topk <= kNumMaxTopK);
 
     // Workspace checks
     auto atomic_counter_per_expert = static_cast<int*>(workspace);
     auto atomic_finish_counter_per_expert = atomic_counter_per_expert + active_expert_bound;
-    // One publication slot per expert, after the two counters
-    auto recv_pub = reinterpret_cast<uint64_t*>(atomic_finish_counter_per_expert + active_expert_bound);
-    EP_HOST_ASSERT(active_expert_bound * sizeof(int) * 2 +
-                   active_expert_bound * sizeof(uint64_t) <= NUM_WORKSPACE_BYTES);
-
-    // Let surplus blocks help copy, one slice per `num_warps_per_group` tokens
-    int recv_slices = 1;
-    if (num_warp_groups == 1 and num_sms > active_expert_bound) {
-        const int tokens_per_pair = ceil_div(num_tokens * num_topk, active_expert_bound);
-        const int slices_needed = max(1, ceil_div(tokens_per_pair, num_warps_per_group));
-        recv_slices = min(slices_needed, num_sms / active_expert_bound);
-    }
-    EP_HOST_ASSERT(recv_slices > 0);
-
-    // All-ones marks a slot as unpublished
-    if (recv_slices > 1 and (phases & EP_RECV_PHASE))
-        CUDA_CHECK(cudaMemsetAsync(recv_pub, 0xFF, active_expert_bound * sizeof(uint64_t), stream));
+    EP_HOST_ASSERT(active_expert_bound * sizeof(int) * 2 <= NUM_WORKSPACE_BYTES);
 
     // FP8 checks
     if (use_ue8m0)
@@ -497,7 +449,6 @@ LAUNCH_KERNEL(&cfg, dispatch_func, \
               num_tokens, num_max_dispatch_tokens_per_rank, \
               num_topk, active_rank_bound, num_experts_per_rank, rank, \
               num_warp_groups, num_warps_per_group, \
-              recv_pub, recv_slices, \
               round_scale, timeout_cycles, phases, nixl_ctx); } break
 
     SETUP_LAUNCH_CONFIG(num_sms, num_warps * 32, stream);
@@ -677,7 +628,7 @@ combine(void* combined_x,
         int num_combined_tokens, int hidden, int num_topk,
         int num_max_dispatch_tokens_per_rank,
         int active_rank_bound, int num_local_experts, int rank,
-        int num_warp_groups, int num_warps_per_group, int send_slices, int send_signals,
+        int num_warp_groups, int num_warps_per_group,
         uint64_t timeout_cycles, int phases, bool zero_copy, nixl_ep::gpu_nixl_ctx* nixl_ctx_ptr) {
     auto nixl_ctx = *nixl_ctx_ptr;
     const auto sm_id = __shfl_sync(0xffffffff, static_cast<int>(blockIdx.x), 0);
@@ -725,22 +676,13 @@ combine(void* combined_x,
         // Notify before executing `int_p`
         __syncwarp();
         if (lane_id == 0)
-            atomic_add_release_global(atomic_clean_flag, active_expert_bound * send_slices);
+            atomic_add_release_global(atomic_clean_flag, active_expert_bound);
     }
 
     // Issue NIXL sends
-    // Split each (destination rank, local expert) send across `send_slices` blocks
-    int send_expert_idx, send_slice;
-    if (send_slices > 1) {
-        send_expert_idx = sm_id % active_expert_bound;
-        send_slice = sm_id / active_expert_bound;
-    } else {
-        send_expert_idx = responsible_expert_idx;
-        send_slice = 0;
-    }
-    if (send_expert_idx < active_expert_bound and send_slice < send_slices) {
-        const auto dst_rank = send_expert_idx / num_local_experts;
-        const auto local_expert_idx = send_expert_idx % num_local_experts;
+    if (responsible_expert_idx < active_expert_bound) {
+        const auto dst_rank = responsible_expert_idx / num_local_experts;
+        const auto local_expert_idx = responsible_expert_idx % num_local_experts;
         const auto global_expert_idx = rank * num_local_experts + local_expert_idx;
         const auto layout = __ldg(layout_range + local_expert_idx * active_rank_bound + dst_rank);
         const auto local_x = static_cast<const int4*>(x) +
@@ -784,9 +726,7 @@ combine(void* combined_x,
 
         // Issue NIXL send
         if (not is_rank_masked<true>(mask_buffer_ptr, dst_rank)) {
-            const int worker_id = send_slice * num_warps_per_group + sub_warp_id;
-            const int num_workers = send_slices * num_warps_per_group;
-            for (int token_idx = offset + worker_id; token_idx < offset + num_tokens_to_send; token_idx += num_workers) {
+            for (int token_idx = offset + sub_warp_id; token_idx < offset + num_tokens_to_send; token_idx += num_warps_per_group) {
                 const auto x_int4 = local_x + token_idx * hidden_bf16_int4;
                 const auto rdma_send_type_row = reinterpret_cast<int*>(rdma_send_x_vec + token_idx * num_bytes_per_slot);
                 const auto rdma_send_x_vec_row = reinterpret_cast<uint8_t*>(rdma_send_type_row);
@@ -875,16 +815,13 @@ combine(void* combined_x,
         if (sub_warp_id == 1 and lane_id == 0) {
             while (ld_acquire_global(atomic_clean_flag) == 0);
             auto dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_flag + global_expert_idx);
-            // Slice 0 covers the signals for slices this grid had no room to run
-            const uint64_t signals = 1 + (send_slice == 0 ? send_signals - send_slices : 0);
             if (not is_rank_masked(mask_buffer_ptr, dst_rank)) {
                 void* dst_p2p_ptr = p2p_ptr_get(nixl_ctx, dst_ptr, dst_rank);
                 if (dst_p2p_ptr == 0) {
                     nixlMemViewElem dst_mdesc{nixl_ctx.remote_mvh, (size_t) dst_rank, nixl_ctx.offset_get(dst_ptr)};
-                    EP_DEVICE_ASSERT(nixlAtomicAdd(signals, dst_mdesc, local_expert_idx) == NIXL_IN_PROG);
+                    EP_DEVICE_ASSERT(nixlAtomicAdd(1, dst_mdesc, local_expert_idx) == NIXL_IN_PROG);
                 } else {
-                    // Several slices share the flag, so accumulate
-                    atomic_add_release_sys_global(static_cast<uint64_t*>(dst_p2p_ptr), signals);
+                    st_release_sys_global(static_cast<uint64_t*>(dst_p2p_ptr), 1);
                 }
             }
             atomic_add_release_global(atomic_clean_flag, -1);
@@ -911,10 +848,9 @@ COMBINE_RECV:
             const auto src_rank = responsible_expert_idx / num_local_experts;
             auto start_time = clock64();
             uint64_t wait_recv_cost = 0;
-            const auto signals_needed = static_cast<uint64_t>(send_signals);
             if (not is_rank_masked(mask_buffer_ptr, src_rank)) {
-                while (ld_acquire_sys_global(rdma_recv_flag + responsible_expert_idx) < signals_needed  // recv not ready
-                       && (wait_recv_cost = clock64() - start_time) <= timeout_cycles                   // not timeout
+                while (ld_acquire_sys_global(rdma_recv_flag + responsible_expert_idx) == 0  // recv not ready
+                       && (wait_recv_cost = clock64() - start_time) <= timeout_cycles        // not timeout
                 )
                     ;
             }
@@ -1103,15 +1039,6 @@ void combine(void* combined_x,
     const auto num_sms = max(ceil_div(active_expert_bound, num_warp_groups),
                              num_recv_per_sm == 0 ? 1 : ceil_div(num_combined_tokens, num_recv_per_sm));
 
-    // NOTES: `send_signals` must agree across ranks, so derive it from the dispatch
-    // capacity, never from a device property; `send_slices` is what this grid can run
-    const int tokens_per_pair = ceil_div(num_max_dispatch_tokens_per_rank * num_topk,
-                                         active_expert_bound);
-    const int send_signals = max(1, ceil_div(tokens_per_pair, kNumMaxWarpGroups));
-    int send_slices = 1;
-    if (num_warp_groups == 1 and num_sms > active_expert_bound)
-        send_slices = min(send_signals, num_sms / active_expert_bound);
-
     // Check workspace
     auto atomic_clean_flag = static_cast<int*>(workspace);
     EP_HOST_ASSERT(sizeof(int) <= NUM_WORKSPACE_BYTES);
@@ -1152,7 +1079,7 @@ LAUNCH_KERNEL(&cfg, combine_func, \
               num_combined_tokens, hidden, num_topk, \
               num_max_dispatch_tokens_per_rank, \
               active_rank_bound, num_experts_per_rank, rank, \
-              num_warp_groups, num_warps_per_group, send_slices, send_signals, \
+              num_warp_groups, num_warps_per_group, \
               timeout_cycles, phases, zero_copy, nixl_ctx); } break
 
     SETUP_LAUNCH_CONFIG(num_sms, num_warps * 32, stream);

--- a/examples/device/ep/csrc/kernels/utils.cuh
+++ b/examples/device/ep/csrc/kernels/utils.cuh
@@ -129,12 +129,6 @@ __device__ __forceinline__ uint64_t ld_acquire_global(const uint64_t *ptr) {
     return ret;
 }
 
-__device__ __forceinline__ uint64_t atomic_add_release_sys_global(const uint64_t *ptr, uint64_t value) {
-    uint64_t ret;
-    asm volatile("atom.add.release.sys.global.u64 %0, [%1], %2;" : "=l"(ret) : "l"(ptr), "l"(value));
-    return ret;
-}
-
 __device__ __forceinline__ int atomic_add_release_global(const int* ptr, int value) {
     int ret;
     asm volatile("atom.add.release.gpu.global.s32 %0, [%1], %2;" : "=r"(ret) : "l"(ptr), "r"(value));


### PR DESCRIPTION
#2112 broke the NIXL EP nightly elastic test.

We reproduced the failure with an A/B test on 4 GPUs, comparing #2112 with its parent.

Plan: [[0, 1], [0, 1, 2, 3], [0, -2, 3]]

Args: --num-processes 4 --num-tokens 128 --num-topk 2 --num-experts-per-rank 2 --hidden-dim 8192 --timeout-ms 30000 --kineto

The parent passes. #2112 fails with dispatch receive timeouts and then an assertion while removing a rank.

The motivation for this optimization is questionable, and the implementation is too risky because it affects a much wider scope than intended. We are reverting it for now.

If this optimization is upstreamed again, we should revisit the implementation and review and test it properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified expert dispatch and combine processing to use streamlined synchronization and completion handling.
  - Updated processing to handle each active expert directly, reducing coordination overhead.
  - Reduced workspace requirements for these operations.
  - Removed support for receive/send slicing and related multi-slice completion tracking.
  - Removed an unused system-scope atomic helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->