### PR TITLE
CI: Update Blossom CI to support automatic trigger

### DIFF
--- a/.github/workflows/blossom-ci.yml
+++ b/.github/workflows/blossom-ci.yml
@@ -12,6 +12,8 @@ run-name: >
 on:
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
       inputs:
           platform:
@@ -28,7 +30,7 @@ jobs:
       args: ${{ env.args }}
 
     # This job only runs for pull request comments
-    if: github.event.comment.body == '/build'
+    if: github.event.comment.body == '/build' || (github.event_name == 'pull_request_target')
     steps:
       - name: Check if comment is issued by authorized person
         run: blossom-ci


### PR DESCRIPTION
## What?
Add support for automatic trigger for authorized users, which starts CI pipeline without commenting /build

## Why?
_Justification for the PR. If there is an existing issue/bug, please reference it. For
bug fixes, the 'Why?' and 'What?' can be merged into a single item._

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to run automatically when pull requests are opened, updated, or reopened.
  * Authorization checks continue to run for approved build commands in pull request comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->