### PR TITLE
fix(posix): retry partial asynchronous I/Os in uring and linux AIO

### DIFF
--- a/src/plugins/posix/io_uring_io_queue.cpp
+++ b/src/plugins/posix/io_uring_io_queue.cpp
@@ -39,13 +39,36 @@ struct nixlPosixIoUringCQEData {
 struct nixlPosixIoUringIO : public nixlPosixIoUringCQEData {
     nixlPosixIoUringIO() : nixlPosixIoUringCQEData(nixlPosixIoUringCQEKind::IO) {}
 
+    void *
+    currentBuf() const {
+        return static_cast<char *>(buf_) + completed_;
+    }
+
+    off_t
+    currentOffset() const {
+        return offset_ + static_cast<off_t>(completed_);
+    }
+
+    size_t
+    remaining() const {
+        return len_ - completed_;
+    }
+
+    void
+    advance(size_t completed) {
+        NIXL_ASSERT(completed <= remaining());
+        completed_ += completed;
+    }
+
     int fd;
     void *buf_;
     size_t len_;
     off_t offset_;
+    size_t completed_ = 0;
     bool read_;
     nixlPosixIOQueueDoneCb clb_;
     bool in_flight_ = false; // owned by the ring, not yet reaped
+    bool cancel_requested_ = false;
     bool cancel_pending_ = false; // cancellation is queued or its CQE is pending
 };
 
@@ -89,6 +112,14 @@ private:
     prepareSQEs(void);
     void
     releaseIOIfIdle(nixlPosixIoUringIO *io);
+    void
+    queueForSubmission(nixlPosixIoUringIO *io);
+    void
+    finishIO(nixlPosixIoUringIO *io, int res, bool error);
+    void
+    handleIOCompletion(nixlPosixIoUringIO *io, int res);
+    void
+    handleCancelCompletion(nixlPosixIoUringCancel *cancel);
 
     struct io_uring uring; // The io_uring instance for async I/O operations
     bool terminal_error_ = false;
@@ -137,9 +168,11 @@ nixlPosixIOQueueUring::prepareSQEs(void) {
             nixlPosixIoUringIO *io = ios_to_submit_.front();
             ios_to_submit_.pop_front();
             if (io->read_) {
-                io_uring_prep_read(sqe, io->fd, io->buf_, io->len_, io->offset_);
+                io_uring_prep_read(
+                    sqe, io->fd, io->currentBuf(), io->remaining(), io->currentOffset());
             } else {
-                io_uring_prep_write(sqe, io->fd, io->buf_, io->len_, io->offset_);
+                io_uring_prep_write(
+                    sqe, io->fd, io->currentBuf(), io->remaining(), io->currentOffset());
             }
             io_uring_sqe_set_data(sqe, static_cast<nixlPosixIoUringCQEData *>(io));
             io->in_flight_ = true;
@@ -169,6 +202,76 @@ nixlPosixIOQueueUring::releaseIOIfIdle(nixlPosixIoUringIO *io) {
     if (!io->in_flight_ && !io->cancel_pending_) {
         free_ios_.push_back(io);
     }
+}
+
+void
+nixlPosixIOQueueUring::queueForSubmission(nixlPosixIoUringIO *io) {
+    io->in_flight_ = false;
+    ios_to_submit_.push_back(io);
+}
+
+void
+nixlPosixIOQueueUring::finishIO(nixlPosixIoUringIO *io, int res, bool error) {
+    if (error) {
+        NIXL_DEBUG << absl::StrFormat(
+            "IO operation incomplete: result %d, %zu bytes remaining", res, io->remaining());
+    }
+
+    if (io->clb_) {
+        io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(io->len_), error);
+    }
+
+    io->in_flight_ = false;
+    releaseIOIfIdle(io);
+}
+
+void
+nixlPosixIOQueueUring::handleIOCompletion(nixlPosixIoUringIO *io, int res) {
+    if (res < 0) {
+        finishIO(io, res, true);
+        return;
+    }
+
+    const size_t completed = static_cast<size_t>(res);
+
+    if (completed == 0 && io->remaining() != 0) {
+        finishIO(io, res, true);
+        return;
+    }
+
+    io->advance(completed);
+
+    if (io->remaining() == 0) {
+        finishIO(io, res, false);
+        return;
+    }
+
+    if (io->cancel_requested_) {
+        finishIO(io, res, true);
+        return;
+    }
+
+    NIXL_DEBUG << absl::StrFormat(
+        "io_uring operation completed partially: %zu bytes completed, %zu remaining; "
+        "resubmitting remainder",
+        completed,
+        io->remaining());
+    queueForSubmission(io);
+}
+
+void
+nixlPosixIOQueueUring::handleCancelCompletion(nixlPosixIoUringCancel *cancel) {
+    nixlPosixIoUringIO *io = cancel->io_;
+    NIXL_ASSERT(io && io->cancel_pending_);
+    io->cancel_pending_ = false;
+
+    if (cancel->clb_) {
+        cancel->clb_(cancel->ctx_);
+    }
+
+    cancel->clb_ = nullptr;
+    cancel->ctx_ = nullptr;
+    releaseIOIfIdle(io);
 }
 
 nixl_status_t
@@ -204,30 +307,16 @@ nixlPosixIOQueueUring::doCheckCompleted(void) {
         int res = cqe->res;
         auto *data = static_cast<nixlPosixIoUringCQEData *>(io_uring_cqe_get_data(cqe));
         NIXL_ASSERT(data);
-        nixlPosixIoUringIO *io;
-        if (data->kind_ == nixlPosixIoUringCQEKind::CANCEL) {
-            auto *cancel = static_cast<nixlPosixIoUringCancel *>(data);
-            io = cancel->io_;
-            NIXL_ASSERT(io && io->cancel_pending_);
-            io->cancel_pending_ = false;
-            if (cancel->clb_) {
-                cancel->clb_(cancel->ctx_);
-            }
-            cancel->clb_ = nullptr;
-            cancel->ctx_ = nullptr;
-        } else {
-            io = static_cast<nixlPosixIoUringIO *>(data);
-            int error = res < 0 || static_cast<size_t>(res) != io->len_;
-            if (error) {
-                NIXL_DEBUG << absl::StrFormat(
-                    "IO operation incomplete: result %d, expected %zu", res, io->len_);
-            }
-            if (io->clb_) {
-                io->clb_(io->ctx_, error ? 0 : static_cast<uint32_t>(res), error);
-            }
-            io->in_flight_ = false;
+
+        switch (data->kind_) {
+        case nixlPosixIoUringCQEKind::IO:
+            handleIOCompletion(static_cast<nixlPosixIoUringIO *>(data), res);
+            break;
+        case nixlPosixIoUringCQEKind::CANCEL:
+            handleCancelCompletion(static_cast<nixlPosixIoUringCancel *>(data));
+            break;
         }
-        releaseIOIfIdle(io);
+
         if (++count == MAX_IO_CHECK_COMPLETED_BATCH_SIZE) {
             break;
         }
@@ -251,6 +340,8 @@ nixlPosixIOQueueUring::enqueue(int fd,
                                bool read,
                                nixlPosixIOQueueDoneCb clb,
                                void *ctx) {
+    NIXL_ASSERT(buf != nullptr);
+
     if (free_ios_.empty()) {
         NIXL_ERROR << "No more free blocks available";
         return NIXL_ERR_NOT_ALLOWED;
@@ -262,13 +353,15 @@ nixlPosixIOQueueUring::enqueue(int fd,
     io->buf_ = buf;
     io->len_ = len;
     io->offset_ = offset;
+    io->completed_ = 0;
     io->read_ = read;
     io->clb_ = clb;
     io->ctx_ = ctx;
     io->in_flight_ = false;
+    io->cancel_requested_ = false;
     io->cancel_pending_ = false;
 
-    ios_to_submit_.push_back(io);
+    queueForSubmission(io);
 
     return NIXL_SUCCESS;
 }
@@ -298,6 +391,7 @@ nixlPosixIOQueueUring::cancel(void *ctx, nixlPosixIOQueueCancelDoneCb clb) {
     for (auto &io : ios_) {
         if (io.in_flight_ && io.ctx_ == ctx && !io.cancel_pending_) {
             size_t index = static_cast<size_t>(&io - ios_.data());
+            io.cancel_requested_ = true;
             io.cancel_pending_ = true;
             cancels_[index].clb_ = clb;
             cancels_[index].ctx_ = ctx;

--- a/src/plugins/posix/linux_aio_io_queue.cpp
+++ b/src/plugins/posix/linux_aio_io_queue.cpp
@@ -27,10 +27,37 @@
 
 struct nixlPosixLinuxAioIO {
 public:
+    void *
+    currentBuf() const {
+        return static_cast<char *>(buf_) + completed_;
+    }
+
+    off_t
+    currentOffset() const {
+        return offset_ + static_cast<off_t>(completed_);
+    }
+
+    size_t
+    remaining() const {
+        return len_ - completed_;
+    }
+
+    void
+    advance(size_t completed) {
+        NIXL_ASSERT(completed <= remaining());
+        completed_ += completed;
+    }
+
+    int fd_ = -1;
+    void *buf_ = nullptr;
+    off_t offset_ = 0;
+    bool read_ = false;
     nixlPosixIOQueueDoneCb clb_;
     void *ctx_ = nullptr;
     size_t len_ = 0;
+    size_t completed_ = 0;
     bool in_flight_ = false;
+    bool cancel_requested_ = false;
     struct iocb io_;
 };
 
@@ -59,8 +86,12 @@ protected:
     doCheckCompleted(void);
 
 private:
+    void
+    queueForSubmission(nixlPosixLinuxAioIO *io);
     bool
-    completeIO(nixlPosixLinuxAioIO *io, int64_t result);
+    finishIO(nixlPosixLinuxAioIO *io, int64_t result, bool error);
+    bool
+    handleIOCompletion(nixlPosixLinuxAioIO *io, int64_t result);
     void
     failIO(nixlPosixLinuxAioIO *io);
     void
@@ -96,6 +127,8 @@ nixlPosixIOQueueLinuxAIO::enqueue(int fd,
                                   bool read,
                                   nixlPosixIOQueueDoneCb clb,
                                   void *ctx) {
+    NIXL_ASSERT(buf != nullptr);
+
     if (terminal_error_) {
         return NIXL_ERR_BACKEND;
     }
@@ -106,19 +139,31 @@ nixlPosixIOQueueLinuxAIO::enqueue(int fd,
     nixlPosixLinuxAioIO *io = free_ios_.front();
     free_ios_.pop_front();
 
-    if (read) {
-        io_prep_pread(&io->io_, fd, buf, len, offset);
-    } else {
-        io_prep_pwrite(&io->io_, fd, buf, len, offset);
-    }
+    io->fd_ = fd;
+    io->buf_ = buf;
+    io->offset_ = offset;
+    io->read_ = read;
     io->clb_ = clb;
     io->ctx_ = ctx;
     io->len_ = len;
+    io->completed_ = 0;
     io->in_flight_ = false;
-    io->io_.data = io;
-    ios_to_submit_.push_back(io);
+    io->cancel_requested_ = false;
+    queueForSubmission(io);
 
     return NIXL_SUCCESS;
+}
+
+void
+nixlPosixIOQueueLinuxAIO::queueForSubmission(nixlPosixLinuxAioIO *io) {
+    if (io->read_) {
+        io_prep_pread(&io->io_, io->fd_, io->currentBuf(), io->remaining(), io->currentOffset());
+    } else {
+        io_prep_pwrite(&io->io_, io->fd_, io->currentBuf(), io->remaining(), io->currentOffset());
+    }
+    io->io_.data = io;
+    io->in_flight_ = false;
+    ios_to_submit_.push_back(io);
 }
 
 nixlPosixIOQueueLinuxAIO::~nixlPosixIOQueueLinuxAIO() {
@@ -183,21 +228,51 @@ nixlPosixIOQueueLinuxAIO::requeueFrom(nixlPosixLinuxAioIO *const *ios, int first
 }
 
 bool
-nixlPosixIOQueueLinuxAIO::completeIO(nixlPosixLinuxAioIO *io, int64_t result) {
-    NIXL_ASSERT(io->in_flight_);
-    bool error = result < 0 || static_cast<size_t>(result) != io->len_;
+nixlPosixIOQueueLinuxAIO::finishIO(nixlPosixLinuxAioIO *io, int64_t result, bool error) {
     if (error) {
         NIXL_DEBUG << absl::StrFormat(
-            "AIO operation incomplete: result %ld, expected %zu", result, io->len_);
+            "AIO operation incomplete: result %ld, %zu bytes remaining", result, io->remaining());
         failIO(io);
         return true;
     }
 
     io->in_flight_ = false;
     if (io->clb_) {
-        io->clb_(io->ctx_, static_cast<uint32_t>(result), 0);
+        io->clb_(io->ctx_, static_cast<uint32_t>(io->len_), 0);
     }
     free_ios_.push_back(io);
+    return false;
+}
+
+bool
+nixlPosixIOQueueLinuxAIO::handleIOCompletion(nixlPosixLinuxAioIO *io, int64_t result) {
+    NIXL_ASSERT(io->in_flight_);
+    if (result < 0) {
+        return finishIO(io, result, true);
+    }
+
+    const size_t completed = static_cast<size_t>(result);
+
+    if (completed == 0 && io->remaining() != 0) {
+        return finishIO(io, result, true);
+    }
+
+    io->advance(completed);
+
+    if (io->remaining() == 0) {
+        return finishIO(io, result, false);
+    }
+
+    if (io->cancel_requested_) {
+        return finishIO(io, result, true);
+    }
+
+    NIXL_DEBUG << absl::StrFormat(
+        "AIO operation completed partially: %zu bytes completed, %zu remaining; resubmitting "
+        "remainder",
+        completed,
+        io->remaining());
+    queueForSubmission(io);
     return false;
 }
 
@@ -231,7 +306,7 @@ nixlPosixIOQueueLinuxAIO::doCheckCompleted(void) {
     for (int i = 0; i < rc; i++) {
         auto *io = static_cast<nixlPosixLinuxAioIO *>(events[i].obj->data);
         void *ctx = io->ctx_;
-        if (completeIO(io, events[i].res)) {
+        if (handleIOCompletion(io, events[i].res)) {
             failQueuedIOs(ctx);
         }
     }
@@ -306,10 +381,11 @@ nixlPosixIOQueueLinuxAIO::cancel(void *ctx, nixlPosixIOQueueCancelDoneCb) {
             continue;
         }
 
+        io.cancel_requested_ = true;
         struct io_event event{};
         if (io_cancel(io_ctx_, &io.io_, &event) == 0) {
             // io_cancel returns the canceled operation's completion synchronously.
-            completeIO(&io, event.res);
+            handleIOCompletion(&io, event.res);
         }
     }
 

--- a/test/unit/plugins/posix/nixl_posix_aio_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_aio_test.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <cstdlib>
 #include <dlfcn.h>
@@ -23,6 +24,9 @@
 namespace {
 constexpr int request_count = 32, max_poll_iterations = 2000;
 constexpr size_t block_size = 4096;
+constexpr size_t partial_io_offset = 123;
+constexpr size_t partial_read_size = block_size / 4;
+constexpr size_t partial_write_size = 3 * block_size / 8;
 constexpr auto poll_pause = std::chrono::microseconds(50);
 
 enum class submitMode {
@@ -31,6 +35,9 @@ enum class submitMode {
     TRANSIENT_ONCE,
     PARTIAL_THEN_ERROR,
     COMPLETION_ERROR,
+    PARTIAL_READ,
+    PARTIAL_WRITE,
+    PARTIAL_CANCEL,
     TERMINAL_CONTEXT
 };
 submitMode submit_mode = submitMode::PASS_THROUGH;
@@ -42,6 +49,9 @@ long first_requested = 0;
 int first_submitted = 0;
 bool completion_error_injected = false;
 int submissions_after_completion_error = 0;
+std::vector<size_t> partial_io_lengths;
+std::vector<size_t> partial_io_offsets;
+std::vector<uintptr_t> partial_io_buffers;
 
 struct completionState {
     int completions = 0;
@@ -124,7 +134,12 @@ struct aioRequest {
     nixl_meta_dlist_t remote{FILE_SEG};
     nixlPosixBackendReqH request;
 
-    aioRequest(aioTest &test, nixlPosixFileMD &file_md, int first, int count)
+    aioRequest(aioTest &test,
+               nixlPosixFileMD &file_md,
+               int first,
+               int count,
+               nixl_xfer_op_t op = NIXL_WRITE,
+               size_t offset_bias = 0)
         : local([&] {
               nixl_meta_dlist_t list(DRAM_SEG);
               for (int i = first; i < first + count; i++) {
@@ -136,11 +151,12 @@ struct aioRequest {
           remote([&] {
               nixl_meta_dlist_t list(FILE_SEG);
               for (int i = first; i < first + count; i++) {
-                  list.addDesc(nixlMetaDesc(i * block_size, block_size, test.fd, &file_md));
+                  list.addDesc(
+                      nixlMetaDesc(offset_bias + i * block_size, block_size, test.fd, &file_md));
               }
               return list;
           }()),
-          request(NIXL_WRITE, local, remote, test.queue) {}
+          request(op, local, remote, test.queue) {}
 };
 
 nixl_status_t
@@ -163,6 +179,9 @@ setSubmitMode(submitMode mode) {
     first_submitted = 0;
     completion_error_injected = false;
     submissions_after_completion_error = 0;
+    partial_io_lengths.clear();
+    partial_io_offsets.clear();
+    partial_io_buffers.clear();
 }
 
 #define AIO_CHECK(condition)                                                                      \
@@ -187,6 +206,16 @@ io_submit(io_context_t ctx, long nr, struct iocb **iocbpp) {
         submissions_after_completion_error++;
     }
     submit_calls++;
+    if (nr > 0 &&
+        (submit_mode == submitMode::PARTIAL_READ || submit_mode == submitMode::PARTIAL_WRITE)) {
+        struct iocb *const iocb = iocbpp[0];
+        partial_io_lengths.push_back(iocb->u.c.nbytes);
+        partial_io_offsets.push_back(iocb->u.c.offset);
+        partial_io_buffers.push_back(reinterpret_cast<uintptr_t>(iocb->u.c.buf));
+        if (submit_mode == submitMode::PARTIAL_WRITE && partial_io_lengths.size() <= 2) {
+            iocb->u.c.nbytes = partial_write_size;
+        }
+    }
     if (submit_calls == 1) {
         first_requested = nr;
         if (submit_mode == submitMode::TRANSIENT_ONCE) {
@@ -221,7 +250,7 @@ io_cancel(io_context_t ctx, struct iocb *iocb, struct io_event *event) {
         failDlvsym("io_cancel", "LIBAIO_0.4");
     }
     if (submit_mode == submitMode::PARTIAL_THEN_ERROR ||
-        submit_mode == submitMode::COMPLETION_ERROR) {
+        submit_mode == submitMode::COMPLETION_ERROR || submit_mode == submitMode::PARTIAL_CANCEL) {
         return -EAGAIN;
     }
     return real_cancel(ctx, iocb, event);
@@ -260,7 +289,17 @@ io_getevents(io_context_t ctx,
         }
         return rc;
     }
-    return real_getevents(ctx, min_nr, nr, events, timeout);
+    const int rc = real_getevents(ctx, min_nr, nr, events, timeout);
+    if (rc > 0 && partial_io_lengths.size() <= 2 &&
+        (submit_mode == submitMode::PARTIAL_READ || submit_mode == submitMode::PARTIAL_WRITE)) {
+        if (submit_mode == submitMode::PARTIAL_READ) {
+            events[0].res = partial_read_size;
+        }
+    }
+    if (rc > 0 && submit_mode == submitMode::PARTIAL_CANCEL) {
+        events[0].res /= 2;
+    }
+    return rc;
 }
 
 int
@@ -284,6 +323,67 @@ main() {
         AIO_CHECK(test.drain() == NIXL_SUCCESS);
         AIO_CHECK(submit_calls > 1);
         AIO_CHECK(state.completions == request_count && state.errors == 0);
+    }
+    for (const bool read : {true, false}) {
+        const size_t partial_size = read ? partial_read_size : partial_write_size;
+        setSubmitMode(read ? submitMode::PARTIAL_READ : submitMode::PARTIAL_WRITE);
+        aioTest test(1);
+        std::array<char, partial_io_offset> prefix;
+        std::array<char, block_size> expected;
+        std::memset(prefix.data(), 0x3c, prefix.size());
+        std::memset(expected.data(), read ? 0x5a : 0x1, expected.size());
+        AIO_CHECK(pwrite(test.fd, prefix.data(), prefix.size(), 0) ==
+                  static_cast<ssize_t>(prefix.size()));
+        if (read) {
+            AIO_CHECK(pwrite(test.fd, expected.data(), expected.size(), partial_io_offset) ==
+                      static_cast<ssize_t>(expected.size()));
+            std::memset(test.buffers[0].data(), 0, block_size);
+        }
+        nixlPosixFileMD file_md(test.fd, "");
+        aioRequest transfer(test, file_md, 0, 1, read ? NIXL_READ : NIXL_WRITE, partial_io_offset);
+        AIO_CHECK(transfer.request.postXfer() == NIXL_IN_PROG);
+        AIO_CHECK(waitFor(transfer) == NIXL_SUCCESS);
+        AIO_CHECK(partial_io_lengths.size() == 3);
+
+        const uintptr_t buffer = reinterpret_cast<uintptr_t>(test.buffers[0].data());
+        for (size_t i = 0; i < 3; i++) {
+            const size_t completed = i * partial_size;
+            AIO_CHECK(partial_io_lengths[i] == block_size - completed &&
+                      partial_io_offsets[i] == partial_io_offset + completed &&
+                      partial_io_buffers[i] == buffer + completed);
+        }
+
+        std::array<char, partial_io_offset> actual_prefix{};
+        std::array<char, block_size> actual{};
+        AIO_CHECK(pread(test.fd, actual_prefix.data(), actual_prefix.size(), 0) ==
+                      static_cast<ssize_t>(actual_prefix.size()) &&
+                  std::memcmp(actual_prefix.data(), prefix.data(), prefix.size()) == 0);
+        if (read) {
+            std::memcpy(actual.data(), test.buffers[0].data(), block_size);
+        } else {
+            AIO_CHECK(pread(test.fd, actual.data(), actual.size(), partial_io_offset) ==
+                      static_cast<ssize_t>(actual.size()));
+        }
+        AIO_CHECK(std::memcmp(actual.data(), expected.data(), block_size) == 0);
+    }
+    for (const size_t file_size : {size_t{0}, block_size / 2}) {
+        setSubmitMode(submitMode::PASS_THROUGH);
+        aioTest test(1);
+        std::array<char, block_size> expected;
+        std::memset(expected.data(), 0x6b, expected.size());
+        if (file_size) {
+            AIO_CHECK(pwrite(test.fd, expected.data(), expected.size(), 0) ==
+                          static_cast<ssize_t>(expected.size()) &&
+                      ftruncate(test.fd, file_size) == 0);
+        }
+        std::memset(test.buffers[0].data(), 0, block_size);
+
+        nixlPosixFileMD file_md(test.fd, "");
+        aioRequest read(test, file_md, 0, 1, NIXL_READ);
+        AIO_CHECK(read.request.postXfer() == NIXL_IN_PROG);
+        AIO_CHECK(waitFor(read) == NIXL_ERR_BACKEND && submit_calls == (file_size ? 2 : 1));
+        AIO_CHECK(!file_size ||
+                  std::memcmp(test.buffers[0].data(), expected.data(), file_size) == 0);
     }
     {
         setSubmitMode(submitMode::PARTIAL_THEN_ERROR);
@@ -315,19 +415,11 @@ main() {
         nixlPosixFileMD file_md(test.fd, "");
         aioRequest failed(test, file_md, 0, completion_error_request_count);
 
-        nixl_status_t status = failed.request.postXfer();
-        AIO_CHECK(status == NIXL_IN_PROG);
+        AIO_CHECK(failed.request.postXfer() == NIXL_IN_PROG);
         AIO_CHECK(first_submitted > 0 && first_submitted < first_requested);
-
-        for (int i = 0;
-             i < max_poll_iterations && !completion_error_injected && status == NIXL_IN_PROG;
-             i++) {
-            status = failed.request.checkXfer();
-            std::this_thread::sleep_for(poll_pause);
-        }
+        AIO_CHECK(waitFor(failed) == NIXL_ERR_BACKEND);
         AIO_CHECK(completion_error_injected);
         AIO_CHECK(submissions_after_completion_error == 0);
-        AIO_CHECK(waitFor(failed, status) == NIXL_ERR_BACKEND);
     }
     {
         setSubmitMode(submitMode::TERMINAL_CONTEXT);
@@ -348,6 +440,29 @@ main() {
                                       false,
                                       completionCallback,
                                       &state) == NIXL_ERR_BACKEND);
+    }
+    for (const bool read : {true, false}) {
+        setSubmitMode(submitMode::PARTIAL_CANCEL);
+        aioTest test(1);
+        if (read) {
+            AIO_CHECK(pwrite(test.fd, test.buffers[0].data(), block_size, 0) ==
+                      static_cast<ssize_t>(block_size));
+        }
+        completionState cancelled;
+        AIO_CHECK(test.queue->enqueue(test.fd,
+                                      test.buffers[0].data(),
+                                      block_size,
+                                      0,
+                                      read,
+                                      completionCallback,
+                                      &cancelled) == NIXL_SUCCESS);
+        AIO_CHECK(test.queue->post() == NIXL_IN_PROG);
+        AIO_CHECK(submit_calls == 1);
+
+        const unsigned waits = test.queue->cancel(&cancelled, cancelCompletionCallback);
+        AIO_CHECK(waits == 0 && test.drain() == NIXL_SUCCESS);
+        AIO_CHECK(submit_calls == 1);
+        AIO_CHECK(cancelled.completions == 1 && cancelled.errors == 1);
     }
     {
         constexpr int scoped_request_count = 65;

--- a/test/unit/plugins/posix/nixl_posix_uring_test.cpp
+++ b/test/unit/plugins/posix/nixl_posix_uring_test.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -24,13 +25,28 @@
 namespace {
 constexpr int request_count = 32, ring_entries = 16, max_poll_iterations = 2000;
 constexpr size_t block_size = 4096;
+constexpr size_t partial_io_offset = 123;
+constexpr size_t partial_read_size = block_size / 4;
+constexpr size_t partial_write_size = 3 * block_size / 8;
 constexpr auto poll_pause = std::chrono::microseconds(50);
 using buffers_t = std::array<std::array<char, block_size>, request_count>;
 
-enum class submit_mode_t { PARTIAL_ONLY, TRANSIENT_ERRORS, PASS_THROUGH };
+enum class submit_mode_t {
+    PARTIAL_ONLY,
+    TRANSIENT_ERRORS,
+    PARTIAL_READ,
+    PARTIAL_WRITE,
+    PARTIAL_CANCEL,
+    PASS_THROUGH
+};
 submit_mode_t submit_mode = submit_mode_t::PASS_THROUGH;
 int submit_calls = 0, transient_submit_errors = 0, cancel_completions = 0;
 unsigned first_ready = 0, first_submitted = 0;
+int partial_io_submissions = 0;
+struct io_uring *last_submitted_ring = nullptr;
+std::array<unsigned, 3> partial_io_lengths{};
+std::array<size_t, 3> partial_io_offsets{};
+std::array<uintptr_t, 3> partial_io_buffers{};
 
 struct completionState {
     int count = 0, errors = 0;
@@ -58,6 +74,8 @@ struct uringTest {
         submit_mode = mode;
         submit_calls = transient_submit_errors = cancel_completions = first_ready =
             first_submitted = 0;
+        partial_io_submissions = 0;
+        last_submitted_ring = nullptr;
         char path[] = "/tmp/nixl_uring_test_XXXXXX";
         if ((fd = mkstemp(path)) < 0) {
             throw std::runtime_error("mkstemp failed");
@@ -106,7 +124,11 @@ struct uringRequest {
     nixl_xfer_op_t operation = NIXL_WRITE;
     nixlPosixBackendReqH request;
 
-    uringRequest(uringTest &test, nixlPosixFileMD &file_md, int index)
+    uringRequest(uringTest &test,
+                 nixlPosixFileMD &file_md,
+                 int index,
+                 nixl_xfer_op_t op = NIXL_WRITE,
+                 size_t offset_bias = 0)
         : local([&] {
               nixl_meta_dlist_t list(DRAM_SEG);
               list.addDesc(nixlMetaDesc(
@@ -115,11 +137,22 @@ struct uringRequest {
           }()),
           remote([&] {
               nixl_meta_dlist_t list(FILE_SEG);
-              list.addDesc(nixlMetaDesc(index * block_size, block_size, test.fd, &file_md));
+              list.addDesc(
+                  nixlMetaDesc(offset_bias + index * block_size, block_size, test.fd, &file_md));
               return list;
           }()),
+          operation(op),
           request(operation, local, remote, test.queue) {}
 };
+
+nixl_status_t
+waitFor(uringRequest &request, nixl_status_t status = NIXL_IN_PROG) {
+    for (int i = 0; i < max_poll_iterations && status == NIXL_IN_PROG; i++) {
+        status = request.request.checkXfer();
+        std::this_thread::sleep_for(poll_pause);
+    }
+    return status;
+}
 
 #define URING_CHECK(condition)                                                        \
     do {                                                                              \
@@ -138,13 +171,36 @@ io_uring_submit(struct io_uring *ring) LIBURING_NOEXCEPT {
     if (!real_submit) {
         return -EINVAL;
     }
+    last_submitted_ring = ring;
     if (submit_mode == submit_mode_t::TRANSIENT_ERRORS && transient_submit_errors == 0) {
         transient_submit_errors++;
         return -EAGAIN;
     }
 
     const unsigned ready = io_uring_sq_ready(ring);
-    if (ready == 0 || submit_mode == submit_mode_t::PASS_THROUGH || ++submit_calls != 1 ||
+    submit_calls += ready > 0;
+    if (submit_mode == submit_mode_t::PARTIAL_CANCEL && ready > 0 && partial_io_submissions == 0) {
+        struct io_uring_sqe *const sqe = &ring->sq.sqes[ring->sq.sqe_head & *ring->sq.kring_mask];
+        sqe->len /= 2;
+        partial_io_submissions++;
+        return real_submit(ring);
+    }
+    if (ready > 0 &&
+        (submit_mode == submit_mode_t::PARTIAL_READ ||
+         submit_mode == submit_mode_t::PARTIAL_WRITE)) {
+        struct io_uring_sqe *const sqe = &ring->sq.sqes[ring->sq.sqe_head & *ring->sq.kring_mask];
+        if (partial_io_submissions < static_cast<int>(partial_io_lengths.size())) {
+            partial_io_lengths[partial_io_submissions] = sqe->len;
+            partial_io_offsets[partial_io_submissions] = sqe->off;
+            partial_io_buffers[partial_io_submissions] = sqe->addr;
+        }
+        if (partial_io_submissions++ < 2) {
+            sqe->len =
+                submit_mode == submit_mode_t::PARTIAL_READ ? partial_read_size : partial_write_size;
+        }
+        return real_submit(ring);
+    }
+    if (ready == 0 || submit_mode == submit_mode_t::PASS_THROUGH || submit_calls != 1 ||
         ready < 2) {
         return real_submit(ring);
     }
@@ -187,6 +243,86 @@ main() {
         URING_CHECK(test.drain() == NIXL_SUCCESS && transient_submit_errors == 1);
         URING_CHECK(state.count == request_count && !state.errors);
     }
+    for (const bool read : {true, false}) {
+        const size_t partial_size = read ? partial_read_size : partial_write_size;
+        uringTest test(read ? submit_mode_t::PARTIAL_READ : submit_mode_t::PARTIAL_WRITE);
+        std::array<char, partial_io_offset> prefix;
+        std::array<char, block_size> expected;
+        std::memset(prefix.data(), 0x3c, prefix.size());
+        std::memset(expected.data(), read ? 0x5a : 0x1, expected.size());
+        URING_CHECK(pwrite(test.fd, prefix.data(), prefix.size(), 0) ==
+                    static_cast<ssize_t>(prefix.size()));
+        if (read) {
+            URING_CHECK(pwrite(test.fd, expected.data(), expected.size(), partial_io_offset) ==
+                        static_cast<ssize_t>(expected.size()));
+            std::memset(test.buffers[0].data(), 0, block_size);
+        }
+        nixlPosixFileMD file_md(test.fd, "");
+        uringRequest transfer(test, file_md, 0, read ? NIXL_READ : NIXL_WRITE, partial_io_offset);
+        URING_CHECK(transfer.request.postXfer() == NIXL_IN_PROG);
+        URING_CHECK(waitFor(transfer) == NIXL_SUCCESS && partial_io_submissions == 3);
+        const uintptr_t buffer = reinterpret_cast<uintptr_t>(test.buffers[0].data());
+        for (size_t i = 0; i < partial_io_lengths.size(); i++) {
+            const size_t completed = i * partial_size;
+            URING_CHECK(partial_io_lengths[i] == block_size - completed &&
+                        partial_io_offsets[i] == partial_io_offset + completed &&
+                        partial_io_buffers[i] == buffer + completed);
+        }
+        std::array<char, partial_io_offset> actual_prefix{};
+        std::array<char, block_size> actual{};
+        URING_CHECK(pread(test.fd, actual_prefix.data(), actual_prefix.size(), 0) ==
+                        static_cast<ssize_t>(actual_prefix.size()) &&
+                    std::memcmp(actual_prefix.data(), prefix.data(), prefix.size()) == 0);
+        if (read) {
+            std::memcpy(actual.data(), test.buffers[0].data(), block_size);
+        } else {
+            URING_CHECK(pread(test.fd, actual.data(), actual.size(), partial_io_offset) ==
+                        static_cast<ssize_t>(actual.size()));
+        }
+        URING_CHECK(std::memcmp(actual.data(), expected.data(), block_size) == 0);
+    }
+    for (const size_t file_size : {size_t{0}, block_size / 2}) {
+        uringTest test(submit_mode_t::PASS_THROUGH);
+        std::array<char, block_size> expected;
+        std::memset(expected.data(), 0x6b, expected.size());
+        if (file_size) {
+            URING_CHECK(pwrite(test.fd, expected.data(), expected.size(), 0) ==
+                            static_cast<ssize_t>(expected.size()) &&
+                        ftruncate(test.fd, file_size) == 0);
+        }
+        std::memset(test.buffers[0].data(), 0, block_size);
+        nixlPosixFileMD file_md(test.fd, "");
+        uringRequest read(test, file_md, 0, NIXL_READ);
+        URING_CHECK(read.request.postXfer() == NIXL_IN_PROG);
+        URING_CHECK(waitFor(read) == NIXL_ERR_BACKEND && submit_calls == (file_size ? 2 : 1));
+        URING_CHECK(!file_size ||
+                    std::memcmp(test.buffers[0].data(), expected.data(), file_size) == 0);
+    }
+    for (const bool read : {true, false}) {
+        uringTest test(submit_mode_t::PARTIAL_CANCEL);
+        if (read) {
+            URING_CHECK(pwrite(test.fd, test.buffers[0].data(), block_size, 0) ==
+                        static_cast<ssize_t>(block_size));
+        }
+        completionState cancelled;
+        URING_CHECK(test.queue->enqueue(test.fd,
+                                        test.buffers[0].data(),
+                                        block_size,
+                                        0,
+                                        read,
+                                        completionCallback,
+                                        &cancelled) == NIXL_SUCCESS);
+        URING_CHECK(test.queue->post() == NIXL_IN_PROG);
+        for (int i = 0; i < max_poll_iterations &&
+             (!last_submitted_ring || io_uring_cq_ready(last_submitted_ring) == 0);
+             i++) {
+            std::this_thread::sleep_for(poll_pause);
+        }
+        URING_CHECK(last_submitted_ring && io_uring_cq_ready(last_submitted_ring) > 0);
+        URING_CHECK(test.queue->cancel(&cancelled, cancelCompletionCallback) == 1);
+        URING_CHECK(test.drain() == NIXL_SUCCESS && partial_io_submissions == 1);
+        URING_CHECK(cancelled.count == 1 && cancelled.errors == 1 && cancel_completions == 1);
+    }
     {
         uringTest test(submit_mode_t::PASS_THROUGH);
         nixlPosixFileMD file_md(test.fd, "");
@@ -195,18 +331,9 @@ main() {
         URING_CHECK(cancelled_status >= NIXL_IN_PROG);
         URING_CHECK(test.queue->cancel(&cancelled.request, cancelCompletionCallback) == 1);
 
-        nixl_status_t status = unrelated.request.postXfer();
-        URING_CHECK(status >= NIXL_IN_PROG);
-        for (int i = 0; i < max_poll_iterations && status == NIXL_IN_PROG; i++) {
-            status = unrelated.request.checkXfer();
-            std::this_thread::sleep_for(poll_pause);
-        }
-        URING_CHECK(status == NIXL_SUCCESS);
-
-        for (int i = 0; i < max_poll_iterations && cancelled_status == NIXL_IN_PROG; i++) {
-            cancelled_status = cancelled.request.checkXfer();
-            std::this_thread::sleep_for(poll_pause);
-        }
+        URING_CHECK(unrelated.request.postXfer() >= NIXL_IN_PROG);
+        URING_CHECK(waitFor(unrelated) == NIXL_SUCCESS);
+        cancelled_status = waitFor(cancelled, cancelled_status);
         URING_CHECK(cancelled_status == NIXL_SUCCESS || cancelled_status == NIXL_ERR_BACKEND);
         URING_CHECK(test.drain() == NIXL_SUCCESS && cancel_completions == 1);
     }


### PR DESCRIPTION
## What?
We currently treat partial reads in the uring and AIO POSIX backends as errors. This PR changes it to resubmit and the requests stays in `IN_PROC`.  0-byte reads are treated as errors, that can happen if for example the file is truncated while reading. 

We had some discussions about this with @vvenkates27 , let's continue the discussion on this PR

## Why?

Retries can happen, for example if the process is sent a signal etc.

## How?

Keep track of total lenght. On non-error, partial I/Os we resubmit the request. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for asynchronous file reads and writes that complete in partial transfers.
  - Correctly resumes incomplete operations without losing progress or data.
  - Improved handling of cancellation requests, including cancellation errors and in-progress operations.
  - Added validation for end-of-file, zero-progress, and other incomplete-transfer conditions.
  - Completion notifications now consistently report the full requested transfer length.

- **Tests**
  - Expanded coverage for partial reads and writes, truncated files, errors, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->