### PR TITLE
build: enable cuObject S3 acceleration in the NIXL and nixlbench containers

### DIFF
--- a/benchmark/nixlbench/contrib/Dockerfile
+++ b/benchmark/nixlbench/contrib/Dockerfile
@@ -16,12 +16,50 @@
 ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
 
+# libcuobjclient dev files: the cuda-dl-base devel images ship the runtime but
+# not libcuobjclient-dev, so the OBJ plugin silently loses cuObject RDMA
+# acceleration. Keep pinned to the same release as BASE_IMAGE_TAG.
+ARG CUOBJ_DEV_IMAGE="nvcr.io/nvidia/cuda-dl-base:26.08-cuda13.4-inference-devel-ubuntu24.04"
+
 # UCX argument is either "upstream" (default installed in base image) or "custom" (build from source)
 ARG UCX="upstream"
 ARG DEFAULT_PYTHON_VERSION="3.12"
 
+FROM ${CUOBJ_DEV_IMAGE} AS cuobj_dev
+RUN set -e; \
+    T="$(echo "$(readlink -f /usr/local/cuda)"/targets/*-linux)"; \
+    mkdir -p /cuobj/include /cuobj/lib /cuobj/pkgconfig; \
+    cp -a "$T"/include/cuobj*.h /cuobj/include/; \
+    cp -a "$T"/lib/libcuobjclient.so /cuobj/lib/; \
+    cp -a /usr/lib/pkgconfig/cuobjclient-*.pc /cuobj/pkgconfig/; \
+    basename "$(ls "$T"/lib/libcuobjclient.so.1.*)" > /cuobj/soname
+
 # --- Stage 1: Common OS setup ---
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG} AS os_setup_stage
+
+# Install them only when the base has a matching runtime and no dev files of
+# its own, so bases that are already correct or have no cuObject are untouched.
+COPY --from=cuobj_dev /cuobj /tmp/cuobj
+RUN set -e; \
+    CUDA_DIR="$(readlink -f /usr/local/cuda)"; \
+    T="$(echo "$CUDA_DIR"/targets/*-linux)"; \
+    have="$(basename "$(ls "$T"/lib/libcuobjclient.so.1.* 2>/dev/null | head -1)" 2>/dev/null)"; \
+    want="$(cat /tmp/cuobj/soname)"; \
+    if [ -e "$T/include/cuobjclient.h" ]; then \
+        echo "cuObject: dev files already present, leaving base untouched"; \
+    elif [ -z "$have" ]; then \
+        echo "cuObject: no runtime in base, skipping dev files"; \
+    elif [ "$have" != "$want" ]; then \
+        echo "cuObject: base runtime $have != dev files $want, skipping"; \
+    else \
+        cp -a /tmp/cuobj/include/*.h "$T/include/"; \
+        cp -a /tmp/cuobj/lib/libcuobjclient.so "$T/lib/"; \
+        PC="$(ls /tmp/cuobj/pkgconfig/cuobjclient-*.pc | head -1)"; \
+        mkdir -p /usr/lib/pkgconfig; \
+        sed "s|^cudaroot=.*|cudaroot=$CUDA_DIR|" "$PC" > "/usr/lib/pkgconfig/$(basename "$PC")"; \
+        echo "cuObject: installed dev files for $want"; \
+    fi; \
+    rm -rf /tmp/cuobj
 
 # Re-declare for use in this stage
 ARG ARCH="x86_64"
@@ -277,6 +315,20 @@ RUN rm -rf build && \
     cd build && \
     ninja -j${NPROC:-$(nproc)} && \
     ninja install
+
+# Fail the build if cuObject acceleration did not make it into the plugin.
+RUN set -e; \
+    T="$(echo "$(readlink -f /usr/local/cuda)"/targets/*-linux)"; \
+    if ! ls "$T"/lib/libcuobjclient.so.1.* >/dev/null 2>&1; then \
+        echo "cuObject: no runtime in base, skipping OBJ plugin check"; \
+    else \
+        P="$(find /usr/local/nixl -name libplugin_OBJ.so -print -quit)"; \
+        test -n "$P" || { echo "ERROR: libplugin_OBJ.so not found" >&2; exit 1; }; \
+        readelf -d "$P" | grep -q libcuobjclient || { \
+            echo "ERROR: libplugin_OBJ.so is missing libcuobjclient; S3 acceleration is not compiled in" >&2; \
+            exit 1; }; \
+        echo "cuObject: libplugin_OBJ.so links libcuobjclient"; \
+    fi
 
 RUN echo "/usr/local/nixl/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
     echo "/usr/local/nixl/lib/$ARCH-linux-gnu/plugins" >> /etc/ld.so.conf.d/nixl.conf && \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -17,7 +17,45 @@ ARG BASE_IMAGE="nvcr.io/nvidia/cuda-dl-base"
 ARG BASE_IMAGE_TAG="25.10-cuda13.0-devel-ubuntu24.04"
 ARG OS
 
+# libcuobjclient dev files: the cuda-dl-base devel images ship the runtime but
+# not libcuobjclient-dev, so the OBJ plugin silently loses cuObject RDMA
+# acceleration. Keep pinned to the same release as BASE_IMAGE_TAG.
+ARG CUOBJ_DEV_IMAGE="nvcr.io/nvidia/cuda-dl-base:26.08-cuda13.4-inference-devel-ubuntu24.04"
+
+FROM ${CUOBJ_DEV_IMAGE} AS cuobj_dev
+RUN set -e; \
+    T="$(echo "$(readlink -f /usr/local/cuda)"/targets/*-linux)"; \
+    mkdir -p /cuobj/include /cuobj/lib /cuobj/pkgconfig; \
+    cp -a "$T"/include/cuobj*.h /cuobj/include/; \
+    cp -a "$T"/lib/libcuobjclient.so /cuobj/lib/; \
+    cp -a /usr/lib/pkgconfig/cuobjclient-*.pc /cuobj/pkgconfig/; \
+    basename "$(ls "$T"/lib/libcuobjclient.so.1.*)" > /cuobj/soname
+
 FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
+
+# Install them only when the base has a matching runtime and no dev files of
+# its own, so bases that are already correct or have no cuObject are untouched.
+COPY --from=cuobj_dev /cuobj /tmp/cuobj
+RUN set -e; \
+    CUDA_DIR="$(readlink -f /usr/local/cuda)"; \
+    T="$(echo "$CUDA_DIR"/targets/*-linux)"; \
+    have="$(basename "$(ls "$T"/lib/libcuobjclient.so.1.* 2>/dev/null | head -1)" 2>/dev/null)"; \
+    want="$(cat /tmp/cuobj/soname)"; \
+    if [ -e "$T/include/cuobjclient.h" ]; then \
+        echo "cuObject: dev files already present, leaving base untouched"; \
+    elif [ -z "$have" ]; then \
+        echo "cuObject: no runtime in base, skipping dev files"; \
+    elif [ "$have" != "$want" ]; then \
+        echo "cuObject: base runtime $have != dev files $want, skipping"; \
+    else \
+        cp -a /tmp/cuobj/include/*.h "$T/include/"; \
+        cp -a /tmp/cuobj/lib/libcuobjclient.so "$T/lib/"; \
+        PC="$(ls /tmp/cuobj/pkgconfig/cuobjclient-*.pc | head -1)"; \
+        mkdir -p /usr/lib/pkgconfig; \
+        sed "s|^cudaroot=.*|cudaroot=$CUDA_DIR|" "$PC" > "/usr/lib/pkgconfig/$(basename "$PC")"; \
+        echo "cuObject: installed dev files for $want"; \
+    fi; \
+    rm -rf /tmp/cuobj
 
 # Set default OS if not provided
 ARG OS=${OS:-ubuntu24}
@@ -378,6 +416,20 @@ RUN rm -rf build && \
     cd build && \
     ninja -j${NPROC:-$(nproc)} && \
     ninja install
+
+# Fail the build if cuObject acceleration did not make it into the plugin.
+RUN set -e; \
+    T="$(echo "$(readlink -f /usr/local/cuda)"/targets/*-linux)"; \
+    if ! ls "$T"/lib/libcuobjclient.so.1.* >/dev/null 2>&1; then \
+        echo "cuObject: no runtime in base, skipping OBJ plugin check"; \
+    else \
+        P="$(find "$NIXL_PREFIX" -name libplugin_OBJ.so -print -quit)"; \
+        test -n "$P" || { echo "ERROR: libplugin_OBJ.so not found" >&2; exit 1; }; \
+        readelf -d "$P" | grep -q libcuobjclient || { \
+            echo "ERROR: libplugin_OBJ.so is missing libcuobjclient; S3 acceleration is not compiled in" >&2; \
+            exit 1; }; \
+        echo "cuObject: libplugin_OBJ.so links libcuobjclient"; \
+    fi
 
 RUN echo "$NIXL_PREFIX/lib/$ARCH-linux-gnu" > /etc/ld.so.conf.d/nixl.conf && \
     echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \

--- a/meson.build
+++ b/meson.build
@@ -147,10 +147,29 @@ has_posix_aio = cpp.has_function('aio_cancel', prefix: '#include <aio.h>', depen
 # Check whether the POSIX plugin is enabled
 has_posix_plugin = has_linux_aio or has_io_uring or has_posix_aio
 
-# Check for CUObject Client library — try newest first so CUDA 13.2+ wheels
-# pick up the versioned pkg-config module that matches the build environment.
+# Check for CUObject Client library. The pkg-config module is versioned as
+# cuobjclient-<major>.<minor>, so ask pkg-config what the build environment
+# actually provides rather than relying only on a hardcoded list, which goes
+# stale with every CUDA release. The static list below is the fallback for
+# environments where pkg-config cannot be invoked directly.
 cuobj_dep = dependency('', required: false)
-foreach _cuobj_pkg : ['cuobjclient-13.3', 'cuobjclient-13.2', 'cuobjclient-13.1']
+_cuobj_modules = []
+_cuobj_probe = run_command('sh', '-c',
+    'pkg-config --list-all 2>/dev/null | cut -d" " -f1 | grep "^cuobjclient-" | sort -V -r',
+    check: false)
+if _cuobj_probe.returncode() == 0
+    foreach _line : _cuobj_probe.stdout().strip().split('\n')
+        if _line != ''
+            _cuobj_modules += _line
+        endif
+    endforeach
+endif
+foreach _fallback : ['cuobjclient-13.4', 'cuobjclient-13.3', 'cuobjclient-13.2', 'cuobjclient-13.1']
+    if _fallback not in _cuobj_modules
+        _cuobj_modules += _fallback
+    endif
+endforeach
+foreach _cuobj_pkg : _cuobj_modules
     _candidate = dependency(_cuobj_pkg, required: false)
     if _candidate.found()
         cuobj_dep = _candidate
@@ -160,6 +179,15 @@ foreach _cuobj_pkg : ['cuobjclient-13.3', 'cuobjclient-13.2', 'cuobjclient-13.1'
 endforeach
 if cuobj_dep.found()
     add_project_arguments('-DHAVE_CUOBJ_CLIENT', language: ['cpp'])
+    summary({'cuObject (OBJ plugin RDMA)': 'enabled'}, section: 'Dependencies')
+else
+    warning('cuObjClient not found: the OBJ plugin will be built WITHOUT cuObject ' +
+            'RDMA acceleration. Searched pkg-config modules: ' +
+            ', '.join(_cuobj_modules) + '. Install the libcuobjclient development ' +
+            'package, which provides cuobjclient-<version>.pc, and make sure ' +
+            'pkg-config can find it (PKG_CONFIG_PATH).')
+    summary({'cuObject (OBJ plugin RDMA)': 'DISABLED - cuobjclient not found'},
+            section: 'Dependencies')
 endif
 
 # Search for Abseil dependencies in the system first


### PR DESCRIPTION
## What?
 - meson.build: discover the cuobjclient pkg-config module from pkg-config --list-all (newest first) instead of a hardcoded list that stopped at cuobjclient-13.3. Warn when none is found.
 - Both contrib/Dockerfiles: install the libcuobjclient development files from the inference-devel image of the same release, then assert with readelf that libplugin_OBJ.so links libcuobjclient.

No change to how the containers are invoked; no new build flags.

## Why?
The NGC cuda-dl-base devel images ship the libcuobjclient runtime but not libcuobjclient-dev. NIXL's cuObject probe is required: false, so both containers built an OBJ plugin with no RDMA data path and nothing said so — every plugin loaded and the containers were otherwise fully functional, so it went unnoticed until a downstream accelerated-OBJ test failed its preflight check.

Separately, meson never probed cuobjclient-13.4, so CUDA 13.4 was undetected even where packaging is correct. 

The wheels were unaffected: they build from cuda:13.2.1-devel-ubi8, which packages cuObject completely, and Dockerfile.manylinux already has this readelf assertion. This brings the containers in line.

## How?
Both Dockerfile steps are guarded, so the change is inert unless it is needed. Dev files are installed only when the base has no cuobjclient.h of its own, does have a libcuobjclient.so.1.* runtime, and that runtime's SONAME matches the staged files — otherwise it prints a note and continues. The assertion is gated on the same runtime check, which also covers CUDA 12 without a separate flag.

Keep CUOBJ_DEV_IMAGE pinned to the same release as BASE_IMAGE_TAG; readelf catches a missing link, not a subtly wrong pin.

Verified on stock NGC images:

``` 
  ┌──────────────────────┬───────────────────────────────────────────────────────────────────┐
  │         Base         │                              Result                               │
  ├──────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ 26.08-cuda13.4-devel │ installs; both containers link libcuobjclient.so.1, NIXL EP built │
  ├──────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ 26.07-cuda13.3-devel │ no cuObject, skips, builds unchanged                              │
  ├──────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ cuda:13.3.1-devel    │ already has 13.3 dev files, left untouched                        │ 
  └──────────────────────┴───────────────────────────────────────────────────────────────────┘
```

### Release builds

The current default `BASE_IMAGE_TAG` (`25.10-cuda13.0-devel-ubuntu24.04`) ships no cuObject at all, so on the default this change is inert — it prints `cuObject: no runtime in base, skipping` and builds exactly as before.

Until the default moves to a 13.4 image, **release container builds should pin the base explicitly**:

```
--base-image-tag 26.08-cuda13.4-devel-ubuntu24.04
```

With that pin the `readelf` assertion makes acceleration enforced rather than assumed: if the base ever stops providing cuObject, the release build fails instead of quietly shipping an unaccelerated OBJ plugin. Both containers are verified on that image (NIXL EP built, 11 plugins, `ldd -r` clean). Wheels are unaffected — they build from
`cuda:13.2.1-devel-ubi8`.

Note: #2205 flips the default `BASE_IMAGE_TAG` to `26.08-cuda13.4-devel` and touches the same files. Once it lands the pin becomes redundant, though it stays valid either way; whichever of the two merges second needs a trivial rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for automatically detecting compatible CUDA cuObject development files during container builds.
  - Added compatibility handling for multiple CUDA cuObject runtime versions.

- **Bug Fixes**
  - Container builds now verify that required cuObject plugin libraries are present and correctly linked when CUDA support is available.
  - Improved cuObject dependency discovery across supported CUDA versions.

- **Documentation**
  - Configuration warnings now identify missing cuObject dependencies and the modules that were searched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->