### PR TITLE
GPUNETIO: add opt-in native GPU PUT and completion

### DIFF
--- a/README_GPUNETIO.md
+++ b/README_GPUNETIO.md
@@ -1,0 +1,172 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Native GPUNETIO Device API GTest harness
+
+## Supported API and lifetime
+
+Build capability and runtime selection are both opt-in. Set the GPUNETIO
+backend parameter `native_device_api=true`; the default remains the legacy
+host READ/WRITE backend. Select that backend explicitly in both memory-view
+preparation calls. An application CUDA thread can then call:
+
+```cpp
+nixlGpuXferStatusH status{};
+auto rc = nixlPut<nixl_gpu_level_t::THREAD>(
+    {local_view, local_index, local_offset},
+    {remote_view, remote_index, remote_offset}, bytes, 0, 0, &status);
+// Only an accepted operation (rc == NIXL_IN_PROG) may be polled.
+// Use a bounded polling loop in the caller.
+rc = nixlGpuGetXferStatus<nixl_gpu_level_t::THREAD>(status);
+```
+
+The initial implementation supports one remote peer, one unretired PUT per
+shared data QP, and ordinary registered VRAM on the engine's execution GPU.
+All views of that peer share the same lane. Submission is not completion;
+an occupied lane rejects another request without posting. A terminal status
+is cached; status objects are single-owner and must not be reused in flight.
+Zero-sized transfers, other execution levels, channels/flags, atomics and
+host transfers/notifications in native mode are unsupported. No proxy fallback
+is supplied. This is not a throughput or production receiver-ready protocol.
+
+Prepare/release are cold operations: no capture, no concurrent application
+kernels, and no outstanding work requiring progress in that CUDA context.
+In particular, allocator synchronization must not run alongside a persistent
+legacy kernel in the same context. Views, registrations, remote metadata,
+payload buffers and the engine must outlive all submitted operations.
+Finish application kernels and establish terminal NIC completion before
+normal release. Native local views pin their registrations. A release on a
+non-idle lane retains the backend view and MR pins until QP teardown; it is
+not cancellation and does not permit freeing payload memory or running kernels
+against released public handles. Errors latch the lane; recovery/error teardown
+requires additional validation before production use. The test exits nonzero
+without normal cleanup if accepted operations cannot be safely retired.
+
+This branch changes the plugin ABI to version 2 and reserves the last four
+bytes of the existing 64-byte device status for a backend tag. Rebuild core,
+plugins and application CUDA extensions together; old-header compatibility
+is not claimed.
+
+This harness is a bounded correctness test for the public NIXL GPU Device API.
+It runs one GTest process per endpoint, with one CUDA GPU per process. The
+sender calls only `nixlAgent::prepMemView`, `nixlPut<THREAD>`, and
+`nixlGpuGetXferStatus<THREAD>` for the data path. It does not call host
+`postXfer`, notifications, a CPU proxy, or a GPUNETIO posting kernel.
+
+The receiver flushes GPUDirect RDMA writes with the documented
+`cuFlushGPUDirectRDMAWrites` API before copying and checking the destination.
+If that API is unavailable or unsupported, the test fails; a plain CUDA
+synchronization is not treated as a visibility proof.
+
+The test covers 4 KiB, 64 KiB, and 1 MiB writes, nonzero descriptor-relative
+offsets, payload and guard validation, cached terminal-status repolling, busy
+lane rejection, invalid index/offset/flags/channel/null-status/zero/oversize
+arguments, and 8,193 sequential 4 KiB writes to distinct destination slots.
+The wrap case is about 34 MiB of payload and the process GPU allocation stays
+below 128 MiB.
+
+## Configuration
+
+Both processes must use the same fresh coordination directory and run ID.
+The following variables are read by the test:
+
+| Variable | Meaning |
+| --- | --- |
+| `GPUNETIO_DEVICE_API_ROLE` | `sender` or `receiver` |
+| `GPUNETIO_DEVICE_API_COORD_DIR` | unique shared file-exchange directory |
+| `GPUNETIO_DEVICE_API_RUN_ID` | unique run prefix within that directory |
+| `GPUNETIO_DEVICE_API_GPU` | one CUDA ordinal; defaults to `0` |
+| `GPUNETIO_DEVICE_API_RDMA` | optional GPUNETIO `network_devices` value |
+| `GPUNETIO_DEVICE_API_OOB_INTERFACE` | optional GPUNETIO `oob_interface` value |
+| `GPUNETIO_DEVICE_API_GID_INDEX` | optional GPUNETIO `gid_index` value |
+| `GPUNETIO_DEVICE_API_OOB_PORT` | optional per-endpoint GPUNETIO OOB port |
+| `GPUNETIO_DEVICE_API_TARGET_IPV4` | sender’s receiver IPv4 for the control TCP channel |
+| `GPUNETIO_DEVICE_API_CONTROL_PORT` | caller-selected unused control TCP port |
+
+Metadata files are written through a temporary file, `fsync`, atomic `rename`,
+and directory `fsync`. A tiny TCP control channel carries `M` (metadata
+published), `S` (sender setup complete), and per-case `R`/`D`/`V` tokens for
+receiver-ready, sender-data-done, and receiver-validated. The sender opens
+metadata directly only after `M`; there is no filesystem existence polling.
+The control channel has a 45-second socket/connect bound, and the device
+completion poll has a 5-second deadline per request.
+
+Setup is directional. The receiver creates its backend, registers its VRAM,
+and publishes metadata plus the descriptor record, then waits only for the
+sender’s TCP session-ready token. The sender imports the receiver metadata, makes the OOB
+connection, and prepares both public memory views before issuing PUTs. The
+receiver does not call `loadRemoteMD`, `makeConnection`, or `prepMemView`.
+
+## Build and run
+
+Run these commands from the checkout. Select the legacy SDK contract with
+Meson's `gpunetio_device_api_profile=legacy-doca31` option; Meson emits
+`NIXL_ENABLE_GPUNETIO_DEVICE_API=1` and
+`NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31=1` for the CUDA target.
+
+```bash
+cd /path/to/nixl-checkout
+meson setup build-native -Dbuildtype=debugoptimized -Denable_plugins=GPUNETIO \
+  -Dbuild_examples=false -Dnixl_cuda_arch_list=90 \
+  -Dgpunetio_device_api=enabled -Dgpunetio_device_api_profile=legacy-doca31
+ninja -C build-native src/plugins/gpunetio/libplugin_GPUNETIO.so \
+  src/utils/device/libnixl_device_allocator_cuda.so \
+  test/gtest/native-device-api-test \
+  test/gtest/unit/device_memview/device-memview-test
+./build-native/test/gtest/unit/device_memview/device-memview-test
+```
+
+Use the exact installed CUDA/DOCA and NIXL plugin paths for the build. Do not
+run this on a shared GPU unless the owner has explicitly authorized a bounded
+normal-path correctness run; do not add profiling, fault injection, or
+performance workloads to this harness.
+
+Start the receiver first. `coord` must be a new shared directory visible to
+both endpoint processes, and `run_id` must be unique:
+
+```bash
+: "${SHARED_TEST_DIR:?Set a directory shared by both endpoints}"
+coord=$(mktemp -d "$SHARED_TEST_DIR/nixl-device-api.XXXXXX")
+run_id=$(date +%s)-$$
+export LD_LIBRARY_PATH="/opt/mellanox/doca/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+export NIXL_PLUGIN_DIR="$PWD/build-native/src/plugins/gpunetio"
+export LD_LIBRARY_PATH="$NIXL_PLUGIN_DIR:$LD_LIBRARY_PATH"
+export CUDA_MODULE_LOADING=EAGER
+export GPUNETIO_DEVICE_API_COORD_DIR="$coord"
+export GPUNETIO_DEVICE_API_RUN_ID="$run_id"
+export GPUNETIO_DEVICE_API_GPU=0
+export GPUNETIO_DEVICE_API_RDMA=mlx5_0
+export GPUNETIO_DEVICE_API_OOB_INTERFACE=eth0
+export GPUNETIO_DEVICE_API_GID_INDEX=3
+export GPUNETIO_DEVICE_API_OOB_PORT=6544
+export GPUNETIO_DEVICE_API_CONTROL_PORT=6546
+
+GPUNETIO_DEVICE_API_ROLE=receiver \
+  ./build-native/test/gtest/native-device-api-test \
+  --gtest_filter=GpunetioDeviceApiTest.*
+```
+
+Export the same coordination directory, run ID and control port in the sender
+shell, with its own build/library/device configuration. Use the receiver's
+reachable IPv4 address and an unused local OOB port:
+
+```bash
+GPUNETIO_DEVICE_API_ROLE=sender \
+  GPUNETIO_DEVICE_API_TARGET_IPV4="$RECEIVER_IPV4" \
+  GPUNETIO_DEVICE_API_OOB_PORT=6545 \
+  ./build-native/test/gtest/native-device-api-test \
+  --gtest_filter=GpunetioDeviceApiTest.*
+```
+
+The receiver and sender must use the endpoint-specific OOB interface, RDMA
+device, GID, and port values valid in their own environment. The commands
+above are an example configuration, not a hardware claim.
+
+## Current boundary
+
+This file intentionally contains the normal-path and bounded argument
+harness only. Host wrapper/tag tests are provided separately. Foreign-engine and wrong-role tests,
+concurrent submitter tests, stale-registration error teardown, and explicit
+native-path tracing remain to be added alongside the corresponding public
+implementation and test wiring. See the PR's validation table for tested
+revisions; no serving, latency or bandwidth improvement is claimed.

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -511,8 +511,6 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 **GPUNETIO Backend:**
 ```
 --gpunetio_device_list LIST # Comma-separated GPU CUDA device id for GPUNETIO
---gpunetio_oob_list IFACE  # OOB interface; set explicitly for bonded network devices
---gpunetio_gid_index N     # RoCE GID table index (default: 0)
 ```
 
 **OBJ (S3) Backend:**

--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -511,6 +511,8 @@ sudo systemctl start etcd && sudo systemctl enable etcd
 **GPUNETIO Backend:**
 ```
 --gpunetio_device_list LIST # Comma-separated GPU CUDA device id for GPUNETIO
+--gpunetio_oob_list IFACE  # OOB interface; set explicitly for bonded network devices
+--gpunetio_gid_index N     # RoCE GID table index (default: 0)
 ```
 
 **OBJ (S3) Backend:**

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,10 +175,9 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
-NB_ARG_STRING(
-    gpunetio_gid_index,
-    "",
-    "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
+NB_ARG_STRING(gpunetio_gid_index,
+              "",
+              "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,6 +175,10 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
+NB_ARG_STRING(
+    gpunetio_gid_index,
+    "",
+    "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");
@@ -285,6 +289,7 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
+std::string xferBenchConfig::gpunetio_gid_index = "";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
@@ -431,6 +436,7 @@ xferBenchConfig::loadParams(void) {
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             gpunetio_device_list = NB_ARG(gpunetio_device_list);
             gpunetio_oob_list = NB_ARG(gpunetio_oob_list);
+            gpunetio_gid_index = NB_ARG(gpunetio_gid_index);
         }
 
         // Load HD3FS-specific configurations if backend is HD3FS
@@ -822,6 +828,7 @@ xferBenchConfig::printConfig() {
                         gpunetio_device_list);
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
+            printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -176,7 +176,7 @@ NB_ARG_STRING(
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
 NB_ARG_STRING(gpunetio_gid_index,
-              "",
+              "0",
               "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
@@ -288,7 +288,7 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
-std::string xferBenchConfig::gpunetio_gid_index = "";
+std::string xferBenchConfig::gpunetio_gid_index = "0";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -175,9 +175,6 @@ NB_ARG_STRING(
     gpunetio_oob_list,
     "",
     "Comma-separated OOB network interface name for control path (only used with nixl worker)");
-NB_ARG_STRING(gpunetio_gid_index,
-              "0",
-              "RoCE GID table index for GPUNetIO (only used with nixl worker; default: 0)");
 
 // OBJ options - only used when backend is OBJ
 NB_ARG_STRING(obj_access_key, "", "Access key for S3 backend");
@@ -288,7 +285,6 @@ int xferBenchConfig::gds_batch_limit = 0;
 int xferBenchConfig::gds_mt_num_threads = 0;
 std::string xferBenchConfig::gpunetio_device_list = "";
 std::string xferBenchConfig::gpunetio_oob_list = "";
-std::string xferBenchConfig::gpunetio_gid_index = "0";
 std::vector<std::string> devices = {};
 int xferBenchConfig::num_files = 0;
 std::string xferBenchConfig::posix_api_type = "";
@@ -435,7 +431,6 @@ xferBenchConfig::loadParams(void) {
         if (backend == XFERBENCH_BACKEND_GPUNETIO) {
             gpunetio_device_list = NB_ARG(gpunetio_device_list);
             gpunetio_oob_list = NB_ARG(gpunetio_oob_list);
-            gpunetio_gid_index = NB_ARG(gpunetio_gid_index);
         }
 
         // Load HD3FS-specific configurations if backend is HD3FS
@@ -827,7 +822,6 @@ xferBenchConfig::printConfig() {
                         gpunetio_device_list);
             printOption("OOB network interface name for control path (--oob_list=ifface)",
                         gpunetio_oob_list);
-            printOption("RoCE GID table index (--gpunetio_gid_index=N)", gpunetio_gid_index);
         }
     }
     printOption("Initiator seg type (--initiator_seg_type=[DRAM,VRAM])", initiator_seg_type);

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -202,7 +202,6 @@ public:
     static int gds_mt_num_threads;
     static std::string gpunetio_device_list;
     static std::string gpunetio_oob_list;
-    static std::string gpunetio_gid_index;
     static long page_size;
     static std::string obj_access_key;
     static std::string obj_secret_key;

--- a/benchmark/nixlbench/src/utils/utils.h
+++ b/benchmark/nixlbench/src/utils/utils.h
@@ -202,6 +202,7 @@ public:
     static int gds_mt_num_threads;
     static std::string gpunetio_device_list;
     static std::string gpunetio_oob_list;
+    static std::string gpunetio_gid_index;
     static long page_size;
     static std::string obj_access_key;
     static std::string obj_secret_key;

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -220,10 +220,12 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GPUNETIO)) {
         std::cout << "GPUNETIO backend, network device " << devices[0] << " GPU device "
                   << xferBenchConfig::gpunetio_device_list << " OOB interface "
-                  << xferBenchConfig::gpunetio_oob_list << std::endl;
+                  << xferBenchConfig::gpunetio_oob_list << " GID index "
+                  << xferBenchConfig::gpunetio_gid_index << std::endl;
         backend_params["network_devices"] = devices[0];
         backend_params["gpu_devices"] = xferBenchConfig::gpunetio_device_list;
         backend_params["oob_interface"] = xferBenchConfig::gpunetio_oob_list;
+        backend_params["gid_index"] = xferBenchConfig::gpunetio_gid_index;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE)) {
         std::cout << "Mooncake backend" << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_HF3FS)) {

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -220,12 +220,10 @@ xferBenchNixlWorker::xferBenchNixlWorker(const std::vector<std::string> &devices
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_GPUNETIO)) {
         std::cout << "GPUNETIO backend, network device " << devices[0] << " GPU device "
                   << xferBenchConfig::gpunetio_device_list << " OOB interface "
-                  << xferBenchConfig::gpunetio_oob_list << " GID index "
-                  << xferBenchConfig::gpunetio_gid_index << std::endl;
+                  << xferBenchConfig::gpunetio_oob_list << std::endl;
         backend_params["network_devices"] = devices[0];
         backend_params["gpu_devices"] = xferBenchConfig::gpunetio_device_list;
         backend_params["oob_interface"] = xferBenchConfig::gpunetio_oob_list;
-        backend_params["gid_index"] = xferBenchConfig::gpunetio_gid_index;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_MOONCAKE)) {
         std::cout << "Mooncake backend" << std::endl;
     } else if (0 == xferBenchConfig::backend.compare(XFERBENCH_BACKEND_HF3FS)) {

--- a/meson.build
+++ b/meson.build
@@ -448,15 +448,26 @@ else
 endif
 
 # UCX GPU device API detection
+if not get_option('gpunetio_device_api').disabled()
+    if not cuda_dep.found() or not doca_gpunetio_dep.found() or not enabled_plugins.get('GPUNETIO')
+        error('GPUNETIO native Device API requires CUDA and the GPUNETIO plugin')
+    endif
+endif
+
 nvcc_prog = find_program('nvcc', required: false)
 ucx_gpu_device_api_available = false
 if ucx_dep.found() and cuda_dep.found() and nvcc_prog.found()
     cuda = meson.get_compiler('cuda')
-    # TODO: Expose doca_gpunetio_dep through UCX
     have_gpu_side = cuda.compiles('''
             #include <ucp/api/device/ucp_device_impl.h>
             int main() { return 0; }
-        ''', dependencies : [ucx_dep, doca_gpunetio_dep], args: nvcc_flags)
+        ''', dependencies : [ucx_dep], args: nvcc_flags)
+    if not have_gpu_side and doca_gpunetio_dep.found()
+        have_gpu_side = cuda.compiles('''
+            #include <ucp/api/device/ucp_device_impl.h>
+            int main() { return 0; }
+        ''', dependencies: [ucx_dep, doca_gpunetio_dep], args: nvcc_flags)
+    endif
 
     have_host_side = cpp.has_function('ucp_device_remote_mem_list_create',
         prefix: '#include <ucp/api/device/ucp_host.h>',
@@ -591,6 +602,7 @@ endif
 if get_option('install_headers')
   install_headers('src/api/cpp/nixl.h', install_dir: prefix_inc)
   install_headers('src/api/cpp/nixl_types.h', install_dir: prefix_inc)
+  install_headers('src/api/cpp/nixl_device_backend_types.h', install_dir: prefix_inc)
   install_headers('src/api/cpp/nixl_params.h', install_dir: prefix_inc)
   install_headers('src/api/cpp/nixl_descriptors.h', install_dir: prefix_inc)
   install_headers('src/utils/serdes/serdes.h', install_dir: prefix_inc + '/utils/serdes')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 option('ucx_path', type: 'string', value: '', description: 'Path to UCX install')
+option('gpunetio_device_api', type: 'feature', value: 'disabled', description: 'Opt-in native GPUNETIO GPU PUT/status API')
+option('gpunetio_device_api_profile', type: 'combo', choices: ['public', 'legacy-doca31'], value: 'public', description: 'Explicit GPUNETIO device-header completion contract')
 option('libfabric_path', type: 'string', value: '', description: 'Path to LIBFABRIC install')
 option('etcd_inc_path', type: 'string', value: '', description: 'Path to ETCD Headers')
 option('etcd_lib_path', type: 'string', value: '', description: 'Path to ETCD Libraries')

--- a/src/api/cpp/backend/backend_engine.h
+++ b/src/api/cpp/backend/backend_engine.h
@@ -24,6 +24,7 @@
 #include <mutex>
 
 #include "nixl_types.h"
+#include "nixl_device_backend_types.h"
 #include "backend_aux.h"
 #include "telemetry_event.h"
 
@@ -110,6 +111,11 @@ class nixlBackendEngine {
         // Determines if a backend supports sending notifications. Related methods are not
         // pure virtual, and return errors, as parent shouldn't call if supportsNotif is false.
         virtual bool supportsNotif() const = 0;
+
+        virtual nixl_device_exec_mode_t
+        getDeviceExecMode() const noexcept {
+            return nixl_device_exec_mode_t::NONE;
+        }
 
         virtual nixl_mem_list_t getSupportedMems() const = 0;  // TODO: Return by const-reference and mark noexcept?
 

--- a/src/api/cpp/backend/backend_plugin.h
+++ b/src/api/cpp/backend/backend_plugin.h
@@ -30,7 +30,7 @@ class nixlUcxEngine;
 // libstdc++ ABI as the NIXL core library. NIXL core currently requires C++20.
 
 // Define the plugin API version
-#define NIXL_PLUGIN_API_VERSION 1
+#define NIXL_PLUGIN_API_VERSION 2
 
 // Define the plugin interface class
 class nixlBackendPlugin {

--- a/src/api/cpp/nixl_device_backend_types.h
+++ b/src/api/cpp/nixl_device_backend_types.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef NIXL_SRC_API_CPP_NIXL_DEVICE_BACKEND_TYPES_H
+#define NIXL_SRC_API_CPP_NIXL_DEVICE_BACKEND_TYPES_H
+
+#include <cstdint>
+
+#include "nixl_types.h"
+
+enum class nixl_device_exec_mode_t : uint8_t {
+    NONE = 0,
+    UCX_DIRECT = 1,
+    PROXY = 2,
+    GPUNETIO_DIRECT = 3,
+};
+
+struct nixlDeviceMemViewWrapper {
+    // Deliberately a two-field POD: the installed header/consumer ABI is the
+    // contract; release uses the host ownership record and never copies this
+    // wrapper back from device memory.
+    nixl_device_exec_mode_t execution_mode;
+    nixlMemViewH backend_memview;
+};
+
+static_assert(sizeof(nixl_device_exec_mode_t) == 1);
+static_assert(sizeof(nixlDeviceMemViewWrapper) == 2 * sizeof(void *));
+
+#endif // NIXL_SRC_API_CPP_NIXL_DEVICE_BACKEND_TYPES_H

--- a/src/api/device/gpu/device_types.cuh
+++ b/src/api/device/gpu/device_types.cuh
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include <nixl_types.h>
+#include <nixl_device_backend_types.h>
 
 namespace nixl::gpu {
 
@@ -28,9 +29,11 @@ struct xferStatusH {
     alignas(16) unsigned char storage[64] = {};
 };
 
-constexpr size_t xfer_status_payload_size = 64;
+constexpr size_t xfer_status_payload_size = 60;
+constexpr size_t xfer_status_mode_offset = xfer_status_payload_size;
 
-static_assert(xfer_status_payload_size == sizeof(xferStatusH));
+static_assert(xfer_status_payload_size < sizeof(xferStatusH));
+static_assert(sizeof(xferStatusH) - xfer_status_payload_size == sizeof(uint32_t));
 
 enum class level_t : uint64_t { THREAD = 0, WARP = 1, BLOCK = 2, GRID = 3 };
 

--- a/src/api/device/gpu/impl/device_dispatch.cuh
+++ b/src/api/device/gpu/impl/device_dispatch.cuh
@@ -3,23 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * you may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 #ifndef NIXL_SRC_API_DEVICE_GPU_IMPL_DEVICE_DISPATCH_CUH
 #define NIXL_SRC_API_DEVICE_GPU_IMPL_DEVICE_DISPATCH_CUH
 
 #include <gpu/device_types.cuh>
 
-#if __has_include(<ucp/api/device/ucp_device_impl.h>)
+#if !defined(NIXL_DISABLE_UCX_DEVICE_API) && \
+    (defined(HAVE_UCX_GPU_DEVICE_API) || __has_include(<ucp/api/device/ucp_device_impl.h>))
 #include <gpu/impl/ucx/device_ucx.cuh>
 #else
 namespace nixl::gpu::impl::ucx {
@@ -50,12 +44,103 @@ getPtr(nixlMemViewH, size_t) {
 } // namespace nixl::gpu::impl::ucx
 #endif
 
+#if defined(NIXL_ENABLE_GPUNETIO_DEVICE_API)
+#include <gpu/impl/gpunetio/device_gpunetio.cuh>
+#else
+namespace nixl::gpu::impl::gpunetio {
+
+template<level_t level>
+__device__ nixl_status_t
+getXferStatus(xferStatusH &) {
+    return NIXL_ERR_NOT_SUPPORTED;
+}
+
+template<level_t level>
+__device__ nixl_status_t
+put(const memViewElem &, const memViewElem &, size_t, unsigned, uint64_t, xferStatusH *) {
+    return NIXL_ERR_NOT_SUPPORTED;
+}
+
+template<level_t level>
+__device__ nixl_status_t
+atomicAdd(uint64_t, const memViewElem &, unsigned, uint64_t, xferStatusH *) {
+    return NIXL_ERR_NOT_SUPPORTED;
+}
+
+__device__ inline void *
+getPtr(nixlMemViewH, size_t) {
+    return nullptr;
+}
+
+} // namespace nixl::gpu::impl::gpunetio
+#endif
+
 namespace nixl::gpu::impl {
+
+__device__ inline uint32_t
+statusModeTag(const xferStatusH &xfer_status) noexcept {
+    return *reinterpret_cast<const uint32_t *>(xfer_status.storage + xfer_status_mode_offset);
+}
+
+__device__ inline void
+setStatusModeTag(xferStatusH &xfer_status, nixl_device_exec_mode_t mode) noexcept {
+    *reinterpret_cast<uint32_t *>(xfer_status.storage + xfer_status_mode_offset) =
+        static_cast<uint32_t>(mode);
+}
+
+__device__ inline bool
+isKnownMode(nixl_device_exec_mode_t mode) noexcept {
+    return mode == nixl_device_exec_mode_t::UCX_DIRECT ||
+        mode == nixl_device_exec_mode_t::GPUNETIO_DIRECT;
+}
+
+__device__ inline const nixlDeviceMemViewWrapper *
+viewWrapper(nixlMemViewH mvh) noexcept {
+    return reinterpret_cast<const nixlDeviceMemViewWrapper *>(mvh);
+}
+
+__device__ inline bool
+unwrapViews(const memViewElem &src,
+            const memViewElem &dst,
+            const nixlDeviceMemViewWrapper *&src_wrapper,
+            const nixlDeviceMemViewWrapper *&dst_wrapper,
+            nixl_device_exec_mode_t &mode) noexcept {
+    if (src.mvh == nullptr || dst.mvh == nullptr) {
+        return false;
+    }
+
+    src_wrapper = viewWrapper(src.mvh);
+    dst_wrapper = viewWrapper(dst.mvh);
+    if (!isKnownMode(src_wrapper->execution_mode) ||
+        src_wrapper->execution_mode != dst_wrapper->execution_mode ||
+        src_wrapper->backend_memview == nullptr || dst_wrapper->backend_memview == nullptr) {
+        return false;
+    }
+
+    mode = src_wrapper->execution_mode;
+    return true;
+}
+
+__device__ inline bool
+prepareStatus(const xferStatusH *xfer_status, nixl_device_exec_mode_t mode) noexcept {
+    if (xfer_status == nullptr) {
+        return false;
+    }
+    const uint32_t current = statusModeTag(*xfer_status);
+    return current == 0 || current == static_cast<uint32_t>(mode);
+}
 
 template<level_t level>
 __device__ nixl_status_t
 getXferStatus(xferStatusH &xfer_status) {
-    return ucx::getXferStatus<level>(xfer_status);
+    switch (statusModeTag(xfer_status)) {
+    case static_cast<uint32_t>(nixl_device_exec_mode_t::UCX_DIRECT):
+        return ucx::getXferStatus<level>(xfer_status);
+    case static_cast<uint32_t>(nixl_device_exec_mode_t::GPUNETIO_DIRECT):
+        return gpunetio::getXferStatus<level>(xfer_status);
+    default:
+        return NIXL_ERR_INVALID_PARAM;
+    }
 }
 
 template<level_t level>
@@ -66,7 +151,35 @@ put(const memViewElem &src,
     unsigned channel_id,
     uint64_t flags,
     xferStatusH *xfer_status) {
-    return ucx::put<level>(src, dst, size, channel_id, flags, xfer_status);
+    const nixlDeviceMemViewWrapper *src_wrapper = nullptr;
+    const nixlDeviceMemViewWrapper *dst_wrapper = nullptr;
+    nixl_device_exec_mode_t mode = nixl_device_exec_mode_t::NONE;
+    if (!unwrapViews(src, dst, src_wrapper, dst_wrapper, mode) ||
+        !prepareStatus(xfer_status, mode)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+#if defined(NIXL_ENABLE_GPUNETIO_DEVICE_API)
+    if (mode == nixl_device_exec_mode_t::GPUNETIO_DIRECT &&
+        gpunetio::isStatusInProgress(*xfer_status)) {
+        return NIXL_ERR_REPOST_ACTIVE;
+    }
+#endif
+
+    const memViewElem backend_src{src_wrapper->backend_memview, src.index, src.offset};
+    const memViewElem backend_dst{dst_wrapper->backend_memview, dst.index, dst.offset};
+    nixl_status_t status = NIXL_ERR_NOT_SUPPORTED;
+    if (mode == nixl_device_exec_mode_t::UCX_DIRECT) {
+        status = ucx::put<level>(backend_src, backend_dst, size, channel_id, flags, xfer_status);
+    } else if (mode == nixl_device_exec_mode_t::GPUNETIO_DIRECT) {
+        status =
+            gpunetio::put<level>(backend_src, backend_dst, size, channel_id, flags, xfer_status);
+    }
+
+    if (status == NIXL_IN_PROG) {
+        setStatusModeTag(*xfer_status, mode);
+    }
+    return status;
 }
 
 template<level_t level>
@@ -76,12 +189,43 @@ atomicAdd(uint64_t value,
           unsigned channel_id,
           uint64_t flags,
           xferStatusH *xfer_status) {
-    return ucx::atomicAdd<level>(value, counter, channel_id, flags, xfer_status);
+    if (counter.mvh == nullptr || xfer_status == nullptr) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    const nixlDeviceMemViewWrapper *wrapper = viewWrapper(counter.mvh);
+    if (!isKnownMode(wrapper->execution_mode) || wrapper->backend_memview == nullptr ||
+        !prepareStatus(xfer_status, wrapper->execution_mode)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    if (wrapper->execution_mode == nixl_device_exec_mode_t::GPUNETIO_DIRECT) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    const memViewElem backend_counter{wrapper->backend_memview, counter.index, counter.offset};
+    const nixl_status_t status =
+        ucx::atomicAdd<level>(value, backend_counter, channel_id, flags, xfer_status);
+    if (status == NIXL_IN_PROG) {
+        setStatusModeTag(*xfer_status, wrapper->execution_mode);
+    }
+    return status;
 }
 
 __device__ inline void *
 getPtr(nixlMemViewH mvh, size_t index) {
-    return ucx::getPtr(mvh, index);
+    if (mvh == nullptr) {
+        return nullptr;
+    }
+
+    const nixlDeviceMemViewWrapper *wrapper = viewWrapper(mvh);
+    if (!isKnownMode(wrapper->execution_mode) || wrapper->backend_memview == nullptr) {
+        return nullptr;
+    }
+    if (wrapper->execution_mode == nixl_device_exec_mode_t::UCX_DIRECT) {
+        return ucx::getPtr(wrapper->backend_memview, index);
+    }
+    return gpunetio::getPtr(wrapper->backend_memview, index);
 }
 
 } // namespace nixl::gpu::impl

--- a/src/api/device/gpu/impl/gpunetio/device_gpunetio.cuh
+++ b/src/api/device/gpu/impl/gpunetio/device_gpunetio.cuh
@@ -1,0 +1,249 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_CUH
+#define NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_CUH
+
+#include <gpu/device_types.cuh>
+#include <gpu/impl/gpunetio/device_gpunetio_compat.cuh>
+
+#include <cstdint>
+#include <cuda/atomic>
+
+namespace nixl::gpu::impl::gpunetio {
+
+static_assert(sizeof(nixl_status_t) <= sizeof(int32_t));
+static_assert(sizeof(GpunetioStatusPayload) <= 60);
+static_assert(xfer_status_payload_size >= 60);
+
+__device__ inline GpunetioStatusPayload *
+statusPayload(xferStatusH *xfer_status) {
+    return reinterpret_cast<GpunetioStatusPayload *>(xfer_status->storage);
+}
+
+__device__ inline const GpunetioStatusPayload *
+statusPayload(const xferStatusH *xfer_status) {
+    return reinterpret_cast<const GpunetioStatusPayload *>(xfer_status->storage);
+}
+
+template<typename T> using device_atomic_ref = cuda::atomic_ref<T, cuda::thread_scope_device>;
+
+template<typename T>
+__device__ inline device_atomic_ref<T>
+deviceAtomic(T &value) {
+    return device_atomic_ref<T>(value);
+}
+
+__device__ inline void
+failLane(GpunetioStatusPayload *payload) {
+    payload->cached_status = NIXL_ERR_BACKEND;
+    deviceAtomic(payload->lane->failed).store(1U, cuda::memory_order_relaxed);
+    deviceAtomic(payload->lane->phase)
+        .store(gpunetio_lane_phase_failed, cuda::memory_order_release);
+}
+
+// The dispatcher calls this only after it has established that the status
+// carries the GPUNETIO_DIRECT mode tag.  put() intentionally does not read an
+// untagged caller buffer: a caller may pass an uninitialized xferStatusH.
+__device__ inline bool
+isStatusInProgress(const xferStatusH &xfer_status) {
+    const auto *payload = statusPayload(&xfer_status);
+    return payload->initialized != 0 && payload->cached_status == NIXL_IN_PROG;
+}
+
+__device__ inline bool
+rangeIsValid(uint64_t base, uint64_t length, size_t offset, size_t bytes, uint64_t *address) {
+    if (offset > length || bytes > length - offset) {
+        return false;
+    }
+    const uint64_t offset64 = static_cast<uint64_t>(offset);
+    const uint64_t bytes64 = static_cast<uint64_t>(bytes);
+    if (static_cast<size_t>(offset64) != offset || static_cast<size_t>(bytes64) != bytes) {
+        return false;
+    }
+    if (base > ~uint64_t{0} - offset64) {
+        return false;
+    }
+    *address = base + offset64;
+    return *address <= ~uint64_t{0} - bytes64;
+}
+
+template<level_t level>
+__device__ nixl_status_t
+putViews(const GpunetioDeviceView *src_view,
+         size_t src_index,
+         size_t src_offset,
+         const GpunetioDeviceView *dst_view,
+         size_t dst_index,
+         size_t dst_offset,
+         size_t bytes,
+         unsigned channel_id,
+         uint64_t flags,
+         xferStatusH *xfer_status) {
+#if !NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE
+    (void)src_view;
+    (void)src_index;
+    (void)src_offset;
+    (void)dst_view;
+    (void)dst_index;
+    (void)dst_offset;
+    (void)bytes;
+    (void)channel_id;
+    (void)flags;
+    (void)xfer_status;
+    return NIXL_ERR_NOT_SUPPORTED;
+#else
+    if constexpr (level != level_t::THREAD) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+    if (channel_id != 0 || flags != 0) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+    if (xfer_status == nullptr || bytes == 0 ||
+        bytes > static_cast<size_t>(DOCA_GPUNETIO_VERBS_MAX_TRANSFER_SIZE)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (src_view == nullptr || dst_view == nullptr ||
+        src_view->abi_version != gpunetio_device_view_abi_version ||
+        dst_view->abi_version != gpunetio_device_view_abi_version ||
+        src_view->role != gpunetio_device_view_role_local ||
+        dst_view->role != gpunetio_device_view_role_remote || src_view->context == nullptr ||
+        src_view->context != dst_view->context || src_view->context_cookie == 0 ||
+        src_view->context_cookie != dst_view->context_cookie ||
+        src_view->execution_gpu != dst_view->execution_gpu || src_view->context->lane == nullptr ||
+        src_view->elems == nullptr || dst_view->elems == nullptr || src_index >= src_view->count ||
+        dst_index >= dst_view->count) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    const auto &src = src_view->elems[src_index];
+    const auto &dst = dst_view->elems[dst_index];
+    uint64_t local_address;
+    uint64_t remote_address;
+    if (src.valid == 0 || dst.valid == 0 || src.peer_slot != gpunetio_local_peer_slot ||
+        dst.peer_slot != gpunetio_remote_peer_slot ||
+        !rangeIsValid(src.base, src.length, src_offset, bytes, &local_address) ||
+        !rangeIsValid(dst.base, dst.length, dst_offset, bytes, &remote_address)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    auto *lane = src_view->context->lane;
+    auto phase = deviceAtomic(lane->phase);
+    uint32_t observed_phase = gpunetio_lane_phase_idle;
+    if (!phase.compare_exchange_strong(observed_phase,
+                                       gpunetio_lane_phase_posting,
+                                       cuda::memory_order_acq_rel,
+                                       cuda::memory_order_acquire)) {
+        return observed_phase == gpunetio_lane_phase_failed ||
+                deviceAtomic(lane->failed).load(cuda::memory_order_relaxed) != 0 ?
+            NIXL_ERR_BACKEND :
+            NIXL_ERR_NOT_ALLOWED;
+    }
+    if (deviceAtomic(lane->failed).load(cuda::memory_order_relaxed) != 0 || lane->qp == nullptr ||
+        !compat::usesGpuSmDoorbell(lane->qp)) {
+        deviceAtomic(lane->failed).store(1U, cuda::memory_order_relaxed);
+        phase.store(gpunetio_lane_phase_failed, cuda::memory_order_release);
+        return NIXL_ERR_BACKEND;
+    }
+
+    auto generation_ref = deviceAtomic(lane->generation);
+    const uint64_t previous_generation = generation_ref.load(cuda::memory_order_relaxed);
+    if (previous_generation == ~uint64_t{0}) {
+        phase.store(gpunetio_lane_phase_idle, cuda::memory_order_release);
+        return NIXL_ERR_BACKEND;
+    }
+    const uint64_t generation = generation_ref.fetch_add(1U, cuda::memory_order_relaxed) + 1U;
+
+    uint64_t ticket;
+    compat::releaseFence();
+    compat::put(lane->qp, remote_address, dst.key, local_address, src.key, bytes, &ticket);
+    deviceAtomic(lane->active_ticket).store(ticket, cuda::memory_order_relaxed);
+
+    // All state becomes visible before POSTED.  The common dispatcher writes
+    // the final four-byte mode tag only after this function returns IN_PROG.
+    auto *payload = statusPayload(xfer_status);
+    payload->lane = lane;
+    payload->generation = generation;
+    payload->ticket = ticket;
+    payload->cached_status = NIXL_IN_PROG;
+    payload->initialized = 1;
+    phase.store(gpunetio_lane_phase_posted, cuda::memory_order_release);
+    return NIXL_IN_PROG;
+#endif
+}
+
+template<level_t level>
+__device__ nixl_status_t
+put(const memViewElem &src,
+    const memViewElem &dst,
+    size_t bytes,
+    unsigned channel_id,
+    uint64_t flags,
+    xferStatusH *xfer_status) {
+    return putViews<level>(static_cast<const GpunetioDeviceView *>(src.mvh),
+                           src.index,
+                           src.offset,
+                           static_cast<const GpunetioDeviceView *>(dst.mvh),
+                           dst.index,
+                           dst.offset,
+                           bytes,
+                           channel_id,
+                           flags,
+                           xfer_status);
+}
+
+template<level_t level>
+__device__ nixl_status_t
+getXferStatus(xferStatusH &xfer_status) {
+#if !NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE
+    (void)xfer_status;
+    return NIXL_ERR_NOT_SUPPORTED;
+#else
+    if constexpr (level != level_t::THREAD) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    auto *payload = statusPayload(&xfer_status);
+    if (payload->initialized == 0 || payload->lane == nullptr) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (payload->cached_status != NIXL_IN_PROG) {
+        return static_cast<nixl_status_t>(payload->cached_status);
+    }
+
+    auto *lane = payload->lane;
+    if (deviceAtomic(lane->phase).load(cuda::memory_order_acquire) != gpunetio_lane_phase_posted ||
+        deviceAtomic(lane->generation).load(cuda::memory_order_relaxed) != payload->generation ||
+        deviceAtomic(lane->active_ticket).load(cuda::memory_order_relaxed) != payload->ticket) {
+        failLane(payload);
+        return NIXL_ERR_BACKEND;
+    }
+
+    const int completion = compat::pollOne(lane->qp, payload->ticket);
+    if (completion == EBUSY) {
+        return NIXL_IN_PROG;
+    }
+    if (completion != 0) {
+        failLane(payload);
+        return NIXL_ERR_BACKEND;
+    }
+
+    payload->cached_status = NIXL_SUCCESS;
+    deviceAtomic(lane->last_success_generation)
+        .store(payload->generation, cuda::memory_order_relaxed);
+    // IDLE is the last release: a new submitter may now replace active_ticket.
+    deviceAtomic(lane->phase).store(gpunetio_lane_phase_idle, cuda::memory_order_release);
+    return NIXL_SUCCESS;
+#endif
+}
+
+__device__ inline void *
+getPtr(void *, size_t) {
+    return nullptr;
+}
+
+} // namespace nixl::gpu::impl::gpunetio
+
+#endif // NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_CUH

--- a/src/api/device/gpu/impl/gpunetio/device_gpunetio_compat.cuh
+++ b/src/api/device/gpu/impl/gpunetio/device_gpunetio_compat.cuh
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_COMPAT_CUH
+#define NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_COMPAT_CUH
+
+#include <gpu/impl/gpunetio/device_gpunetio_types.h>
+
+// A device consumer must explicitly opt in and select a profile proven by the
+// build probes.  There is deliberately no SDK-version-derived default.
+#if defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31) && defined(NIXL_GPUNETIO_DEVICE_API_PUBLIC)
+#error "GPUNetIO device API profiles are mutually exclusive"
+#endif
+
+#if defined(NIXL_ENABLE_GPUNETIO_DEVICE_API) && \
+    !defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31) && !defined(NIXL_GPUNETIO_DEVICE_API_PUBLIC)
+#error \
+    "SDK_CONTRACT_UNVERIFIED: NIXL_ENABLE_GPUNETIO_DEVICE_API requires an explicitly proven SDK profile"
+#endif
+
+#if defined(NIXL_ENABLE_GPUNETIO_DEVICE_API) && \
+    (defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31) || defined(NIXL_GPUNETIO_DEVICE_API_PUBLIC))
+#define NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE 1
+#include <cerrno>
+#include <cstdio>
+#include <doca_gpunetio_dev_verbs_cq.cuh>
+#include <doca_gpunetio_dev_verbs_onesided.cuh>
+#else
+#define NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE 0
+#endif
+
+namespace nixl::gpu::impl::gpunetio::compat {
+
+#if NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE
+
+static_assert(sizeof(doca_gpu_dev_verbs_ticket_t) == sizeof(uint64_t));
+
+__device__ inline uint64_t
+ticketToBits(doca_gpu_dev_verbs_ticket_t ticket) {
+    uint64_t bits;
+    __builtin_memcpy(&bits, &ticket, sizeof(bits));
+    return bits;
+}
+
+__device__ inline doca_gpu_dev_verbs_ticket_t
+ticketFromBits(uint64_t bits) {
+    doca_gpu_dev_verbs_ticket_t ticket;
+    __builtin_memcpy(&ticket, &bits, sizeof(ticket));
+    return ticket;
+}
+
+__device__ inline void
+releaseFence() {
+    doca_gpu_dev_verbs_fence_release<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS>();
+}
+
+__device__ inline bool
+usesGpuSmDoorbell(const doca_gpu_dev_verbs_qp *qp) {
+    return static_cast<enum doca_gpu_dev_verbs_nic_handler>(__ldg(reinterpret_cast<const int *>(
+               &qp->nic_handler))) == DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB;
+}
+
+__device__ inline void
+put(doca_gpu_dev_verbs_qp *qp,
+    uint64_t remote_address,
+    uint32_t remote_key,
+    uint64_t local_address,
+    uint32_t local_key,
+    size_t bytes,
+    uint64_t *ticket_bits) {
+    doca_gpu_dev_verbs_ticket_t ticket;
+    doca_gpu_dev_verbs_put<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                           DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO,
+                           DOCA_GPUNETIO_VERBS_EXEC_SCOPE_THREAD>(
+        qp,
+        doca_gpu_dev_verbs_addr{remote_address, remote_key},
+        doca_gpu_dev_verbs_addr{local_address, local_key},
+        bytes,
+        &ticket);
+    *ticket_bits = ticketToBits(ticket);
+}
+
+#if defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31)
+
+// Extracted from foraxe/nixl 292249b8 gpunetio_kernels.cu.  This is the
+// verified DOCA 3.1 ordinary-CQ parser, not the installed same-name helper
+// that can report success before inspecting the CQE.
+__device__ inline void
+nixl_gpunetio_dev_cq_print_cqe_err(struct mlx5_cqe64 *cqe64) {
+    struct mlx5_err_cqe_ex *err_cqe = (struct mlx5_err_cqe_ex *)cqe64;
+    printf("got completion with err: syndrome=%#x, vendor_err_synd=%#x, "
+           "hw_err_synd=%#x, hw_synd_type=%#x, wqe_counter=%u wqe_qpn=%x\\n",
+           err_cqe->syndrome,
+           err_cqe->vendor_err_synd,
+           err_cqe->hw_err_synd,
+           err_cqe->hw_synd_type,
+           err_cqe->wqe_counter,
+           err_cqe->s_wqe_opcode_qpn);
+}
+
+template<enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode =
+             DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+         enum doca_gpu_dev_verbs_qp_type qp_type = DOCA_GPUNETIO_VERBS_QP_SQ>
+__device__ int
+nixl_gpunetio_dev_priv_poll_one_cq_at(doca_gpu_dev_verbs_cq *cq, uint64_t cons_index) {
+    uint8_t *cqe = (uint8_t *)__ldg((uintptr_t *)&cq->cqe_daddr);
+    const uint32_t cqe_num = __ldg(&cq->cqe_num);
+    uint32_t idx = cons_index & (cqe_num - 1);
+    struct mlx5_cqe64 *cqe64 = (struct mlx5_cqe64 *)(cqe + (idx * DOCA_GPUNETIO_VERBS_CQE_SIZE));
+
+    uint8_t opown = doca_gpu_dev_verbs_load_relaxed_sys_global((uint8_t *)&cqe64->op_own);
+    uint8_t opcode = opown >> DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT;
+    bool observed_completion = !((opown & MLX5_CQE_OWNER_MASK) ^ !!(cons_index & cqe_num));
+    observed_completion = observed_completion && (opcode != MLX5_CQE_INVALID);
+    if (!observed_completion) {
+        return EBUSY;
+    }
+
+    if ((opcode == MLX5_CQE_REQ_ERR || opcode == MLX5_CQE_RESP_ERR) * -EIO) {
+        nixl_gpunetio_dev_cq_print_cqe_err(cqe64);
+    }
+
+    return ((opcode == MLX5_CQE_REQ_ERR || opcode == MLX5_CQE_RESP_ERR) * -EIO);
+}
+
+#endif // NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31
+
+#if defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31)
+template<enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode =
+             DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+         enum doca_gpu_dev_verbs_qp_type qp_type = DOCA_GPUNETIO_VERBS_QP_SQ>
+__device__ int
+nixl_gpunetio_dev_poll_one_cq_at(doca_gpu_dev_verbs_cq *cq, uint64_t cons_index) {
+    int status =
+        nixl_gpunetio_dev_priv_poll_one_cq_at<resource_sharing_mode, qp_type>(cq, cons_index);
+    if (status != EBUSY) {
+        doca_gpu_dev_verbs_fence_acquire<DOCA_GPUNETIO_VERBS_SYNC_SCOPE_SYS>();
+        doca_gpu_dev_verbs_atomic_max<uint64_t, resource_sharing_mode>(&cq->cqe_ci, cons_index + 1);
+    }
+    return status;
+}
+#endif
+
+__device__ inline int
+pollOne(doca_gpu_dev_verbs_qp *qp, uint64_t ticket_bits) {
+    const auto ticket = ticketFromBits(ticket_bits);
+#if defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31)
+    auto *cq = doca_gpu_dev_verbs_qp_get_cq_sq(qp);
+    return nixl_gpunetio_dev_poll_one_cq_at<>(cq, ticket);
+#else
+    return doca_gpu_dev_verbs_poll_one_cq_at<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
+                                             DOCA_GPUNETIO_VERBS_QP_SQ>(qp, ticket);
+#endif
+}
+
+#endif // NIXL_GPUNETIO_DEVICE_API_HAS_SDK_PROFILE
+
+} // namespace nixl::gpu::impl::gpunetio::compat
+
+#endif // NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_COMPAT_CUH

--- a/src/api/device/gpu/impl/gpunetio/device_gpunetio_types.h
+++ b/src/api/device/gpu/impl/gpunetio/device_gpunetio_types.h
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_TYPES_H
+#define NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_TYPES_H
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+// Keep this header CUDA- and DOCA-header-free: host preparation and CUDA
+// consumers share these POD layouts.  The complete type is required only by
+// device_gpunetio_compat.cuh.
+struct doca_gpu_dev_verbs_qp;
+
+namespace nixl::gpu::impl::gpunetio {
+
+constexpr uint32_t gpunetio_device_view_abi_version = 1;
+constexpr uint32_t gpunetio_device_view_role_local = 1;
+constexpr uint32_t gpunetio_device_view_role_remote = 2;
+constexpr uint32_t gpunetio_local_peer_slot = ~uint32_t{0};
+constexpr uint32_t gpunetio_remote_peer_slot = 0;
+
+constexpr uint32_t gpunetio_lane_phase_idle = 0;
+constexpr uint32_t gpunetio_lane_phase_posting = 1;
+constexpr uint32_t gpunetio_lane_phase_posted = 2;
+constexpr uint32_t gpunetio_lane_phase_failed = 3;
+
+enum class GpunetioLanePhase : uint32_t {
+    IDLE = gpunetio_lane_phase_idle,
+    POSTING = gpunetio_lane_phase_posting,
+    POSTED = gpunetio_lane_phase_posted,
+    FAILED = gpunetio_lane_phase_failed,
+};
+
+struct alignas(16) GpunetioDeviceLane {
+    doca_gpu_dev_verbs_qp *qp;
+    alignas(8) uint64_t generation;
+    alignas(8) uint64_t active_ticket;
+    alignas(8) uint64_t last_success_generation;
+    alignas(4) uint32_t phase;
+    alignas(4) uint32_t failed;
+};
+
+// The host allocates this once per native engine.  Every native local and
+// remote view for that engine carries the same context pointer.
+struct GpunetioDeviceContext {
+    GpunetioDeviceLane *lane;
+};
+
+struct GpunetioViewElem {
+    uint64_t base;
+    uint64_t length;
+    uint32_t key;
+    uint32_t peer_slot;
+    uint32_t valid;
+    uint32_t reserved;
+};
+
+struct GpunetioDeviceView {
+    uint32_t abi_version;
+    uint32_t role;
+    uint64_t count;
+    uint64_t context_cookie;
+    uint32_t execution_gpu;
+    uint32_t reserved;
+    const GpunetioViewElem *elems;
+    GpunetioDeviceContext *context;
+};
+
+struct GpunetioStatusPayload {
+    GpunetioDeviceLane *lane;
+    uint64_t generation;
+    uint64_t ticket;
+    int32_t cached_status;
+    uint32_t initialized;
+};
+
+static_assert(sizeof(GpunetioViewElem) == 32);
+static_assert(sizeof(GpunetioStatusPayload) == 32);
+static_assert(sizeof(GpunetioStatusPayload) <= 60);
+static_assert(alignof(GpunetioDeviceLane) >= 16);
+static_assert(std::is_standard_layout_v<GpunetioDeviceLane>);
+static_assert(std::is_trivial_v<GpunetioDeviceLane>);
+static_assert(std::is_standard_layout_v<GpunetioDeviceContext>);
+static_assert(std::is_trivial_v<GpunetioDeviceContext>);
+static_assert(std::is_standard_layout_v<GpunetioDeviceView>);
+static_assert(std::is_trivial_v<GpunetioDeviceView>);
+
+} // namespace nixl::gpu::impl::gpunetio
+
+#endif // NIXL_SRC_API_DEVICE_GPU_IMPL_GPUNETIO_DEVICE_GPUNETIO_TYPES_H

--- a/src/api/device/gpu/meson.build
+++ b/src/api/device/gpu/meson.build
@@ -21,4 +21,10 @@ if get_option('install_headers')
     )
     install_headers('impl/device_dispatch.cuh', install_dir: prefix_inc + '/gpu/impl')
     install_headers('impl/ucx/device_ucx.cuh', install_dir: prefix_inc + '/gpu/impl/ucx')
+    install_headers(
+        'impl/gpunetio/device_gpunetio_types.h',
+        'impl/gpunetio/device_gpunetio_compat.cuh',
+        'impl/gpunetio/device_gpunetio.cuh',
+        install_dir: prefix_inc + '/gpu/impl/gpunetio',
+    )
 endif

--- a/src/core/agent_data.h
+++ b/src/core/agent_data.h
@@ -30,6 +30,21 @@
 
 using backend_list_t = std::vector<nixlBackendEngine*>;
 
+[[nodiscard]] inline bool
+nixlRemoteBackendAdmissionAllowed(const nixl_backend_t &type,
+                                  bool supports_remote,
+                                  bool supports_notif,
+                                  nixl_device_exec_mode_t mode) noexcept {
+    return !supports_remote || supports_notif ||
+        (type == "GPUNETIO" && mode == nixl_device_exec_mode_t::GPUNETIO_DIRECT);
+}
+
+struct nixlDeviceMemViewRecord {
+    nixlBackendEngine *engine = nullptr;
+    nixlMemViewH backend_memview = nullptr;
+    int execution_device = -1;
+};
+
 // Implements nixlMetadataContext, which is the whole surface a metadata backend
 // sees of the agent: serialization, cache load and invalidation, nothing else.
 // Preserve the grandfathered 8-space class layout below.
@@ -54,8 +69,8 @@ class nixlAgentData final : public nixlMetadataContext {
         backend_list_t                         notifEngines;
         std::array<backend_list_t, FILE_SEG+1> memToBackend;
 
-        // Bookkeeping from memory view handles to backend engines
-        std::unordered_map<nixlMemViewH, nixlBackendEngine &> mvhToEngine;
+        // Bookkeeping from public device-view wrappers to their backend handles.
+        std::unordered_map<nixlMemViewH, nixlDeviceMemViewRecord> mvhToEngine;
 
         std::unordered_map<std::string, std::unordered_map<nixl_backend_t, nixl_blob_t>>
             remoteBackends_;
@@ -98,7 +113,8 @@ class nixlAgentData final : public nixlMetadataContext {
         [[nodiscard]] static backend_set_t
         getBackends(const nixl_opt_args_t *opt_args,
                     const nixlMemSection &section,
-                    nixl_mem_t mem_type);
+                    nixl_mem_t mem_type,
+                    bool require_device_api = false);
         void
         warnAboutEfaHardwareMismatch();
 

--- a/src/core/device/device_memview.cpp
+++ b/src/core/device/device_memview.cpp
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include "device/device_memview.h"
+
+#include "device/device_allocator.h"
+
+nixl_status_t
+nixlDeviceMemViewAllocate(nixl_device_exec_mode_t execution_mode,
+                          nixlMemViewH backend_memview,
+                          nixlMemViewH &wrapper_out,
+                          nixlDeviceAllocator *allocator_override) noexcept {
+    wrapper_out = nullptr;
+    if (execution_mode == nixl_device_exec_mode_t::NONE || backend_memview == nullptr) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    nixlDeviceAllocator &allocator =
+        allocator_override == nullptr ? nixlGetDeviceAllocator() : *allocator_override;
+    nixlDeviceMem wrapper_mem;
+    nixl_status_t status = allocator.allocDeviceMem(sizeof(nixlDeviceMemViewWrapper), wrapper_mem);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    const nixlDeviceMemViewWrapper host_wrapper{execution_mode, backend_memview};
+    status = allocator.copyHostToDevice(wrapper_mem.get(), &host_wrapper, sizeof(host_wrapper));
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+    status = allocator.synchronize();
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+
+    wrapper_out = wrapper_mem.release();
+    return NIXL_SUCCESS;
+}
+
+void
+nixlDeviceMemViewFree(nixlMemViewH wrapper, nixlDeviceAllocator *allocator_override) noexcept {
+    if (wrapper != nullptr) {
+        nixlDeviceAllocator &allocator =
+            allocator_override == nullptr ? nixlGetDeviceAllocator() : *allocator_override;
+        allocator.freeDeviceMem(wrapper);
+    }
+}

--- a/src/core/device/device_memview.h
+++ b/src/core/device/device_memview.h
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef NIXL_SRC_CORE_DEVICE_DEVICE_MEMVIEW_H
+#define NIXL_SRC_CORE_DEVICE_DEVICE_MEMVIEW_H
+
+#include "nixl_device_backend_types.h"
+
+class nixlDeviceAllocator;
+
+[[nodiscard]] nixl_status_t
+nixlDeviceMemViewAllocate(nixl_device_exec_mode_t execution_mode,
+                          nixlMemViewH backend_memview,
+                          nixlMemViewH &wrapper_out,
+                          nixlDeviceAllocator *allocator_override = nullptr) noexcept;
+
+void
+nixlDeviceMemViewFree(nixlMemViewH wrapper,
+                      nixlDeviceAllocator *allocator_override = nullptr) noexcept;
+
+#endif // NIXL_SRC_CORE_DEVICE_DEVICE_MEMVIEW_H

--- a/src/core/meson.build
+++ b/src/core/meson.build
@@ -15,7 +15,13 @@
 
 # Add dependency on the common utility library which brings in logging deps
 
-nixl_lib_deps = [nixl_infra, serdes_interface, stream_interface, dl_dep, nixl_common_dep, thread_dep]
+nixl_lib_deps = [nixl_infra,
+                serdes_interface,
+                stream_interface,
+                dl_dep,
+                nixl_common_dep,
+                thread_dep,
+                device_allocator_interface]
 
 if etcd_dep.found()
     nixl_lib_deps += [ etcd_dep ]
@@ -63,6 +69,7 @@ endif
 # src/plugins/tracing, loaded on demand by nixlPluginManager.
 nixl_lib_sources = [
     'nixl_agent.cpp',
+    'device/device_memview.cpp',
     'nixl_enum_strings.cpp',
     'nixl_md_manager.cpp',
     'nixl_metadata_worker.cpp',

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -1298,15 +1298,16 @@ nixlAgent::releaseXferReq(nixlXferReqH *req_hndl) const {
 
         if(req_hndl->status == NIXL_IN_PROG) {
 
-            req_hndl->status = req_hndl->engine->releaseReqH(
-                                         req_hndl->backendHandle);
+            const nixl_status_t release_status =
+                req_hndl->engine->releaseReqH(req_hndl->backendHandle);
 
-            if (req_hndl->status < 0) {
+            if (release_status < 0) {
                 NIXL_ERROR_FUNC << "backend '" << req_hndl->engine->getType()
                                 << "' could not release transfer request and returned error status "
-                                << req_hndl->status;
+                                << release_status;
                 return NIXL_ERR_REPOST_ACTIVE; // Might need renaming
             }
+            req_hndl->status = release_status;
             // just in case the backend doesn't set to NULL on success
             // this will prevent calling releaseReqH again in destructor
             req_hndl->backendHandle = nullptr;

--- a/src/core/nixl_agent.cpp
+++ b/src/core/nixl_agent.cpp
@@ -27,6 +27,8 @@
 #include "backend/backend_engine.h"
 #include "transfer_request.h"
 #include "agent_data.h"
+#include "device/device_memview.h"
+#include "device/device_allocator.h"
 #include "nixl_md_manager.h"
 #include "plugin_manager.h"
 #include "common/configuration.h"
@@ -351,7 +353,8 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     std::string conn_info;
 
     if (backend->supportsRemote()) {
-        if (!backend->supportsNotif()) {
+        if (!nixlRemoteBackendAdmissionAllowed(
+                backend->getType(), true, backend->supportsNotif(), backend->getDeviceExecMode())) {
             NIXL_ERROR_FUNC << "backend '" << type << "' supportsRemote but not notifications";
             return NIXL_ERR_BACKEND;
         }
@@ -382,7 +385,9 @@ nixlAgent::createBackend(const nixl_backend_t &type,
     }
 
     if (backend->supportsRemote()) {
-        data->notifEngines.push_back(backend.get());
+        if (backend->supportsNotif()) {
+            data->notifEngines.push_back(backend.get());
+        }
         data->connMd_[type] = conn_info;
     }
 
@@ -1871,24 +1876,39 @@ nixlAgent::checkRemoteMD (const std::string remote_name,
 backend_set_t
 nixlAgentData::getBackends(const nixl_opt_args_t *opt_args,
                            const nixlMemSection &section,
-                           nixl_mem_t mem_type) {
+                           nixl_mem_t mem_type,
+                           bool require_device_api) {
     if (opt_args && !opt_args->backends.empty()) {
         backend_set_t backends;
         for (const auto &backend : opt_args->backends) {
-            backends.insert(backend->engine);
+            if (!require_device_api ||
+                backend->engine->getDeviceExecMode() != nixl_device_exec_mode_t::NONE) {
+                backends.insert(backend->engine);
+            }
         }
 
         return backends;
     }
 
     const auto mem_type_backends = section.queryBackends(mem_type);
-    return mem_type_backends ? *mem_type_backends : backend_set_t{};
+    if (!mem_type_backends || !require_device_api) {
+        return mem_type_backends ? *mem_type_backends : backend_set_t{};
+    }
+
+    backend_set_t backends;
+    for (auto *backend : *mem_type_backends) {
+        if (backend->getDeviceExecMode() != nixl_device_exec_mode_t::NONE) {
+            backends.insert(backend);
+        }
+    }
+    return backends;
 }
 
 nixl_status_t
 nixlAgent::prepMemView(const nixl_remote_dlist_t &dlist,
                        nixlMemViewH &mvh,
                        const nixl_opt_args_t *extra_params) const {
+    mvh = nullptr;
     const auto desc_count = static_cast<size_t>(dlist.descCount());
     const auto mem_type = dlist.getType();
     NIXL_TRACE_SCOPE(
@@ -1929,7 +1949,7 @@ nixlAgent::prepMemView(const nixl_remote_dlist_t &dlist,
 
         // Engine has not been selected yet, try to find a backend that can add an element to the
         // remote metadata
-        const auto backends = data->getBackends(extra_params, *it->second, mem_type);
+        const auto backends = data->getBackends(extra_params, *it->second, mem_type, true);
         for (const auto &backend : backends) {
             const auto status = it->second->addElement(desc, backend, remote_meta_dlist);
             if (status == NIXL_SUCCESS) {
@@ -1951,9 +1971,45 @@ nixlAgent::prepMemView(const nixl_remote_dlist_t &dlist,
         return NIXL_ERR_NOT_FOUND;
     }
 
-    const auto status = engine->prepMemView(remote_meta_dlist, mvh, &opt_args);
-    if (status == NIXL_SUCCESS) {
-        data->mvhToEngine.emplace(mvh, *engine);
+    int execution_device = -1;
+    const nixl_status_t device_status = nixlGetDeviceAllocator().getActiveDevice(execution_device);
+    if (device_status != NIXL_SUCCESS) {
+        return device_status;
+    }
+    nixlMemViewH backend_mvh = nullptr;
+    const auto backend_status = engine->prepMemView(remote_meta_dlist, backend_mvh, &opt_args);
+    if (backend_status != NIXL_SUCCESS) {
+        return backend_status;
+    }
+    if (backend_mvh == nullptr || engine->getDeviceExecMode() == nixl_device_exec_mode_t::NONE) {
+        if (backend_mvh != nullptr) {
+            engine->releaseMemView(backend_mvh);
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    const auto status = nixlDeviceMemViewAllocate(engine->getDeviceExecMode(), backend_mvh, mvh);
+    if (status != NIXL_SUCCESS) {
+        engine->releaseMemView(backend_mvh);
+        mvh = nullptr;
+        return status;
+    }
+
+    try {
+        const auto [_, inserted] = data->mvhToEngine.emplace(
+            mvh, nixlDeviceMemViewRecord{engine, backend_mvh, execution_device});
+        if (!inserted) {
+            nixlDeviceMemViewFree(mvh);
+            engine->releaseMemView(backend_mvh);
+            mvh = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+    }
+    catch (...) {
+        nixlDeviceMemViewFree(mvh);
+        engine->releaseMemView(backend_mvh);
+        mvh = nullptr;
+        return NIXL_ERR_BACKEND;
     }
 
     return status;
@@ -1963,6 +2019,7 @@ nixl_status_t
 nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
                        nixlMemViewH &mvh,
                        const nixl_opt_args_t *extra_params) const {
+    mvh = nullptr;
     const auto mem_type = dlist.getType();
     NIXL_TRACE_SCOPE(
         trace_span, data->tracer_.get(), "nixl::prepMemView", nixl::trace::Kind::MemoryR);
@@ -1977,7 +2034,7 @@ nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
     }
 
     const std::lock_guard lock_guard(data->lock);
-    const auto backends = data->getBackends(extra_params, data->localSection_, mem_type);
+    const auto backends = data->getBackends(extra_params, data->localSection_, mem_type, true);
     for (const auto &backend : backends) {
         const auto status = data->localSection_.populate(dlist, backend, meta_dlist);
         if (status == NIXL_SUCCESS) {
@@ -1993,9 +2050,45 @@ nixlAgent::prepMemView(const nixl_local_dlist_t &dlist,
         return NIXL_ERR_NOT_FOUND;
     }
 
-    const auto status = engine->prepMemView(meta_dlist, mvh, &opt_args);
-    if (status == NIXL_SUCCESS) {
-        data->mvhToEngine.emplace(mvh, *engine);
+    int execution_device = -1;
+    const nixl_status_t device_status = nixlGetDeviceAllocator().getActiveDevice(execution_device);
+    if (device_status != NIXL_SUCCESS) {
+        return device_status;
+    }
+    nixlMemViewH backend_mvh = nullptr;
+    const auto backend_status = engine->prepMemView(meta_dlist, backend_mvh, &opt_args);
+    if (backend_status != NIXL_SUCCESS) {
+        return backend_status;
+    }
+    if (backend_mvh == nullptr || engine->getDeviceExecMode() == nixl_device_exec_mode_t::NONE) {
+        if (backend_mvh != nullptr) {
+            engine->releaseMemView(backend_mvh);
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    const auto status = nixlDeviceMemViewAllocate(engine->getDeviceExecMode(), backend_mvh, mvh);
+    if (status != NIXL_SUCCESS) {
+        engine->releaseMemView(backend_mvh);
+        mvh = nullptr;
+        return status;
+    }
+
+    try {
+        const auto [_, inserted] = data->mvhToEngine.emplace(
+            mvh, nixlDeviceMemViewRecord{engine, backend_mvh, execution_device});
+        if (!inserted) {
+            nixlDeviceMemViewFree(mvh);
+            engine->releaseMemView(backend_mvh);
+            mvh = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+    }
+    catch (...) {
+        nixlDeviceMemViewFree(mvh);
+        engine->releaseMemView(backend_mvh);
+        mvh = nullptr;
+        return NIXL_ERR_BACKEND;
     }
 
     return status;
@@ -2013,6 +2106,28 @@ nixlAgent::releaseMemView(nixlMemViewH mvh) const {
         return;
     }
 
-    it->second.releaseMemView(mvh);
+    const nixlDeviceMemViewRecord record = it->second;
+    nixlDeviceAllocator &allocator = nixlGetDeviceAllocator();
+    int previous_device = -1;
+    bool restore_device = false;
+    if (record.execution_device >= 0) {
+        if (allocator.getActiveDevice(previous_device) != NIXL_SUCCESS) {
+            NIXL_ERROR << "Cannot select execution device " << record.execution_device
+                       << " before releasing memory view " << mvh;
+            return;
+        }
+        if (previous_device != record.execution_device &&
+            allocator.setActiveDevice(record.execution_device) != NIXL_SUCCESS) {
+            NIXL_ERROR << "Cannot select execution device " << record.execution_device
+                       << " before releasing memory view " << mvh;
+            return;
+        }
+        restore_device = previous_device != record.execution_device;
+    }
+    record.engine->releaseMemView(record.backend_memview);
+    nixlDeviceMemViewFree(mvh);
+    if (restore_device) {
+        allocator.setActiveDevice(previous_device);
+    }
     data->mvhToEngine.erase(it);
 }

--- a/src/infra/nixl_memory_section.cpp
+++ b/src/infra/nixl_memory_section.cpp
@@ -247,7 +247,9 @@ nixlMemSection::addElement(const nixlRemoteDesc &query,
         return NIXL_ERR_UNKNOWN;
     }
 
-    resp.addDesc({query.addr, query.len, query.devId, base[s_index].metadataP});
+    nixlRemoteMetaDesc element{query.addr, query.len, query.devId, base[s_index].metadataP};
+    element.remoteAgent = query.remoteAgent;
+    resp.addDesc(element);
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -34,11 +34,12 @@ Stream pool mode instead is when applications mostly wants to process data on th
 
 ## Input parameters
 
-DOCA GPUNetIO backend takes 3 input parameters:
+DOCA GPUNetIO backend takes 5 input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
-- oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
+- oob_interface: network interface to be used when exchanging control info during initiator/target connection. Set this explicitly for bonded network devices whose IPv4 address cannot be obtained from DOCA.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
+- gid_index: RoCE GID table index. Defaults to 0; use the GID corresponding to the selected RoCE path.
 
 ## Example
 

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -34,9 +34,10 @@ Stream pool mode instead is when applications mostly wants to process data on th
 
 ## Input parameters
 
-DOCA GPUNetIO backend takes 3 input parameters:
+DOCA GPUNetIO backend takes these input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
 - oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
+- oob_port: TCP port used to listen for OOB connection setup. Defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
 

--- a/src/plugins/gpunetio/README.md
+++ b/src/plugins/gpunetio/README.md
@@ -37,7 +37,7 @@ Stream pool mode instead is when applications mostly wants to process data on th
 DOCA GPUNetIO backend takes these input parameters:
 - network_devices: network device to be used during the execution (e.g. mlx5_0). Current release supports only 1 network device.
 - oob_interface: network interface to be used when exchanging control info during initiator/target connection. Optional parameter, not needed if the network device is set in Ethernet mode.
-- oob_port: TCP port used to listen for OOB connection setup. Defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
+- oob_port: TCP port used to listen for OOB connection setup. It must be an integer in the inclusive range [1, 65535] and defaults to 6544. Set a distinct port for each GPUNETIO backend sharing a host network namespace.
 - gpu_devices: GPU CUDA ID to be used during the execution (e.g. 0). Current release supports only 1 GPU device.
 - cuda_streams: how many CUDA streams the backend should created at setup time in the internal pool. Relevant only if the application wants to use the "stream pool" mode. If this parameter is not specified, default value is `DOCA_POST_STREAM_NUM`.
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1292,7 +1292,8 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
-    treq->completed = false;
+    treq->completionState.store(nixlDocaBckndReq::CompletionState::IN_PROGRESS,
+                                std::memory_order_release);
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
         const uint32_t completion_index =
@@ -1321,7 +1322,12 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    if (treq->completed) {
+    auto state = treq->completionState.load(std::memory_order_acquire);
+    if (state == nixlDocaBckndReq::CompletionState::COMPLETE) {
+        return treq->postStatus;
+    }
+    if (state == nixlDocaBckndReq::CompletionState::COMPLETING) {
+        treq->completionState.wait(state, std::memory_order_acquire);
         return treq->postStatus;
     }
 
@@ -1334,13 +1340,23 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    for (size_t i = 0; i < treq->postedCount; ++i) {
-        const uint32_t idx = treq->positions[i];
-        *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-        NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
+    auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
+    if (treq->completionState.compare_exchange_strong(
+            expected,
+            nixlDocaBckndReq::CompletionState::COMPLETING,
+            std::memory_order_acq_rel)) {
+        for (size_t i = 0; i < treq->postedCount; ++i) {
+            const uint32_t idx = treq->positions[i];
+            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+            NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
+        }
+        treq->completionState.store(nixlDocaBckndReq::CompletionState::COMPLETE,
+                                    std::memory_order_release);
+        treq->completionState.notify_all();
+    } else if (expected == nixlDocaBckndReq::CompletionState::COMPLETING) {
+        treq->completionState.wait(expected, std::memory_order_acquire);
     }
 
-    treq->completed = true;
     return treq->postStatus;
 }
 
@@ -1355,7 +1371,8 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
         return NIXL_SUCCESS;
     }
 
-    if (!treq->completed) {
+    if (treq->completionState.load(std::memory_order_acquire) !=
+        nixlDocaBckndReq::CompletionState::COMPLETE) {
         nixl_status_t status = checkXfer(handle);
         if (status == NIXL_IN_PROG) {
             return NIXL_ERR_BACKEND;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1286,6 +1286,9 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
     if (operation != NIXL_READ && operation != NIXL_WRITE) {
         return NIXL_ERR_INVALID_PARAM;
     }
+    if (treq->postStatus != NIXL_SUCCESS) {
+        return treq->postStatus;
+    }
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1289,6 +1289,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
+    treq->completed = false;
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
         const uint32_t completion_index =
@@ -1317,6 +1318,10 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
+    if (treq->completed) {
+        return treq->postStatus;
+    }
+
     for (size_t i = 0; i < treq->postedCount; ++i) {
         const uint32_t idx = treq->positions[i];
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
@@ -1332,6 +1337,7 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
+    treq->completed = true;
     return treq->postStatus;
 }
 
@@ -1346,9 +1352,11 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
         return NIXL_SUCCESS;
     }
 
-    nixl_status_t status = checkXfer(handle);
-    if (status == NIXL_IN_PROG) {
-        return NIXL_ERR_BACKEND;
+    if (!treq->completed) {
+        nixl_status_t status = checkXfer(handle);
+        if (status == NIXL_IN_PROG) {
+            return NIXL_ERR_BACKEND;
+        }
     }
 
     for (uint32_t idx : treq->positions) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -39,18 +39,25 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     union ibv_gid rgid;
 
     result = doca_log_backend_create_standard();
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_create_with_file_sdk(stderr, &sdk_log);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_set_sdk_level(sdk_log, DOCA_LOG_LEVEL_ERROR);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     NIXL_INFO << "DOCA network devices ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("network_devices") > 1)
+    if (custom_params->count("network_devices") > 1) {
         throw std::invalid_argument("Only 1 network device is allowed");
+    }
 
     if (custom_params->count("network_devices") == 0 || (*custom_params)["network_devices"] == "" ||
         (*custom_params)["network_devices"] == "all") {
@@ -65,8 +72,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (custom_params->count("oob_interface") > 0) {
         NIXL_INFO << "DOCA network devices ";
         // Temporary: will extend to more GPUs in a dedicated PR
-        if (custom_params->count("oob_interface") > 1)
+        if (custom_params->count("oob_interface") > 1) {
             throw std::invalid_argument("Only 1 oob interface is allowed");
+        }
 
         oobdev = absl::StrSplit((*custom_params)["oob_interface"], " ");
         NIXL_INFO << "Using oob interface" << oobdev[0];
@@ -75,8 +83,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "DOCA GPU devices: ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("gpu_devices") > 1)
+    if (custom_params->count("gpu_devices") > 1) {
         throw std::invalid_argument("Only 1 GPU device is allowed");
+    }
 
     if (custom_params->count("gpu_devices") == 0 || (*custom_params)["gpu_devices"] == "" ||
         (*custom_params)["gpu_devices"] == "all") {
@@ -92,9 +101,12 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     NIXL_INFO << std::endl;
 
     nstreams = 0;
-    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "")
+    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "") {
         nstreams = std::stoi((*custom_params)["cuda_streams"]);
-    if (nstreams == 0) nstreams = DOCA_POST_STREAM_NUM;
+    }
+    if (nstreams == 0) {
+        nstreams = DOCA_POST_STREAM_NUM;
+    }
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
@@ -112,7 +124,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     pd = doca_verbs_bridge_verbs_pd_get_ibv_pd(verbs_pd);
-    if (pd == NULL) throw std::invalid_argument("Failed to get ibv_pd");
+    if (pd == NULL) {
+        throw std::invalid_argument("Failed to get ibv_pd");
+    }
 
     result = doca_rdma_bridge_open_dev_from_pd(pd, &ddev);
     if (result != DOCA_SUCCESS) {
@@ -137,8 +151,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
         result = create_verbs_ah_attr(
             verbs_context, gid_index, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH, &verbs_ah_attr);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             throw std::invalid_argument("Failed to create doca verbs ah attributes");
+        }
 
         lid = port_attr.lid;
     } else {
@@ -164,8 +179,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         cudaFree(0);
 
         result = doca_gpu_create(pciBusId, &item.second);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to create DOCA GPU device " << doca_error_get_descr(result);
+        }
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
@@ -241,10 +257,11 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     nixlDocaEngineCheckCudaError(cudaStreamCreateWithFlags(&wait_stream, cudaStreamNonBlocking),
                                  "Failed to create CUDA stream");
-    for (int i = 0; i < nstreams; i++)
+    for (int i = 0; i < nstreams; i++) {
         nixlDocaEngineCheckCudaError(
             cudaStreamCreateWithFlags(&post_stream[i], cudaStreamNonBlocking),
             "Failed to create CUDA stream");
+    }
     xferStream = 0;
 
     result = doca_gpu_mem_alloc(gdevs[0].second,
@@ -370,8 +387,9 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
-    for (auto notif : notifMap)
+    for (auto notif : notifMap) {
         nixlDocaDestroyNotif(gdevs[0].second, notif.second);
+    }
     notifMap.clear();
 
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
@@ -381,17 +399,20 @@ nixlDocaEngine::~nixlDocaEngine() {
 
     NIXL_DEBUG << "Before qpMap.clear ";
 
-    for (auto &qp : qpMap)
+    for (auto &qp : qpMap) {
         delete qp.second;
+    }
     qpMap.clear();
 
     result = doca_dev_close(ddev);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
+    }
 
     result = doca_gpu_destroy(gdevs[0].second);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
+    }
 }
 
 /****************************************
@@ -471,7 +492,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
 
 nixl_status_t
 nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif) {
-    if (notif == nullptr) return NIXL_SUCCESS;
+    if (notif == nullptr) {
+        return NIXL_SUCCESS;
+    }
 
     notif->send_mr.reset();
     notif->recv_mr.reset();
@@ -1081,8 +1104,9 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     md->conn = conn;
 
     std::stringstream ss(input.metaInfo.data());
-    while (std::getline(ss, token, info_delimiter))
+    while (std::getline(ss, token, info_delimiter)) {
         tokens.push_back(token);
+    }
 
     uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
     uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
@@ -1132,7 +1156,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-        if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
+        if (lmd->devId != gdevs[0].first) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
 
     auto search = qpMap.find(remote_agent);
@@ -1143,9 +1169,13 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
+    if (lcnt != rcnt) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
+    if (lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     if (opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
@@ -1161,7 +1191,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
             size_t lsize = local[idx].len;
             size_t rsize = remote[idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
+            if (lsize != rsize) {
+                return NIXL_ERR_INVALID_PARAM;
+            }
 
             lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
             rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
@@ -1276,8 +1308,9 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
             NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
                       << " COMPLETED!\n";
             return NIXL_SUCCESS;
-        } else
+        } else {
             return NIXL_IN_PROG;
+        }
     }
 
     return NIXL_SUCCESS;
@@ -1286,10 +1319,11 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
     uint32_t tmp = xferRingPos.load() & (DOCA_XFER_REQ_MAX - 1);
-    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0)
+    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0) {
         return NIXL_SUCCESS;
-    else
+    } else {
         return NIXL_IN_PROG;
+    }
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1250,12 +1250,11 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
             (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
-        final_request.msg_sz = newMsg.size();
+        final_request.msg_sz = newMsg.size() + 1;
         final_request.lbuf_notif = notif_addr;
         final_request.lkey_notif = notif->send_mr->get_lkey();
 
-        memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
-        reinterpret_cast<char *>(notif_addr)[newMsg.size()] = '\0';
+        memcpy((void *)notif_addr, newMsg.c_str(), final_request.msg_sz);
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1342,9 +1342,7 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 
     auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
     if (treq->completionState.compare_exchange_strong(
-            expected,
-            nixlDocaBckndReq::CompletionState::COMPLETING,
-            std::memory_order_acq_rel)) {
+            expected, nixlDocaBckndReq::CompletionState::COMPLETING, std::memory_order_acq_rel)) {
         for (size_t i = 0; i < treq->postedCount; ++i) {
             const uint32_t idx = treq->positions[i];
             *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "gpunetio_backend.h"
-#include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <cassert>
 #include <stdexcept>
@@ -98,6 +97,8 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
+    local_port = parseGpunetioOobPort((*custom_params)["oob_port"]);
+    NIXL_INFO << "OOB listen port: " << local_port;
     /* Open DOCA device */
     verbs_context = open_ib_device((char *)(ndevs[0].c_str()));
     if (verbs_context == nullptr) {
@@ -503,21 +504,21 @@ nixlDocaEngine::progressThreadStart() {
     if (oobdev.size() > 0 && oobdev[0] != "") {
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         /* Bind to the set port and IP: */
-        addr_in->sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        addr_in->sin_port = htons(local_port);
         if (bind(oob_sock_server, (struct sockaddr *)addr_in, sizeof(struct sockaddr_in)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
     } else {
         /* Set port and IP: */
         server_addr.sin_family = AF_INET;
-        server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
+        server_addr.sin_port = htons(local_port);
         server_addr.sin_addr.s_addr = INADDR_ANY; /* listen on any interface */
 
         /* Bind to the set port and IP: */
         if (bind(oob_sock_server, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-            NIXL_ERROR << "Couldn't bind to the port " << DOCA_RDMA_CM_LOCAL_PORT_SERVER;
+            NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
             return NIXL_ERR_NOT_SUPPORTED;
         }
@@ -557,7 +558,7 @@ nixlDocaEngine::progressThreadStop() {
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd);
+    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
     close(oob_sock_server);
@@ -928,7 +929,7 @@ nixlDocaEngine::getConnInfo(std::string &str) const {
     std::stringstream ss;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
-    str = ss.str();
+    str = formatGpunetioOobEndpoint(ss.str(), local_port);
     return NIXL_SUCCESS;
 }
 
@@ -953,17 +954,20 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     // TODO: Connect part should be moved into connect() method
     nixlDocaConnection conn;
-    size_t size = remote_conn_info.size();
-    // TODO: eventually std::byte?
-    char *addr = new char[size];
-
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    GpunetioOobEndpoint endpoint;
+    try {
+        endpoint = parseGpunetioOobEndpoint(remote_conn_info);
+    }
+    catch (const std::invalid_argument &error) {
+        NIXL_ERROR << error.what();
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(endpoint.ipv4.c_str(), &oob_sock_client, endpoint.port);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
@@ -986,8 +990,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -48,6 +48,58 @@ parseGidIndex(const std::string &value) {
 
     return parsed_value;
 }
+
+void
+rollbackOobDiscoveryFailure(std::vector<std::pair<uint32_t, doca_gpu *>> &gdevs,
+                            doca_verbs_ah_attr *&verbs_ah_attr,
+                            doca_dev *&ddev,
+                            doca_verbs_pd *&verbs_pd,
+                            doca_verbs_context *&verbs_context) noexcept {
+    doca_error_t result;
+
+    for (auto item = gdevs.rbegin(); item != gdevs.rend(); ++item) {
+        if (item->second == nullptr) {
+            continue;
+        }
+        result = doca_gpu_destroy(item->second);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to roll back DOCA GPU device " << doca_error_get_descr(result);
+        }
+        item->second = nullptr;
+    }
+
+    if (verbs_ah_attr != nullptr) {
+        result = doca_verbs_ah_attr_destroy(verbs_ah_attr);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to roll back DOCA verbs AH " << doca_error_get_descr(result);
+        }
+        verbs_ah_attr = nullptr;
+    }
+
+    if (ddev != nullptr) {
+        result = doca_dev_close(ddev);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to roll back DOCA device " << doca_error_get_descr(result);
+        }
+        ddev = nullptr;
+    }
+
+    if (verbs_pd != nullptr) {
+        result = doca_verbs_pd_destroy(verbs_pd);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to roll back DOCA verbs PD " << doca_error_get_descr(result);
+        }
+        verbs_pd = nullptr;
+    }
+
+    if (verbs_context != nullptr) {
+        result = doca_verbs_context_destroy(verbs_context);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to roll back DOCA verbs context " << doca_error_get_descr(result);
+        }
+        verbs_context = nullptr;
+    }
+}
 } // namespace
 
 /****************************************
@@ -95,6 +147,12 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         oobdev = absl::StrSplit((*custom_params)["oob_interface"], " ");
         NIXL_INFO << "Using oob interface" << oobdev[0];
         NIXL_INFO << std::endl;
+    }
+
+    if (oobdev.size() > 0 && oobdev[0] != "" &&
+        netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask) != 0) {
+        throw std::invalid_argument("Failed to get IPv4 address for GPUNETIO OOB interface '" +
+                                    oobdev[0] + "'");
     }
 
     NIXL_INFO << "DOCA GPU devices: ";
@@ -194,10 +252,6 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
-        if (netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask) != 0) {
-            throw std::invalid_argument("Failed to get IPv4 address for GPUNETIO OOB interface '" +
-                                        oobdev[0] + "'");
-        }
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         memcpy(ipv4_addr, (uint8_t *)&(addr_in->sin_addr.s_addr), 4);
         NIXL_DEBUG << "Eth IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
@@ -208,6 +262,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         result = doca_devinfo_get_ipv4_addr(
             doca_dev_as_devinfo(ddev), (uint8_t *)ipv4_addr, DOCA_DEVINFO_IPV4_ADDR_SIZE);
         if (result != DOCA_SUCCESS) {
+            rollbackOobDiscoveryFailure(gdevs, verbs_ah_attr, ddev, verbs_pd, verbs_context);
             throw std::invalid_argument(
                 "Failed to determine the GPUNETIO IPv4 address; set oob_interface explicitly "
                 "when using a bonded network device");

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -372,6 +372,7 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap)
         nixlDocaDestroyNotif(gdevs[0].second, notif.second);
+    notifMap.clear();
 
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
@@ -380,6 +381,8 @@ nixlDocaEngine::~nixlDocaEngine() {
 
     NIXL_DEBUG << "Before qpMap.clear ";
 
+    for (auto &qp : qpMap)
+        delete qp.second;
     qpMap.clear();
 
     result = doca_dev_close(ddev);
@@ -397,8 +400,6 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
-    struct nixlDocaNotif *notif;
-
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -406,7 +407,7 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         return NIXL_SUCCESS;
     }
 
-    notif = new struct nixlDocaNotif;
+    auto notif = std::make_unique<nixlDocaNotif>();
 
     notif->elems_num = DOCA_MAX_NOTIF_INFLIGHT;
     notif->elems_size = DOCA_MAX_NOTIF_MESSAGE_SIZE;
@@ -423,12 +424,15 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
 
     notif->recv_addr = (uint8_t *)calloc(notif->elems_size * notif->elems_num, sizeof(uint8_t));
     if (notif->recv_addr == nullptr) {
         NIXL_ERROR << "Can't alloc memory for send notif";
+        notif->send_mr.reset();
+        free(notif->send_addr);
         return NIXL_ERR_BACKEND;
     }
     memset(notif->recv_addr, 0, notif->elems_size * notif->elems_num);
@@ -439,6 +443,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        notif->send_mr.reset();
+        free(notif->send_addr);
+        free(notif->recv_addr);
         return NIXL_ERR_BACKEND;
     }
 
@@ -446,10 +453,11 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->recv_pi = 0;
 
     // Ensure notif list is not added twice for the same peer
-    notifMap[remote_agent] = notif;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
-    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
+    auto *notif_ptr = notif.get();
+    notifMap[remote_agent] = notif.release();
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif_ptr->recv_addr;
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif_ptr->recv_mr->get_lkey();
+    ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif_ptr->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
         qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
@@ -463,6 +471,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
 
 nixl_status_t
 nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif) {
+    if (notif == nullptr) return NIXL_SUCCESS;
+
+    notif->send_mr.reset();
+    notif->recv_mr.reset();
+    free(notif->send_addr);
+    free(notif->recv_addr);
     delete notif;
 
     return NIXL_SUCCESS;
@@ -571,8 +585,6 @@ nixlDocaEngine::getGpuCudaId() {
 
 nixl_status_t
 nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
-    struct nixlDocaRdmaQp *rdma_qp;
-
     std::lock_guard<std::mutex> lock(qpLock);
 
     NIXL_DEBUG << "addRdmaQp for " << remote_agent << std::endl;
@@ -584,7 +596,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
 
-    rdma_qp = new struct nixlDocaRdmaQp;
+    auto rdma_qp = std::make_unique<nixlDocaRdmaQp>();
 
     try {
         rdma_qp->qp_data =
@@ -621,7 +633,7 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     rdma_qp->qpn_notif = doca_verbs_qp_get_qpn(rdma_qp->qp_notif->get_qp());
 
-    qpMap[remote_agent] = rdma_qp;
+    qpMap[remote_agent] = rdma_qp.release();
 
     NIXL_DEBUG << "DOCA addRdmaQp new QP added for " << remote_agent;
 
@@ -999,7 +1011,7 @@ nixl_status_t
 nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
                             const nixl_mem_t &nixl_mem,
                             nixlBackendMD *&out) {
-    nixlDocaPrivateMetadata *priv = new nixlDocaPrivateMetadata;
+    auto priv = std::make_unique<nixlDocaPrivateMetadata>();
     std::stringstream ss;
 
     auto it = std::find_if(gdevs.begin(), gdevs.end(), [&mem](std::pair<uint32_t, doca_gpu *> &x) {
@@ -1025,7 +1037,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
        << info_delimiter << ((size_t)priv->mr->get_tot_size());
     priv->remoteMrStr = ss.str();
 
-    out = (nixlBackendMD *)priv;
+    out = priv.release();
 
     return NIXL_SUCCESS;
 }
@@ -1055,7 +1067,7 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     nixlDocaConnection conn;
     std::vector<std::string> tokens;
     std::string token;
-    nixlDocaPublicMetadata *md = new nixlDocaPublicMetadata;
+    auto md = std::make_unique<nixlDocaPublicMetadata>();
     auto search = remoteConnMap.find(remote_agent);
 
     if (search == remoteConnMap.end()) {
@@ -1085,13 +1097,14 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
         return NIXL_ERR_BACKEND;
     }
 
-    output = (nixlBackendMD *)md;
+    output = md.release();
 
     return NIXL_SUCCESS;
 }
 
 nixl_status_t
 nixlDocaEngine::unloadMD(nixlBackendMD *input) {
+    delete static_cast<nixlDocaPublicMetadata *>(input);
     return NIXL_SUCCESS;
 }
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -38,7 +38,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     int ret;
     union ibv_gid rgid;
 
-    for (auto &reserved : xferReqReserved) {
+    for (auto &reserved : xferReqReserved_) {
         reserved.store(false, std::memory_order_relaxed);
     }
 
@@ -1155,7 +1155,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     treq = new nixlDocaBckndReq;
     auto abandon_request = [&]() {
         for (uint32_t reserved_pos : treq->positions) {
-            xferReqReserved[reserved_pos].store(false, std::memory_order_release);
+            xferReqReserved_[reserved_pos].store(false, std::memory_order_release);
         }
         delete treq;
     };
@@ -1164,14 +1164,18 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
         treq->stream = post_stream[stream_id];
     } else {
-        treq->stream = (cudaStream_t) * ((uintptr_t *)opt_args->customParam.data());
+        if (opt_args->customParam.size() != sizeof(cudaStream_t)) {
+            abandon_request();
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        std::memcpy(&treq->stream, opt_args->customParam.data(), sizeof(treq->stream));
     }
 
     auto reserve_position = [&]() -> bool {
         for (uint32_t attempt = 0; attempt < DOCA_XFER_REQ_MAX; ++attempt) {
             const uint32_t candidate = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
             bool expected = false;
-            if (xferReqReserved[candidate].compare_exchange_strong(
+            if (xferReqReserved_[candidate].compare_exchange_strong(
                     expected, true, std::memory_order_acq_rel)) {
                 pos = candidate;
                 treq->positions.push_back(candidate);
@@ -1237,6 +1241,10 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         // Check notifMsg size
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
+        if (newMsg.size() >= notif->elems_size) {
+            abandon_request();
+            return NIXL_ERR_INVALID_PARAM;
+        }
 
         auto &final_request = xferReqRingCpu[final_pos];
         final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
@@ -1247,6 +1255,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
+        reinterpret_cast<char *>(notif_addr)[newMsg.size()] = '\0';
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
                   << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
@@ -1275,24 +1284,33 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const nixl_opt_b_args_t *opt_args) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
-    for (uint32_t idx : treq->positions) {
-        xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
-        completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
-        completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
-
-        switch (operation) {
-        case NIXL_READ:
-            doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
-            break;
-        case NIXL_WRITE:
-            doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
-            break;
-        default:
-            return NIXL_ERR_INVALID_PARAM;
-        }
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
     }
 
-    return NIXL_IN_PROG;
+    treq->postedCount = 0;
+    treq->postStatus = NIXL_SUCCESS;
+    for (uint32_t idx : treq->positions) {
+        std::lock_guard<std::mutex> lock(postLock_);
+        const uint32_t completion_index =
+            lastPostedReq.load(std::memory_order_relaxed) & DOCA_MAX_COMPLETION_INFLIGHT_MASK;
+        xferReqRingCpu[idx].id = completion_index;
+        completion_list_cpu[completion_index].xferReqRingGpu = nullptr;
+        completion_list_cpu[completion_index].completed = 0;
+
+        const doca_error_t result = operation == NIXL_READ ?
+            doca_kernel_read(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx) :
+            doca_kernel_write(treq->stream, xferReqRingCpu[idx].qp_data, xferReqRingGpu, idx);
+        if (result != DOCA_SUCCESS) {
+            treq->postStatus = NIXL_ERR_BACKEND;
+            break;
+        }
+        completion_list_cpu[completion_index].xferReqRingGpu = xferReqRingGpu + idx;
+        lastPostedReq.fetch_add(1, std::memory_order_relaxed);
+        ++treq->postedCount;
+    }
+
+    return treq->postedCount == 0 ? treq->postStatus : NIXL_IN_PROG;
 }
 
 nixl_status_t
@@ -1300,7 +1318,8 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    for (uint32_t idx : treq->positions) {
+    for (size_t i = 0; i < treq->postedCount; ++i) {
+        const uint32_t idx = treq->positions[i];
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
 
         if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed != 1) {
@@ -1308,27 +1327,36 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    for (uint32_t idx : treq->positions) {
+    for (size_t i = 0; i < treq->postedCount; ++i) {
+        const uint32_t idx = treq->positions[i];
         *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
         NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
-    return NIXL_SUCCESS;
+    return treq->postStatus;
 }
 
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
-    nixl_status_t status = checkXfer(handle);
-    if (status == NIXL_IN_PROG) {
-        return status;
+    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    if (treq->postedCount == 0) {
+        for (uint32_t idx : treq->positions) {
+            xferReqReserved_[idx].store(false, std::memory_order_release);
+        }
+        delete treq;
+        return NIXL_SUCCESS;
     }
 
-    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    nixl_status_t status = checkXfer(handle);
+    if (status == NIXL_IN_PROG) {
+        return NIXL_ERR_BACKEND;
+    }
+
     for (uint32_t idx : treq->positions) {
-        xferReqReserved[idx].store(false, std::memory_order_release);
+        xferReqReserved_[idx].store(false, std::memory_order_release);
     }
     delete treq;
-    return status;
+    return NIXL_SUCCESS;
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -769,7 +769,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     NIXL_DEBUG << "connectClientRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
     std::unique_lock<std::mutex> lock(connectLock);
-    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+    if (rdma_qp->dataProgrammed || rdma_qp->notifProgrammed) {
         if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
             rdma_qp->remote_lid != remote_lid ||
             memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
@@ -789,26 +789,26 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    if (!rdma_qp->data_programmed) {
+    if (!rdma_qp->dataProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->data_programmed = true;
+        rdma_qp->dataProgrammed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    if (!rdma_qp->notif_programmed) {
+    if (!rdma_qp->notifProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->notif_programmed = true;
+        rdma_qp->notifProgrammed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -970,7 +970,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     NIXL_DEBUG << "connectServerRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
     std::unique_lock<std::mutex> lock(connectLock);
-    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+    if (rdma_qp->dataProgrammed || rdma_qp->notifProgrammed) {
         if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
             rdma_qp->remote_lid != remote_lid ||
             memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
@@ -990,26 +990,26 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    if (!rdma_qp->data_programmed) {
+    if (!rdma_qp->dataProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->data_programmed = true;
+        rdma_qp->dataProgrammed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    if (!rdma_qp->notif_programmed) {
+    if (!rdma_qp->notifProgrammed) {
         result = connect_verbs_qp(
             this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
         if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
             return NIXL_ERR_BACKEND;
         }
-        rdma_qp->notif_programmed = true;
+        rdma_qp->notifProgrammed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -383,13 +383,24 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
 
     bool qps_closed = true;
+    bool retained_closed = true;
     for (auto &qp : qpMap) {
         const bool data_closed = qp.second->qp_data->close();
         const bool notif_closed = qp.second->qp_notif->close();
         qps_closed = data_closed && notif_closed && qps_closed;
     }
+    if (retainedQp_ != nullptr) {
+        const bool data_closed = retainedQp_->qp_data == nullptr || retainedQp_->qp_data->close();
+        const bool notif_closed =
+            retainedQp_->qp_notif == nullptr || retainedQp_->qp_notif->close();
+        retained_closed = data_closed && notif_closed;
+        qps_closed = retained_closed && qps_closed;
+    }
     if (!qps_closed) {
         NIXL_ERROR << "GPUNETIO QP unexport failed; retaining dependent resources";
+        if (!retained_closed) {
+            retainedQp_.release();
+        }
         return;
     }
 
@@ -397,6 +408,7 @@ nixlDocaEngine::~nixlDocaEngine() {
         delete qp.second;
     }
     qpMap.clear();
+    retainedQp_.reset();
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -650,6 +662,9 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     if (qpMap.find(remote_agent) != qpMap.end()) {
         return NIXL_IN_PROG;
     }
+    if (retainedQp_ != nullptr) {
+        return NIXL_ERR_BACKEND;
+    }
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
 
@@ -685,6 +700,9 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     }
     catch (const std::exception &e) {
         NIXL_ERROR << e.what();
+        if (!rdma_qp->qp_data->close()) {
+            retainedQp_ = std::move(rdma_qp);
+        }
         return NIXL_ERR_BACKEND;
     }
 
@@ -1028,25 +1046,38 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     nixlDocaConnection conn;
     size_t size = remote_conn_info.size();
     // TODO: eventually std::byte?
-    char *addr = new char[size];
+    auto addr = std::make_unique<char[]>(size);
 
     if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    nixlSerDes::_stringToBytes((void *)addr, remote_conn_info, size);
+    nixlSerDes::_stringToBytes((void *)addr.get(), remote_conn_info, size);
 
-    int ret = oob_connection_client_setup(addr, &oob_sock_client);
+    int ret = oob_connection_client_setup(addr.get(), &oob_sock_client);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status == NIXL_SUCCESS) {
+        status = addRdmaQp(remote_agent);
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+    }
+    if (status == NIXL_SUCCESS) {
+        status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    }
+    if (status == NIXL_SUCCESS) {
+        status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    }
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        return status;
+    }
 
     conn.remoteAgent = remote_agent;
     conn.connected = true;
@@ -1059,8 +1090,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
 
     close(oob_sock_client);
-
-    delete[] addr;
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -29,19 +29,22 @@ const char info_delimiter = '-';
 namespace {
 int
 parse_gid_index(const std::string &value) {
-    if (value.empty())
+    if (value.empty()) {
         return 0;
+    }
 
     size_t parsed_chars = 0;
     int parsed_value = 0;
     try {
         parsed_value = std::stoi(value, &parsed_chars);
-    } catch (const std::exception &) {
+    }
+    catch (const std::exception &) {
         throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
     }
 
-    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255)
+    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255) {
         throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+    }
 
     return parsed_value;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -678,13 +678,13 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -702,8 +702,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -712,8 +715,11 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -819,13 +825,13 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &dlid, sizeof(uint32_t), 0) < 0) {
+    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -872,8 +878,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_data->get_qp(), rdma_qp->rqpn_data, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_data->get_qp(),
+                              rdma_qp->rqpn_data,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -882,8 +891,11 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), rdma_qp->rqpn_notif, rdma_qp->remote_gid_data);
+    result = connect_verbs_qp(this,
+                              rdma_qp->qp_notif->get_qp(),
+                              rdma_qp->rqpn_notif,
+                              rdma_qp->remote_gid,
+                              rdma_qp->remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -1292,7 +1292,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
 
     treq->postedCount = 0;
     treq->postStatus = NIXL_SUCCESS;
-    treq->completionState.store(nixlDocaBckndReq::CompletionState::IN_PROGRESS,
+    treq->completionState.store(nixlDocaBckndReq::completion_state::IN_PROGRESS,
                                 std::memory_order_release);
     for (uint32_t idx : treq->positions) {
         std::lock_guard<std::mutex> lock(postLock_);
@@ -1323,10 +1323,10 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     uint32_t completion_index;
 
     auto state = treq->completionState.load(std::memory_order_acquire);
-    if (state == nixlDocaBckndReq::CompletionState::COMPLETE) {
+    if (state == nixlDocaBckndReq::completion_state::COMPLETE) {
         return treq->postStatus;
     }
-    if (state == nixlDocaBckndReq::CompletionState::COMPLETING) {
+    if (state == nixlDocaBckndReq::completion_state::COMPLETING) {
         treq->completionState.wait(state, std::memory_order_acquire);
         return treq->postStatus;
     }
@@ -1340,22 +1340,35 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
         }
     }
 
-    auto expected = nixlDocaBckndReq::CompletionState::IN_PROGRESS;
-    if (treq->completionState.compare_exchange_strong(
-            expected, nixlDocaBckndReq::CompletionState::COMPLETING, std::memory_order_acq_rel)) {
-        for (size_t i = 0; i < treq->postedCount; ++i) {
-            const uint32_t idx = treq->positions[i];
-            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-            NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
-        }
-        treq->completionState.store(nixlDocaBckndReq::CompletionState::COMPLETE,
-                                    std::memory_order_release);
-        treq->completionState.notify_all();
-    } else if (expected == nixlDocaBckndReq::CompletionState::COMPLETING) {
-        treq->completionState.wait(expected, std::memory_order_acquire);
+    retireRequest(treq);
+    return treq->postStatus;
+}
+
+void
+nixlDocaEngine::retireRequest(nixlDocaBckndReq *request) const {
+    auto state = request->completionState.load(std::memory_order_acquire);
+    if (state == nixlDocaBckndReq::completion_state::COMPLETE) {
+        return;
+    }
+    if (state == nixlDocaBckndReq::completion_state::COMPLETING) {
+        request->completionState.wait(state, std::memory_order_acquire);
+        return;
     }
 
-    return treq->postStatus;
+    auto expected = nixlDocaBckndReq::completion_state::IN_PROGRESS;
+    if (request->completionState.compare_exchange_strong(
+            expected, nixlDocaBckndReq::completion_state::COMPLETING, std::memory_order_acq_rel)) {
+        for (size_t i = 0; i < request->postedCount; ++i) {
+            const uint32_t idx = request->positions[i];
+            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+            NIXL_INFO << "DOCA retireRequest pos " << idx << " COMPLETED!";
+        }
+        request->completionState.store(nixlDocaBckndReq::completion_state::COMPLETE,
+                                       std::memory_order_release);
+        request->completionState.notify_all();
+    } else if (expected == nixlDocaBckndReq::completion_state::COMPLETING) {
+        request->completionState.wait(expected, std::memory_order_acquire);
+    }
 }
 
 nixl_status_t
@@ -1370,7 +1383,7 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
     }
 
     if (treq->completionState.load(std::memory_order_acquire) !=
-        nixlDocaBckndReq::CompletionState::COMPLETE) {
+        nixlDocaBckndReq::completion_state::COMPLETE) {
         nixl_status_t status = checkXfer(handle);
         if (status == NIXL_IN_PROG) {
             return NIXL_ERR_BACKEND;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -38,6 +38,10 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     int ret;
     union ibv_gid rgid;
 
+    for (auto &reserved : xferReqReserved) {
+        reserved.store(false, std::memory_order_relaxed);
+    }
+
     result = doca_log_backend_create_standard();
     if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
 
@@ -1106,20 +1110,38 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    nixlDocaBckndReq *treq;
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
-    uint32_t lcnt = (uint32_t)local.descCount();
-    uint32_t rcnt = (uint32_t)remote.descCount();
-    uint32_t stream_id;
+    const uint32_t lcnt = (uint32_t)local.descCount();
+    const uint32_t rcnt = (uint32_t)remote.descCount();
+    uint32_t stream_id = DOCA_POST_STREAM_NUM;
     struct nixlDocaRdmaQp *rdma_qp;
     uintptr_t notif_addr;
+
+    if (operation != NIXL_READ && operation != NIXL_WRITE) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if (lcnt != rcnt || lcnt == 0) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    if ((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE > DOCA_XFER_REQ_MAX) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+
+    for (uint32_t idx = 0; idx < lcnt; idx++) {
+        if (local[idx].len != remote[idx].len) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
 
     // TODO: check device id from local dlist mr that should be all the same and same of
     // the engine
     for (uint32_t idx = 0; idx < lcnt; idx++) {
         lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-        if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
+        if (lmd->devId != gdevs[0].first) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
     }
 
     auto search = qpMap.find(remote_agent);
@@ -1130,52 +1152,75 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     rdma_qp = search->second;
 
-    if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
+    treq = new nixlDocaBckndReq;
+    auto abandon_request = [&]() {
+        for (uint32_t reserved_pos : treq->positions) {
+            xferReqReserved[reserved_pos].store(false, std::memory_order_release);
+        }
+        delete treq;
+    };
 
-    if (lcnt == 0) return NIXL_ERR_INVALID_PARAM;
-
-    if (opt_args->customParam.empty()) {
+    if (opt_args == nullptr || opt_args->customParam.empty()) {
         stream_id = (xferStream.fetch_add(1) & (nstreams - 1));
         treq->stream = post_stream[stream_id];
     } else {
         treq->stream = (cudaStream_t) * ((uintptr_t *)opt_args->customParam.data());
     }
 
-    treq->start_pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-    pos = treq->start_pos;
+    auto reserve_position = [&]() -> bool {
+        for (uint32_t attempt = 0; attempt < DOCA_XFER_REQ_MAX; ++attempt) {
+            const uint32_t candidate = xferRingPos.fetch_add(1) & DOCA_XFER_REQ_MASK;
+            bool expected = false;
+            if (xferReqReserved[candidate].compare_exchange_strong(
+                    expected, true, std::memory_order_acq_rel)) {
+                pos = candidate;
+                treq->positions.push_back(candidate);
+                return true;
+            }
+        }
+        NIXL_ERROR << "GPUNETIO transfer ring exhausted";
+        return false;
+    };
 
+    treq->positions.reserve((lcnt + DOCA_XFER_REQ_SIZE - 1) / DOCA_XFER_REQ_SIZE);
+    if (!reserve_position()) {
+        abandon_request();
+        return NIXL_ERR_BACKEND;
+    }
+
+    uint32_t desc_offset = 0;
     do {
-        for (uint32_t idx = 0; idx < lcnt && idx < DOCA_XFER_REQ_SIZE; idx++) {
-            size_t lsize = local[idx].len;
-            size_t rsize = remote[idx].len;
-            if (lsize != rsize) return NIXL_ERR_INVALID_PARAM;
+        docaXferReqGpu staged_req{};
+        staged_req.has_notif_msg_idx = DOCA_NOTIF_NULL;
 
-            lmd = (nixlDocaPrivateMetadata *)local[idx].metadataP;
-            rmd = (nixlDocaPublicMetadata *)remote[idx].metadataP;
+        while (desc_offset < lcnt && staged_req.num < DOCA_XFER_REQ_SIZE) {
+            const uint32_t idx = staged_req.num;
+            const uint32_t desc_idx = desc_offset++;
 
-            xferReqRingCpu[pos].lbuf[idx] = (uintptr_t)lmd->mr->get_addr();
-            xferReqRingCpu[pos].lkey[idx] = (uintptr_t)lmd->mr->get_lkey();
-            xferReqRingCpu[pos].rbuf[idx] = (uintptr_t)rmd->mr->get_addr();
-            xferReqRingCpu[pos].rkey[idx] = (uintptr_t)rmd->mr->get_rkey();
-            xferReqRingCpu[pos].size[idx] = lsize;
-            xferReqRingCpu[pos].num++;
+            lmd = (nixlDocaPrivateMetadata *)local[desc_idx].metadataP;
+            rmd = (nixlDocaPublicMetadata *)remote[desc_idx].metadataP;
+
+            staged_req.lbuf[idx] = local[desc_idx].addr;
+            staged_req.lkey[idx] = lmd->mr->get_lkey();
+            staged_req.rbuf[idx] = remote[desc_idx].addr;
+            staged_req.rkey[idx] = rmd->mr->get_rkey();
+            staged_req.size[idx] = local[desc_idx].len;
+            staged_req.num++;
         }
 
-        xferReqRingCpu[pos].last_rsvd = last_rsvd_flags;
-        xferReqRingCpu[pos].last_posted = last_posted_flags;
+        staged_req.last_rsvd = last_rsvd_flags;
+        staged_req.last_posted = last_posted_flags;
+        staged_req.qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
+        staged_req.qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
+        memcpy(&xferReqRingCpu[pos], &staged_req, sizeof(staged_req));
 
-        xferReqRingCpu[pos].qp_data = rdma_qp->qp_data->get_qp_gpu_dev();
-        xferReqRingCpu[pos].qp_notif = rdma_qp->qp_notif->get_qp_gpu_dev();
-
-        if (lcnt > DOCA_XFER_REQ_SIZE) {
-            lcnt -= DOCA_XFER_REQ_SIZE;
-            pos = (xferRingPos.fetch_add(1) & (DOCA_XFER_REQ_MAX - 1));
-        } else {
-            lcnt = 0;
+        if (desc_offset < lcnt && !reserve_position()) {
+            abandon_request();
+            return NIXL_ERR_BACKEND;
         }
-    } while (lcnt > 0);
+    } while (desc_offset < lcnt);
 
-    treq->end_pos = xferRingPos;
+    const uint32_t final_pos = treq->positions.back();
 
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
@@ -1183,6 +1228,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         auto search = notifMap.find(remote_agent);
         if (search == notifMap.end()) {
             NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+            abandon_request();
             return NIXL_ERR_INVALID_PARAM;
         }
 
@@ -1192,27 +1238,26 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
             msg_tag_end + opt_args->notifMsg;
 
+        auto &final_request = xferReqRingCpu[final_pos];
+        final_request.has_notif_msg_idx = (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
         notif_addr =
-            (uintptr_t)(notif->send_addr +
-                        (xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx * notif->elems_size));
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx =
-            (notif->send_pi.fetch_add(1) & (notif->elems_num - 1));
-        xferReqRingCpu[treq->end_pos - 1].msg_sz = newMsg.size();
-        xferReqRingCpu[treq->end_pos - 1].lbuf_notif = notif_addr;
-        xferReqRingCpu[treq->end_pos - 1].lkey_notif = notif->send_mr->get_lkey();
+            (uintptr_t)(notif->send_addr + (final_request.has_notif_msg_idx * notif->elems_size));
+        final_request.msg_sz = newMsg.size();
+        final_request.lbuf_notif = notif_addr;
+        final_request.lkey_notif = notif->send_mr->get_lkey();
 
         memcpy((void *)notif_addr, newMsg.c_str(), newMsg.size());
 
         NIXL_INFO << "DOCA prepXfer with notif to " << remote_agent << " at "
-                  << xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx << " msg " << newMsg
-                  << " to " << remote_agent;
+                  << final_request.has_notif_msg_idx << " msg " << newMsg << " to " << remote_agent;
 
     } else {
-        xferReqRingCpu[treq->end_pos - 1].has_notif_msg_idx = DOCA_NOTIF_NULL;
+        xferReqRingCpu[final_pos].has_notif_msg_idx = DOCA_NOTIF_NULL;
     }
 
-    NIXL_INFO << "DOCA REQUEST from " << treq->start_pos << " to " << treq->end_pos - 1
-              << " stream " << stream_id << std::endl;
+    NIXL_INFO << "DOCA REQUEST with " << treq->positions.size() << " ring positions, first "
+              << treq->positions.front() << ", last " << final_pos << ", stream " << stream_id
+              << std::endl;
 
     treq->backendHandleGpu = 0;
 
@@ -1230,7 +1275,7 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const nixl_opt_b_args_t *opt_args) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         xferReqRingCpu[idx].id = (lastPostedReq.fetch_add(1) & (DOCA_MAX_COMPLETION_INFLIGHT_MASK));
         completion_list_cpu[xferReqRingCpu[idx].id].xferReqRingGpu = xferReqRingGpu + idx;
         completion_list_cpu[xferReqRingCpu[idx].id].completed = 0;
@@ -1255,16 +1300,17 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
     uint32_t completion_index;
 
-    for (uint32_t idx = treq->start_pos; idx < treq->end_pos; idx++) {
+    for (uint32_t idx : treq->positions) {
         completion_index = xferReqRingCpu[idx].id & (DOCA_MAX_COMPLETION_INFLIGHT_MASK);
 
-        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed == 1) {
-            *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
-            NIXL_INFO << "DOCA checkXfer pos " << idx << " compl_idx " << completion_index
-                      << " COMPLETED!\n";
-            return NIXL_SUCCESS;
-        } else
+        if (((volatile docaXferCompletion *)completion_list_cpu)[completion_index].completed != 1) {
             return NIXL_IN_PROG;
+        }
+    }
+
+    for (uint32_t idx : treq->positions) {
+        *((volatile uint8_t *)&xferReqRingCpu[idx].in_use) = 0;
+        NIXL_INFO << "DOCA checkXfer pos " << idx << " COMPLETED!";
     }
 
     return NIXL_SUCCESS;
@@ -1272,11 +1318,17 @@ nixlDocaEngine::checkXfer(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
-    uint32_t tmp = xferRingPos.load() & (DOCA_XFER_REQ_MAX - 1);
-    if (((volatile docaXferCompletion *)completion_list_cpu)[tmp].completed > 0)
-        return NIXL_SUCCESS;
-    else
-        return NIXL_IN_PROG;
+    nixl_status_t status = checkXfer(handle);
+    if (status == NIXL_IN_PROG) {
+        return status;
+    }
+
+    auto *treq = static_cast<nixlDocaBckndReq *>(handle);
+    for (uint32_t idx : treq->positions) {
+        xferReqReserved[idx].store(false, std::memory_order_release);
+    }
+    delete treq;
+    return status;
 }
 
 nixl_status_t

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -18,6 +18,7 @@
 #include "gpunetio_backend.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <cstring>
 #include <cerrno>
 #include <stdexcept>
 #include <unistd.h>
@@ -767,36 +768,47 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     // Avoid duplicating RDMA connection to the same QP by client/server threads
     NIXL_DEBUG << "connectClientRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
-    connectLock.lock();
+    std::unique_lock<std::mutex> lock(connectLock);
+    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+        if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
+            rdma_qp->remote_lid != remote_lid ||
+            memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
+            NIXL_ERROR << "Remote QP route changed during retry";
+            return NIXL_ERR_BACKEND;
+        }
+    } else {
+        rdma_qp->rqpn_data = remote_qpn_data;
+        rdma_qp->rqpn_notif = remote_qpn_notif;
+        rdma_qp->remote_gid = remote_gid;
+        rdma_qp->remote_lid = remote_lid;
+    }
     if (connMap.find(remote_agent) != connMap.end()) {
         NIXL_INFO << "QP for " << remote_agent << " already connected" << std::endl;
         goto sync;
-        // return NIXL_SUCCESS;
     }
-
-    rdma_qp->rqpn_data = remote_qpn_data;
-    rdma_qp->rqpn_notif = remote_qpn_notif;
-    rdma_qp->remote_gid = remote_gid;
-    rdma_qp->remote_lid = remote_lid;
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result =
-        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->data_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->data_programmed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->notif_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->notif_programmed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -804,7 +816,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     connMap[remote_agent] = 1;
 
 sync:
-    connectLock.unlock();
+    lock.unlock();
     NIXL_DEBUG << "Client recv lack";
     if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
@@ -957,36 +969,47 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     // Avoid duplicating RDMA connection to the same QP by client/server threads
     NIXL_DEBUG << "connectServerRdmaQp: before lock";
     // std::lock_guard<std::mutex> lock(connectLock);
-    connectLock.lock();
+    std::unique_lock<std::mutex> lock(connectLock);
+    if (rdma_qp->data_programmed || rdma_qp->notif_programmed) {
+        if (rdma_qp->rqpn_data != remote_qpn_data || rdma_qp->rqpn_notif != remote_qpn_notif ||
+            rdma_qp->remote_lid != remote_lid ||
+            memcmp(rdma_qp->remote_gid.raw, remote_gid.raw, sizeof(remote_gid.raw)) != 0) {
+            NIXL_ERROR << "Remote QP route changed during retry";
+            return NIXL_ERR_BACKEND;
+        }
+    } else {
+        rdma_qp->rqpn_data = remote_qpn_data;
+        rdma_qp->rqpn_notif = remote_qpn_notif;
+        rdma_qp->remote_gid = remote_gid;
+        rdma_qp->remote_lid = remote_lid;
+    }
     if (connMap.find(remote_agent) != connMap.end()) {
         NIXL_DEBUG << "QP for " << remote_agent << " already connected";
         goto sync;
-        // return NIXL_SUCCESS;
     }
-
-    rdma_qp->rqpn_data = remote_qpn_data;
-    rdma_qp->rqpn_notif = remote_qpn_notif;
-    rdma_qp->remote_gid = remote_gid;
-    rdma_qp->remote_lid = remote_lid;
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result =
-        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->data_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->data_programmed = true;
     }
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(
-        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
-        connectLock.unlock();
-        return NIXL_ERR_BACKEND;
+    if (!rdma_qp->notif_programmed) {
+        result = connect_verbs_qp(
+            this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
+        if (result != DOCA_SUCCESS) {
+            NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
+            return NIXL_ERR_BACKEND;
+        }
+        rdma_qp->notif_programmed = true;
     }
 
     // QP programming is complete even if the final ACK exchange later fails.
@@ -994,8 +1017,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     connMap[remote_agent] = 1;
 
 sync:
-
-    connectLock.unlock();
+    lock.unlock();
 
     NIXL_DEBUG << "Server send rack " << rack;
     if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -382,10 +382,21 @@ nixlDocaEngine::~nixlDocaEngine() {
         nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
     }
 
-    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
-    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
-    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
-    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
+    bool qps_closed = true;
+    for (auto &qp : qpMap) {
+        const bool data_closed = qp.second->qp_data->close();
+        const bool notif_closed = qp.second->qp_notif->close();
+        qps_closed = data_closed && notif_closed && qps_closed;
+    }
+    if (!qps_closed) {
+        NIXL_ERROR << "GPUNETIO QP unexport failed; retaining dependent resources";
+        return;
+    }
+
+    for (auto &qp : qpMap) {
+        delete qp.second;
+    }
+    qpMap.clear();
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -393,17 +404,14 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
     notifMap.clear();
 
+    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
+    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
+    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
+    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_send_gpu);
     doca_gpu_mem_free(gdevs[0].second, completion_list_gpu);
-
-    NIXL_DEBUG << "Before qpMap.clear ";
-
-    for (auto &qp : qpMap) {
-        delete qp.second;
-    }
-    qpMap.clear();
 
     result = doca_gpu_destroy(gdevs[0].second);
     if (result != DOCA_SUCCESS) {

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -375,16 +375,17 @@ nixlDocaEngine::~nixlDocaEngine() {
     NIXL_DEBUG << "Before cudaStreamSynchronize ";
     nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
     nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
-    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
-    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
-    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
-    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
 
     for (int i = 0; i < nstreams; i++) {
         NIXL_DEBUG << "Before cudaStreamSynchronize post_stream " << i;
         nixlDocaEngineCheckCudaError(cudaStreamSynchronize(post_stream[i]), "stream synchronize");
         nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
     }
+
+    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
+    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
+    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
+    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
     for (auto notif : notifMap) {
@@ -404,15 +405,36 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
     qpMap.clear();
 
-    result = doca_dev_close(ddev);
-    if (result != DOCA_SUCCESS) {
-        NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
-    }
-
     result = doca_gpu_destroy(gdevs[0].second);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
     }
+    gdevs[0].second = nullptr;
+
+    result = doca_verbs_ah_attr_destroy(verbs_ah_attr);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs AH " << doca_error_get_descr(result);
+    }
+    verbs_ah_attr = nullptr;
+
+    result = doca_dev_close(ddev);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
+    }
+    ddev = nullptr;
+
+    result = doca_verbs_pd_destroy(verbs_pd);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs PD " << doca_error_get_descr(result);
+    }
+    verbs_pd = nullptr;
+    pd = nullptr;
+
+    result = doca_verbs_context_destroy(verbs_context);
+    if (result != DOCA_SUCCESS) {
+        NIXL_ERROR << "Failed to destroy DOCA verbs context " << doca_error_get_descr(result);
+    }
+    verbs_context = nullptr;
 }
 
 /****************************************
@@ -474,8 +496,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->recv_pi = 0;
 
     // Ensure notif list is not added twice for the same peer
-    auto *notif_ptr = notif.get();
-    notifMap[remote_agent] = notif.release();
+    const auto [notif_it, inserted] = notifMap.emplace(remote_agent, notif.get());
+    if (!inserted) {
+        return NIXL_SUCCESS;
+    }
+    notif.release();
+    auto *notif_ptr = notif_it->second;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif_ptr->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif_ptr->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif_ptr->elems_size;
@@ -656,7 +682,11 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 
     rdma_qp->qpn_notif = doca_verbs_qp_get_qpn(rdma_qp->qp_notif->get_qp());
 
-    qpMap[remote_agent] = rdma_qp.release();
+    const auto [qp_it, inserted] = qpMap.emplace(remote_agent, rdma_qp.get());
+    if (!inserted) {
+        return NIXL_IN_PROG;
+    }
+    rdma_qp.release();
 
     NIXL_DEBUG << "DOCA addRdmaQp new QP added for " << remote_agent;
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -26,6 +26,27 @@
 
 const char info_delimiter = '-';
 
+namespace {
+int
+parse_gid_index(const std::string &value) {
+    if (value.empty())
+        return 0;
+
+    size_t parsed_chars = 0;
+    int parsed_value = 0;
+    try {
+        parsed_value = std::stoi(value, &parsed_chars);
+    } catch (const std::exception &) {
+        throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+    }
+
+    if (parsed_chars != value.size() || parsed_value < 0 || parsed_value > 255)
+        throw std::invalid_argument("gid_index must be an integer in the range [0, 255]");
+
+    return parsed_value;
+}
+} // namespace
+
 /****************************************
  * Constructor/Destructor
  *****************************************/
@@ -98,6 +119,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
+    gid_index = parse_gid_index((*custom_params)["gid_index"]);
+    NIXL_INFO << "RoCE GID index: " << gid_index;
+
     /* Open DOCA device */
     verbs_context = open_ib_device((char *)(ndevs[0].c_str()));
     if (verbs_context == nullptr) {
@@ -124,8 +148,6 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (ret) {
         throw std::invalid_argument("Failed to query ibv port attributes");
     }
-
-    gid_index = 0;
 
     ret = ibv_query_gid(pd->context, 1, gid_index, &rgid);
     if (ret) {
@@ -169,7 +191,10 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
-        netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask);
+        if (netif_get_addr(oobdev[0].c_str(), AF_INET, &oob_saddr, &oob_netmask) != 0) {
+            throw std::invalid_argument("Failed to get IPv4 address for GPUNETIO OOB interface '" +
+                                        oobdev[0] + "'");
+        }
         struct sockaddr_in *addr_in = (struct sockaddr_in *)&oob_saddr;
         memcpy(ipv4_addr, (uint8_t *)&(addr_in->sin_addr.s_addr), 4);
         NIXL_DEBUG << "Eth IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
@@ -177,8 +202,13 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
                    << static_cast<unsigned>(ipv4_addr[2]) << " "
                    << static_cast<unsigned>(ipv4_addr[3]) << " " << "ifface " << oobdev[0].c_str();
     } else {
-        doca_devinfo_get_ipv4_addr(
+        result = doca_devinfo_get_ipv4_addr(
             doca_dev_as_devinfo(ddev), (uint8_t *)ipv4_addr, DOCA_DEVINFO_IPV4_ADDR_SIZE);
+        if (result != DOCA_SUCCESS) {
+            throw std::invalid_argument(
+                "Failed to determine the GPUNETIO IPv4 address; set oob_interface explicitly "
+                "when using a bonded network device");
+        }
         NIXL_DEBUG << "DOCA IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
                    << static_cast<unsigned>(ipv4_addr[1]) << " "
                    << static_cast<unsigned>(ipv4_addr[2]) << " "

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -28,7 +28,7 @@ const char info_delimiter = '-';
 
 namespace {
 int
-parse_gid_index(const std::string &value) {
+parseGidIndex(const std::string &value) {
     if (value.empty()) {
         return 0;
     }
@@ -122,7 +122,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
-    gid_index = parse_gid_index((*custom_params)["gid_index"]);
+    gid_index = parseGidIndex((*custom_params)["gid_index"]);
     NIXL_INFO << "RoCE GID index: " << gid_index;
 
     /* Open DOCA device */

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -264,8 +264,7 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         if (result != DOCA_SUCCESS) {
             rollbackOobDiscoveryFailure(gdevs, verbs_ah_attr, ddev, verbs_pd, verbs_context);
             throw std::invalid_argument(
-                "Failed to determine the GPUNETIO IPv4 address; set oob_interface explicitly "
-                "when using a bonded network device");
+                "Failed to determine the GPUNETIO IPv4 address; set oob_interface explicitly");
         }
         NIXL_DEBUG << "DOCA IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
                    << static_cast<unsigned>(ipv4_addr[1]) << " "

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -18,12 +18,49 @@
 #include "gpunetio_backend.h"
 #include <arpa/inet.h>
 #include <cassert>
+#include <cerrno>
 #include <stdexcept>
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <absl/strings/str_split.h>
 
 const char info_delimiter = '-';
+
+namespace {
+bool
+sendAll(int fd, const void *buffer, size_t size) {
+    const auto *cursor = static_cast<const uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t sent = send(fd, cursor, size, MSG_NOSIGNAL);
+        if (sent < 0 && errno == EINTR) {
+            continue;
+        }
+        if (sent <= 0) {
+            return false;
+        }
+        cursor += sent;
+        size -= static_cast<size_t>(sent);
+    }
+    return true;
+}
+
+bool
+recvAll(int fd, void *buffer, size_t size) {
+    auto *cursor = static_cast<uint8_t *>(buffer);
+    while (size > 0) {
+        const ssize_t received = recv(fd, cursor, size, 0);
+        if (received < 0 && errno == EINTR) {
+            continue;
+        }
+        if (received <= 0) {
+            return false;
+        }
+        cursor += received;
+        size -= static_cast<size_t>(received);
+    }
+    return true;
+}
+} // namespace
 
 /****************************************
  * Constructor/Destructor
@@ -341,7 +378,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     lastPostedReq = 0;
     xferRingPos = 0;
 
-    progressThreadStart();
+    if (progressThreadStart() != NIXL_SUCCESS) {
+        throw std::runtime_error("Failed to start GPUNETIO connection thread");
+    }
 }
 
 nixl_mem_list_t
@@ -446,14 +485,22 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     notif->send_pi = 0;
     notif->recv_pi = 0;
 
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
+    {
+        std::lock_guard<std::mutex> qp_lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+    }
     // Ensure notif list is not added twice for the same peer
     notifMap[remote_agent] = notif;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu =
-        qpMap[remote_agent]->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
         ;
 
@@ -485,19 +532,17 @@ nixlDocaEngine::progressThreadStart() {
     oob_sock_server = socket(AF_INET, SOCK_STREAM, 0);
     if (oob_sock_server < 0) {
         NIXL_ERROR << "Error while creating socket " << oob_sock_server;
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
     NIXL_INFO << "DOCA Server socket created successfully";
 
-    if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable))) {
-        NIXL_ERROR << "Error setting socket options";
-        close(oob_sock_server);
-        return NIXL_ERR_NOT_SUPPORTED;
-    }
-
     if (setsockopt(oob_sock_server, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable))) {
         NIXL_ERROR << "Error setting socket options";
         close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
 
@@ -508,6 +553,8 @@ nixlDocaEngine::progressThreadStart() {
         if (bind(oob_sock_server, (struct sockaddr *)addr_in, sizeof(struct sockaddr_in)) < 0) {
             NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
+            free((void *)pthrStop);
+            pthrStop = nullptr;
             return NIXL_ERR_NOT_SUPPORTED;
         }
     } else {
@@ -520,6 +567,8 @@ nixlDocaEngine::progressThreadStart() {
         if (bind(oob_sock_server, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
             NIXL_ERROR << "Couldn't bind to the port " << local_port;
             close(oob_sock_server);
+            free((void *)pthrStop);
+            pthrStop = nullptr;
             return NIXL_ERR_NOT_SUPPORTED;
         }
     }
@@ -527,9 +576,11 @@ nixlDocaEngine::progressThreadStart() {
     NIXL_INFO << "Done with binding";
 
     /* Listen for clients: */
-    if (listen(oob_sock_server, 1) < 0) {
+    if (listen(oob_sock_server, SOMAXCONN) < 0) {
         NIXL_ERROR << "Error while listening";
         close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_NOT_SUPPORTED;
     }
     NIXL_INFO << "Listening for incoming connections";
@@ -543,26 +594,41 @@ nixlDocaEngine::progressThreadStart() {
     result = pthread_create(&server_thread_id, nullptr, threadProgressFunc, (void *)this);
     if (result != 0) {
         NIXL_ERROR << "Failed to create threadProgressFunc thread";
+        close(oob_sock_server);
+        free((void *)pthrStop);
+        pthrStop = nullptr;
         return NIXL_ERR_BACKEND;
     }
+    serverThreadStarted = true;
 
     return NIXL_SUCCESS;
 }
 
 void
 nixlDocaEngine::progressThreadStop() {
-    int fake_sock_fd;
+    if (!serverThreadStarted) {
+        return;
+    }
+
+    int fake_sock_fd = -1;
     std::stringstream ss;
 
     ACCESS_ONCE(*pthrStop) = 1;
     ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
        << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port);
+    if (oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port) < 0) {
+        shutdown(oob_sock_server, SHUT_RDWR);
+    }
     // pthr.join();
     pthread_join(server_thread_id, nullptr);
+    serverThreadStarted = false;
     close(oob_sock_server);
-    close(fake_sock_fd);
+    if (fake_sock_fd >= 0) {
+        close(fake_sock_fd);
+    }
+    free((void *)pthrStop);
+    pthrStop = nullptr;
 }
 
 uint32_t
@@ -632,31 +698,40 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
 nixl_status_t
 nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent];
+    struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "connectClientRdmaQp: Send to server data qp connection details";
     // Data QP
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     // Notif QP
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send LID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -664,7 +739,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -672,19 +747,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -729,7 +804,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 sync:
     connectLock.unlock();
     NIXL_DEBUG << "Client recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -743,7 +818,7 @@ sync:
     }
 
     NIXL_DEBUG << "Client sending rack" << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -759,23 +834,20 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
     size_t msg_size;
 
     // Msg
-    if (recv(oob_sock_client, &msg_size, sizeof(size_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &msg_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
     if (msg_size == 0) {
         NIXL_ERROR << "recvRemoteAgentName received msg size 0";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
     remote_agent.resize(msg_size);
 
-    if (recv(oob_sock_client, remote_agent.data(), msg_size, 0) < 0) {
+    if (!recvAll(oob_sock_client, remote_agent.data(), msg_size)) {
         NIXL_ERROR << "Failed to recv msg details";
-        close(oob_sock_client);
         return NIXL_ERR_BACKEND;
     }
 
@@ -786,12 +858,12 @@ nixl_status_t
 nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
     size_t agent_size = localAgent.size();
 
-    if (send(oob_sock_client, &agent_size, sizeof(size_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &agent_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, localAgent.c_str(), localAgent.size(), 0) < 0) {
+    if (!sendAll(oob_sock_client, localAgent.c_str(), localAgent.size())) {
         NIXL_ERROR << "Failed to send connection details";
         return NIXL_ERR_BACKEND;
     }
@@ -804,14 +876,23 @@ nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
 nixl_status_t
 nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remote_agent) {
     doca_error_t result;
-    struct nixlDocaRdmaQp *rdma_qp = qpMap[remote_agent]; // validate
+    struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto qp = qpMap.find(remote_agent);
+        if (qp == qpMap.end()) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = qp->second;
+    }
 
     NIXL_DEBUG << "DOCA connectServerRdmaQp for agent " << remote_agent.c_str();
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -819,19 +900,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (recv(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (recv(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -839,7 +920,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -847,20 +928,20 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Send remote notif qp connection details";
-    if (send(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rdma_qp->qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (send(oob_sock_client, &gid.raw, sizeof(gid.raw), 0) < 0) {
+    if (!sendAll(oob_sock_client, &gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to send local GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server Send remote notif qp connection details 4";
-    if (send(oob_sock_client, &lid, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send local GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -909,14 +990,14 @@ sync:
     connectLock.unlock();
 
     NIXL_DEBUG << "Server send rack " << rack;
-    if (send(oob_sock_client, &rack, sizeof(uint32_t), 0) < 0) {
+    if (!sendAll(oob_sock_client, &rack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to send connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_DEBUG << "Server recv lack";
-    if (recv(oob_sock_client, &lack, sizeof(uint32_t), 0) < 0) {
+    if (!recvAll(oob_sock_client, &lack, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote ACK connection";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -964,12 +1045,6 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
 
     int oob_sock_client;
 
-    // TODO: Connect part should be moved into connect() method
-    nixlDocaConnection conn;
-    if (remoteConnMap.find(remote_agent) != remoteConnMap.end()) {
-        return NIXL_ERR_INVALID_PARAM;
-    }
-
     GpunetioOobEndpoint endpoint;
     try {
         endpoint = parseGpunetioOobEndpoint(remote_conn_info);
@@ -979,24 +1054,56 @@ nixlDocaEngine::loadRemoteConnInfo(const std::string &remote_agent,
         return NIXL_ERR_INVALID_PARAM;
     }
 
+    // TODO: Connect part should be moved into connect() method
+    nixlDocaConnection conn;
+    conn.remoteAgent = remote_agent;
+    conn.connected = false;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        if (!remoteConnMap.emplace(remote_agent, conn).second) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+    }
+    auto clear_pending = [&]() {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        auto pending = remoteConnMap.find(remote_agent);
+        if (pending != remoteConnMap.end() && !pending->second.connected) {
+            remoteConnMap.erase(pending);
+        }
+    };
+
     int ret = oob_connection_client_setup(endpoint.ipv4.c_str(), &oob_sock_client, endpoint.port);
     if (ret < 0) {
         NIXL_ERROR << "Can't connect to server " << ret;
+        clear_pending();
         return NIXL_ERR_BACKEND;
     }
 
     NIXL_INFO << "loadRemoteConnInfo calling addRdmaQp for " << remote_agent.c_str();
-    sendLocalAgentName(oob_sock_client);
-    addRdmaQp(remote_agent);
-    nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
-    connectClientRdmaQp(oob_sock_client, remote_agent);
+    nixl_status_t status = sendLocalAgentName(oob_sock_client);
+    if (status == NIXL_SUCCESS) {
+        status = addRdmaQp(remote_agent);
+    }
+    if (status == NIXL_IN_PROG) {
+        status = NIXL_SUCCESS;
+    }
+    if (status == NIXL_SUCCESS) {
+        status = nixlDocaInitNotif(remote_agent, ddev, gdevs[0].second);
+    }
+    if (status == NIXL_SUCCESS) {
+        status = connectClientRdmaQp(oob_sock_client, remote_agent);
+    }
+    if (status != NIXL_SUCCESS) {
+        close(oob_sock_client);
+        clear_pending();
+        return status;
+    }
 
-    conn.remoteAgent = remote_agent;
     conn.connected = true;
-    // if client or server already created this QP, no need to re-create
-    if (remoteConnMap.find(remote_agent) == remoteConnMap.end()) {
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
         remoteConnMap[remote_agent] = conn;
-        NIXL_INFO << "remoteConnMap extended with remote agent " << remote_agent << std::endl;
+        NIXL_INFO << "remoteConnMap connected remote agent " << remote_agent << std::endl;
     }
 
     NIXL_INFO << "DOCA loadRemoteConnInfo connected agent " << remote_agent;
@@ -1070,14 +1177,16 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     std::vector<std::string> tokens;
     std::string token;
     nixlDocaPublicMetadata *md = new nixlDocaPublicMetadata;
-    auto search = remoteConnMap.find(remote_agent);
-
-    if (search == remoteConnMap.end()) {
-        NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
-        return NIXL_ERR_NOT_FOUND;
+    {
+        std::lock_guard<std::mutex> lock(remoteConnLock);
+        auto search = remoteConnMap.find(remote_agent);
+        if (search == remoteConnMap.end() || !search->second.connected) {
+            NIXL_ERROR << "err: remote connection not found remote_agent " << remote_agent;
+            delete md;
+            return NIXL_ERR_NOT_FOUND;
+        }
+        conn = search->second;
     }
-
-    conn = (nixlDocaConnection)search->second;
 
     // directly copy underlying conn struct
     md->conn = conn;
@@ -1136,13 +1245,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
         if (lmd->devId != gdevs[0].first) return NIXL_ERR_INVALID_PARAM;
     }
 
-    auto search = qpMap.find(remote_agent);
-    if (search == qpMap.end()) {
-        NIXL_ERROR << "Can't find remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto search = qpMap.find(remote_agent);
+        if (search == qpMap.end()) {
+            NIXL_ERROR << "Can't find remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        rdma_qp = search->second;
     }
-
-    rdma_qp = search->second;
 
     if (lcnt != rcnt) return NIXL_ERR_INVALID_PARAM;
 
@@ -1194,13 +1305,15 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
     if (opt_args && opt_args->hasNotif) {
         struct nixlDocaNotif *notif;
 
-        auto search = notifMap.find(remote_agent);
-        if (search == notifMap.end()) {
-            NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
-            return NIXL_ERR_INVALID_PARAM;
+        {
+            std::lock_guard<std::mutex> lock(notifLock);
+            auto search = notifMap.find(remote_agent);
+            if (search == notifMap.end()) {
+                NIXL_ERROR << "Can't find notif for remote_agent " << remote_agent;
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            notif = search->second;
         }
-
-        notif = search->second;
 
         // Check notifMsg size
         std::string newMsg = msg_tag_start + std::to_string(opt_args->notifMsg.size()) +
@@ -1305,8 +1418,16 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
     // while getNotifs is running
     std::lock_guard<std::mutex> lock(notifLock);
     for (auto &notif : notifMap) {
-        ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu =
-            qpMap[notif.first]->qp_notif->get_qp_gpu_dev();
+        doca_gpu_dev_verbs_qp *notif_qp_gpu;
+        {
+            std::lock_guard<std::mutex> qp_lock(qpLock);
+            auto qp = qpMap.find(notif.first);
+            if (qp == qpMap.end()) {
+                return NIXL_ERR_BACKEND;
+            }
+            notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
+        }
+        ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu = notif_qp_gpu;
         std::atomic_thread_fence(std::memory_order_seq_cst);
         while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr)
             ;
@@ -1360,10 +1481,15 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     uint32_t buf_idx;
     uintptr_t msg_buf;
 
-    auto searchNotif = notifMap.find(remote_agent);
-    if (searchNotif == notifMap.end()) {
-        NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent << std::endl;
-        return NIXL_ERR_INVALID_PARAM;
+    {
+        std::lock_guard<std::mutex> lock(notifLock);
+        auto searchNotif = notifMap.find(remote_agent);
+        if (searchNotif == notifMap.end()) {
+            NIXL_ERROR << "genNotif: can't find notif for remote_agent " << remote_agent
+                       << std::endl;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif = searchNotif->second;
     }
 
     // 16B is uint16_t msg size
@@ -1374,12 +1500,15 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
         return NIXL_ERR_INVALID_PARAM;
     }
 
-    notif = searchNotif->second;
-
-    auto searchQp = qpMap.find(remote_agent);
-    if (searchQp == qpMap.end()) {
-        NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
-        return NIXL_ERR_INVALID_PARAM;
+    doca_gpu_dev_verbs_qp *notif_qp_gpu;
+    {
+        std::lock_guard<std::mutex> lock(qpLock);
+        auto searchQp = qpMap.find(remote_agent);
+        if (searchQp == qpMap.end()) {
+            NIXL_ERROR << "Can't find QP for remote_agent " << remote_agent;
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        notif_qp_gpu = searchQp->second->qp_notif->get_qp_gpu_dev();
     }
 
     std::string newMsg = msg_tag_start + std::to_string((int)msg.size()) + msg_tag_end + msg;
@@ -1395,8 +1524,7 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     ((volatile struct docaNotif *)notif_send_cpu)->msg_lkey = notif->send_mr->get_lkey();
     ((volatile struct docaNotif *)notif_send_cpu)->msg_size = newMsg.size();
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu =
-        searchQp->second->qp_notif->get_qp_gpu_dev();
+    ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr)
         ;
 

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -437,8 +437,6 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
-    struct nixlDocaNotif *notif;
-
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -446,7 +444,7 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         return NIXL_SUCCESS;
     }
 
-    notif = new struct nixlDocaNotif;
+    auto notif = std::make_unique<nixlDocaNotif>();
 
     notif->elems_num = DOCA_MAX_NOTIF_INFLIGHT;
     notif->elems_size = DOCA_MAX_NOTIF_MESSAGE_SIZE;
@@ -495,7 +493,6 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
         notif_qp_gpu = qp->second->qp_notif->get_qp_gpu_dev();
     }
     // Ensure notif list is not added twice for the same peer
-    notifMap[remote_agent] = notif;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_buf = (uintptr_t)notif->recv_addr;
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_lkey = notif->recv_mr->get_lkey();
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
@@ -503,6 +500,12 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
     while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
         ;
+
+    const bool inserted = notifMap.emplace(remote_agent, notif.get()).second;
+    if (!inserted) {
+        return NIXL_ERR_BACKEND;
+    }
+    notif.release();
 
     NIXL_INFO << "nixlDocaInitNotif added new qp for " << remote_agent << std::endl;
 
@@ -610,23 +613,17 @@ nixlDocaEngine::progressThreadStop() {
         return;
     }
 
-    int fake_sock_fd = -1;
-    std::stringstream ss;
-
     ACCESS_ONCE(*pthrStop) = 1;
-    ss << (int)ipv4_addr[0] << "." << (int)ipv4_addr[1] << "." << (int)ipv4_addr[2] << "."
-       << (int)ipv4_addr[3];
     std::atomic_thread_fence(std::memory_order_seq_cst);
-    if (oob_connection_client_setup(ss.str().c_str(), &fake_sock_fd, local_port) < 0) {
-        shutdown(oob_sock_server, SHUT_RDWR);
+
+    const int active_socket = activeOobSocket.exchange(-1);
+    if (active_socket >= 0) {
+        shutdown(active_socket, SHUT_RDWR);
     }
-    // pthr.join();
+    shutdown(oob_sock_server, SHUT_RDWR);
     pthread_join(server_thread_id, nullptr);
     serverThreadStarted = false;
     close(oob_sock_server);
-    if (fake_sock_fd >= 0) {
-        close(fake_sock_fd);
-    }
     free((void *)pthrStop);
     pthrStop = nullptr;
 }
@@ -700,6 +697,8 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
     doca_error_t result;
     struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+    uint32_t remote_qpn_data = 0, remote_qpn_notif = 0, remote_lid = 0;
+    doca_verbs_gid remote_gid{};
 
     {
         std::lock_guard<std::mutex> lock(qpLock);
@@ -739,7 +738,7 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "connectClientRdmaQp: Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -747,19 +746,19 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_INFO << "Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -775,13 +774,15 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -790,16 +791,17 @@ nixlDocaEngine::connectClientRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
         return NIXL_ERR_BACKEND;
     }
+
+    // QP programming is complete even if the final ACK exchange later fails.
+    // A retry must skip another QP state transition and repeat only the handshake.
+    connMap[remote_agent] = 1;
 
 sync:
     connectLock.unlock();
@@ -824,8 +826,6 @@ sync:
         return NIXL_ERR_BACKEND;
     }
 
-    connMap[remote_agent] = 1;
-
     return NIXL_SUCCESS;
 }
 
@@ -839,8 +839,8 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
         return NIXL_ERR_BACKEND;
     }
 
-    if (msg_size == 0) {
-        NIXL_ERROR << "recvRemoteAgentName received msg size 0";
+    if (!isValidGpunetioAgentNameSize(msg_size)) {
+        NIXL_ERROR << "recvRemoteAgentName received invalid msg size " << msg_size;
         return NIXL_ERR_BACKEND;
     }
 
@@ -857,6 +857,11 @@ nixlDocaEngine::recvRemoteAgentName(int oob_sock_client, std::string &remote_age
 nixl_status_t
 nixlDocaEngine::sendLocalAgentName(int oob_sock_client) {
     size_t agent_size = localAgent.size();
+
+    if (!isValidGpunetioAgentNameSize(agent_size)) {
+        NIXL_ERROR << "sendLocalAgentName has invalid msg size " << agent_size;
+        return NIXL_ERR_INVALID_PARAM;
+    }
 
     if (!sendAll(oob_sock_client, &agent_size, sizeof(size_t))) {
         NIXL_ERROR << "Failed to send connection details";
@@ -878,6 +883,8 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
     doca_error_t result;
     struct nixlDocaRdmaQp *rdma_qp;
     uint32_t lack = 0, rack = 1;
+    uint32_t remote_qpn_data = 0, remote_qpn_notif = 0, remote_lid = 0;
+    doca_verbs_gid remote_gid{};
 
     {
         std::lock_guard<std::mutex> lock(qpLock);
@@ -892,7 +899,7 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Data QP
     NIXL_DEBUG << "Server Receive client remote data qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_data, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_data, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -900,19 +907,19 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     // Notif QP
     NIXL_DEBUG << "Server Receive remote notif qp connection details";
-    if (!recvAll(oob_sock_client, &rdma_qp->rqpn_notif, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_qpn_notif, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote connection details";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_gid.raw, sizeof(gid.raw))) {
+    if (!recvAll(oob_sock_client, &remote_gid.raw, sizeof(gid.raw))) {
         NIXL_ERROR << "Failed to receive remote GID raw address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
     }
 
-    if (!recvAll(oob_sock_client, &rdma_qp->remote_lid, sizeof(uint32_t))) {
+    if (!recvAll(oob_sock_client, &remote_lid, sizeof(uint32_t))) {
         NIXL_ERROR << "Failed to receive remote GID address";
         result = DOCA_ERROR_CONNECTION_ABORTED;
         return NIXL_ERR_BACKEND;
@@ -957,13 +964,15 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
         // return NIXL_SUCCESS;
     }
 
+    rdma_qp->rqpn_data = remote_qpn_data;
+    rdma_qp->rqpn_notif = remote_qpn_notif;
+    rdma_qp->remote_gid = remote_gid;
+    rdma_qp->remote_lid = remote_lid;
+
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- data";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_data->get_qp(),
-                              rdma_qp->rqpn_data,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result =
+        connect_verbs_qp(this, rdma_qp->qp_data->get_qp(), remote_qpn_data, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp data failed " << doca_error_get_descr(result);
         connectLock.unlock();
@@ -972,17 +981,16 @@ nixlDocaEngine::connectServerRdmaQp(int oob_sock_client, const std::string &remo
 
     /* Connect local rdma to the remote rdma */
     NIXL_DEBUG << "Connect DOCA RDMA to remote RDMA -- notif";
-    result = connect_verbs_qp(this,
-                              rdma_qp->qp_notif->get_qp(),
-                              rdma_qp->rqpn_notif,
-                              rdma_qp->remote_gid,
-                              rdma_qp->remote_lid);
+    result = connect_verbs_qp(
+        this, rdma_qp->qp_notif->get_qp(), remote_qpn_notif, remote_gid, remote_lid);
     if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Function connect_verbs_qp notif failed " << doca_error_get_descr(result);
         connectLock.unlock();
         return NIXL_ERR_BACKEND;
     }
 
+    // QP programming is complete even if the final ACK exchange later fails.
+    // A retry must skip another QP state transition and repeat only the handshake.
     connMap[remote_agent] = 1;
 
 sync:
@@ -1229,7 +1237,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
     uint32_t pos;
-    nixlDocaBckndReq *treq = new nixlDocaBckndReq;
+    auto treq = std::make_unique<nixlDocaBckndReq>();
     nixlDocaPrivateMetadata *lmd;
     nixlDocaPublicMetadata *rmd;
     uint32_t lcnt = (uint32_t)local.descCount();
@@ -1343,7 +1351,7 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
 
     treq->backendHandleGpu = 0;
 
-    handle = treq;
+    handle = treq.release();
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -28,6 +28,34 @@
 const char info_delimiter = '-';
 
 namespace {
+class cudaDeviceGuard {
+public:
+    explicit cudaDeviceGuard(uint32_t device) : device_(static_cast<int>(device)) {
+        status_ = cudaGetDevice(&previous_device_);
+        if (status_ == cudaSuccess) {
+            status_ = cudaSetDevice(device_);
+            restore_ = status_ == cudaSuccess && previous_device_ != device_;
+        }
+    }
+
+    ~cudaDeviceGuard() {
+        if (restore_) {
+            cudaSetDevice(previous_device_);
+        }
+    }
+
+    cudaError_t
+    status() const {
+        return status_;
+    }
+
+private:
+    int device_;
+    int previous_device_ = 0;
+    bool restore_ = false;
+    cudaError_t status_ = cudaSuccess;
+};
+
 int
 parseGidIndex(const std::string &value) {
     if (value.empty()) {
@@ -154,18 +182,25 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     result = doca_log_backend_create_standard();
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_create_with_file_sdk(stderr, &sdk_log);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     result = doca_log_backend_set_sdk_level(sdk_log, DOCA_LOG_LEVEL_ERROR);
-    if (result != DOCA_SUCCESS) throw std::invalid_argument("Can't initialize doca log");
+    if (result != DOCA_SUCCESS) {
+        throw std::invalid_argument("Can't initialize doca log");
+    }
 
     NIXL_INFO << "DOCA network devices ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("network_devices") > 1)
+    if (custom_params->count("network_devices") > 1) {
         throw std::invalid_argument("Only 1 network device is allowed");
+    }
 
     if (custom_params->count("network_devices") == 0 || (*custom_params)["network_devices"] == "" ||
         (*custom_params)["network_devices"] == "all") {
@@ -180,8 +215,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (custom_params->count("oob_interface") > 0) {
         NIXL_INFO << "DOCA network devices ";
         // Temporary: will extend to more GPUs in a dedicated PR
-        if (custom_params->count("oob_interface") > 1)
+        if (custom_params->count("oob_interface") > 1) {
             throw std::invalid_argument("Only 1 oob interface is allowed");
+        }
 
         oobdev = absl::StrSplit((*custom_params)["oob_interface"], " ");
         NIXL_INFO << "Using oob interface" << oobdev[0];
@@ -196,8 +232,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     NIXL_INFO << "DOCA GPU devices: ";
     // Temporary: will extend to more GPUs in a dedicated PR
-    if (custom_params->count("gpu_devices") > 1)
+    if (custom_params->count("gpu_devices") > 1) {
         throw std::invalid_argument("Only 1 GPU device is allowed");
+    }
 
     if (custom_params->count("gpu_devices") == 0 || (*custom_params)["gpu_devices"] == "" ||
         (*custom_params)["gpu_devices"] == "all") {
@@ -213,9 +250,12 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     NIXL_INFO << std::endl;
 
     nstreams = 0;
-    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "")
+    if (custom_params->count("cuda_streams") != 0 && (*custom_params)["cuda_streams"] != "") {
         nstreams = std::stoi((*custom_params)["cuda_streams"]);
-    if (nstreams == 0) nstreams = DOCA_POST_STREAM_NUM;
+    }
+    if (nstreams == 0) {
+        nstreams = DOCA_POST_STREAM_NUM;
+    }
 
     NIXL_INFO << "CUDA streams used for pool mode: " << nstreams;
 
@@ -238,7 +278,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     }
 
     pd = doca_verbs_bridge_verbs_pd_get_ibv_pd(verbs_pd);
-    if (pd == NULL) throw std::invalid_argument("Failed to get ibv_pd");
+    if (pd == NULL) {
+        throw std::invalid_argument("Failed to get ibv_pd");
+    }
 
     result = doca_rdma_bridge_open_dev_from_pd(pd, &ddev);
     if (result != DOCA_SUCCESS) {
@@ -261,8 +303,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     if (port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
         result = create_verbs_ah_attr(
             verbs_context, gid_index, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH, &verbs_ah_attr);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             throw std::invalid_argument("Failed to create doca verbs ah attributes");
+        }
 
         lid = port_attr.lid;
     } else {
@@ -288,8 +331,9 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         cudaFree(0);
 
         result = doca_gpu_create(pciBusId, &item.second);
-        if (result != DOCA_SUCCESS)
+        if (result != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to create DOCA GPU device " << doca_error_get_descr(result);
+        }
     }
 
     if (oobdev.size() > 0 && oobdev[0] != "") {
@@ -298,7 +342,8 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
         NIXL_DEBUG << "Eth IP address " << static_cast<unsigned>(ipv4_addr[0]) << " "
                    << static_cast<unsigned>(ipv4_addr[1]) << " "
                    << static_cast<unsigned>(ipv4_addr[2]) << " "
-                   << static_cast<unsigned>(ipv4_addr[3]) << " " << "ifface " << oobdev[0].c_str();
+                   << static_cast<unsigned>(ipv4_addr[3]) << " "
+                   << "ifface " << oobdev[0].c_str();
     } else {
         result = doca_devinfo_get_ipv4_addr(
             doca_dev_as_devinfo(ddev), (uint8_t *)ipv4_addr, DOCA_DEVINFO_IPV4_ADDR_SIZE);
@@ -369,10 +414,11 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
     nixlDocaEngineCheckCudaError(cudaStreamCreateWithFlags(&wait_stream, cudaStreamNonBlocking),
                                  "Failed to create CUDA stream");
-    for (int i = 0; i < nstreams; i++)
+    for (int i = 0; i < nstreams; i++) {
         nixlDocaEngineCheckCudaError(
             cudaStreamCreateWithFlags(&post_stream[i], cudaStreamNonBlocking),
             "Failed to create CUDA stream");
+    }
     xferStream = 0;
 
     result = doca_gpu_mem_alloc(gdevs[0].second,
@@ -500,8 +546,9 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
 
     NIXL_DEBUG << "Before nixlDocaDestroyNotif ";
-    for (auto notif : notifMap)
+    for (auto notif : notifMap) {
         nixlDocaDestroyNotif(gdevs[0].second, notif.second);
+    }
 
     doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
     doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
@@ -513,12 +560,14 @@ nixlDocaEngine::~nixlDocaEngine() {
     qpMap.clear();
 
     result = doca_dev_close(ddev);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA device " << doca_error_get_descr(result);
+    }
 
     result = doca_gpu_destroy(gdevs[0].second);
-    if (result != DOCA_SUCCESS)
+    if (result != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to close DOCA GPU device " << doca_error_get_descr(result);
+    }
 }
 
 /****************************************
@@ -588,8 +637,9 @@ nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev
     ((volatile struct docaNotif *)notif_fill_cpu)->msg_size = notif->elems_size;
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu = notif_qp_gpu;
-    while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr)
+    while (((volatile struct docaNotif *)notif_fill_cpu)->qp_gpu != nullptr) {
         ;
+    }
 
     const bool inserted = notifMap.emplace(remote_agent, notif.get()).second;
     if (!inserted) {
@@ -737,6 +787,13 @@ nixlDocaEngine::addRdmaQp(const std::string &remote_agent) {
     }
 
     NIXL_DEBUG << "DOCA addRdmaQp for remote " << remote_agent << std::endl;
+
+    cudaDeviceGuard cuda_device(gdevs[0].first);
+    if (cuda_device.status() != cudaSuccess) {
+        NIXL_ERROR << "Failed to select CUDA device " << gdevs[0].first
+                   << " for QP setup: " << cudaGetErrorString(cuda_device.status());
+        return NIXL_ERR_BACKEND;
+    }
 
     rdma_qp = new struct nixlDocaRdmaQp;
 
@@ -1311,8 +1368,9 @@ nixlDocaEngine::loadRemoteMD(const nixlBlobDesc &input,
     md->conn = conn;
 
     std::stringstream ss(input.metaInfo.data());
-    while (std::getline(ss, token, info_delimiter))
+    while (std::getline(ss, token, info_delimiter)) {
         tokens.push_back(token);
+    }
 
     uint32_t rkey = static_cast<uint32_t>(atoi(tokens[0].c_str()));
     uintptr_t addr = static_cast<uintptr_t>(atol(tokens[1].c_str()));
@@ -1658,8 +1716,9 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
         }
         ((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu = notif_qp_gpu;
         std::atomic_thread_fence(std::memory_order_seq_cst);
-        while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr)
+        while (((volatile struct docaNotif *)notif_progress_cpu)->qp_gpu != nullptr) {
             ;
+        }
         num_msg = ((volatile struct docaNotif *)notif_progress_cpu)->msg_num;
         while (num_msg > 0) {
             recv_idx = notif.second->recv_pi.load() & (DOCA_MAX_NOTIF_INFLIGHT - 1);
@@ -1754,8 +1813,9 @@ nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg
     ((volatile struct docaNotif *)notif_send_cpu)->msg_size = newMsg.size();
     std::atomic_thread_fence(std::memory_order_seq_cst);
     ((volatile struct docaNotif *)notif_send_cpu)->qp_gpu = notif_qp_gpu;
-    while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr)
+    while (((volatile struct docaNotif *)notif_send_cpu)->qp_gpu != nullptr) {
         ;
+    }
 
     return NIXL_SUCCESS;
 }

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -174,6 +174,18 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
     std::vector<std::string> ndevs, tmp_gdevs; /* Empty vector */
     doca_error_t result;
     nixl_b_params_t *custom_params = init_params->customParams;
+    const auto native_option = custom_params->find("native_device_api");
+    if (native_option != custom_params->end()) {
+        if (native_option->second != "true" && native_option->second != "false") {
+            throw std::invalid_argument("native_device_api must be true or false");
+        }
+        nativeMode_ = native_option->second == "true";
+    }
+#ifndef NIXL_GPUNETIO_DEVICE_API_HOST
+    if (nativeMode_) {
+        throw std::invalid_argument("GPUNETIO native Device API was not built");
+    }
+#endif
     int ret;
     union ibv_gid rgid;
 
@@ -358,6 +370,21 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
                    << static_cast<unsigned>(ipv4_addr[3]);
     }
 
+    if (nativeMode_) {
+        try {
+            initializeNativeState();
+            if (progressThreadStart() != NIXL_SUCCESS) {
+                throw std::runtime_error("Failed to start GPUNETIO connection thread");
+            }
+        }
+        catch (...) {
+            nativeState_.reset();
+            rollbackOobDiscoveryFailure(gdevs, verbs_ah_attr, ddev, verbs_pd, verbs_context);
+            throw;
+        }
+        return;
+    }
+
     // DOCA_GPU_MEM_TYPE_GPU_CPU == GDRCopy
     result = doca_gpu_mem_alloc(gdevs[0].second,
                                 sizeof(struct docaXferReqGpu) * DOCA_XFER_REQ_MAX,
@@ -521,24 +548,36 @@ nixlDocaEngine::nixlDocaEngine(const nixlBackendInitParams *init_params)
 
 nixl_mem_list_t
 nixlDocaEngine::getSupportedMems() const {
+    if (nativeMode_) {
+        return {VRAM_SEG};
+    }
     return {DRAM_SEG, VRAM_SEG};
 }
 
 nixlDocaEngine::~nixlDocaEngine() {
     doca_error_t result;
-
-    NIXL_DEBUG << "Before progressThreadStop ";
+    // The listener references this engine; it must stop even if CUDA selection fails.
     progressThreadStop();
+    cudaDeviceGuard cuda_device(gdevs[0].first);
+    if (cuda_device.status() != cudaSuccess) {
+        // No safe CUDA context: retain dependencies rather than free live resources.
+        nativeState_.release();
+        retainedQp_.release();
+        return;
+    }
 
-    ((volatile uint8_t *)wait_exit_cpu)[0] = 1;
-    NIXL_DEBUG << "Before cudaStreamSynchronize ";
-    nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
-    nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
+    if (!nativeMode_) {
+        ((volatile uint8_t *)wait_exit_cpu)[0] = 1;
+        NIXL_DEBUG << "Before cudaStreamSynchronize ";
+        nixlDocaEngineCheckCudaError(cudaStreamSynchronize(wait_stream), "stream synchronize");
+        nixlDocaEngineCheckCudaError(cudaStreamDestroy(wait_stream), "stream destroy");
 
-    for (int i = 0; i < nstreams; i++) {
-        NIXL_DEBUG << "Before cudaStreamSynchronize post_stream " << i;
-        nixlDocaEngineCheckCudaError(cudaStreamSynchronize(post_stream[i]), "stream synchronize");
-        nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
+        for (int i = 0; i < nstreams; i++) {
+            NIXL_DEBUG << "Before cudaStreamSynchronize post_stream " << i;
+            nixlDocaEngineCheckCudaError(cudaStreamSynchronize(post_stream[i]),
+                                         "stream synchronize");
+            nixlDocaEngineCheckCudaError(cudaStreamDestroy(post_stream[i]), "stream destroy");
+        }
     }
 
     bool qps_closed = true;
@@ -560,6 +599,7 @@ nixlDocaEngine::~nixlDocaEngine() {
         if (!retained_closed) {
             retainedQp_.release();
         }
+        nativeState_.release();
         return;
     }
 
@@ -575,14 +615,17 @@ nixlDocaEngine::~nixlDocaEngine() {
     }
     notifMap.clear();
 
-    doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
-    doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
-    doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
-    doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
-    doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
-    doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
-    doca_gpu_mem_free(gdevs[0].second, notif_send_gpu);
-    doca_gpu_mem_free(gdevs[0].second, completion_list_gpu);
+    nativeState_.reset();
+    if (!nativeMode_) {
+        doca_gpu_mem_free(gdevs[0].second, wait_exit_gpu);
+        doca_gpu_mem_free(gdevs[0].second, xferReqRingGpu);
+        doca_gpu_mem_free(gdevs[0].second, last_rsvd_flags);
+        doca_gpu_mem_free(gdevs[0].second, last_posted_flags);
+        doca_gpu_mem_free(gdevs[0].second, notif_fill_gpu);
+        doca_gpu_mem_free(gdevs[0].second, notif_progress_gpu);
+        doca_gpu_mem_free(gdevs[0].second, notif_send_gpu);
+        doca_gpu_mem_free(gdevs[0].second, completion_list_gpu);
+    }
 
     result = doca_gpu_destroy(gdevs[0].second);
     if (result != DOCA_SUCCESS) {
@@ -622,6 +665,9 @@ nixlDocaEngine::~nixlDocaEngine() {
 
 nixl_status_t
 nixlDocaEngine::nixlDocaInitNotif(const std::string &remote_agent, doca_dev *dev, doca_gpu *gpu) {
+    if (nativeMode_) {
+        return NIXL_SUCCESS;
+    }
     std::lock_guard<std::mutex> lock(notifLock);
     // Same peer can be server or client
     if (notifMap.find(remote_agent) != notifMap.end()) {
@@ -1360,6 +1406,15 @@ nixl_status_t
 nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
                             const nixl_mem_t &nixl_mem,
                             nixlBackendMD *&out) {
+    if (nativeMode_) {
+        cudaPointerAttributes attributes{};
+        if (nixl_mem != VRAM_SEG || mem.devId != gdevs[0].first ||
+            cudaPointerGetAttributes(&attributes, reinterpret_cast<void *>(mem.addr)) !=
+                cudaSuccess ||
+            attributes.type != cudaMemoryTypeDevice || attributes.device != int(gdevs[0].first)) {
+            return NIXL_ERR_NOT_SUPPORTED;
+        }
+    }
     auto priv = std::make_unique<nixlDocaPrivateMetadata>();
     std::stringstream ss;
 
@@ -1373,7 +1428,7 @@ nixlDocaEngine::registerMem(const nixlBlobDesc &mem,
     }
 
     try {
-        priv->mr = std::make_unique<nixl::doca::verbs::mr>(
+        priv->mr = std::make_shared<nixl::doca::verbs::mr>(
             it->second, (void *)mem.addr, 1, (size_t)mem.len, pd);
     }
     catch (const std::exception &e) {
@@ -1469,6 +1524,9 @@ nixlDocaEngine::prepXfer(const nixl_xfer_op_t &operation,
                          const std::string &remote_agent,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
+    if (nativeMode_) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
     uint32_t pos;
     nixlDocaBckndReq *treq;
     nixlDocaPrivateMetadata *lmd;
@@ -1641,6 +1699,9 @@ nixlDocaEngine::postXfer(const nixl_xfer_op_t &operation,
                          const std::string &remote_agent,
                          nixlBackendReqH *&handle,
                          const nixl_opt_b_args_t *opt_args) const {
+    if (nativeMode_) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
     nixlDocaBckndReq *treq = (nixlDocaBckndReq *)handle;
 
     if (operation != NIXL_READ && operation != NIXL_WRITE) {
@@ -1759,6 +1820,9 @@ nixlDocaEngine::releaseReqH(nixlBackendReqH *handle) const {
 
 nixl_status_t
 nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
+    if (nativeMode_) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
     uint32_t recv_idx;
     std::string msg_src;
     uint32_t num_msg = 0;
@@ -1829,6 +1893,9 @@ nixlDocaEngine::getNotifs(notif_list_t &notif_list) {
 
 nixl_status_t
 nixlDocaEngine::genNotif(const std::string &remote_agent, const std::string &msg) const {
+    if (nativeMode_) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
     struct nixlDocaNotif *notif;
     uint32_t buf_idx;
     uintptr_t msg_buf;

--- a/src/plugins/gpunetio/gpunetio_backend.cpp
+++ b/src/plugins/gpunetio/gpunetio_backend.cpp
@@ -710,10 +710,6 @@ nixlDocaEngine::nixlDocaDestroyNotif(doca_gpu *gpu, struct nixlDocaNotif *notif)
         return NIXL_SUCCESS;
     }
 
-    notif->send_mr.reset();
-    notif->recv_mr.reset();
-    free(notif->send_addr);
-    free(notif->recv_addr);
     delete notif;
 
     return NIXL_SUCCESS;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -28,11 +28,11 @@ public:
     std::mutex qpLock;
     std::mutex connectLock;
     std::vector<std::pair<uint32_t, doca_gpu *>> gdevs; /* List of DOCA GPUNetIO device handlers */
-    doca_dev *ddev; /* DOCA device handler associated to queues */
-    doca_verbs_context *verbs_context; /* DOCA Verbs Context */
-    doca_verbs_pd *verbs_pd; /* DOCA Verbs Protection Domain */
-    doca_verbs_ah_attr *verbs_ah_attr; /* DOCA Verbs address handle */
-    struct ibv_pd *pd; /* local protection domain */
+    doca_dev *ddev = nullptr; /* DOCA device handler associated to queues */
+    doca_verbs_context *verbs_context = nullptr; /* DOCA Verbs Context */
+    doca_verbs_pd *verbs_pd = nullptr; /* DOCA Verbs Protection Domain */
+    doca_verbs_ah_attr *verbs_ah_attr = nullptr; /* DOCA Verbs address handle */
+    struct ibv_pd *pd = nullptr; /* local protection domain */
     doca_verbs_gid gid; /* local gid address */
     doca_verbs_gid remote_gid; /* remote gid address */
     int lid; /* IB: local ID */
@@ -158,7 +158,7 @@ private:
     std::thread pthr;
     uint64_t *last_rsvd_flags;
     uint64_t *last_posted_flags;
-    cudaStream_t post_stream[DOCA_POST_STREAM_NUM];
+    cudaStream_t post_stream[DOCA_POST_STREAM_NUM]{};
     cudaStream_t wait_stream;
     mutable std::atomic<uint32_t> xferStream;
     mutable std::atomic<uint32_t> lastPostedReq;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -182,6 +182,7 @@ private:
     // Map of agent name to saved nixlDocaConnection info
     std::unordered_map<std::string, nixlDocaConnection> remoteConnMap;
     std::unordered_map<std::string, struct nixlDocaRdmaQp *> qpMap;
+    std::unique_ptr<nixlDocaRdmaQp> retainedQp_;
     std::unordered_map<std::string, int> connMap;
     std::unordered_map<std::string, struct nixlDocaNotif *> notifMap;
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -192,13 +192,15 @@ private:
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:
     public:
+        enum class CompletionState : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
+
         cudaStream_t stream;
         uint32_t devId;
         std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
-        bool completed = false;
+        std::atomic<CompletionState> completionState{CompletionState::IN_PROGRESS};
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -24,6 +24,7 @@ class nixlDocaEngine : public nixlBackendEngine {
 public:
     CUcontext main_cuda_ctx;
     int oob_sock_server;
+    std::atomic<int> activeOobSocket{-1};
     mutable std::mutex notifLock;
     mutable std::mutex qpLock;
     std::mutex connectLock;
@@ -36,7 +37,7 @@ public:
     struct ibv_pd *pd; /* local protection domain */
     doca_verbs_gid gid; /* local gid address */
     doca_verbs_gid remote_gid; /* remote gid address */
-    int lid; /* IB: local ID */
+    int lid = 0; /* IB: local ID */
     int dlid; /* IB: destination ID */
     int gid_index;
     struct ibv_port_attr port_attr;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -150,7 +150,7 @@ private:
     std::vector<struct nixlDocaRdmaQp> rdma_qp_v;
     int nstreams;
 
-    uint32_t local_port;
+    uint16_t local_port;
     int noSyncIters;
     uint8_t ipv4_addr[4];
     struct sockaddr oob_saddr;

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -24,9 +24,10 @@ class nixlDocaEngine : public nixlBackendEngine {
 public:
     CUcontext main_cuda_ctx;
     int oob_sock_server;
-    std::mutex notifLock;
-    std::mutex qpLock;
+    mutable std::mutex notifLock;
+    mutable std::mutex qpLock;
     std::mutex connectLock;
+    mutable std::mutex remoteConnLock;
     std::vector<std::pair<uint32_t, doca_gpu *>> gdevs; /* List of DOCA GPUNetIO device handlers */
     doca_dev *ddev; /* DOCA device handler associated to queues */
     doca_verbs_context *verbs_context; /* DOCA Verbs Context */
@@ -186,6 +187,7 @@ private:
     std::unordered_map<std::string, struct nixlDocaNotif *> notifMap;
 
     pthread_t server_thread_id;
+    bool serverThreadStarted = false;
 
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -198,6 +198,7 @@ private:
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
+        bool completed = false;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,6 +166,7 @@ private:
     struct docaXferReqGpu *xferReqRingGpu;
     struct docaXferReqGpu *xferReqRingCpu;
     mutable std::atomic<uint32_t> xferRingPos;
+    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved;
 
     struct docaXferCompletion *completion_list_gpu;
     struct docaXferCompletion *completion_list_cpu;
@@ -192,8 +193,7 @@ private:
     public:
         cudaStream_t stream;
         uint32_t devId;
-        uint32_t start_pos;
-        uint32_t end_pos;
+        std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -192,7 +192,7 @@ private:
     class nixlDocaBckndReq : public nixlBackendReqH {
     private:
     public:
-        enum class CompletionState : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
+        enum class completion_state : uint8_t { IN_PROGRESS, COMPLETING, COMPLETE };
 
         cudaStream_t stream;
         uint32_t devId;
@@ -200,12 +200,15 @@ private:
         uintptr_t backendHandleGpu;
         size_t postedCount = 0;
         nixl_status_t postStatus = NIXL_SUCCESS;
-        std::atomic<CompletionState> completionState{CompletionState::IN_PROGRESS};
+        std::atomic<completion_state> completionState{completion_state::IN_PROGRESS};
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 
         ~nixlDocaBckndReq() {}
     };
+
+    void
+    retireRequest(nixlDocaBckndReq *request) const;
 
     nixl_status_t
     progressThreadStart();

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -162,11 +162,12 @@ private:
     cudaStream_t wait_stream;
     mutable std::atomic<uint32_t> xferStream;
     mutable std::atomic<uint32_t> lastPostedReq;
+    mutable std::mutex postLock_;
 
     struct docaXferReqGpu *xferReqRingGpu;
     struct docaXferReqGpu *xferReqRingCpu;
     mutable std::atomic<uint32_t> xferRingPos;
-    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved;
+    mutable std::array<std::atomic_bool, DOCA_XFER_REQ_MAX> xferReqReserved_;
 
     struct docaXferCompletion *completion_list_gpu;
     struct docaXferCompletion *completion_list_cpu;
@@ -195,6 +196,8 @@ private:
         uint32_t devId;
         std::vector<uint32_t> positions;
         uintptr_t backendHandleGpu;
+        size_t postedCount = 0;
+        nixl_status_t postStatus = NIXL_SUCCESS;
 
         nixlDocaBckndReq() : nixlBackendReqH() {}
 

--- a/src/plugins/gpunetio/gpunetio_backend.h
+++ b/src/plugins/gpunetio/gpunetio_backend.h
@@ -19,6 +19,7 @@
 #define GPUNETIO_BACKEND_H
 
 #include "gpunetio_backend_aux.h"
+#include "gpunetio_device_memview.h"
 
 class nixlDocaEngine : public nixlBackendEngine {
 public:
@@ -66,8 +67,21 @@ public:
 
     bool
     supportsNotif() const {
-        return true;
+        return !nativeMode_;
     }
+
+    nixl_device_exec_mode_t
+    getDeviceExecMode() const noexcept override;
+
+    nixl_status_t
+    prepMemView(const nixl_meta_dlist_t &,
+                nixlMemViewH &,
+                const nixl_opt_b_args_t * = nullptr) const override;
+    nixl_status_t
+    prepMemView(const nixl_remote_meta_dlist_t &,
+                nixlMemViewH &,
+                const nixl_opt_b_args_t * = nullptr) const override;
+    void releaseMemView(nixlMemViewH) const override;
 
     bool
     supportsProgTh() const {
@@ -146,6 +160,14 @@ public:
     recvRemoteAgentName(int oob_sock_client, std::string &remote_agent);
 
 private:
+    bool nativeMode_ = false;
+    mutable std::unique_ptr<nixlGpunetioNativeState> nativeState_;
+    void
+    initializeNativeState();
+    nixl_status_t
+    prepareNativeView(const nixl_meta_dlist_t *,
+                      const nixl_remote_meta_dlist_t *,
+                      nixlMemViewH &) const;
     struct doca_log_backend *sdk_log;
     std::string msg_tag_start = "DOCAS";
     std::string msg_tag_end = "DOCAE";

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -184,8 +184,8 @@ struct nixlDocaRdmaQp {
     uint32_t rqpn_notif;
     doca_verbs_gid remote_gid{};
     uint32_t remote_lid = 0;
-    bool data_programmed = false;
-    bool notif_programmed = false;
+    bool dataProgrammed = false;
+    bool notifProgrammed = false;
 };
 
 struct nixlDocaEngine;

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -19,6 +19,7 @@
 #define GPUNETIO_BACKEND_AUX_H
 
 #include <atomic>
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <mutex>
@@ -71,6 +72,7 @@ constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
 // Pre-fill the whole recv queue with notif once
 constexpr uint32_t DOCA_MAX_NOTIF_INFLIGHT = RDMA_RECV_QUEUE_SIZE;
 constexpr uint32_t DOCA_MAX_NOTIF_MESSAGE_SIZE = 8192;
+constexpr time_t DOCA_OOB_SOCKET_TIMEOUT_SEC = 10;
 constexpr uint32_t DOCA_NOTIF_NULL = 0xFFFFFFFF;
 
 #ifndef ACCESS_ONCE
@@ -100,14 +102,21 @@ struct docaXferReqGpu {
 };
 
 struct nixlDocaNotif {
-    uint32_t elems_num;
-    uint32_t elems_size;
-    uint8_t *send_addr;
-    std::atomic<uint32_t> send_pi;
+    uint32_t elems_num = 0;
+    uint32_t elems_size = 0;
+    uint8_t *send_addr = nullptr;
+    std::atomic<uint32_t> send_pi{0};
     std::unique_ptr<nixl::doca::verbs::mr> send_mr;
-    uint8_t *recv_addr;
-    std::atomic<uint32_t> recv_pi;
+    uint8_t *recv_addr = nullptr;
+    std::atomic<uint32_t> recv_pi{0};
     std::unique_ptr<nixl::doca::verbs::mr> recv_mr;
+
+    ~nixlDocaNotif() {
+        send_mr.reset();
+        recv_mr.reset();
+        free(send_addr);
+        free(recv_addr);
+    }
 };
 
 struct docaXferCompletion {
@@ -187,6 +196,8 @@ int
 oob_connection_client_setup(const char *server_ip,
                             int *oob_sock_fd,
                             uint16_t server_port = GPUNETIO_DEFAULT_OOB_PORT);
+int
+setOobSocketTimeouts(int oob_sock_fd);
 void
 oob_connection_client_close(int oob_sock_fd);
 void

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -169,12 +169,12 @@ struct nixlDocaRdmaQp {
     std::unique_ptr<nixl::doca::verbs::qp> qp_data;
     uint32_t qpn_data;
     uint32_t rqpn_data;
-    uint32_t remote_gid_data;
 
     std::unique_ptr<nixl::doca::verbs::qp> qp_notif;
     uint32_t qpn_notif;
     uint32_t rqpn_notif;
-    uint32_t remote_gid_notif;
+    doca_verbs_gid remote_gid{};
+    uint32_t remote_lid = 0;
 };
 
 struct nixlDocaEngine;
@@ -199,7 +199,11 @@ create_verbs_ah_attr(doca_verbs_context *verbs_context,
                      enum doca_verbs_addr_type addr_type,
                      doca_verbs_ah_attr **verbs_ah_attr);
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid);
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid);
 void *
 threadProgressFunc(void *arg);
 int

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -102,10 +102,10 @@ struct docaXferReqGpu {
 struct nixlDocaNotif {
     uint32_t elems_num;
     uint32_t elems_size;
-    uint8_t *send_addr;
+    uint8_t *send_addr = nullptr;
     std::atomic<uint32_t> send_pi;
     std::unique_ptr<nixl::doca::verbs::mr> send_mr;
-    uint8_t *recv_addr;
+    uint8_t *recv_addr = nullptr;
     std::atomic<uint32_t> recv_pi;
     std::unique_ptr<nixl::doca::verbs::mr> recv_mr;
 };

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -52,6 +52,7 @@
 
 // Local includes
 #include "common/nixl_time.h"
+#include "gpunetio_oob_endpoint.h"
 
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT = 128;
 constexpr uint32_t DOCA_MAX_COMPLETION_INFLIGHT_MASK = (DOCA_MAX_COMPLETION_INFLIGHT - 1);
@@ -62,7 +63,6 @@ constexpr uint32_t DOCA_XFER_REQ_SIZE = 512;
 constexpr uint32_t DOCA_XFER_REQ_MAX = 32;
 constexpr uint32_t DOCA_XFER_REQ_MASK = (DOCA_XFER_REQ_MAX - 1);
 constexpr uint32_t DOCA_ENG_MAX_CONN = 20;
-constexpr uint32_t DOCA_RDMA_CM_LOCAL_PORT_SERVER = 6544;
 constexpr uint32_t VERBS_TEST_HOP_LIMIT = 255;
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
@@ -184,7 +184,9 @@ nixlDocaEngineCheckCudaError(cudaError_t result, const char *message);
 void
 nixlDocaEngineCheckCuError(CUresult result, const char *message);
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd);
+oob_connection_client_setup(const char *server_ip,
+                            int *oob_sock_fd,
+                            uint16_t server_port = GPUNETIO_DEFAULT_OOB_PORT);
 void
 oob_connection_client_close(int oob_sock_fd);
 void

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -18,6 +18,7 @@
 #ifndef GPUNETIO_BACKEND_AUX_H
 #define GPUNETIO_BACKEND_AUX_H
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -184,6 +184,8 @@ struct nixlDocaRdmaQp {
     uint32_t rqpn_notif;
     doca_verbs_gid remote_gid{};
     uint32_t remote_lid = 0;
+    bool data_programmed = false;
+    bool notif_programmed = false;
 };
 
 struct nixlDocaEngine;

--- a/src/plugins/gpunetio/gpunetio_backend_aux.h
+++ b/src/plugins/gpunetio/gpunetio_backend_aux.h
@@ -146,7 +146,7 @@ public:
 // A private metadata has to implement get, and has all the metadata
 class nixlDocaPrivateMetadata : public nixlBackendMD {
 private:
-    std::unique_ptr<nixl::doca::verbs::mr> mr;
+    std::shared_ptr<nixl::doca::verbs::mr> mr;
     uint32_t devId;
     nixl_blob_t remoteMrStr;
 

--- a/src/plugins/gpunetio/gpunetio_device_memview.cpp
+++ b/src/plugins/gpunetio/gpunetio_device_memview.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#include "gpunetio_backend.h"
+#include <gpu/impl/gpunetio/device_gpunetio_types.h>
+#include <limits>
+#include <stdexcept>
+
+using namespace nixl::gpu::impl::gpunetio;
+
+namespace {
+std::atomic<uint64_t> nextCookie{1};
+
+void
+checkAllocation(nixl_status_t status) {
+    if (status != NIXL_SUCCESS) {
+        throw std::runtime_error("GPUNETIO native state allocation/upload failed");
+    }
+}
+
+bool
+validRange(uint64_t base, uint64_t length) {
+    return length != 0 && length <= std::numeric_limits<uint64_t>::max() - base;
+}
+} // namespace
+
+nixl_device_exec_mode_t
+nixlDocaEngine::getDeviceExecMode() const noexcept {
+    return nativeMode_ ? nixl_device_exec_mode_t::GPUNETIO_DIRECT : nixl_device_exec_mode_t::NONE;
+}
+
+void
+nixlDocaEngine::initializeNativeState() {
+    auto &allocator = nixlGetDeviceAllocator();
+    auto state = std::make_unique<nixlGpunetioNativeState>();
+    state->cookie = nextCookie.fetch_add(1, std::memory_order_relaxed);
+    if (state->cookie == 0) {
+        throw std::runtime_error("GPUNETIO native context cookie exhausted");
+    }
+    checkAllocation(allocator.allocDeviceMem(sizeof(GpunetioDeviceLane), state->lane));
+    checkAllocation(allocator.allocDeviceMem(sizeof(GpunetioDeviceContext), state->context));
+    GpunetioDeviceLane lane{};
+    GpunetioDeviceContext context{state->lane.as<GpunetioDeviceLane>()};
+    checkAllocation(allocator.copyHostToDevice(state->lane.get(), &lane, sizeof(lane)));
+    checkAllocation(allocator.copyHostToDevice(state->context.get(), &context, sizeof(context)));
+    checkAllocation(allocator.synchronize());
+    nativeState_ = std::move(state);
+}
+
+nixl_status_t
+nixlDocaEngine::prepMemView(const nixl_meta_dlist_t &list,
+                            nixlMemViewH &out,
+                            const nixl_opt_b_args_t *) const {
+    return prepareNativeView(&list, nullptr, out);
+}
+
+nixl_status_t
+nixlDocaEngine::prepMemView(const nixl_remote_meta_dlist_t &list,
+                            nixlMemViewH &out,
+                            const nixl_opt_b_args_t *) const {
+    return prepareNativeView(nullptr, &list, out);
+}
+
+nixl_status_t
+nixlDocaEngine::prepareNativeView(const nixl_meta_dlist_t *local,
+                                  const nixl_remote_meta_dlist_t *remote,
+                                  nixlMemViewH &out) const {
+    out = nullptr;
+    if (!nativeMode_ || !nativeState_) {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+    const size_t count = local ? local->descCount() : remote->descCount();
+    const auto type = local ? local->getType() : remote->getType();
+    if (type != VRAM_SEG || count == 0 || count > SIZE_MAX / sizeof(GpunetioViewElem)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    auto &allocator = nixlGetDeviceAllocator();
+    int device = -1;
+    if (allocator.getActiveDevice(device) != NIXL_SUCCESS || device != int(gdevs[0].first)) {
+        return NIXL_ERR_INVALID_PARAM;
+    }
+    std::lock_guard lock(nativeState_->mutex);
+    try {
+        nixlGpunetioNativeViewStorage storage;
+        storage.remote = remote != nullptr;
+        std::vector<GpunetioViewElem> elements(count);
+        std::string peer = nativeState_->peer;
+        doca_gpu_dev_verbs_qp *qp = nullptr;
+        for (size_t i = 0; i < count; ++i) {
+            if (remote && (*remote)[i].remoteAgent == nixl_null_agent) {
+                continue;
+            }
+            const nixlMetaDesc &desc = local ? (*local)[i] : (*remote)[i];
+            if (!desc.metadataP || !validRange(desc.addr, desc.len)) {
+                return NIXL_ERR_INVALID_PARAM;
+            }
+            auto &elem = elements[i];
+            elem.base = desc.addr;
+            elem.length = desc.len;
+            elem.valid = 1;
+            elem.peer_slot = local ? UINT32_MAX : 0;
+            if (local) {
+                const auto *md = static_cast<const nixlDocaPrivateMetadata *>(desc.metadataP);
+                if (desc.devId != gdevs[0].first || md->devId != gdevs[0].first || !md->mr) {
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                const auto base = reinterpret_cast<uintptr_t>(md->mr->get_addr());
+                if (desc.addr < base || desc.addr - base > md->mr->get_tot_size() ||
+                    desc.len > md->mr->get_tot_size() - (desc.addr - base)) {
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                elem.key = md->mr->get_lkey();
+                storage.pins.push_back(md->mr);
+            } else {
+                const auto &agent = (*remote)[i].remoteAgent;
+                if (!peer.empty() && peer != agent) {
+                    return NIXL_ERR_NOT_SUPPORTED;
+                }
+                peer = agent;
+                const auto *md = static_cast<const nixlDocaPublicMetadata *>(desc.metadataP);
+                if (!md->mr || md->conn.remoteAgent != agent) {
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                const auto base = reinterpret_cast<uintptr_t>(md->mr->get_addr());
+                if (desc.addr < base || desc.addr - base > md->mr->get_tot_size() ||
+                    desc.len > md->mr->get_tot_size() - (desc.addr - base)) {
+                    return NIXL_ERR_INVALID_PARAM;
+                }
+                elem.key = md->mr->get_rkey();
+                std::lock_guard qp_lock(qpLock);
+                const auto it = qpMap.find(peer);
+                if (it == qpMap.end()) {
+                    return NIXL_ERR_NOT_FOUND;
+                }
+                qp = it->second->qp_data->get_qp_gpu_dev();
+            }
+        }
+        if (remote && !qp) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        if (qp) {
+            doca_gpu_dev_verbs_nic_handler handler;
+            if (cudaMemcpy(&handler, &qp->nic_handler, sizeof(handler), cudaMemcpyDeviceToHost) !=
+                    cudaSuccess ||
+                handler != DOCA_GPUNETIO_VERBS_NIC_HANDLER_GPU_SM_DB) {
+                return NIXL_ERR_NOT_SUPPORTED;
+            }
+        }
+        auto rc = allocator.allocDeviceMem(count * sizeof(GpunetioViewElem), storage.elements);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        rc = allocator.allocDeviceMem(sizeof(GpunetioDeviceView), storage.header);
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        GpunetioDeviceView header{};
+        header.abi_version = 1;
+        header.role = local ? 1 : 2;
+        header.count = count;
+        header.context_cookie = nativeState_->cookie;
+        header.execution_gpu = gdevs[0].first;
+        header.elems = storage.elements.as<GpunetioViewElem>();
+        header.context = nativeState_->context.as<GpunetioDeviceContext>();
+        rc = allocator.copyHostToDevice(
+            storage.elements.get(), elements.data(), count * sizeof(GpunetioViewElem));
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        rc = allocator.copyHostToDevice(storage.header.get(), &header, sizeof(header));
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        // Bind the shared lane only once; later views must not reset its generation/credits.
+        if (remote && nativeState_->peer.empty()) {
+            GpunetioDeviceLane lane{};
+            lane.qp = qp;
+            rc = allocator.copyHostToDevice(nativeState_->lane.get(), &lane, sizeof(lane));
+            if (rc != NIXL_SUCCESS) {
+                return rc;
+            }
+        }
+        rc = allocator.synchronize();
+        if (rc != NIXL_SUCCESS) {
+            return rc;
+        }
+        auto handle = storage.header.get();
+        const auto [it, inserted] = nativeState_->views.emplace(handle, std::move(storage));
+        if (!inserted) {
+            return NIXL_ERR_BACKEND;
+        }
+        nativeState_->peer = std::move(peer);
+        if (remote) {
+            ++nativeState_->remoteViews;
+        }
+        out = handle;
+        return NIXL_SUCCESS;
+    }
+    catch (const std::exception &) {
+        return NIXL_ERR_BACKEND;
+    }
+}
+
+void
+nixlDocaEngine::releaseMemView(nixlMemViewH handle) const {
+    if (!nativeState_) {
+        return;
+    }
+    // Caller must finish its CUDA kernels and retire accepted NIC work before release.
+    std::lock_guard lock(nativeState_->mutex);
+    auto it = nativeState_->views.find(handle);
+    if (it == nativeState_->views.end()) {
+        return;
+    }
+    auto &allocator = nixlGetDeviceAllocator();
+    GpunetioDeviceLane snapshot{};
+    if (allocator.copyDeviceToHost(&snapshot, nativeState_->lane.get(), sizeof(snapshot)) !=
+            NIXL_SUCCESS ||
+        snapshot.phase != gpunetio_lane_phase_idle) {
+        // No cancellation is implied by release: keep the view/MR pins until
+        // engine teardown has successfully quiesced its QPs.
+        return;
+    }
+    const bool was_remote = it->second.remote;
+    nativeState_->views.erase(it);
+    if (was_remote && --nativeState_->remoteViews == 0) {
+        // Common-wrapper publication can fail after backend prep succeeded.
+        // Undo an unused binding, never reset an operated/live lane or its credits.
+        GpunetioDeviceLane lane{};
+        if (allocator.copyDeviceToHost(&lane, nativeState_->lane.get(), sizeof(lane)) ==
+                NIXL_SUCCESS &&
+            lane.phase == gpunetio_lane_phase_idle && lane.generation == 0) {
+            lane.qp = nullptr;
+            if (allocator.copyHostToDevice(nativeState_->lane.get(), &lane, sizeof(lane)) ==
+                    NIXL_SUCCESS &&
+                allocator.synchronize() == NIXL_SUCCESS) {
+                nativeState_->peer.clear();
+            }
+        }
+    }
+}

--- a/src/plugins/gpunetio/gpunetio_device_memview.h
+++ b/src/plugins/gpunetio/gpunetio_device_memview.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef NIXL_GPUNETIO_DEVICE_MEMVIEW_H
+#define NIXL_GPUNETIO_DEVICE_MEMVIEW_H
+
+#include "device/device_allocator.h"
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <memory>
+#include <vector>
+
+namespace nixl::doca::verbs {
+class mr;
+}
+
+struct nixlGpunetioNativeViewStorage {
+    std::vector<std::shared_ptr<nixl::doca::verbs::mr>> pins;
+    bool remote = false;
+    nixlDeviceMem elements;
+    nixlDeviceMem header;
+};
+
+struct nixlGpunetioNativeState {
+    std::mutex mutex;
+    uint64_t cookie = 0;
+    std::string peer;
+    size_t remoteViews = 0;
+    nixlDeviceMem lane;
+    nixlDeviceMem context;
+    std::unordered_map<nixlMemViewH, nixlGpunetioNativeViewStorage> views;
+};
+
+#endif

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -23,7 +23,7 @@
 
 #include "gpunetio_backend.h"
 
-#if DOCA_VERSION_MINOR >= 2
+#if DOCA_VERSION_MAJOR == 3 && DOCA_VERSION_MINOR >= 2
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_mcst)
 #else
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_dump)

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,17 @@
 
 #include <doca_gpunetio_dev_verbs_onesided.cuh>
 #include <doca_gpunetio_dev_verbs_twosided.cuh>
+#include <doca_version.h>
 #include <cuda.h>
 #include <cuda/atomic>
 
 #include "gpunetio_backend.h"
+
+#if DOCA_VERSION_MINOR >= 2
+#define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_mcst)
+#else
+#define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_dump)
+#endif
 
 #define ENABLE_DEBUG 0
 
@@ -107,10 +114,11 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
     tot_wqe = xferReqRing[pos].num;
 
     if (threadIdx.x == 0) {
-        if (qp->need_mcst == true)
+        if (NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) == true) {
             base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots(qp, tot_wqe + 1);
-        else
+        } else {
             base_wqe_idx = doca_gpu_dev_verbs_reserve_wq_slots(qp, tot_wqe);
+        }
     }
     __syncthreads();
 
@@ -131,7 +139,7 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
     __syncthreads();
 
     if ((idx - blockDim.x) == (tot_wqe - 1)) {
-        if (qp->need_mcst == true) {
+        if (NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) == true) {
             wqe_idx++;
             wqe_ptr = doca_gpu_dev_verbs_get_wqe_ptr(qp, wqe_idx);
 
@@ -162,6 +170,8 @@ kernel_read(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint3
                base_wqe_idx);
 #endif
 }
+
+#undef NIXL_GPUNETIO_QP_NEEDS_DUMP
 
 __global__ void
 kernel_write(doca_gpu_dev_verbs_qp *qp, struct docaXferReqGpu *xferReqRing, uint32_t pos) {

--- a/src/plugins/gpunetio/gpunetio_kernels.cu
+++ b/src/plugins/gpunetio/gpunetio_kernels.cu
@@ -23,7 +23,7 @@
 
 #include "gpunetio_backend.h"
 
-#if DOCA_VERSION_MAJOR == 3 && DOCA_VERSION_MINOR >= 2
+#if DOCA_VERSION_MAJOR > 3 || (DOCA_VERSION_MAJOR == 3 && DOCA_VERSION_MINOR >= 2)
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_mcst)
 #else
 #define NIXL_GPUNETIO_QP_NEEDS_DUMP(qp) ((qp)->need_dump)

--- a/src/plugins/gpunetio/gpunetio_oob_endpoint.h
+++ b/src/plugins/gpunetio/gpunetio_oob_endpoint.h
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef GPUNETIO_OOB_ENDPOINT_H
+#define GPUNETIO_OOB_ENDPOINT_H
+
+#include <arpa/inet.h>
+
+#include <charconv>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+constexpr uint16_t GPUNETIO_DEFAULT_OOB_PORT = 6544;
+
+struct GpunetioOobEndpoint {
+    std::string ipv4;
+    uint16_t port;
+};
+
+inline uint16_t
+parseGpunetioOobPort(std::string_view value) {
+    if (value.empty()) {
+        return GPUNETIO_DEFAULT_OOB_PORT;
+    }
+
+    uint32_t port = 0;
+    const auto [end, error] = std::from_chars(value.data(), value.data() + value.size(), port);
+    if (error != std::errc() || end != value.data() + value.size() || port == 0 || port > 65535) {
+        throw std::invalid_argument("oob_port must be an integer in the range [1, 65535]");
+    }
+    return static_cast<uint16_t>(port);
+}
+
+inline GpunetioOobEndpoint
+parseGpunetioOobEndpoint(std::string_view metadata) {
+    if (metadata.empty() || metadata.find('\0') != std::string_view::npos) {
+        throw std::invalid_argument("GPUNETIO connection metadata is empty or malformed");
+    }
+
+    const size_t separator = metadata.find(':');
+    if (separator != std::string_view::npos &&
+        (separator == 0 || separator + 1 == metadata.size() ||
+         metadata.find(':', separator + 1) != std::string_view::npos)) {
+        throw std::invalid_argument("GPUNETIO connection metadata must be IPv4 or IPv4:port");
+    }
+
+    const std::string ipv4(metadata.substr(0, separator));
+    in_addr address{};
+    if (inet_pton(AF_INET, ipv4.c_str(), &address) != 1) {
+        throw std::invalid_argument(
+            "GPUNETIO connection metadata contains an invalid IPv4 address");
+    }
+
+    const uint16_t port = separator == std::string_view::npos ?
+        GPUNETIO_DEFAULT_OOB_PORT :
+        parseGpunetioOobPort(metadata.substr(separator + 1));
+    return {ipv4, port};
+}
+
+inline std::string
+formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
+    if (port == GPUNETIO_DEFAULT_OOB_PORT) {
+        return std::string(ipv4);
+    }
+    return std::string(ipv4) + ":" + std::to_string(port);
+}
+
+#endif

--- a/src/plugins/gpunetio/gpunetio_oob_endpoint.h
+++ b/src/plugins/gpunetio/gpunetio_oob_endpoint.h
@@ -3,24 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef GPUNETIO_OOB_ENDPOINT_H
-#define GPUNETIO_OOB_ENDPOINT_H
+#ifndef NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H
+#define NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H
 
 #include <arpa/inet.h>
 
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 
 constexpr uint16_t GPUNETIO_DEFAULT_OOB_PORT = 6544;
+constexpr std::size_t GPUNETIO_MAX_AGENT_NAME_SIZE = 4096;
 
+/** Return whether an OOB agent-name payload length is safe to allocate. */
+inline bool
+isValidGpunetioAgentNameSize(std::size_t size) noexcept {
+    return size > 0 && size <= GPUNETIO_MAX_AGENT_NAME_SIZE;
+}
+
+/** Parsed GPUNETIO IPv4 endpoint and TCP port. */
 struct GpunetioOobEndpoint {
     std::string ipv4;
     uint16_t port;
 };
 
+/**
+ * Parse a decimal TCP port in [1, 65535]. An empty value selects the default port.
+ *
+ * @throws std::invalid_argument if the value is not a valid TCP port.
+ */
 inline uint16_t
 parseGpunetioOobPort(std::string_view value) {
     if (value.empty()) {
@@ -35,6 +49,12 @@ parseGpunetioOobPort(std::string_view value) {
     return static_cast<uint16_t>(port);
 }
 
+/**
+ * Parse connection metadata encoded as IPv4 or IPv4:port.
+ *
+ * IPv4-only metadata selects the default port for backward compatibility.
+ * @throws std::invalid_argument if the metadata or port is malformed.
+ */
 inline GpunetioOobEndpoint
 parseGpunetioOobEndpoint(std::string_view metadata) {
     if (metadata.empty() || metadata.find('\0') != std::string_view::npos) {
@@ -61,6 +81,7 @@ parseGpunetioOobEndpoint(std::string_view metadata) {
     return {ipv4, port};
 }
 
+/** Format an IPv4 endpoint, omitting the port when it is the default. */
 inline std::string
 formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
     if (port == GPUNETIO_DEFAULT_OOB_PORT) {
@@ -69,4 +90,4 @@ formatGpunetioOobEndpoint(std::string_view ipv4, uint16_t port) {
     return std::string(ipv4) + ":" + std::to_string(port);
 }
 
-#endif
+#endif // NIXL_SRC_PLUGINS_GPUNETIO_GPUNETIO_OOB_ENDPOINT_H

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -57,6 +57,7 @@ get_backend_options() {
     params["oob_interface"] = "";
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
+    params["gid_index"] = "";
     return params;
 }
 

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -55,6 +55,7 @@ get_backend_options() {
     nixl_b_params_t params;
     params["network_devices"] = "";
     params["oob_interface"] = "";
+    params["oob_port"] = "";
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
     return params;

--- a/src/plugins/gpunetio/gpunetio_plugin.cpp
+++ b/src/plugins/gpunetio/gpunetio_plugin.cpp
@@ -59,6 +59,7 @@ get_backend_options() {
     params["gpu_devices"] = "";
     params["cuda_streams"] = "";
     params["gid_index"] = "";
+    params["native_device_api"] = "false";
     return params;
 }
 

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -48,7 +48,7 @@ nixlDocaEngineCheckCuError(CUresult result, const char *message) {
 }
 
 int
-oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
+oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t server_port) {
     struct sockaddr_in server_addr = {0};
     int oob_sock_fd_;
 
@@ -62,13 +62,17 @@ oob_connection_client_setup(const char *server_ip, int *oob_sock_fd) {
 
     /* Set port and IP the same as server-side: */
     server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(DOCA_RDMA_CM_LOCAL_PORT_SERVER);
-    server_addr.sin_addr.s_addr = inet_addr(server_ip);
+    server_addr.sin_port = htons(server_port);
+    if (inet_pton(AF_INET, server_ip, &server_addr.sin_addr) != 1) {
+        close(oob_sock_fd_);
+        NIXL_ERROR << "Invalid server IPv4 address " << server_ip;
+        return -1;
+    }
 
     /* Send connection request to server: */
     if (connect(oob_sock_fd_, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         close(oob_sock_fd_);
-        NIXL_ERROR << "Unable to connect to server at " << server_ip;
+        NIXL_ERROR << "Unable to connect to server at " << server_ip << ":" << server_port;
         return -1;
     }
     NIXL_INFO << "Connected with server successfully";

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -19,6 +19,7 @@
 #include "serdes/serdes.h"
 #include <arpa/inet.h>
 #include <stdexcept>
+#include <sys/time.h>
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <chrono>
@@ -48,6 +49,17 @@ nixlDocaEngineCheckCuError(CUresult result, const char *message) {
 }
 
 int
+setOobSocketTimeouts(int oob_sock_fd) {
+    const timeval timeout{DOCA_OOB_SOCKET_TIMEOUT_SEC, 0};
+    if (setsockopt(oob_sock_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0 ||
+        setsockopt(oob_sock_fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0) {
+        NIXL_ERROR << "Unable to set OOB socket timeout";
+        return -1;
+    }
+    return 0;
+}
+
+int
 oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t server_port) {
     struct sockaddr_in server_addr = {0};
     int oob_sock_fd_;
@@ -59,6 +71,11 @@ oob_connection_client_setup(const char *server_ip, int *oob_sock_fd, uint16_t se
         return -1;
     }
     NIXL_INFO << "Socket created successfully";
+
+    if (setOobSocketTimeouts(oob_sock_fd_) != 0) {
+        close(oob_sock_fd_);
+        return -1;
+    }
 
     /* Set port and IP the same as server-side: */
     server_addr.sin_family = AF_INET;
@@ -384,10 +401,19 @@ threadProgressFunc(void *arg) {
             return nullptr;
         }
 
+        eng->activeOobSocket.store(oob_sock_client);
+
         if (ACCESS_ONCE(*eng->pthrStop) == 1) {
             NIXL_DEBUG << "Stopping thread " << oob_sock_client;
+            eng->activeOobSocket.store(-1);
             close(oob_sock_client);
             return nullptr;
+        }
+
+        if (setOobSocketTimeouts(oob_sock_client) != 0) {
+            eng->activeOobSocket.store(-1);
+            close(oob_sock_client);
+            continue;
         }
 
         NIXL_INFO << "Server: client connected at IP: " << inet_ntoa(client_addr.sin_addr)
@@ -412,6 +438,7 @@ threadProgressFunc(void *arg) {
         if (status != NIXL_SUCCESS) {
             NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
         }
+        eng->activeOobSocket.store(-1);
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -185,11 +185,15 @@ destroy_verbs_ah:
 }
 
 doca_error_t
-connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t remote_gid) {
+connect_verbs_qp(nixlDocaEngine *eng,
+                 doca_verbs_qp *qp,
+                 uint32_t rqpn,
+                 const doca_verbs_gid &remote_gid,
+                 uint32_t remote_lid) {
     doca_error_t status = DOCA_SUCCESS, tmp_status = DOCA_SUCCESS;
     doca_verbs_qp_attr *verbs_qp_attr = NULL;
 
-    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, eng->remote_gid);
+    status = doca_verbs_ah_attr_set_gid(eng->verbs_ah_attr, remote_gid);
     if (status != DOCA_SUCCESS) {
         NIXL_ERROR << "Failed to set remote gid " << doca_error_get_descr(status);
         return status;
@@ -197,7 +201,7 @@ connect_verbs_qp(nixlDocaEngine *eng, doca_verbs_qp *qp, uint32_t rqpn, uint32_t
 
     // IB
     if (eng->port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
-        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, eng->dlid);
+        status = doca_verbs_ah_attr_set_dlid(eng->verbs_ah_attr, remote_lid);
         if (status != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to set dlid";
             return status;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -428,7 +428,7 @@ netif_get_addr(const char *if_name,
                sa_family_t af,
                struct sockaddr *saddr,
                struct sockaddr *netmask) {
-    int status = 0;
+    int status = -1;
     struct ifaddrs *ifa;
     struct ifaddrs *ifaddrs;
     const struct sockaddr_in6 *saddr6;

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -386,6 +386,7 @@ threadProgressFunc(void *arg) {
 
         if (ACCESS_ONCE(*eng->pthrStop) == 1) {
             NIXL_DEBUG << "Stopping thread " << oob_sock_client;
+            close(oob_sock_client);
             return nullptr;
         }
 
@@ -394,11 +395,23 @@ threadProgressFunc(void *arg) {
 
         // cuCtxSetCurrent(eng->main_cuda_ctx);
 
-        eng->recvRemoteAgentName(oob_sock_client, remote_agent);
-
-        eng->addRdmaQp(remote_agent);
-        eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
-        eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        remote_agent.clear();
+        nixl_status_t status = eng->recvRemoteAgentName(oob_sock_client, remote_agent);
+        if (status == NIXL_SUCCESS) {
+            status = eng->addRdmaQp(remote_agent);
+        }
+        if (status == NIXL_IN_PROG) {
+            status = NIXL_SUCCESS;
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->nixlDocaInitNotif(remote_agent, eng->ddev, eng->gdevs[0].second);
+        }
+        if (status == NIXL_SUCCESS) {
+            status = eng->connectServerRdmaQp(oob_sock_client, remote_agent);
+        }
+        if (status != NIXL_SUCCESS) {
+            NIXL_ERROR << "Failed to set up GPUNETIO connection for " << remote_agent;
+        }
         close(oob_sock_client);
 
         /* Wait for predefined number of */

--- a/src/plugins/gpunetio/gpunetio_utils.cpp
+++ b/src/plugins/gpunetio/gpunetio_utils.cpp
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include "common/nixl_log.h"
 #include <chrono>
+#include <thread>
 
 // constexpr auto connection_delay = 500ms;
 constexpr std::chrono::microseconds connection_delay(500000);
@@ -394,11 +395,12 @@ threadProgressFunc(void *arg) {
         oob_sock_client =
             accept(eng->oob_sock_server, (struct sockaddr *)&client_addr, &client_size);
         if (oob_sock_client < 0) {
+            if (ACCESS_ONCE(*eng->pthrStop) != 0) {
+                return nullptr;
+            }
             NIXL_ERROR << "Can't accept new socket connection " << oob_sock_client;
-            if (ACCESS_ONCE(*eng->pthrStop) == 0)
-                NIXL_ERROR << "Can't accept new socket connection " << oob_sock_client;
-            // close(eng->oob_sock_server);
-            return nullptr;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            continue;
         }
 
         eng->activeOobSocket.store(oob_sock_client);

--- a/src/plugins/gpunetio/meson.build
+++ b/src/plugins/gpunetio/meson.build
@@ -18,11 +18,40 @@ plugin_gpunetio_deps = [dependency('libibverbs'), dependency('libmlx5'), depende
 # C++20 for CUDA is set project-wide in the root meson.build.
 compile_flags = ['-D DOCA_ALLOW_EXPERIMENTAL_API']
 
+native_device_args = []
+if not get_option('gpunetio_device_api').disabled()
+    profile = get_option('gpunetio_device_api_profile')
+    native_device_args = ['-DNIXL_ENABLE_GPUNETIO_DEVICE_API=1']
+    if profile == 'legacy-doca31'
+        if not doca_gpunetio_dep.version().startswith('3.1.')
+            error('SDK_CONTRACT_UNVERIFIED: legacy-doca31 requires DOCA 3.1 headers/libraries')
+        endif
+        native_device_args += ['-DNIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31=1']
+    else
+        native_device_args += ['-DNIXL_GPUNETIO_DEVICE_API_PUBLIC=1']
+    endif
+    if not nvcc.compiles('''
+        #include <gpu/impl/gpunetio/device_gpunetio.cuh>
+        using namespace nixl::gpu;
+        __global__ void probe(memViewElem a, memViewElem b, xferStatusH *s) {
+            impl::gpunetio::put<level_t::THREAD>(a, b, 4096, 0, 0, s);
+            impl::gpunetio::getXferStatus<level_t::THREAD>(*s);
+        }
+        int main() { return 0; }
+    ''', dependencies: plugin_gpunetio_deps,
+         args: native_device_args + nvcc_flags + ['-std=c++20',
+             '-I' + meson.project_source_root() / 'src/api/device',
+             '-I' + meson.project_source_root() / 'src/api/cpp'])
+        error('SDK_CONTRACT_UNVERIFIED: native PUT/status adapter failed CUDA compile probe')
+    endif
+    compile_flags += ['-DNIXL_GPUNETIO_DEVICE_API_HOST=1']
+endif
+
 if 'GPUNETIO' in static_plugins
     gpunetio_backend_lib = static_library('GPUNETIO',
-               'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
-               dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
-               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               'verbs/verbs.cpp', 'gpunetio_device_memview.cpp', 'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
+               dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep, device_allocator_interface],
+               include_directories: [nixl_inc_dirs, utils_inc_dirs, nixl_device_inc_dirs],
                install: true,
                cpp_args : compile_flags,
                cuda_args : ['-rdc=true'],
@@ -30,9 +59,9 @@ if 'GPUNETIO' in static_plugins
                install_dir: plugin_install_dir)  # Custom prefix for plugin libraries
 else
     gpunetio_backend_lib = shared_library('GPUNETIO',
-               'verbs/verbs.cpp', 'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
-               dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep],
-               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               'verbs/verbs.cpp', 'gpunetio_device_memview.cpp', 'gpunetio_backend.cpp', 'gpunetio_backend.h', 'gpunetio_backend_aux.h', 'gpunetio_plugin.cpp', 'gpunetio_utils.cpp', 'gpunetio_kernels.cu',
+               dependencies: [nixl_infra, serdes_interface, cuda_dep, plugin_gpunetio_deps, absl_log_dep, device_allocator_interface],
+               include_directories: [nixl_inc_dirs, utils_inc_dirs, nixl_device_inc_dirs],
                install: true,
                cpp_args : compile_flags + ['-fPIC'],
                name_prefix: 'libplugin_',  # Custom prefix for plugin libraries

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -68,6 +68,26 @@ mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
             (MLX5_CQE_INVALID << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT) | MLX5_CQE_OWNER_MASK;
 }
 
+class CqAttrGuard {
+public:
+    doca_verbs_cq_attr *value = nullptr;
+
+    ~CqAttrGuard() {
+        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
+    }
+};
+
+class QpAttrGuard {
+public:
+    doca_verbs_qp_init_attr *value = nullptr;
+
+    ~QpAttrGuard() {
+        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
+    }
+};
+
 namespace nixl::doca::verbs {
 
 cq::cq(doca_gpu *gpu_dev_,
@@ -91,27 +111,22 @@ doca_verbs_cq *
 cq::createCq() {
     doca_error_t status = DOCA_SUCCESS;
     cudaError_t status_cuda = cudaSuccess;
-    doca_verbs_cq_attr *verbs_cq_attr = nullptr;
+    CqAttrGuard verbs_cq_attr;
     doca_verbs_cq *new_cq = nullptr;
     struct mlx5_cqe64 *cq_ring_haddr = nullptr;
     uint32_t external_umem_size = 0;
     external_uar = nullptr;
 
-    status = doca_verbs_cq_attr_create(&verbs_cq_attr);
+    status = doca_verbs_cq_attr_create(&verbs_cq_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to create doca verbs cq attributes");
 
-    status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr, 1);
+    status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
-        doca_verbs_cq_attr_destroy(verbs_cq_attr);
         throw std::runtime_error("Failed to set doca verbs cq external datapath en");
     }
 
     external_umem_size = calc_cq_external_umem_size(ncqe);
-    if (status != DOCA_SUCCESS) {
-        doca_verbs_cq_attr_destroy(verbs_cq_attr);
-        throw std::runtime_error("Failed to calc external umem size");
-    }
 
     status = doca_gpu_mem_alloc(gpu_dev,
                                 external_umem_size,
@@ -136,6 +151,8 @@ cq::createCq() {
     status_cuda =
         cudaMemcpy(cq_umem_gpu_ptr, (void *)(cq_ring_haddr), external_umem_size, cudaMemcpyDefault);
     if (status_cuda != cudaSuccess) {
+        free(cq_ring_haddr);
+        cq_ring_haddr = nullptr;
         destroyCq();
         throw std::runtime_error("Failed to cudaMempy gpu cq cq ring buffer");
     }
@@ -155,19 +172,19 @@ cq::createCq() {
         throw std::runtime_error("Failed to create gpu umem");
     }
 
-    status = doca_verbs_cq_attr_set_external_umem(verbs_cq_attr, cq_umem, 0);
+    status = doca_verbs_cq_attr_set_external_umem(verbs_cq_attr.value, cq_umem, 0);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq external umem");
     }
 
-    status = doca_verbs_cq_attr_set_cq_size(verbs_cq_attr, ncqe);
+    status = doca_verbs_cq_attr_set_cq_size(verbs_cq_attr.value, ncqe);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq size");
     }
 
-    status = doca_verbs_cq_attr_set_cq_overrun(verbs_cq_attr, 1);
+    status = doca_verbs_cq_attr_set_cq_overrun(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq size");
@@ -179,23 +196,25 @@ cq::createCq() {
         throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
     }
 
-    status = doca_verbs_cq_attr_set_external_uar(verbs_cq_attr, external_uar);
+    status = doca_verbs_cq_attr_set_external_uar(verbs_cq_attr.value, external_uar);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to set doca verbs cq external uar");
     }
 
-    status = doca_verbs_cq_create(verbs_ctx, verbs_cq_attr, &new_cq);
+    status = doca_verbs_cq_create(verbs_ctx, verbs_cq_attr.value, &new_cq);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to create doca verbs cq");
     }
+    cq_verbs = new_cq;
 
-    status = doca_verbs_cq_attr_destroy(verbs_cq_attr);
+    status = doca_verbs_cq_attr_destroy(verbs_cq_attr.value);
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to destroy doca verbs cq attributes");
     }
+    verbs_cq_attr.value = nullptr;
 
     return new_cq;
 }
@@ -204,32 +223,40 @@ void
 cq::destroyCq() {
     doca_error_t status;
 
-    status = doca_verbs_cq_destroy(cq_verbs);
-    if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+    if (cq_verbs != nullptr) {
+        status = doca_verbs_cq_destroy(cq_verbs);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        cq_verbs = nullptr;
+    }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        external_uar = nullptr;
     }
 
     if (cq_umem != nullptr) {
         status = doca_umem_destroy(cq_umem);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        cq_umem = nullptr;
     }
 
-    if (cq_umem_gpu_ptr != 0) {
+    if (cq_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        cq_umem_gpu_ptr = nullptr;
     }
 
     if (cq_umem_dbr != nullptr) {
         status = doca_umem_destroy(cq_umem_dbr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        cq_umem_dbr = nullptr;
     }
 
-    if (cq_umem_dbr_gpu_ptr != 0) {
+    if (cq_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_dbr_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        cq_umem_dbr_gpu_ptr = nullptr;
     }
 }
 
@@ -249,30 +276,43 @@ qp::qp(doca_gpu *gpu_dev_,
       nic_handler(nic_handler_) {
     doca_error_t status;
 
-    cq_rq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, rq_nwqe);
-    cq_sq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, sq_nwqe);
-    qp_verbs = createQp();
+    try {
+        cq_rq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, rq_nwqe);
+        cq_sq = std::make_unique<nixl::doca::verbs::cq>(gpu_dev, dev, verbs_ctx, verbs_pd, sq_nwqe);
+        qp_verbs = createQp();
 
-    status = doca_gpu_verbs_export_qp(gpu_dev,
-                                      dev,
-                                      qp_verbs,
-                                      nic_handler,
-                                      qp_umem_gpu_ptr,
-                                      cq_sq->get_cq(),
-                                      cq_rq->get_cq(),
-                                      &qp_gverbs);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        status = doca_gpu_verbs_export_qp(gpu_dev,
+                                          dev,
+                                          qp_verbs,
+                                          nic_handler,
+                                          qp_umem_gpu_ptr,
+                                          cq_sq->get_cq(),
+                                          cq_rq->get_cq(),
+                                          &qp_gverbs);
+        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
 
-    status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
+        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+    }
+    catch (...) {
+        if (qp_gverbs != nullptr) {
+            doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            qp_gverbs = nullptr;
+        }
+        destroyQp();
+        throw;
+    }
 }
 
 qp::~qp() {
     doca_error_t status;
 
-    status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
-    if (status != DOCA_SUCCESS)
-        NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+    if (qp_gverbs != nullptr) {
+        status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+        if (status != DOCA_SUCCESS)
+            NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+        qp_gverbs = nullptr;
+    }
 
     destroyQp();
 }
@@ -280,23 +320,23 @@ qp::~qp() {
 doca_verbs_qp *
 qp::createQp() {
     doca_error_t status = DOCA_SUCCESS;
-    doca_verbs_qp_init_attr *verbs_qp_init_attr = nullptr;
+    QpAttrGuard verbs_qp_init_attr;
     doca_verbs_qp *new_qp = nullptr;
     uint32_t external_umem_size = 0;
     size_t dbr_umem_align_sz = ROUND_UP(VERBS_TEST_DBR_SIZE, get_page_size());
 
-    status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr);
+    status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to create doca verbs qp attributes");
 
-    status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr, 1);
+    status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr.value, 1);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs external datapath en");
 
     status = doca_uar_create(dev, DOCA_UAR_ALLOCATION_TYPE_NONCACHE_DEDICATED, &external_uar);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
 
-    status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr, external_uar);
+    status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr.value, external_uar);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set external_uar");
 
     external_umem_size = calc_qp_external_umem_size(rq_nwqe, sq_nwqe);
@@ -319,7 +359,7 @@ qp::createQp() {
                                   &qp_umem);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
 
-    status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr, qp_umem, 0);
+    status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr.value, qp_umem, 0);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs qp external umem");
 
@@ -341,71 +381,86 @@ qp::createQp() {
                                   &qp_umem_dbr);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
 
-    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr, qp_umem_dbr, 0);
+    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
 
-    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr, verbs_pd);
+    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs PD");
 
-    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr, sq_nwqe);
+    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set SQ size");
 
-    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr, rq_nwqe);
+    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set RQ size");
 
-    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr, DOCA_VERBS_QP_TYPE_RC);
+    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set QP type");
 
-    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr, cq_sq->get_cq());
+    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
 
     status =
-        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr, VERBS_TEST_MAX_SEND_SEGS);
+        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value, VERBS_TEST_MAX_SEND_SEGS);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set send_max_sges");
 
-    status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr,
+    status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr.value,
                                                           VERBS_TEST_MAX_RECEIVE_SEGS);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set receive_max_sges");
 
-    status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr, cq_rq->get_cq());
+    status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr.value, cq_rq->get_cq());
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
 
-    status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr, &new_qp);
+    status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr.value, &new_qp);
     if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create doca verbs QP");
+    qp_verbs = new_qp;
 
-    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr);
+    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
     if (status != DOCA_SUCCESS)
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
+    verbs_qp_init_attr.value = nullptr;
 
-    return new_qp;
+    return qp_verbs;
 }
 
 void
 qp::destroyQp() {
     doca_error_t status;
 
-    status = doca_verbs_qp_destroy(qp_verbs);
-    if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+    if (qp_verbs != nullptr) {
+        status = doca_verbs_qp_destroy(qp_verbs);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+        qp_verbs = nullptr;
+    }
+
+    if (external_uar != nullptr) {
+        status = doca_uar_destroy(external_uar);
+        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        external_uar = nullptr;
+    }
 
     if (qp_umem != nullptr) {
         status = doca_umem_destroy(qp_umem);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem";
+        qp_umem = nullptr;
     }
 
-    if (qp_umem_gpu_ptr != 0) {
+    if (qp_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        qp_umem_gpu_ptr = nullptr;
     }
 
     if (qp_umem_dbr != nullptr) {
         status = doca_umem_destroy(qp_umem_dbr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        qp_umem_dbr = nullptr;
     }
 
-    if (qp_umem_dbr_gpu_ptr != 0) {
+    if (qp_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_dbr_gpu_ptr);
         if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        qp_umem_dbr_gpu_ptr = nullptr;
     }
 }
 
@@ -476,8 +531,10 @@ mr::mr(void *addr_, size_t tot_size_, uint32_t rkey_)
 }
 
 mr::~mr() {
-    int ret = ibv_dereg_mr(ibmr);
-    if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+    if (ibmr != nullptr) {
+        int ret = ibv_dereg_mr(ibmr);
+        if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+    }
 }
 
 } // namespace nixl::doca::verbs

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,14 +29,18 @@
 static uint32_t
 align_up_uint32(uint32_t value, uint32_t alignment) {
     uint64_t remainder = (value % alignment);
-    if (remainder == 0) return value;
+    if (remainder == 0) {
+        return value;
+    }
     return (uint32_t)(value + (alignment - remainder));
 }
 
 static size_t
 get_page_size(void) {
     long ret = sysconf(_SC_PAGESIZE);
-    if (ret == -1) return 4096; // 4KB, default Linux page size
+    if (ret == -1) {
+        return 4096; // 4KB, default Linux page size
+    }
 
     return (size_t)ret;
 }
@@ -46,8 +50,12 @@ calc_qp_external_umem_size(uint32_t rq_nwqes, uint32_t sq_nwqes) {
     uint32_t rq_ring_size = 0;
     uint32_t sq_ring_size = 0;
 
-    if (rq_nwqes != 0) rq_ring_size = (uint32_t)(rq_nwqes * sizeof(struct mlx5_wqe_data_seg));
-    if (sq_nwqes != 0) sq_ring_size = (uint32_t)(sq_nwqes * sizeof(doca_gpu_dev_verbs_wqe));
+    if (rq_nwqes != 0) {
+        rq_ring_size = (uint32_t)(rq_nwqes * sizeof(struct mlx5_wqe_data_seg));
+    }
+    if (sq_nwqes != 0) {
+        sq_ring_size = (uint32_t)(sq_nwqes * sizeof(doca_gpu_dev_verbs_wqe));
+    }
 
     return align_up_uint32(rq_ring_size + sq_ring_size, get_page_size());
 }
@@ -56,16 +64,19 @@ static uint32_t
 calc_cq_external_umem_size(uint32_t queue_size) {
     uint32_t cqe_buf_size = 0;
 
-    if (queue_size != 0) cqe_buf_size = (uint32_t)(queue_size * sizeof(struct mlx5_cqe64));
+    if (queue_size != 0) {
+        cqe_buf_size = (uint32_t)(queue_size * sizeof(struct mlx5_cqe64));
+    }
 
     return align_up_uint32(cqe_buf_size + VERBS_TEST_DBR_SIZE, get_page_size());
 }
 
 static void
 mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
-    for (uint32_t cqe_idx = 0; cqe_idx < nb_cqes; cqe_idx++)
+    for (uint32_t cqe_idx = 0; cqe_idx < nb_cqes; cqe_idx++) {
         cqes[cqe_idx].op_own =
             (MLX5_CQE_INVALID << DOCA_GPUNETIO_VERBS_MLX5_CQE_OPCODE_SHIFT) | MLX5_CQE_OWNER_MASK;
+    }
 }
 
 class CqAttrGuard {
@@ -73,8 +84,9 @@ public:
     doca_verbs_cq_attr *value = nullptr;
 
     ~CqAttrGuard() {
-        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS)
+        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
+        }
     }
 };
 
@@ -83,8 +95,9 @@ public:
     doca_verbs_qp_init_attr *value = nullptr;
 
     ~QpAttrGuard() {
-        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS)
+        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
+        }
     }
 };
 
@@ -118,8 +131,9 @@ cq::createCq() {
     external_uar = nullptr;
 
     status = doca_verbs_cq_attr_create(&verbs_cq_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to create doca verbs cq attributes");
+    }
 
     status = doca_verbs_cq_attr_set_external_datapath_en(verbs_cq_attr.value, 1);
     if (status != DOCA_SUCCESS) {
@@ -225,37 +239,49 @@ cq::destroyCq() {
 
     if (cq_verbs != nullptr) {
         status = doca_verbs_cq_destroy(cq_verbs);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy doca verbs CQ";
+        }
         cq_verbs = nullptr;
     }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu external_uar";
+        }
         external_uar = nullptr;
     }
 
     if (cq_umem != nullptr) {
         status = doca_umem_destroy(cq_umem);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem";
+        }
         cq_umem = nullptr;
     }
 
     if (cq_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of cq_umem_gpu_ptr";
+        }
         cq_umem_gpu_ptr = nullptr;
     }
 
     if (cq_umem_dbr != nullptr) {
         status = doca_umem_destroy(cq_umem_dbr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr";
+        }
         cq_umem_dbr = nullptr;
     }
 
     if (cq_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, cq_umem_dbr_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu cq_umem_dbr_gpu_ptr";
+        }
         cq_umem_dbr_gpu_ptr = nullptr;
     }
 }
@@ -289,10 +315,14 @@ qp::qp(doca_gpu *gpu_dev_,
                                           cq_sq->get_cq(),
                                           cq_rq->get_cq(),
                                           &qp_gverbs);
-        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        if (status != DOCA_SUCCESS) {
+            throw std::runtime_error("Failed to create GPU verbs QP");
+        }
 
         status = doca_gpu_verbs_get_qp_dev(qp_gverbs, &qp_gdev_verbs);
-        if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create GPU verbs QP");
+        if (status != DOCA_SUCCESS) {
+            throw std::runtime_error("Failed to create GPU verbs QP");
+        }
     }
     catch (...) {
         if (qp_gverbs != nullptr) {
@@ -309,8 +339,9 @@ qp::~qp() {
 
     if (qp_gverbs != nullptr) {
         status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
-        if (status != DOCA_SUCCESS)
+        if (status != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+        }
         qp_gverbs = nullptr;
     }
 
@@ -326,18 +357,24 @@ qp::createQp() {
     size_t dbr_umem_align_sz = ROUND_UP(VERBS_TEST_DBR_SIZE, get_page_size());
 
     status = doca_verbs_qp_init_attr_create(&verbs_qp_init_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to create doca verbs qp attributes");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_datapath_en(verbs_qp_init_attr.value, 1);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to set doca verbs external datapath en");
+    }
 
     status = doca_uar_create(dev, DOCA_UAR_ALLOCATION_TYPE_NONCACHE_DEDICATED, &external_uar);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to doca_uar_create NC DEDICATED");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_uar(verbs_qp_init_attr.value, external_uar);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set external_uar");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set external_uar");
+    }
 
     external_umem_size = calc_qp_external_umem_size(rq_nwqe, sq_nwqe);
 
@@ -347,8 +384,9 @@ qp::createQp() {
                                 DOCA_GPU_MEM_TYPE_GPU,
                                 (void **)&qp_umem_gpu_ptr,
                                 nullptr);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to alloc gpu memory for external umem qp");
+    }
 
     status = doca_umem_gpu_create(gpu_dev,
                                   dev,
@@ -357,11 +395,14 @@ qp::createQp() {
                                   DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
                                       DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
                                   &qp_umem);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create gpu umem");
+    }
 
     status = doca_verbs_qp_init_attr_set_external_umem(verbs_qp_init_attr.value, qp_umem, 0);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to set doca verbs qp external umem");
+    }
 
     status = doca_gpu_mem_alloc(gpu_dev,
                                 dbr_umem_align_sz,
@@ -369,8 +410,9 @@ qp::createQp() {
                                 DOCA_GPU_MEM_TYPE_GPU,
                                 (void **)&qp_umem_dbr_gpu_ptr,
                                 nullptr);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to alloc gpu memory for external umem qp");
+    }
 
     status = doca_umem_gpu_create(gpu_dev,
                                   dev,
@@ -379,45 +421,68 @@ qp::createQp() {
                                   DOCA_ACCESS_FLAG_LOCAL_READ_WRITE | DOCA_ACCESS_FLAG_RDMA_WRITE |
                                       DOCA_ACCESS_FLAG_RDMA_READ | DOCA_ACCESS_FLAG_RDMA_ATOMIC,
                                   &qp_umem_dbr);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create gpu umem");
-
-    status = doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
-    if (status != DOCA_SUCCESS)
-        throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
-
-    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs PD");
-
-    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set SQ size");
-
-    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set RQ size");
-
-    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set QP type");
-
-    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create gpu umem");
+    }
 
     status =
-        doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value, VERBS_TEST_MAX_SEND_SEGS);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set send_max_sges");
+        doca_verbs_qp_init_attr_set_external_dbr_umem(verbs_qp_init_attr.value, qp_umem_dbr, 0);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs qp external dbr umem");
+    }
+
+    status = doca_verbs_qp_init_attr_set_pd(verbs_qp_init_attr.value, verbs_pd);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs PD");
+    }
+
+    status = doca_verbs_qp_init_attr_set_sq_wr(verbs_qp_init_attr.value, sq_nwqe);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set SQ size");
+    }
+
+    status = doca_verbs_qp_init_attr_set_rq_wr(verbs_qp_init_attr.value, rq_nwqe);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set RQ size");
+    }
+
+    status = doca_verbs_qp_init_attr_set_qp_type(verbs_qp_init_attr.value, DOCA_VERBS_QP_TYPE_RC);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set QP type");
+    }
+
+    status = doca_verbs_qp_init_attr_set_send_cq(verbs_qp_init_attr.value, cq_sq->get_cq());
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs CQ");
+    }
+
+    status = doca_verbs_qp_init_attr_set_send_max_sges(verbs_qp_init_attr.value,
+                                                       VERBS_TEST_MAX_SEND_SEGS);
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set send_max_sges");
+    }
 
     status = doca_verbs_qp_init_attr_set_receive_max_sges(verbs_qp_init_attr.value,
                                                           VERBS_TEST_MAX_RECEIVE_SEGS);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set receive_max_sges");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set receive_max_sges");
+    }
 
     status = doca_verbs_qp_init_attr_set_receive_cq(verbs_qp_init_attr.value, cq_rq->get_cq());
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to set doca verbs CQ");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to set doca verbs CQ");
+    }
 
     status = doca_verbs_qp_create(verbs_ctx, verbs_qp_init_attr.value, &new_qp);
-    if (status != DOCA_SUCCESS) throw std::runtime_error("Failed to create doca verbs QP");
+    if (status != DOCA_SUCCESS) {
+        throw std::runtime_error("Failed to create doca verbs QP");
+    }
     qp_verbs = new_qp;
 
     status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
-    if (status != DOCA_SUCCESS)
+    if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
+    }
     verbs_qp_init_attr.value = nullptr;
 
     return qp_verbs;
@@ -429,37 +494,49 @@ qp::destroyQp() {
 
     if (qp_verbs != nullptr) {
         status = doca_verbs_qp_destroy(qp_verbs);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy doca verbs QP";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy doca verbs QP";
+        }
         qp_verbs = nullptr;
     }
 
     if (external_uar != nullptr) {
         status = doca_uar_destroy(external_uar);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu external_uar";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu external_uar";
+        }
         external_uar = nullptr;
     }
 
     if (qp_umem != nullptr) {
         status = doca_umem_destroy(qp_umem);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu qp umem";
+        }
         qp_umem = nullptr;
     }
 
     if (qp_umem_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of qp ring buffer";
+        }
         qp_umem_gpu_ptr = nullptr;
     }
 
     if (qp_umem_dbr != nullptr) {
         status = doca_umem_destroy(qp_umem_dbr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu qp umem dbr";
+        }
         qp_umem_dbr = nullptr;
     }
 
     if (qp_umem_dbr_gpu_ptr != nullptr) {
         status = doca_gpu_mem_free(gpu_dev, qp_umem_dbr_gpu_ptr);
-        if (status != DOCA_SUCCESS) NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        if (status != DOCA_SUCCESS) {
+            NIXL_ERROR << "Failed to destroy gpu memory of qp dbr";
+        }
         qp_umem_dbr_gpu_ptr = nullptr;
     }
 }
@@ -470,8 +547,9 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
       elem_num(elem_num_),
       elem_size(elem_size_),
       pd(pd_) {
-    if (gpu_dev == nullptr || addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr)
+    if (gpu_dev == nullptr || addr == nullptr || elem_num == 0 || elem_size == 0 || pd == nullptr) {
         throw std::invalid_argument("Invalid mr input values");
+    }
 
     doca_error_t status;
     static size_t host_page_size = sysconf(_SC_PAGESIZE);
@@ -515,7 +593,9 @@ mr::mr(doca_gpu *gpu_dev_, void *addr_, uint32_t elem_num_, size_t elem_size_, s
                           tot_size,
                           IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
                               IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC);
-        if (ibmr == nullptr) throw std::invalid_argument("Failed to create mr");
+        if (ibmr == nullptr) {
+            throw std::invalid_argument("Failed to create mr");
+        }
     }
 
     lkey = htobe32(ibmr->lkey);
@@ -533,7 +613,9 @@ mr::mr(void *addr_, size_t tot_size_, uint32_t rkey_)
 mr::~mr() {
     if (ibmr != nullptr) {
         int ret = ibv_dereg_mr(ibmr);
-        if (ret != 0) NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+        if (ret != 0) {
+            NIXL_ERROR << "ibv_dereg_mr failed with error " << ret;
+        }
     }
 }
 

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -347,17 +347,29 @@ qp::qp(doca_gpu *gpu_dev_,
 }
 
 qp::~qp() {
-    doca_error_t status;
+    if (!close()) {
+        // Keep CQ dependencies alive when DOCA still owns the exported QP.
+        cq_rq.release();
+        cq_sq.release();
+    }
+}
 
+bool
+qp::close() noexcept {
     if (qp_gverbs != nullptr) {
-        status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+        const doca_error_t status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
         if (status != DOCA_SUCCESS) {
-            NIXL_ERROR << "Failed to destroy doca gpu thread argument cq memory";
+            NIXL_ERROR << "Failed to unexport DOCA GPU verbs QP";
+            return false;
         }
         qp_gverbs = nullptr;
+        qp_gdev_verbs = nullptr;
     }
 
     destroyQp();
+    cq_rq.reset();
+    cq_sq.reset();
+    return true;
 }
 
 doca_verbs_qp *

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -79,8 +79,15 @@ mlx5_init_cqes(struct mlx5_cqe64 *cqes, uint32_t nb_cqes) {
     }
 }
 
+namespace {
+
 class CqAttrGuard {
 public:
+    CqAttrGuard() = default;
+    CqAttrGuard(const CqAttrGuard &) = delete;
+    CqAttrGuard &
+    operator=(const CqAttrGuard &) = delete;
+
     doca_verbs_cq_attr *value = nullptr;
 
     doca_error_t
@@ -99,6 +106,11 @@ public:
 
 class QpAttrGuard {
 public:
+    QpAttrGuard() = default;
+    QpAttrGuard(const QpAttrGuard &) = delete;
+    QpAttrGuard &
+    operator=(const QpAttrGuard &) = delete;
+
     doca_verbs_qp_init_attr *value = nullptr;
 
     doca_error_t
@@ -114,6 +126,8 @@ public:
         }
     }
 };
+
+} // namespace
 
 namespace nixl::doca::verbs {
 
@@ -338,8 +352,16 @@ qp::qp(doca_gpu *gpu_dev_,
     }
     catch (...) {
         if (qp_gverbs != nullptr) {
-            doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            const doca_error_t unexport_status = doca_gpu_verbs_unexport_qp(gpu_dev, qp_gverbs);
+            if (unexport_status != DOCA_SUCCESS) {
+                NIXL_ERROR << "Failed to unexport DOCA GPU verbs QP during rollback; retaining "
+                              "dependent resources";
+                cq_rq.release();
+                cq_sq.release();
+                throw;
+            }
             qp_gverbs = nullptr;
+            qp_gdev_verbs = nullptr;
         }
         destroyQp();
         throw;

--- a/src/plugins/gpunetio/verbs/verbs.cpp
+++ b/src/plugins/gpunetio/verbs/verbs.cpp
@@ -83,8 +83,15 @@ class CqAttrGuard {
 public:
     doca_verbs_cq_attr *value = nullptr;
 
+    doca_error_t
+    destroy() noexcept {
+        auto *attr = value;
+        value = nullptr;
+        return attr == nullptr ? DOCA_SUCCESS : doca_verbs_cq_attr_destroy(attr);
+    }
+
     ~CqAttrGuard() {
-        if (value != nullptr && doca_verbs_cq_attr_destroy(value) != DOCA_SUCCESS) {
+        if (destroy() != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs cq attributes";
         }
     }
@@ -94,8 +101,15 @@ class QpAttrGuard {
 public:
     doca_verbs_qp_init_attr *value = nullptr;
 
+    doca_error_t
+    destroy() noexcept {
+        auto *attr = value;
+        value = nullptr;
+        return attr == nullptr ? DOCA_SUCCESS : doca_verbs_qp_init_attr_destroy(attr);
+    }
+
     ~QpAttrGuard() {
-        if (value != nullptr && doca_verbs_qp_init_attr_destroy(value) != DOCA_SUCCESS) {
+        if (destroy() != DOCA_SUCCESS) {
             NIXL_ERROR << "Failed to destroy doca verbs qp attributes";
         }
     }
@@ -223,13 +237,11 @@ cq::createCq() {
     }
     cq_verbs = new_cq;
 
-    status = doca_verbs_cq_attr_destroy(verbs_cq_attr.value);
+    status = verbs_cq_attr.destroy();
     if (status != DOCA_SUCCESS) {
         destroyCq();
         throw std::runtime_error("Failed to destroy doca verbs cq attributes");
     }
-    verbs_cq_attr.value = nullptr;
-
     return new_cq;
 }
 
@@ -479,12 +491,10 @@ qp::createQp() {
     }
     qp_verbs = new_qp;
 
-    status = doca_verbs_qp_init_attr_destroy(verbs_qp_init_attr.value);
+    status = verbs_qp_init_attr.destroy();
     if (status != DOCA_SUCCESS) {
         throw std::runtime_error("Failed to destroy doca verbs QP attributes");
     }
-    verbs_qp_init_attr.value = nullptr;
-
     return qp_verbs;
 }
 

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -94,6 +94,13 @@ public:
 
     ~qp();
 
+    /**
+     * @brief Unexport the GPU QP and release its backing resources.
+     * @return true when teardown completed; false when the exported QP must remain alive.
+     */
+    bool
+    close() noexcept;
+
     [[nodiscard]] doca_verbs_qp *
     get_qp() const {
         return qp_verbs;

--- a/src/plugins/gpunetio/verbs/verbs.h
+++ b/src/plugins/gpunetio/verbs/verbs.h
@@ -72,14 +72,14 @@ private:
     doca_dev *dev;
     doca_verbs_context *verbs_ctx;
     doca_verbs_pd *verbs_pd;
-    doca_uar *external_uar;
+    doca_uar *external_uar = nullptr;
     uint16_t ncqe;
 
-    doca_verbs_cq *cq_verbs;
-    void *cq_umem_gpu_ptr;
-    doca_umem *cq_umem;
-    void *cq_umem_dbr_gpu_ptr;
-    doca_umem *cq_umem_dbr;
+    doca_verbs_cq *cq_verbs = nullptr;
+    void *cq_umem_gpu_ptr = nullptr;
+    doca_umem *cq_umem = nullptr;
+    void *cq_umem_dbr_gpu_ptr = nullptr;
+    doca_umem *cq_umem_dbr = nullptr;
 };
 
 class qp {
@@ -124,14 +124,14 @@ private:
     uint16_t rq_nwqe;
     doca_gpu_dev_verbs_nic_handler nic_handler;
 
-    doca_verbs_qp *qp_verbs;
-    void *qp_umem_gpu_ptr;
-    doca_umem *qp_umem;
-    void *qp_umem_dbr_gpu_ptr;
-    doca_umem *qp_umem_dbr;
-    doca_uar *external_uar;
-    doca_gpu_verbs_qp *qp_gverbs;
-    doca_gpu_dev_verbs_qp *qp_gdev_verbs;
+    doca_verbs_qp *qp_verbs = nullptr;
+    void *qp_umem_gpu_ptr = nullptr;
+    doca_umem *qp_umem = nullptr;
+    void *qp_umem_dbr_gpu_ptr = nullptr;
+    doca_umem *qp_umem_dbr = nullptr;
+    doca_uar *external_uar = nullptr;
+    doca_gpu_verbs_qp *qp_gverbs = nullptr;
+    doca_gpu_dev_verbs_qp *qp_gdev_verbs = nullptr;
 
     std::unique_ptr<nixl::doca::verbs::cq> cq_rq;
     std::unique_ptr<nixl::doca::verbs::cq> cq_sq;

--- a/src/plugins/ucx/ucx_backend.h
+++ b/src/plugins/ucx/ucx_backend.h
@@ -107,6 +107,15 @@ public:
         return true;
     }
 
+    nixl_device_exec_mode_t
+    getDeviceExecMode() const noexcept override {
+#ifdef HAVE_UCX_GPU_DEVICE_API
+        return nixl_device_exec_mode_t::UCX_DIRECT;
+#else
+        return nixl_device_exec_mode_t::NONE;
+#endif
+    }
+
     nixl_mem_list_t
     getSupportedMems() const override;
 

--- a/src/utils/device/device_allocator.cpp
+++ b/src/utils/device/device_allocator.cpp
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "device/device_allocator.h"
+
+#include <dlfcn.h>
+
+#include <filesystem>
+
+namespace {
+
+constexpr const char *kCudaAllocatorLibrary = "libnixl_device_allocator_cuda.so";
+constexpr const char *kCudaAllocatorFactory = "nixlCreateCudaDeviceAllocatorV1";
+
+class nixlUnsupportedDeviceAllocator final : public nixlDeviceAllocator {
+public:
+    nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t) noexcept override {
+        if (ptr != nullptr) {
+            *ptr = nullptr;
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    void
+    doFreeDeviceMem(void *) noexcept override {}
+
+    nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t) noexcept override {
+        if (host_ptr != nullptr) {
+            *host_ptr = nullptr;
+        }
+        if (dev_ptr != nullptr) {
+            *dev_ptr = nullptr;
+        }
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    void
+    doFreeMappedHostMem(void *) noexcept override {}
+
+    nixl_status_t
+    copyHostToDevice(void *, const void *, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    copyDeviceToHost(void *, const void *, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    memsetDeviceMem(void *, int, size_t) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    synchronize() noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    getActiveDevice(int &) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    nixl_status_t
+    setActiveDevice(int) noexcept override {
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+};
+
+using CudaAllocatorFactory = nixlDeviceAllocator *(*)() noexcept;
+
+nixlDeviceAllocator *
+loadCudaAllocator() noexcept {
+    Dl_info info{};
+    if (dladdr(reinterpret_cast<void *>(&nixlGetDeviceAllocator), &info) == 0 ||
+        info.dli_fname == nullptr) {
+        return nullptr;
+    }
+
+    // The frontend and optional CUDA implementation are installed side by side.
+    const auto library_path =
+        std::filesystem::path(info.dli_fname).parent_path() / kCudaAllocatorLibrary;
+    void *handle = dlopen(library_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+    if (handle == nullptr) {
+        return nullptr;
+    }
+
+    auto factory = reinterpret_cast<CudaAllocatorFactory>(dlsym(handle, kCudaAllocatorFactory));
+    if (factory == nullptr) {
+        dlclose(handle);
+        return nullptr;
+    }
+
+    nixlDeviceAllocator *allocator = factory();
+    if (allocator == nullptr) {
+        dlclose(handle);
+    }
+    // Keep the library loaded on success because the allocator and its vtable live in it.
+    return allocator;
+}
+
+} // namespace
+
+nixlDeviceAllocator &
+nixlGetDeviceAllocator() noexcept {
+    static nixlUnsupportedDeviceAllocator unsupported;
+    static nixlDeviceAllocator *allocator = []() noexcept {
+        nixlDeviceAllocator *cuda_allocator = loadCudaAllocator();
+        return cuda_allocator == nullptr ? &unsupported : cuda_allocator;
+    }();
+    return *allocator;
+}

--- a/src/utils/device/device_allocator.h
+++ b/src/utils/device/device_allocator.h
@@ -1,0 +1,315 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H
+#define NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H
+
+#include <cstddef>
+#include <utility>
+
+#include <nixl_types.h>
+
+class nixlDeviceMem;
+class nixlMappedHostMem;
+
+/**
+ * Device memory-ops interface. All host-side interaction with the GPU memory
+ * runtime goes through this class so that no other host code needs a
+ * cuda_runtime.h include. CUDA is the current platform implementation; HIP
+ * can provide another. Allocations are returned as owning RAII handles, while
+ * raw alloc/free remain protected implementation hooks. The class is not
+ * internally synchronized. Transfers are issued on the default stream and are
+ * ordered there, but not all are complete on return; synchronize() is the
+ * barrier. Active device state is thread-local: copies, memset, and
+ * synchronize use the caller's current device; freeing works from any.
+ */
+class nixlDeviceAllocator {
+public:
+    virtual ~nixlDeviceAllocator() = default;
+
+    [[nodiscard]] nixl_status_t
+    allocDeviceMem(size_t size, nixlDeviceMem &out) noexcept;
+
+    /**
+     * Allocate pinned host memory that is mapped into the device address
+     * space; the handle exposes both the host pointer and its
+     * device-visible alias.
+     */
+    [[nodiscard]] nixl_status_t
+    allocMappedHostMem(size_t size, nixlMappedHostMem &out) noexcept;
+
+    /**
+     * Free device memory. Used for pointers whose ownership left RAII scope
+     * via nixlDeviceMem::release() (for example, nixlMemViewH handles crossing
+     * the public API boundary). The pointer must be one allocDeviceMem
+     * produced; it is not validated. Prefer the RAII handles everywhere else.
+     */
+    void
+    freeDeviceMem(void *ptr) noexcept {
+        doFreeDeviceMem(ptr);
+    }
+
+    /** src is reusable on return; the device-side write may still be pending. */
+    [[nodiscard]] virtual nixl_status_t
+    copyHostToDevice(void *dst, const void *src, size_t size) noexcept = 0;
+
+    /** Blocking: dst holds the data on return. */
+    [[nodiscard]] virtual nixl_status_t
+    copyDeviceToHost(void *dst, const void *src, size_t size) noexcept = 0;
+
+    /** Enqueued, not complete on return; ordered against later default-stream work. */
+    [[nodiscard]] virtual nixl_status_t
+    memsetDeviceMem(void *ptr, int value, size_t size) noexcept = 0;
+
+    /** Block until all outstanding work on the active device completes. */
+    [[nodiscard]] virtual nixl_status_t
+    synchronize() noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    getActiveDevice(int &device_id) noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    setActiveDevice(int device_id) noexcept = 0;
+
+protected:
+    [[nodiscard]] virtual nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t size) noexcept = 0;
+
+    virtual void
+    doFreeDeviceMem(void *ptr) noexcept = 0;
+
+    [[nodiscard]] virtual nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t size) noexcept = 0;
+
+    virtual void
+    doFreeMappedHostMem(void *host_ptr) noexcept = 0;
+
+private:
+    friend class nixlDeviceMem;
+    friend class nixlMappedHostMem;
+};
+
+/**
+ * Owning, move-only handle to device (HBM) memory. The handle stores only the
+ * allocator, the pointer, and the size; the owning device is recovered by
+ * the platform free, so the destroying thread may be on any device.
+ */
+class nixlDeviceMem {
+public:
+    nixlDeviceMem() = default;
+
+    ~nixlDeviceMem() {
+        reset();
+    }
+
+    nixlDeviceMem(nixlDeviceMem &&other) noexcept {
+        *this = std::move(other);
+    }
+
+    nixlDeviceMem &
+    operator=(nixlDeviceMem &&other) noexcept {
+        if (this != &other) {
+            reset();
+            allocator_ = std::exchange(other.allocator_, nullptr);
+            ptr_ = std::exchange(other.ptr_, nullptr);
+            size_ = std::exchange(other.size_, 0);
+        }
+        return *this;
+    }
+
+    nixlDeviceMem(const nixlDeviceMem &) = delete;
+    nixlDeviceMem &
+    operator=(const nixlDeviceMem &) = delete;
+
+    [[nodiscard]] void *
+    get() const noexcept {
+        return ptr_;
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    as() const noexcept {
+        return static_cast<T *>(ptr_);
+    }
+
+    [[nodiscard]] size_t
+    size() const noexcept {
+        return size_;
+    }
+
+    explicit
+    operator bool() const noexcept {
+        return ptr_ != nullptr;
+    }
+
+    void
+    reset() noexcept {
+        if (ptr_ == nullptr) {
+            return;
+        }
+        allocator_->doFreeDeviceMem(ptr_);
+        allocator_ = nullptr;
+        ptr_ = nullptr;
+        size_ = 0;
+    }
+
+    /** Give up ownership; the pointer must later go to freeDeviceMem(). */
+    [[nodiscard]] void *
+    release() noexcept {
+        allocator_ = nullptr;
+        size_ = 0;
+        return std::exchange(ptr_, nullptr);
+    }
+
+private:
+    friend class nixlDeviceAllocator;
+
+    nixlDeviceMem(nixlDeviceAllocator *allocator, void *ptr, size_t size) noexcept
+        : allocator_(allocator),
+          ptr_(ptr),
+          size_(size) {}
+
+    nixlDeviceAllocator *allocator_ = nullptr;
+    void *ptr_ = nullptr;
+    size_t size_ = 0;
+};
+
+/**
+ * Owning, move-only handle to pinned host memory mapped into the device
+ * address space. Exposes the host pointer and its device-visible alias.
+ */
+class nixlMappedHostMem {
+public:
+    nixlMappedHostMem() = default;
+
+    ~nixlMappedHostMem() {
+        reset();
+    }
+
+    nixlMappedHostMem(nixlMappedHostMem &&other) noexcept {
+        *this = std::move(other);
+    }
+
+    nixlMappedHostMem &
+    operator=(nixlMappedHostMem &&other) noexcept {
+        if (this != &other) {
+            reset();
+            allocator_ = std::exchange(other.allocator_, nullptr);
+            host_ptr_ = std::exchange(other.host_ptr_, nullptr);
+            dev_ptr_ = std::exchange(other.dev_ptr_, nullptr);
+            size_ = std::exchange(other.size_, 0);
+        }
+        return *this;
+    }
+
+    nixlMappedHostMem(const nixlMappedHostMem &) = delete;
+    nixlMappedHostMem &
+    operator=(const nixlMappedHostMem &) = delete;
+
+    [[nodiscard]] void *
+    hostPtr() const noexcept {
+        return host_ptr_;
+    }
+
+    [[nodiscard]] void *
+    devPtr() const noexcept {
+        return dev_ptr_;
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    asHost() const noexcept {
+        return static_cast<T *>(host_ptr_);
+    }
+
+    template<class T>
+    [[nodiscard]] T *
+    asDev() const noexcept {
+        return static_cast<T *>(dev_ptr_);
+    }
+
+    [[nodiscard]] size_t
+    size() const noexcept {
+        return size_;
+    }
+
+    explicit
+    operator bool() const noexcept {
+        return host_ptr_ != nullptr;
+    }
+
+    void
+    reset() noexcept {
+        if (host_ptr_ == nullptr) {
+            return;
+        }
+        allocator_->doFreeMappedHostMem(host_ptr_);
+        allocator_ = nullptr;
+        host_ptr_ = nullptr;
+        dev_ptr_ = nullptr;
+        size_ = 0;
+    }
+
+private:
+    friend class nixlDeviceAllocator;
+
+    nixlMappedHostMem(nixlDeviceAllocator *allocator,
+                      void *host_ptr,
+                      void *dev_ptr,
+                      size_t size) noexcept
+        : allocator_(allocator),
+          host_ptr_(host_ptr),
+          dev_ptr_(dev_ptr),
+          size_(size) {}
+
+    nixlDeviceAllocator *allocator_ = nullptr;
+    void *host_ptr_ = nullptr;
+    void *dev_ptr_ = nullptr;
+    size_t size_ = 0;
+};
+
+inline nixl_status_t
+nixlDeviceAllocator::allocDeviceMem(size_t size, nixlDeviceMem &out) noexcept {
+    // `out` is only touched on success; a failed allocation leaves the
+    // caller's existing buffer intact.
+    void *ptr = nullptr;
+    const nixl_status_t status = doAllocDeviceMem(&ptr, size);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+    out = nixlDeviceMem(this, ptr, size);
+    return NIXL_SUCCESS;
+}
+
+inline nixl_status_t
+nixlDeviceAllocator::allocMappedHostMem(size_t size, nixlMappedHostMem &out) noexcept {
+    // `out` is only touched on success; a failed allocation leaves the
+    // caller's existing buffer intact.
+    void *host_ptr = nullptr;
+    void *dev_ptr = nullptr;
+    const nixl_status_t status = doAllocMappedHostMem(&host_ptr, &dev_ptr, size);
+    if (status != NIXL_SUCCESS) {
+        return status;
+    }
+    out = nixlMappedHostMem(this, host_ptr, dev_ptr, size);
+    return NIXL_SUCCESS;
+}
+
+/** Process-wide allocator for the device runtime available to this process. */
+[[nodiscard]] nixlDeviceAllocator &
+nixlGetDeviceAllocator() noexcept;
+
+#endif // NIXL_SRC_UTILS_DEVICE_DEVICE_ALLOCATOR_H

--- a/src/utils/device/device_allocator_cuda.cpp
+++ b/src/utils/device/device_allocator_cuda.cpp
@@ -1,0 +1,180 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "device/device_allocator.h"
+
+#include <cuda_runtime.h>
+
+#include "common/nixl_log.h"
+
+namespace {
+
+void
+logCudaFailure(const char *operation, cudaError_t error) {
+    NIXL_ERROR << operation << " failed: " << cudaGetErrorString(error);
+}
+
+class nixlCudaDeviceAllocator final : public nixlDeviceAllocator {
+public:
+    nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t size) noexcept override {
+        if (ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        *ptr = nullptr;
+        const cudaError_t error = cudaMalloc(ptr, size);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMalloc", error);
+            *ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    void
+    doFreeDeviceMem(void *ptr) noexcept override {
+        // cudaFree is a no-op on nullptr and resolves the allocation's owning
+        // device from the pointer itself, so neither a null guard nor a device
+        // switch belongs here. The caller must pass a pointer that
+        // allocDeviceMem produced.
+        const cudaError_t error = cudaFree(ptr);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaFree", error);
+        }
+    }
+
+    nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t size) noexcept override {
+        if (host_ptr == nullptr || dev_ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        *host_ptr = nullptr;
+        *dev_ptr = nullptr;
+        // Mapped guarantees cudaHostGetDevicePointer; portable permits use from other GPUs.
+        cudaError_t error =
+            cudaHostAlloc(host_ptr, size, cudaHostAllocMapped | cudaHostAllocPortable);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaHostAlloc", error);
+            *host_ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        error = cudaHostGetDevicePointer(dev_ptr, *host_ptr, 0);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaHostGetDevicePointer", error);
+            const cudaError_t free_error = cudaFreeHost(*host_ptr);
+            if (free_error != cudaSuccess) {
+                logCudaFailure("cudaFreeHost after cudaHostGetDevicePointer", free_error);
+            }
+            *host_ptr = nullptr;
+            *dev_ptr = nullptr;
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    void
+    doFreeMappedHostMem(void *host_ptr) noexcept override {
+        if (host_ptr == nullptr) {
+            return;
+        }
+        const cudaError_t error = cudaFreeHost(host_ptr);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaFreeHost", error);
+        }
+    }
+
+    nixl_status_t
+    copyHostToDevice(void *dst, const void *src, size_t size) noexcept override {
+        if (dst == nullptr || src == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemcpy host to device", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    copyDeviceToHost(void *dst, const void *src, size_t size) noexcept override {
+        if (dst == nullptr || src == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemcpy device to host", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    memsetDeviceMem(void *ptr, int value, size_t size) noexcept override {
+        if (ptr == nullptr || size == 0) {
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        const cudaError_t error = cudaMemset(ptr, value, size);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaMemset", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    synchronize() noexcept override {
+        const cudaError_t error = cudaDeviceSynchronize();
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaDeviceSynchronize", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    getActiveDevice(int &device_id) noexcept override {
+        const cudaError_t error = cudaGetDevice(&device_id);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaGetDevice", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    setActiveDevice(int device_id) noexcept override {
+        const cudaError_t error = cudaSetDevice(device_id);
+        if (error != cudaSuccess) {
+            logCudaFailure("cudaSetDevice", error);
+            return NIXL_ERR_BACKEND;
+        }
+        return NIXL_SUCCESS;
+    }
+};
+
+} // namespace
+
+extern "C" __attribute__((visibility("default"))) nixlDeviceAllocator *
+nixlCreateCudaDeviceAllocatorV1() noexcept {
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+        return nullptr;
+    }
+
+    static nixlCudaDeviceAllocator allocator;
+    return &allocator;
+}

--- a/src/utils/device/meson.build
+++ b/src/utils/device/meson.build
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+device_allocator_lib = shared_library('nixl_device_allocator',
+           ['device_allocator.cpp', 'device_allocator.h'],
+           include_directories: [nixl_inc_dirs, utils_inc_dirs],
+           dependencies: [dl_dep],
+           install: true)
+
+device_allocator_interface = declare_dependency(link_with: device_allocator_lib)
+
+if cuda_dep.found()
+    shared_library('nixl_device_allocator_cuda',
+               'device_allocator_cuda.cpp',
+               include_directories: [nixl_inc_dirs, utils_inc_dirs],
+               dependencies: [cuda_dep, nixl_common_dep],
+               install: true)
+endif

--- a/src/utils/meson.build
+++ b/src/utils/meson.build
@@ -18,6 +18,7 @@ subdir('serdes')
 subdir('stream')
 subdir('file')
 subdir('object')
+subdir('device')
 
 if enabled_plugins.get('LIBFABRIC') and libfabric_dep.found()
     subdir('libfabric')

--- a/test/gtest/device_api/gpunetio_device_api_test.cu
+++ b/test/gtest/device_api/gpunetio_device_api_test.cu
@@ -1,0 +1,926 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <gpu/nixl_device.cuh>
+#include <nixl.h>
+
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <netinet/in.h>
+#include <optional>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if !defined(NIXL_ENABLE_GPUNETIO_DEVICE_API) || !NIXL_ENABLE_GPUNETIO_DEVICE_API
+#error "Build this test with NIXL_ENABLE_GPUNETIO_DEVICE_API=1"
+#endif
+
+#if !defined(NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31) || !NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31
+#error "Build this test with NIXL_GPUNETIO_DEVICE_API_LEGACY_DOCA31=1"
+#endif
+
+namespace {
+
+constexpr uint64_t kArenaBytes = 40ull * 1024 * 1024;
+constexpr uint64_t kDescriptorPrefix = 256;
+constexpr uint64_t kDescriptorSuffix = 256;
+constexpr uint64_t kGuardBytes = 64;
+constexpr uint8_t kSourceGuard = 0x5a;
+constexpr uint8_t kDestinationGuard = 0xa5;
+constexpr uint64_t kWrapRequests = 8193;
+constexpr uint64_t kWrapPayloadBytes = 4096;
+constexpr uint64_t kWrapSlotBytes = 4352;
+constexpr auto kWaitTimeout = std::chrono::seconds(45);
+constexpr auto kPollTimeout = std::chrono::seconds(5);
+constexpr size_t kStatusModeTagOffset = sizeof(nixlGpuXferStatusH) - sizeof(uint32_t);
+
+struct DeviceBuffer {
+    void *ptr = nullptr;
+    size_t bytes = 0;
+
+    DeviceBuffer() = default;
+
+    explicit DeviceBuffer(size_t size) : bytes(size) {
+        if (cudaMalloc(&ptr, bytes) != cudaSuccess) {
+            ptr = nullptr;
+            bytes = 0;
+        }
+    }
+
+    DeviceBuffer(const DeviceBuffer &) = delete;
+    DeviceBuffer &
+    operator=(const DeviceBuffer &) = delete;
+
+    ~DeviceBuffer() {
+        if (ptr != nullptr) {
+            cudaFree(ptr);
+        }
+    }
+};
+
+struct DeviceResult {
+    int32_t submission_status = NIXL_ERR_UNKNOWN;
+    int32_t completion_status = NIXL_ERR_UNKNOWN;
+    int32_t old_status = NIXL_ERR_UNKNOWN;
+    uint64_t expected = 0;
+    uint64_t accepted = 0;
+    uint64_t completed = 0;
+    uint64_t first_failure = std::numeric_limits<uint64_t>::max();
+    uint64_t poll_count = 0;
+    uint32_t timed_out = 0;
+    uint32_t status_untouched = 0;
+};
+
+struct PutSpec {
+    nixlMemViewElem src;
+    nixlMemViewElem dst;
+    uint64_t bytes;
+    uint64_t seed;
+    uint64_t count;
+};
+
+struct InvalidSpec {
+    nixlMemViewElem src;
+    nixlMemViewElem dst;
+    uint64_t bytes;
+    uint64_t flags;
+    unsigned channel;
+    nixl_status_t expected_status;
+    uint32_t kind;
+};
+
+struct RunCase {
+    const char *name;
+    uint64_t bytes;
+    uint64_t src_offset;
+    uint64_t dst_offset;
+    uint64_t seed;
+};
+
+__device__ uint64_t
+deviceNow() {
+    return clock64();
+}
+
+template<nixl_gpu_level_t level>
+__global__ void
+putKernel(PutSpec spec, DeviceResult *result, uint64_t timeout_cycles) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) {
+        return;
+    }
+
+    result->expected = spec.count;
+    nixlGpuXferStatusH status{};
+    nixlGpuXferStatusH old_status{};
+    bool have_old_status = false;
+
+    for (uint64_t i = 0; i < spec.count; ++i) {
+        const nixlMemViewElem src{
+            spec.src.mvh, spec.src.index, spec.src.offset + i * kWrapSlotBytes};
+        const nixlMemViewElem dst{
+            spec.dst.mvh, spec.dst.index, spec.dst.offset + i * kWrapSlotBytes};
+
+        status = nixlGpuXferStatusH{};
+        const auto submitted = nixlPut<level>(src, dst, spec.bytes, 0, 0, &status);
+        if (i == 0) {
+            result->submission_status = submitted;
+        }
+        if (submitted != NIXL_IN_PROG) {
+            result->first_failure = i;
+            result->completion_status = submitted;
+            return;
+        }
+        ++result->accepted;
+
+        const uint64_t deadline = deviceNow() + timeout_cycles;
+        nixl_status_t completed = NIXL_IN_PROG;
+        do {
+            completed = nixlGpuGetXferStatus<level>(status);
+            ++result->poll_count;
+            if (completed == NIXL_IN_PROG && deviceNow() >= deadline) {
+                result->timed_out = 1;
+                result->first_failure = i;
+                result->completion_status = NIXL_IN_PROG;
+                return;
+            }
+        } while (completed == NIXL_IN_PROG);
+
+        if (completed != NIXL_SUCCESS) {
+            result->first_failure = i;
+            result->completion_status = completed;
+            return;
+        }
+        ++result->completed;
+        result->completion_status = completed;
+
+        if (!have_old_status) {
+            old_status = status;
+            have_old_status = true;
+        }
+    }
+
+    if (have_old_status) {
+        result->old_status = nixlGpuGetXferStatus<level>(old_status);
+    }
+}
+
+__device__ bool
+sameStatus(const nixlGpuXferStatusH &lhs, const nixlGpuXferStatusH &rhs) {
+    const auto *a = reinterpret_cast<const unsigned char *>(&lhs);
+    const auto *b = reinterpret_cast<const unsigned char *>(&rhs);
+    for (size_t i = 0; i < sizeof(nixlGpuXferStatusH); ++i) {
+        if (a[i] != b[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+__device__ void
+initRejectedStatus(nixlGpuXferStatusH &status) {
+    auto *bytes = reinterpret_cast<unsigned char *>(&status);
+    for (size_t i = 0; i < sizeof(nixlGpuXferStatusH); ++i) {
+        bytes[i] = 0xa5;
+    }
+    for (size_t i = kStatusModeTagOffset; i < sizeof(nixlGpuXferStatusH); ++i) {
+        bytes[i] = 0;
+    }
+}
+
+__global__ void
+busyKernel(PutSpec spec, DeviceResult *result, uint64_t timeout_cycles) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) {
+        return;
+    }
+
+    nixlGpuXferStatusH first{};
+    nixlGpuXferStatusH second_before{};
+    nixlGpuXferStatusH second{};
+    initRejectedStatus(second_before);
+    second = second_before;
+    const auto first_submit =
+        nixlPut<nixl_gpu_level_t::THREAD>(spec.src, spec.dst, spec.bytes, 0, 0, &first);
+    const auto second_submit =
+        nixlPut<nixl_gpu_level_t::THREAD>(spec.src, spec.dst, spec.bytes, 0, 0, &second);
+    result->submission_status = first_submit;
+    result->completion_status = second_submit;
+    result->status_untouched = sameStatus(second_before, second) ? 1 : 0;
+    if (first_submit == NIXL_IN_PROG) {
+        ++result->accepted;
+    }
+
+    const uint64_t deadline = deviceNow() + timeout_cycles;
+    nixl_status_t status = NIXL_IN_PROG;
+    while (status == NIXL_IN_PROG) {
+        status = nixlGpuGetXferStatus<nixl_gpu_level_t::THREAD>(first);
+        ++result->poll_count;
+        if (status == NIXL_IN_PROG && deviceNow() >= deadline) {
+            result->timed_out = 1;
+            return;
+        }
+    }
+    result->old_status = status;
+    result->completed = status == NIXL_SUCCESS ? 1 : 0;
+}
+
+__global__ void
+invalidKernel(InvalidSpec spec, DeviceResult *result) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) {
+        return;
+    }
+
+    nixlGpuXferStatusH before{};
+    nixlGpuXferStatusH after{};
+    initRejectedStatus(before);
+    after = before;
+    const auto returned = nixlPut<nixl_gpu_level_t::THREAD>(
+        spec.src, spec.dst, spec.bytes, spec.channel, spec.flags, &after);
+    result->submission_status = returned;
+    result->status_untouched = sameStatus(before, after) ? 1 : 0;
+    result->expected = static_cast<int32_t>(spec.expected_status);
+}
+
+__global__ void
+nullStatusKernel(PutSpec spec, DeviceResult *result) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) {
+        return;
+    }
+    result->submission_status =
+        nixlPut<nixl_gpu_level_t::THREAD>(spec.src, spec.dst, spec.bytes, 0, 0, nullptr);
+    result->status_untouched = 1;
+}
+
+std::optional<std::string>
+env(const char *name) {
+    const char *value = std::getenv(name);
+    if (value == nullptr || *value == '\0') {
+        return std::nullopt;
+    }
+    return std::string(value);
+}
+
+uint64_t
+envUint(const char *name, uint64_t fallback) {
+    const auto value = env(name);
+    if (!value) {
+        return fallback;
+    }
+    size_t consumed = 0;
+    const uint64_t parsed = std::stoull(*value, &consumed, 0);
+    if (consumed != value->size()) {
+        throw std::invalid_argument(std::string(name) + " is not an integer");
+    }
+    return parsed;
+}
+
+class Control {
+public:
+    Control(const std::string &role, const std::string &target_ipv4, uint16_t port) {
+        fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (fd_ < 0) {
+            throw std::runtime_error("control socket failed");
+        }
+
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_port = htons(port);
+        if (role == "receiver") {
+            int reuse = 1;
+            ::setsockopt(fd_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+            address.sin_addr.s_addr = htonl(INADDR_ANY);
+            if (::bind(fd_, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0 ||
+                ::listen(fd_, 1) != 0) {
+                throw std::runtime_error("control bind/listen failed");
+            }
+            pollfd listener{fd_, POLLIN, 0};
+            const int timeout_ms = static_cast<int>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(kWaitTimeout).count());
+            if (::poll(&listener, 1, timeout_ms) <= 0) {
+                throw std::runtime_error("control accept timeout");
+            }
+            const int accepted = ::accept(fd_, nullptr, nullptr);
+            ::close(fd_);
+            fd_ = accepted;
+            if (fd_ < 0) {
+                throw std::runtime_error("control accept failed");
+            }
+        } else {
+            if (::inet_pton(AF_INET, target_ipv4.c_str(), &address.sin_addr) != 1) {
+                throw std::runtime_error("GPUNETIO_DEVICE_API_TARGET_IPV4 must be numeric IPv4");
+            }
+            const auto deadline = std::chrono::steady_clock::now() + kWaitTimeout;
+            while (::connect(fd_, reinterpret_cast<sockaddr *>(&address), sizeof(address)) != 0) {
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    throw std::runtime_error("control connect timeout");
+                }
+                ::close(fd_);
+                fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+                if (fd_ < 0) {
+                    throw std::runtime_error("control retry socket failed");
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+        }
+
+        timeval timeout{static_cast<long>(kWaitTimeout.count()), 0};
+        ::setsockopt(fd_, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+        ::setsockopt(fd_, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    }
+
+    ~Control() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
+    }
+
+    Control(const Control &) = delete;
+    Control &
+    operator=(const Control &) = delete;
+
+    void
+    send(char token) const {
+        if (::send(fd_, &token, 1, MSG_NOSIGNAL) != 1) {
+            throw std::runtime_error("control send failed");
+        }
+    }
+
+    void
+    expect(char expected) const {
+        char actual = 0;
+        if (::recv(fd_, &actual, 1, MSG_WAITALL) != 1 || actual != expected) {
+            throw std::runtime_error("control token/order mismatch");
+        }
+    }
+
+private:
+    int fd_ = -1;
+};
+
+void
+writeAll(int fd, const char *data, size_t size) {
+    while (size != 0) {
+        const ssize_t written = ::write(fd, data, size);
+        if (written < 0 && errno == EINTR) {
+            continue;
+        }
+        if (written <= 0) {
+            throw std::runtime_error("write failed: " + std::string(std::strerror(errno)));
+        }
+        data += written;
+        size -= static_cast<size_t>(written);
+    }
+}
+
+void
+publishFile(const std::filesystem::path &path, const std::string &contents) {
+    const auto tmp = path.string() + ".tmp." + std::to_string(static_cast<long long>(::getpid()));
+    const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_EXCL, 0600);
+    if (fd < 0) {
+        throw std::runtime_error("open temporary file failed: " + tmp + ": " +
+                                 std::strerror(errno));
+    }
+    try {
+        writeAll(fd, contents.data(), contents.size());
+        if (::fsync(fd) != 0 || ::close(fd) != 0) {
+            throw std::runtime_error("fsync/close failed for " + tmp);
+        }
+        if (::rename(tmp.c_str(), path.c_str()) != 0) {
+            throw std::runtime_error("atomic rename failed for " + path.string());
+        }
+        const int dir_fd = ::open(path.parent_path().c_str(), O_RDONLY | O_DIRECTORY);
+        if (dir_fd < 0 || ::fsync(dir_fd) != 0 || ::close(dir_fd) != 0) {
+            throw std::runtime_error("directory fsync failed for " + path.parent_path().string());
+        }
+    }
+    catch (...) {
+        ::close(fd);
+        ::unlink(tmp.c_str());
+        throw;
+    }
+}
+
+std::string
+readFile(const std::filesystem::path &path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        throw std::runtime_error("cannot open " + path.string());
+    }
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+uint8_t
+patternByte(uint64_t seed, uint64_t offset) {
+    uint64_t value = seed ^ (offset + 0x9e3779b97f4a7c15ull);
+    value ^= value >> 30;
+    value *= 0xbf58476d1ce4e5b9ull;
+    value ^= value >> 27;
+    value *= 0x94d049bb133111ebull;
+    value ^= value >> 31;
+    return static_cast<uint8_t>(value);
+}
+
+void
+fillPattern(std::vector<uint8_t> &buffer, size_t offset, size_t size, uint64_t seed) {
+    for (size_t i = 0; i < size; ++i) {
+        buffer[offset + i] = patternByte(seed, i);
+    }
+}
+
+DeviceResult
+copyResult(DeviceBuffer &device_result) {
+    DeviceResult result{};
+    const auto copied =
+        cudaMemcpy(&result, device_result.ptr, sizeof(result), cudaMemcpyDeviceToHost);
+    if (copied != cudaSuccess || result.timed_out || result.accepted > result.completed) {
+        // Do not run normal MR/buffer teardown after an unretired operation.
+        // The supervising process watchdog treats this nonzero exit as failure.
+        std::fputs("FAIL: native operation not safely retired; terminating endpoint\n", stderr);
+        std::fflush(stderr);
+        std::_Exit(2);
+    }
+    return result;
+}
+
+uint64_t
+pollCycles() {
+    cudaDeviceProp prop{};
+    int device = 0;
+    EXPECT_EQ(cudaGetDevice(&device), cudaSuccess);
+    EXPECT_EQ(cudaGetDeviceProperties(&prop, device), cudaSuccess);
+    return static_cast<uint64_t>(prop.clockRate) *
+        static_cast<uint64_t>(
+               std::chrono::duration_cast<std::chrono::milliseconds>(kPollTimeout).count());
+}
+
+bool
+flushGpuDirectWrites(std::string &error) {
+#if defined(CUDA_VERSION) && CUDA_VERSION >= 11030
+    CUcontext context = nullptr;
+    if (cuInit(0) != CUDA_SUCCESS || cuCtxGetCurrent(&context) != CUDA_SUCCESS ||
+        context == nullptr) {
+        error = "CUDA driver context unavailable for GPUDirect RDMA flush";
+        return false;
+    }
+    const CUresult result =
+        cuFlushGPUDirectRDMAWrites(CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TARGET_CURRENT_CTX,
+                                   CU_FLUSH_GPU_DIRECT_RDMA_WRITES_TO_OWNER);
+    if (result != CUDA_SUCCESS) {
+        const char *name = nullptr;
+        cuGetErrorName(result, &name);
+        error = "cuFlushGPUDirectRDMAWrites failed";
+        if (name != nullptr) {
+            error += ": ";
+            error += name;
+        }
+        return false;
+    }
+    return true;
+#else
+    error = "CUDA headers do not expose cuFlushGPUDirectRDMAWrites";
+    return false;
+#endif
+}
+
+class GpunetioDeviceApiTest : public ::testing::Test {
+protected:
+    void
+    SetUp() override {
+        role_ = env("GPUNETIO_DEVICE_API_ROLE").value_or("");
+        coord_dir_ = env("GPUNETIO_DEVICE_API_COORD_DIR").value_or("");
+        run_id_ = env("GPUNETIO_DEVICE_API_RUN_ID").value_or("");
+        test_id_ = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+        if (role_ != "sender" && role_ != "receiver") {
+            GTEST_SKIP() << "Set GPUNETIO_DEVICE_API_ROLE=sender or receiver";
+        }
+        if (coord_dir_.empty() || run_id_.empty()) {
+            GTEST_SKIP() << "Set GPUNETIO_DEVICE_API_COORD_DIR and GPUNETIO_DEVICE_API_RUN_ID";
+        }
+        control_target_ipv4_ = env("GPUNETIO_DEVICE_API_TARGET_IPV4").value_or("");
+        control_port_ = envUint("GPUNETIO_DEVICE_API_CONTROL_PORT", 0);
+        if (control_port_ == 0 || control_port_ > 65535) {
+            GTEST_SKIP() << "Set GPUNETIO_DEVICE_API_CONTROL_PORT to 1..65535";
+        }
+        if (role_ == "sender" && control_target_ipv4_.empty()) {
+            GTEST_SKIP() << "Set GPUNETIO_DEVICE_API_TARGET_IPV4 for sender";
+        }
+
+        const auto directory = std::filesystem::path(coord_dir_);
+        std::error_code error;
+        std::filesystem::create_directories(directory, error);
+        ASSERT_FALSE(error) << "cannot create coordination directory: " << error.message();
+        ASSERT_EQ(cudaSetDevice(static_cast<int>(envUint("GPUNETIO_DEVICE_API_GPU", 0))),
+                  cudaSuccess);
+
+        buffer_ = std::make_unique<DeviceBuffer>(kArenaBytes);
+        ASSERT_NE(buffer_->ptr, nullptr) << "cudaMalloc failed";
+        ASSERT_EQ(cudaMemset(buffer_->ptr, kDestinationGuard, kArenaBytes), cudaSuccess);
+
+        nixlAgentConfig config;
+        config.useProgThread = true;
+        config.syncMode = nixl_thread_sync_t::NIXL_THREAD_SYNC_RW;
+        config.pthrDelay = 100000;
+        agent_ = std::make_unique<nixlAgent>(agentName(), config);
+
+        nixl_b_params_t params;
+        params["native_device_api"] = "true";
+        params["gpu_devices"] = std::to_string(envUint("GPUNETIO_DEVICE_API_GPU", 0));
+        setParam(params, "network_devices", "GPUNETIO_DEVICE_API_RDMA");
+        setParam(params, "oob_interface", "GPUNETIO_DEVICE_API_OOB_INTERFACE");
+        setParam(params, "gid_index", "GPUNETIO_DEVICE_API_GID_INDEX");
+        setParam(params, "oob_port", "GPUNETIO_DEVICE_API_OOB_PORT");
+        ASSERT_EQ(agent_->createBackend("GPUNETIO", params, backend_), NIXL_SUCCESS);
+        ASSERT_NE(backend_, nullptr);
+
+        nixl_opt_args_t backend_hint;
+        backend_hint.backends.push_back(backend_);
+        registration_address_ = reinterpret_cast<uintptr_t>(buffer_->ptr);
+        registration_length_ = kArenaBytes;
+        local_address_ = registration_address_ + kDescriptorPrefix;
+        local_length_ = kArenaBytes - kDescriptorPrefix - kDescriptorSuffix;
+        nixl_reg_dlist_t registration(VRAM_SEG);
+        registration.addDesc({registration_address_, registration_length_, 0, {}});
+        ASSERT_EQ(agent_->registerMem(registration, &backend_hint), NIXL_SUCCESS);
+
+        nixl_blob_t metadata;
+        ASSERT_EQ(agent_->getLocalMD(metadata), NIXL_SUCCESS);
+        publishFile(path(".md"), metadata);
+        publishFile(path(".desc"),
+                    std::to_string(local_address_) + " " + std::to_string(local_length_));
+
+        control_ = std::make_unique<Control>(
+            role_, control_target_ipv4_, static_cast<uint16_t>(control_port_));
+        control_->send('M');
+        control_->expect('M');
+
+        // The receiver is intentionally metadata-only.  Only the sender imports
+        // the receiver metadata, creates the OOB data connection, and prepares
+        // the public Device API views used by the PUT path.
+        if (role_ == "receiver") {
+            control_->expect('S');
+            return;
+        }
+
+        std::string peer_name;
+        ASSERT_EQ(agent_->loadRemoteMD(readFile(peerPath(".md")), peer_name), NIXL_SUCCESS);
+        ASSERT_EQ(peer_name, peerAgentName());
+        ASSERT_EQ(agent_->makeConnection(peer_name, &backend_hint), NIXL_SUCCESS);
+
+        const auto peer_desc = parseDescriptor(readFile(peerPath(".desc")));
+        ASSERT_TRUE(peer_desc.has_value()) << "invalid peer descriptor record";
+        nixl_local_dlist_t local(VRAM_SEG);
+        local.addDesc({local_address_, local_length_, 0});
+        nixl_remote_dlist_t remote(VRAM_SEG);
+        remote.addDesc({peer_desc->first, peer_desc->second, 0, peer_name});
+        local_view_ = nullptr;
+        remote_view_ = nullptr;
+        ASSERT_EQ(agent_->prepMemView(local, local_view_, &backend_hint), NIXL_SUCCESS);
+        ASSERT_EQ(agent_->prepMemView(remote, remote_view_, &backend_hint), NIXL_SUCCESS);
+        ASSERT_NE(local_view_, nullptr);
+        ASSERT_NE(remote_view_, nullptr);
+        control_->send('S');
+    }
+
+    void
+    TearDown() override {
+        if (agent_ != nullptr) {
+            if (local_view_ != nullptr) {
+                agent_->releaseMemView(local_view_);
+            }
+            if (remote_view_ != nullptr) {
+                agent_->releaseMemView(remote_view_);
+            }
+            local_view_ = nullptr;
+            remote_view_ = nullptr;
+            agent_.reset();
+        }
+        control_.reset();
+        buffer_.reset();
+    }
+
+    std::filesystem::path
+    path(const char *suffix) const {
+        return std::filesystem::path(coord_dir_) /
+            (run_id_ + "." + test_id_ + "." + role_ + suffix);
+    }
+
+    std::filesystem::path
+    peerPath(const char *suffix) const {
+        const std::string peer = role_ == "sender" ? "receiver" : "sender";
+        return std::filesystem::path(coord_dir_) / (run_id_ + "." + test_id_ + "." + peer + suffix);
+    }
+
+    std::string
+    agentName() const {
+        return "gpunetio_native_" + role_;
+    }
+
+    std::string
+    peerAgentName() const {
+        return std::string("gpunetio_native_") + (role_ == "sender" ? "receiver" : "sender");
+    }
+
+    static void
+    setParam(nixl_b_params_t &params, const char *param, const char *variable) {
+        if (const auto value = env(variable)) {
+            params[param] = *value;
+        }
+    }
+
+    static std::optional<std::pair<uintptr_t, size_t>>
+    parseDescriptor(const std::string &contents) {
+        std::istringstream input(contents);
+        uint64_t address = 0;
+        size_t length = 0;
+        if (!(input >> address >> length)) {
+            return std::nullopt;
+        }
+        return std::make_pair(static_cast<uintptr_t>(address), length);
+    }
+
+    DeviceResult
+    launchPut(const PutSpec &spec, uint64_t count) {
+        DeviceBuffer device_result(sizeof(DeviceResult));
+        EXPECT_NE(device_result.ptr, nullptr);
+        resetResult(device_result);
+        PutSpec kernel_spec = spec;
+        kernel_spec.count = count;
+        putKernel<nixl_gpu_level_t::THREAD>
+            <<<1, 1>>>(kernel_spec, static_cast<DeviceResult *>(device_result.ptr), pollCycles());
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+        return copyResult(device_result);
+    }
+
+    DeviceResult
+    launchBusy(const PutSpec &spec) {
+        DeviceBuffer device_result(sizeof(DeviceResult));
+        EXPECT_NE(device_result.ptr, nullptr);
+        resetResult(device_result);
+        busyKernel<<<1, 1>>>(spec, static_cast<DeviceResult *>(device_result.ptr), pollCycles());
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+        return copyResult(device_result);
+    }
+
+    DeviceResult
+    launchInvalid(const InvalidSpec &spec) {
+        DeviceBuffer device_result(sizeof(DeviceResult));
+        EXPECT_NE(device_result.ptr, nullptr);
+        resetResult(device_result);
+        invalidKernel<<<1, 1>>>(spec, static_cast<DeviceResult *>(device_result.ptr));
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+        return copyResult(device_result);
+    }
+
+    DeviceResult
+    launchNullStatus(const PutSpec &spec) {
+        DeviceBuffer device_result(sizeof(DeviceResult));
+        EXPECT_NE(device_result.ptr, nullptr);
+        resetResult(device_result);
+        nullStatusKernel<<<1, 1>>>(spec, static_cast<DeviceResult *>(device_result.ptr));
+        EXPECT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        EXPECT_EQ(cudaGetLastError(), cudaSuccess);
+        return copyResult(device_result);
+    }
+
+    void
+    prepareSource(const RunCase &test_case, std::vector<uint8_t> &host) {
+        host.assign(kArenaBytes, kSourceGuard);
+        fillPattern(
+            host, kDescriptorPrefix + test_case.src_offset, test_case.bytes, test_case.seed);
+        ASSERT_EQ(cudaMemcpy(buffer_->ptr, host.data(), host.size(), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+    }
+
+    void
+    validateDestination(const RunCase &test_case) {
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        std::vector<uint8_t> received(kArenaBytes);
+        ASSERT_EQ(
+            cudaMemcpy(received.data(), buffer_->ptr, received.size(), cudaMemcpyDeviceToHost),
+            cudaSuccess);
+        const uint64_t count = std::string(test_case.name) == "wrap" ? kWrapRequests : 1;
+        for (uint64_t slot = 0; slot < count; ++slot) {
+            const size_t offset = kDescriptorPrefix + test_case.dst_offset + slot * kWrapSlotBytes;
+            for (size_t i = 0; i < kGuardBytes; ++i) {
+                ASSERT_EQ(received[offset - kGuardBytes + i], kDestinationGuard);
+            }
+            const size_t trailing_guard =
+                count > 1 ? kWrapSlotBytes - test_case.bytes : kGuardBytes;
+            for (size_t i = 0; i < trailing_guard; ++i) {
+                ASSERT_EQ(received[offset + test_case.bytes + i], kDestinationGuard);
+            }
+            const uint64_t seed = test_case.seed + slot;
+            for (size_t i = 0; i < test_case.bytes; ++i) {
+                ASSERT_EQ(received[offset + i], patternByte(seed, i))
+                    << "slot " << slot << ", payload byte " << i;
+            }
+        }
+    }
+
+    void
+    resetDestinationAndSendReady() {
+        ASSERT_EQ(cudaMemset(buffer_->ptr, kDestinationGuard, kArenaBytes), cudaSuccess);
+        ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+        control_->send('R');
+    }
+
+    void
+    waitReady() {
+        control_->expect('R');
+    }
+
+    void
+    sendDataDone() {
+        control_->send('D');
+    }
+
+    void
+    waitDataDoneAndValidate(const RunCase &test_case) {
+        control_->expect('D');
+        std::string error;
+        ASSERT_TRUE(flushGpuDirectWrites(error)) << error;
+        validateDestination(test_case);
+        control_->send('V');
+    }
+
+    void
+    waitValidated() {
+        control_->expect('V');
+    }
+
+    std::string role_;
+    std::string coord_dir_;
+    std::string run_id_;
+    std::string test_id_;
+    std::string control_target_ipv4_;
+    uint64_t control_port_ = 0;
+    std::unique_ptr<DeviceBuffer> buffer_;
+    std::unique_ptr<nixlAgent> agent_;
+    std::unique_ptr<Control> control_;
+    nixlBackendH *backend_ = nullptr;
+    nixlMemViewH local_view_ = nullptr;
+    nixlMemViewH remote_view_ = nullptr;
+    uintptr_t local_address_ = 0;
+    size_t local_length_ = 0;
+    uintptr_t registration_address_ = 0;
+    size_t registration_length_ = 0;
+
+private:
+    static void
+    resetResult(DeviceBuffer &device_result) {
+        DeviceResult initial{};
+        ASSERT_EQ(cudaMemcpy(device_result.ptr, &initial, sizeof(initial), cudaMemcpyHostToDevice),
+                  cudaSuccess);
+    }
+};
+
+TEST_F(GpunetioDeviceApiTest, BoundedNormalPutAndValidation) {
+    const std::array<RunCase, 4> cases{{
+        {"4k", 4 * 1024, 1024, 2048, 0x4100},
+        {"64k", 64 * 1024, 8192, 16384, 0x6400},
+        {"1m", 1024 * 1024, 131072, 262144, 0x100000},
+        {"wrap", kWrapPayloadBytes, 512, 1024, 0x8193},
+    }};
+    std::vector<uint8_t> source(kArenaBytes, kSourceGuard);
+
+    if (role_ == "sender") {
+        for (const auto &test_case : cases) {
+            waitReady();
+            if (std::string(test_case.name) == "wrap") {
+                source.assign(kArenaBytes, kSourceGuard);
+                for (uint64_t i = 0; i < kWrapRequests; ++i) {
+                    fillPattern(source,
+                                kDescriptorPrefix + test_case.src_offset + i * kWrapSlotBytes,
+                                test_case.bytes,
+                                test_case.seed + i);
+                }
+                ASSERT_EQ(
+                    cudaMemcpy(buffer_->ptr, source.data(), source.size(), cudaMemcpyHostToDevice),
+                    cudaSuccess);
+                PutSpec spec{{local_view_, 0, test_case.src_offset},
+                             {remote_view_, 0, test_case.dst_offset},
+                             test_case.bytes,
+                             test_case.seed,
+                             kWrapRequests};
+                const DeviceResult result = launchPut(spec, kWrapRequests);
+                ASSERT_EQ(result.submission_status, NIXL_IN_PROG);
+                ASSERT_EQ(result.completion_status, NIXL_SUCCESS);
+                ASSERT_EQ(result.old_status, NIXL_SUCCESS);
+                ASSERT_EQ(result.expected, kWrapRequests);
+                ASSERT_EQ(result.accepted, kWrapRequests);
+                ASSERT_EQ(result.completed, kWrapRequests);
+                ASSERT_EQ(result.first_failure, std::numeric_limits<uint64_t>::max());
+                ASSERT_EQ(result.timed_out, 0u);
+            } else {
+                prepareSource(test_case, source);
+                PutSpec spec{{local_view_, 0, test_case.src_offset},
+                             {remote_view_, 0, test_case.dst_offset},
+                             test_case.bytes,
+                             test_case.seed,
+                             1};
+                const DeviceResult result = launchPut(spec, 1);
+                ASSERT_EQ(result.submission_status, NIXL_IN_PROG);
+                ASSERT_EQ(result.completion_status, NIXL_SUCCESS);
+                ASSERT_EQ(result.old_status, NIXL_SUCCESS);
+                ASSERT_EQ(result.expected, 1u);
+                ASSERT_EQ(result.accepted, 1u);
+                ASSERT_EQ(result.completed, 1u);
+                ASSERT_EQ(result.first_failure, std::numeric_limits<uint64_t>::max());
+                ASSERT_EQ(result.timed_out, 0u);
+            }
+            sendDataDone();
+            waitValidated();
+        }
+    } else {
+        for (const auto &test_case : cases) {
+            resetDestinationAndSendReady();
+            waitDataDoneAndValidate(test_case);
+        }
+    }
+}
+
+TEST_F(GpunetioDeviceApiTest, BusyAndRejectedArgumentsDoNotMutateStatus) {
+    const RunCase busy_case{"busy", 4096, 4 * 1024 * 1024, 4 * 1024 * 1024, 0xbeef};
+    if (role_ == "receiver") {
+        resetDestinationAndSendReady();
+        waitDataDoneAndValidate(busy_case);
+        return;
+    }
+
+    std::vector<uint8_t> source;
+    waitReady();
+    prepareSource(busy_case, source);
+    const PutSpec valid{{local_view_, 0, busy_case.src_offset},
+                        {remote_view_, 0, busy_case.dst_offset},
+                        busy_case.bytes,
+                        busy_case.seed,
+                        1};
+    const DeviceResult busy = launchBusy(valid);
+    ASSERT_EQ(busy.submission_status, NIXL_IN_PROG);
+    ASSERT_NE(busy.completion_status, NIXL_IN_PROG);
+    ASSERT_NE(busy.completion_status, NIXL_SUCCESS);
+    ASSERT_EQ(busy.status_untouched, 1u);
+    ASSERT_EQ(busy.accepted, 1u);
+    ASSERT_EQ(busy.completed, 1u);
+    ASSERT_EQ(busy.timed_out, 0u);
+
+    const std::array<InvalidSpec, 6> invalid{{
+        {{local_view_, 1, 0}, {remote_view_, 0, 0}, 1, 0, 0, NIXL_ERR_INVALID_PARAM, 1},
+        {{local_view_, 0, local_length_}, {remote_view_, 0, 0}, 1, 0, 0, NIXL_ERR_INVALID_PARAM, 2},
+        {{local_view_, 0, 0}, {remote_view_, 0, 0}, 0, 0, 0, NIXL_ERR_INVALID_PARAM, 3},
+        {{local_view_, 0, 0}, {remote_view_, 0, 0}, 4096, 1, 0, NIXL_ERR_NOT_SUPPORTED, 4},
+        {{local_view_, 0, 0}, {remote_view_, 0, 0}, 4096, 0, 1, NIXL_ERR_NOT_SUPPORTED, 5},
+        {{local_view_, 0, 0},
+         {remote_view_, 0, 0},
+         std::numeric_limits<uint64_t>::max(),
+         0,
+         0,
+         NIXL_ERR_INVALID_PARAM,
+         6},
+    }};
+    for (const auto &spec : invalid) {
+        const DeviceResult result = launchInvalid(spec);
+        ASSERT_EQ(static_cast<nixl_status_t>(result.submission_status), spec.expected_status)
+            << spec.kind;
+        ASSERT_EQ(static_cast<nixl_status_t>(result.expected), spec.expected_status) << spec.kind;
+        ASSERT_EQ(result.status_untouched, 1u) << spec.kind;
+    }
+    const DeviceResult null_status = launchNullStatus(valid);
+    ASSERT_EQ(static_cast<nixl_status_t>(null_status.submission_status), NIXL_ERR_INVALID_PARAM);
+    sendDataDone();
+    waitValidated();
+}
+
+} // namespace

--- a/test/gtest/meson.build
+++ b/test/gtest/meson.build
@@ -53,6 +53,14 @@ subdir('mocks')
 subdir('unit')
 subdir('plugins')
 
+if not get_option('gpunetio_device_api').disabled()
+    native_device_test = executable('native-device-api-test',
+        'device_api/gpunetio_device_api_test.cu',
+        include_directories: [nixl_inc_dirs, nixl_device_inc_dirs],
+        dependencies: [nixl_dep, nixl_infra, cuda_dep, doca_gpunetio_dep, dependency('gtest', main: true)],
+        cuda_args: native_device_args)
+endif
+
 if ucx_gpu_device_api_available
     subdir('device_api')
 endif
@@ -122,7 +130,10 @@ gtest_sources = [
 if ucx_gpu_device_api_available
     gtest_sources += device_api_test_sources
     device_api_inc = [nixl_device_inc_dirs, include_directories('device_api')]
-    device_api_dep = [ucx_dep, doca_gpunetio_dep]
+    device_api_dep = [ucx_dep]
+    if doca_gpunetio_dep.found()
+        device_api_dep += [doca_gpunetio_dep]
+    endif
 else
     device_api_inc = []
     device_api_dep = []

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
@@ -6,6 +6,7 @@
 #include "gpunetio_oob_endpoint.h"
 
 #include <cassert>
+#include <limits>
 #include <stdexcept>
 
 template<typename Fn>
@@ -23,6 +24,12 @@ assertInvalid(Fn &&fn) {
 
 int
 main() {
+    assert(!isValidGpunetioAgentNameSize(0));
+    assert(isValidGpunetioAgentNameSize(1));
+    assert(isValidGpunetioAgentNameSize(GPUNETIO_MAX_AGENT_NAME_SIZE));
+    assert(!isValidGpunetioAgentNameSize(GPUNETIO_MAX_AGENT_NAME_SIZE + 1));
+    assert(!isValidGpunetioAgentNameSize(std::numeric_limits<std::size_t>::max()));
+
     assert(parseGpunetioOobPort("") == GPUNETIO_DEFAULT_OOB_PORT);
     assert(parseGpunetioOobPort("1") == 1);
     assert(parseGpunetioOobPort("65535") == 65535);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -20,10 +20,8 @@ main() {
     timeval send_timeout{};
     socklen_t recv_size = sizeof(recv_timeout);
     socklen_t send_size = sizeof(send_timeout);
-    assert(getsockopt(
-               sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
-    assert(getsockopt(
-               sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
+    assert(getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
+    assert(getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
     assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
     assert(recv_timeout.tv_usec == 0);
     assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -5,7 +5,7 @@
 
 #include "gpunetio_backend_aux.h"
 
-#include <cassert>
+#include <iostream>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -13,19 +13,39 @@
 int
 main() {
     int sockets[2] = {-1, -1};
-    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
-    assert(setOobSocketTimeouts(sockets[0]) == 0);
+    auto fail = [&](const char *message) {
+        std::cerr << message << std::endl;
+        if (sockets[0] >= 0) {
+            close(sockets[0]);
+        }
+        if (sockets[1] >= 0) {
+            close(sockets[1]);
+        }
+        return 1;
+    };
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) {
+        return fail("socketpair failed");
+    }
+    if (setOobSocketTimeouts(sockets[0]) != 0) {
+        return fail("setting socket timeouts failed");
+    }
 
     timeval recv_timeout{};
     timeval send_timeout{};
     socklen_t recv_size = sizeof(recv_timeout);
     socklen_t send_size = sizeof(send_timeout);
-    assert(getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
-    assert(getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
-    assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
-    assert(recv_timeout.tv_usec == 0);
-    assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
-    assert(send_timeout.tv_usec == 0);
+    if (getsockopt(sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) != 0) {
+        return fail("reading receive timeout failed");
+    }
+    if (getsockopt(sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) != 0) {
+        return fail("reading send timeout failed");
+    }
+    if (recv_timeout.tv_sec != DOCA_OOB_SOCKET_TIMEOUT_SEC || recv_timeout.tv_usec != 0) {
+        return fail("receive timeout mismatch");
+    }
+    if (send_timeout.tv_sec != DOCA_OOB_SOCKET_TIMEOUT_SEC || send_timeout.tv_usec != 0) {
+        return fail("send timeout mismatch");
+    }
 
     close(sockets[0]);
     close(sockets[1]);

--- a/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
+++ b/test/gtest/plugins/gpunetio/gpunetio_oob_socket_test.cpp
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_backend_aux.h"
+
+#include <cassert>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+int
+main() {
+    int sockets[2] = {-1, -1};
+    assert(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == 0);
+    assert(setOobSocketTimeouts(sockets[0]) == 0);
+
+    timeval recv_timeout{};
+    timeval send_timeout{};
+    socklen_t recv_size = sizeof(recv_timeout);
+    socklen_t send_size = sizeof(send_timeout);
+    assert(getsockopt(
+               sockets[0], SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, &recv_size) == 0);
+    assert(getsockopt(
+               sockets[0], SOL_SOCKET, SO_SNDTIMEO, &send_timeout, &send_size) == 0);
+    assert(recv_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
+    assert(recv_timeout.tv_usec == 0);
+    assert(send_timeout.tv_sec == DOCA_OOB_SOCKET_TIMEOUT_SEC);
+    assert(send_timeout.tv_usec == 0);
+
+    close(sockets[0]);
+    close(sockets[1]);
+    return 0;
+}

--- a/test/gtest/plugins/gpunetio/meson.build
+++ b/test/gtest/plugins/gpunetio/meson.build
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+gpunetio_oob_endpoint_test = executable(
+    'gpunetio_oob_endpoint_test',
+    'gpunetio_oob_endpoint_test.cpp',
+    include_directories: include_directories('../../../../src/plugins/gpunetio'),
+    install: true,
+)
+test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
+
+gpunetio_oob_socket_test = executable(
+    'gpunetio_oob_socket_test',
+    'gpunetio_oob_socket_test.cpp',
+    include_directories: [
+        nixl_inc_dirs,
+        utils_inc_dirs,
+        include_directories('../../../../src/plugins/gpunetio'),
+    ],
+    dependencies: [gpunetio_backend_interface, cuda_dep, absl_log_dep] + plugin_gpunetio_deps,
+    install: true,
+)
+test('gpunetio_oob_socket', gpunetio_oob_socket_test)

--- a/test/gtest/plugins/meson.build
+++ b/test/gtest/plugins/meson.build
@@ -21,6 +21,10 @@ if enabled_plugins.get('AZURE_BLOB')
     subdir('azure_blob')
 endif
 
+if enabled_plugins.get('GPUNETIO')
+    subdir('gpunetio')
+endif
+
 if not enabled_plugins.get('OBJ')
     message('OBJ plugin not enabled, skipping plugins_gtest build')
     subdir_done()

--- a/test/gtest/unit/agent/agent.cpp
+++ b/test/gtest/unit/agent/agent.cpp
@@ -433,6 +433,45 @@ namespace agent {
         EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
     }
 
+    TEST_F(dualAgentBridgeFixture, FailedActiveReleaseKeepsRequestPollable) {
+        DualAgentSetup s(DRAM_SEG);
+        setupDualAgent(s);
+
+        nixl_xfer_dlist_t local_xfer_dlist(DRAM_SEG), remote_xfer_dlist(DRAM_SEG);
+        local_xfer_dlist.addDesc(s.local_blob.getDesc());
+        remote_xfer_dlist.addDesc(s.remote_blob.getDesc());
+
+        nixlBackendReqH backend_request;
+        auto &engine = local_agent_helper_->getGMockEngine();
+        EXPECT_CALL(engine, prepXfer)
+            .WillOnce([&](const auto &,
+                          const auto &,
+                          const auto &,
+                          const auto &,
+                          nixlBackendReqH *&request,
+                          const auto *) {
+                request = &backend_request;
+                return NIXL_SUCCESS;
+            });
+        EXPECT_CALL(engine, postXfer).WillOnce(testing::Return(NIXL_IN_PROG));
+        EXPECT_CALL(engine, checkXfer)
+            .WillOnce(testing::Return(NIXL_IN_PROG))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+        EXPECT_CALL(engine, releaseReqH)
+            .WillOnce(testing::Return(NIXL_ERR_BACKEND))
+            .WillOnce(testing::Return(NIXL_SUCCESS));
+
+        nixlXferReqH *xfer_req;
+        EXPECT_EQ(
+            local_agent_->createXferReq(
+                NIXL_WRITE, local_xfer_dlist, remote_xfer_dlist, s.remote_agent_name, xfer_req),
+            NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->postXferReq(xfer_req), NIXL_IN_PROG);
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_ERR_REPOST_ACTIVE);
+        EXPECT_EQ(local_agent_->getXferStatus(xfer_req), NIXL_SUCCESS);
+        EXPECT_EQ(local_agent_->releaseXferReq(xfer_req), NIXL_SUCCESS);
+    }
+
     TEST_F(dualAgentBridgeFixture, PrepMemViewRemoteDRAM) {
         DualAgentSetup s(DRAM_SEG);
         setupDualAgent(s, /*register_local=*/false);

--- a/test/gtest/unit/device_allocator/device_allocator.cpp
+++ b/test/gtest/unit/device_allocator/device_allocator.cpp
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "device/device_allocator.h"
+
+namespace gtest {
+namespace device_allocator {
+
+    constexpr size_t kSize = 4096;
+
+    class deviceAllocatorTest : public testing::Test {
+    protected:
+        nixlDeviceAllocator *allocator_ = nullptr;
+
+        void
+        SetUp() override {
+            int count = 0;
+            if (cudaGetDeviceCount(&count) != cudaSuccess || count < 1) {
+                GTEST_SKIP() << "No CUDA-capable GPU is available.";
+            }
+            ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+            allocator_ = &nixlGetDeviceAllocator();
+        }
+    };
+
+    TEST_F(deviceAllocatorTest, AllocCopyFree) {
+        nixlDeviceAllocator &allocator = *allocator_;
+
+        nixlDeviceMem mem;
+        ASSERT_EQ(allocator.allocDeviceMem(kSize, mem), NIXL_SUCCESS);
+
+        std::vector<unsigned char> src(kSize, 0xA5);
+        std::vector<unsigned char> dst(kSize, 0);
+        ASSERT_EQ(allocator.copyHostToDevice(mem.get(), src.data(), kSize), NIXL_SUCCESS);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mem.get(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, src);
+
+        ASSERT_EQ(allocator.memsetDeviceMem(mem.get(), 0, kSize), NIXL_SUCCESS);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mem.get(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, std::vector<unsigned char>(kSize, 0));
+
+        allocator.freeDeviceMem(mem.release());
+
+        nixlMappedHostMem mapped;
+        ASSERT_EQ(allocator.allocMappedHostMem(kSize, mapped), NIXL_SUCCESS);
+        std::fill_n(mapped.asHost<unsigned char>(), kSize, 0x5A);
+        ASSERT_EQ(allocator.copyDeviceToHost(dst.data(), mapped.devPtr(), kSize), NIXL_SUCCESS);
+        EXPECT_EQ(dst, std::vector<unsigned char>(kSize, 0x5A));
+    }
+
+} // namespace device_allocator
+} // namespace gtest

--- a/test/gtest/unit/device_allocator/meson.build
+++ b/test/gtest/unit/device_allocator/meson.build
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+device_allocator_unit_test_dep = declare_dependency()
+
+if cuda_dep.found() and is_variable('device_allocator_interface')
+    device_allocator_unit_test_dep = declare_dependency(
+        sources: ['device_allocator.cpp'],
+        include_directories: [nixl_inc_dirs, utils_inc_dirs, gtest_inc_dirs],
+        dependencies: [nixl_common_dep, cuda_dep, device_allocator_interface],
+    )
+endif

--- a/test/gtest/unit/device_memview/device_memview.cpp
+++ b/test/gtest/unit/device_memview/device_memview.cpp
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <new>
+
+#include "device/device_allocator.h"
+#include "device/device_memview.h"
+#include "gpu/device_types.cuh"
+#include "agent_data.h"
+
+namespace {
+
+class MockAllocator final : public nixlDeviceAllocator {
+public:
+    bool fail_copy = false;
+    bool fail_sync = false;
+    size_t allocations = 0;
+    int active_device = 0;
+
+    nixl_status_t
+    copyHostToDevice(void *dst, const void *src, size_t size) noexcept override {
+        if (fail_copy) {
+            return NIXL_ERR_BACKEND;
+        }
+        std::memcpy(dst, src, size);
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    copyDeviceToHost(void *dst, const void *src, size_t size) noexcept override {
+        std::memcpy(dst, src, size);
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    memsetDeviceMem(void *ptr, int value, size_t size) noexcept override {
+        std::memset(ptr, value, size);
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    synchronize() noexcept override {
+        return fail_sync ? NIXL_ERR_BACKEND : NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    getActiveDevice(int &device_id) noexcept override {
+        device_id = active_device;
+        return NIXL_SUCCESS;
+    }
+
+    nixl_status_t
+    setActiveDevice(int device_id) noexcept override {
+        active_device = device_id;
+        return NIXL_SUCCESS;
+    }
+
+protected:
+    nixl_status_t
+    doAllocDeviceMem(void **ptr, size_t size) noexcept override {
+        *ptr = new (std::nothrow) unsigned char[size];
+        if (*ptr == nullptr) {
+            return NIXL_ERR_BACKEND;
+        }
+        ++allocations;
+        return NIXL_SUCCESS;
+    }
+
+    void
+    doFreeDeviceMem(void *ptr) noexcept override {
+        delete[] static_cast<unsigned char *>(ptr);
+        --allocations;
+    }
+
+    nixl_status_t
+    doAllocMappedHostMem(void **host_ptr, void **dev_ptr, size_t) noexcept override {
+        *host_ptr = nullptr;
+        *dev_ptr = nullptr;
+        return NIXL_ERR_NOT_SUPPORTED;
+    }
+
+    void
+    doFreeMappedHostMem(void *) noexcept override {}
+};
+
+TEST(DeviceMemViewTest, UploadAndFreeUseInjectedAllocator) {
+    MockAllocator allocator;
+    nixlMemViewH wrapper = nullptr;
+    void *backend_view = reinterpret_cast<void *>(0x1234);
+
+    ASSERT_EQ(nixlDeviceMemViewAllocate(
+                  nixl_device_exec_mode_t::UCX_DIRECT, backend_view, wrapper, &allocator),
+              NIXL_SUCCESS);
+    ASSERT_NE(wrapper, nullptr);
+    EXPECT_EQ(allocator.allocations, 1U);
+
+    nixlDeviceMemViewFree(wrapper, &allocator);
+    EXPECT_EQ(allocator.allocations, 0U);
+}
+
+TEST(DeviceMemViewTest, CopyFailureRollsBackDeviceAllocation) {
+    MockAllocator allocator;
+    allocator.fail_copy = true;
+    nixlMemViewH wrapper = reinterpret_cast<void *>(0x1);
+
+    EXPECT_EQ(nixlDeviceMemViewAllocate(nixl_device_exec_mode_t::UCX_DIRECT,
+                                        reinterpret_cast<void *>(0x1234),
+                                        wrapper,
+                                        &allocator),
+              NIXL_ERR_BACKEND);
+    EXPECT_EQ(wrapper, nullptr);
+    EXPECT_EQ(allocator.allocations, 0U);
+}
+
+TEST(DeviceMemViewTest, SyncFailureRollsBackDeviceAllocation) {
+    MockAllocator allocator;
+    allocator.fail_sync = true;
+    nixlMemViewH wrapper = reinterpret_cast<void *>(0x1);
+
+    EXPECT_EQ(nixlDeviceMemViewAllocate(nixl_device_exec_mode_t::UCX_DIRECT,
+                                        reinterpret_cast<void *>(0x1234),
+                                        wrapper,
+                                        &allocator),
+              NIXL_ERR_BACKEND);
+    EXPECT_EQ(wrapper, nullptr);
+    EXPECT_EQ(allocator.allocations, 0U);
+}
+
+TEST(DeviceMemViewTest, InvalidInputsDoNotAllocate) {
+    MockAllocator allocator;
+    nixlMemViewH wrapper = reinterpret_cast<void *>(0x1);
+
+    EXPECT_EQ(
+        nixlDeviceMemViewAllocate(
+            nixl_device_exec_mode_t::NONE, reinterpret_cast<void *>(0x1234), wrapper, &allocator),
+        NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(wrapper, nullptr);
+    EXPECT_EQ(allocator.allocations, 0U);
+
+    wrapper = reinterpret_cast<void *>(0x1);
+    EXPECT_EQ(nixlDeviceMemViewAllocate(
+                  nixl_device_exec_mode_t::UCX_DIRECT, nullptr, wrapper, &allocator),
+              NIXL_ERR_INVALID_PARAM);
+    EXPECT_EQ(wrapper, nullptr);
+    EXPECT_EQ(allocator.allocations, 0U);
+}
+
+TEST(DeviceMemViewTest, StatusTagReservesFourBytesOutsidePayload) {
+    nixlGpuXferStatusH status{};
+    uint32_t tag = 0;
+    std::memcpy(&tag, status.storage + nixl::gpu::xfer_status_mode_offset, sizeof(tag));
+    EXPECT_EQ(sizeof(status), 64U);
+    EXPECT_EQ(nixl_gpu_xfer_status_payload_size, 60U);
+    EXPECT_EQ(tag, 0U);
+
+    tag = static_cast<uint32_t>(nixl_device_exec_mode_t::GPUNETIO_DIRECT);
+    std::memcpy(status.storage + nixl::gpu::xfer_status_mode_offset, &tag, sizeof(tag));
+    std::memcpy(&tag, status.storage + nixl::gpu::xfer_status_mode_offset, sizeof(tag));
+    EXPECT_EQ(tag, 3U);
+}
+
+TEST(DeviceMemViewTest, NativeRemoteAdmissionIsNarrow) {
+    EXPECT_TRUE(nixlRemoteBackendAdmissionAllowed(
+        "GPUNETIO", true, false, nixl_device_exec_mode_t::GPUNETIO_DIRECT));
+    EXPECT_FALSE(nixlRemoteBackendAdmissionAllowed(
+        "UCX", true, false, nixl_device_exec_mode_t::GPUNETIO_DIRECT));
+    EXPECT_FALSE(
+        nixlRemoteBackendAdmissionAllowed("GPUNETIO", true, false, nixl_device_exec_mode_t::NONE));
+    EXPECT_TRUE(
+        nixlRemoteBackendAdmissionAllowed("UCX", true, true, nixl_device_exec_mode_t::NONE));
+}
+
+} // namespace

--- a/test/gtest/unit/device_memview/meson.build
+++ b/test/gtest/unit/device_memview/meson.build
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+device_memview_unit_test_dep = declare_dependency(
+    sources: ['device_memview.cpp'],
+    include_directories: [nixl_inc_dirs, nixl_device_inc_dirs, utils_inc_dirs, gtest_inc_dirs],
+)
+
+device_memview_test_exe = executable(
+    'device-memview-test',
+    'device_memview.cpp',
+    include_directories: [nixl_inc_dirs, nixl_device_inc_dirs, utils_inc_dirs, gtest_inc_dirs],
+    dependencies: [
+        nixl_dep,
+        device_allocator_interface,
+        absl_log_dep,
+        dependency('gtest', main: true),
+    ],
+)
+
+test('device-memview-test', device_memview_test_exe)

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -29,6 +29,9 @@ unit_test_deps += [agent_unit_test_dep]
 subdir('descriptors')
 unit_test_deps += [descriptors_unit_test_dep]
 
+subdir('device_allocator')
+unit_test_deps += [device_allocator_unit_test_dep]
+
 subdir('util')
 unit_test_deps += [util_unit_test_dep]
 

--- a/test/gtest/unit/meson.build
+++ b/test/gtest/unit/meson.build
@@ -32,6 +32,9 @@ unit_test_deps += [descriptors_unit_test_dep]
 subdir('device_allocator')
 unit_test_deps += [device_allocator_unit_test_dep]
 
+subdir('device_memview')
+unit_test_deps += [device_memview_unit_test_dep]
+
 subdir('util')
 unit_test_deps += [util_unit_test_dep]
 
@@ -57,6 +60,7 @@ unit_test_exe = executable('unit',
     dependencies : unit_test_deps,
     include_directories: [
         nixl_inc_dirs,
+        nixl_device_inc_dirs,
         utils_inc_dirs,
     ],
     link_with: [nixl_build_lib],

--- a/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
+++ b/test/unit/plugins/gpunetio/gpunetio_oob_endpoint_test.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gpunetio_oob_endpoint.h"
+
+#include <cassert>
+#include <stdexcept>
+
+template<typename Fn>
+void
+assertInvalid(Fn &&fn) {
+    bool rejected = false;
+    try {
+        fn();
+    }
+    catch (const std::invalid_argument &) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+int
+main() {
+    assert(parseGpunetioOobPort("") == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(parseGpunetioOobPort("1") == 1);
+    assert(parseGpunetioOobPort("65535") == 65535);
+
+    const auto legacy = parseGpunetioOobEndpoint("192.0.2.1");
+    assert(legacy.ipv4 == "192.0.2.1");
+    assert(legacy.port == GPUNETIO_DEFAULT_OOB_PORT);
+    assert(formatGpunetioOobEndpoint(legacy.ipv4, legacy.port) == "192.0.2.1");
+
+    const auto configured = parseGpunetioOobEndpoint("198.51.100.2:16544");
+    assert(configured.ipv4 == "198.51.100.2");
+    assert(configured.port == 16544);
+    assert(formatGpunetioOobEndpoint(configured.ipv4, configured.port) == "198.51.100.2:16544");
+
+    for (const auto *value : {"0", "-1", "+1", "65536", "12x", " 6544", "6544 "}) {
+        assertInvalid([=] { parseGpunetioOobPort(value); });
+    }
+
+    for (const auto *value : {"",
+                              "192.0.2",
+                              "256.0.0.1",
+                              "192.0.2.1:",
+                              "192.0.2.1:0",
+                              "192.0.2.1:65536",
+                              "192.0.2.1:12x",
+                              "192.0.2.1:6544:1",
+                              "[::1]:6544"}) {
+        assertInvalid([=] { parseGpunetioOobEndpoint(value); });
+    }
+    assertInvalid([] { parseGpunetioOobEndpoint(std::string("192.0.2.1\0:6544", 16)); });
+
+    return 0;
+}

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +14,6 @@
 # limitations under the License.
 
 compile_flags = []
-
-gpunetio_oob_endpoint_test = executable(
-        'gpunetio_oob_endpoint_test',
-        'gpunetio_oob_endpoint_test.cpp',
-        include_directories: include_directories('../../../../src/plugins/gpunetio'),
-        install: false)
-test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
 
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]

--- a/test/unit/plugins/gpunetio/meson.build
+++ b/test/unit/plugins/gpunetio/meson.build
@@ -15,6 +15,13 @@
 
 compile_flags = []
 
+gpunetio_oob_endpoint_test = executable(
+        'gpunetio_oob_endpoint_test',
+        'gpunetio_oob_endpoint_test.cpp',
+        include_directories: include_directories('../../../../src/plugins/gpunetio'),
+        install: false)
+test('gpunetio_oob_endpoint', gpunetio_oob_endpoint_test)
+
 if cuda_dep.found()
         cuda_dependencies = [cuda_dep]
         compile_flags += '-DHAVE_CUDA'


### PR DESCRIPTION
## What?

Design discussion: #2233 (follow-up to #2232). This draft exposes the prototype
for interface/ABI review; design acceptance and merge readiness are not claimed.

Add an opt-in native GPUNetIO implementation of the existing NIXL GPU PUT and
transfer-status API. An application CUDA thread submits a WRITE and polls its
completion directly, without host posting or the legacy data-progress kernel.

Scope: THREAD, ordinary registered VRAM on the execution GPU, one remote peer
per engine, one accepted/unretired PUT per shared data QP. Multiple views share
that lane. No CPU-proxy fallback, atomics, peer-GPU payloads or serving integration.

## Why?

Enable application GPU code to issue transfers through NIXL's public memory-view
API. This is a functional integration, not a throughput optimization or a
performance comparison with the host API.

## How?

- Tag memory views and the existing 64-byte status: 60 payload bytes plus mode.
- Keep host wrapper ownership and use the runtime-loaded device allocator.
- Give native mode exclusive CQ ownership while retaining the OOB QP handshake.
- Submit one signaled WRITE with the SDK-returned ticket; poll once per query,
  cache terminal status, and latch errors.
- Pin local registrations in native views and retain unretired dependencies
  until QP teardown. Preserve remote-agent identity in metadata descriptors.
- Check the resolved GPU SM doorbell handler; reject unsupported operations.

Both build capability and `native_device_api=true` are opt-in. Legacy host
READ/WRITE remains default. Tested SDK profile: `legacy-doca31`, using the
completion helper from #2222. The newer public profile is compile-gated but
has not been hardware-tested here.

### Dependencies and compatibility

Feature: `c5d5b95cf0a0fda63924488a1cc97a67b52cbed7`.
Foundation: `d8d76fd1de0800302231fd256c254b6aa5fdbe39`, based on upstream
`8585eee0b2a37be52bb5c727f0d21e714518b689` with #2052/#2174/#2175/#2178
platform, connection, request and lifecycle prerequisites plus #2196's allocator.
The foundation resolves duplicate notification-buffer ownership when composing
those branches. #2111 informed the wrapper semantics; its old directory layout
was not restored.

This is a stacked review branch: the feature is 31 files, +2698/-65 against its
foundation; the upstream diff also includes prerequisites. It is not a small
independent patch. Upstream design discussion and prerequisite integration remain
review gates.

Plugin ABI changes 1 → 2. Rebuild core, plugins and application CUDA extensions.
Old-device-header compatibility is not claimed. UCX's device request must fit
the reduced 60-byte payload; the adapter enforces this at compile time.

## Validation

Two H20 endpoints, CUDA 12.8, DOCA 3.1, bonded RoCE; bounded correctness tests,
not performance measurements.

- Native: 4 KiB/64 KiB/1 MiB, 8,193 distinct-destination 4 KiB PUTs across CQ/SQ
  wraps, full payload/guards, cached terminal repoll, busy and invalid-argument
  rejection with unchanged status.
- Six CPU wrapper/admission/status-layout tests.
- Legacy: 120 WRITE + 120 READ with payload/epoch validation and clean teardown.
- Actual old-plugin rejection: expected ABI 2, got 1.

Final exact-commit validation: two independent native process pairs passed both
GTests on each endpoint; six host tests passed; the legacy READ/WRITE pair passed
with clean teardown. All 31 changed files matched the deployed source. Receiver
validation uses checked GPUDirect
RDMA flush; TCP ready/done/validated messages are only test coordination.

Not run: real stale-registration/CQE fault injection, full CPU-only build,
UCX device-enabled and dual-backend build/runtime matrix, concurrent submitters,
cross-engine/null-placeholder boundary cases, hardware ticket low-bit wrap,
native path tracing, and performance. No full-M1, production-readiness,
fault-recovery or performance claim is made for these.

### Reproduce

The checked-in `README_GPUNETIO.md` provides both endpoint commands and all
caller-supplied device, interface, address, GID, port and coordination settings.
With compatible CUDA/DOCA, current Abseil and GTest installed:

```bash
git rev-parse HEAD
meson setup build-native -Dbuildtype=debugoptimized \
  -Denable_plugins=GPUNETIO -Dbuild_examples=false -Dnixl_cuda_arch_list=90 \
  -Dgpunetio_device_api=enabled -Dgpunetio_device_api_profile=legacy-doca31
ninja -C build-native src/plugins/gpunetio/libplugin_GPUNETIO.so \
  src/utils/device/libnixl_device_allocator_cuda.so \
  test/gtest/native-device-api-test \
  test/gtest/unit/device_memview/device-memview-test
./build-native/test/gtest/unit/device_memview/device-memview-test

# Run on each endpoint after setting the variables documented in README_GPUNETIO.md.
export NIXL_PLUGIN_DIR="$PWD/build-native/src/plugins/gpunetio"
export CUDA_MODULE_LOADING=EAGER
./build-native/test/gtest/native-device-api-test --gtest_filter='GpunetioDeviceApiTest.*'
```

Prepare/release are cold operations outside capture and concurrent kernels.
Keep buffers, registrations and remote metadata alive until accepted work is
retired. Release is not cancellation; test timeouts/unretired work cause a
nonzero process exit without normal MR teardown.
