### PR TITLE
Add IPv6 support to socket-based metadata exchange.

### DIFF
--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -206,7 +206,8 @@ struct nixlAgentOptionalArgs {
 
     /**
      * @var ipAddr Numeric IPv4 or IPv6 address of a remote peer for metadata transfer.
-     *             IPv6 addresses must be unbracketed, e.g. "::1".
+     *             IPv6 addresses must be unbracketed, e.g. "::1" or "fe80::1%eth0".
+     *             A zone suffix selects an interface on the calling host by name or index.
      *             Used by sendLocalMD, fetchRemoteMD, invalidateLocalMD and sendLocalPartialMD.
      */
     std::string ipAddr;

--- a/src/api/cpp/nixl_types.h
+++ b/src/api/cpp/nixl_types.h
@@ -205,8 +205,9 @@ struct nixlAgentOptionalArgs {
     bool includeConnInfo = false;
 
     /**
-     * @var ipAddr Used to specify the IP address of a remote peer for metadata transfer.
-     *                      used in sendLocalMD, fetchRemoteMD, invalidateLocalMD, sendLocalPartialMD.
+     * @var ipAddr Numeric IPv4 or IPv6 address of a remote peer for metadata transfer.
+     *             IPv6 addresses must be unbracketed, e.g. "::1".
+     *             Used by sendLocalMD, fetchRemoteMD, invalidateLocalMD and sendLocalPartialMD.
      */
     std::string ipAddr;
 

--- a/src/core/nixl_p2p_metadata_backend.cpp
+++ b/src/core/nixl_p2p_metadata_backend.cpp
@@ -22,6 +22,7 @@
 
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
@@ -54,18 +55,23 @@ connectToIP(const std::string &ip_addr, int port) {
     sockaddr_storage listener_addr{};
     socklen_t listener_addr_len;
     auto *addr4 = reinterpret_cast<sockaddr_in *>(&listener_addr);
-    auto *addr6 = reinterpret_cast<sockaddr_in6 *>(&listener_addr);
     if (inet_pton(AF_INET, ip_addr.c_str(), &addr4->sin_addr) == 1) {
         addr4->sin_family = AF_INET;
         addr4->sin_port = htons(port);
         listener_addr_len = sizeof(*addr4);
-    } else if (inet_pton(AF_INET6, ip_addr.c_str(), &addr6->sin6_addr) == 1) {
-        addr6->sin6_family = AF_INET6;
-        addr6->sin6_port = htons(port);
-        listener_addr_len = sizeof(*addr6);
     } else {
-        NIXL_ERROR << "Invalid IPv4 or IPv6 address: " << ip_addr;
-        return -1;
+        addrinfo hints{};
+        hints.ai_family = AF_INET6;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+        addrinfo *result = nullptr;
+        if (getaddrinfo(ip_addr.c_str(), std::to_string(port).c_str(), &hints, &result) != 0) {
+            NIXL_ERROR << "Invalid IPv4 or IPv6 address: " << ip_addr;
+            return -1;
+        }
+        listener_addr_len = result->ai_addrlen;
+        memcpy(&listener_addr, result->ai_addr, listener_addr_len);
+        freeaddrinfo(result);
     }
 
     int ret_fd = socket(listener_addr.ss_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
@@ -382,7 +388,15 @@ nixlP2PMetadataBackend::acceptPeers() {
             close(new_fd);
             continue;
         }
-        remoteSockets_[std::make_pair(std::string(client_ip), client_port)] = new_fd;
+        std::string peer_ip(client_ip);
+        if (family == AF_INET6) {
+            const auto scope_id =
+                reinterpret_cast<const sockaddr_in6 *>(&client_address)->sin6_scope_id;
+            if (scope_id != 0) {
+                peer_ip += "%" + std::to_string(scope_id);
+            }
+        }
+        remoteSockets_[std::make_pair(peer_ip, client_port)] = new_fd;
         const int flags = fcntl(new_fd, F_GETFL, 0);
         if (flags == -1 || fcntl(new_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
             NIXL_PERROR << "fcntl failed for accepted client";

--- a/src/core/nixl_p2p_metadata_backend.cpp
+++ b/src/core/nixl_p2p_metadata_backend.cpp
@@ -33,6 +33,7 @@
 #include <absl/strings/str_split.h>
 
 #include <chrono>
+#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -51,37 +52,35 @@ constexpr size_t max_frame_bytes = 1UL << 30; // 1 GiB
 constexpr auto frame_body_timeout = std::chrono::seconds(5);
 
 int
-connectToIP(const std::string &ip_addr, int port) {
-    sockaddr_storage listener_addr{};
-    socklen_t listener_addr_len;
-    auto *addr4 = reinterpret_cast<sockaddr_in *>(&listener_addr);
-    if (inet_pton(AF_INET, ip_addr.c_str(), &addr4->sin_addr) == 1) {
-        addr4->sin_family = AF_INET;
-        addr4->sin_port = htons(port);
-        listener_addr_len = sizeof(*addr4);
-    } else {
-        addrinfo hints{};
-        hints.ai_family = AF_INET6;
-        hints.ai_socktype = SOCK_STREAM;
-        hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
-        addrinfo *result = nullptr;
-        if (getaddrinfo(ip_addr.c_str(), std::to_string(port).c_str(), &hints, &result) != 0) {
-            NIXL_ERROR << "Invalid IPv4 or IPv6 address: " << ip_addr;
-            return -1;
-        }
-        listener_addr_len = result->ai_addrlen;
-        memcpy(&listener_addr, result->ai_addr, listener_addr_len);
-        freeaddrinfo(result);
+connectToIP(const std::string &ip_addr, std::uint16_t port) {
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+    addrinfo *result = nullptr;
+    if (getaddrinfo(ip_addr.c_str(), std::to_string(port).c_str(), &hints, &result) != 0) {
+        NIXL_ERROR << "Invalid IPv4 or IPv6 address: " << ip_addr;
+        return -1;
     }
+    if (result->ai_family != AF_INET && result->ai_family != AF_INET6) {
+        NIXL_ERROR << "Unsupported address family: " << result->ai_family;
+        freeaddrinfo(result);
+        return -1;
+    }
+    sockaddr_storage listener_addr{};
+    const socklen_t listener_addr_len = result->ai_addrlen;
+    std::memcpy(&listener_addr, result->ai_addr, listener_addr_len);
+    freeaddrinfo(result);
 
-    int ret_fd = socket(listener_addr.ss_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    const int ret_fd = socket(listener_addr.ss_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (ret_fd == -1) {
         NIXL_ERROR << "socket creation failed for ip_addr: " << ip_addr << " and port: " << port;
         return -1;
     }
 
-    int ret = connect(ret_fd, reinterpret_cast<sockaddr *>(&listener_addr), listener_addr_len);
-    if (ret < 0 && errno != EINPROGRESS) {
+    const int connect_ret =
+        connect(ret_fd, reinterpret_cast<const sockaddr *>(&listener_addr), listener_addr_len);
+    if (connect_ret < 0 && errno != EINPROGRESS) {
         close(ret_fd);
         return -1;
     }
@@ -91,7 +90,7 @@ connectToIP(const std::string &ip_addr, int port) {
     pfd.events = POLLOUT;
     pfd.revents = 0;
 
-    ret = poll(&pfd, 1, 1000); // 1000ms timeout
+    const int ret = poll(&pfd, 1, 1000); // 1000ms timeout
     if (ret <= 0) {
         if (ret < 0) {
             NIXL_PERROR << "poll failed for ip_addr: " << ip_addr << " and port: " << port;
@@ -271,7 +270,7 @@ nixlP2PMetadataBackend::sendLocal(const nixl_opt_args_t *extra_params) {
         return ret;
     }
     const std::string ip = extra_params->ipAddr;
-    const int port = extra_params->port;
+    const std::uint16_t port = extra_params->port;
     worker_.submit([this, ip, port, blob = std::move(blob)]() {
         sendToPeer(ip, port, "NIXLCOMM:LOAD" + blob);
     });
@@ -290,7 +289,7 @@ nixlP2PMetadataBackend::sendLocalPartial(const nixl_reg_dlist_t &descs,
         return ret;
     }
     const std::string ip = extra_params->ipAddr;
-    const int port = extra_params->port;
+    const std::uint16_t port = extra_params->port;
     worker_.submit([this, ip, port, blob = std::move(blob)]() {
         sendToPeer(ip, port, "NIXLCOMM:LOAD" + blob);
     });
@@ -306,7 +305,7 @@ nixlP2PMetadataBackend::fetchRemote(const std::string & /*remote_name*/,
     // Socket fetch is keyed by address, not name; the reply is loaded into the
     // remote-section cache by serviceEvents() when the peer answers.
     const std::string ip = extra_params->ipAddr;
-    const int port = extra_params->port;
+    const std::uint16_t port = extra_params->port;
     worker_.submit([this, ip, port]() { sendToPeer(ip, port, "NIXLCOMM:SEND"); });
     return NIXL_SUCCESS;
 }
@@ -317,7 +316,7 @@ nixlP2PMetadataBackend::invalidateLocal(const nixl_opt_args_t *extra_params) {
         return NIXL_ERR_INVALID_PARAM;
     }
     const std::string ip = extra_params->ipAddr;
-    const int port = extra_params->port;
+    const std::uint16_t port = extra_params->port;
     worker_.submit(
         [this, ip, port]() { sendToPeer(ip, port, "NIXLCOMM:INVL" + ctx_.agentName()); });
     return NIXL_SUCCESS;
@@ -330,7 +329,9 @@ nixlP2PMetadataBackend::serviceEvents() {
 }
 
 void
-nixlP2PMetadataBackend::sendToPeer(const std::string &ip, int port, const std::string &msg) {
+nixlP2PMetadataBackend::sendToPeer(const std::string &ip,
+                                   std::uint16_t port,
+                                   const std::string &msg) {
     const auto key = std::make_pair(ip, port);
     auto client = remoteSockets_.find(key);
     if (client == remoteSockets_.end()) {
@@ -368,20 +369,29 @@ nixlP2PMetadataBackend::acceptPeers() {
         }
         char client_ip[INET6_ADDRSTRLEN];
         const void *address;
-        int client_port;
+        std::uint16_t client_port;
         int family = client_address.ss_family;
-        if (family == AF_INET6) {
-            const auto *client6 = reinterpret_cast<const sockaddr_in6 *>(&client_address);
+        switch (family) {
+        case AF_INET6: {
+            const auto *const client6 = reinterpret_cast<const sockaddr_in6 *>(&client_address);
             address = &client6->sin6_addr;
             if (IN6_IS_ADDR_V4MAPPED(&client6->sin6_addr)) {
                 family = AF_INET;
                 address = &client6->sin6_addr.s6_addr[12];
             }
             client_port = ntohs(client6->sin6_port);
-        } else {
-            const auto *client4 = reinterpret_cast<const sockaddr_in *>(&client_address);
+            break;
+        }
+        case AF_INET: {
+            const auto *const client4 = reinterpret_cast<const sockaddr_in *>(&client_address);
             address = &client4->sin_addr;
             client_port = ntohs(client4->sin_port);
+            break;
+        }
+        default:
+            NIXL_ERROR << "Unsupported client address family: " << family;
+            close(new_fd);
+            continue;
         }
         if (inet_ntop(family, address, client_ip, sizeof(client_ip)) == nullptr) {
             NIXL_PERROR << "inet_ntop failed for client address";

--- a/src/core/nixl_p2p_metadata_backend.cpp
+++ b/src/core/nixl_p2p_metadata_backend.cpp
@@ -51,22 +51,30 @@ constexpr auto frame_body_timeout = std::chrono::seconds(5);
 
 int
 connectToIP(const std::string &ip_addr, int port) {
-    struct sockaddr_in listenerAddr{};
-    listenerAddr.sin_port = htons(port);
-    listenerAddr.sin_family = AF_INET;
-
-    if (inet_pton(AF_INET, ip_addr.c_str(), &listenerAddr.sin_addr) <= 0) {
-        NIXL_ERROR << "inet_pton failed for ip_addr: " << ip_addr;
+    sockaddr_storage listener_addr{};
+    socklen_t listener_addr_len;
+    auto *addr4 = reinterpret_cast<sockaddr_in *>(&listener_addr);
+    auto *addr6 = reinterpret_cast<sockaddr_in6 *>(&listener_addr);
+    if (inet_pton(AF_INET, ip_addr.c_str(), &addr4->sin_addr) == 1) {
+        addr4->sin_family = AF_INET;
+        addr4->sin_port = htons(port);
+        listener_addr_len = sizeof(*addr4);
+    } else if (inet_pton(AF_INET6, ip_addr.c_str(), &addr6->sin6_addr) == 1) {
+        addr6->sin6_family = AF_INET6;
+        addr6->sin6_port = htons(port);
+        listener_addr_len = sizeof(*addr6);
+    } else {
+        NIXL_ERROR << "Invalid IPv4 or IPv6 address: " << ip_addr;
         return -1;
     }
 
-    int ret_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    int ret_fd = socket(listener_addr.ss_family, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (ret_fd == -1) {
         NIXL_ERROR << "socket creation failed for ip_addr: " << ip_addr << " and port: " << port;
         return -1;
     }
 
-    int ret = connect(ret_fd, (struct sockaddr *)&listenerAddr, sizeof(listenerAddr));
+    int ret = connect(ret_fd, reinterpret_cast<sockaddr *>(&listener_addr), listener_addr_len);
     if (ret < 0 && errno != EINPROGRESS) {
         close(ret_fd);
         return -1;
@@ -345,21 +353,36 @@ nixlP2PMetadataBackend::acceptPeers() {
         if (new_fd == -1) {
             break;
         }
-        sockaddr_in client_address;
+        sockaddr_storage client_address;
         socklen_t client_addrlen = sizeof(client_address);
         if (getpeername(new_fd, (sockaddr *)&client_address, &client_addrlen) != 0) {
             NIXL_PERROR << "getpeername failed for accepted client";
             close(new_fd);
             continue;
         }
-        char client_ip[INET_ADDRSTRLEN];
-        if (inet_ntop(AF_INET, &client_address.sin_addr, client_ip, INET_ADDRSTRLEN) == nullptr) {
+        char client_ip[INET6_ADDRSTRLEN];
+        const void *address;
+        int client_port;
+        int family = client_address.ss_family;
+        if (family == AF_INET6) {
+            const auto *client6 = reinterpret_cast<const sockaddr_in6 *>(&client_address);
+            address = &client6->sin6_addr;
+            if (IN6_IS_ADDR_V4MAPPED(&client6->sin6_addr)) {
+                family = AF_INET;
+                address = &client6->sin6_addr.s6_addr[12];
+            }
+            client_port = ntohs(client6->sin6_port);
+        } else {
+            const auto *client4 = reinterpret_cast<const sockaddr_in *>(&client_address);
+            address = &client4->sin_addr;
+            client_port = ntohs(client4->sin_port);
+        }
+        if (inet_ntop(family, address, client_ip, sizeof(client_ip)) == nullptr) {
             NIXL_PERROR << "inet_ntop failed for client address";
             close(new_fd);
             continue;
         }
-        remoteSockets_[std::make_pair(std::string(client_ip),
-                                      (int)ntohs(client_address.sin_port))] = new_fd;
+        remoteSockets_[std::make_pair(std::string(client_ip), client_port)] = new_fd;
         const int flags = fcntl(new_fd, F_GETFL, 0);
         if (flags == -1 || fcntl(new_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
             NIXL_PERROR << "fcntl failed for accepted client";

--- a/src/core/nixl_p2p_metadata_backend.h
+++ b/src/core/nixl_p2p_metadata_backend.h
@@ -25,6 +25,7 @@
 #include "nixl_metadata_backend.h"
 #include "nixl_metadata_worker.h"
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -85,7 +86,7 @@ private:
     // Connect-on-demand to (ip, port) and send msg; disconnect on error. Runs as
     // a worker task, so never concurrently with serviceEvents().
     void
-    sendToPeer(const std::string &ip, int port, const std::string &msg);
+    sendToPeer(const std::string &ip, std::uint16_t port, const std::string &msg);
     void
     acceptPeers();
     void
@@ -93,7 +94,7 @@ private:
 
     nixlMetadataContext &ctx_;
     const nixlMDConfig config_;
-    std::map<std::pair<std::string, int>, int> remoteSockets_;
+    std::map<std::pair<std::string, std::uint16_t>, int> remoteSockets_;
     std::unique_ptr<nixlMDStreamListener> listener_;
     // Declared last so it joins before the state its tasks touch is destroyed.
     nixlMetadataWorker worker_;

--- a/src/utils/stream/metadata_stream.cpp
+++ b/src/utils/stream/metadata_stream.cpp
@@ -25,7 +25,7 @@
 #include "common/nixl_log.h"
 
 nixlMetadataStream::nixlMetadataStream(uint16_t port) noexcept : port(port), socketFd(-1) {
-    memset(&listenerAddr, 0, sizeof(listenerAddr));
+    std::memset(&listenerAddr, 0, sizeof(listenerAddr));
 }
 
 nixlMetadataStream::~nixlMetadataStream() {
@@ -35,25 +35,29 @@ nixlMetadataStream::~nixlMetadataStream() {
 bool
 nixlMetadataStream::setupStream(int family) {
 
-    socketFd = socket(family, SOCK_STREAM | SOCK_NONBLOCK, 0);
-    if (socketFd == -1) {
-        return false;
-    }
-
-    memset(&listenerAddr, 0, sizeof(listenerAddr));
-    if (family == AF_INET6) {
-        auto *addr = reinterpret_cast<sockaddr_in6 *>(&listenerAddr);
+    std::memset(&listenerAddr, 0, sizeof(listenerAddr));
+    switch (family) {
+    case AF_INET6: {
+        auto *const addr = reinterpret_cast<sockaddr_in6 *>(&listenerAddr);
         addr->sin6_family = AF_INET6;
         addr->sin6_addr = in6addr_any;
         addr->sin6_port = htons(port);
-    } else {
-        auto *addr = reinterpret_cast<sockaddr_in *>(&listenerAddr);
+        break;
+    }
+    case AF_INET: {
+        auto *const addr = reinterpret_cast<sockaddr_in *>(&listenerAddr);
         addr->sin_family = AF_INET;
         addr->sin_addr.s_addr = INADDR_ANY;
         addr->sin_port = htons(port);
+        break;
+    }
+    default:
+        errno = EAFNOSUPPORT;
+        return false;
     }
 
-    return true;
+    socketFd = socket(family, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    return socketFd != -1;
 }
 
 void nixlMetadataStream::closeStream() {
@@ -84,7 +88,8 @@ void nixlMDStreamListener::setupListener() {
             throw std::runtime_error("Failed to create metadata listener socket");
         }
         if (family == AF_INET6) {
-            int v6only = 0;
+            // Explicitly allow IPv4 peers to connect through the IPv6 listener.
+            const int v6only = 0;
             if (setsockopt(socketFd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) < 0) {
                 if (errno == ENOPROTOOPT) {
                     closeStream();
@@ -96,14 +101,14 @@ void nixlMDStreamListener::setupListener() {
             }
         }
 
-        int opt = 1;
+        const int opt = 1;
         if (setsockopt(socketFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
             NIXL_PERROR << "setsockopt(REUSEADDR) failed while setting up listener for MD";
             closeStream();
             throw std::runtime_error("Failed to configure metadata listener socket");
         }
 
-        const auto *address = reinterpret_cast<const sockaddr *>(&listenerAddr);
+        const auto *const address = reinterpret_cast<const sockaddr *>(&listenerAddr);
         const socklen_t length = family == AF_INET6 ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
         if (bind(socketFd, address, length) < 0) {
             if (family == AF_INET6 && errno == EADDRNOTAVAIL) {
@@ -121,9 +126,17 @@ void nixlMDStreamListener::setupListener() {
     sockaddr_storage bound_addr;
     socklen_t addr_len = sizeof(bound_addr);
     if (getsockname(socketFd, reinterpret_cast<sockaddr *>(&bound_addr), &addr_len) == 0) {
-        port = ntohs(bound_addr.ss_family == AF_INET6 ?
-                         reinterpret_cast<sockaddr_in6 *>(&bound_addr)->sin6_port :
-                         reinterpret_cast<sockaddr_in *>(&bound_addr)->sin_port);
+        switch (bound_addr.ss_family) {
+        case AF_INET6:
+            port = ntohs(reinterpret_cast<const sockaddr_in6 *>(&bound_addr)->sin6_port);
+            break;
+        case AF_INET:
+            port = ntohs(reinterpret_cast<const sockaddr_in *>(&bound_addr)->sin_port);
+            break;
+        default:
+            closeStream();
+            throw std::runtime_error("Unsupported metadata listener address family");
+        }
     } else {
         closeStream();
         throw std::runtime_error(

--- a/src/utils/stream/metadata_stream.cpp
+++ b/src/utils/stream/metadata_stream.cpp
@@ -32,17 +32,26 @@ nixlMetadataStream::~nixlMetadataStream() {
     closeStream();
 }
 
-bool nixlMetadataStream::setupStream() {
+bool
+nixlMetadataStream::setupStream(int family) {
 
-    socketFd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    socketFd = socket(family, SOCK_STREAM | SOCK_NONBLOCK, 0);
     if (socketFd == -1) {
-        NIXL_PERROR << "failed to create stream socket for listener";
         return false;
     }
 
-    listenerAddr.sin_family = AF_INET;
-    listenerAddr.sin_addr.s_addr = INADDR_ANY;
-    listenerAddr.sin_port = htons(port);
+    memset(&listenerAddr, 0, sizeof(listenerAddr));
+    if (family == AF_INET6) {
+        auto *addr = reinterpret_cast<sockaddr_in6 *>(&listenerAddr);
+        addr->sin6_family = AF_INET6;
+        addr->sin6_addr = in6addr_any;
+        addr->sin6_port = htons(port);
+    } else {
+        auto *addr = reinterpret_cast<sockaddr_in *>(&listenerAddr);
+        addr->sin_family = AF_INET;
+        addr->sin_addr.s_addr = INADDR_ANY;
+        addr->sin_port = htons(port);
+    }
 
     return true;
 }
@@ -66,30 +75,55 @@ nixlMDStreamListener::~nixlMDStreamListener() {
 }
 
 void nixlMDStreamListener::setupListener() {
-    if (!setupStream()) {
-        throw std::runtime_error("Failed to create metadata listener socket");
-    }
+    for (const int family : {AF_INET6, AF_INET}) {
+        if (!setupStream(family)) {
+            if (family == AF_INET6 && (errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT)) {
+                continue;
+            }
+            NIXL_PERROR << "failed to create stream socket for listener";
+            throw std::runtime_error("Failed to create metadata listener socket");
+        }
+        if (family == AF_INET6) {
+            int v6only = 0;
+            if (setsockopt(socketFd, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) < 0) {
+                if (errno == ENOPROTOOPT) {
+                    closeStream();
+                    continue;
+                }
+                NIXL_PERROR << "setsockopt(IPV6_V6ONLY) failed while setting up listener for MD";
+                closeStream();
+                throw std::runtime_error("Failed to configure metadata listener socket");
+            }
+        }
 
-    int opt = 1;
-    if (setsockopt(socketFd, SOL_SOCKET, SO_REUSEADDR,
-                   &opt, sizeof(opt)) < 0) {
-        NIXL_PERROR << "setsockopt(REUSEADDR) failed while setting up listener for MD";
-        closeStream();
-        throw std::runtime_error("Failed to configure metadata listener socket");
-    }
+        int opt = 1;
+        if (setsockopt(socketFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+            NIXL_PERROR << "setsockopt(REUSEADDR) failed while setting up listener for MD";
+            closeStream();
+            throw std::runtime_error("Failed to configure metadata listener socket");
+        }
 
-    if (bind(socketFd, (struct sockaddr*)&listenerAddr,
-             sizeof(listenerAddr)) < 0) {
-        NIXL_PERROR << "Socket Bind failed while setting up listener for MD";
-        closeStream();
-        throw std::runtime_error("Failed to bind metadata listener socket");
+        const auto *address = reinterpret_cast<const sockaddr *>(&listenerAddr);
+        const socklen_t length = family == AF_INET6 ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
+        if (bind(socketFd, address, length) < 0) {
+            if (family == AF_INET6 && errno == EADDRNOTAVAIL) {
+                closeStream();
+                continue;
+            }
+            NIXL_PERROR << "Socket Bind failed while setting up listener for MD";
+            closeStream();
+            throw std::runtime_error("Failed to bind metadata listener socket");
+        }
+        break;
     }
 
     const bool os_assigned_port = (port == 0);
-    sockaddr_in bound_addr;
+    sockaddr_storage bound_addr;
     socklen_t addr_len = sizeof(bound_addr);
     if (getsockname(socketFd, reinterpret_cast<sockaddr *>(&bound_addr), &addr_len) == 0) {
-        port = ntohs(bound_addr.sin_port);
+        port = ntohs(bound_addr.ss_family == AF_INET6 ?
+                         reinterpret_cast<sockaddr_in6 *>(&bound_addr)->sin6_port :
+                         reinterpret_cast<sockaddr_in *>(&bound_addr)->sin_port);
     } else {
         closeStream();
         throw std::runtime_error(
@@ -192,7 +226,7 @@ nixlMDStreamClient::~nixlMDStreamClient() {
 }
 
 bool nixlMDStreamClient::setupClient() {
-    if (!setupStream()) {
+    if (!setupStream(AF_INET)) {
         NIXL_PERROR << "Failed to create metadata client socket";
         return false;
     }

--- a/src/utils/stream/metadata_stream.h
+++ b/src/utils/stream/metadata_stream.h
@@ -36,9 +36,10 @@ class nixlMetadataStream {
         uint16_t port;
         int                 socketFd;
         std::string         listenerAddress;
-        struct sockaddr_in  listenerAddr;
+        sockaddr_storage listenerAddr;
 
-        bool setupStream();
+        bool
+        setupStream(int family);
         void closeStream();
 
     public:

--- a/test/gtest/metadata_exchange.cpp
+++ b/test/gtest/metadata_exchange.cpp
@@ -16,6 +16,11 @@
  */
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <cerrno>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <thread>
 #include <random>
 #include "nixl.h"
@@ -443,6 +448,22 @@ TEST_F(MetadataExchangeTestFixture, SocketFetchRemoteAndInvalidateLocal) {
 }
 
 TEST_F(MetadataExchangeTestFixture, SocketExchangeIPv6) {
+    const int fd = socket(AF_INET6, SOCK_STREAM, 0);
+    if (fd < 0 && (errno == EAFNOSUPPORT || errno == EPROTONOSUPPORT)) {
+        GTEST_SKIP() << "IPv6 is unavailable";
+    }
+    ASSERT_GE(fd, 0);
+    sockaddr_in6 loopback{};
+    loopback.sin6_family = AF_INET6;
+    loopback.sin6_addr = in6addr_loopback;
+    const int bind_result = bind(fd, reinterpret_cast<sockaddr *>(&loopback), sizeof(loopback));
+    const int bind_error = errno;
+    close(fd);
+    if (bind_result < 0 && bind_error == EADDRNOTAVAIL) {
+        GTEST_SKIP() << "IPv6 loopback is unavailable";
+    }
+    ASSERT_EQ(bind_result, 0);
+
     initAgentsDefault();
 
     auto &src = agents_[0];
@@ -455,6 +476,9 @@ TEST_F(MetadataExchangeTestFixture, SocketExchangeIPv6) {
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_EQ(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
 
+    const auto scope_id = if_nametoindex("lo");
+    ASSERT_NE(scope_id, 0);
+    args.ipAddr = "::1%" + std::to_string(scope_id);
     ASSERT_EQ(dst.agent->sendLocalMD(&args), NIXL_SUCCESS);
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_EQ(src.agent->checkRemoteMD(dst.name, {DRAM_SEG}), NIXL_SUCCESS);

--- a/test/gtest/metadata_exchange.cpp
+++ b/test/gtest/metadata_exchange.cpp
@@ -442,6 +442,29 @@ TEST_F(MetadataExchangeTestFixture, SocketFetchRemoteAndInvalidateLocal) {
     ASSERT_NE(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
 }
 
+TEST_F(MetadataExchangeTestFixture, SocketExchangeIPv6) {
+    initAgentsDefault();
+
+    auto &src = agents_[0];
+    auto &dst = agents_[1];
+    nixl_opt_args_t args;
+    args.ipAddr = "::1";
+    args.port = src.port;
+
+    ASSERT_EQ(dst.agent->fetchRemoteMD(src.name, &args), NIXL_SUCCESS);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_SUCCESS);
+
+    ASSERT_EQ(dst.agent->sendLocalMD(&args), NIXL_SUCCESS);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(src.agent->checkRemoteMD(dst.name, {DRAM_SEG}), NIXL_SUCCESS);
+
+    args.port = dst.port;
+    ASSERT_EQ(src.agent->invalidateLocalMD(&args), NIXL_SUCCESS);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(dst.agent->checkRemoteMD(src.name, {DRAM_SEG}), NIXL_ERR_NOT_FOUND);
+}
+
 TEST_F(MetadataExchangeTestFixture, SocketSendPartialLocal) {
     initAgentsDefault();
 


### PR DESCRIPTION
## What?
Add IPv6 support to socket-based metadata exchange while preserving IPv4 support.

## Why?
The metadata listener and outbound connections currently assume IPv4, preventing peers from exchanging metadata over IPv6-only networks.

## How?
Use sockaddr_storage in the existing stream abstraction and infer the outbound socket family from the numeric address. Accept IPv4 and IPv6 through a dual-stack listener, falling back to IPv4 when IPv6 is unavailable. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added IPv6 support for metadata connections and peer address handling.
  - Metadata listeners now prefer IPv6, with automatic IPv4 fallback and dual-stack support where available.
  - IPv4-mapped IPv6 addresses and IPv6 scope identifiers are recognized and normalized.
  - Existing IPv4 connectivity remains supported.
  - Added coverage for IPv6 loopback and scoped-interface metadata exchanges.

- **Documentation**
  - Clarified accepted address formats, including numeric IPv4 and unbracketed IPv6 notation.
  - Documented IPv6 zone suffixes and which metadata-transfer methods use the configured address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->