### PR TITLE
ci: make wheel builds DR-safe

### DIFF
--- a/.ci/cleanup-spec.json
+++ b/.ci/cleanup-spec.json
@@ -67,6 +67,19 @@
           ]
         }
       }
+    },
+    {
+      "//": "Staging PyPI wheels — older than 1 week",
+      "aql": {
+        "items.find": {
+          "$and": [
+            { "repo": "sw-nbu-swx-nixl-pypi-local" },
+            { "path": { "$match": "staging/**" } },
+            { "name": { "$match": "*.whl" } },
+            { "modified": { "$before": "1w" } }
+          ]
+        }
+      }
     }
   ]
 }

--- a/.ci/docs/ci-overview.md
+++ b/.ci/docs/ci-overview.md
@@ -21,21 +21,23 @@ runs on-demand (`workflow_dispatch`, a PR comment, or a cron schedule).
 | [External Contributor](#external-contributor-external_contributoryaml) | GitHub Actions | `pull_request_target` (opened, fork only) | Yes (fork PRs only) |
 | [Blossom-CI](#blossom-ci-blossom-ciyml) | GitHub Actions | `/build` PR comment, or `workflow_dispatch` | No — manual |
 | `nixl-ci-dispatcher` → `non-gpu`, `gpu`, `dl-gpu`, `dl-gpu-ep`, `build-wheel`, `test-sanitizers`, `build-container-pr` | Jenkins (dispatcher-triggered) | Fan-out from Blossom-CI `Job-trigger` | No — only after `/build`, but these 7 are the *only* Jenkins jobs in the PR CI path |
-| `nixl-ci-build-container` | Jenkins (standalone) | Nightly cron + manual | No — never runs as part of PR CI |
-| `nixl-ci-build-wheel-nightly` | Jenkins (standalone) | Nightly cron, triggered by `build-wheel-release-poller`, or manual | No — never runs as part of PR CI |
+| `nixl-ci-build-container` | Jenkins (standalone) | Triggered by `verification-launcher` (daily 9 PM) or manual | No — never runs as part of PR CI |
+| `nixl-ci-build-wheel-nightly` | Jenkins (standalone) | Triggered by `verification-launcher` (nightly) or `build-wheel-release-poller`, or manual | No — never runs as part of PR CI |
+| `nixl-ci-verification-launcher` | Jenkins (standalone) | Cron: midnight (wheels) + 9 PM (containers) | No — never runs as part of PR CI |
 | `nixl-build-wheel-release-poller` | Jenkins (standalone) | 4-hourly cron + manual | No — never runs as part of PR CI |
 | `nixl-ci-build-llm-container` | Jenkins (standalone) | Manual only | No — never runs as part of PR CI |
 | `nixl-ci-test-llm-container` | Jenkins (standalone) | Manual, or chained from `build-llm-container` via `RUN_TEST` | No — never runs as part of PR CI |
 | `nixl-ci-cleanup-artifacts` | Jenkins (standalone) | Daily cron (6 AM) + manual | No — never runs as part of PR CI |
 | `nixl-ci-nightly` | Jenkins (standalone) | Nightly cron (`H 0`) + manual | No — orchestrates the nightly UCX-`master` run of the 3 GPU jobs |
 
-> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 15 Jenkins jobs: the
-> dispatcher, the 7 jobs it fans out to (the PR CI flow), and 7 standalone jobs
-> (`build-container`, `build-wheel-nightly`, `build-wheel-release-poller`,
-> `build-llm-container`, `test-llm-container`, `cleanup-artifacts`, `nightly`). The
-> standalone ones run only on their own cron, when someone triggers them manually
-> from the Jenkins UI, or when chained from another standalone job,
-> and are never invoked by the dispatcher or by a PR event.
+> **Note on Jenkins jobs:** `proj-jjb.yaml` defines 16 Jenkins jobs: the
+> dispatcher, the 7 jobs it fans out to (the PR CI flow), and 8 standalone jobs
+> (`build-container`, `build-wheel-nightly`, `verification-launcher`,
+> `build-wheel-release-poller`, `build-llm-container`, `test-llm-container`,
+> `cleanup-artifacts`, `nightly`). The standalone ones run only on their own
+> cron, when someone triggers them manually from the Jenkins UI, or when
+> chained from another standalone job, and are never invoked by the dispatcher
+> or by a PR event.
 
 ## GitHub Actions workflows
 
@@ -153,7 +155,8 @@ their own nightly/manual trigger. They split into two groups:
   the 7 jobs it fans out to. This is the *only* way any Jenkins job runs
   against a PR, and only after a `/build` comment.
 - **Standalone (never run against a PR):** `nixl-ci-build-container`,
-  `nixl-ci-build-wheel-nightly`, `nixl-build-wheel-release-poller`,
+  `nixl-ci-build-wheel-nightly`, `nixl-ci-verification-launcher`,
+  `nixl-build-wheel-release-poller`,
   `nixl-ci-build-llm-container`, `nixl-ci-test-llm-container`,
   `nixl-ci-cleanup-artifacts`, `nixl-ci-nightly` — each has its own cron, manual
   trigger, and/or upstream standalone job, and is invoked independently of PRs
@@ -186,16 +189,21 @@ their own nightly/manual trigger. They split into two groups:
 - **`CI_IMAGE_TAG`:** Same convention as the other five matrix files (also tags `build_helper_*` and the sanity `*-nixl-base` images). `contrib/Dockerfile.manylinux` is part of the `CI_FILES` list in `cidemo-init.sh`, so changing it (or any other CI file) automatically derives a new `CI_IMAGE_TAG` and rebuilds the cached `wheel_base` image (see [CI_IMAGE_TAG management](#ci_image_tag-management)).
 
 ### `nixl-ci-build-container` (standalone)
-- **Trigger:** Nightly cron (builds `nixlbench` and `nixl` targets, on both the default CUDA base image and the PyTorch release image `nvcr.io/nvidia/pytorch:26.06-py3`, ~22:00), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.).
+- **Trigger:** Triggered daily around 9 PM by [`nixl-ci-verification-launcher`](#nixl-ci-verification-launcher-standalone) (four runs: `nixlbench` and `nixl` targets, each on the default CUDA base image and on the DLFW PyTorch daily image), or manual run with parameters (`BUILD_TARGET`, `NIXL_VERSION`, `UCX_VERSION`, base image overrides, etc.). Carries no schedule trigger of its own.
 - **What it does:** Builds and pushes x86_64/aarch64 NIXL/NIXLBench container images to Artifactory, then sets build metadata properties on each image via the Artifactory REST API. The Push step runs with `set -eo pipefail` so auth or API failures abort the build immediately. `BUILD_UCX_SPCX_PLUGIN` (default on, `nixl` target only) builds the internal UCX spcx plugin against the image's UCX and installs it into the UCX plugin dir; it needs the `svc-nixl-gitlab-token` + `ucx-plugin-gitlab-url` credentials, bound on the Build NIXL step. `BUILD_NIXL_EP` is on by default and has no off-switch — `contrib/build-container.sh` builds EP regardless. `BUILD_INFINIA` (default off, `nixl` target only) stages the DDN libs from harbor.mellanox.com and builds `libplugin_INFINIA.so` into the image; it is off by default because it adds an external registry dependency.
 - **Image tag:** `pipeline_start` resolves the NIXL and UCX commits once (`NIXL_SHA`, `UCX_SHA`) and exports `IMAGE_TAG_BASE`; both arches build from those exact commits and tag from that base, and `pipeline_stop` reuses it to name the images. Previously each arch re-resolved UCX independently, so a branch moving mid-build could ship two arches from different UCX commits under one tag.
 - **Completion mail:** When `MAIL_TO` is set, `pipeline_stop` mails the build result, listing the pushed image URLs (and the `-latest` tags when `UPDATE_LATEST`) so the verification team can pull them directly. The list is included only on `SUCCESS` — a failed run may not have pushed, and a link to a missing image is worse than no link.
 - **Automatic on every PR:** No — standalone/nightly + manual only.
 
 ### `nixl-ci-build-wheel-nightly` (standalone)
-- **Trigger:** Nightly cron (two runs, `CUDA_MAJOR=13` and `CUDA_MAJOR=12`), triggered by [`nixl-build-wheel-release-poller`](#nixl-build-wheel-release-poller-standalone) for release publishing, or manual run. The pipeline and matrix config run from `ci_refspec` (default `main`; pass `refs/pull/<n>/head` to test CI changes end to end before merge); the NIXL source is cloned inside the build from the `NIXL_VERSION` parameter (branch/tag/PR ref/sha), so any ref is buildable without CI files on it.
-- **What it does:** Reuses the per-PR wheel build path (`contrib/build-container.sh` + `Dockerfile.manylinux`) and publishes wheels to `sw-nbu-swx-nixl-pypi-local`. With `PUBLISH_DIR` empty (the default, and what the nightly cron uses) wheels land under `verification/g<nixl-sha8>.ucx<ucx-sha8>/` — the long-standing schema the `build-llm-container` verification pipeline consumes; the poller and manual release runs pass `release/<ver>`, which co-locates cu12/cu13 under `release/<ver>/<nixl-sha8>/` (unkeyed to UCX). `CUDA_MAJOR` selects the CUDA line to build: `13` (default) passes no base-image flags to `build-container.sh` and relies on its own defaults; `12` passes the pinned CUDA 12 base image/tag from the matrix env. The UCX spcx and Infinia DDN plugins are always bundled (`--build-ucx-spcx-plugin --build-infinia`, unconditional — not job parameters); the source ref's `contrib/build-container.sh` must carry both flags and pin their versions. The resolved build options (base image, UCX ref/sha, plugin flags, etc.) are written to `build_options.env` via `--build-options-file`; Publish reads it and attaches `UCX_REF`, `UCX_SHA`, `CUDA_VERSION`, and (when built) `UCX_SPCX_PLUGIN_REF`/`INFINIA_LIBS_IMAGE` as Artifactory properties on each uploaded wheel (skipped if the built ref's `build-container.sh` predates `--build-options-file`).
-- **Automatic on every PR:** No — standalone nightly/poller-triggered + manual only.
+- **Trigger:** Triggered by [`nixl-ci-verification-launcher`](#nixl-ci-verification-launcher-standalone) (nightly, two runs: `CUDA_MAJOR=13` and `CUDA_MAJOR=12`) or by [`nixl-build-wheel-release-poller`](#nixl-build-wheel-release-poller-standalone) for release publishing, or manual run. Carries no schedule trigger of its own. The pipeline and matrix config run from `ci_refspec` (default `main`; pass `refs/pull/<n>/head` to test CI changes end to end before merge); the NIXL source is cloned inside the build from the `NIXL_VERSION` parameter (branch/tag/PR ref/sha), so any ref is buildable without CI files on it.
+- **What it does:** Reuses the per-PR wheel build path (`contrib/build-container.sh` + `Dockerfile.manylinux`) and publishes wheels to `sw-nbu-swx-nixl-pypi-local`. With `PUBLISH_DIR` empty (the default, and what the verification launcher uses) wheels land under `verification/g<nixl-sha8>.ucx<ucx-sha8>/` — the long-standing schema the `build-llm-container` verification pipeline consumes; manual runs can pass `staging`, which uses the same `g<nixl-sha8>.ucx<ucx-sha8>/` schema under `staging/` for short-lived test/DR publishes (cleaned up after 1 week — see [`nixl-ci-cleanup-artifacts`](#nixl-ci-cleanup-artifacts-standalone)); the poller and manual release runs pass `release/<ver>`, which co-locates cu12/cu13 under `release/<ver>/<nixl-sha8>/` (unkeyed to UCX). `CUDA_MAJOR` selects the CUDA line to build: `13` (default) passes no base-image flags to `build-container.sh` and relies on its own defaults; `12` passes the pinned CUDA 12 base image/tag from the matrix env. The UCX spcx and Infinia DDN plugins are always bundled (`--build-ucx-spcx-plugin --build-infinia`, unconditional — not job parameters); the source ref's `contrib/build-container.sh` must carry both flags and pin their versions. The resolved build options (base image, UCX ref/sha, plugin flags, etc.) are written to `build_options.env` via `--build-options-file`; Publish reads it and attaches `UCX_REF`, `UCX_SHA`, `CUDA_VERSION`, and (when built) `UCX_SPCX_PLUGIN_REF`/`INFINIA_LIBS_IMAGE` as Artifactory properties on each uploaded wheel (skipped if the built ref's `build-container.sh` predates `--build-options-file`).
+- **Automatic on every PR:** No — standalone launcher/poller-triggered + manual only.
+
+### `nixl-ci-verification-launcher` (standalone)
+- **Trigger:** Two cron entries (`parameterized-timer`) or manual run: `H 0 * * * %LAUNCH_TARGET=wheels` and `H 21 * * * %LAUNCH_TARGET=containers`. The pipeline and matrix config (`.ci/jenkins/lib/verification-launcher-matrix.yaml`) run from `ci_refspec` (default `main`).
+- **What it does:** Single scheduler for the unattended verification builds — both build jobs it fires carry no cron of their own. `LAUNCH_TARGET=wheels` fires [`nixl-ci-build-wheel-nightly`](#nixl-ci-build-wheel-nightly-standalone) twice, `NIXL_VERSION=main` with `CUDA_MAJOR=13` and `CUDA_MAJOR=12`, `PUBLISH_DIR` left empty so both land under `verification/`; `ci_refspec` is forwarded so a pre-merge test run drives the whole chain from one PR ref. `LAUNCH_TARGET=containers` fires [`nixl-ci-build-container`](#nixl-ci-build-container-standalone) four times — `BUILD_TARGET=nixlbench` and `BUILD_TARGET=nixl`, each on the job's default base image and on the DLFW PyTorch daily (`gitlab-master.nvidia.com:5005/dl/dgx/pytorch:main-py3-devel`), all with `UPDATE_LATEST=true`; `ci_refspec` is not forwarded (`build-container` has no such param — it checks out `NIXL_VERSION`). All triggers are fire-and-forget (`wait:false, propagate:false`) with a per-trigger guard, so one bad trigger marks the launcher `UNSTABLE` without dropping the rest; each triggered build reports its own result.
+- **Automatic on every PR:** No — cron + manual only.
 
 ### `nixl-build-wheel-release-poller` (standalone)
 
@@ -244,7 +252,7 @@ Use `squeue --name <pattern>` or `squeue -u <user>` to identify which pipeline o
 
 - **Full Jenkins pipeline for a PR:** comment `/build` on the PR (requires authorization — see `Authorization` step in `blossom-ci.yml`).
 - **Re-run a single Jenkins job with different parameters:** use `workflow_dispatch` on `blossom-ci.yml`, or trigger the Jenkins job directly if you have Jenkins access.
-- **Container/wheel builds outside the nightly schedule:** run `nixl-ci-build-container` or `nixl-ci-build-wheel-nightly` manually from the Jenkins UI with custom parameters.
+- **Container/wheel builds outside the launcher schedule:** run `nixl-ci-build-container` or `nixl-ci-build-wheel-nightly` manually from the Jenkins UI with custom parameters.
 
 ## CI_IMAGE_TAG management
 

--- a/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
+++ b/.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
@@ -1,7 +1,8 @@
 # Nightly NIXL wheel verification build. Pipeline and this config run from
 # main; the source ref (NIXL_VERSION) is cloned into nixl-src, so built refs
 # carry no CI config. Wheels publish to
-# WHEEL_REPO_URL/verification/g<nixl-sha>.ucx<ucx-sha> (default) or
+# WHEEL_REPO_URL/verification/g<nixl-sha>.ucx<ucx-sha> (default),
+# WHEEL_REPO_URL/staging/g<nixl-sha>.ucx<ucx-sha> for manual staging runs, or
 # WHEEL_REPO_URL/<PUBLISH_DIR>/<nixl-sha> for manual release runs.
 
 ---
@@ -154,11 +155,12 @@ steps:
       ls -l dist/
 
       # Nightly runs leave PUBLISH_DIR empty and publish to verification/;
-      # manual release runs can pass release/<ver>. Allowlist it - the URL is
-      # PUT with the service token, and a path like ../<other-repo> would
-      # normalize into a different Artifactory repo.
+      # manual staging runs can pass staging, manual release runs can pass
+      # release/<ver>. Allowlist it - the URL is PUT with the service token,
+      # and a path like ../<other-repo> would normalize into a different
+      # Artifactory repo.
       PUBLISH_DIR="${PUBLISH_DIR:-verification}"
-      [[ "${PUBLISH_DIR}" =~ ^(verification|release/[A-Za-z0-9][A-Za-z0-9._-]*)$ ]] \
+      [[ "${PUBLISH_DIR}" =~ ^(verification|staging|release/[A-Za-z0-9][A-Za-z0-9._-]*)$ ]] \
         || { echo "ERROR: invalid PUBLISH_DIR '${PUBLISH_DIR}'"; exit 1; }
       . ./wheel_build_ids.env
 
@@ -180,9 +182,10 @@ steps:
 
       # verification/ keeps its long-standing g<nixl-sha>.ucx<ucx-sha> folder
       # schema (consumed by the build-llm-container verification pipeline);
-      # release/<ver> co-locates cu12/cu13 by nixl-sha alone, unkeyed to UCX.
-      if [ "${PUBLISH_DIR}" = "verification" ]; then
-        [ -n "${UCX_SHA:-}" ] || { echo "ERROR: verification publish needs UCX_SHA from build_options.env"; exit 1; }
+      # staging/ mirrors it. release/<ver> co-locates cu12/cu13 by nixl-sha alone, unkeyed
+      # to UCX.
+      if [ "${PUBLISH_DIR}" = "verification" ] || [ "${PUBLISH_DIR}" = "staging" ]; then
+        [ -n "${UCX_SHA:-}" ] || { echo "ERROR: ${PUBLISH_DIR} publish needs UCX_SHA from build_options.env"; exit 1; }
         FOLDER="g${NIXL_SHA}.ucx${UCX_SHA}"
       else
         FOLDER="${NIXL_SHA}"

--- a/.ci/jenkins/lib/verification-launcher-matrix.yaml
+++ b/.ci/jenkins/lib/verification-launcher-matrix.yaml
@@ -1,0 +1,131 @@
+# NIXL verification launcher. Single scheduler for the unattended verification
+# builds: it owns the crons and triggers the build jobs, which carry no
+# schedule of their own. LAUNCH_TARGET selects what a run fires:
+#   wheels     (midnight) -> nixl-ci-build-wheel-nightly, one run per CUDA major
+#   containers (9 PM)     -> nixl-ci-build-container, the 4 nightly variants
+# Fire-and-forget (wait:false): the launcher reports what it spawned, not how
+# the builds ended - each triggered job mails its own failures.
+
+---
+job: nixl-ci-verification-launcher
+
+timeout_minutes: 15
+
+kubernetes:
+  cloud: il-ipp-blossom-prod
+  namespace: nbu-swx-nixl
+  limits: '{memory: 2Gi, cpu: 1000m}'
+  requests: '{memory: 1Gi, cpu: 500m}'
+
+# Minimal pod: the single step is pipeline-level groovy, it never uses the
+# container shell.
+runs_on_dockers:
+  - { name: "launcher", url: "dockerhub.nvidia.com/ubuntu:24.04", arch: "x86_64" }
+
+env:
+  MAIL_FROM: "jenkins@nvidia.com"
+
+steps:
+  - name: Trigger Verification Builds
+    containerSelector: "{name: 'launcher'}"
+    shell: action
+    module: groovy
+    parallel: false
+    run: |
+      def target = params.LAUNCH_TARGET ?: 'wheels'
+      // Forward our CI ref so a pre-merge test run drives the wheel builds with
+      // the same pipeline + config revision. build-container has no ci_refspec
+      // param - it checks out NIXL_VERSION - so it is not forwarded there.
+      def ciRefspec = params.ci_refspec ?: 'main'
+      def spawned = []
+      def failed = []
+
+      currentBuild.description = target
+
+      if (target == 'wheels') {
+          // PUBLISH_DIR left unset: both CUDA majors publish to verification/.
+          for (cu in ['13', '12']) {
+              def label = "build-wheel-nightly CUDA_MAJOR=${cu}"
+              // Per-trigger guard: one bad trigger must not drop the rest.
+              try {
+                  build(job: 'nixl-ci-build-wheel-nightly',
+                        parameters: [
+                            string(name: 'NIXL_VERSION', value: 'main'),
+                            string(name: 'CUDA_MAJOR', value: cu),
+                            string(name: 'ci_refspec', value: ciRefspec),
+                        ],
+                        wait: false, propagate: false)
+                  spawned << label
+              } catch (err) {
+                  failed << "${label}: ${err}"
+                  currentBuild.result = 'UNSTABLE'
+              }
+          }
+      } else {
+          // The 4 variants that used to be build-container's own cron:
+          // nixlbench + nixl, each on the job's default base image and on the
+          // DLFW PyTorch daily. Empty base = the job's own default.
+          def dlfwBase = 'gitlab-master.nvidia.com:5005/dl/dgx/pytorch'
+          def dlfwTag = 'main-py3-devel'
+          def containerRuns = [
+              [buildTarget: 'nixlbench', base: '',       tag: ''],
+              [buildTarget: 'nixl',      base: '',       tag: ''],
+              [buildTarget: 'nixlbench', base: dlfwBase, tag: dlfwTag],
+              [buildTarget: 'nixl',      base: dlfwBase, tag: dlfwTag],
+          ]
+          for (run in containerRuns) {
+              def buildParams = [
+                  string(name: 'BUILD_TARGET', value: run.buildTarget),
+                  booleanParam(name: 'UPDATE_LATEST', value: true),
+              ]
+              if (run.base) {
+                  buildParams << string(name: 'BASE_IMAGE', value: run.base)
+                  buildParams << string(name: 'BASE_IMAGE_TAG', value: run.tag)
+              }
+              def label = "build-container ${run.buildTarget} " + (run.base ? 'dlfw-pytorch' : 'default-base')
+              try {
+                  build(job: 'nixl-ci-build-container',
+                        parameters: buildParams,
+                        wait: false, propagate: false)
+                  spawned << label
+              } catch (err) {
+                  failed << "${label}: ${err}"
+                  currentBuild.result = 'UNSTABLE'
+              }
+          }
+      }
+
+      // build(wait:false) yields no per-run URL, so the report lists what was
+      // spawned; each triggered build back-links here as "upstream
+      // #${BUILD_NUMBER}".
+      def report = ["", "===== launcher (${target}) spawned ${spawned.size()} build(s) ====="]
+      report += spawned.collect { "  + ${it}" }
+      if (failed) {
+          report << "----- ${failed.size()} failed to trigger -----"
+          report += failed.collect { "  ! ${it}" }
+      }
+      echo report.join('\n')
+
+# Mail the unattended launcher only when it fails to trigger; the triggered
+# builds report their own results.
+pipeline_stop:
+  shell: action
+  module: groovy
+  containerSelector: "{name: 'launcher'}"
+  run: |
+    def jobStatus = currentBuild.result ?: 'SUCCESS'
+    if (jobStatus != 'SUCCESS' && params.MAIL_TO) {
+        mail(
+            from: env.MAIL_FROM,
+            to: params.MAIL_TO,
+            subject: "Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' - ${jobStatus}",
+            mimeType: 'text/html',
+            body: """
+                <p>Launch target: <b>${params.LAUNCH_TARGET}</b></p>
+                <p>Status: <span style="color: red;"><b>${jobStatus}</b></span></p>
+                <p>Job: <a href='${env.JOB_URL}'>${env.JOB_NAME}</a></p>
+                <p>Build: <a href='${env.BUILD_URL}'>#${env.BUILD_NUMBER}</a></p>
+                <p>Console Output: <a href='${env.BUILD_URL}console'>Full Log</a></p>
+            """
+        )
+    }

--- a/.ci/jenkins/pipeline/proj-jjb.yaml
+++ b/.ci/jenkins/pipeline/proj-jjb.yaml
@@ -452,7 +452,7 @@
 
 # Template for NIXL build container job
 # Builds and pushes NIXL and NIXLBench container images for x86_64 and aarch64
-# Supports nightly automatic builds and manual builds via parameters
+# Triggered by {jjb_proj}-verification-launcher and manual builds via parameters
 - job-template:
     name: "{jjb_proj}-build-container"
     project-type: pipeline
@@ -472,23 +472,12 @@
       • Choose between <b>nixlbench</b> or <b>nixl</b> build targets<br/>
       • Optional latest tag update via <code>UPDATE_LATEST</code> parameter<br/>
       • Images pushed to: https://artifactory.nvidia.com/sw-nbu-swx-nixl-docker-local/ <code>verification/nixlbench/</code> or <code>verification/nixl/</code> based on target<br/>
-      • You must be part of access-artifactory-nbu-swx-nixl-users DL group in order to work with these images
+      • You must be part of access-artifactory-nbu-swx-nixl-users DL group in order to work with these images<br/>
+      • Triggered by <code>{jjb_proj}-verification-launcher</code>
       <br/>
       <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
     concurrent: true
     sandbox: true
-    # Nightly scheduler for automatic builds with default versions
-    triggers:
-      - parameterized-timer:
-          cron: |
-            # Build nixlbench nightly around 22:00 - Ubuntu 24.04
-            H 22 * * * %BUILD_TARGET=nixlbench;UPDATE_LATEST=true
-            # Build nixl nightly around 22:00 - Ubuntu 24.04
-            H 22 * * * %BUILD_TARGET=nixl;UPDATE_LATEST=true
-            # Build nixlbench nightly around 22:00 - PyTorch release
-            H 22 * * * %BUILD_TARGET=nixlbench;BASE_IMAGE=nvcr.io/nvidia/pytorch;BASE_IMAGE_TAG=26.06-py3;UPDATE_LATEST=true
-            # Build nixl nightly around 22:00 - PyTorch release
-            H 22 * * * %BUILD_TARGET=nixl;BASE_IMAGE=nvcr.io/nvidia/pytorch;BASE_IMAGE_TAG=26.06-py3;UPDATE_LATEST=true
     # Manual build parameters
     parameters:
       - choice:
@@ -896,8 +885,8 @@
               parent-credentials: true
       script-path: "{jjb_jenkinsfile}"
 
-# Wheel verification job: builds and publishes NIXL wheels to Artifactory. Runs on
-# a nightly schedule (from main) and on manual runs (any branch/tag/PR/SHA).
+# Wheel verification job: builds and publishes NIXL wheels to Artifactory. Triggered by
+# {jjb_proj}-verification-launcher (from main), the release poller, and manual runs (any branch/tag/PR/SHA).
 - job-template:
     name: "{jjb_proj}-build-wheel-nightly"
     project-type: pipeline
@@ -913,25 +902,17 @@
             conf_file=.ci/jenkins/lib/build-wheel-nightly-matrix.yaml
     description: >
       <b>NIXL nightly wheel verification build</b><br/>
-      • Builds NIXL wheels (x86_64 &amp; aarch64) nightly from <code>main</code> for CUDA 13
-      and CUDA 12, with the UCX spcx and Infinia plugins always bundled, and publishes them
-      to the verification Artifactory space<br/>
+      • Builds NIXL wheels (x86_64 &amp; aarch64) for CUDA 13 and CUDA 12, with the UCX spcx
+      and Infinia plugins always bundled, and publishes them to the verification (default),
+      staging, or release Artifactory space per <code>PUBLISH_DIR</code><br/>
       • Run manually from any NIXL branch / tag / PR / SHA via <code>NIXL_VERSION</code><br/>
+      • Triggered (both CUDA variants, from <code>main</code>) by
+      <code>nixl-ci-verification-launcher</code><br/>
       • Also triggered per missing CUDA variant by <code>nixl-build-wheel-release-poller</code>
       with <code>PUBLISH_DIR=release/&lt;ver&gt;</code><br/>
       • <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
     concurrent: true
     sandbox: true
-    # Nightly scheduler; manual runs use the parameter defaults below
-    triggers:
-      - parameterized-timer:
-          cron: |
-            # Build NIXL wheels nightly around midnight for CUDA 13 and CUDA 12
-            # (the cu12 run also produces the nixl meta wheel). Both publish to
-            # the repo.
-            H 0 * * * %NIXL_VERSION=main;CUDA_MAJOR=13
-            H 0 * * * %NIXL_VERSION=main;CUDA_MAJOR=12
-    # Manual build parameters
     parameters:
       - string:
           name: "NIXL_VERSION"
@@ -946,7 +927,7 @@
       - string:
           name: "PUBLISH_DIR"
           default: ""
-          description: "Artifactory publish subdir; empty = verification (nightly default). The release poller and manual release runs pass release/&lt;ver&gt;."
+          description: "Artifactory publish subdir; empty = verification (nightly default). staging publishes to the same g&lt;nixl-sha&gt;.ucx&lt;ucx-sha&gt; schema as verification. The release poller and manual release runs pass release/&lt;ver&gt;."
       - string:
           name: "DEBUG"
           default: 0
@@ -964,6 +945,79 @@
             <code>refs/pull/1234/head</code> to test CI changes end to end before merge.
     # SCM = ci_refspec (default main): supplies the pipeline + matrix config
     # only; the build clones the source from NIXL_VERSION itself
+    pipeline-scm:
+      scm:
+        - git:
+            url: "{jjb_git}"
+            branches: ['${{ci_refspec}}']
+            shallow-clone: false
+            do-not-fetch-tags: false
+            refspec: "+refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/* +refs/pull/*/head:refs/pull/*/head"
+            browser: githubweb
+            browser-url: "{jjb_git}"
+            submodule:
+              disable: false
+              recursive: true
+              tracking: true
+              parent-credentials: true
+      script-path: "{jjb_jenkinsfile}"
+
+# Verification launcher: single scheduler for verification builds.
+- job-template:
+    name: "{jjb_proj}-verification-launcher"
+    project-type: pipeline
+    disabled: false
+    properties:
+      - build-discarder:
+          days-to-keep: 30
+          num-to-keep: 30
+      - inject:
+          keep-system-variables: true
+          properties-content: |
+            jjb_proj={jjb_proj}-verification-launcher
+            conf_file=.ci/jenkins/lib/verification-launcher-matrix.yaml
+    description: >
+      <b>NIXL verification build launcher</b><br/>
+      • <code>LAUNCH_TARGET=wheels</code> (nightly, around midnight): triggers
+      <code>{jjb_proj}-build-wheel-nightly</code> for <code>NIXL_VERSION=main</code>, once each
+      for <code>CUDA_MAJOR=13</code> and <code>CUDA_MAJOR=12</code><br/>
+      • <code>LAUNCH_TARGET=containers</code> (daily, around 9 PM): triggers
+      <code>{jjb_proj}-build-container</code> 4 times &mdash; <b>nixlbench</b> and <b>nixl</b>,
+      each on the default base image and on the DLFW PyTorch daily, all with
+      <code>UPDATE_LATEST=true</code><br/>
+      • <i>Do NOT edit this job through the Jenkins GUI &mdash; managed by Jenkins Job Builder.</i>
+    concurrent: false    # Overlapping runs would double-trigger the same builds
+    sandbox: true
+    triggers:
+      - parameterized-timer:
+          cron: |
+            # Wheels around midnight, both CUDA variants (the cu12 run also
+            # produces the nixl meta wheel).
+            H 0 * * * %LAUNCH_TARGET=wheels
+            # Containers around 9 PM, all 4 variants.
+            H 21 * * * %LAUNCH_TARGET=containers
+    parameters:
+      - choice:
+          name: "LAUNCH_TARGET"
+          choices:
+            - "wheels"
+            - "containers"
+          description: >
+            Which builds to trigger:<br/>
+            • <b>wheels</b>: <code>{jjb_proj}-build-wheel-nightly</code>, one run per CUDA major<br/>
+            • <b>containers</b>: <code>{jjb_proj}-build-container</code>, the 4 nightly variants
+      - string:
+          name: "MAIL_TO"
+          default: "nixl-ci-alerts@exchange.nvidia.com"
+          description: "Recipient(s) for the failure report. Mail is sent only when the launcher itself fails to trigger."
+      - string:
+          name: "ci_refspec"
+          default: "{jjb_branch}"
+          description: >
+            Git ref to check out the launcher pipeline + matrix config from. Default main;
+            pass e.g. <code>refs/pull/1234/head</code> to test CI changes end to end before
+            merge - the launcher forwards it to the triggered wheel builds
+            (<code>build-container</code> has no <code>ci_refspec</code> param).
     pipeline-scm:
       scm:
         - git:
@@ -1173,6 +1227,7 @@
         - "{jjb_proj}-dl-gpu-ep"  # Create dl-gpu-ep job for NIXL EP on dlcluster.nvidia.com
         - "{jjb_proj}-build-wheel"  # Create build wheel job
         - "{jjb_proj}-build-wheel-nightly"  # Create nightly wheel verification job
+        - "{jjb_proj}-verification-launcher"  # Create verification build launcher job (wheel + container crons)
         - "nixl-build-wheel-release-poller"  # Create release wheel poller job
         - "{jjb_proj}-cleanup-artifacts"  # Create Artifactory cleanup job
         - "{jjb_proj}-nightly"  # Create nightly UCX-master validation orchestrator


### PR DESCRIPTION
## What?
Test and DR publishes had no target of their own. staging/ mirrors the
verification folder schema and is kept for 1 week.

The wheel and container jobs each carried their own schedule, so they
cannot be enabled in DR: the DR copies would fire on that schedule and
publish over prod artifacts.

Move both schedules to a new launcher job that triggers them.

## Why?
To enable and run [nixl-ci-build-wheel-nightly](https://nbuprod.blsm.nvidia.com/nbu-swx-nixl-main/view/None%20CI/job/nixl-ci-build-wheel-nightly/) on DR 

## How?
_It is optional, but for complex PRs, please provide information about the design,
architecture, approach, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a verification launcher for CUDA 12/13 wheel builds and multiple container verification builds.
  - Added configurable launch targets, notification recipients, and CI revision parameters.
  - Added staging as a supported wheel publishing destination alongside verification and release destinations.
  - Verification launch failures are isolated and reported, with notifications sent when triggering fails.

- **Documentation**
  - Updated CI documentation with launcher workflows, schedules, triggers, and build consistency details.

- **Chores**
  - Added automated cleanup for staging wheels older than one week.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->