### PR TITLE
test: verify the foreign-owner handover before asserting on it

### DIFF
--- a/test/gtest/mp_telemetry_fixture.h
+++ b/test/gtest/mp_telemetry_fixture.h
@@ -65,7 +65,7 @@ ownershipEnvironment(const std::filesystem::path &path) {
     std::ifstream status("/proc/self/status");
     for (std::string line; std::getline(status, line);) {
         constexpr std::string_view key = "Seccomp:";
-        if (line.rfind(key, 0) == 0) {
+        if (line.starts_with(key)) {
             const auto value = line.find_first_not_of(" \t", key.size());
             out << ", seccomp " << (value == std::string::npos ? "?" : line.substr(value));
             break;

--- a/test/gtest/mp_telemetry_fixture.h
+++ b/test/gtest/mp_telemetry_fixture.h
@@ -22,11 +22,18 @@
 #include "telemetry/telemetry_exporter.h"
 #include "telemetry_event.h"
 
+#include <sys/stat.h>
+#include <sys/vfs.h>
 #include <unistd.h>
 
+#include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <system_error>
 
@@ -40,6 +47,48 @@ idx(nixl_telemetry_event_type_t t) {
 [[nodiscard]] inline nixlTelemetryExporterInitParams
 initParams(const std::string &agent) {
     return nixlTelemetryExporterInitParams{agent, 4096};
+}
+
+inline constexpr uid_t kNobodyUid = 65534;
+
+[[nodiscard]] inline std::string
+ownershipEnvironment(const std::filesystem::path &path) {
+    std::ostringstream out;
+    out << "euid " << ::geteuid();
+
+    struct statfs fs{};
+    if (::statfs(path.c_str(), &fs) == 0) {
+        out << ", fs type 0x" << std::hex << static_cast<unsigned long>(fs.f_type) << std::dec;
+    }
+
+    std::ifstream uid_map("/proc/self/uid_map");
+    for (std::string line; std::getline(uid_map, line);) {
+        out << ", uid_map [" << line << "]";
+    }
+    return out.str();
+}
+
+[[nodiscard]] inline std::optional<std::string>
+giveAwayOwnership(const std::filesystem::path &path) {
+    if (::geteuid() != 0) {
+        return "needs privileges to give '" + path.string() + "' another owner (" +
+            ownershipEnvironment(path) + ")";
+    }
+    if (::chown(path.c_str(), kNobodyUid, static_cast<gid_t>(-1)) != 0) {
+        return "cannot give '" + path.string() + "' another owner: " + std::strerror(errno) + " (" +
+            ownershipEnvironment(path) + ")";
+    }
+
+    struct stat st{};
+    if (::stat(path.c_str(), &st) != 0) {
+        return "cannot read back the owner of '" + path.string() + "': " + std::strerror(errno);
+    }
+    if (st.st_uid == kNobodyUid) {
+        return std::nullopt;
+    }
+    return "chown to uid " + std::to_string(kNobodyUid) + " reported success but '" +
+        path.string() + "' is still owned by uid " + std::to_string(st.st_uid) + " (" +
+        ownershipEnvironment(path) + ")";
 }
 
 // A telemetry directory of this test's own, mode 0700: the exporter asks

--- a/test/gtest/mp_telemetry_fixture.h
+++ b/test/gtest/mp_telemetry_fixture.h
@@ -35,6 +35,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <system_error>
 
 #include <gtest/gtest.h>
@@ -61,6 +62,16 @@ ownershipEnvironment(const std::filesystem::path &path) {
         out << ", fs type 0x" << std::hex << static_cast<unsigned long>(fs.f_type) << std::dec;
     }
 
+    std::ifstream status("/proc/self/status");
+    for (std::string line; std::getline(status, line);) {
+        constexpr std::string_view key = "Seccomp:";
+        if (line.rfind(key, 0) == 0) {
+            const auto value = line.find_first_not_of(" \t", key.size());
+            out << ", seccomp " << (value == std::string::npos ? "?" : line.substr(value));
+            break;
+        }
+    }
+
     std::ifstream uid_map("/proc/self/uid_map");
     for (std::string line; std::getline(uid_map, line);) {
         out << ", uid_map [" << line << "]";
@@ -68,6 +79,8 @@ ownershipEnvironment(const std::filesystem::path &path) {
     return out.str();
 }
 
+// A chown that returns 0 is not evidence the owner changed: a root-emulating seccomp filter
+// (enroot's, for one) answers it as a successful no-op, so the owner has to be read back.
 [[nodiscard]] inline std::optional<std::string>
 giveAwayOwnership(const std::filesystem::path &path) {
     if (::geteuid() != 0) {
@@ -75,20 +88,22 @@ giveAwayOwnership(const std::filesystem::path &path) {
             ownershipEnvironment(path) + ")";
     }
     if (::chown(path.c_str(), kNobodyUid, static_cast<gid_t>(-1)) != 0) {
-        return "cannot give '" + path.string() + "' another owner: " + std::strerror(errno) + " (" +
+        const int err = errno;
+        return "cannot give '" + path.string() + "' another owner: " + std::strerror(err) + " (" +
             ownershipEnvironment(path) + ")";
     }
 
     struct stat st{};
     if (::stat(path.c_str(), &st) != 0) {
-        return "cannot read back the owner of '" + path.string() + "': " + std::strerror(errno);
+        const int err = errno;
+        return "cannot read back the owner of '" + path.string() + "': " + std::strerror(err);
     }
-    if (st.st_uid == kNobodyUid) {
+    if (st.st_uid != ::geteuid()) {
         return std::nullopt;
     }
     return "chown to uid " + std::to_string(kNobodyUid) + " reported success but '" +
-        path.string() + "' is still owned by uid " + std::to_string(st.st_uid) + " (" +
-        ownershipEnvironment(path) + ")";
+        path.string() + "' is still owned by this process's own uid " + std::to_string(st.st_uid) +
+        " (" + ownershipEnvironment(path) + ")";
 }
 
 // A telemetry directory of this test's own, mode 0700: the exporter asks

--- a/test/gtest/telemetry_mp_exporter_test.cpp
+++ b/test/gtest/telemetry_mp_exporter_test.cpp
@@ -28,12 +28,8 @@
 
 #include <prometheus/exposer.h>
 
-#include <unistd.h>
-
-#include <cerrno>
 #include <chrono>
 #include <cstdlib>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -177,14 +173,10 @@ TEST_F(MpExporterTest, LeftoverLockFileIsNotASecondOwner) {
 }
 
 TEST_F(MpExporterTest, ForeignOwnedLockFileCannotSilenceTheRun) {
-    if (::geteuid() != 0) {
-        GTEST_SKIP() << "needs privileges to give the lock file another owner";
-    }
     const auto lock = dir_ / ownerLockFileName("127.0.0.1:" + std::to_string(port_));
     { std::ofstream(lock).put('\0'); }
-    constexpr uid_t nobody = 65534;
-    if (::chown(lock.c_str(), nobody, static_cast<gid_t>(-1)) != 0) {
-        GTEST_SKIP() << "cannot give the lock file another owner: " << strerror(errno);
+    if (const auto why = giveAwayOwnership(lock)) {
+        GTEST_SKIP() << *why;
     }
 
     // A planted lock must not read as a sibling win, or every rank of a shared

--- a/test/gtest/telemetry_mp_store_test.cpp
+++ b/test/gtest/telemetry_mp_store_test.cpp
@@ -23,10 +23,8 @@
 
 #include <unistd.h>
 
-#include <cerrno>
 #include <chrono>
 #include <cstdint>
-#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
@@ -247,18 +245,14 @@ TEST_F(MpStoreTest, LongAgentNameTruncated) {
 }
 
 TEST_F(MpStoreTest, ForeignOwnedStoreIsIgnoredAndNotReapable) {
-    if (::geteuid() != 0) {
-        GTEST_SKIP() << "needs privileges to give a store file another owner";
-    }
     // A name no run of this process has used: the warning is emitted once per
     // path, so a repeated run would otherwise see none.
     static int run = 0;
     const auto path = storePath("agent-foreign-" + std::to_string(++run));
     storeWriter writer(path, "agent-foreign", "host-1", "", 0, kBuckets);
     writer.addCounter(TX_BYTES, 7);
-    constexpr uid_t nobody = 65534;
-    if (::chown(path.c_str(), nobody, static_cast<gid_t>(-1)) != 0) {
-        GTEST_SKIP() << "cannot give a store file another owner: " << strerror(errno);
+    if (const auto why = giveAwayOwnership(path)) {
+        GTEST_SKIP() << *why;
     }
 
     const gtest::LogIgnoreGuard lig("owned by uid");


### PR DESCRIPTION
## What?

`MpStoreTest.ForeignOwnedStoreIsIgnoredAndNotReapable` and
`MpExporterTest.ForeignOwnedLockFileCannotSilenceTheRun` `chown()` a file to uid 65534 and then
assert `prometheus_mp` ignores it, treating a `chown` that returns 0 as proof the owner changed. On
the v1.5.0 RC0 environments it is not: the call succeeds and the file keeps its owner, so the
product sees `st_uid == geteuid()`, takes the healthy path, and both tests fail on an environment
property.

They now read the owner back and skip when it did not change, reporting the effective uid, the
post-`chown` `st_uid`, the filesystem type, the seccomp mode and the uid map. Test-only; where the
handover works the tests run and assert exactly as before.

## Why?

NVBug 6734875 / NIX-1806: both fail on all four executed RC0 environments, x86_64 and aarch64. The
`st_uid` checks they cover are correct and unchanged -- the tests were asserting a precondition they
never verified.

Mutation-tested: a no-op `chown` makes both skip with the diagnostic, and bypassing the read-back
reproduces the reported failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved diagnostics for multiprocess telemetry test environments, including filesystem, security, and ownership details.
  * Added shared handling for transferring file ownership during test setup.
  * Tests now provide clearer reasons when required permissions or ownership changes are unavailable and skip appropriately.
  * Consolidated ownership management across related telemetry tests, reducing duplicated setup logic and improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->