### PR TITLE
fix(rust): retain ownership after deregistration errors

### DIFF
--- a/src/bindings/rust/src/lib.rs
+++ b/src/bindings/rust/src/lib.rs
@@ -123,6 +123,8 @@ pub enum NixlError {
     NoTelemetry,
     #[error("Not found")]
     NotFound,
+    #[error("Agent lock is poisoned")]
+    AgentLockPoisoned,
 }
 
 /// A safe wrapper around NIXL memory list
@@ -156,7 +158,7 @@ impl RegistrationHandle {
     }
 
     pub fn deregister(&mut self) -> Result<(), NixlError> {
-        if let Some(agent) = self.agent.take() {
+        if let Some(agent) = self.agent.as_ref() {
             tracing::trace!(
                 ptr = self.ptr,
                 size = self.size,
@@ -165,15 +167,30 @@ impl RegistrationHandle {
                 "Deregistering memory"
             );
             let mut reg_dlist = RegDescList::new(self.mem_type)?;
-            unsafe {
-                reg_dlist.add_desc(self.ptr, self.size, self.dev_id);
-                let _opt_args = OptArgs::new().unwrap();
-                nixl_capi_deregister_mem(
-                    agent.write().unwrap().handle.as_ptr(),
-                    reg_dlist.handle(),
-                    _opt_args.inner.as_ptr(),
-                );
+            reg_dlist.add_desc(self.ptr, self.size, self.dev_id);
+            let descriptors = reg_dlist.handle();
+            if descriptors.is_null() {
+                return Err(NixlError::RegDescAddFailed);
             }
+            let opt_args = OptArgs::new()?;
+            let status = unsafe {
+                nixl_capi_deregister_mem(
+                    agent
+                        .write()
+                        .map_err(|_| NixlError::AgentLockPoisoned)?
+                        .handle
+                        .as_ptr(),
+                    descriptors,
+                    opt_args.inner.as_ptr(),
+                )
+            };
+            match status {
+                NIXL_CAPI_SUCCESS => {}
+                NIXL_CAPI_ERROR_INVALID_PARAM => return Err(NixlError::InvalidParam),
+                NIXL_CAPI_ERROR_NOT_FOUND => return Err(NixlError::NotFound),
+                _ => return Err(NixlError::BackendError),
+            }
+            self.agent = None;
             tracing::trace!("Memory deregistered successfully");
         }
         Ok(())
@@ -191,6 +208,10 @@ impl Drop for RegistrationHandle {
         );
         if let Err(e) = self.deregister() {
             tracing::debug!(error = ?e, "Failed to deregister memory");
+            // Keep the agent alive while the backend can still reference the memory.
+            if let Some(agent) = self.agent.take() {
+                std::mem::forget(agent);
+            }
         }
     }
 }
@@ -608,6 +629,19 @@ impl SystemStorage {
     }
 }
 
+impl Drop for SystemStorage {
+    fn drop(&mut self) {
+        if let Some(mut handle) = self.handle.take() {
+            if let Err(error) = handle.deregister() {
+                tracing::error!(?error, "Retaining storage after memory deregistration failed");
+                // The backend can still reference both the allocation and the agent.
+                std::mem::forget(std::mem::take(&mut self.data));
+                std::mem::forget(handle);
+            }
+        }
+    }
+}
+
 impl MemoryRegion for SystemStorage {
     fn size(&self) -> usize {
         self.data.len()
@@ -639,3 +673,6 @@ impl NixlRegistration for SystemStorage {
 pub fn is_stub() -> bool {
     unsafe { nixl_capi_is_stub() }
 }
+
+#[cfg(test)]
+mod registration_tests;

--- a/src/bindings/rust/src/registration_tests.rs
+++ b/src/bindings/rust/src/registration_tests.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+fn unregistered_handle(storage: &SystemStorage) -> Result<RegistrationHandle, NixlError> {
+    let name = CString::new("deregistration_without_backend")?;
+    let mut agent = ptr::null_mut();
+    let status = unsafe { nixl_capi_create_agent(name.as_ptr(), &mut agent) };
+    if status != NIXL_CAPI_SUCCESS {
+        return Err(NixlError::BackendError);
+    }
+    let handle = NonNull::new(agent).ok_or(NixlError::BackendError)?;
+    Ok(RegistrationHandle {
+        agent: Some(Arc::new(RwLock::new(AgentInner {
+            name: name.to_string_lossy().into_owned(),
+            handle,
+            backends: HashMap::new(),
+            remotes: HashSet::new(),
+        }))),
+        ptr: storage.data.as_ptr() as usize,
+        size: storage.data.len(),
+        dev_id: 0,
+        mem_type: MemType::Dram,
+    })
+}
+
+#[test]
+fn deregistration_failure_preserves_owner_for_retry() -> Result<(), NixlError> {
+    let storage = SystemStorage::new(64)?;
+    let mut handle = unregistered_handle(&storage)?;
+    let owner = handle.agent.as_ref().unwrap().clone();
+    for _ in 0..2 {
+        assert!(matches!(
+            handle.deregister(),
+            Err(NixlError::NotFound | NixlError::BackendError)
+        ));
+        assert!(Arc::ptr_eq(handle.agent.as_ref().unwrap(), &owner));
+        assert_eq!(Arc::strong_count(&owner), 2);
+    }
+    // No registration exists, so the test can release the synthetic handle.
+    handle.agent = None;
+    Ok(())
+}
+
+#[test]
+fn poisoned_agent_lock_preserves_owner_for_retry() -> Result<(), NixlError> {
+    let storage = SystemStorage::new(64)?;
+    let mut handle = unregistered_handle(&storage)?;
+    let owner = handle.agent.as_ref().unwrap().clone();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _guard = owner.write().unwrap();
+        panic!("poison the agent lock");
+    }));
+    assert!(result.is_err());
+    assert!(matches!(
+        handle.deregister(),
+        Err(NixlError::AgentLockPoisoned)
+    ));
+    assert!(Arc::ptr_eq(handle.agent.as_ref().unwrap(), &owner));
+    owner.clear_poison();
+    assert!(matches!(
+        handle.deregister(),
+        Err(NixlError::NotFound | NixlError::BackendError)
+    ));
+    handle.agent = None;
+    Ok(())
+}
+
+#[test]
+fn handle_drop_retains_owner_after_failure() -> Result<(), NixlError> {
+    let storage = SystemStorage::new(64)?;
+    let handle = unregistered_handle(&storage)?;
+    let owner = handle.agent.as_ref().unwrap().clone();
+    drop(handle);
+    assert_eq!(Arc::strong_count(&owner), 2);
+    Ok(())
+}
+
+#[test]
+fn storage_drop_retains_owner_after_failure() -> Result<(), NixlError> {
+    let mut storage = SystemStorage::new(64)?;
+    let handle = unregistered_handle(&storage)?;
+    let owner = handle.agent.as_ref().unwrap().clone();
+    storage.handle = Some(handle);
+    drop(storage);
+    assert_eq!(Arc::strong_count(&owner), 2);
+    Ok(())
+}
+
+#[test]
+fn successful_deregistration_releases_owner_and_is_idempotent() -> Result<(), NixlError> {
+    let agent = Agent::new("successful_deregistration")?;
+    let (_, params) = agent.get_plugin_params("UCX")?;
+    let _backend = agent.create_backend("UCX", &params)?;
+    let storage = SystemStorage::new(64)?;
+    let mut handle = agent.register_memory(&storage, None)?;
+    let owner = handle.agent.as_ref().unwrap().clone();
+    let count = Arc::strong_count(&owner);
+    handle.deregister()?;
+    assert!(handle.agent.is_none());
+    assert_eq!(Arc::strong_count(&owner), count - 1);
+    handle.deregister()?;
+    assert_eq!(Arc::strong_count(&owner), count - 1);
+    Ok(())
+}


### PR DESCRIPTION
`RegistrationHandle::deregister` ignores the native result and removes its agent before deregistration succeeds. A backend error therefore returns success and prevents retries. `SystemStorage` can also free memory while a backend still holds its registration.

This change propagates deregistration errors and clears ownership only after success. Descriptor, option, and lock failures also preserve the handle for retry. If destructor cleanup fails, the handle retains its agent and `SystemStorage` retains its registered allocation. This deliberate retention avoids premature release when cleanup cannot succeed.

Five Rust tests cover native failure, repeated attempts, poisoned locks, destructor failure, and successful idempotent cleanup. All pass with the native NIXL 1.3.0 library and UCX host memory registration:

```sh
cargo test --locked -p nixl-sys --features stub-api --lib registration_tests -- --test-threads=1
```

The test process requires `libnixl_capi.so` and its UCX backend. No GPU is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registration cleanup reliability when deregistration fails.
  * Preserved required backend references after unsuccessful cleanup attempts.
  * Added clearer error handling for lock failures and deregistration status errors.
  * Ensured successful deregistration releases resources correctly and remains idempotent.

* **Tests**
  * Added coverage for retry behavior, lock failures, resource cleanup, and successful deregistration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->