### PR TITLE
nixlbench: fix SG many-to-one peer exchange

### DIFF
--- a/benchmark/nixlbench/README.md
+++ b/benchmark/nixlbench/README.md
@@ -705,6 +705,39 @@ NIXL Benchmark uses an ETCD key-value store for coordination between benchmark w
 ```
 The workers automatically coordinate ranks through ETCD as they connect. Note, the second nixlbench should be started within 60s, otherwise the first instance will stop with an error in the barrier.
 
+### SG many-to-one
+
+For a host-driven `N`:1 many-to-one WRITE (incast), start `N + 1` processes
+with identical arguments and the same unique `--benchmark_group`. ETCD ranks
+`0..N-1` are initiators and rank `N` is the single target, so start the
+initiators before the target when deterministic role placement is required.
+The Device API remains limited to the pairwise scheme.
+
+```bash
+./nixlbench \
+  --etcd_endpoints http://etcd-server:2379 \
+  --benchmark_group manytoone-example \
+  --backend UCX --mode SG --scheme manytoone \
+  --num_initiator_dev 4 --num_target_dev 1 \
+  --op_type WRITE \
+  --initiator_seg_type VRAM --target_seg_type VRAM \
+  --total_buffer_size 268435456 \
+  --start_block_size 262144 --max_block_size 262144 \
+  --start_batch_size 1 --max_batch_size 1
+```
+
+Run this command in five processes. Each initiator receives a distinct region
+of the target buffer. Assign one GPU per process and expose that GPU to the
+process as CUDA device 0 (for example, with `CUDA_VISIBLE_DEVICES`). When
+`--use_hugepages` is enabled for DRAM, each per-initiator, per-thread target
+region must be a multiple of 2 MiB.
+
+For SG many-to-one, `--total_buffer_size` is the aggregate target region.
+Each initiator receives `total_buffer_size / num_initiator_dev` bytes in total;
+with `num_threads` threads, each initiator-thread receives
+`total_buffer_size / (num_initiator_dev * num_threads)` bytes. The configured
+`block_size * batch_size * pipeline_depth` must fit in that per-thread region.
+
 ### Backend-Specific Examples
 
 #### Network Backends

--- a/benchmark/nixlbench/src/main.cpp
+++ b/benchmark/nixlbench/src/main.cpp
@@ -52,6 +52,9 @@ static std::pair<size_t, size_t> getStrideScheme(xferBenchWorker &worker, int nu
     } else if (XFERBENCH_SCHEME_MANY_TO_ONE == xferBenchConfig::scheme) {
         if (worker.isTarget()) {
             count = initiator_device;
+            if (XFERBENCH_MODE_SG == xferBenchConfig::mode) {
+                buffer_size = xferBenchConfig::total_buffer_size / num_threads;
+            }
         }
     } else if (XFERBENCH_SCHEME_TP == xferBenchConfig::scheme) {
         if (worker.isInitiator()) {

--- a/benchmark/nixlbench/src/utils/utils.cpp
+++ b/benchmark/nixlbench/src/utils/utils.cpp
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <utility>
 #include <iomanip>
+#include <limits>
 #include <omp.h>
 #include <set>
 
@@ -618,6 +619,15 @@ xferBenchConfig::loadParams(void) {
     total_buffer_size = NB_ARG(total_buffer_size);
     num_initiator_dev = NB_ARG(num_initiator_dev);
     num_target_dev = NB_ARG(num_target_dev);
+    if (num_initiator_dev < 1 || num_target_dev < 1) {
+        std::cerr << "num_initiator_dev and num_target_dev must both be >= 1" << std::endl;
+        return -1;
+    }
+    if (mode == XFERBENCH_MODE_SG && scheme == XFERBENCH_SCHEME_MANY_TO_ONE &&
+        num_target_dev != 1) {
+        std::cerr << "SG manytoone requires exactly one target" << std::endl;
+        return -1;
+    }
     start_block_size = NB_ARG(start_block_size);
     max_block_size = NB_ARG(max_block_size);
     start_batch_size = NB_ARG(start_batch_size);
@@ -630,6 +640,10 @@ xferBenchConfig::loadParams(void) {
     large_blk_iter_ftr = NB_ARG(large_blk_iter_ftr);
     warmup_iter = NB_ARG(warmup_iter);
     num_threads = NB_ARG(num_threads);
+    if (num_threads < 1) {
+        std::cerr << "num_threads must be >= 1" << std::endl;
+        return -1;
+    }
     pipeline_depth = NB_ARG(pipeline_depth);
     if (pipeline_depth < 1) {
         std::cerr << "pipeline_depth must be >= 1" << std::endl;
@@ -659,6 +673,17 @@ xferBenchConfig::loadParams(void) {
         std::cout << "Rounding total_buffer_size from " << total_buffer_size << " to "
                   << hugepage_aligned_size << " for 2MB hugepage alignment." << std::endl;
         total_buffer_size = hugepage_aligned_size;
+    }
+    if (use_hugepages && mode == XFERBENCH_MODE_SG && scheme == XFERBENCH_SCHEME_MANY_TO_ONE) {
+        const size_t slice_count =
+            static_cast<size_t>(num_initiator_dev) * static_cast<size_t>(num_threads);
+        if (total_buffer_size % slice_count != 0 ||
+            (total_buffer_size / slice_count) % HUGEPAGE_SIZE != 0) {
+            std::cerr << "SG manytoone with hugepages requires total_buffer_size / "
+                         "(num_initiator_dev * num_threads) to be 2MB-aligned"
+                      << std::endl;
+            return -1;
+        }
     }
     if (!recreate_xfer && XFERBENCH_BACKEND_GUSLI == backend) {
         std::cout << "GUSLI backend requires per-iteration request creation due to library bug."
@@ -778,6 +803,24 @@ xferBenchConfig::loadParams(void) {
     }
     const int workers = workerNum();
     const char *worker_kind = use_device_api ? "groups" : "threads";
+
+    if (XFERBENCH_MODE_SG == mode && XFERBENCH_SCHEME_MANY_TO_ONE == scheme) {
+        if (max_batch_size >
+            std::numeric_limits<size_t>::max() / static_cast<size_t>(pipeline_depth)) {
+            std::cerr << "Batch size and pipeline depth are too large" << std::endl;
+            return -1;
+        }
+        const size_t effective_batch = max_batch_size * static_cast<size_t>(pipeline_depth);
+        const size_t bytes_per_peer = total_buffer_size /
+            (static_cast<size_t>(workers) * static_cast<size_t>(num_initiator_dev));
+        if (effective_batch == 0 || max_block_size > bytes_per_peer / effective_batch) {
+            std::cerr << "Incorrect buffer size configuration: SG manytoone requires "
+                         "(max_block_size * max_batch_size * pipeline_depth) <= "
+                         "(total_buffer_size / (workers * num_initiator_dev))"
+                      << std::endl;
+            return -1;
+        }
+    }
 
     if ((max_block_size * max_batch_size) > (total_buffer_size / workers)) {
         std::cerr << "Incorrect buffer size configuration "

--- a/benchmark/nixlbench/src/worker/nixl/nixl_topology.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_topology.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NIXL_BENCHMARK_NIXLBENCH_SRC_WORKER_NIXL_NIXL_TOPOLOGY_H
+#define NIXL_BENCHMARK_NIXLBENCH_SRC_WORKER_NIXL_NIXL_TOPOLOGY_H
+
+#include "utils/utils.h"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace nixlbench {
+
+struct descriptorRange {
+    size_t offset;
+    size_t count;
+};
+
+inline std::vector<int>
+exchangePeerRanks(bool is_sg,
+                  const std::string &scheme,
+                  bool is_initiator,
+                  int rank,
+                  int num_initiators,
+                  int num_targets) {
+    if (!is_sg) {
+        return {is_initiator ? 1 : 0};
+    }
+
+    if (scheme == XFERBENCH_SCHEME_PAIRWISE) {
+        return {is_initiator ? rank + num_initiators : rank - num_targets};
+    }
+
+    if (scheme == XFERBENCH_SCHEME_MANY_TO_ONE) {
+        if (is_initiator) {
+            return {num_initiators};
+        }
+
+        std::vector<int> peers;
+        peers.reserve(static_cast<size_t>(num_initiators));
+        for (int peer = 0; peer < num_initiators; ++peer) {
+            peers.push_back(peer);
+        }
+        return peers;
+    }
+
+    // Preserve the existing rank-0/rank-1 behavior for other schemes.
+    return {is_initiator ? 1 : 0};
+}
+
+inline std::optional<descriptorRange>
+manyToOneDescriptorRange(size_t descriptor_count, size_t peer_count, size_t peer_index) {
+    if (descriptor_count == 0 || peer_count == 0 || peer_index >= peer_count ||
+        descriptor_count % peer_count != 0) {
+        return std::nullopt;
+    }
+
+    const size_t descriptors_per_peer = descriptor_count / peer_count;
+    return descriptorRange{peer_index * descriptors_per_peer, descriptors_per_peer};
+}
+
+} // namespace nixlbench
+
+#endif

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "worker/nixl/nixl_worker.h"
+#include "worker/nixl/nixl_topology.h"
 #include <algorithm>
 #include <cassert>
 #include <cctype>
@@ -1025,6 +1026,11 @@ xferBenchNixlWorker::allocateMemory(int num_threads) {
         num_devices = xferBenchConfig::num_target_dev;
     }
     buffer_size = xferBenchConfig::total_buffer_size / (num_devices * num_threads);
+    if (!xferBenchConfig::isStorageBackend() && XFERBENCH_MODE_SG == xferBenchConfig::mode &&
+        XFERBENCH_SCHEME_MANY_TO_ONE == xferBenchConfig::scheme) {
+        // Each SG process uses one assigned GPU, exposed to it as role-local device 0.
+        num_devices = 1;
+    }
 
     if (xferBenchConfig::storage_enable_direct) {
         if (xferBenchConfig::page_size == 0) {
@@ -1258,35 +1264,37 @@ xferBenchNixlWorker::exchangeMetadata() {
         return 0;
     }
 
+    const std::vector<int> peers =
+        nixlbench::exchangePeerRanks(XFERBENCH_MODE_SG == xferBenchConfig::mode,
+                                     xferBenchConfig::scheme,
+                                     isInitiator(),
+                                     rt->getRank(),
+                                     xferBenchConfig::num_initiator_dev,
+                                     xferBenchConfig::num_target_dev);
+
     if (isTarget()) {
         std::string local_metadata;
         const char *buffer;
-        int destrank;
 
         agent->getLocalMD(local_metadata);
 
         buffer = local_metadata.data();
         meta_sz = local_metadata.size();
 
-        if (IS_PAIRWISE_AND_SG()) {
-            destrank = rt->getRank() - xferBenchConfig::num_target_dev;
-            // XXX: Fix up the rank, depends on processes distributed on hosts
-            // assumes placement is adjacent ranks to same node
-        } else {
-            destrank = 0;
+        for (int destrank : peers) {
+            ret = rt->sendInt(&meta_sz, destrank);
+            if (ret != 0) {
+                std::cerr << "NIXL: failed to send metadata size to rank " << destrank << std::endl;
+                return ret;
+            }
+            ret = rt->sendChar((char *)buffer, meta_sz, destrank);
+            if (ret != 0) {
+                std::cerr << "NIXL: failed to send metadata to rank " << destrank << std::endl;
+                return ret;
+            }
         }
-        rt->sendInt(&meta_sz, destrank);
-        rt->sendChar((char *)buffer, meta_sz, destrank);
     } else if (isInitiator()) {
-        int srcrank;
-
-        if (IS_PAIRWISE_AND_SG()) {
-            srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
-            // XXX: Fix up the rank, depends on processes distributed on hosts
-            // assumes placement is adjacent ranks to same node
-        } else {
-            srcrank = 1;
-        }
+        const int srcrank = peers.front();
 
         ret = rt->recvInt(&meta_sz, srcrank);
         if (ret < 0) {
@@ -1368,36 +1376,50 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             }
         }
     } else {
+        const std::vector<int> peers =
+            nixlbench::exchangePeerRanks(XFERBENCH_MODE_SG == xferBenchConfig::mode,
+                                         xferBenchConfig::scheme,
+                                         isInitiator(),
+                                         rt->getRank(),
+                                         xferBenchConfig::num_initiator_dev,
+                                         xferBenchConfig::num_target_dev);
         for (const auto &local_iov : local_iovs) {
-            nixlSerDes ser_des;
-            nixl_xfer_dlist_t local_desc(seg_type);
-
-            iovListToNixlXferDlist(local_iov, local_desc);
-
             if (isTarget()) {
-                int destrank;
-                if (IS_PAIRWISE_AND_SG()) {
-                    destrank = rt->getRank() - xferBenchConfig::num_target_dev;
-                    // XXX: Fix up the rank, depends on processes distributed on hosts
-                    // assumes placement is adjacent ranks to same node
-                } else {
-                    destrank = 0;
-                }
+                for (size_t peer_index = 0; peer_index < peers.size(); ++peer_index) {
+                    size_t offset = 0;
+                    size_t count = local_iov.size();
+                    if (XFERBENCH_MODE_SG == xferBenchConfig::mode &&
+                        XFERBENCH_SCHEME_MANY_TO_ONE == xferBenchConfig::scheme) {
+                        const auto range = nixlbench::manyToOneDescriptorRange(
+                            local_iov.size(), peers.size(), peer_index);
+                        if (!range) {
+                            std::cerr << "NIXL: target descriptor count " << local_iov.size()
+                                      << " cannot be split across " << peers.size()
+                                      << " initiator ranks" << std::endl;
+                            std::exit(EXIT_FAILURE);
+                        }
+                        offset = range->offset;
+                        count = range->count;
+                    }
 
-                local_desc.serialize(&ser_des);
-                std::string desc_str = ser_des.exportStr();
-                desc_str_sz = desc_str.size();
-                rt->sendInt(&desc_str_sz, destrank);
-                rt->sendChar(desc_str.data(), desc_str.size(), destrank);
-            } else if (isInitiator()) {
-                int srcrank;
-                if (IS_PAIRWISE_AND_SG()) {
-                    srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
-                    // XXX: Fix up the rank, depends on processes distributed on hosts
-                    // assumes placement is adjacent ranks to same node
-                } else {
-                    srcrank = 1;
+                    std::vector<xferBenchIOV> peer_iov(local_iov.begin() + offset,
+                                                       local_iov.begin() + offset + count);
+                    nixl_xfer_dlist_t peer_desc(seg_type);
+                    iovListToNixlXferDlist(peer_iov, peer_desc);
+                    nixlSerDes ser_des;
+                    peer_desc.serialize(&ser_des);
+                    std::string desc_str = ser_des.exportStr();
+                    desc_str_sz = desc_str.size();
+                    const int destrank = peers[peer_index];
+                    if (rt->sendInt(&desc_str_sz, destrank) != 0 ||
+                        rt->sendChar(desc_str.data(), desc_str.size(), destrank) != 0) {
+                        std::cerr << "NIXL: failed to send descriptors to rank " << destrank
+                                  << std::endl;
+                        std::exit(EXIT_FAILURE);
+                    }
                 }
+            } else if (isInitiator()) {
+                const int srcrank = peers.front();
 
                 if (rt->recvInt(&desc_str_sz, srcrank) != 0) {
                     std::cerr << "NIXL: failed to receive metadata size" << std::endl;
@@ -1411,6 +1433,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
                     std::exit(EXIT_FAILURE);
                 }
 
+                nixlSerDes ser_des;
                 ser_des.importStr(desc_str);
 
                 nixl_xfer_dlist_t remote_desc(&ser_des);
@@ -2245,19 +2268,25 @@ xferBenchNixlWorker::poll(size_t block_size) {
         return;
     }
 
+    const size_t initiator_count = XFERBENCH_MODE_SG == xferBenchConfig::mode &&
+            XFERBENCH_SCHEME_MANY_TO_ONE == xferBenchConfig::scheme ?
+        static_cast<size_t>(xferBenchConfig::num_initiator_dev) :
+        1;
+    const size_t expected_warmup = static_cast<size_t>(skip) * initiator_count;
+    const size_t expected_total = static_cast<size_t>(total_iter) * initiator_count;
+
     /* Ensure warmup is done*/
     do {
         status = agent->getNotifs(notifs);
         checkLiveness();
-    } while (!signaled() && status == NIXL_SUCCESS && skip != int(notifs["initiator"].size()));
+    } while (!signaled() && status == NIXL_SUCCESS && notifs["initiator"].size() < expected_warmup);
     synchronize();
 
     /* Polling for actual iterations*/
     do {
         status = agent->getNotifs(notifs);
         checkLiveness();
-    } while (!signaled() && status == NIXL_SUCCESS &&
-             total_iter != int(notifs["initiator"].size()));
+    } while (!signaled() && status == NIXL_SUCCESS && notifs["initiator"].size() < expected_total);
     synchronize();
 }
 

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.cpp
@@ -1255,6 +1255,16 @@ xferBenchNixlWorker::deallocateMemory(std::vector<std::vector<xferBenchIOV>> &io
     iov_lists.clear();
 }
 
+std::vector<int>
+xferBenchNixlWorker::exchangePeerRanks() {
+    return nixlbench::exchangePeerRanks(XFERBENCH_MODE_SG == xferBenchConfig::mode,
+                                        xferBenchConfig::scheme,
+                                        isInitiator(),
+                                        rt->getRank(),
+                                        xferBenchConfig::num_initiator_dev,
+                                        xferBenchConfig::num_target_dev);
+}
+
 int
 xferBenchNixlWorker::exchangeMetadata() {
     int meta_sz, ret = 0;
@@ -1264,13 +1274,7 @@ xferBenchNixlWorker::exchangeMetadata() {
         return 0;
     }
 
-    const std::vector<int> peers =
-        nixlbench::exchangePeerRanks(XFERBENCH_MODE_SG == xferBenchConfig::mode,
-                                     xferBenchConfig::scheme,
-                                     isInitiator(),
-                                     rt->getRank(),
-                                     xferBenchConfig::num_initiator_dev,
-                                     xferBenchConfig::num_target_dev);
+    const std::vector<int> peers = exchangePeerRanks();
 
     if (isTarget()) {
         std::string local_metadata;
@@ -1376,13 +1380,7 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             }
         }
     } else {
-        const std::vector<int> peers =
-            nixlbench::exchangePeerRanks(XFERBENCH_MODE_SG == xferBenchConfig::mode,
-                                         xferBenchConfig::scheme,
-                                         isInitiator(),
-                                         rt->getRank(),
-                                         xferBenchConfig::num_initiator_dev,
-                                         xferBenchConfig::num_target_dev);
+        const std::vector<int> peers = exchangePeerRanks();
         for (const auto &local_iov : local_iovs) {
             if (isTarget()) {
                 for (size_t peer_index = 0; peer_index < peers.size(); ++peer_index) {
@@ -1443,6 +1441,8 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
     }
 
     if (xferBenchConfig::use_device_api) {
+        const std::vector<int> peers = exchangePeerRanks();
+        const int peer_rank = peers.front();
         if (isTarget() && completion_counter_iov.has_value()) {
             nixlSerDes cc_ser;
             nixl_xfer_dlist_t cc_dlist(seg_type);
@@ -1454,32 +1454,20 @@ xferBenchNixlWorker::exchangeIOV(const std::vector<std::vector<xferBenchIOV>> &l
             cc_dlist.addDesc(cc_basic);
             cc_dlist.serialize(&cc_ser);
             std::string cc_export = cc_ser.exportStr();
-            int destrank;
-            if (IS_PAIRWISE_AND_SG()) {
-                destrank = rt->getRank() - xferBenchConfig::num_target_dev;
-            } else {
-                destrank = 0;
-            }
             desc_str_sz = static_cast<int>(cc_export.size());
-            rt->sendInt(&desc_str_sz, destrank);
-            rt->sendChar(cc_export.data(), cc_export.size(), destrank);
+            rt->sendInt(&desc_str_sz, peer_rank);
+            rt->sendChar(cc_export.data(), cc_export.size(), peer_rank);
         } else if (isInitiator()) {
             nixlSerDes cc_ser;
-            int srcrank;
-            if (IS_PAIRWISE_AND_SG()) {
-                srcrank = rt->getRank() + xferBenchConfig::num_initiator_dev;
-            } else {
-                srcrank = 1;
-            }
             completion_counter_iov.reset();
-            if (rt->recvInt(&desc_str_sz, srcrank) != 0) {
+            if (rt->recvInt(&desc_str_sz, peer_rank) != 0) {
                 std::cerr << "NIXL: failed to receive completion counter descriptor size"
                           << std::endl;
                 std::exit(EXIT_FAILURE);
             }
             std::string cc_str;
             cc_str.resize(static_cast<size_t>(desc_str_sz), '\0');
-            if (rt->recvChar(cc_str.data(), cc_str.size(), srcrank) != 0) {
+            if (rt->recvChar(cc_str.data(), cc_str.size(), peer_rank) != 0) {
                 std::cerr << "NIXL: failed to receive completion counter descriptor" << std::endl;
                 std::exit(EXIT_FAILURE);
             }

--- a/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
+++ b/benchmark/nixlbench/src/worker/nixl/nixl_worker.h
@@ -101,6 +101,8 @@ class xferBenchNixlWorker: public xferBenchWorker {
                                        uint64_t expected_value,
                                        const char *phase,
                                        const std::function<void()> &checkLiveness);
+        std::vector<int>
+        exchangePeerRanks();
 
         std::mt19937_64 default_rng_;
 };

--- a/benchmark/nixlbench/tests/meson.build
+++ b/benchmark/nixlbench/tests/meson.build
@@ -8,7 +8,7 @@ gtest_dep = dependency('gtest',
 if gtest_dep.found()
   nixlbench_tests = executable(
     'nixlbench_tests',
-    ['raw_cli_test.cpp', 'posix_integration_test.cpp'],
+    ['raw_cli_test.cpp', 'posix_integration_test.cpp', 'sg_manytoone_test.cpp'],
     include_directories: inc_dir,
     link_with: [utils_lib, nixlbench_runtimes],
     dependencies: deps + [gtest_dep],

--- a/benchmark/nixlbench/tests/sg_manytoone_test.cpp
+++ b/benchmark/nixlbench/tests/sg_manytoone_test.cpp
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "worker/nixl/nixl_topology.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace nixlbench {
+namespace {
+
+    TEST(SgManyToOneTopologyTest, RoutesEveryInitiatorToTheSingleTarget) {
+        constexpr int initiators = 4;
+        constexpr int targets = 1;
+
+        for (int rank = 0; rank < initiators; ++rank) {
+            EXPECT_EQ(exchangePeerRanks(
+                          true, XFERBENCH_SCHEME_MANY_TO_ONE, true, rank, initiators, targets),
+                      std::vector<int>({initiators}));
+        }
+
+        EXPECT_EQ(exchangePeerRanks(
+                      true, XFERBENCH_SCHEME_MANY_TO_ONE, false, initiators, initiators, targets),
+                  std::vector<int>({0, 1, 2, 3}));
+    }
+
+    TEST(SgManyToOneTopologyTest, PreservesPairwiseRankMapping) {
+        EXPECT_EQ(exchangePeerRanks(true, XFERBENCH_SCHEME_PAIRWISE, true, 2, 4, 4),
+                  std::vector<int>({6}));
+        EXPECT_EQ(exchangePeerRanks(true, XFERBENCH_SCHEME_PAIRWISE, false, 6, 4, 4),
+                  std::vector<int>({2}));
+    }
+
+    TEST(SgManyToOneTopologyTest, PreservesMultiGpuPeerMapping) {
+        EXPECT_EQ(exchangePeerRanks(false, XFERBENCH_SCHEME_MANY_TO_ONE, true, 0, 4, 1),
+                  std::vector<int>({1}));
+        EXPECT_EQ(exchangePeerRanks(false, XFERBENCH_SCHEME_MANY_TO_ONE, false, 1, 4, 1),
+                  std::vector<int>({0}));
+    }
+
+    TEST(SgManyToOneTopologyTest, AssignsOneDescriptorPartitionPerInitiator) {
+        constexpr size_t descriptor_count = 16;
+        constexpr size_t peer_count = 4;
+
+        for (size_t peer = 0; peer < peer_count; ++peer) {
+            const auto range = manyToOneDescriptorRange(descriptor_count, peer_count, peer);
+            ASSERT_TRUE(range);
+            EXPECT_EQ(range->offset, peer * 4);
+            EXPECT_EQ(range->count, 4U);
+        }
+    }
+
+    TEST(SgManyToOneTopologyTest, RejectsAliasingDescriptorPartitions) {
+        EXPECT_FALSE(manyToOneDescriptorRange(0, 4, 0));
+        EXPECT_FALSE(manyToOneDescriptorRange(3, 4, 0));
+        EXPECT_FALSE(manyToOneDescriptorRange(4, 0, 0));
+        EXPECT_FALSE(manyToOneDescriptorRange(4, 4, 4));
+    }
+
+} // namespace
+} // namespace nixlbench


### PR DESCRIPTION
## What

Fix host-driven, single-GPU-process (`--mode SG`) NIXLBench `manytoone` so
`N` initiator processes can issue concurrent `WRITE` operations into one
target process without hanging or writing overlapping target regions.

The supported topology is deliberately narrow:

- initiator ranks: `0..N-1`
- single target rank: `N`
- `--mode SG --scheme manytoone --num_initiator_dev N --num_target_dev 1`
- one assigned GPU exposed as logical device 0 in each process

Pairwise SG and multi-GPU-process behavior are preserved. The NIXL Device API
remains pairwise-only and is still rejected for `manytoone` by the existing
configuration validation.

## Why

The non-pairwise peer exchange currently assumes ranks 0 and 1. In a 4:1 SG
incast, for example, the target is rank 4. The target publishes metadata only
to rank 0, while initiators 1-3 wait for rank 1, which is another initiator.
All five processes register successfully and then stop before any transfer.

Routing metadata alone is insufficient for a correct concurrent run: every
initiator also needs a non-overlapping portion of the target descriptor list,
and the target must wait for completion notifications from every initiator.

## How

- Resolve the setup-exchange peers from the SG rank topology while retaining
  the existing pairwise and MG mappings.
- Fan the target's NIXL metadata out to all initiator ranks; every initiator
  receives it from the single target rank.
- Partition each target descriptor list evenly, sending one distinct region
  to each initiator.
- Treat an SG process's assigned GPU as role-local device 0 while retaining
  the topology-wide device counts used to size initiator and target regions.
- Make the target wait for warmup and measured notifications from all `N`
  initiators.
- Reject invalid target counts, unsafe buffer layouts, overflow, and invalid
  hugepage layouts before execution.
- Document the process/rank model, target-buffer partitioning, and an example
  five-process invocation.

The key safety invariant is that initiator `i` receives only target descriptor
partition `i`; no two initiators write the same target region.

## Validation

- Reproduced before the change with five local UCX/ETCD/DRAM processes: all
  ranks registered, all five hit the 75-second bound during setup, and no
  result rows were produced.
- The equivalent corrected 4:1 run completed with all five exit codes equal to
  zero, four initiator result rows, and no consistency errors.
- Full enabled NIXLBench unit suite: 25/25 passed, including five focused SG
  many-to-one topology and descriptor-partition tests.
- Additional local UCX/ETCD/DRAM coverage passed for SG 1:1 and 2:1, READ and
  WRITE with consistency checking, two threads, pipeline depth 2, and block-
  and batch-size sweeps.
- MG `manytoone`, MG `onetomany`, and SG pairwise regression runs passed.
- A functionally identical predecessor completed a two-node H100 canary with
  four SG VRAM WRITE initiators and one target. All five ranks exited zero,
  all four result flows were present, and consistency checking passed. The
  subsequent changes preserve that tested mapping while centralizing peer-rank\n  selection for metadata, descriptors, and the pairwise-only Device API\n  completion counter.
- Warnings-as-errors build, `clang-format-19` changed-line check,
  `git diff --check`, and DCO sign-off passed.

The GPU run was a functional canary, not statistically meaningful performance
evidence.

## Deliberate non-goals

- No change to `MG`; it remains a useful independent baseline.
- No change to `onetomany`.
- No Device API support for many-to-one.
- No multi-node launcher, latency emulator, raw-sample export, or performance
  test matrix in NIXLBench itself.
